### PR TITLE
W7 Phase E1 — PlaybackController command-side seam

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -155,6 +155,12 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+        val desktopTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }
 

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
@@ -213,4 +213,37 @@ class AndroidPlaybackControllerTest {
         assertEquals(1, index)
         assertEquals(60_000L, offset)
     }
+
+    // ---------------------------------------------------------------------------
+    // stop / setVolume — null-controller silent no-ops
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `stop does not throw when controller is null`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.stop() // holder.controller == null — must not throw
+    }
+
+    @Test
+    fun `setVolume does not throw when controller is null`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.setVolume(0.5f) // holder.controller == null — must not throw
+    }
+
+    // ---------------------------------------------------------------------------
+    // seekTo — null-controller silent no-op (already covered by existing test,
+    // but verify the enhanced implementation still handles null gracefully)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `seekTo does not throw when controller is null (enhanced impl)`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.seekTo(75_000L) // controller null — must not throw
+    }
 }

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
@@ -1,0 +1,216 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Delegation tests for [AndroidPlaybackController].
+ *
+ * [androidx.media3.session.MediaController] is a final Android framework class that
+ * cannot be instantiated in JVM host tests. Tests therefore cover:
+ *
+ * 1. acquire/release delegate to [ControllerHolder]
+ * 2. isReady mirrors holder.isConnected
+ * 3. All command methods are silent no-ops when controller is null (no crash)
+ * 4. resolveStartPosition index and offset arithmetic
+ */
+class AndroidPlaybackControllerTest {
+    // ---------------------------------------------------------------------------
+    // Fake ControllerHolder (no Media3 framework needed)
+    // ---------------------------------------------------------------------------
+
+    private class FakeControllerHolder(
+        initialConnected: Boolean = true,
+    ) : ControllerHolder {
+        var acquireCount = 0
+        var releaseCount = 0
+        private val _isConnected = MutableStateFlow(initialConnected)
+        override val isConnected: StateFlow<Boolean> = _isConnected
+
+        /** Always null — MediaController cannot be instantiated in JVM host tests. */
+        override val controller: androidx.media3.session.MediaController? = null
+
+        override fun acquire() {
+            acquireCount++
+        }
+
+        override fun release() {
+            releaseCount++
+        }
+
+        fun setConnected(value: Boolean) {
+            _isConnected.value = value
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // acquire / release
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `acquire delegates to holder`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.acquire()
+        sut.acquire()
+
+        assertEquals(2, holder.acquireCount)
+    }
+
+    @Test
+    fun `release delegates to holder`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.release()
+
+        assertEquals(1, holder.releaseCount)
+    }
+
+    // ---------------------------------------------------------------------------
+    // isReady mirrors isConnected
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `isReady reflects holder isConnected initial value true`() {
+        val holder = FakeControllerHolder(initialConnected = true)
+        val sut = AndroidPlaybackController(holder)
+
+        assertTrue(sut.isReady.value)
+    }
+
+    @Test
+    fun `isReady reflects holder isConnected initial value false`() {
+        val holder = FakeControllerHolder(initialConnected = false)
+        val sut = AndroidPlaybackController(holder)
+
+        assertFalse(sut.isReady.value)
+    }
+
+    @Test
+    fun `isReady updates when holder isConnected changes`() {
+        val holder = FakeControllerHolder(initialConnected = true)
+        val sut = AndroidPlaybackController(holder)
+
+        holder.setConnected(false)
+
+        assertFalse(sut.isReady.value)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Null-controller silent no-ops
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `play does not throw when controller is null`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.play() // holder.controller == null — must not throw
+    }
+
+    @Test
+    fun `pause does not throw when controller is null`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.pause()
+    }
+
+    @Test
+    fun `seekTo does not throw when controller is null`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.seekTo(30_000L)
+    }
+
+    @Test
+    fun `setPlaybackSpeed does not throw when controller is null`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        sut.setPlaybackSpeed(1.5f)
+    }
+
+    @Test
+    fun `setMediaQueue does not throw when controller is null`() =
+        runTest {
+            val holder = FakeControllerHolder()
+            val sut = AndroidPlaybackController(holder)
+
+            sut.setMediaQueue(emptyList(), 0L)
+        }
+
+    // ---------------------------------------------------------------------------
+    // resolveStartPosition — pure arithmetic, no Media3 needed
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `resolveStartPosition returns 0,0 for empty item list`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val (index, offset) = sut.resolveStartPosition(emptyList(), 75_000L)
+
+        assertEquals(0, index)
+        assertEquals(0L, offset)
+    }
+
+    @Test
+    fun `resolveStartPosition maps bookPosition to correct segment index and local offset`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val items =
+            listOf(
+                PlaybackMediaItem("id-0", "url0", null, 60_000L, 0L, "Ch 1", null, null, null),
+                PlaybackMediaItem("id-1", "url1", null, 60_000L, 60_000L, "Ch 2", null, null, null),
+            )
+
+        // bookPositionMs = 75_000 → second segment, 15_000ms in
+        val (index, offset) = sut.resolveStartPosition(items, 75_000L)
+
+        assertEquals(1, index)
+        assertEquals(15_000L, offset)
+    }
+
+    @Test
+    fun `resolveStartPosition clamps to start when position precedes first segment`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val items =
+            listOf(
+                PlaybackMediaItem("id-0", "url0", null, 60_000L, 1_000L, "Ch 1", null, null, null),
+            )
+
+        val (index, offset) = sut.resolveStartPosition(items, 0L)
+
+        assertEquals(0, index)
+        assertEquals(0L, offset)
+    }
+
+    @Test
+    fun `resolveStartPosition clamps to last segment end when position exceeds all segments`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val items =
+            listOf(
+                PlaybackMediaItem("id-0", "url0", null, 60_000L, 0L, "Ch 1", null, null, null),
+                PlaybackMediaItem("id-1", "url1", null, 60_000L, 60_000L, "Ch 2", null, null, null),
+            )
+
+        val (index, offset) = sut.resolveStartPosition(items, 200_000L)
+
+        assertEquals(1, index)
+        assertEquals(60_000L, offset)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -181,12 +181,13 @@ val playbackModule =
             AndroidPlaybackController(get<MediaControllerHolder>().asControllerHolder())
         }
 
