### PR TITLE
FIX: Library grpc hookups now function as expected.

### DIFF
--- a/internal/handlers/library/library_handler.go
+++ b/internal/handlers/library/library_handler.go
@@ -2,6 +2,7 @@ package library
 
 import (
 	libraryv1 "buf.build/gen/go/listenup/listenup/protocolbuffers/go/listenup/library/v1"
+	"context"
 	"github.com/ListenUpApp/ListenUp/internal/store"
 	gonanoid "github.com/matoous/go-nanoid/v2"
 	"google.golang.org/grpc/codes"
@@ -19,7 +20,7 @@ func NewLibraryHandler(libraryStore store.LibraryStore) *LibraryHandler {
 	}
 }
 
-func (h *LibraryHandler) GetLibrary(req *libraryv1.GetLibraryRequest) (*libraryv1.GetLibraryResponse, error) {
+func (h *LibraryHandler) GetLibrary(ctx context.Context, req *libraryv1.GetLibraryRequest) (*libraryv1.GetLibraryResponse, error) {
 	// TODO Authorization
 
 	library, err := h.libraryStore.GetLibraryByID(req.GetId())
@@ -33,7 +34,7 @@ func (h *LibraryHandler) GetLibrary(req *libraryv1.GetLibraryRequest) (*libraryv
 	return res, nil
 }
 
-func (h *LibraryHandler) ListLibraries(req *libraryv1.ListLibrariesRequest) (*libraryv1.ListLibrariesResponse, error) {
+func (h *LibraryHandler) ListLibraries(ctx context.Context, req *libraryv1.ListLibrariesRequest) (*libraryv1.ListLibrariesResponse, error) {
 	libraries, err := h.libraryStore.GetAllLibraries()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
@@ -45,7 +46,7 @@ func (h *LibraryHandler) ListLibraries(req *libraryv1.ListLibrariesRequest) (*li
 	return res, nil
 }
 
-func (h *LibraryHandler) CreateLibrary(req *libraryv1.CreateLibraryRequest) (*libraryv1.CreateLibraryResponse, error) {
+func (h *LibraryHandler) CreateLibrary(ctx context.Context, req *libraryv1.CreateLibraryRequest) (*libraryv1.CreateLibraryResponse, error) {
 	id, err := gonanoid.Generate("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 8)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
@@ -66,14 +67,14 @@ func (h *LibraryHandler) CreateLibrary(req *libraryv1.CreateLibraryRequest) (*li
 	return res, nil
 }
 
-func (h *LibraryHandler) GetLibrariesForUser(req *libraryv1.GetLibrariesForUserRequest) (*libraryv1.GetLibrariesForUserResponse, error) {
+func (h *LibraryHandler) GetLibrariesForUser(ctx context.Context, req *libraryv1.GetLibrariesForUserRequest) (*libraryv1.GetLibrariesForUserResponse, error) {
 	// TODO Authorization
 	// TODO implement
 	res := &libraryv1.GetLibrariesForUserResponse{}
 
 	return res, nil
 }
-func (h *LibraryHandler) AddDirectoryToLibrary(req *libraryv1.AddDirectoryToLibraryRequest) (*libraryv1.AddDirectoryToLibraryResponse, error) {
+func (h *LibraryHandler) AddDirectoryToLibrary(ctx context.Context, req *libraryv1.AddDirectoryToLibraryRequest) (*libraryv1.AddDirectoryToLibraryResponse, error) {
 	// TODO Authorization
 
 	err := h.libraryStore.AddDirectory(req.GetLibraryId(), req.GetDirectory())

--- a/internal/handlers/library/library_handler_test.go
+++ b/internal/handlers/library/library_handler_test.go
@@ -2,6 +2,7 @@ package library
 
 import (
 	libraryv1 "buf.build/gen/go/listenup/listenup/protocolbuffers/go/listenup/library/v1"
+	"context"
 	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -72,9 +73,9 @@ func TestGetLibrary(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockStore.On("GetLibraryByID", tc.libraryID).Return(tc.mockLibrary, tc.mockError)
-
+			ctx := context.Background()
 			req := &libraryv1.GetLibraryRequest{Id: tc.libraryID}
-			resp, err := handler.GetLibrary(req)
+			resp, err := handler.GetLibrary(ctx, req)
 
 			if tc.expectedError {
 				assert.Error(t, err)
@@ -125,9 +126,9 @@ func TestListLibraries(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockStore.On("GetAllLibraries").Return(tc.mockLibraries, tc.mockError).Once()
-
+			ctx := context.Background()
 			req := &libraryv1.ListLibrariesRequest{}
-			resp, err := handler.ListLibraries(req)
+			resp, err := handler.ListLibraries(ctx, req)
 
 			if tc.expectedError {
 				assert.Error(t, err)
@@ -186,7 +187,8 @@ func TestCreateLibrary(t *testing.T) {
 			mockStore.On("CreateLibrary", mock.AnythingOfType("*libraryv1.Library")).Return(tc.mockError).Once()
 
 			req := tc.request
-			resp, err := handler.CreateLibrary(req)
+			ctx := context.Background()
+			resp, err := handler.CreateLibrary(ctx, req)
 
 			if tc.expectedError {
 				assert.Error(t, err)
@@ -249,7 +251,8 @@ func TestAddDirectoryToLibrary(t *testing.T) {
 				LibraryId: tc.libraryID,
 				Directory: tc.directory,
 			}
-			resp, err := handler.AddDirectoryToLibrary(req)
+			ctx := context.Background()
+			resp, err := handler.AddDirectoryToLibrary(ctx, req)
 
 			if tc.expectedError {
 				assert.Error(t, err)

--- a/internal/server.go
+++ b/internal/server.go
@@ -2,11 +2,13 @@ package internal
 
 import (
 	"buf.build/gen/go/listenup/listenup/grpc/go/listenup/auth/v1/authv1grpc"
+	"buf.build/gen/go/listenup/listenup/grpc/go/listenup/library/v1/libraryv1grpc"
 	"buf.build/gen/go/listenup/listenup/grpc/go/listenup/server/v1/serverv1grpc"
 	"context"
 	"fmt"
 	"github.com/ListenUpApp/ListenUp/internal/db"
 	"github.com/ListenUpApp/ListenUp/internal/handlers/auth"
+	"github.com/ListenUpApp/ListenUp/internal/handlers/library"
 	"github.com/ListenUpApp/ListenUp/internal/handlers/server"
 	"github.com/ListenUpApp/ListenUp/internal/logger"
 	"github.com/ListenUpApp/ListenUp/internal/store"
@@ -15,11 +17,12 @@ import (
 )
 
 type Server struct {
-	db             db.DBInterface
-	serverHandlers *server.ServerHandler
-	authHandlers   *auth.AuthHandlers
-	grpcServer     *grpc.Server
-	listener       net.Listener
+	db              db.DBInterface
+	serverHandlers  *server.ServerHandler
+	authHandlers    *auth.AuthHandlers
+	libraryHandlers *library.LibraryHandler
+	grpcServer      *grpc.Server
+	listener        net.Listener
 }
 
 func NewServer(database db.DBInterface) *Server {
@@ -57,6 +60,7 @@ func (s *Server) StartServer() error {
 	s.grpcServer = grpc.NewServer()
 	serverv1grpc.RegisterServerServiceServer(s.grpcServer, s.serverHandlers)
 	authv1grpc.RegisterAuthServiceServer(s.grpcServer, s.authHandlers)
+	libraryv1grpc.RegisterLibraryServiceServer(s.grpcServer, s.libraryHandlers)
 
 	logger.Info("Starting Server", "address", lis.Addr().String())
 

--- a/internal/store/auth_store.go
+++ b/internal/store/auth_store.go
@@ -43,8 +43,9 @@ func (s *BadgerAuthStore) StoreRefreshToken(ctx context.Context, userID, token s
 	}
 
 	data, err := json.Marshal(tokenInfo)
-	logger.Error("Failed to marshal token info", "Error", err)
+
 	if err != nil {
+		logger.Error("Failed to marshal token info", "Error", err)
 		return fmt.Errorf("failed to marshal token info: %w", err)
 	}
 


### PR DESCRIPTION
The library handler weren't hooked up accordingly causing an issue when trying to call the endpoints.