### PR TITLE
W7 Phase C2 — ProgressTracker read-method migration

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -104,7 +104,6 @@ val playbackModule =
         // Progress tracker for position persistence and event recording
         single {
             ProgressTracker(
-                positionDao = get(),
                 downloadRepository = get(),
                 listeningEventRepository = get(),
                 syncApi = get(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -30,9 +30,11 @@ import com.calypsan.listenup.client.composeapp.R
 import com.calypsan.listenup.client.automotive.BrowseTree
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.automotive.CustomActions
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.getOrNull
 import com.calypsan.listenup.client.domain.repository.HomeRepository
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.voice.MediaFocus
 import com.calypsan.listenup.client.voice.PlaybackIntent
 import com.calypsan.listenup.client.voice.VoiceHints
@@ -85,6 +87,7 @@ class PlaybackService : MediaLibraryService() {
     // Inject dependencies
     private val playbackManager: PlaybackManager by inject()
     private val progressTracker: ProgressTracker by inject()
+    private val positionRepository: PlaybackPositionRepository by inject()
     private val errorHandler: PlaybackErrorHandler by inject()
     private val tokenProvider: AndroidAudioTokenProvider by inject()
     private val sleepTimerManager: SleepTimerManager by inject()
@@ -991,8 +994,18 @@ class PlaybackService : MediaLibraryService() {
             return CallbackToFutureAdapter.getFuture { completer ->
                 serviceScope.launch {
                     try {
-                        // Get the last played book from ProgressTracker
-                        val lastPlayed = progressTracker.getLastPlayedBook()
+                        // Get the last played book from the repository
+                        val lastPlayed =
+                            when (val r = positionRepository.getLastPlayedBook()) {
+                                is AppResult.Success -> {
+                                    r.data
+                                }
+
+                                is AppResult.Failure -> {
+                                    logger.warn { "Failed to read last played book: ${r.error.message}" }
+                                    null
+                                }
+                            }
 
                         if (lastPlayed == null) {
                             logger.warn { "No last played book found for resumption" }

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -91,7 +91,6 @@ val platformModule: Module =
         // Progress tracker
         single {
             ProgressTracker(
-                positionDao = get(),
                 downloadRepository = get(),
                 listeningEventRepository = get(),
                 syncApi = get(),

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
 import com.calypsan.listenup.client.data.sync.push.MarkCompletePayload
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
+import com.calypsan.listenup.client.domain.repository.LastPlayedInfo
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -91,6 +92,18 @@ class PlaybackPositionRepositoryImpl(
 
     override suspend fun getRecentPositions(limit: Int): List<PlaybackPosition> =
         dao.getRecentPositions(limit).map { it.toDomain() }
+
+    override suspend fun getLastPlayedBook(): AppResult<LastPlayedInfo?> =
+        suspendRunCatching {
+            val positions = dao.getRecentPositions(1)
+            positions.firstOrNull()?.let { position ->
+                LastPlayedInfo(
+                    bookId = position.bookId,
+                    positionMs = position.positionMs,
+                    playbackSpeed = position.playbackSpeed,
+                )
+            }
+        }
 
     // ----- Write paths -----------------------------------------------------------------------
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPositionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPositionRepository.kt
@@ -7,6 +7,16 @@ import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import kotlinx.coroutines.flow.Flow
 
 /**
+ * Information about the last played book for resumption from system UI.
+ * (Android Auto, Wear OS, system notifications, etc.)
+ */
+data class LastPlayedInfo(
+    val bookId: BookId,
+    val positionMs: Long,
+    val playbackSpeed: Float,
+)
+
+/**
  * Repository contract for playback position operations.
  *
  * Provides access to saved playback positions for books.
@@ -160,4 +170,15 @@ interface PlaybackPositionRepository {
         bookId: BookId,
         update: PlaybackUpdate,
     ): AppResult<Unit>
+
+    /**
+     * Read the most recently played book (highest `lastPlayedAt`) or null if no
+     * books have been played. Used by the system UI resumption surface
+     * (Android Auto, Wear OS, system notifications after reboot).
+     *
+     * @return [AppResult.Success] wrapping [LastPlayedInfo] for the most recently
+     *   played book, or null if no books have been played;
+     *   [AppResult.Failure] if the DAO threw.
+     */
+    suspend fun getLastPlayedBook(): AppResult<LastPlayedInfo?>
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -539,7 +539,7 @@ class ProgressTracker(
         finalPositionMs: Long,
     ) {
         val priorState = _sessionState.value
-        _sessionState.value = SessionState.Idle
+        _sessionState.update { _ -> SessionState.Idle }
 
         scope.launch {
             logger.info { "Book finished: ${bookId.value}, finalPosition=$finalPositionMs" }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -367,6 +367,17 @@ class ProgressTracker(
      * 3. Compare timestamps - use whichever is newer
      * 4. If server is newer, update local cache
      *
+     * **HTTP exception (drift #19):** This method retains a synchronous
+     * `syncApi.getProgress(bookId)` call (via [fetchServerProgress]) — the
+     * one remaining direct HTTP read in [ProgressTracker] after W7 Phase C.
+     * Cross-device merge has no SSE coverage today, and resume must reflect
+     * a sibling device's progress at the moment playback starts. The call
+     * is bounded by `withTimeoutOrNull(3_000L)` so a slow or unreachable
+     * server cannot block ExoPlayer startup. Future work (W8 Phase D):
+     * either an SSE-driven cross-device merge that obviates the synchronous
+     * read, or a `PlaybackPositionRepository.fetchAndMerge(bookId)` that
+     * internalises the HTTP call behind the seam.
+     *
      * @param bookId Book to get resume position for
      * @return Position to resume from, or null if never played
      */

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -7,7 +7,6 @@ import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.data.local.db.EntityType
 import com.calypsan.listenup.client.data.local.db.OperationType
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.PlaybackProgressResponse
@@ -47,7 +46,6 @@ private val logger = KotlinLogging.logger {}
  * Events are queued locally via the unified push sync system.
  */
 class ProgressTracker(
-    private val positionDao: PlaybackPositionDao,
     private val downloadRepository: DownloadRepository,
     private val listeningEventRepository: ListeningEventRepository,
     private val syncApi: SyncApiContract,
@@ -609,32 +607,6 @@ class ProgressTracker(
             is SessionState.Paused -> s.speed
             SessionState.Idle -> 1.0f
         }
-
-    /**
-     * Get the most recently played book.
-     * Used for playback resumption from system UI (Android Auto, Wear OS, etc).
-     *
-     * @return The book ID and position of the most recently played book, or null if never played
-     */
-    suspend fun getLastPlayedBook(): LastPlayedInfo? {
-        val positions = positionDao.getRecentPositions(1)
-        val position = positions.firstOrNull() ?: return null
-
-        return LastPlayedInfo(
-            bookId = position.bookId,
-            positionMs = position.positionMs,
-            playbackSpeed = position.playbackSpeed,
-        )
-    }
-
-    /**
-     * Information about the last played book for resumption.
-     */
-    data class LastPlayedInfo(
-        val bookId: BookId,
-        val positionMs: Long,
-        val playbackSpeed: Float,
-    )
 
     /**
      * Validate and delegate a listening event to [ListeningEventRepository].

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -538,8 +539,7 @@ class ProgressTracker(
         bookId: BookId,
         finalPositionMs: Long,
     ) {
-        val priorState = _sessionState.value
-        _sessionState.update { _ -> SessionState.Idle }
+        val priorState = _sessionState.getAndUpdate { _ -> SessionState.Idle }
 
         scope.launch {
             logger.info { "Book finished: ${bookId.value}, finalPosition=$finalPositionMs" }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.client.data.sync.ProgressPayload
 import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
 import com.calypsan.listenup.client.data.sync.push.MarkCompletePayload
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.domain.repository.LastPlayedInfo
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
@@ -799,6 +800,51 @@ class PlaybackPositionRepositoryImplTest {
             val repository = createRepo(dao = dao)
 
             val result = repository.getEntity(BookId("book-1"))
+
+            assertIs<AppResult.Failure>(result)
+        }
+
+    // ========== getLastPlayedBook() Tests (Task 12) ==========
+
+    @Test
+    fun `getLastPlayedBook returns LastPlayedInfo when row exists`() =
+        runTest {
+            val dao = createMockDao()
+            val entity =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 45000L, playbackSpeed = 1.5f)
+            everySuspend { dao.getRecentPositions(1) } returns listOf(entity)
+            val repository = createRepo(dao = dao)
+
+            val result = repository.getLastPlayedBook()
+
+            assertIs<AppResult.Success<LastPlayedInfo?>>(result)
+            val info = result.data
+            assertNotNull(info)
+            assertEquals(BookId("book-1"), info.bookId)
+            assertEquals(45000L, info.positionMs)
+            assertEquals(1.5f, info.playbackSpeed)
+        }
+
+    @Test
+    fun `getLastPlayedBook returns null when no rows`() =
+        runTest {
+            val dao = createMockDao()
+            everySuspend { dao.getRecentPositions(1) } returns emptyList()
+            val repository = createRepo(dao = dao)
+
+            val result = repository.getLastPlayedBook()
+
+            assertEquals(AppResult.Success(null), result)
+        }
+
+    @Test
+    fun `getLastPlayedBook returns Failure when dao throws`() =
+        runTest {
+            val dao = createMockDao()
+            everySuspend { dao.getRecentPositions(any()) } throws RuntimeException("dao boom")
+            val repository = createRepo(dao = dao)
+
+            val result = repository.getLastPlayedBook()
 
             assertIs<AppResult.Failure>(result)
         }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
@@ -7,7 +7,6 @@ import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.error.DataError
 import com.calypsan.listenup.client.data.local.db.EntityType
 import com.calypsan.listenup.client.data.local.db.OperationType
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.PlaybackProgressResponse
@@ -57,7 +56,6 @@ class ProgressTrackerTest {
         val testDispatcher = StandardTestDispatcher()
         val testScope = TestScope(testDispatcher)
 
-        val positionDao: PlaybackPositionDao = mock()
         val downloadRepository: DownloadRepository = mock()
         val listeningEventRepository: ListeningEventRepository = mock()
         val syncApi: SyncApiContract = mock()
@@ -70,7 +68,6 @@ class ProgressTrackerTest {
 
         fun build(): ProgressTracker =
             ProgressTracker(
-                positionDao = positionDao,
                 downloadRepository = downloadRepository,
                 listeningEventRepository = listeningEventRepository,
                 syncApi = syncApi,
@@ -86,11 +83,6 @@ class ProgressTrackerTest {
         val fixture = TestFixture()
 
         // Default stubs
-        everySuspend { fixture.positionDao.get(any()) } returns null
-        everySuspend { fixture.positionDao.save(any()) } returns Unit
-        // updatePositionOnly returns 0 by default (no existing record), causing savePosition
-        // to fall through to positionDao.save(). Override in individual tests if needed.
-        everySuspend { fixture.positionDao.updatePositionOnly(any(), any(), any(), any()) } returns 0
         everySuspend { fixture.syncApi.getProgress(any()) } returns Success(null)
         everySuspend { fixture.listeningEventRepository.queueListeningEvent(any(), any(), any(), any(), any(), any()) } returns AppResult.Success(Unit)
         everySuspend { fixture.pushSyncOrchestrator.flush() } returns Unit

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepository.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
+import com.calypsan.listenup.client.domain.repository.LastPlayedInfo
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import kotlinx.coroutines.flow.Flow
@@ -40,6 +41,17 @@ class FakePlaybackPositionRepository(
             "FakePlaybackPositionRepository does not implement getEntity (no entity store backs the fake). " +
                 "Inject a purpose-built fake or use the real PlaybackPositionRepositoryImpl with an in-memory DAO.",
         )
+
+    override suspend fun getLastPlayedBook(): AppResult<LastPlayedInfo?> {
+        val most = state.value.values.maxByOrNull { it.effectiveLastPlayedAtMs } ?: return Success(null)
+        return Success(
+            LastPlayedInfo(
+                bookId = BookId(most.bookId),
+                positionMs = most.positionMs,
+                playbackSpeed = most.playbackSpeed,
+            ),
+        )
+    }
 
     override fun observe(bookId: String): Flow<PlaybackPosition?> = state.asStateFlow().map { it[bookId] }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepositoryTest.kt
@@ -120,4 +120,34 @@ class FakePlaybackPositionRepositoryTest {
             assertEquals("newest", recent[0].bookId, "most-recently-played first")
             assertEquals("oldest", recent[1].bookId)
         }
+
+    @Test
+    fun getLastPlayedBookReturnsMostRecentlyPlayed() =
+        runTest {
+            var clock = 1_000L
+            val repo = FakePlaybackPositionRepository(nowMs = { clock })
+            repo.save("oldest", positionMs = 100L, playbackSpeed = 1.0f, hasCustomSpeed = false)
+            clock = 2_000L
+            repo.save("newest", positionMs = 5_000L, playbackSpeed = 1.5f, hasCustomSpeed = true)
+
+            val result = repo.getLastPlayedBook()
+
+            assertTrue(result is Success)
+            val info = result.data
+            assertNotNull(info)
+            assertEquals("newest", info.bookId.value)
+            assertEquals(5_000L, info.positionMs)
+            assertEquals(1.5f, info.playbackSpeed)
+        }
+
+    @Test
+    fun getLastPlayedBookReturnsNullWhenEmpty() =
+        runTest {
+            val repo = FakePlaybackPositionRepository()
+
+            val result = repo.getLastPlayedBook()
+
+            assertTrue(result is Success)
+            assertNull(result.data)
+        }
 }

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -77,7 +77,6 @@ val iosPlaybackModule: Module =
         // Progress tracker
         single {
             ProgressTracker(
-                positionDao = get(),
                 downloadRepository = get(),
                 listeningEventRepository = get(),
                 syncApi = get(),

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -6,7 +6,6 @@ import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
@@ -70,15 +69,10 @@ class PlaybackManagerSpeedTest {
     @Test
     fun `onSpeedChanged with 1_0f propagates progressTracker write`() =
         runTest {
-            val positionDao: PlaybackPositionDao = mock()
-            everySuspend { positionDao.get(any()) } returns null
-            everySuspend { positionDao.save(any()) } returns Unit
-
             val positionRepository = defaultPositionRepository()
 
             val (manager, _) =
                 createPlaybackManagerWithScope(
-                    positionDao = positionDao,
                     positionRepository = positionRepository,
                 )
 
@@ -110,13 +104,9 @@ class PlaybackManagerSpeedTest {
             val playbackPreferences: PlaybackPreferences = mock()
             everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
 
-            val positionDao: PlaybackPositionDao = mock()
-            everySuspend { positionDao.get(any()) } returns null
-
             val manager =
                 createPlaybackManager(
                     playbackPreferences = playbackPreferences,
-                    positionDao = positionDao,
                     // Use a detached scope so the positionMs.collect launch does not
                     // keep the TestScope alive and block runTest completion.
                     scope = CoroutineScope(Job()),
@@ -153,16 +143,11 @@ class PlaybackManagerSpeedTest {
             everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
             everySuspend { playbackPreferences.setDefaultPlaybackSpeed(any()) } returns Unit
 
-            val positionDao: PlaybackPositionDao = mock()
-            everySuspend { positionDao.get(any()) } returns null
-            everySuspend { positionDao.save(any()) } returns Unit
-
             val positionRepository = defaultPositionRepository()
 
             val (manager, _) =
                 createPlaybackManagerWithScope(
                     playbackPreferences = playbackPreferences,
-                    positionDao = positionDao,
                     positionRepository = positionRepository,
                 )
 
@@ -198,15 +183,13 @@ class PlaybackManagerSpeedTest {
      */
     private fun TestScope.createPlaybackManagerWithScope(
         playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
-        positionDao: PlaybackPositionDao = defaultPositionDao(),
         positionRepository: PlaybackPositionRepository = defaultPositionRepository(),
-    ): Pair<PlaybackManager, PlaybackPositionDao> {
+    ): Pair<PlaybackManager, PlaybackPositionRepository> {
         val progressTrackerScope = CoroutineScope(coroutineContext)
         val managerScope = CoroutineScope(coroutineContext)
 
         val progressTracker =
             buildProgressTracker(
-                positionDao = positionDao,
                 scope = progressTrackerScope,
                 positionRepository = positionRepository,
             )
@@ -214,12 +197,11 @@ class PlaybackManagerSpeedTest {
         val manager =
             createPlaybackManager(
                 playbackPreferences = playbackPreferences,
-                positionDao = positionDao,
                 progressTracker = progressTracker,
                 scope = managerScope,
             )
 
-        return manager to positionDao
+        return manager to positionRepository
     }
 
     private fun defaultPlaybackPreferences(): PlaybackPreferences {
@@ -231,12 +213,7 @@ class PlaybackManagerSpeedTest {
 
     private fun createPlaybackManager(
         playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
-        positionDao: PlaybackPositionDao = defaultPositionDao(),
-        progressTracker: ProgressTracker =
-            buildProgressTracker(
-                positionDao = positionDao,
-                scope = CoroutineScope(Job()),
-            ),
+        progressTracker: ProgressTracker = buildProgressTracker(scope = CoroutineScope(Job())),
         scope: CoroutineScope = CoroutineScope(Job()),
     ): PlaybackManager {
         val tokenProvider: AudioTokenProvider = mock()

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -178,8 +178,8 @@ class PlaybackManagerSpeedTest {
      * [TestScope] from [runTest]. Use this for tests that need [advanceUntilIdle]
      * to drain coroutines launched inside [PlaybackManager] or [ProgressTracker].
      *
-     * Returns both the manager and the [positionDao] mock so tests can assert
-     * on it.
+     * Returns both the manager and the [PlaybackPositionRepository] mock so tests
+     * can assert on it.
      */
     private fun TestScope.createPlaybackManagerWithScope(
         playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
@@ -2,7 +2,6 @@ package com.calypsan.listenup.client.playback
 
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.sync.push.EndPlaybackSessionHandler
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
@@ -26,13 +25,11 @@ import kotlinx.coroutines.Job
 
 /** Constructs a [ProgressTracker] whose dependencies are all interface mocks. */
 fun buildProgressTracker(
-    positionDao: PlaybackPositionDao = defaultPositionDao(),
     scope: CoroutineScope = CoroutineScope(Job()),
     positionRepository: PlaybackPositionRepository = defaultPositionRepository(),
 ): ProgressTracker {
     val stubSyncApi = mock<SyncApiContract>()
     return ProgressTracker(
-        positionDao = positionDao,
         downloadRepository = mock<DownloadRepository>(),
         listeningEventRepository = mock<ListeningEventRepository>(),
         syncApi = stubSyncApi,
@@ -50,12 +47,4 @@ fun defaultPositionRepository(): PlaybackPositionRepository {
     everySuspend { repo.savePlaybackState(any(), any()) } returns AppResult.Success(Unit)
     everySuspend { repo.getEntity(any<BookId>()) } returns AppResult.Success(null)
     return repo
-}
-
-/** Returns a [PlaybackPositionDao] stub that returns null for all reads and Unit for writes. */
-fun defaultPositionDao(): PlaybackPositionDao {
-    val dao: PlaybackPositionDao = mock()
-    everySuspend { dao.get(any()) } returns null
-    everySuspend { dao.save(any()) } returns Unit
-    return dao
 }

--- a/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -76,7 +76,6 @@ val macosPlaybackModule: Module =
         // Progress tracker
         single {
             ProgressTracker(
-                positionDao = get(),
                 downloadRepository = get(),
                 listeningEventRepository = get(),
                 syncApi = get(),


### PR DESCRIPTION
## Summary

W7 Phase C2 follow-up to C1's structural collapse. Read-method migration completing the ProgressTracker reduction to a pure event-ingestion facade.

- **\`getLastPlayedBook()\` moved** from \`ProgressTracker\` to \`PlaybackPositionRepository\`. New interface method \`suspend fun getLastPlayedBook(): AppResult<LastPlayedInfo?>\`. \`LastPlayedInfo\` data class moved from nested-in-ProgressTracker to \`com.calypsan.listenup.client.domain.repository\`. Sole caller (\`PlaybackService.kt\` for the Continue Listening Android Auto / Wear OS surface) migrated to consume the AppResult shape with graceful Failure-branch (warn-log + null + \`IllegalStateException(\"No book to resume\")\`).
- **\`positionDao\` ctor dep DROPPED** from \`ProgressTracker\`. Cascade fix landed in 4 platform DI sites + \`PlaybackManagerTestSupport.kt\` + \`ProgressTrackerTest\` fixture.
- **\`getResumePosition\` audit:** one live production caller (\`PlaybackManager.kt:259\` on the playback-prepare hot path). Decision: keep the function; document the HTTP exception inline. KDoc extended with a \"**HTTP exception (drift #19)**\" section explaining the cross-device-merge rationale (no SSE coverage; \`withTimeoutOrNull(3_000L)\` bound; W8 Phase D candidate).
- **Bonus — drift #22 closed:** \`onBookFinished\`'s read-then-write window on \`_sessionState\` upgraded to \`_sessionState.getAndUpdate { _ -> SessionState.Idle }\` (atomic read + replace). The initial \`update { _ -> Idle }\` form was cosmetic-only; §M1 reviewer caught the still-vulnerable race; \`getAndUpdate\` is the genuine closure.
- **Tests:** 3 new repo tests for \`getLastPlayedBook\` (field-tight: specific bookId, positionMs, playbackSpeed values). 2 new fake smoke tests covering ordering by \`effectiveLastPlayedAtMs\` + empty-state.

## Drift state

- **Closed by this PR:** #22 (\`onBookFinished\` atomic-update asymmetry — genuine closure via \`getAndUpdate\` in \`da494049\`).
- **Documented inline, deferred to W8:** #19 (\`fetchServerProgress\` HTTP retained for cross-device merge).
- **Rolled forward to W8:** #17 (Discard/Restart facade), #18 (ProgressTracker:526 AppResult discard), #20 (SyncIndicatorViewModel describe split), #21 (get/getEntity asymmetry).

## Architectural impact

After this PR, \`ProgressTracker\` is a pure event-ingestion facade:
- Zero direct DAO touch points (all writes route through \`PlaybackPositionRepository.savePlaybackState\`; \`getLastPlayedBook\` now a repo read).
- Exactly one documented HTTP exception (drift #19, cross-device merge in \`getResumePosition\`).

Phase C goal achieved.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-04-26-w7-c-progresstracker-collapse-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-26-w7-c-progresstracker-collapse.md\` (Tasks 12-14 + §M1 fold-ins)

## Test plan

- [x] \`:shared:jvmTest\` green at every commit
- [x] \`spotlessCheck detekt\` green at every commit
- [x] \`:androidApp:assembleDebug\` green at HEAD (1m 9s, BUILD SUCCESSFUL)
- [x] §M1 code-reviewer pass: APPROVED-WITH-CONCERNS (M1+M2+M3 folded in via \`da494049\`; M4+M5 deferred)

## W7 status

**Phase C complete.** Phase D (defensive cleanup, including drift #17/#18/#19/#20/#21 sweep) and Phase E (VM migration) open next.