-        // Player ViewModel - connects UI to MediaController
+        // Player ViewModel - connects UI to PlaybackController seam
         viewModel {
             PlayerViewModel(
                 playbackManager = get(),
-                mediaControllerHolder = get(),
+                playbackController = get(),
                 networkMonitor = get(),
+                mediaControllerHolder = get(),
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -23,8 +23,11 @@ import com.calypsan.listenup.client.playback.AndroidAudioCapabilityDetector
 import com.calypsan.listenup.client.playback.AndroidAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioCapabilityDetector
 import com.calypsan.listenup.client.playback.AudioTokenProvider
+import com.calypsan.listenup.client.playback.AndroidPlaybackController
 import com.calypsan.listenup.client.playback.MediaControllerHolder
+import com.calypsan.listenup.client.playback.asControllerHolder
 import com.calypsan.listenup.client.playback.NowPlayingViewModel
+import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackErrorHandler
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.PlayerViewModel
@@ -173,6 +176,11 @@ val playbackModule =
             MediaControllerHolder(context = get())
         }
 
+        // PlaybackController seam backed by the shared MediaControllerHolder
+        single<PlaybackController> {
+            AndroidPlaybackController(get<MediaControllerHolder>().asControllerHolder())
+        }
+
         // Player ViewModel - connects UI to MediaController
         viewModel {
             PlayerViewModel(
@@ -188,7 +196,7 @@ val playbackModule =
                 playbackManager = get(),
                 bookRepository = get(),
                 sleepTimerManager = get(),
-                mediaControllerHolder = get(),
+                playbackController = get(),
                 playbackPreferences = get(),
             )
         }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.StateFlow
@@ -56,13 +57,53 @@ class AndroidPlaybackController(
     }
 
     override fun seekTo(positionMs: Long) {
-        holder.controller?.seekTo(positionMs)
-            ?: logger.warn { "AndroidPlaybackController.seekTo($positionMs): controller not ready" }
+        val controller = holder.controller
+        if (controller == null) {
+            logger.warn { "AndroidPlaybackController.seekTo($positionMs): controller not ready" }
+            return
+        }
+        // Resolve book-relative position to (mediaItemIndex, positionInItem) using Media3's
+        // current timeline. The Media3 timeline exposes per-window durations; we accumulate
+        // until we find the window containing positionMs.
+        val (index, offset) = resolveSeekPosition(controller, positionMs)
+        controller.seekTo(index, offset)
+    }
+
+    private fun resolveSeekPosition(
+        controller: MediaController,
+        bookPositionMs: Long,
+    ): Pair<Int, Long> {
+        val itemCount = controller.mediaItemCount
+        if (itemCount == 0) return 0 to 0L
+        var accumulated = 0L
+        for (i in 0 until itemCount) {
+            val window = Timeline.Window()
+            controller.currentTimeline.getWindow(i, window)
+            val itemDuration = window.durationMs
+            if (itemDuration <= 0L) continue // Skip un-prepared windows
+            val itemEnd = accumulated + itemDuration
+            if (bookPositionMs in accumulated until itemEnd) {
+                return i to bookPositionMs - accumulated
+            }
+            accumulated = itemEnd
+        }
+        // Position past end of queue → snap to last item's end
+        return itemCount - 1 to controller.duration.coerceAtLeast(0L)
     }
 
     override fun setPlaybackSpeed(speed: Float) {
         holder.controller?.setPlaybackParameters(PlaybackParameters(speed))
             ?: logger.warn { "AndroidPlaybackController.setPlaybackSpeed($speed): controller not ready" }
+    }
+
+    override fun stop() {
+        holder.controller?.stop()
+            ?: logger.warn { "AndroidPlaybackController.stop: controller not ready" }
+    }
+
+    override fun setVolume(volume: Float) {
+        holder.controller?.let { it.volume = volume }
+            ?: logger.warn { "AndroidPlaybackController.setVolume($volume): controller not ready" }
     }
 
     override suspend fun setMediaQueue(

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -1,0 +1,128 @@
+package com.calypsan.listenup.client.playback
+
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.session.MediaController
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.StateFlow
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Minimal abstraction over [MediaControllerHolder] consumed by [AndroidPlaybackController].
+ *
+ * Exists solely to make [AndroidPlaybackController] testable in androidHostTest
+ * without requiring a real Android [android.content.Context]. [MediaControllerHolder]
+ * satisfies this interface directly.
+ */
+interface ControllerHolder {
+    fun acquire()
+
+    fun release()
+
+    val isConnected: StateFlow<Boolean>
+    val controller: MediaController?
+}
+
+/**
+ * Android implementation of [PlaybackController]. Wraps [ControllerHolder] (backed by
+ * [MediaControllerHolder] in production) + Media3 [MediaController].
+ *
+ * Command methods route through `holder.controller?.X()` — if the controller is
+ * null (not yet connected, or disconnected), the command is silently dropped
+ * with a warn-log. This matches the pre-Phase-E1 VM behavior of
+ * `mediaController ?: return`. Throwing would leak Media3 service-lifecycle
+ * quirks into VM error handling.
+ */
+class AndroidPlaybackController(
+    private val holder: ControllerHolder,
+) : PlaybackController {
+    override fun acquire() = holder.acquire()
+
+    override fun release() = holder.release()
+
+    override val isReady: StateFlow<Boolean> = holder.isConnected
+
+    override fun play() {
+        holder.controller?.play()
+            ?: logger.warn { "AndroidPlaybackController.play: controller not ready" }
+    }
+
+    override fun pause() {
+        holder.controller?.pause()
+            ?: logger.warn { "AndroidPlaybackController.pause: controller not ready" }
+    }
+
+    override fun seekTo(positionMs: Long) {
+        holder.controller?.seekTo(positionMs)
+            ?: logger.warn { "AndroidPlaybackController.seekTo($positionMs): controller not ready" }
+    }
+
+    override fun setPlaybackSpeed(speed: Float) {
+        holder.controller?.setPlaybackParameters(PlaybackParameters(speed))
+            ?: logger.warn { "AndroidPlaybackController.setPlaybackSpeed($speed): controller not ready" }
+    }
+
+    override suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    ) {
+        val controller = holder.controller
+        if (controller == null) {
+            logger.warn { "AndroidPlaybackController.setMediaQueue: controller not ready" }
+            return
+        }
+        val mediaItems =
+            items.map { item ->
+                MediaItem
+                    .Builder()
+                    .setMediaId(item.mediaId)
+                    .setUri(item.uri)
+                    .setMediaMetadata(
+                        MediaMetadata
+                            .Builder()
+                            .setTitle(item.title)
+                            .setArtist(item.artist)
+                            .setAlbumTitle(item.albumTitle)
+                            .setArtworkUri(item.artworkUri?.let { Uri.parse(it) })
+                            .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
+                            .build(),
+                    ).build()
+            }
+        val (startIndex, positionInItem) = resolveStartPosition(items, startPositionMs)
+        controller.setMediaItems(mediaItems, startIndex, positionInItem)
+        controller.prepare()
+    }
+
+    internal fun resolveStartPosition(
+        items: List<PlaybackMediaItem>,
+        bookPositionMs: Long,
+    ): Pair<Int, Long> {
+        if (items.isEmpty()) return 0 to 0L
+        val item = items.firstOrNull { bookPositionMs in it.offsetMs until it.offsetMs + it.durationMs }
+        return if (item != null) {
+            items.indexOf(item) to bookPositionMs - item.offsetMs
+        } else {
+            if (bookPositionMs < items.first().offsetMs) {
+                0 to 0L
+            } else {
+                items.size - 1 to items.last().durationMs
+            }
+        }
+    }
+}
+
+/**
+ * Adapter so that [MediaControllerHolder] satisfies [ControllerHolder] without modification.
+ */
+fun MediaControllerHolder.asControllerHolder(): ControllerHolder =
+    object : ControllerHolder {
+        override fun acquire() = this@asControllerHolder.acquire()
+
+        override fun release() = this@asControllerHolder.release()
+
+        override val isConnected: StateFlow<Boolean> = this@asControllerHolder.isConnected
+        override val controller: MediaController? get() = this@asControllerHolder.controller
+    }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
@@ -4,8 +4,6 @@ package com.calypsan.listenup.client.playback
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.PlaybackParameters
-import androidx.media3.session.MediaController
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.repository.BookRepository
@@ -24,13 +22,13 @@ private val logger = KotlinLogging.logger {}
  *
  * Observes PlaybackManager state and transforms it into UI state.
  * Handles chapter-level position calculations.
- * Uses shared MediaControllerHolder for playback control.
+ * Uses [PlaybackController] for all command-side operations.
  */
 class NowPlayingViewModel(
     private val playbackManager: PlaybackManager,
     private val bookRepository: BookRepository,
     private val sleepTimerManager: SleepTimerManager,
-    private val mediaControllerHolder: MediaControllerHolder,
+    private val playbackController: PlaybackController,
     private val playbackPreferences: PlaybackPreferences,
 ) : ViewModel() {
     val state: StateFlow<NowPlayingState>
@@ -44,12 +42,9 @@ class NowPlayingViewModel(
         private const val FADE_DURATION_MS = 3000L
     }
 
-    private val mediaController: MediaController?
-        get() = mediaControllerHolder.controller
-
     init {
         // Acquire reference to shared controller
-        mediaControllerHolder.acquire()
+        playbackController.acquire()
         observePlayback()
         observeSleepTimer()
         loadDefaultPlaybackSpeed()
@@ -152,13 +147,6 @@ class NowPlayingViewModel(
      * Called when sleep timer fires.
      */
     private suspend fun fadeOutAndPause() {
-        val controller = mediaController
-        if (controller == null) {
-            logger.warn { "Cannot fade out: no MediaController" }
-            sleepTimerManager.onFadeCompleted()
-            return
-        }
-
         logger.info { "Starting volume fade out" }
 
         val steps = 30
@@ -169,16 +157,16 @@ class NowPlayingViewModel(
 
         repeat(steps) {
             currentVolume = (currentVolume - volumeStep).coerceAtLeast(0f)
-            controller.volume = currentVolume
+            playbackController.setVolume(currentVolume)
             delay(stepDelay)
         }
 
         // Pause playback
-        controller.pause()
+        playbackController.pause()
 
         // Brief delay then restore volume for next play
         delay(100)
-        controller.volume = 1f
+        playbackController.setVolume(1f)
 
         logger.info { "Fade complete, playback paused" }
         sleepTimerManager.onFadeCompleted()
@@ -336,7 +324,7 @@ class NowPlayingViewModel(
      * Close the book entirely - stops playback and clears state.
      */
     fun closeBook() {
-        mediaController?.stop()
+        playbackController.stop()
         playbackManager.clearPlayback()
         sleepTimerManager.cancelTimer()
         collapse()
@@ -345,21 +333,15 @@ class NowPlayingViewModel(
     // Playback Actions
 
     fun playPause() {
-        val controller = mediaController ?: return
-        if (controller.isPlaying) {
-            controller.pause()
+        if (state.value.isPlaying) {
+            playbackController.pause()
         } else {
-            controller.play()
+            playbackController.play()
         }
     }
 
     fun skipBack(seconds: Int = 10) {
         logger.debug { "skipBack called: seconds=$seconds" }
-        val controller = mediaController
-        if (controller == null) {
-            logger.warn { "skipBack: mediaController is null" }
-            return
-        }
         val timeline = playbackManager.currentTimeline.value
         if (timeline == null) {
             logger.warn { "skipBack: timeline is null" }
@@ -370,24 +352,13 @@ class NowPlayingViewModel(
         val newBookPos = (currentBookPos - (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtLeast(0)
         logger.debug { "skipBack: currentPos=$currentBookPos, newPos=$newBookPos" }
 
-        val position = timeline.resolve(newBookPos)
-        logger.debug {
-            "skipBack: resolved to mediaItemIndex=${position.mediaItemIndex}, positionInFile=${position.positionInFileMs}"
-        }
-
-        if (safeSeekTo(controller, position.mediaItemIndex, position.positionInFileMs, "skipBack")) {
-            // Update PlaybackManager so UI updates immediately (even when paused)
-            playbackManager.updatePosition(newBookPos)
-        }
+        playbackController.seekTo(newBookPos)
+        // Update PlaybackManager so UI updates immediately (even when paused)
+        playbackManager.updatePosition(newBookPos)
     }
 
     fun skipForward(seconds: Int = 30) {
         logger.debug { "skipForward called: seconds=$seconds" }
-        val controller = mediaController
-        if (controller == null) {
-            logger.warn { "skipForward: mediaController is null" }
-            return
-        }
         val timeline = playbackManager.currentTimeline.value
         if (timeline == null) {
             logger.warn { "skipForward: timeline is null" }
@@ -402,60 +373,9 @@ class NowPlayingViewModel(
             )
         logger.debug { "skipForward: currentPos=$currentBookPos, newPos=$newBookPos, totalDuration=$totalDuration" }
 
-        val position = timeline.resolve(newBookPos)
-        logger.debug {
-            "skipForward: resolved to mediaItemIndex=${position.mediaItemIndex}, positionInFile=${position.positionInFileMs}"
-        }
-
-        if (safeSeekTo(controller, position.mediaItemIndex, position.positionInFileMs, "skipForward")) {
-            // Update PlaybackManager so UI updates immediately (even when paused)
-            playbackManager.updatePosition(newBookPos)
-        }
-    }
-
-    /**
-     * Safe wrapper around MediaController.seekTo that validates parameters
-     * before calling to prevent native crashes from invalid values.
-     *
-     * @return true if seek was attempted, false if validation failed
-     */
-    private fun safeSeekTo(
-        controller: androidx.media3.session.MediaController,
-        mediaItemIndex: Int,
-        positionMs: Long,
-        caller: String,
-    ): Boolean {
-        // Validate mediaItemIndex
-        val mediaItemCount = controller.mediaItemCount
-        if (mediaItemIndex < 0) {
-            logger.error { "$caller: INVALID mediaItemIndex=$mediaItemIndex (negative!)" }
-            return false
-        }
-        if (mediaItemIndex >= mediaItemCount) {
-            logger.error { "$caller: INVALID mediaItemIndex=$mediaItemIndex >= mediaItemCount=$mediaItemCount" }
-            return false
-        }
-
-        // Validate position
-        if (positionMs < 0) {
-            logger.error { "$caller: INVALID positionMs=$positionMs (negative!)" }
-            return false
-        }
-
-        logger.debug {
-            "$caller: safeSeekTo - mediaItemCount=$mediaItemCount, " +
-                "currentMediaItemIndex=${controller.currentMediaItemIndex}, " +
-                "playbackState=${controller.playbackState}"
-        }
-
-        return try {
-            controller.seekTo(mediaItemIndex, positionMs)
-            logger.debug { "$caller: seekTo completed successfully" }
-            true
-        } catch (e: Exception) {
-            logger.error(e) { "$caller: seekTo threw exception" }
-            false
-        }
+        playbackController.seekTo(newBookPos)
+        // Update PlaybackManager so UI updates immediately (even when paused)
+        playbackManager.updatePosition(newBookPos)
     }
 
     fun previousChapter() {
@@ -479,27 +399,11 @@ class NowPlayingViewModel(
             logger.warn { "seekToChapter: chapter at index $index not found" }
             return
         }
-        val controller = mediaController
-        if (controller == null) {
-            logger.warn { "seekToChapter: mediaController is null" }
-            return
-        }
-        val timeline = playbackManager.currentTimeline.value
-        if (timeline == null) {
-            logger.warn { "seekToChapter: timeline is null" }
-            return
-        }
 
         logger.debug { "seekToChapter: chapter='${chapter.title}', startTime=${chapter.startTime}" }
-        val position = timeline.resolve(chapter.startTime)
-        logger.debug {
-            "seekToChapter: resolved to mediaItemIndex=${position.mediaItemIndex}, positionInFile=${position.positionInFileMs}"
-        }
-
-        if (safeSeekTo(controller, position.mediaItemIndex, position.positionInFileMs, "seekToChapter")) {
-            // Update PlaybackManager so UI updates immediately (even when paused)
-            playbackManager.updatePosition(chapter.startTime)
-        }
+        playbackController.seekTo(chapter.startTime)
+        // Update PlaybackManager so UI updates immediately (even when paused)
+        playbackManager.updatePosition(chapter.startTime)
         hideChapterPicker()
     }
 
@@ -511,29 +415,13 @@ class NowPlayingViewModel(
             logger.warn { "seekWithinChapter: no current chapter" }
             return
         }
-        val controller = mediaController
-        if (controller == null) {
-            logger.warn { "seekWithinChapter: mediaController is null" }
-            return
-        }
-        val timeline = playbackManager.currentTimeline.value
-        if (timeline == null) {
-            logger.warn { "seekWithinChapter: timeline is null" }
-            return
-        }
 
         val targetPosition = currentChapter.startTime + (currentChapter.duration * progress).toLong()
         logger.debug { "seekWithinChapter: chapter='${currentChapter.title}', targetPosition=$targetPosition" }
 
-        val position = timeline.resolve(targetPosition)
-        logger.debug {
-            "seekWithinChapter: resolved to mediaItemIndex=${position.mediaItemIndex}, positionInFile=${position.positionInFileMs}"
-        }
-
-        if (safeSeekTo(controller, position.mediaItemIndex, position.positionInFileMs, "seekWithinChapter")) {
-            // Update PlaybackManager so UI updates immediately (even when paused)
-            playbackManager.updatePosition(targetPosition)
-        }
+        playbackController.seekTo(targetPosition)
+        // Update PlaybackManager so UI updates immediately (even when paused)
+        playbackManager.updatePosition(targetPosition)
     }
 
     /**
@@ -541,7 +429,7 @@ class NowPlayingViewModel(
      * Marks the book as having a custom speed (hasCustomSpeed=true).
      */
     fun setSpeed(speed: Float) {
-        mediaController?.playbackParameters = PlaybackParameters(speed)
+        playbackController.setPlaybackSpeed(speed)
         // Notify PlaybackManager that user explicitly changed speed
         playbackManager.onSpeedChanged(speed)
     }
@@ -553,7 +441,7 @@ class NowPlayingViewModel(
     fun resetSpeedToDefault() {
         viewModelScope.launch {
             val defaultSpeed = playbackPreferences.getDefaultPlaybackSpeed()
-            mediaController?.playbackParameters = PlaybackParameters(defaultSpeed)
+            playbackController.setPlaybackSpeed(defaultSpeed)
             // Notify PlaybackManager that user reset to default
             playbackManager.onSpeedReset(defaultSpeed)
         }
@@ -577,6 +465,6 @@ class NowPlayingViewModel(
     override fun onCleared() {
         super.onCleared()
         // Release our reference to the shared controller
-        mediaControllerHolder.release()
+        playbackController.release()
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
@@ -2,15 +2,11 @@
 
 package com.calypsan.listenup.client.playback
 
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
-import androidx.media3.common.PlaybackException
-import androidx.media3.session.MediaController
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
@@ -28,15 +24,27 @@ private val logger = KotlinLogging.logger {}
  * ViewModel for playback UI.
  *
  * Responsibilities:
- * - Uses shared MediaControllerHolder for player connection
+ * - Uses PlaybackController seam for player commands
  * - Exposes playback state as flows for Compose
  * - Handles position updates using book-relative timeline
  * - Provides control actions
+ *
+ * Note: [Player.Listener] registration and direct [MediaController] position polling
+ * ([updatePosition]) are retained via [mediaControllerHolder] because the events
+ * observed (onPlaybackStateChanged buffering/ended, onPlayerError with Media3-specific
+ * error codes, currentMediaItemIndex/currentPosition polling) are NOT surfaced by
+ * [PlaybackManager] or [PlaybackController]. Removing them would require extending
+ * PlaybackManager with isBuffering, error, and per-item position flows — a separate
+ * task deferred beyond Task 6.
  */
 class PlayerViewModel(
     private val playbackManager: PlaybackManager,
-    private val mediaControllerHolder: MediaControllerHolder,
+    private val playbackController: PlaybackController,
     private val networkMonitor: NetworkMonitor,
+    // TODO(Task-6-followup): mediaControllerHolder retained solely for Player.Listener
+    //  registration and updatePosition() polling. Remove once PlaybackManager exposes
+    //  isBuffering, playback errors, and per-mediaItem position flows.
+    private val mediaControllerHolder: MediaControllerHolder,
 ) : ViewModel() {
     private var positionUpdateJob: Job? = null
     private var playerListener: Player.Listener? = null
@@ -48,10 +56,10 @@ class PlayerViewModel(
 
     init {
         // Acquire reference to shared controller
-        mediaControllerHolder.acquire()
+        playbackController.acquire()
     }
 
-    private val mediaController: MediaController?
+    private val mediaController: androidx.media3.session.MediaController?
         get() = mediaControllerHolder.controller
 
     /**
@@ -123,103 +131,70 @@ class PlayerViewModel(
         }
     }
 
-    private fun connectAndPlay(prepareResult: PlaybackManager.PrepareResult) {
-        // Use shared controller - wait for it to be available
-        mediaControllerHolder.withController { controller ->
-            try {
-                // Remove old listener if any
+    private suspend fun connectAndPlay(prepareResult: PlaybackManager.PrepareResult) {
+        try {
+            // Remove old listener if any, then register fresh one.
+            // TODO(Task-6-followup): listener registration uses mediaControllerHolder
+            //  directly because Player.Listener surfaces events (isBuffering, error codes,
+            //  playback state) not yet exposed through PlaybackController or PlaybackManager.
+            mediaControllerHolder.withController { controller ->
                 playerListener?.let { controller.removeListener(it) }
-
-                // Add our listener
                 val listener = PlayerListener()
                 playerListener = listener
                 controller.addListener(listener)
-
-                // Build media items from timeline
-                logger.debug { "Building ${prepareResult.timeline.files.size} media items" }
-                val mediaItems =
-                    prepareResult.timeline.files.mapIndexed { index, file ->
-                        logger.debug {
-                            "MediaItem[$index]: id=${file.audioFileId}, " +
-                                "duration=${file.durationMs}ms, " +
-                                "uri=${file.playbackUri.takeLast(40)} (local=${file.isDownloaded})"
-                        }
-                        MediaItem
-                            .Builder()
-                            .setMediaId(file.audioFileId)
-                            .setUri(file.playbackUri)
-                            .setMediaMetadata(
-                                MediaMetadata
-                                    .Builder()
-                                    .setTitle(prepareResult.bookTitle)
-                                    .setArtist(prepareResult.bookAuthor)
-                                    .setAlbumTitle(prepareResult.seriesName)
-                                    .setArtworkUri(prepareResult.coverPath?.let { Uri.parse("file://$it") })
-                                    .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
-                                    .build(),
-                            ).build()
-                    }
-
-                // Set items with initial resume position
-                val startPosition = prepareResult.timeline.resolve(prepareResult.resumePositionMs)
-                logger.debug {
-                    "Starting playback: resumePos=${prepareResult.resumePositionMs}ms -> " +
-                        "mediaItem=${startPosition.mediaItemIndex}, " +
-                        "posInFile=${startPosition.positionInFileMs}ms"
-                }
-
-                // Validate start position before passing to ExoPlayer
-                if (startPosition.mediaItemIndex < 0 || startPosition.mediaItemIndex >= mediaItems.size) {
-                    logger.error {
-                        "INVALID startPosition.mediaItemIndex: ${startPosition.mediaItemIndex}, mediaItems.size=${mediaItems.size}"
-                    }
-                    state.value = state.value.copy(isLoading = false, error = "Invalid start position")
-                    return@withController
-                }
-                if (startPosition.positionInFileMs < 0) {
-                    logger.error { "INVALID startPosition.positionInFileMs: ${startPosition.positionInFileMs}" }
-                    state.value = state.value.copy(isLoading = false, error = "Invalid start position")
-                    return@withController
-                }
-
-                // setMediaItems with startIndex and startPosition to seek atomically
-                controller.setMediaItems(mediaItems, startPosition.mediaItemIndex, startPosition.positionInFileMs)
-                controller.playbackParameters = PlaybackParameters(prepareResult.resumeSpeed)
-                logger.debug { "Calling controller.prepare()..." }
-                controller.prepare()
-                logger.debug { "Calling controller.play()..." }
-                controller.play()
-
-                playbackManager.setPlaying(true)
-
-                state.value =
-                    state.value.copy(
-                        isLoading = false,
-                        isPlaying = true,
-                    )
-
-                startPositionUpdates()
-                logger.info { "Playback started for: ${prepareResult.bookTitle}" }
-            } catch (e: Exception) {
-                logger.error(e) { "Failed to start playback" }
-                state.value =
-                    state.value.copy(
-                        isLoading = false,
-                        error = "Failed to start playback",
-                    )
             }
+
+            // Build queue from timeline and hand off to PlaybackController.
+            logger.debug { "Building ${prepareResult.timeline.files.size} media items" }
+            val items = buildPlaybackMediaItems(prepareResult)
+            playbackController.setMediaQueue(items, prepareResult.resumePositionMs)
+            playbackController.setPlaybackSpeed(prepareResult.resumeSpeed)
+            logger.debug { "Calling playbackController.play()..." }
+            playbackController.play()
+
+            playbackManager.setPlaying(true)
+
+            state.value =
+                state.value.copy(
+                    isLoading = false,
+                    isPlaying = true,
+                )
+
+            startPositionUpdates()
+            logger.info { "Playback started for: ${prepareResult.bookTitle}" }
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to start playback" }
+            state.value =
+                state.value.copy(
+                    isLoading = false,
+                    error = "Failed to start playback",
+                )
         }
     }
+
+    private fun buildPlaybackMediaItems(prepareResult: PlaybackManager.PrepareResult): List<PlaybackMediaItem> =
+        prepareResult.timeline.files.map { file ->
+            PlaybackMediaItem(
+                mediaId = file.audioFileId,
+                uri = file.playbackUri,
+                localPath = file.localPath,
+                durationMs = file.durationMs,
+                offsetMs = file.startOffsetMs,
+                title = prepareResult.bookTitle,
+                artist = prepareResult.bookAuthor,
+                albumTitle = prepareResult.seriesName,
+                artworkUri = prepareResult.coverPath?.let { "file://$it" },
+            )
+        }
 
     /**
      * Toggle play/pause.
      */
     fun togglePlayPause() {
-        val controller = mediaController ?: return
-        if (controller.isPlaying) {
-            controller.pause()
+        if (state.value.isPlaying) {
+            playbackController.pause()
         } else {
-            controller.play()
+            playbackController.play()
         }
     }
 
@@ -227,11 +202,7 @@ class PlayerViewModel(
      * Seek to a position in the book timeline.
      */
     fun seekTo(bookPositionMs: Long) {
-        val controller = mediaController ?: return
-        val timeline = currentTimeline ?: return
-
-        val position = timeline.resolve(bookPositionMs)
-        controller.seekTo(position.mediaItemIndex, position.positionInFileMs)
+        playbackController.seekTo(bookPositionMs)
         state.value = state.value.copy(currentPositionMs = bookPositionMs)
 
         // Notify PlaybackManager so NowPlayingViewModel updates immediately (even when paused)
@@ -261,8 +232,7 @@ class PlayerViewModel(
      * Marks the book as having a custom speed (hasCustomSpeed=true).
      */
     fun setSpeed(speed: Float) {
-        val controller = mediaController ?: return
-        controller.playbackParameters = PlaybackParameters(speed)
+        playbackController.setPlaybackSpeed(speed)
         state.value = state.value.copy(playbackSpeed = speed)
         // Notify PlaybackManager that user explicitly changed speed
         playbackManager.onSpeedChanged(speed)
@@ -275,8 +245,7 @@ class PlayerViewModel(
      * @param defaultSpeed The universal default speed from settings
      */
     fun resetSpeedToDefault(defaultSpeed: Float) {
-        val controller = mediaController ?: return
-        controller.playbackParameters = PlaybackParameters(defaultSpeed)
+        playbackController.setPlaybackSpeed(defaultSpeed)
         state.value = state.value.copy(playbackSpeed = defaultSpeed)
         // Notify PlaybackManager that user reset to default
         playbackManager.onSpeedReset(defaultSpeed)
@@ -297,7 +266,7 @@ class PlayerViewModel(
      * Stop playback and release resources.
      */
     fun stop() {
-        mediaController?.stop()
+        playbackController.stop()
         playbackManager.setPlaying(false)
         playbackManager.clearPlayback()
         state.value = PlayerUiState()
@@ -320,6 +289,9 @@ class PlayerViewModel(
     }
 
     private fun updatePosition() {
+        // TODO(Task-6-followup): position polling reads directly from mediaControllerHolder
+        //  because PlaybackController is command-only and PlaybackManager does not expose
+        //  per-mediaItem index + position as flows on Android. Migrate once those flows exist.
         val controller = mediaController ?: return
         val timeline = currentTimeline ?: return
 
@@ -438,7 +410,7 @@ class PlayerViewModel(
         playerListener = null
 
         // Release our reference to the shared controller
-        mediaControllerHolder.release()
+        playbackController.release()
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
@@ -162,6 +162,8 @@ class PlayerViewModel(
 
             startPositionUpdates()
             logger.info { "Playback started for: ${prepareResult.bookTitle}" }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error(e) { "Failed to start playback" }
             state.value =

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -12,7 +12,9 @@ import com.calypsan.listenup.client.platform.StubDownloadService
 import com.calypsan.listenup.client.playback.AudioCapabilityDetector
 import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.playback.AudioTokenProvider
+import com.calypsan.listenup.client.playback.DesktopPlaybackController
 import com.calypsan.listenup.client.playback.DesktopPlayerViewModel
+import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
@@ -82,6 +84,9 @@ val platformModule: Module =
             )
         }
 
+        // Playback controller seam (delegates to AudioPlayer for command-side operations)
+        single<PlaybackController> { DesktopPlaybackController(audioPlayer = get()) }
+
         // Download service (stub)
         single<DownloadService> { StubDownloadService() }
 
@@ -134,6 +139,7 @@ val platformModule: Module =
         single {
             DesktopPlayerViewModel(
                 playbackManager = get(),
+                playbackController = get(),
                 audioPlayer = get(),
                 progressTracker = get(),
                 bookRepository = get(),

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
@@ -1,11 +1,8 @@
 package com.calypsan.listenup.client.playback
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * Desktop implementation of [PlaybackController]. Wraps the existing shared [AudioPlayer]

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
@@ -32,6 +32,16 @@ class DesktopPlaybackController(
 
     override fun setPlaybackSpeed(speed: Float) = audioPlayer.setSpeed(speed)
 
+    override fun stop() {
+        audioPlayer.pause()
+        audioPlayer.seekTo(0L)
+    }
+
+    override fun setVolume(volume: Float) {
+        // No-op: AudioPlayer interface does not expose volume control.
+        // Sleep-timer fade-out is Android-only.
+    }
+
     override suspend fun setMediaQueue(
         items: List<PlaybackMediaItem>,
         startPositionMs: Long,

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.client.playback
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Desktop implementation of [PlaybackController]. Wraps the existing shared [AudioPlayer]
+ * (typically [FfmpegAudioPlayer] in production).
+ *
+ * `acquire`/`release` are no-ops — the AudioPlayer is constructed eagerly and
+ * has no service-lifecycle. `isReady` is a constant `true` for the same reason.
+ *
+ * Note: `release` here does NOT call [AudioPlayer.release]; that would tear down the
+ * player permanently.
+ */
+class DesktopPlaybackController(
+    private val audioPlayer: AudioPlayer,
+) : PlaybackController {
+    private val _isReady = MutableStateFlow(true)
+    override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    override fun acquire() = Unit
+
+    override fun release() = Unit
+
+    override fun play() = audioPlayer.play()
+
+    override fun pause() = audioPlayer.pause()
+
+    override fun seekTo(positionMs: Long) = audioPlayer.seekTo(positionMs)
+
+    override fun setPlaybackSpeed(speed: Float) = audioPlayer.setSpeed(speed)
+
+    override suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    ) {
+        val segments =
+            items.map { item ->
+                AudioSegment(
+                    url = item.uri,
+                    localPath = item.localPath,
+                    durationMs = item.durationMs,
+                    offsetMs = item.offsetMs,
+                )
+            }
+        audioPlayer.load(segments)
+        if (startPositionMs > 0L) {
+            audioPlayer.seekTo(startPositionMs)
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
@@ -28,6 +28,7 @@ private val logger = KotlinLogging.logger {}
  */
 class DesktopPlayerViewModel(
     private val playbackManager: PlaybackManager,
+    private val playbackController: PlaybackController,
     private val audioPlayer: AudioPlayer,
     private val progressTracker: ProgressTracker,
     private val bookRepository: BookRepository,
@@ -166,14 +167,14 @@ class DesktopPlayerViewModel(
     fun playPause() {
         val currentState = audioPlayer.state.value
         if (currentState == PlaybackState.Playing) {
-            audioPlayer.pause()
+            playbackController.pause()
             // Notify progress tracker of pause
             val bookId = playbackManager.currentBookId.value ?: return
             val positionMs = playbackManager.currentPositionMs.value
             val speed = playbackManager.playbackSpeed.value
             progressTracker.onPlaybackPaused(bookId, positionMs, speed)
         } else {
-            audioPlayer.play()
+            playbackController.play()
             // Notify progress tracker of resume
             val bookId = playbackManager.currentBookId.value ?: return
             val positionMs = playbackManager.currentPositionMs.value
@@ -185,38 +186,38 @@ class DesktopPlayerViewModel(
     fun skipBack(seconds: Int = 10) {
         val currentPos = playbackManager.currentPositionMs.value
         val newPos = (currentPos - (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtLeast(0)
-        audioPlayer.seekTo(newPos)
+        playbackController.seekTo(newPos)
     }
 
     fun skipForward(seconds: Int = 30) {
         val currentPos = playbackManager.currentPositionMs.value
         val totalDuration = playbackManager.totalDurationMs.value
         val newPos = (currentPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(totalDuration)
-        audioPlayer.seekTo(newPos)
+        playbackController.seekTo(newPos)
     }
 
     fun seekToChapter(index: Int) {
         val chapters = playbackManager.chapters.value
         val chapter = chapters.getOrNull(index) ?: return
-        audioPlayer.seekTo(chapter.startTime)
+        playbackController.seekTo(chapter.startTime)
     }
 
     fun seekWithinChapter(progress: Float) {
         val chapters = playbackManager.chapters.value
         val currentChapter = chapters.getOrNull(state.value.chapterIndex) ?: return
         val targetPosition = currentChapter.startTime + (currentChapter.duration * progress).toLong()
-        audioPlayer.seekTo(targetPosition)
+        playbackController.seekTo(targetPosition)
     }
 
     fun setSpeed(speed: Float) {
-        audioPlayer.setSpeed(speed)
+        playbackController.setPlaybackSpeed(speed)
         playbackManager.onSpeedChanged(speed)
     }
 
     fun resetSpeedToDefault() {
         viewModelScope.launch {
             val defaultSpeed = playbackPreferences.getDefaultPlaybackSpeed()
-            audioPlayer.setSpeed(defaultSpeed)
+            playbackController.setPlaybackSpeed(defaultSpeed)
             playbackManager.onSpeedReset(defaultSpeed)
         }
     }
@@ -241,7 +242,7 @@ class DesktopPlayerViewModel(
     }
 
     fun closeBook() {
-        audioPlayer.pause()
+        playbackController.pause()
         val bookId = playbackManager.currentBookId.value
         if (bookId != null) {
             val positionMs = playbackManager.currentPositionMs.value

--- a/composeApp/src/desktopTest/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackControllerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackControllerTest.kt
@@ -206,4 +206,28 @@ class DesktopPlaybackControllerTest {
             assertEquals(1, player.calls.size)
             assertTrue(player.calls[0] is Call.Load)
         }
+
+    // ---------------------------------------------------------------------------
+    // stop / setVolume
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `stop pauses and seeks to zero`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.stop()
+
+        assertEquals(listOf(Call.Pause, Call.SeekTo(0L)), player.calls)
+    }
+
+    @Test
+    fun `setVolume is a no-op`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.setVolume(0.5f)
+
+        assertTrue(player.calls.isEmpty())
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackControllerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackControllerTest.kt
@@ -1,0 +1,209 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Delegation tests for [DesktopPlaybackController].
+ *
+ * Uses an inline [FakeAudioPlayer] (local to this test file) because [FakePlayer]
+ * from shared's commonTest is not on the desktopTest classpath.
+ */
+class DesktopPlaybackControllerTest {
+    // ---------------------------------------------------------------------------
+    // Inline fake — mirrors shared's FakePlayer call-tracking API
+    // ---------------------------------------------------------------------------
+
+    private sealed interface Call {
+        data object Play : Call
+
+        data object Pause : Call
+
+        data class SeekTo(
+            val positionMs: Long,
+        ) : Call
+
+        data class SetSpeed(
+            val speed: Float,
+        ) : Call
+
+        data class Load(
+            val segments: List<AudioSegment>,
+        ) : Call
+    }
+
+    private class FakeAudioPlayer : AudioPlayer {
+        override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState.Idle)
+        override val positionMs: StateFlow<Long> = MutableStateFlow(0L)
+        override val durationMs: StateFlow<Long> = MutableStateFlow(0L)
+
+        private val _calls = mutableListOf<Call>()
+        val calls: List<Call> get() = _calls.toList()
+
+        override fun play() {
+            _calls += Call.Play
+        }
+
+        override fun pause() {
+            _calls += Call.Pause
+        }
+
+        override fun seekTo(positionMs: Long) {
+            _calls += Call.SeekTo(positionMs)
+        }
+
+        override fun setSpeed(speed: Float) {
+            _calls += Call.SetSpeed(speed)
+        }
+
+        override suspend fun load(segments: List<AudioSegment>) {
+            _calls += Call.Load(segments)
+        }
+
+        override fun release() {}
+    }
+
+    // ---------------------------------------------------------------------------
+    // acquire / release are no-ops
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `acquire is a no-op`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.acquire() // must not throw or delegate to player
+
+        assertTrue(player.calls.isEmpty())
+    }
+
+    @Test
+    fun `release is a no-op`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.release()
+
+        assertTrue(player.calls.isEmpty())
+    }
+
+    // ---------------------------------------------------------------------------
+    // isReady is constant true
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `isReady is always true`() {
+        val sut = DesktopPlaybackController(FakeAudioPlayer())
+
+        assertTrue(sut.isReady.value)
+    }
+
+    // ---------------------------------------------------------------------------
+    // play / pause / seekTo / setPlaybackSpeed delegate to AudioPlayer
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `play delegates to audioPlayer`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.play()
+
+        assertEquals(listOf(Call.Play), player.calls)
+    }
+
+    @Test
+    fun `pause delegates to audioPlayer`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.pause()
+
+        assertEquals(listOf(Call.Pause), player.calls)
+    }
+
+    @Test
+    fun `seekTo delegates to audioPlayer`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.seekTo(45_000L)
+
+        assertEquals(listOf(Call.SeekTo(45_000L)), player.calls)
+    }
+
+    @Test
+    fun `setPlaybackSpeed delegates to audioPlayer setSpeed`() {
+        val player = FakeAudioPlayer()
+        val sut = DesktopPlaybackController(player)
+
+        sut.setPlaybackSpeed(1.5f)
+
+        assertEquals(listOf(Call.SetSpeed(1.5f)), player.calls)
+    }
+
+    // ---------------------------------------------------------------------------
+    // setMediaQueue
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `setMediaQueue maps items to AudioSegments and calls load`() =
+        runTest {
+            val player = FakeAudioPlayer()
+            val sut = DesktopPlaybackController(player)
+
+            val items =
+                listOf(
+                    PlaybackMediaItem("id-0", "url0", "/local/0", 60_000L, 0L, "Ch 1", "Author", "Book", null),
+                    PlaybackMediaItem("id-1", "url1", null, 60_000L, 60_000L, "Ch 2", "Author", "Book", null),
+                )
+
+            sut.setMediaQueue(items, 0L)
+
+            val expectedSegments =
+                listOf(
+                    AudioSegment(url = "url0", localPath = "/local/0", durationMs = 60_000L, offsetMs = 0L),
+                    AudioSegment(url = "url1", localPath = null, durationMs = 60_000L, offsetMs = 60_000L),
+                )
+            assertEquals(listOf(Call.Load(expectedSegments)), player.calls)
+        }
+
+    @Test
+    fun `setMediaQueue seeks after load when startPositionMs is positive`() =
+        runTest {
+            val player = FakeAudioPlayer()
+            val sut = DesktopPlaybackController(player)
+
+            val items =
+                listOf(
+                    PlaybackMediaItem("id-0", "url0", null, 120_000L, 0L, "Ch 1", null, null, null),
+                )
+
+            sut.setMediaQueue(items, 30_000L)
+
+            assertEquals(2, player.calls.size)
+            assertTrue(player.calls[0] is Call.Load)
+            assertEquals(Call.SeekTo(30_000L), player.calls[1])
+        }
+
+    @Test
+    fun `setMediaQueue does not seek when startPositionMs is zero`() =
+        runTest {
+            val player = FakeAudioPlayer()
+            val sut = DesktopPlaybackController(player)
+
+            val items =
+                listOf(
+                    PlaybackMediaItem("id-0", "url0", null, 60_000L, 0L, "Ch 1", null, null, null),
+                )
+
+            sut.setMediaQueue(items, 0L)
+
+            assertEquals(1, player.calls.size)
+            assertTrue(player.calls[0] is Call.Load)
+        }
+}

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.flow.StateFlow
+
+actual interface PlaybackController {
+    actual fun acquire()
+
+    actual fun release()
+
+    actual val isReady: StateFlow<Boolean>
+
+    actual fun play()
+
+    actual fun pause()
+
+    actual fun seekTo(positionMs: Long)
+
+    actual fun setPlaybackSpeed(speed: Float)
+
+    actual suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    )
+}

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -17,6 +17,10 @@ actual interface PlaybackController {
 
     actual fun setPlaybackSpeed(speed: Float)
 
+    actual fun stop()
+
+    actual fun setVolume(volume: Float)
+
     actual suspend fun setMediaQueue(
         items: List<PlaybackMediaItem>,
         startPositionMs: Long,

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/ApplePlaybackController.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/ApplePlaybackController.kt
@@ -1,0 +1,59 @@
+package com.calypsan.listenup.client.playback
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Apple implementation of [PlaybackController]. Wraps the shared [AudioPlayer]
+ * (typically [AvFoundationAudioPlayer]).
+ *
+ * `acquire`/`release` are no-ops — the AudioPlayer is constructed eagerly and
+ * has no service-lifecycle. `isReady` is a constant `true` for the same reason.
+ *
+ * Currently no Kotlin VM consumes this actual — the iOS app uses Swift-side
+ * NowPlayingObserver. This class ships for cross-target compilation.
+ *
+ * Note: `release` here does NOT call [AudioPlayer.release]; that would tear down the
+ * player permanently.
+ */
+class ApplePlaybackController(
+    private val audioPlayer: AudioPlayer,
+) : PlaybackController {
+    private val _isReady = MutableStateFlow(true)
+    override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    override fun acquire() = Unit
+
+    override fun release() = Unit
+
+    override fun play() = audioPlayer.play()
+
+    override fun pause() = audioPlayer.pause()
+
+    override fun seekTo(positionMs: Long) = audioPlayer.seekTo(positionMs)
+
+    override fun setPlaybackSpeed(speed: Float) = audioPlayer.setSpeed(speed)
+
+    override suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    ) {
+        val segments =
+            items.map { item ->
+                AudioSegment(
+                    url = item.uri,
+                    localPath = item.localPath,
+                    durationMs = item.durationMs,
+                    offsetMs = item.offsetMs,
+                )
+            }
+        audioPlayer.load(segments)
+        if (startPositionMs > 0L) {
+            audioPlayer.seekTo(startPositionMs)
+        }
+    }
+}

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/ApplePlaybackController.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/ApplePlaybackController.kt
@@ -1,11 +1,8 @@
 package com.calypsan.listenup.client.playback
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * Apple implementation of [PlaybackController]. Wraps the shared [AudioPlayer]

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/ApplePlaybackController.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/ApplePlaybackController.kt
@@ -35,6 +35,16 @@ class ApplePlaybackController(
 
     override fun setPlaybackSpeed(speed: Float) = audioPlayer.setSpeed(speed)
 
+    override fun stop() {
+        audioPlayer.pause()
+        audioPlayer.seekTo(0L)
+    }
+
+    override fun setVolume(volume: Float) {
+        // No-op: AudioPlayer interface does not expose volume control.
+        // Sleep-timer fade-out is Android-only.
+    }
+
     override suspend fun setMediaQueue(
         items: List<PlaybackMediaItem>,
         startPositionMs: Long,

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.flow.StateFlow
+
+actual interface PlaybackController {
+    actual fun acquire()
+
+    actual fun release()
+
+    actual val isReady: StateFlow<Boolean>
+
+    actual fun play()
+
+    actual fun pause()
+
+    actual fun seekTo(positionMs: Long)
+
+    actual fun setPlaybackSpeed(speed: Float)
+
+    actual suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    )
+}

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -17,6 +17,10 @@ actual interface PlaybackController {
 
     actual fun setPlaybackSpeed(speed: Float)
 
+    actual fun stop()
+
+    actual fun setVolume(volume: Float)
+
     actual suspend fun setMediaQueue(
         items: List<PlaybackMediaItem>,
         startPositionMs: Long,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -1,0 +1,72 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-agnostic command-side abstraction for the playback layer.
+ *
+ * Android wraps Media3's [androidx.media3.session.MediaController] (asynchronous,
+ * service-bound) via [MediaControllerHolder]. Desktop and Apple wrap the shared
+ * [AudioPlayer] interface directly.
+ *
+ * VMs consume this interface for all command-side operations (play/pause, seek,
+ * speed, queue management). Read-side state (currentBookId, isPlaying, position
+ * polling, etc.) continues to flow through [PlaybackManager].
+ *
+ * Lifecycle: [acquire]/[release] are refcounted on Android (Media3 service binding);
+ * no-ops on Desktop/Apple (AudioPlayer instances are eagerly ready).
+ *
+ * Note: [release] is a refcount decrement, NOT a permanent resource release.
+ * Do NOT confuse with [AudioPlayer.release] which tears down the player permanently.
+ */
+expect interface PlaybackController {
+    /** Refcounted reference acquisition. Android: connects to Media3 service if first acquire. Desktop/Apple: no-op. */
+    fun acquire()
+
+    /** Refcounted reference release. Android: disconnects from Media3 service when refcount hits zero. Desktop/Apple: no-op. */
+    fun release()
+
+    /** Emits true when the underlying player is connected and accepting commands. */
+    val isReady: StateFlow<Boolean>
+
+    /** Start or resume playback of the current queue. */
+    fun play()
+
+    /** Pause playback. */
+    fun pause()
+
+    /** Seek to absolute book position. */
+    fun seekTo(positionMs: Long)
+
+    /** Set playback speed multiplier (1.0 = normal). */
+    fun setPlaybackSpeed(speed: Float)
+
+    /**
+     * Replace the active queue with [items], starting playback at [startPositionMs] inside the queue (book-relative).
+     * Suspends until the queue is loaded and prepared.
+     */
+    suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    )
+}
+
+/**
+ * One queue entry consumed by [PlaybackController.setMediaQueue].
+ *
+ * Carries both per-segment data (used by all platforms) and book-level metadata
+ * (used by Android's Media3 [androidx.media3.common.MediaMetadata] for Android
+ * Auto, lock screen, notification). Desktop and Apple actuals ignore the
+ * metadata fields when constructing their internal [AudioSegment].
+ */
+data class PlaybackMediaItem(
+    val mediaId: String,
+    val uri: String,
+    val localPath: String?,
+    val durationMs: Long,
+    val offsetMs: Long,
+    val title: String,
+    val artist: String?,
+    val albumTitle: String?,
+    val artworkUri: String?,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -42,6 +42,21 @@ expect interface PlaybackController {
     fun setPlaybackSpeed(speed: Float)
 
     /**
+     * Stop playback and clear the current queue. Use to fully terminate a playback
+     * session (vs. [pause] which can be resumed). On Android, calls Media3's
+     * `MediaController.stop()`. On Desktop/Apple, pauses and resets position to 0.
+     */
+    fun stop()
+
+    /**
+     * Set output volume multiplier (0.0 = silent, 1.0 = normal). Used for sleep
+     * timer fade-out on Android (Media3 supports per-controller volume); on
+     * Desktop/Apple the underlying [AudioPlayer] does NOT expose volume control,
+     * so this is a no-op with a debug log.
+     */
+    fun setVolume(volume: Float)
+
+    /**
      * Replace the active queue with [items], starting playback at [startPositionMs] inside the queue (book-relative).
      * Suspends until the queue is loaded and prepared.
      */

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackController.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackController.kt
@@ -24,12 +24,17 @@ class FakePlaybackController(
         private set
     var pauseCount: Int = 0
         private set
+    var stopCount: Int = 0
+        private set
 
     private val _seekCalls: MutableList<Long> = mutableListOf()
     val seekCalls: List<Long> get() = _seekCalls.toList()
 
     private val _speedCalls: MutableList<Float> = mutableListOf()
     val speedCalls: List<Float> get() = _speedCalls.toList()
+
+    private val _volumeCalls: MutableList<Float> = mutableListOf()
+    val volumeCalls: List<Float> get() = _volumeCalls.toList()
 
     private val _setMediaQueueCalls: MutableList<Pair<List<PlaybackMediaItem>, Long>> = mutableListOf()
     val setMediaQueueCalls: List<Pair<List<PlaybackMediaItem>, Long>> get() = _setMediaQueueCalls.toList()
@@ -48,6 +53,14 @@ class FakePlaybackController(
 
     override fun pause() {
         pauseCount++
+    }
+
+    override fun stop() {
+        stopCount++
+    }
+
+    override fun setVolume(volume: Float) {
+        _volumeCalls += volume
     }
 
     override fun seekTo(positionMs: Long) {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackController.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackController.kt
@@ -1,0 +1,72 @@
+package com.calypsan.listenup.client.test.fake
+
+import com.calypsan.listenup.client.playback.PlaybackController
+import com.calypsan.listenup.client.playback.PlaybackMediaItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * In-memory fake of [PlaybackController]. Records all method invocations for verification.
+ * Reused by E2 VM tests.
+ */
+class FakePlaybackController(
+    initialReady: Boolean = true,
+) : PlaybackController {
+    private val _isReady = MutableStateFlow(initialReady)
+    override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    var acquireCount: Int = 0
+        private set
+    var releaseCount: Int = 0
+        private set
+    var playCount: Int = 0
+        private set
+    var pauseCount: Int = 0
+        private set
+
+    private val _seekCalls: MutableList<Long> = mutableListOf()
+    val seekCalls: List<Long> get() = _seekCalls.toList()
+
+    private val _speedCalls: MutableList<Float> = mutableListOf()
+    val speedCalls: List<Float> get() = _speedCalls.toList()
+
+    private val _setMediaQueueCalls: MutableList<Pair<List<PlaybackMediaItem>, Long>> = mutableListOf()
+    val setMediaQueueCalls: List<Pair<List<PlaybackMediaItem>, Long>> get() = _setMediaQueueCalls.toList()
+
+    override fun acquire() {
+        acquireCount++
+    }
+
+    override fun release() {
+        releaseCount++
+    }
+
+    override fun play() {
+        playCount++
+    }
+
+    override fun pause() {
+        pauseCount++
+    }
+
+    override fun seekTo(positionMs: Long) {
+        _seekCalls += positionMs
+    }
+
+    override fun setPlaybackSpeed(speed: Float) {
+        _speedCalls += speed
+    }
+
+    override suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    ) {
+        _setMediaQueueCalls += (items to startPositionMs)
+    }
+
+    /** Test helper: drive `isReady` from outside to simulate connection state changes. */
+    fun setReady(ready: Boolean) {
+        _isReady.value = ready
+    }
+}

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -6,10 +6,12 @@ import com.calypsan.listenup.client.core.IODispatcher
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
+import com.calypsan.listenup.client.playback.ApplePlaybackController
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.AppleAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.playback.AvFoundationAudioPlayer
+import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
@@ -123,6 +125,9 @@ val iosPlaybackModule: Module =
                 scope = get(qualifier = named("playbackScope")),
             )
         }
+
+        // Playback controller seam (delegates to AudioPlayer for command-side operations)
+        single<PlaybackController> { ApplePlaybackController(audioPlayer = get()) }
 
         // Background sync scheduler
         single<BackgroundSyncScheduler> { IosBackgroundSyncScheduler() }

--- a/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.playback
+
+import kotlinx.coroutines.flow.StateFlow
+
+actual interface PlaybackController {
+    actual fun acquire()
+
+    actual fun release()
+
+    actual val isReady: StateFlow<Boolean>
+
+    actual fun play()
+
+    actual fun pause()
+
+    actual fun seekTo(positionMs: Long)
+
+    actual fun setPlaybackSpeed(speed: Float)
+
+    actual suspend fun setMediaQueue(
+        items: List<PlaybackMediaItem>,
+        startPositionMs: Long,
+    )
+}

--- a/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
+++ b/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/playback/PlaybackController.kt
@@ -17,6 +17,10 @@ actual interface PlaybackController {
 
     actual fun setPlaybackSpeed(speed: Float)
 
+    actual fun stop()
+
+    actual fun setVolume(volume: Float)
+
     actual suspend fun setMediaQueue(
         items: List<PlaybackMediaItem>,
         startPositionMs: Long,

--- a/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -6,10 +6,12 @@ import com.calypsan.listenup.client.core.IODispatcher
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
+import com.calypsan.listenup.client.playback.ApplePlaybackController
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.AppleAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.playback.AvFoundationAudioPlayer
+import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
@@ -122,6 +124,9 @@ val macosPlaybackModule: Module =
                 scope = get(qualifier = named("playbackScope")),
             )
         }
+
+        // Playback controller seam (delegates to AudioPlayer for command-side operations)
+        single<PlaybackController> { ApplePlaybackController(audioPlayer = get()) }
 
         // Background sync scheduler (stub for now)
         single<BackgroundSyncScheduler> { MacosBackgroundSyncScheduler() }


### PR DESCRIPTION
## Summary

W7 Phase E1 introduces a platform-agnostic command-side abstraction for the playback layer. Pre-E1, Android VMs called Media3's \`MediaController\` directly via \`MediaControllerHolder\`; Desktop and Apple VMs called the existing shared \`AudioPlayer\`. E1 unifies these into \`expect interface PlaybackController\` and migrates VMs to consume it.

- **New** \`expect interface PlaybackController\` in \`shared/commonMain/.../playback/\` with 9 members: \`acquire/release\`, \`isReady\`, \`play/pause/stop\`, \`seekTo(Long)\`, \`setPlaybackSpeed(Float)\`, \`setVolume(Float)\`, \`suspend setMediaQueue(items, startPositionMs)\`. Command-only by design; read-side flows through \`PlaybackManager\`.
- **3 platform actuals** + their delegation tests:
  - \`AndroidPlaybackController\` wraps \`MediaControllerHolder\` via internal \`ControllerHolder\` adapter. Silent warn-log on null controller (matches pre-E1 \`?: return\` pattern). \`seekTo(Long)\` is queue-aware — resolves \`(mediaItemIndex, positionInItem)\` from Media3's live \`currentTimeline\`. 17 tests.
  - \`DesktopPlaybackController\` wraps \`AudioPlayer\`. \`acquire/release\` no-ops; \`setVolume\` no-op (AudioPlayer doesn't expose volume control — sleep-timer fade is Android-only). \`stop\` = pause + seekTo(0). 12 tests.
  - \`ApplePlaybackController\` mirrors Desktop. Ships even without a Kotlin consumer for cross-target compilation.
- **\`PlaybackMediaItem\`** data class carries per-segment + book-level metadata. Android translates → Media3 \`MediaItem\` with \`MediaMetadata\` for Android Auto / lock-screen / notification. Desktop/Apple translate → \`AudioSegment\`.
- **\`FakePlaybackController\`** in commonTest records all calls. Reused by E2 VM tests.
- **3 VM migrations:**
  - \`NowPlayingViewModel\` (Android): FULL migration. Zero residual \`MediaControllerHolder\` / \`MediaController\` references. The 4 chapter-seek call sites that used \`safeSeekTo(controller, mediaItemIndex, positionMs)\` collapse to \`playbackController.seekTo(bookPositionMs)\` — the actual handles queue resolution. Sleep-timer fade now via \`setVolume\`; close-book via \`stop\`.
  - \`PlayerViewModel\` (Android): PARTIAL migration. Command-side fully migrated. \`MediaControllerHolder\` retained for \`Player.Listener\` (Media3 buffering/error/playback-params events) and \`updatePosition()\` polling. See drift #25.
  - \`DesktopPlayerViewModel\` (Desktop): PARTIAL migration. Command-side fully migrated. \`AudioPlayer\` retained because \`PlaybackManager.startPlayback(player = audioPlayer)\` takes \`AudioPlayer\` directly + \`audioPlayer.state\` flow subscriptions for error detection. See drift #25.
- **DI:** 4 platform Koin bindings register the platform actual (Android \`ListenUp.kt\`, Desktop \`PlatformModule.kt\`, iOS + macOS \`PlaybackModule.{ios,macos}.kt\`). \`MediaControllerHolder\` retained as Android impl detail.

## Out of scope (deferred to E2)

- Moving VMs to \`shared/presentation/\`
- Sealed \`NowPlayingState\` hierarchy (currently flat data class with picker booleans)
- \`combine().stateIn(WhileSubscribed)\` state production
- Splitting picker/dialog ephemera into separate flows or \`Channel<NowPlayingEvent>\`
- Extending \`PlaybackManager\`'s read-side surface to close drift #25 (allow \`PlayerViewModel\` + \`DesktopPlayerViewModel\` to shed retained platform deps)
- Consolidating \`AndroidPlaybackController.seekTo\` per drift #26

## Notable design decisions

1. **\`actual interface\` not \`actual class\`** — Kotlin's expect/actual matching requires interface→interface. Concrete classes implement the actual interface without an \`actual\` keyword.
2. **Android actual silently no-ops on null controller** rather than throwing. Media3 service connection has natural windows of unreadiness (process start, foreground service rebinding); throwing would leak Media3 service-lifecycle into VM error handling.
3. **\`PlaybackController.release()\` is refcount decrement, not permanent resource release.** Distinct from \`AudioPlayer.release()\` which tears down the player permanently. Documented in interface KDoc.
4. **Seam expanded mid-phase** with \`stop()\`, \`setVolume(Float)\`, and a queue-aware \`seekTo(Long)\` enhancement on Android. Required by NowPlayingViewModel's actual usage. User-approved.
5. **Partial VM migrations** — \`PlayerViewModel\` and \`DesktopPlayerViewModel\` retain pre-E1 platform deps because their read-side concerns aren't on the command-only seam. User-approved; tracked as drift #25.

## Drift state

- **Newly opened by this PR:** #25 (partial VM migrations — read-side platform deps retained), #26 (\`AndroidPlaybackController.seekTo\` queue-aware concerns: wrong past-end duration, untested helper, lost diagnostic logging, source-of-truth divergence).
- **Rolled forward:** #17 (Discard/Restart facade — W8), #20 (SyncIndicatorViewModel describe split — W8), #23 (observeBookDetail flake — post-W7), #24 (PlaybackPositionRepository String parameters — post-W7).

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-04-28-w7-e1-playback-controller-seam-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-28-w7-e1-playback-controller-seam.md\`

## Test plan

- [x] \`:shared:jvmTest\` green at every commit
- [x] \`spotlessCheck detekt\` green at every commit
- [x] \`:androidApp:assembleDebug\` green at HEAD
- [x] \`composeApp:testAndroidHostTest\` (17 cases) green
- [x] \`composeApp:desktopTest\` (12 cases) green
- [x] §M1 code-reviewer pass: APPROVED-WITH-CONCERNS (C1 EM-R1 fix landed in \`d92feb09\`; I1-I4 filed as drift #26; M1-M5 deferred or accepted)

## W7 status

**Phase E1 complete.** Phase E2 opens next as a separate PR — moves VMs to \`shared/presentation/\`, sealed \`NowPlayingState\` + \`combine().stateIn(WhileSubscribed)\` + picker-flow split, AND extends \`PlaybackManager\` read-side surface to close drift #25 and consolidates \`AndroidPlaybackController.seekTo\` per drift #26.