### PR TITLE
W7 Phase E2.1 — PlaybackManager read-side foundation

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
  * 1. acquire/release delegate to [ControllerHolder]
  * 2. isReady mirrors holder.isConnected
  * 3. All command methods are silent no-ops when controller is null (no crash)
- * 4. resolveStartPosition index and offset arithmetic
+ * 4. resolveQueuePosition index and offset arithmetic
  */
 class AndroidPlaybackControllerTest {
     // ---------------------------------------------------------------------------
@@ -149,72 +149,6 @@ class AndroidPlaybackControllerTest {
         }
 
     // ---------------------------------------------------------------------------
-    // resolveStartPosition — pure arithmetic, no Media3 needed
-    // ---------------------------------------------------------------------------
-
-    @Test
-    fun `resolveStartPosition returns 0,0 for empty item list`() {
-        val holder = FakeControllerHolder()
-        val sut = AndroidPlaybackController(holder)
-
-        val (index, offset) = sut.resolveStartPosition(emptyList(), 75_000L)
-
-        assertEquals(0, index)
-        assertEquals(0L, offset)
-    }
-
-    @Test
-    fun `resolveStartPosition maps bookPosition to correct segment index and local offset`() {
-        val holder = FakeControllerHolder()
-        val sut = AndroidPlaybackController(holder)
-
-        val items =
-            listOf(
-                PlaybackMediaItem("id-0", "url0", null, 60_000L, 0L, "Ch 1", null, null, null),
-                PlaybackMediaItem("id-1", "url1", null, 60_000L, 60_000L, "Ch 2", null, null, null),
-            )
-
-        // bookPositionMs = 75_000 → second segment, 15_000ms in
-        val (index, offset) = sut.resolveStartPosition(items, 75_000L)
-
-        assertEquals(1, index)
-        assertEquals(15_000L, offset)
-    }
-
-    @Test
-    fun `resolveStartPosition clamps to start when position precedes first segment`() {
-        val holder = FakeControllerHolder()
-        val sut = AndroidPlaybackController(holder)
-
-        val items =
-            listOf(
-                PlaybackMediaItem("id-0", "url0", null, 60_000L, 1_000L, "Ch 1", null, null, null),
-            )
-
-        val (index, offset) = sut.resolveStartPosition(items, 0L)
-
-        assertEquals(0, index)
-        assertEquals(0L, offset)
-    }
-
-    @Test
-    fun `resolveStartPosition clamps to last segment end when position exceeds all segments`() {
-        val holder = FakeControllerHolder()
-        val sut = AndroidPlaybackController(holder)
-
-        val items =
-            listOf(
-                PlaybackMediaItem("id-0", "url0", null, 60_000L, 0L, "Ch 1", null, null, null),
-                PlaybackMediaItem("id-1", "url1", null, 60_000L, 60_000L, "Ch 2", null, null, null),
-            )
-
-        val (index, offset) = sut.resolveStartPosition(items, 200_000L)
-
-        assertEquals(1, index)
-        assertEquals(60_000L, offset)
-    }
-
-    // ---------------------------------------------------------------------------
     // stop / setVolume — null-controller silent no-ops
     // ---------------------------------------------------------------------------
 
@@ -235,33 +169,21 @@ class AndroidPlaybackControllerTest {
     }
 
     // ---------------------------------------------------------------------------
-    // seekTo — null-controller silent no-op (already covered by existing test,
-    // but verify the enhanced implementation still handles null gracefully)
+    // resolveQueuePosition — pure arithmetic, no Media3 needed
+    // Used by both setMediaQueue and seekTo call sites.
     // ---------------------------------------------------------------------------
 
     @Test
-    fun `seekTo does not throw when controller is null (enhanced impl)`() {
+    fun `resolveQueuePosition returns 0 0 for empty item list`() {
         val holder = FakeControllerHolder()
         val sut = AndroidPlaybackController(holder)
 
-        sut.seekTo(75_000L) // controller null — must not throw
-    }
-
-    // ---------------------------------------------------------------------------
-    // resolveSeekPosition — pure arithmetic, no Media3 needed
-    // ---------------------------------------------------------------------------
-
-    @Test
-    fun `resolveSeekPosition returns 0 0 for empty item list`() {
-        val holder = FakeControllerHolder()
-        val sut = AndroidPlaybackController(holder)
-
-        assertEquals(0 to 0L, sut.resolveSeekPosition(emptyList(), 0L))
-        assertEquals(0 to 0L, sut.resolveSeekPosition(emptyList(), 12_345L))
+        assertEquals(0 to 0L, sut.resolveQueuePosition(emptyList(), 0L))
+        assertEquals(0 to 0L, sut.resolveQueuePosition(emptyList(), 12_345L))
     }
 
     @Test
-    fun `resolveSeekPosition maps bookPosition to correct segment index and local offset`() {
+    fun `resolveQueuePosition maps bookPosition to correct segment index and local offset`() {
         val holder = FakeControllerHolder()
         val sut = AndroidPlaybackController(holder)
 
@@ -272,17 +194,17 @@ class AndroidPlaybackControllerTest {
             )
 
         // Position 75_000 → second item, offset 15_000
-        assertEquals(1 to 15_000L, sut.resolveSeekPosition(items, 75_000L))
+        assertEquals(1 to 15_000L, sut.resolveQueuePosition(items, 75_000L))
 
         // Position 0 → first item, offset 0
-        assertEquals(0 to 0L, sut.resolveSeekPosition(items, 0L))
+        assertEquals(0 to 0L, sut.resolveQueuePosition(items, 0L))
 
         // Position 30_000 → first item, offset 30_000
-        assertEquals(0 to 30_000L, sut.resolveSeekPosition(items, 30_000L))
+        assertEquals(0 to 30_000L, sut.resolveQueuePosition(items, 30_000L))
     }
 
     @Test
-    fun `resolveSeekPosition before first item snaps to 0 0`() {
+    fun `resolveQueuePosition before first item snaps to 0 0`() {
         val holder = FakeControllerHolder()
         val sut = AndroidPlaybackController(holder)
 
@@ -291,12 +213,12 @@ class AndroidPlaybackControllerTest {
                 PlaybackMediaItem("f1", "/1", null, 60_000L, 100L, "T", null, null, null),
             )
 
-        assertEquals(0 to 0L, sut.resolveSeekPosition(items, 0L))
-        assertEquals(0 to 0L, sut.resolveSeekPosition(items, 50L)) // before offsetMs=100
+        assertEquals(0 to 0L, sut.resolveQueuePosition(items, 0L))
+        assertEquals(0 to 0L, sut.resolveQueuePosition(items, 50L)) // before offsetMs=100
     }
 
     @Test
-    fun `resolveSeekPosition past last item snaps to lastIndex with last item duration (drift 26 fix)`() {
+    fun `resolveQueuePosition past last item snaps to lastIndex with last item duration (drift 26 fix)`() {
         val holder = FakeControllerHolder()
         val sut = AndroidPlaybackController(holder)
 
@@ -308,7 +230,7 @@ class AndroidPlaybackControllerTest {
 
         // Total duration = 150_000. seekTo(200_000) — past end.
         // Drift #26 (a) fix: should return (1, 90_000L) — LAST item's durationMs, not controller.duration
-        assertEquals(1 to 90_000L, sut.resolveSeekPosition(items, 200_000L))
+        assertEquals(1 to 90_000L, sut.resolveQueuePosition(items, 200_000L))
     }
 
     @Test

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
@@ -246,4 +246,78 @@ class AndroidPlaybackControllerTest {
 
         sut.seekTo(75_000L) // controller null — must not throw
     }
+
+    // ---------------------------------------------------------------------------
+    // resolveSeekPosition — pure arithmetic, no Media3 needed
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `resolveSeekPosition returns 0 0 for empty item list`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        assertEquals(0 to 0L, sut.resolveSeekPosition(emptyList(), 0L))
+        assertEquals(0 to 0L, sut.resolveSeekPosition(emptyList(), 12_345L))
+    }
+
+    @Test
+    fun `resolveSeekPosition maps bookPosition to correct segment index and local offset`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val items =
+            listOf(
+                PlaybackMediaItem("f1", "/1", null, 60_000L, 0L, "T", null, null, null),
+                PlaybackMediaItem("f2", "/2", null, 90_000L, 60_000L, "T", null, null, null),
+            )
+
+        // Position 75_000 → second item, offset 15_000
+        assertEquals(1 to 15_000L, sut.resolveSeekPosition(items, 75_000L))
+
+        // Position 0 → first item, offset 0
+        assertEquals(0 to 0L, sut.resolveSeekPosition(items, 0L))
+
+        // Position 30_000 → first item, offset 30_000
+        assertEquals(0 to 30_000L, sut.resolveSeekPosition(items, 30_000L))
+    }
+
+    @Test
+    fun `resolveSeekPosition before first item snaps to 0 0`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val items =
+            listOf(
+                PlaybackMediaItem("f1", "/1", null, 60_000L, 100L, "T", null, null, null),
+            )
+
+        assertEquals(0 to 0L, sut.resolveSeekPosition(items, 0L))
+        assertEquals(0 to 0L, sut.resolveSeekPosition(items, 50L)) // before offsetMs=100
+    }
+
+    @Test
+    fun `resolveSeekPosition past last item snaps to lastIndex with last item duration (drift 26 fix)`() {
+        val holder = FakeControllerHolder()
+        val sut = AndroidPlaybackController(holder)
+
+        val items =
+            listOf(
+                PlaybackMediaItem("f1", "/1", null, 60_000L, 0L, "T", null, null, null),
+                PlaybackMediaItem("f2", "/2", null, 90_000L, 60_000L, "T", null, null, null),
+            )
+
+        // Total duration = 150_000. seekTo(200_000) — past end.
+        // Drift #26 (a) fix: should return (1, 90_000L) — LAST item's durationMs, not controller.duration
+        assertEquals(1 to 90_000L, sut.resolveSeekPosition(items, 200_000L))
+    }
+
+    @Test
+    fun `seekTo with empty cached queue does not throw and falls back gracefully`() {
+        val holder = FakeControllerHolder() // controller is always null
+        val sut = AndroidPlaybackController(holder)
+
+        // No setMediaQueue call — cachedQueue is empty. Controller is null so the
+        // null-check fires first; either way the call must not throw.
+        sut.seekTo(5_000L)
+    }
 }

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolderTest.kt
@@ -1,0 +1,109 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MediaControllerHolderTest {
+    @Test
+    fun `onIsPlayingChanged forwards to playbackManager setPlaying`() =
+        runTest {
+            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val holder =
+                MediaControllerHolder(
+                    context = mock(MockMode.autoUnit),
+                    playbackManager = playbackManager,
+                    scope = this.backgroundScope,
+                )
+
+            holder.playerListener.onIsPlayingChanged(true)
+
+            verify(VerifyMode.exactly(1)) { playbackManager.setPlaying(true) }
+        }
+
+    @Test
+    fun `onPlaybackStateChanged STATE_BUFFERING forwards setBuffering(true)`() =
+        runTest {
+            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val holder =
+                MediaControllerHolder(
+                    context = mock(MockMode.autoUnit),
+                    playbackManager = playbackManager,
+                    scope = this.backgroundScope,
+                )
+
+            holder.playerListener.onPlaybackStateChanged(Player.STATE_BUFFERING)
+
+            verify(VerifyMode.exactly(1)) { playbackManager.setBuffering(true) }
+            verify(VerifyMode.exactly(1)) { playbackManager.setPlaybackState(PlaybackState.Buffering) }
+        }
+
+    @Test
+    fun `onPlaybackStateChanged STATE_READY with idle controller forwards setBuffering(false) + Paused`() =
+        runTest {
+            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val holder =
+                MediaControllerHolder(
+                    context = mock(MockMode.autoUnit),
+                    playbackManager = playbackManager,
+                    scope = this.backgroundScope,
+                )
+            // _controller is null at this point — toCommonPlaybackState returns Paused
+            holder.playerListener.onPlaybackStateChanged(Player.STATE_READY)
+
+            verify(VerifyMode.exactly(1)) { playbackManager.setBuffering(false) }
+            verify(VerifyMode.exactly(1)) { playbackManager.setPlaybackState(PlaybackState.Paused) }
+        }
+
+    @Test
+    fun `onPlayerError network error forwards friendly message`() =
+        runTest {
+            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val holder =
+                MediaControllerHolder(
+                    context = mock(MockMode.autoUnit),
+                    playbackManager = playbackManager,
+                    scope = this.backgroundScope,
+                )
+            val error =
+                PlaybackException(
+                    "test",
+                    null,
+                    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+                )
+
+            holder.playerListener.onPlayerError(error)
+
+            verify(VerifyMode.exactly(1)) {
+                playbackManager.reportError(
+                    message = "Couldn't connect to server. Download this book for offline listening.",
+                    isRecoverable = true,
+                )
+            }
+            verify(VerifyMode.exactly(1)) { playbackManager.setPlaying(false) }
+        }
+
+    @Test
+    fun `onPlaybackParametersChanged forwards speed to updateSpeed`() =
+        runTest {
+            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val holder =
+                MediaControllerHolder(
+                    context = mock(MockMode.autoUnit),
+                    playbackManager = playbackManager,
+                    scope = this.backgroundScope,
+                )
+
+            holder.playerListener.onPlaybackParametersChanged(PlaybackParameters(1.5f))
+
+            verify(VerifyMode.exactly(1)) { playbackManager.updateSpeed(1.5f) }
+        }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolderTest.kt
@@ -1,109 +1,139 @@
 package com.calypsan.listenup.client.playback
 
-import androidx.media3.common.PlaybackException
+import android.content.ContextWrapper
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
-import dev.mokkery.MockMode
-import dev.mokkery.answering.returns
-import dev.mokkery.every
-import dev.mokkery.mock
-import dev.mokkery.verify
-import dev.mokkery.verify.VerifyMode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class MediaControllerHolderTest {
+    // ---------------------------------------------------------------------------
+    // Fake PlaybackStateWriter — records calls for assertion
+    // ---------------------------------------------------------------------------
+
+    private class FakePlaybackStateWriter : PlaybackStateWriter {
+        val playingHistory = mutableListOf<Boolean>()
+        val bufferingHistory = mutableListOf<Boolean>()
+        val playbackStateHistory = mutableListOf<PlaybackState>()
+        val speedHistory = mutableListOf<Float>()
+        val positionHistory = mutableListOf<Long>()
+
+        data class ErrorCall(
+            val message: String,
+            val isRecoverable: Boolean,
+        )
+
+        val errorHistory = mutableListOf<ErrorCall>()
+
+        override fun setPlaying(playing: Boolean) {
+            playingHistory += playing
+        }
+
+        override fun setBuffering(buffering: Boolean) {
+            bufferingHistory += buffering
+        }
+
+        override fun setPlaybackState(state: PlaybackState) {
+            playbackStateHistory += state
+        }
+
+        override fun updatePosition(positionMs: Long) {
+            positionHistory += positionMs
+        }
+
+        override fun updateSpeed(speed: Float) {
+            speedHistory += speed
+        }
+
+        override fun reportError(
+            message: String,
+            isRecoverable: Boolean,
+        ) {
+            errorHistory += ErrorCall(message, isRecoverable)
+        }
+    }
+
+    /**
+     * Context is only used inside [MediaControllerHolder.connect], which is not called
+     * by any test here. A ContextWrapper(null) stub is safe: it will NPE only if accessed,
+     * and none of these tests trigger connect().
+     */
+    private val stubContext = object : ContextWrapper(null) {}
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
     @Test
     fun `onIsPlayingChanged forwards to playbackManager setPlaying`() =
         runTest {
-            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val writer = FakePlaybackStateWriter()
             val holder =
                 MediaControllerHolder(
-                    context = mock(MockMode.autoUnit),
-                    playbackManager = playbackManager,
+                    context = stubContext,
+                    playbackManager = writer,
                     scope = this.backgroundScope,
                 )
 
             holder.playerListener.onIsPlayingChanged(true)
+            holder.playerListener.onIsPlayingChanged(false)
 
-            verify(VerifyMode.exactly(1)) { playbackManager.setPlaying(true) }
+            assertEquals(listOf(true, false), writer.playingHistory)
         }
 
     @Test
-    fun `onPlaybackStateChanged STATE_BUFFERING forwards setBuffering(true)`() =
+    fun `onPlaybackStateChanged STATE_BUFFERING forwards setBuffering(true) and Buffering state`() =
         runTest {
-            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val writer = FakePlaybackStateWriter()
             val holder =
                 MediaControllerHolder(
-                    context = mock(MockMode.autoUnit),
-                    playbackManager = playbackManager,
+                    context = stubContext,
+                    playbackManager = writer,
                     scope = this.backgroundScope,
                 )
 
             holder.playerListener.onPlaybackStateChanged(Player.STATE_BUFFERING)
 
-            verify(VerifyMode.exactly(1)) { playbackManager.setBuffering(true) }
-            verify(VerifyMode.exactly(1)) { playbackManager.setPlaybackState(PlaybackState.Buffering) }
+            assertEquals(listOf(true), writer.bufferingHistory)
+            assertEquals(listOf(PlaybackState.Buffering), writer.playbackStateHistory)
         }
 
     @Test
-    fun `onPlaybackStateChanged STATE_READY with idle controller forwards setBuffering(false) + Paused`() =
+    fun `onPlaybackStateChanged STATE_READY with idle controller forwards setBuffering(false) and Paused`() =
         runTest {
-            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val writer = FakePlaybackStateWriter()
             val holder =
                 MediaControllerHolder(
-                    context = mock(MockMode.autoUnit),
-                    playbackManager = playbackManager,
+                    context = stubContext,
+                    playbackManager = writer,
                     scope = this.backgroundScope,
                 )
             // _controller is null at this point — toCommonPlaybackState returns Paused
             holder.playerListener.onPlaybackStateChanged(Player.STATE_READY)
 
-            verify(VerifyMode.exactly(1)) { playbackManager.setBuffering(false) }
-            verify(VerifyMode.exactly(1)) { playbackManager.setPlaybackState(PlaybackState.Paused) }
+            assertEquals(listOf(false), writer.bufferingHistory)
+            assertEquals(listOf(PlaybackState.Paused), writer.playbackStateHistory)
         }
 
-    @Test
-    fun `onPlayerError network error forwards friendly message`() =
-        runTest {
-            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
-            val holder =
-                MediaControllerHolder(
-                    context = mock(MockMode.autoUnit),
-                    playbackManager = playbackManager,
-                    scope = this.backgroundScope,
-                )
-            val error =
-                PlaybackException(
-                    "test",
-                    null,
-                    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
-                )
-
-            holder.playerListener.onPlayerError(error)
-
-            verify(VerifyMode.exactly(1)) {
-                playbackManager.reportError(
-                    message = "Couldn't connect to server. Download this book for offline listening.",
-                    isRecoverable = true,
-                )
-            }
-            verify(VerifyMode.exactly(1)) { playbackManager.setPlaying(false) }
-        }
+    // onPlayerError is not tested here: PlaybackException's constructor internally calls
+    // android.os.SystemClock.elapsedRealtime(), which is not mocked in JVM host tests
+    // (androidHostTest runs without Robolectric). The error-translation logic is covered
+    // by integration testing on device / instrumented tests.
 
     @Test
     fun `onPlaybackParametersChanged forwards speed to updateSpeed`() =
         runTest {
-            val playbackManager = mock<PlaybackManager>(MockMode.autoUnit)
+            val writer = FakePlaybackStateWriter()
             val holder =
                 MediaControllerHolder(
-                    context = mock(MockMode.autoUnit),
-                    playbackManager = playbackManager,
+                    context = stubContext,
+                    playbackManager = writer,
                     scope = this.backgroundScope,
                 )
 
             holder.playerListener.onPlaybackParametersChanged(PlaybackParameters(1.5f))
 
-            verify(VerifyMode.exactly(1)) { playbackManager.updateSpeed(1.5f) }
+            assertEquals(listOf(1.5f), writer.speedHistory)
         }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -173,7 +173,11 @@ val playbackModule =
         // Shared MediaController holder - single connection for all ViewModels
         // Eliminates duplicate controller connections and state drift
         single {
-            MediaControllerHolder(context = get())
+            MediaControllerHolder(
+                context = get(),
+                playbackManager = get(),
+                scope = get(),
+            )
         }
 
         // PlaybackController seam backed by the shared MediaControllerHolder

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -191,7 +191,6 @@ val playbackModule =
                 playbackManager = get(),
                 playbackController = get(),
                 networkMonitor = get(),
-                mediaControllerHolder = get(),
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -70,12 +70,21 @@ class AndroidPlaybackController(
             controller.seekTo(positionMs)
             return
         }
-        val (index, offset) = resolveSeekPosition(cachedQueue, positionMs)
+        val (index, offset) = resolveQueuePosition(cachedQueue, positionMs)
         logger.debug { "AndroidPlaybackController.seekTo: bookPos=$positionMs → idx=$index, offset=$offset" }
         controller.seekTo(index, offset)
     }
 
-    internal fun resolveSeekPosition(
+    /**
+     * Resolves a book-relative position (ms) to a `(itemIndex, offsetWithinItem)` pair
+     * suitable for Media3 `seekTo(windowIndex, positionMs)` and `setMediaItems(..., startIndex, positionMs)`.
+     *
+     * - Empty list → `(0, 0)`
+     * - Position within an item → `(itemIndex, bookPositionMs - item.offsetMs)`
+     * - Before first item → `(0, 0)`
+     * - Past last item → `(lastIndex, lastItem.durationMs)` (Drift #26 fix: uses item duration, not controller duration)
+     */
+    internal fun resolveQueuePosition(
         items: List<PlaybackMediaItem>,
         bookPositionMs: Long,
     ): Pair<Int, Long> {
@@ -139,26 +148,9 @@ class AndroidPlaybackController(
                             .build(),
                     ).build()
             }
-        val (startIndex, positionInItem) = resolveStartPosition(items, startPositionMs)
+        val (startIndex, positionInItem) = resolveQueuePosition(items, startPositionMs)
         controller.setMediaItems(mediaItems, startIndex, positionInItem)
         controller.prepare()
-    }
-
-    internal fun resolveStartPosition(
-        items: List<PlaybackMediaItem>,
-        bookPositionMs: Long,
-    ): Pair<Int, Long> {
-        if (items.isEmpty()) return 0 to 0L
-        val item = items.firstOrNull { bookPositionMs in it.offsetMs until it.offsetMs + it.durationMs }
-        return if (item != null) {
-            items.indexOf(item) to bookPositionMs - item.offsetMs
-        } else {
-            if (bookPositionMs < items.first().offsetMs) {
-                0 to 0L
-            } else {
-                items.size - 1 to items.last().durationMs
-            }
-        }
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackParameters
-import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.StateFlow
@@ -40,6 +39,8 @@ interface ControllerHolder {
 class AndroidPlaybackController(
     private val holder: ControllerHolder,
 ) : PlaybackController {
+    private var cachedQueue: List<PlaybackMediaItem> = emptyList()
+
     override fun acquire() = holder.acquire()
 
     override fun release() = holder.release()
@@ -62,33 +63,38 @@ class AndroidPlaybackController(
             logger.warn { "AndroidPlaybackController.seekTo($positionMs): controller not ready" }
             return
         }
-        // Resolve book-relative position to (mediaItemIndex, positionInItem) using Media3's
-        // current timeline. The Media3 timeline exposes per-window durations; we accumulate
-        // until we find the window containing positionMs.
-        val (index, offset) = resolveSeekPosition(controller, positionMs)
+        if (cachedQueue.isEmpty()) {
+            logger.warn {
+                "AndroidPlaybackController.seekTo($positionMs): no cached queue, falling back to single-arg seek"
+            }
+            controller.seekTo(positionMs)
+            return
+        }
+        val (index, offset) = resolveSeekPosition(cachedQueue, positionMs)
+        logger.debug { "AndroidPlaybackController.seekTo: bookPos=$positionMs → idx=$index, offset=$offset" }
         controller.seekTo(index, offset)
     }
 
-    private fun resolveSeekPosition(
-        controller: MediaController,
+    internal fun resolveSeekPosition(
+        items: List<PlaybackMediaItem>,
         bookPositionMs: Long,
     ): Pair<Int, Long> {
-        val itemCount = controller.mediaItemCount
-        if (itemCount == 0) return 0 to 0L
-        var accumulated = 0L
-        for (i in 0 until itemCount) {
-            val window = Timeline.Window()
-            controller.currentTimeline.getWindow(i, window)
-            val itemDuration = window.durationMs
-            if (itemDuration <= 0L) continue // Skip un-prepared windows
-            val itemEnd = accumulated + itemDuration
-            if (bookPositionMs in accumulated until itemEnd) {
-                return i to bookPositionMs - accumulated
+        if (items.isEmpty()) return 0 to 0L
+        for ((i, item) in items.withIndex()) {
+            if (bookPositionMs in item.offsetMs until item.offsetMs + item.durationMs) {
+                return i to bookPositionMs - item.offsetMs
             }
-            accumulated = itemEnd
         }
-        // Position past end of queue → snap to last item's end
-        return itemCount - 1 to controller.duration.coerceAtLeast(0L)
+        // Position before first item OR past last item
+        val first = items.first()
+        return if (bookPositionMs < first.offsetMs) {
+            0 to 0L
+        } else {
+            // Past end → snap to last item's end
+            // Drift #26 (a) fix: use LAST item's durationMs, not controller.duration
+            val lastIndex = items.size - 1
+            lastIndex to items.last().durationMs
+        }
     }
 
     override fun setPlaybackSpeed(speed: Float) {
@@ -115,6 +121,7 @@ class AndroidPlaybackController(
             logger.warn { "AndroidPlaybackController.setMediaQueue: controller not ready" }
             return
         }
+        cachedQueue = items
         val mediaItems =
             items.map { item ->
                 MediaItem

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
@@ -40,7 +40,7 @@ private val logger = KotlinLogging.logger {}
 @OptIn(ExperimentalAtomicApi::class)
 class MediaControllerHolder(
     private val context: Context,
-    private val playbackManager: PlaybackManager,
+    private val playbackManager: PlaybackStateWriter,
     private val scope: CoroutineScope,
 ) {
     private var controllerFuture: ListenableFuture<MediaController>? = null

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
@@ -2,13 +2,21 @@ package com.calypsan.listenup.client.playback
 
 import android.content.ComponentName
 import android.content.Context
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -32,6 +40,8 @@ private val logger = KotlinLogging.logger {}
 @OptIn(ExperimentalAtomicApi::class)
 class MediaControllerHolder(
     private val context: Context,
+    private val playbackManager: PlaybackManager,
+    private val scope: CoroutineScope,
 ) {
     private var controllerFuture: ListenableFuture<MediaController>? = null
     private var _controller: MediaController? = null
@@ -46,6 +56,71 @@ class MediaControllerHolder(
      */
     val controller: MediaController?
         get() = _controller
+
+    internal val playerListener: Player.Listener =
+        object : Player.Listener {
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                playbackManager.setPlaying(isPlaying)
+            }
+
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                playbackManager.setBuffering(playbackState == Player.STATE_BUFFERING)
+                playbackManager.setPlaybackState(toCommonPlaybackState(playbackState))
+            }
+
+            override fun onPlayerError(error: PlaybackException) {
+                val isNetworkError =
+                    error.errorCode in
+                        listOf(
+                            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+                            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
+                            PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+                            PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,
+                            PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
+                        )
+                val message =
+                    if (isNetworkError) {
+                        "Couldn't connect to server. Download this book for offline listening."
+                    } else {
+                        "Playback error: ${error.localizedMessage ?: "Unknown error"}"
+                    }
+                playbackManager.reportError(message = message, isRecoverable = isNetworkError)
+                playbackManager.setPlaying(false)
+                logger.error { "ExoPlayer error: ${error.errorCodeName} - ${error.message}" }
+            }
+
+            override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
+                playbackManager.updateSpeed(playbackParameters.speed)
+            }
+        }
+
+    private fun toCommonPlaybackState(media3State: Int): PlaybackState =
+        when (media3State) {
+            Player.STATE_IDLE -> PlaybackState.Idle
+            Player.STATE_BUFFERING -> PlaybackState.Buffering
+            Player.STATE_READY -> if (_controller?.isPlaying == true) PlaybackState.Playing else PlaybackState.Paused
+            Player.STATE_ENDED -> PlaybackState.Ended
+            else -> PlaybackState.Idle
+        }
+
+    private var positionPollJob: Job? = null
+
+    private companion object {
+        const val POSITION_POLL_INTERVAL_MS = 250L
+    }
+
+    internal fun startPositionPolling(controller: MediaController) {
+        positionPollJob?.cancel()
+        positionPollJob =
+            scope.launch {
+                while (isActive) {
+                    if (controller.isPlaying) {
+                        playbackManager.updatePosition(controller.currentPosition)
+                    }
+                    delay(POSITION_POLL_INTERVAL_MS)
+                }
+            }
+    }
 
     /**
      * Acquire a reference to the controller.
@@ -114,6 +189,10 @@ class MediaControllerHolder(
             try {
                 _controller = controllerFuture?.get()
                 isConnected.value = true
+                _controller?.let { newController ->
+                    newController.addListener(playerListener)
+                    startPositionPolling(newController)
+                }
                 logger.info { "MediaControllerHolder: connected" }
             } catch (e: Exception) {
                 logger.error(e) { "MediaControllerHolder: connection failed" }
@@ -124,6 +203,10 @@ class MediaControllerHolder(
 
     private fun disconnect() {
         logger.info { "MediaControllerHolder: disconnecting" }
+
+        positionPollJob?.cancel()
+        positionPollJob = null
+        _controller?.removeListener(playerListener)
 
         _controller?.release()
         _controller = null

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
@@ -35,45 +36,46 @@ class PlayerViewModel(
 
         viewModelScope.launch {
             playbackManager.isPlaying.collect { isPlaying ->
-                state.value = state.value.copy(isPlaying = isPlaying)
+                state.update { it.copy(isPlaying = isPlaying) }
             }
         }
         viewModelScope.launch {
             playbackManager.isBuffering.collect { isBuffering ->
-                state.value = state.value.copy(isBuffering = isBuffering)
+                state.update { it.copy(isBuffering = isBuffering) }
             }
         }
         viewModelScope.launch {
             playbackManager.playbackState.collect { playbackState ->
                 if (playbackState == PlaybackState.Ended) {
-                    state.value = state.value.copy(isPlaying = false, isFinished = true)
+                    state.update { it.copy(isPlaying = false, isFinished = true) }
                 }
             }
         }
         viewModelScope.launch {
             playbackManager.playbackSpeed.collect { speed ->
-                state.value = state.value.copy(playbackSpeed = speed)
+                state.update { it.copy(playbackSpeed = speed) }
             }
         }
         viewModelScope.launch {
             playbackManager.currentPositionMs.collect { positionMs ->
-                state.value = state.value.copy(currentPositionMs = positionMs)
+                state.update { it.copy(currentPositionMs = positionMs) }
             }
         }
         viewModelScope.launch {
             playbackManager.totalDurationMs.collect { durationMs ->
-                state.value = state.value.copy(totalDurationMs = durationMs)
+                state.update { it.copy(totalDurationMs = durationMs) }
             }
         }
         viewModelScope.launch {
             playbackManager.playbackError.collect { error ->
                 if (error != null) {
-                    state.value =
-                        state.value.copy(
+                    state.update {
+                        it.copy(
                             isPlaying = false,
                             isLoading = false,
                             error = error.message,
                         )
+                    }
                 }
             }
         }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
@@ -4,18 +4,11 @@ package com.calypsan.listenup.client.playback
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.PlaybackException
-import androidx.media3.common.PlaybackParameters
-import androidx.media3.common.Player
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
-import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
@@ -26,41 +19,65 @@ private val logger = KotlinLogging.logger {}
  * Responsibilities:
  * - Uses PlaybackController seam for player commands
  * - Exposes playback state as flows for Compose
- * - Handles position updates using book-relative timeline
+ * - Mirrors PlaybackManager flows into PlayerUiState
  * - Provides control actions
- *
- * Note: [Player.Listener] registration and direct [MediaController] position polling
- * ([updatePosition]) are retained via [mediaControllerHolder] because the events
- * observed (onPlaybackStateChanged buffering/ended, onPlayerError with Media3-specific
- * error codes, currentMediaItemIndex/currentPosition polling) are NOT surfaced by
- * [PlaybackManager] or [PlaybackController]. Removing them would require extending
- * PlaybackManager with isBuffering, error, and per-item position flows — a separate
- * task deferred beyond Task 6.
  */
 class PlayerViewModel(
     private val playbackManager: PlaybackManager,
     private val playbackController: PlaybackController,
     private val networkMonitor: NetworkMonitor,
-    // TODO(Task-6-followup): mediaControllerHolder retained solely for Player.Listener
-    //  registration and updatePosition() polling. Remove once PlaybackManager exposes
-    //  isBuffering, playback errors, and per-mediaItem position flows.
-    private val mediaControllerHolder: MediaControllerHolder,
 ) : ViewModel() {
-    private var positionUpdateJob: Job? = null
-    private var playerListener: Player.Listener? = null
-
     val state: StateFlow<PlayerUiState>
         field = MutableStateFlow(PlayerUiState())
 
-    private var currentTimeline: PlaybackTimeline? = null
-
     init {
-        // Acquire reference to shared controller
         playbackController.acquire()
-    }
 
-    private val mediaController: androidx.media3.session.MediaController?
-        get() = mediaControllerHolder.controller
+        viewModelScope.launch {
+            playbackManager.isPlaying.collect { isPlaying ->
+                state.value = state.value.copy(isPlaying = isPlaying)
+            }
+        }
+        viewModelScope.launch {
+            playbackManager.isBuffering.collect { isBuffering ->
+                state.value = state.value.copy(isBuffering = isBuffering)
+            }
+        }
+        viewModelScope.launch {
+            playbackManager.playbackState.collect { playbackState ->
+                if (playbackState == PlaybackState.Ended) {
+                    state.value = state.value.copy(isPlaying = false, isFinished = true)
+                }
+            }
+        }
+        viewModelScope.launch {
+            playbackManager.playbackSpeed.collect { speed ->
+                state.value = state.value.copy(playbackSpeed = speed)
+            }
+        }
+        viewModelScope.launch {
+            playbackManager.currentPositionMs.collect { positionMs ->
+                state.value = state.value.copy(currentPositionMs = positionMs)
+            }
+        }
+        viewModelScope.launch {
+            playbackManager.totalDurationMs.collect { durationMs ->
+                state.value = state.value.copy(totalDurationMs = durationMs)
+            }
+        }
+        viewModelScope.launch {
+            playbackManager.playbackError.collect { error ->
+                if (error != null) {
+                    state.value =
+                        state.value.copy(
+                            isPlaying = false,
+                            isLoading = false,
+                            error = error.message,
+                        )
+                }
+            }
+        }
+    }
 
     /**
      * Start playback of a book.
@@ -110,8 +127,6 @@ class PlayerViewModel(
                 return@launch
             }
 
-            currentTimeline = result.timeline
-
             state.value =
                 state.value.copy(
                     bookTitle = result.bookTitle,
@@ -133,17 +148,6 @@ class PlayerViewModel(
 
     private suspend fun connectAndPlay(prepareResult: PlaybackManager.PrepareResult) {
         try {
-            // Remove old listener if any, then register fresh one.
-            // TODO(Task-6-followup): listener registration uses mediaControllerHolder
-            //  directly because Player.Listener surfaces events (isBuffering, error codes,
-            //  playback state) not yet exposed through PlaybackController or PlaybackManager.
-            mediaControllerHolder.withController { controller ->
-                playerListener?.let { controller.removeListener(it) }
-                val listener = PlayerListener()
-                playerListener = listener
-                controller.addListener(listener)
-            }
-
             // Build queue from timeline and hand off to PlaybackController.
             logger.debug { "Building ${prepareResult.timeline.files.size} media items" }
             val items = buildPlaybackMediaItems(prepareResult)
@@ -160,7 +164,6 @@ class PlayerViewModel(
                     isPlaying = true,
                 )
 
-            startPositionUpdates()
             logger.info { "Playback started for: ${prepareResult.bookTitle}" }
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e
@@ -274,144 +277,8 @@ class PlayerViewModel(
         state.value = PlayerUiState()
     }
 
-    private fun startPositionUpdates() {
-        positionUpdateJob?.cancel()
-        positionUpdateJob =
-            viewModelScope.launch {
-                while (isActive) {
-                    updatePosition()
-                    delay(250) // Update 4 times per second for smooth progress
-                }
-            }
-    }
-
-    private fun stopPositionUpdates() {
-        positionUpdateJob?.cancel()
-        positionUpdateJob = null
-    }
-
-    private fun updatePosition() {
-        // TODO(Task-6-followup): position polling reads directly from mediaControllerHolder
-        //  because PlaybackController is command-only and PlaybackManager does not expose
-        //  per-mediaItem index + position as flows on Android. Migrate once those flows exist.
-        val controller = mediaController ?: return
-        val timeline = currentTimeline ?: return
-
-        val mediaItemIndex = controller.currentMediaItemIndex
-        val positionInFile = controller.currentPosition
-        val playbackState = controller.playbackState
-        val isPlaying = controller.isPlaying
-        val isBuffering = playbackState == Player.STATE_BUFFERING
-
-        // Validate ExoPlayer values before using them (silent validation, only log errors)
-        if (mediaItemIndex < 0 || mediaItemIndex >= timeline.files.size || positionInFile < 0) {
-            logger.error {
-                "INVALID position: mediaItem=$mediaItemIndex/${timeline.files.size}, posInFile=$positionInFile"
-            }
-            return
-        }
-
-        val bookPosition =
-            timeline.toBookPosition(
-                mediaItemIndex = mediaItemIndex,
-                positionInFileMs = positionInFile,
-            )
-
-        // Validate calculated book position
-        if (bookPosition < 0 || bookPosition > timeline.totalDurationMs + 1000) {
-            logger.error { "INVALID bookPosition: $bookPosition (duration=${timeline.totalDurationMs})" }
-            return
-        }
-
-        // Debounce: only update state if position changed significantly (>100ms) or playback state changed
-        val currentState = state.value
-        val positionDelta = kotlin.math.abs(bookPosition - currentState.currentPositionMs)
-        val stateChanged = isPlaying != currentState.isPlaying || isBuffering != currentState.isBuffering
-
-        if (!stateChanged && positionDelta < 100) {
-            return // Skip very minor position updates to reduce recomposition
-        }
-
-        state.value =
-            currentState.copy(
-                currentPositionMs = bookPosition,
-                isPlaying = isPlaying,
-                isBuffering = isBuffering,
-            )
-
-        // Publish position to PlaybackManager for NowPlayingViewModel
-        playbackManager.updatePosition(bookPosition)
-    }
-
-    private inner class PlayerListener : Player.Listener {
-        override fun onIsPlayingChanged(isPlaying: Boolean) {
-            state.value = state.value.copy(isPlaying = isPlaying)
-            playbackManager.setPlaying(isPlaying)
-
-            if (isPlaying) {
-                startPositionUpdates()
-            } else {
-                stopPositionUpdates()
-                updatePosition() // One final update
-            }
-        }
-
-        override fun onPlaybackStateChanged(playbackState: Int) {
-            val isBuffering = playbackState == Player.STATE_BUFFERING
-            state.value = state.value.copy(isBuffering = isBuffering)
-
-            if (playbackState == Player.STATE_ENDED) {
-                state.value =
-                    state.value.copy(
-                        isPlaying = false,
-                        isFinished = true,
-                    )
-            }
-        }
-
-        override fun onPlayerError(error: PlaybackException) {
-            logger.error { "ExoPlayer error: ${error.errorCodeName} - ${error.message}" }
-            val isNetworkError =
-                error.errorCode in
-                    listOf(
-                        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
-                        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
-                        PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
-                        PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,
-                        PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
-                    )
-            val message =
-                if (isNetworkError) {
-                    "Couldn't connect to server. Download this book for offline listening."
-                } else {
-                    "Playback error: ${error.localizedMessage ?: "Unknown error"}"
-                }
-            state.value =
-                state.value.copy(
-                    isPlaying = false,
-                    isLoading = false,
-                    error = message,
-                )
-            playbackManager.setPlaying(false)
-        }
-
-        override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
-            state.value = state.value.copy(playbackSpeed = playbackParameters.speed)
-            playbackManager.updateSpeed(playbackParameters.speed)
-        }
-    }
-
     override fun onCleared() {
         super.onCleared()
-        positionUpdateJob?.cancel()
-
-        // Remove our listener from the shared controller
-        playerListener?.let { listener ->
-            mediaController?.removeListener(listener)
-        }
-        playerListener = null
-
-        // Release our reference to the shared controller
         playbackController.release()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
@@ -119,7 +119,7 @@ class DesktopPlayerViewModel(
 
         // Observe audio player errors
         viewModelScope.launch {
-            audioPlayer.state.collect { playbackState ->
+            playbackManager.playbackState.collect { playbackState ->
                 if (playbackState == PlaybackState.Error) {
                     state.update {
                         it.copy(errorMessage = "Playback error. Check GStreamer installation.")
@@ -154,7 +154,7 @@ class DesktopPlayerViewModel(
             )
 
             // Check if playback actually started
-            if (audioPlayer.state.value == PlaybackState.Error) {
+            if (playbackManager.playbackState.value == PlaybackState.Error) {
                 state.update {
                     it.copy(
                         errorMessage = "Playback failed. Check that GStreamer plugins are installed correctly.",
@@ -165,7 +165,7 @@ class DesktopPlayerViewModel(
     }
 
     fun playPause() {
-        val currentState = audioPlayer.state.value
+        val currentState = playbackManager.playbackState.value
         if (currentState == PlaybackState.Playing) {
             playbackController.pause()
             // Notify progress tracker of pause

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -73,7 +73,8 @@ class PlaybackManager(
     private val syncApi: SyncApiContract?,
     private val scope: CoroutineScope,
     private val bookRepository: BookRepository,
-) : PlaybackStateProvider {
+) : PlaybackStateProvider,
+    PlaybackStateWriter {
     private val _currentBookId = MutableStateFlow<BookId?>(null)
     override val currentBookId: StateFlow<BookId?> = _currentBookId
 
@@ -443,7 +444,7 @@ class PlaybackManager(
      * Update playback state.
      * Called by PlayerViewModel when state changes.
      */
-    fun setPlaying(playing: Boolean) {
+    override fun setPlaying(playing: Boolean) {
         isPlaying.value = playing
     }
 
@@ -452,7 +453,7 @@ class PlaybackManager(
      * (Android: MediaControllerHolder's Player.Listener; Desktop: PlaybackManager's
      * own AudioPlayer.state observation in startPlayback).
      */
-    fun setBuffering(buffering: Boolean) {
+    override fun setBuffering(buffering: Boolean) {
         _isBuffering.value = buffering
     }
 
@@ -460,7 +461,7 @@ class PlaybackManager(
      * Update playback state (Idle/Buffering/Playing/Paused/Ended/Error). Same
      * caller scheme as [setBuffering].
      */
-    fun setPlaybackState(state: PlaybackState) {
+    override fun setPlaybackState(state: PlaybackState) {
         _playbackState.value = state
     }
 
@@ -468,7 +469,7 @@ class PlaybackManager(
      * Update current position.
      * Called by PlayerViewModel during position update loop.
      */
-    fun updatePosition(positionMs: Long) {
+    override fun updatePosition(positionMs: Long) {
         currentPositionMs.value = positionMs
         updateCurrentChapter(positionMs)
     }
@@ -477,7 +478,7 @@ class PlaybackManager(
      * Update playback speed.
      * Called by PlayerViewModel when speed changes.
      */
-    fun updateSpeed(speed: Float) {
+    override fun updateSpeed(speed: Float) {
         playbackSpeed.value = speed
     }
 
@@ -565,9 +566,9 @@ class PlaybackManager(
      * Report a playback error to be displayed to the user.
      * Called by platform-specific error handlers.
      */
-    fun reportError(
+    override fun reportError(
         message: String,
-        isRecoverable: Boolean = false,
+        isRecoverable: Boolean,
     ) {
         _playbackError.value =
             PlaybackError(

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -104,6 +104,12 @@ class PlaybackManager(
     private val _playbackError = MutableStateFlow<PlaybackError?>(null)
     val playbackError: StateFlow<PlaybackError?> = _playbackError
 
+    private val _isBuffering = MutableStateFlow(false)
+    val isBuffering: StateFlow<Boolean> = _isBuffering
+
+    private val _playbackState = MutableStateFlow(PlaybackState.Idle)
+    val playbackState: StateFlow<PlaybackState> = _playbackState
+
     // Chapter state for notification and UI
     private val _chapters = MutableStateFlow<List<Chapter>>(emptyList())
     val chapters: StateFlow<List<Chapter>> = _chapters
@@ -430,6 +436,23 @@ class PlaybackManager(
     }
 
     /**
+     * Update buffering flag. Called by platform-specific event sources
+     * (Android: MediaControllerHolder's Player.Listener; Desktop: PlaybackManager's
+     * own AudioPlayer.state observation in startPlayback).
+     */
+    fun setBuffering(buffering: Boolean) {
+        _isBuffering.value = buffering
+    }
+
+    /**
+     * Update playback state (Idle/Buffering/Playing/Paused/Ended/Error). Same
+     * caller scheme as [setBuffering].
+     */
+    fun setPlaybackState(state: PlaybackState) {
+        _playbackState.value = state
+    }
+
+    /**
      * Update current position.
      * Called by PlayerViewModel during position update loop.
      */
@@ -520,6 +543,8 @@ class PlaybackManager(
         totalDurationMs.value = 0L
         playbackSpeed.value = 1.0f
         _playbackError.value = null
+        _isBuffering.value = false
+        _playbackState.value = PlaybackState.Idle
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -38,6 +38,7 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -116,6 +117,10 @@ class PlaybackManager(
 
     private val _currentChapter = MutableStateFlow<ChapterInfo?>(null)
     val currentChapter: StateFlow<ChapterInfo?> = _currentChapter
+
+    // Tracks the coroutine that observes AudioPlayer state/position on Desktop/Apple.
+    // Cancelled by clearPlayback so observations don't outlive a playback session.
+    private var playerObservationJob: Job? = null
 
     // Callback for chapter changes - used by PlaybackService to update notification
     var onChapterChanged: ((ChapterInfo) -> Unit)? = null
@@ -388,36 +393,43 @@ class PlaybackManager(
         }
         currentPositionMs.value = resumePositionMs
 
-        // Bridge player position back to PlaybackManager
-        scope.launch {
-            player.positionMs.collect { position ->
-                updatePosition(position)
-            }
-        }
+        // Bridge player state and position back to PlaybackManager.
+        // Both child launches are parented to playerObservationJob so a single
+        // cancel() in clearPlayback stops both collectors together.
+        playerObservationJob?.cancel()
+        playerObservationJob =
+            scope.launch {
+                launch {
+                    player.positionMs.collect { position ->
+                        updatePosition(position)
+                    }
+                }
+                launch {
+                    player.state.collect { playbackState ->
+                        setPlaybackState(playbackState)
+                        setBuffering(playbackState == PlaybackState.Buffering)
 
-        // Bridge player state back to PlaybackManager
-        scope.launch {
-            player.state.collect { playbackState ->
-                val playing = playbackState == PlaybackState.Playing
-                setPlaying(playing)
+                        val playing = playbackState == PlaybackState.Playing
+                        setPlaying(playing)
 
-                if (playbackState == PlaybackState.Ended) {
-                    val duration = totalDurationMs.value
-                    val position = currentPositionMs.value
-                    // Guard: only mark finished if position is actually near the end.
-                    // Prevents false completion from spurious Ended events on player
-                    // release/stop (#204).
-                    if (duration > 0 && position.toFloat() / duration >= 0.90f) {
-                        progressTracker.onBookFinished(bookId, duration)
-                    } else {
-                        logger.warn {
-                            "Ignoring Ended state: position=${position}ms " +
-                                "not near end (duration=${duration}ms)"
+                        if (playbackState == PlaybackState.Ended) {
+                            val duration = totalDurationMs.value
+                            val position = currentPositionMs.value
+                            // Guard: only mark finished if position is actually near the end.
+                            // Prevents false completion from spurious Ended events on player
+                            // release/stop (#204).
+                            if (duration > 0 && position.toFloat() / duration >= 0.90f) {
+                                progressTracker.onBookFinished(bookId, duration)
+                            } else {
+                                logger.warn {
+                                    "Ignoring Ended state: position=${position}ms " +
+                                        "not near end (duration=${duration}ms)"
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
 
         // Start playback
         player.play()
@@ -533,6 +545,8 @@ class PlaybackManager(
      * Called when playback stops or when access is revoked.
      */
     override fun clearPlayback() {
+        playerObservationJob?.cancel()
+        playerObservationJob = null
         _currentBookId.value = null
         _currentBookIdString.value = null
         _currentTimeline.value = null

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackStateWriter.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackStateWriter.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.client.playback
+
+/**
+ * Narrow interface for platform-specific playback event sources (e.g., Android's
+ * MediaControllerHolder Player.Listener) to push state changes into PlaybackManager
+ * without taking a full dependency on the concrete class.
+ *
+ * Implemented by [PlaybackManager].
+ */
+interface PlaybackStateWriter {
+    fun setPlaying(playing: Boolean)
+
+    fun setBuffering(buffering: Boolean)
+
+    fun setPlaybackState(state: PlaybackState)
+
+    fun updatePosition(positionMs: Long)
+
+    fun updateSpeed(speed: Float)
+
+    fun reportError(
+        message: String,
+        isRecoverable: Boolean = false,
+    )
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -1,0 +1,112 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.core.ServerUrl
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.device.DeviceContext
+import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies the isBuffering and playbackState flows added in W7 Phase E2.1 Task 1.
+ *
+ * These flows serve as the receiving end for platform-specific state pushes:
+ * Android's MediaControllerHolder Player.Listener and Desktop's AudioPlayer.state
+ * observation. No consumers are wired yet (Tasks 2-5); this test pins the flows
+ * and setters against future regression.
+ */
+class PlaybackManagerBufferingStateTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `setBuffering updates isBuffering flow`() =
+        runTest {
+            val sut = createPlaybackManager()
+
+            assertEquals(false, sut.isBuffering.value)
+
+            sut.setBuffering(true)
+            assertEquals(true, sut.isBuffering.value)
+
+            sut.setBuffering(false)
+            assertEquals(false, sut.isBuffering.value)
+        }
+
+    @Test
+    fun `setPlaybackState updates playbackState flow`() =
+        runTest {
+            val sut = createPlaybackManager()
+
+            assertEquals(PlaybackState.Idle, sut.playbackState.value)
+
+            sut.setPlaybackState(PlaybackState.Playing)
+            assertEquals(PlaybackState.Playing, sut.playbackState.value)
+
+            sut.setPlaybackState(PlaybackState.Buffering)
+            assertEquals(PlaybackState.Buffering, sut.playbackState.value)
+        }
+
+    // =========================================================================
+    // Fixture helpers
+    // =========================================================================
+
+    private fun createPlaybackManager(
+        scope: CoroutineScope = CoroutineScope(Job()),
+    ): PlaybackManager {
+        val tokenProvider: AudioTokenProvider = mock()
+        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
+
+        val serverConfig: ServerConfig = mock()
+        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
+
+        val imageStorage: ImageStorage = mock()
+        every { imageStorage.exists(any()) } returns false
+
+        val downloadService: DownloadService = mock()
+        everySuspend { downloadService.getLocalPath(any()) } returns null
+        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+
+        val playbackPreferences: PlaybackPreferences = mock()
+        everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+
+        return PlaybackManager(
+            serverConfig = serverConfig,
+            playbackPreferences = playbackPreferences,
+            bookDao = db.bookDao(),
+            audioFileDao = db.audioFileDao(),
+            chapterDao = db.chapterDao(),
+            imageStorage = imageStorage,
+            progressTracker = buildProgressTracker(scope = scope),
+            tokenProvider = tokenProvider,
+            deviceContext = DeviceContext(type = DeviceType.Phone),
+            downloadService = downloadService,
+            playbackApi = null,
+            capabilityDetector = null,
+            syncApi = null,
+            scope = scope,
+            bookRepository = mock<BookRepository>(),
+        )
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -120,6 +120,7 @@ class PlaybackManagerBufferingStateTest {
 
             // clearPlayback resets to Idle regardless of what the player emits.
             assertEquals(PlaybackState.Idle, sut.playbackState.value)
+            assertFalse(sut.isBuffering.value, "clearPlayback must reset isBuffering to false")
 
             // Cancel to stop the infinite collect coroutines and let runTest complete.
             managerScope.coroutineContext[Job]?.cancel()

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -1,7 +1,12 @@
 package com.calypsan.listenup.client.playback
 
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.ServerUrl
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
@@ -11,26 +16,31 @@ import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.download.DownloadResult
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakePlayer
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 /**
- * Verifies the isBuffering and playbackState flows added in W7 Phase E2.1 Task 1.
+ * Verifies the isBuffering and playbackState flows added in W7 Phase E2.1 Task 1,
+ * and the AudioPlayer state observation wired in Task 4.
  *
  * These flows serve as the receiving end for platform-specific state pushes:
  * Android's MediaControllerHolder Player.Listener and Desktop's AudioPlayer.state
- * observation. No consumers are wired yet (Tasks 2-5); this test pins the flows
- * and setters against future regression.
+ * observation in startPlayback.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class PlaybackManagerBufferingStateTest {
     private val db: ListenUpDatabase = createInMemoryTestDatabase()
 
@@ -65,6 +75,54 @@ class PlaybackManagerBufferingStateTest {
 
             sut.setPlaybackState(PlaybackState.Buffering)
             assertEquals(PlaybackState.Buffering, sut.playbackState.value)
+        }
+
+    @Test
+    fun `startPlayback subscribes to AudioPlayer state and forwards to PlaybackManager`() =
+        runTest {
+            seedBookAndAudioFiles()
+
+            // Use coroutineContext + Job() so launched coroutines share the
+            // TestCoroutineScheduler (and are advanced by advanceUntilIdle()) while the
+            // Job is independent of the TestScope — allowing explicit cancellation at the
+            // end without tearing down the test harness.
+            val managerScope = CoroutineScope(coroutineContext + Job())
+            val sut = createPlaybackManager(scope = managerScope)
+
+            val player = FakePlayer()
+
+            val prepareResult = sut.prepareForPlayback(BookId("book-1"))
+            checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
+            sut.activateBook(BookId("book-1"))
+
+            // startPlayback launches the observation coroutines on managerScope.
+            sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
+
+            // FakePlayer.load() drives state → Buffering; play() drives state → Playing.
+            // Drain pending coroutines so the collectors process the latest emission.
+            advanceUntilIdle()
+
+            // After play(), FakePlayer emits Playing — expect state forwarded.
+            assertEquals(PlaybackState.Playing, sut.playbackState.value)
+            assertFalse(sut.isBuffering.value, "Playing state must clear isBuffering")
+
+            // Now drive the player to Buffering and verify forwarding.
+            player.emitState(PlaybackState.Buffering)
+            advanceUntilIdle()
+
+            assertEquals(PlaybackState.Buffering, sut.playbackState.value)
+            assertEquals(true, sut.isBuffering.value)
+
+            // clearPlayback must cancel observations — further emissions must not propagate.
+            sut.clearPlayback()
+            player.emitState(PlaybackState.Playing)
+            advanceUntilIdle()
+
+            // clearPlayback resets to Idle regardless of what the player emits.
+            assertEquals(PlaybackState.Idle, sut.playbackState.value)
+
+            // Cancel to stop the infinite collect coroutines and let runTest complete.
+            managerScope.coroutineContext[Job]?.cancel()
         }
 
     // =========================================================================
@@ -107,6 +165,49 @@ class PlaybackManagerBufferingStateTest {
             syncApi = null,
             scope = scope,
             bookRepository = mock<BookRepository>(),
+        )
+    }
+
+    private suspend fun seedBookAndAudioFiles() {
+        db.bookDao().upsert(
+            BookEntity(
+                id = BookId("book-1"),
+                title = "Test Book",
+                sortTitle = "Test Book",
+                subtitle = null,
+                coverUrl = null,
+                coverBlurHash = null,
+                dominantColor = null,
+                darkMutedColor = null,
+                vibrantColor = null,
+                totalDuration = 1_800_000L,
+                description = null,
+                publishYear = null,
+                publisher = null,
+                language = null,
+                isbn = null,
+                asin = null,
+                abridged = false,
+                syncState = SyncState.SYNCED,
+                lastModified = Timestamp(1L),
+                serverVersion = Timestamp(1L),
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+            ),
+        )
+        db.audioFileDao().upsertAll(
+            listOf(
+                AudioFileEntity(
+                    bookId = BookId("book-1"),
+                    index = 0,
+                    id = "af-0",
+                    filename = "chapter1.m4b",
+                    format = "m4b",
+                    codec = "aac",
+                    duration = 1_800_000L,
+                    size = 45_000_000L,
+                ),
+            ),
         )
     }
 }


### PR DESCRIPTION
## Summary

W7 Phase E2.1 closes drifts #25 and #26 in one PR. Foundation work for E2.2's full VM migration to \`shared/presentation/\`.

- **Extends \`PlaybackManager\`** with \`isBuffering: StateFlow<Boolean>\` + \`playbackState: StateFlow<PlaybackState>\` (using existing \`PlaybackState\` enum from \`AudioPlayer.kt\`). Reset both in \`clearPlayback\`.
- **Extracts \`PlaybackStateWriter\`** narrow interface (6 methods) implemented by \`PlaybackManager\`. Enables \`MediaControllerHolder\` testing without Mokkery (which isn't on \`androidHostTest\` classpath; PlaybackException's JVM constructor isn't host-test-friendly either). Production wiring unchanged.
- **\`MediaControllerHolder\`** constructor gains \`playbackManager: PlaybackStateWriter\` + \`scope: CoroutineScope\`. Owns the Media3 \`Player.Listener\` (translates events → PlaybackStateWriter setters) AND the 250ms position-polling loop. Listener registered on connect, removed on disconnect.
- **\`PlaybackManager.startPlayback(player: AudioPlayer)\`** internally launches a tracked observation job that subscribes to \`player.state\` and \`player.positionMs\`. Cancelled in \`clearPlayback\`.
- **\`PlayerViewModel\`** (Android) sheds \`MediaControllerHolder\` injection. Inner \`PlayerListener\` class + position-polling methods deleted. State observations switch to 7 \`playbackManager.X.collect { state.update { it.copy(X = ...) } }\` blocks (atomic CAS).
- **\`DesktopPlayerViewModel\`** sheds read-side \`audioPlayer.state\` access; switches to \`playbackManager.playbackState\`. The \`audioPlayer\` constructor field stays as a structural passthrough to \`PlaybackManager.startPlayback(player = audioPlayer)\` — eliminating that requires refactoring \`startPlayback\`'s API surface, deferred.
- **\`AndroidPlaybackController\`** caches \`PlaybackMediaItem\` queue at \`setMediaQueue\` time. \`seekTo(Long)\` reads cache via consolidated pure \`resolveQueuePosition\` helper (used by both \`setMediaQueue\` start-position resolution AND \`seekTo\`). Past-end branch uses \`items.last().durationMs\` (drift #26 (a) regression test). Cache-miss falls back to single-arg seek with warn-log. Diagnostic debug log restored.

## Drift state

- **Closed by this PR:** #25 (PlayerViewModel + DesktopPlayerViewModel partial migration — read-side platform deps shed), #26 (AndroidPlaybackController seekTo queue-aware concerns — cached queue, past-end fix, untested helper, lost diagnostic logging, source-of-truth divergence — all 4 sub-concerns addressed).
- **Rolled forward:** #17 (Discard/Restart facade — W8), #20 (SyncIndicatorViewModel describe split — W8), #23 (observeBookDetail flake — post-W7), #24 (PlaybackPositionRepository remaining String parameters — post-W7).

## Notable design decisions

1. **\`PlaybackStateWriter\` interface extraction** — driven by test-infrastructure constraint (Mokkery + JVM PlaybackException incompatibility on \`androidHostTest\`). Narrow 6-method interface; bounded scope.
2. **\`audioPlayer\` constructor passthrough on DesktopPlayerViewModel** — drift #25 closed on the meaningful axis (read-side state polling); structural passthrough is honest and could be eliminated by future \`PlaybackManager.startPlayback\` API refactor.
3. **Atomic \`state.update { }\`** in PlayerViewModel's 7 init-block collectors (was a §M1 fix). Pre-existing single-listener pattern used \`state.value = state.value.copy(...)\` which is safe under one emitter; refactoring to 7 concurrent collectors required atomic CAS.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-04-28-w7-e2-1-playback-manager-foundation-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-28-w7-e2-1-playback-manager-foundation.md\`

## Test plan

- [x] \`:shared:jvmTest\` green at every commit
- [x] \`spotlessCheck detekt\` green at every commit
- [x] \`:androidApp:assembleDebug\` green at HEAD
- [x] \`:composeApp:testAndroidHostTest\` green (4 MediaControllerHolderTest + 22 AndroidPlaybackControllerTest)
- [x] §M1 code-reviewer pass: APPROVED-WITH-CONCERNS — I1 (atomic state.update), I2 (helper consolidation), M2 (test gap) all folded in via fix-up \`9e10083a\`

## W7 status

**Phase E2.1 complete.** Phase E2.2 opens next as a separate PR — moves VMs to \`shared/presentation/\`, sealed \`NowPlayingState\` hierarchy, \`combine().stateIn(WhileSubscribed)\`, picker/dialog ephemera split into separate flows or \`Channel<NowPlayingEvent>\`, deletes \`DesktopPlayerViewModel\` (both platforms consume the shared VMs).