### PR TITLE
W7 Phase E2.2.1 — NowPlayingState sealed hierarchy + combine().stateIn migration

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/DockedNowPlayingBar.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/DockedNowPlayingBar.kt
@@ -37,8 +37,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -51,18 +51,29 @@ import com.calypsan.listenup.client.playback.NowPlayingState
  *
  * Full-width, flush with screen edges, Spotify-desktop style.
  * Progress bar at top, transport controls centered, chapter info on the right.
+ *
+ * Renders for [NowPlayingState.Active] and [NowPlayingState.Preparing] only;
+ * hidden on Idle/Error.
  */
 @Composable
 fun DockedNowPlayingBar(
     state: NowPlayingState,
+    isExpanded: Boolean,
     onTap: () -> Unit,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isVisible =
+        when (state) {
+            is NowPlayingState.Active -> !isExpanded
+            is NowPlayingState.Preparing -> !isExpanded
+            else -> false
+        }
+
     AnimatedVisibility(
-        visible = (state.isVisible || state.isPreparing) && !state.isExpanded,
+        visible = isVisible,
         enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
         modifier = modifier,
@@ -98,155 +109,214 @@ fun DockedNowPlayingBar(
             shape = RectangleShape,
             tonalElevation = 3.dp,
         ) {
-            Column {
-                // Progress bar at the top
-                if (state.isPreparing) {
-                    LinearProgressIndicator(
-                        progress = { state.prepareProgress / 100f },
-                        modifier = Modifier.fillMaxWidth().height(4.dp),
-                        trackColor = Color.Transparent,
-                        color = MaterialTheme.colorScheme.tertiary,
-                        drawStopIndicator = {},
-                    )
-                } else {
-                    LinearProgressIndicator(
-                        progress = { state.bookProgress },
-                        modifier = Modifier.fillMaxWidth().height(4.dp),
-                        trackColor = Color.Transparent,
-                        drawStopIndicator = {},
+            when (state) {
+                is NowPlayingState.Active -> {
+                    ActiveDockedContent(
+                        state = state,
+                        onPlayPause = onPlayPause,
+                        onSkipBack = onSkipBack,
+                        onSkipForward = onSkipForward,
                     )
                 }
 
-                // Main content row — three sections with controls centered
-                Row(
+                is NowPlayingState.Preparing -> {
+                    PreparingDockedContent(state = state)
+                }
+
+                else -> { /* Idle/Error: not visible */ }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActiveDockedContent(
+    state: NowPlayingState.Active,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+) {
+    Column {
+        // Progress bar at the top
+        LinearProgressIndicator(
+            progress = { state.bookProgress },
+            modifier = Modifier.fillMaxWidth().height(4.dp),
+            trackColor = Color.Transparent,
+            drawStopIndicator = {},
+        )
+
+        // Main content row — three sections with controls centered
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .padding(horizontal = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Left: Cover + title/author
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BookCoverImage(
+                    bookId = state.bookId,
+                    coverPath = state.coverPath,
+                    blurHash = state.coverBlurHash,
+                    contentDescription = "Book cover",
                     modifier =
                         Modifier
-                            .fillMaxWidth()
-                            .height(80.dp)
-                            .padding(horizontal = 20.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                            .size(64.dp)
+                            .clip(RoundedCornerShape(8.dp)),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                Column {
+                    Text(
+                        text = state.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state.author,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            // Center: Transport controls
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FilledTonalIconButton(
+                    onClick = onSkipBack,
+                    modifier = Modifier.size(44.dp),
+                    shape = RoundedCornerShape(12.dp),
                 ) {
-                    // Left: Cover + title/author
-                    Row(
-                        modifier = Modifier.weight(1f),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        BookCoverImage(
-                            bookId = state.bookId,
-                            coverPath = state.coverUrl,
-                            blurHash = state.coverBlurHash,
-                            contentDescription = "Book cover",
-                            modifier =
-                                Modifier
-                                    .size(64.dp)
-                                    .clip(RoundedCornerShape(8.dp)),
+                    Icon(
+                        Icons.Default.Replay10,
+                        contentDescription = "Skip back 10 seconds",
+                        modifier = Modifier.size(22.dp),
+                    )
+                }
+
+                FilledIconButton(
+                    onClick = onPlayPause,
+                    modifier = Modifier.size(52.dp),
+                    shape = RoundedCornerShape(14.dp),
+                ) {
+                    Icon(
+                        if (state.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (state.isPlaying) "Pause" else "Play",
+                        modifier = Modifier.size(30.dp),
+                    )
+                }
+
+                FilledTonalIconButton(
+                    onClick = onSkipForward,
+                    modifier = Modifier.size(44.dp),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Icon(
+                        Icons.Default.Forward30,
+                        contentDescription = "Skip forward 30 seconds",
+                        modifier = Modifier.size(22.dp),
+                    )
+                }
+            }
+
+            // Right: Chapter + time remaining
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.End,
+                ) {
+                    state.chapterTitle?.let { chapter ->
+                        Text(
+                            text = chapter,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.End,
                         )
-
-                        Spacer(Modifier.width(16.dp))
-
-                        Column {
-                            Text(
-                                text = state.title.ifEmpty { "Preparing..." },
-                                style = MaterialTheme.typography.titleMedium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            if (state.isPreparing) {
-                                Text(
-                                    text = state.prepareMessage ?: "Preparing audio...",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            } else {
-                                Text(
-                                    text = state.author,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
-                        }
                     }
-
-                    // Center: Transport controls
-                    if (!state.isPreparing) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            FilledTonalIconButton(
-                                onClick = onSkipBack,
-                                modifier = Modifier.size(44.dp),
-                                shape = RoundedCornerShape(12.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Replay10,
-                                    contentDescription = "Skip back 10 seconds",
-                                    modifier = Modifier.size(22.dp),
-                                )
-                            }
-
-                            FilledIconButton(
-                                onClick = onPlayPause,
-                                modifier = Modifier.size(52.dp),
-                                shape = RoundedCornerShape(14.dp),
-                            ) {
-                                Icon(
-                                    if (state.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                                    contentDescription = if (state.isPlaying) "Pause" else "Play",
-                                    modifier = Modifier.size(30.dp),
-                                )
-                            }
-
-                            FilledTonalIconButton(
-                                onClick = onSkipForward,
-                                modifier = Modifier.size(44.dp),
-                                shape = RoundedCornerShape(12.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Forward30,
-                                    contentDescription = "Skip forward 30 seconds",
-                                    modifier = Modifier.size(22.dp),
-                                )
-                            }
-                        }
+                    val remainingMs = state.bookDurationMs - state.bookPositionMs
+                    if (remainingMs > 0) {
+                        Text(
+                            text = formatTimeRemaining(remainingMs),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                            textAlign = TextAlign.End,
+                        )
                     }
+                }
+            }
+        }
+    }
+}
 
-                    // Right: Chapter + time remaining
-                    if (!state.isPreparing) {
-                        Row(
-                            modifier = Modifier.weight(1f),
-                            horizontalArrangement = Arrangement.End,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Column(
-                                horizontalAlignment = Alignment.End,
-                            ) {
-                                state.chapterTitle?.let { chapter ->
-                                    Text(
-                                        text = chapter,
-                                        style = MaterialTheme.typography.labelMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                        textAlign = TextAlign.End,
-                                    )
-                                }
-                                val remainingMs = state.bookDurationMs - state.bookPositionMs
-                                if (remainingMs > 0) {
-                                    Text(
-                                        text = formatTimeRemaining(remainingMs),
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                                        textAlign = TextAlign.End,
-                                    )
-                                }
-                            }
-                        }
-                    }
+@Composable
+private fun PreparingDockedContent(state: NowPlayingState.Preparing) {
+    Column {
+        // Progress bar at the top
+        LinearProgressIndicator(
+            progress = { state.progress / 100f },
+            modifier = Modifier.fillMaxWidth().height(4.dp),
+            trackColor = Color.Transparent,
+            color = MaterialTheme.colorScheme.tertiary,
+            drawStopIndicator = {},
+        )
+
+        // Cover + title/message — no transport controls or chapter info during preparing
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .padding(horizontal = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BookCoverImage(
+                    bookId = state.bookId,
+                    coverPath = state.coverPath,
+                    blurHash = state.coverBlurHash,
+                    contentDescription = "Book cover",
+                    modifier =
+                        Modifier
+                            .size(64.dp)
+                            .clip(RoundedCornerShape(8.dp)),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                Column {
+                    Text(
+                        text = state.title.ifEmpty { "Preparing..." },
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state.message ?: "Preparing audio...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
         }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingBar.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingBar.kt
@@ -1,10 +1,14 @@
 package com.calypsan.listenup.client.features.nowplaying
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,19 +24,15 @@ import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FilledTonalIconButton
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.border
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -52,19 +52,29 @@ import com.calypsan.listenup.client.playback.NowPlayingState
  * - Diverse button sizes (play larger than skips)
  * - Pill-shaped skip buttons (horizontally elongated)
  * - Tonal elevation for depth
+ *
+ * Renders for [NowPlayingState.Active] and [NowPlayingState.Preparing] only;
+ * hidden on Idle/Error.
  */
 @Composable
 fun NowPlayingBar(
     state: NowPlayingState,
+    isExpanded: Boolean,
     onTap: () -> Unit,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Show bar when visible (playing) OR when preparing (transcoding)
+    val isVisible =
+        when (state) {
+            is NowPlayingState.Active -> !isExpanded
+            is NowPlayingState.Preparing -> !isExpanded
+            else -> false
+        }
+
     AnimatedVisibility(
-        visible = (state.isVisible || state.isPreparing) && !state.isExpanded,
+        visible = isVisible,
         enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
         modifier = modifier,
@@ -104,102 +114,155 @@ fun NowPlayingBar(
             tonalElevation = 6.dp,
             shadowElevation = 4.dp,
         ) {
-            Column {
-                Row(
-                    modifier =
-                        Modifier
-                            .weight(1f)
-                            .padding(start = 12.dp, end = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    // Cover art
-                    BookCoverImage(
-                        bookId = state.bookId,
-                        coverPath = state.coverUrl,
-                        blurHash = state.coverBlurHash,
-                        contentDescription = "Book cover",
-                        modifier =
-                            Modifier
-                                .size(56.dp)
-                                .clip(RoundedCornerShape(12.dp)),
+            when (state) {
+                is NowPlayingState.Active -> {
+                    ActiveContent(
+                        state = state,
+                        focusBorderColor = focusBorderColor,
+                        onPlayPause = onPlayPause,
+                        onSkipBack = onSkipBack,
+                        onSkipForward = onSkipForward,
                     )
-
-                    Spacer(Modifier.width(12.dp))
-
-                    // Text info
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = state.title.ifEmpty { "Preparing..." },
-                            style = MaterialTheme.typography.titleMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        if (state.isPreparing) {
-                            // Show prepare message during transcoding
-                            Text(
-                                text = state.prepareMessage ?: "Preparing audio...",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = focusBorderColor,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        } else {
-                            Text(
-                                text = state.author,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            state.chapterTitle?.let { chapter ->
-                                Text(
-                                    text = chapter,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = focusBorderColor,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
-                        }
-                    }
-
-                    // Controls (hide during preparing)
-                    if (!state.isPreparing) {
-                        NowPlayingBarControls(
-                            isPlaying = state.isPlaying,
-                            isBuffering = state.isBuffering,
-                            onPlayPause = onPlayPause,
-                            onSkipBack = onSkipBack,
-                            onSkipForward = onSkipForward,
-                        )
-                    }
                 }
 
-                // Progress bar - show transcode progress during preparing, playback progress otherwise
-                if (state.isPreparing) {
-                    LinearProgressIndicator(
-                        progress = { state.prepareProgress / 100f },
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(3.dp),
-                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                        color = MaterialTheme.colorScheme.tertiary,
-                        drawStopIndicator = {},
-                    )
-                } else {
-                    LinearProgressIndicator(
-                        progress = { state.bookProgress },
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(3.dp),
-                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                        drawStopIndicator = {},
+                is NowPlayingState.Preparing -> {
+                    PreparingContent(state = state, focusBorderColor = focusBorderColor)
+                }
+
+                else -> { /* Idle/Error: not visible */ }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActiveContent(
+    state: NowPlayingState.Active,
+    focusBorderColor: androidx.compose.ui.graphics.Color,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+) {
+    Column {
+        Row(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(start = 12.dp, end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BookCoverImage(
+                bookId = state.bookId,
+                coverPath = state.coverPath,
+                blurHash = state.coverBlurHash,
+                contentDescription = "Book cover",
+                modifier =
+                    Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+            )
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = state.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = state.author,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                state.chapterTitle?.let { chapter ->
+                    Text(
+                        text = chapter,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = focusBorderColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }
+
+            NowPlayingBarControls(
+                isPlaying = state.isPlaying,
+                isBuffering = state.isBuffering,
+                onPlayPause = onPlayPause,
+                onSkipBack = onSkipBack,
+                onSkipForward = onSkipForward,
+            )
         }
+
+        LinearProgressIndicator(
+            progress = { state.bookProgress },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(3.dp),
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            drawStopIndicator = {},
+        )
+    }
+}
+
+@Composable
+private fun PreparingContent(
+    state: NowPlayingState.Preparing,
+    focusBorderColor: androidx.compose.ui.graphics.Color,
+) {
+    Column {
+        Row(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(start = 12.dp, end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BookCoverImage(
+                bookId = state.bookId,
+                coverPath = state.coverPath,
+                blurHash = state.coverBlurHash,
+                contentDescription = "Book cover",
+                modifier =
+                    Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+            )
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = state.title.ifEmpty { "Preparing..." },
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = state.message ?: "Preparing audio...",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = focusBorderColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        LinearProgressIndicator(
+            progress = { state.progress / 100f },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(3.dp),
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            color = MaterialTheme.colorScheme.tertiary,
+            drawStopIndicator = {},
+        )
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -15,17 +15,20 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.calypsan.listenup.client.design.LocalDeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.features.shell.components.NavigationBarHeight
 import com.calypsan.listenup.client.playback.ContributorPickerType
+import com.calypsan.listenup.client.playback.NowPlayingOverlay
+import com.calypsan.listenup.client.playback.NowPlayingState
 import com.calypsan.listenup.client.playback.NowPlayingViewModel
+import com.calypsan.listenup.client.playback.SleepTimerState
 
 /** Height of a standard snackbar for padding calculations */
 private val SnackbarHeight = 48.dp
@@ -49,18 +52,21 @@ fun NowPlayingHost(
     viewModel: NowPlayingViewModel,
     modifier: Modifier = Modifier,
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-    val sleepTimerState by viewModel.sleepTimerState.collectAsStateWithLifecycle()
+    val screenState by viewModel.screenState.collectAsStateWithLifecycle()
     val isSnackbarVisible = snackbarHostState?.currentSnackbarData != null
 
     val deviceContext = LocalDeviceContext.current
     val useDockedBar = deviceContext.type in setOf(DeviceType.Tv, DeviceType.Desktop, DeviceType.Tablet)
     val isTv = deviceContext.isLeanback
 
+    val state = screenState.state
+    val activeState = state as? NowPlayingState.Active
+
     Box(modifier = modifier.fillMaxSize()) {
-        // Full screen (slides up when expanded)
+        // Full screen (slides up when expanded). Only renders when we have an Active book —
+        // expanding into Idle/Error has no meaningful UI.
         AnimatedVisibility(
-            visible = state.isExpanded,
+            visible = screenState.isExpanded && activeState != null,
             enter =
                 slideInVertically(
                     initialOffsetY = { it },
@@ -80,42 +86,45 @@ fun NowPlayingHost(
                         ),
                 ) + fadeOut(),
         ) {
-            NowPlayingScreen(
-                state = state,
-                sleepTimerState = sleepTimerState,
-                onCollapse = viewModel::collapse,
-                onPlayPause = viewModel::playPause,
-                onSeek = viewModel::seekWithinChapter,
-                onSkipBack = { viewModel.skipBack() },
-                onSkipForward = { viewModel.skipForward() },
-                onPreviousChapter = viewModel::previousChapter,
-                onNextChapter = viewModel::nextChapter,
-                onSpeedClick = viewModel::showSpeedPicker,
-                onChaptersClick = viewModel::showChapterPicker,
-                onSleepTimerClick = viewModel::showSleepTimer,
-                onGoToBook = {
-                    viewModel.collapse()
-                    onNavigateToBook(state.bookId)
-                },
-                onGoToSeries = { seriesId ->
-                    viewModel.collapse()
-                    onNavigateToSeries(seriesId)
-                },
-                onGoToContributor = { contributorId ->
-                    viewModel.collapse()
-                    onNavigateToContributor(contributorId)
-                },
-                onShowAuthorPicker = { viewModel.showContributorPicker(ContributorPickerType.AUTHORS) },
-                onShowNarratorPicker = { viewModel.showContributorPicker(ContributorPickerType.NARRATORS) },
-                onCloseBook = viewModel::closeBook,
-                isTv = isTv,
-            )
+            if (activeState != null) {
+                NowPlayingScreen(
+                    state = activeState,
+                    sleepTimerState = screenState.sleepTimerState,
+                    onCollapse = viewModel::collapse,
+                    onPlayPause = viewModel::playPause,
+                    onSeek = viewModel::seekWithinChapter,
+                    onSkipBack = { viewModel.skipBack() },
+                    onSkipForward = { viewModel.skipForward() },
+                    onPreviousChapter = viewModel::previousChapter,
+                    onNextChapter = viewModel::nextChapter,
+                    onSpeedClick = viewModel::showSpeedPicker,
+                    onChaptersClick = viewModel::showChapterPicker,
+                    onSleepTimerClick = viewModel::showSleepTimer,
+                    onGoToBook = {
+                        viewModel.collapse()
+                        onNavigateToBook(activeState.bookId)
+                    },
+                    onGoToSeries = { seriesId ->
+                        viewModel.collapse()
+                        onNavigateToSeries(seriesId)
+                    },
+                    onGoToContributor = { contributorId ->
+                        viewModel.collapse()
+                        onNavigateToContributor(contributorId)
+                    },
+                    onShowAuthorPicker = { viewModel.showContributorPicker(ContributorPickerType.AUTHORS) },
+                    onShowNarratorPicker = { viewModel.showContributorPicker(ContributorPickerType.NARRATORS) },
+                    onCloseBook = viewModel::closeBook,
+                    isTv = isTv,
+                )
+            }
         }
 
         // Mini player — docked bar for TV/Desktop/Tablet, floating pill for phone
         if (useDockedBar) {
             DockedNowPlayingBar(
                 state = state,
+                isExpanded = screenState.isExpanded,
                 onTap = viewModel::expand,
                 onPlayPause = viewModel::playPause,
                 onSkipBack = { viewModel.skipBack() },
@@ -147,6 +156,7 @@ fun NowPlayingHost(
 
             NowPlayingBar(
                 state = state,
+                isExpanded = screenState.isExpanded,
                 onTap = viewModel::expand,
                 onPlayPause = viewModel::playPause,
                 onSkipBack = { viewModel.skipBack() },
@@ -158,18 +168,39 @@ fun NowPlayingHost(
             )
         }
 
-        // Chapter picker sheet
-        if (state.showChapterPicker) {
-            ChapterPickerSheet(
-                chapters = viewModel.getChapters(),
-                currentChapterIndex = state.chapterIndex,
-                onChapterSelected = viewModel::seekToChapter,
-                onDismiss = viewModel::hideChapterPicker,
-            )
+        OverlayDispatch(
+            overlay = screenState.overlay,
+            sleepTimerState = screenState.sleepTimerState,
+            activeState = activeState,
+            viewModel = viewModel,
+            onNavigateToContributor = onNavigateToContributor,
+        )
+    }
+}
+
+@Composable
+private fun OverlayDispatch(
+    overlay: NowPlayingOverlay,
+    sleepTimerState: SleepTimerState,
+    activeState: NowPlayingState.Active?,
+    viewModel: NowPlayingViewModel,
+    onNavigateToContributor: (String) -> Unit,
+) {
+    when (overlay) {
+        NowPlayingOverlay.None -> { /* no overlay */ }
+
+        NowPlayingOverlay.ChapterPicker -> {
+            if (activeState != null) {
+                ChapterPickerSheet(
+                    chapters = viewModel.getChapters(),
+                    currentChapterIndex = activeState.chapterIndex,
+                    onChapterSelected = viewModel::seekToChapter,
+                    onDismiss = viewModel::hideChapterPicker,
+                )
+            }
         }
 
-        // Sleep timer sheet
-        if (state.showSleepTimer) {
+        NowPlayingOverlay.SleepTimer -> {
             SleepTimerSheet(
                 currentState = sleepTimerState,
                 onSetTimer = viewModel::setSleepTimer,
@@ -179,34 +210,36 @@ fun NowPlayingHost(
             )
         }
 
-        // Contributor picker sheet (for multiple authors/narrators)
-        state.showContributorPicker?.let { pickerType ->
-            val contributors =
-                when (pickerType) {
-                    ContributorPickerType.AUTHORS -> state.authors
-                    ContributorPickerType.NARRATORS -> state.narrators
-                }
-            ContributorPickerSheet(
-                type = pickerType,
-                contributors = contributors,
-                onContributorSelected = { contributorId ->
-                    viewModel.hideContributorPicker()
-                    viewModel.collapse()
-                    onNavigateToContributor(contributorId)
-                },
-                onDismiss = viewModel::hideContributorPicker,
-            )
+        is NowPlayingOverlay.ContributorPicker -> {
+            if (activeState != null) {
+                val contributors =
+                    when (overlay.type) {
+                        ContributorPickerType.AUTHORS -> activeState.authors
+                        ContributorPickerType.NARRATORS -> activeState.narrators
+                    }
+                ContributorPickerSheet(
+                    type = overlay.type,
+                    contributors = contributors,
+                    onContributorSelected = { contributorId ->
+                        viewModel.hideContributorPicker()
+                        viewModel.collapse()
+                        onNavigateToContributor(contributorId)
+                    },
+                    onDismiss = viewModel::hideContributorPicker,
+                )
+            }
         }
 
-        // Speed picker sheet
-        if (state.showSpeedPicker) {
-            PlaybackSpeedSheet(
-                currentSpeed = state.playbackSpeed,
-                defaultSpeed = state.defaultPlaybackSpeed,
-                onSpeedChange = viewModel::setSpeed,
-                onResetToDefault = viewModel::resetSpeedToDefault,
-                onDismiss = viewModel::hideSpeedPicker,
-            )
+        NowPlayingOverlay.SpeedPicker -> {
+            if (activeState != null) {
+                PlaybackSpeedSheet(
+                    currentSpeed = activeState.playbackSpeed,
+                    defaultSpeed = activeState.defaultPlaybackSpeed,
+                    onSpeedChange = viewModel::setSpeed,
+                    onResetToDefault = viewModel::resetSpeedToDefault,
+                    onDismiss = viewModel::hideSpeedPicker,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
@@ -119,7 +119,7 @@ private val logger = KotlinLogging.logger {}
 @Suppress("LongMethod", "LongParameterList")
 @Composable
 fun NowPlayingScreen(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     sleepTimerState: SleepTimerState,
     onCollapse: () -> Unit,
     onPlayPause: () -> Unit,
@@ -376,7 +376,7 @@ fun NowPlayingScreen(
 @Suppress("LongParameterList")
 @Composable
 private fun TallNowPlayingLayout(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     sleepTimerState: SleepTimerState,
     breathScale: Float,
     ambientAlpha: Float,
@@ -432,7 +432,7 @@ private fun TallNowPlayingLayout(
         ) {
             CoverArt(
                 bookId = state.bookId,
-                coverUrl = state.coverUrl,
+                coverUrl = state.coverPath,
                 breathScale = breathScale,
                 onColorExtracted = onColorExtracted,
             )
@@ -501,7 +501,7 @@ private fun TallNowPlayingLayout(
 @Suppress("LongParameterList", "LongMethod")
 @Composable
 private fun WideNowPlayingLayout(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     sleepTimerState: SleepTimerState,
     dominantColor: Color,
     breathScale: Float,
@@ -543,7 +543,7 @@ private fun WideNowPlayingLayout(
         ) {
             CoverArt(
                 bookId = state.bookId,
-                coverUrl = state.coverUrl,
+                coverUrl = state.coverPath,
                 breathScale = breathScale,
                 onColorExtracted = onColorExtracted,
             )
@@ -655,7 +655,7 @@ private fun WideNowPlayingLayout(
 @Suppress("CognitiveComplexMethod")
 @Composable
 private fun NowPlayingTopBar(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     onCollapse: () -> Unit,
     onGoToBook: () -> Unit,
     onGoToSeries: (String) -> Unit,
@@ -720,7 +720,7 @@ private fun NowPlayingTopBar(
                 )
 
                 // Go to Series (if available)
-                if (state.hasSeries) {
+                if (state.seriesId != null) {
                     DropdownMenuItem(
                         text = { Text("Go to Series") },
                         onClick = {

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -534,8 +534,12 @@ private fun AuthenticatedNavigation(
                                 currentDestination = currentShellDestination,
                                 onDestinationChange = { currentShellDestination = it },
                                 nowPlayingContent = {
+                                    val nowPlayingScreenState by nowPlayingViewModel
+                                        .screenState
+                                        .collectAsStateWithLifecycle()
                                     NowPlayingBar(
-                                        state = nowPlayingViewModel.state.collectAsStateWithLifecycle().value,
+                                        state = nowPlayingScreenState.state,
+                                        isExpanded = nowPlayingScreenState.isExpanded,
                                         onTap = nowPlayingViewModel::expand,
                                         onPlayPause = nowPlayingViewModel::playPause,
                                         onSkipBack = { nowPlayingViewModel.skipBack() },

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
@@ -94,7 +96,7 @@ class NowPlayingViewModel(
         }
 
     /** Sealed playback state derived from book + dynamics + metadata via the pure mapper. */
-    private val nowPlayingState: StateFlow<NowPlayingState> =
+    private val nowPlayingState: Flow<NowPlayingState> =
         combine(
             bookFlow,
             dynamicsRawFlow,
@@ -113,11 +115,7 @@ class NowPlayingViewModel(
                     ),
                 metadata = metadata,
             )
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
-            initialValue = NowPlayingState.Idle,
-        )
+        }
 
     /** Tail-combined screen state; the only flow the UI subscribes to. */
     val screenState: StateFlow<NowPlayingScreenState> =
@@ -145,8 +143,6 @@ class NowPlayingViewModel(
                 ),
         )
 
-    private var lastNotifiedChapterIndex: Int = -1
-
     init {
         // Acquire reference to shared controller
         playbackController.acquire()
@@ -157,15 +153,15 @@ class NowPlayingViewModel(
         }
 
         // Side effect: notify SleepTimerManager when the chapter index changes
-        // (drives end-of-chapter sleep timer). This is NOT replaced by the combine
-        // chain — it is a side effect, not a state derivation.
+        // (drives end-of-chapter sleep timer). Distinct-by-index dedupes within the
+        // flow rather than via a private var.
         viewModelScope.launch {
-            playbackManager.currentChapter.collect { chapterInfo ->
-                if (chapterInfo != null && chapterInfo.index != lastNotifiedChapterIndex) {
-                    lastNotifiedChapterIndex = chapterInfo.index
+            playbackManager.currentChapter
+                .filterNotNull()
+                .distinctUntilChangedBy { it.index }
+                .collect { chapterInfo ->
                     sleepTimerManager.onChapterChanged(chapterInfo.index)
                 }
-            }
         }
 
         // Side effect: handle sleep timer fade-out events
@@ -290,8 +286,7 @@ class NowPlayingViewModel(
     // === Playback actions ===
 
     fun playPause() {
-        val isPlaying = (nowPlayingState.value as? NowPlayingState.Active)?.isPlaying == true
-        if (isPlaying) {
+        if (playbackManager.isPlaying.value) {
             playbackController.pause()
         } else {
             playbackController.play()
@@ -339,16 +334,14 @@ class NowPlayingViewModel(
     }
 
     fun previousChapter() {
-        val activeState = nowPlayingState.value as? NowPlayingState.Active
-        val currentIndex = activeState?.chapterIndex ?: 0
+        val currentIndex = playbackManager.currentChapter.value?.index ?: 0
         logger.debug { "previousChapter called: current=$currentIndex" }
         val newIndex = (currentIndex - 1).coerceAtLeast(0)
         seekToChapter(newIndex)
     }
 
     fun nextChapter() {
-        val activeState = nowPlayingState.value as? NowPlayingState.Active
-        val currentIndex = activeState?.chapterIndex ?: 0
+        val currentIndex = playbackManager.currentChapter.value?.index ?: 0
         val chapters = playbackManager.chapters.value
         logger.debug { "nextChapter called: current=$currentIndex, total=${chapters.size}" }
         val newIndex = (currentIndex + 1).coerceAtMost(chapters.lastIndex.coerceAtLeast(0))
@@ -373,8 +366,7 @@ class NowPlayingViewModel(
 
     fun seekWithinChapter(progress: Float) {
         logger.debug { "seekWithinChapter called: progress=$progress" }
-        val activeState = nowPlayingState.value as? NowPlayingState.Active
-        val currentIndex = activeState?.chapterIndex ?: 0
+        val currentIndex = playbackManager.currentChapter.value?.index ?: 0
         val chapters = playbackManager.chapters.value
         val currentChapter = chapters.getOrNull(currentIndex)
         if (currentChapter == null) {

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
@@ -5,14 +5,22 @@ package com.calypsan.listenup.client.playback
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
@@ -20,9 +28,13 @@ private val logger = KotlinLogging.logger {}
 /**
  * ViewModel for Now Playing UI (mini player and full screen).
  *
- * Observes PlaybackManager state and transforms it into UI state.
- * Handles chapter-level position calculations.
- * Uses [PlaybackController] for all command-side operations.
+ * Composes [PlaybackManager] flows + book metadata + UI ephemera into a single
+ * [NowPlayingScreenState] via layered `combine().stateIn(WhileSubscribed)`. The
+ * heavy upstream pipeline ([nowPlayingState]) is independent of overlay/expand
+ * ephemera, which join only at the screen-state boundary so picker toggles do
+ * not re-execute the upstream combine chain.
+ *
+ * All command-side operations route through [PlaybackController].
  */
 class NowPlayingViewModel(
     private val playbackManager: PlaybackManager,
@@ -31,114 +43,148 @@ class NowPlayingViewModel(
     private val playbackController: PlaybackController,
     private val playbackPreferences: PlaybackPreferences,
 ) : ViewModel() {
-    val state: StateFlow<NowPlayingState>
-        field = MutableStateFlow(NowPlayingState())
+    private companion object {
+        const val FADE_DURATION_MS = 3000L
+        const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
+    }
 
-    val sleepTimerState: StateFlow<SleepTimerState> = sleepTimerManager.state
+    private val overlayFlow = MutableStateFlow<NowPlayingOverlay>(NowPlayingOverlay.None)
+    private val isExpandedFlow = MutableStateFlow(false)
+    private val defaultPlaybackSpeedFlow = MutableStateFlow(1.0f)
+
+    /** Reactive book metadata for the current book id. One-shot fetch on bookId change via flatMapLatest. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val bookFlow: Flow<BookListItem?> =
+        playbackManager.currentBookId.flatMapLatest { bookId ->
+            flow {
+                emit(loadBook(bookId))
+            }
+        }
+
+    /** Aggregated playback dynamics (4 flows joined into one). */
+    private val dynamicsRawFlow: Flow<DynamicsRaw> =
+        combine(
+            playbackManager.isPlaying,
+            playbackManager.isBuffering,
+            playbackManager.currentPositionMs,
+            playbackManager.totalDurationMs,
+        ) { isPlaying, isBuffering, position, duration ->
+            DynamicsRaw(
+                isPlaying = isPlaying,
+                isBuffering = isBuffering,
+                currentPositionMs = position,
+                totalDurationMs = duration,
+            )
+        }
+
+    /** Aggregated surface metadata (chapter info + prepare progress + error + default speed). */
+    private val surfaceMetadataFlow: Flow<SurfaceMetadata> =
+        combine(
+            playbackManager.currentChapter,
+            playbackManager.prepareProgress,
+            playbackManager.playbackError,
+            defaultPlaybackSpeedFlow,
+        ) { chapter, prepare, error, defaultSpeed ->
+            SurfaceMetadata(
+                currentChapter = chapter,
+                prepareProgress = prepare,
+                error = error,
+                defaultPlaybackSpeed = defaultSpeed,
+            )
+        }
+
+    /** Sealed playback state derived from book + dynamics + metadata via the pure mapper. */
+    private val nowPlayingState: StateFlow<NowPlayingState> =
+        combine(
+            bookFlow,
+            dynamicsRawFlow,
+            playbackManager.playbackSpeed,
+            surfaceMetadataFlow,
+        ) { book, dynamicsRaw, speed, metadata ->
+            mapToNowPlayingState(
+                book = book,
+                dynamics =
+                    PlaybackDynamics(
+                        isPlaying = dynamicsRaw.isPlaying,
+                        isBuffering = dynamicsRaw.isBuffering,
+                        currentPositionMs = dynamicsRaw.currentPositionMs,
+                        totalDurationMs = dynamicsRaw.totalDurationMs,
+                        playbackSpeed = speed,
+                    ),
+                metadata = metadata,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
+            initialValue = NowPlayingState.Idle,
+        )
+
+    /** Tail-combined screen state; the only flow the UI subscribes to. */
+    val screenState: StateFlow<NowPlayingScreenState> =
+        combine(
+            nowPlayingState,
+            overlayFlow,
+            isExpandedFlow,
+            sleepTimerManager.state,
+        ) { state, overlay, isExpanded, sleepTimer ->
+            NowPlayingScreenState(
+                state = state,
+                overlay = overlay,
+                isExpanded = isExpanded,
+                sleepTimerState = sleepTimer,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
+            initialValue =
+                NowPlayingScreenState(
+                    state = NowPlayingState.Idle,
+                    overlay = NowPlayingOverlay.None,
+                    isExpanded = false,
+                    sleepTimerState = sleepTimerManager.state.value,
+                ),
+        )
 
     private var lastNotifiedChapterIndex: Int = -1
-
-    companion object {
-        private const val FADE_DURATION_MS = 3000L
-    }
 
     init {
         // Acquire reference to shared controller
         playbackController.acquire()
-        observePlayback()
-        observeSleepTimer()
-        loadDefaultPlaybackSpeed()
-    }
 
-    private fun loadDefaultPlaybackSpeed() {
+        // Load default playback speed (drives surfaceMetadataFlow)
         viewModelScope.launch {
-            val defaultSpeed = playbackPreferences.getDefaultPlaybackSpeed()
-            state.update { it.copy(defaultPlaybackSpeed = defaultSpeed) }
-        }
-    }
-
-    private fun observePlayback() {
-        // Observe current book
-        viewModelScope.launch {
-            playbackManager.currentBookId.collect { bookId ->
-                if (bookId != null) {
-                    loadBookInfo(bookId)
-                } else {
-                    state.update { it.copy(isVisible = false, isExpanded = false) }
-                }
-            }
+            defaultPlaybackSpeedFlow.value = playbackPreferences.getDefaultPlaybackSpeed()
         }
 
-        // Observe playback state (playing/paused)
-        viewModelScope.launch {
-            playbackManager.isPlaying.collect { isPlaying ->
-                state.update { it.copy(isPlaying = isPlaying) }
-            }
-        }
-
-        // Observe position updates
-        viewModelScope.launch {
-            playbackManager.currentPositionMs.collect { positionMs ->
-                updatePosition(positionMs)
-            }
-        }
-
-        // Observe current chapter from PlaybackManager
+        // Side effect: notify SleepTimerManager when the chapter index changes
+        // (drives end-of-chapter sleep timer). This is NOT replaced by the combine
+        // chain — it is a side effect, not a state derivation.
         viewModelScope.launch {
             playbackManager.currentChapter.collect { chapterInfo ->
-                if (chapterInfo != null) {
-                    // Notify sleep timer manager of chapter changes (for end-of-chapter mode)
-                    if (chapterInfo.index != lastNotifiedChapterIndex) {
-                        lastNotifiedChapterIndex = chapterInfo.index
-                        sleepTimerManager.onChapterChanged(chapterInfo.index)
-                    }
-
-                    state.update {
-                        it.copy(
-                            chapterIndex = chapterInfo.index,
-                            chapterTitle = chapterInfo.title,
-                            totalChapters = chapterInfo.totalChapters,
-                            chapterDurationMs = chapterInfo.endMs - chapterInfo.startMs,
-                        )
-                    }
+                if (chapterInfo != null && chapterInfo.index != lastNotifiedChapterIndex) {
+                    lastNotifiedChapterIndex = chapterInfo.index
+                    sleepTimerManager.onChapterChanged(chapterInfo.index)
                 }
             }
         }
 
-        // Observe playback speed
-        viewModelScope.launch {
-            playbackManager.playbackSpeed.collect { speed ->
-                state.update { it.copy(playbackSpeed = speed) }
-            }
-        }
-
-        // Observe total duration
-        viewModelScope.launch {
-            playbackManager.totalDurationMs.collect { durationMs ->
-                state.update { it.copy(bookDurationMs = durationMs) }
-            }
-        }
-
-        // Observe prepare progress (transcode status)
-        viewModelScope.launch {
-            playbackManager.prepareProgress.collect { progress ->
-                state.update {
-                    it.copy(
-                        isPreparing = progress != null,
-                        prepareProgress = progress?.progress ?: 0,
-                        prepareMessage = progress?.message,
-                    )
-                }
-            }
-        }
-    }
-
-    private fun observeSleepTimer() {
-        // Handle sleep timer events (fade out and pause)
+        // Side effect: handle sleep timer fade-out events
         viewModelScope.launch {
             sleepTimerManager.sleepEvent.collect {
                 fadeOutAndPause()
             }
+        }
+    }
+
+    private suspend fun loadBook(bookId: BookId?): BookListItem? {
+        if (bookId == null) return null
+        return try {
+            bookRepository.getBookListItem(bookId.value)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "getBookListItem failed for ${bookId.value}" }
+            null
         }
     }
 
@@ -172,128 +218,49 @@ class NowPlayingViewModel(
         sleepTimerManager.onFadeCompleted()
     }
 
-    private suspend fun loadBookInfo(bookId: BookId) {
-        logger.debug { "loadBookInfo called for bookId=${bookId.value}" }
-        val book = bookRepository.getBookListItem(bookId.value)
-        if (book == null) {
-            logger.warn { "Book not found: $bookId" }
-            return
-        }
-
-        // Chapters are now loaded by PlaybackManager and observed via currentChapter flow
-        val chapters = playbackManager.chapters.value
-
-        state.update {
-            it.copy(
-                isVisible = true,
-                bookId = bookId.value,
-                title = book.title,
-                author = book.authorNames,
-                coverUrl = book.coverPath,
-                coverBlurHash = book.coverBlurHash,
-                authors = book.authors,
-                narrators = book.narrators,
-                seriesId = book.seriesId,
-                seriesName = book.seriesName,
-                bookDurationMs = book.duration,
-                totalChapters = chapters.size,
-            )
-        }
-
-        logger.debug { "Loaded book info: ${book.title}, ${chapters.size} chapters" }
-    }
-
-    private fun updatePosition(bookPositionMs: Long) {
-        val bookDurationMs = state.value.bookDurationMs
-        val bookProgress =
-            if (bookDurationMs > 0) {
-                bookPositionMs.toFloat() / bookDurationMs
-            } else {
-                0f
-            }
-
-        // Chapter info comes from PlaybackManager.currentChapter observer
-        val chapterInfo = playbackManager.currentChapter.value
-        val (chapterProgress, chapterPositionMs) =
-            if (chapterInfo != null) {
-                val posInChapter = bookPositionMs - chapterInfo.startMs
-                val chapterDuration = chapterInfo.endMs - chapterInfo.startMs
-                val progress =
-                    if (chapterDuration > 0) {
-                        posInChapter.toFloat() / chapterDuration
-                    } else {
-                        0f
-                    }
-                progress.coerceIn(0f, 1f) to posInChapter.coerceAtLeast(0)
-            } else {
-                0f to 0L
-            }
-
-        // Only log errors for invalid progress values
-        @Suppress("ComplexCondition")
-        if (bookProgress.isNaN() ||
-            bookProgress.isInfinite() ||
-            chapterProgress.isNaN() ||
-            chapterProgress.isInfinite()
-        ) {
-            logger.error { "Invalid progress: book=$bookProgress, chapter=$chapterProgress, duration=$bookDurationMs" }
-            return // Don't update state with invalid values
-        }
-
-        // Debounce: only update if position changed by >200ms to prevent excessive recomposition
-        val currentState = state.value
-        val positionDeltaMs = kotlin.math.abs(bookPositionMs - currentState.bookPositionMs)
-
-        // Skip update if change is too small (time-based, not percentage-based)
-        if (positionDeltaMs < 200) {
-            return
-        }
-
-        state.update {
-            it.copy(
-                bookProgress = bookProgress.coerceIn(0f, 1f),
-                bookPositionMs = bookPositionMs,
-                chapterProgress = chapterProgress,
-                chapterPositionMs = chapterPositionMs,
-            )
-        }
-    }
-
-    // UI Actions
+    // === UI ephemera setters ===
 
     fun expand() {
-        state.update { it.copy(isExpanded = true) }
+        isExpandedFlow.value = true
     }
 
     fun collapse() {
-        state.update { it.copy(isExpanded = false) }
+        isExpandedFlow.value = false
     }
 
     fun showChapterPicker() {
-        state.update { it.copy(showChapterPicker = true) }
+        overlayFlow.value = NowPlayingOverlay.ChapterPicker
     }
 
     fun hideChapterPicker() {
-        state.update { it.copy(showChapterPicker = false) }
+        overlayFlow.value = NowPlayingOverlay.None
     }
 
     fun showSpeedPicker() {
-        state.update { it.copy(showSpeedPicker = true) }
+        overlayFlow.value = NowPlayingOverlay.SpeedPicker
     }
 
     fun hideSpeedPicker() {
-        state.update { it.copy(showSpeedPicker = false) }
+        overlayFlow.value = NowPlayingOverlay.None
     }
 
     fun showSleepTimer() {
-        state.update { it.copy(showSleepTimer = true) }
+        overlayFlow.value = NowPlayingOverlay.SleepTimer
     }
 
     fun hideSleepTimer() {
-        state.update { it.copy(showSleepTimer = false) }
+        overlayFlow.value = NowPlayingOverlay.None
     }
 
-    // Sleep Timer Actions
+    fun showContributorPicker(type: ContributorPickerType) {
+        overlayFlow.value = NowPlayingOverlay.ContributorPicker(type)
+    }
+
+    fun hideContributorPicker() {
+        overlayFlow.value = NowPlayingOverlay.None
+    }
+
+    // === Sleep Timer ===
 
     fun setSleepTimer(mode: SleepTimerMode) {
         sleepTimerManager.setTimer(mode)
@@ -308,17 +275,7 @@ class NowPlayingViewModel(
         sleepTimerManager.extendTimer(minutes)
     }
 
-    // Contributor Picker Actions
-
-    fun showContributorPicker(type: ContributorPickerType) {
-        state.update { it.copy(showContributorPicker = type) }
-    }
-
-    fun hideContributorPicker() {
-        state.update { it.copy(showContributorPicker = null) }
-    }
-
-    // Book Actions
+    // === Book actions ===
 
     /**
      * Close the book entirely - stops playback and clears state.
@@ -330,10 +287,11 @@ class NowPlayingViewModel(
         collapse()
     }
 
-    // Playback Actions
+    // === Playback actions ===
 
     fun playPause() {
-        if (state.value.isPlaying) {
+        val isPlaying = (nowPlayingState.value as? NowPlayingState.Active)?.isPlaying == true
+        if (isPlaying) {
             playbackController.pause()
         } else {
             playbackController.play()
@@ -349,7 +307,8 @@ class NowPlayingViewModel(
         }
 
         val currentBookPos = playbackManager.currentPositionMs.value
-        val newBookPos = (currentBookPos - (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtLeast(0)
+        val speed = playbackManager.playbackSpeed.value
+        val newBookPos = (currentBookPos - (seconds * speed * 1000).toLong()).coerceAtLeast(0)
         logger.debug { "skipBack: currentPos=$currentBookPos, newPos=$newBookPos" }
 
         playbackController.seekTo(newBookPos)
@@ -367,8 +326,9 @@ class NowPlayingViewModel(
 
         val currentBookPos = playbackManager.currentPositionMs.value
         val totalDuration = playbackManager.totalDurationMs.value
+        val speed = playbackManager.playbackSpeed.value
         val newBookPos =
-            (currentBookPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(
+            (currentBookPos + (seconds * speed * 1000).toLong()).coerceAtMost(
                 totalDuration,
             )
         logger.debug { "skipForward: currentPos=$currentBookPos, newPos=$newBookPos, totalDuration=$totalDuration" }
@@ -379,15 +339,19 @@ class NowPlayingViewModel(
     }
 
     fun previousChapter() {
-        logger.debug { "previousChapter called: current=${state.value.chapterIndex}" }
-        val newIndex = (state.value.chapterIndex - 1).coerceAtLeast(0)
+        val activeState = nowPlayingState.value as? NowPlayingState.Active
+        val currentIndex = activeState?.chapterIndex ?: 0
+        logger.debug { "previousChapter called: current=$currentIndex" }
+        val newIndex = (currentIndex - 1).coerceAtLeast(0)
         seekToChapter(newIndex)
     }
 
     fun nextChapter() {
+        val activeState = nowPlayingState.value as? NowPlayingState.Active
+        val currentIndex = activeState?.chapterIndex ?: 0
         val chapters = playbackManager.chapters.value
-        logger.debug { "nextChapter called: current=${state.value.chapterIndex}, total=${chapters.size}" }
-        val newIndex = (state.value.chapterIndex + 1).coerceAtMost(chapters.lastIndex.coerceAtLeast(0))
+        logger.debug { "nextChapter called: current=$currentIndex, total=${chapters.size}" }
+        val newIndex = (currentIndex + 1).coerceAtMost(chapters.lastIndex.coerceAtLeast(0))
         seekToChapter(newIndex)
     }
 
@@ -409,8 +373,10 @@ class NowPlayingViewModel(
 
     fun seekWithinChapter(progress: Float) {
         logger.debug { "seekWithinChapter called: progress=$progress" }
+        val activeState = nowPlayingState.value as? NowPlayingState.Active
+        val currentIndex = activeState?.chapterIndex ?: 0
         val chapters = playbackManager.chapters.value
-        val currentChapter = chapters.getOrNull(state.value.chapterIndex)
+        val currentChapter = chapters.getOrNull(currentIndex)
         if (currentChapter == null) {
             logger.warn { "seekWithinChapter: no current chapter" }
             return
@@ -441,6 +407,7 @@ class NowPlayingViewModel(
     fun resetSpeedToDefault() {
         viewModelScope.launch {
             val defaultSpeed = playbackPreferences.getDefaultPlaybackSpeed()
+            defaultPlaybackSpeedFlow.value = defaultSpeed
             playbackController.setPlaybackSpeed(defaultSpeed)
             // Notify PlaybackManager that user reset to default
             playbackManager.onSpeedReset(defaultSpeed)
@@ -454,7 +421,7 @@ class NowPlayingViewModel(
 
     fun cycleSpeed() {
         val speeds = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 2.5f, 3.0f)
-        val currentSpeed = state.value.playbackSpeed
+        val currentSpeed = playbackManager.playbackSpeed.value
         val currentIndex = speeds.indexOfFirst { it >= currentSpeed - 0.01f }
         val nextIndex = if (currentIndex == -1 || currentIndex >= speeds.lastIndex) 0 else currentIndex + 1
         setSpeed(speeds[nextIndex])
@@ -467,4 +434,11 @@ class NowPlayingViewModel(
         // Release our reference to the shared controller
         playbackController.release()
     }
+
+    private data class DynamicsRaw(
+        val isPlaying: Boolean,
+        val isBuffering: Boolean,
+        val currentPositionMs: Long,
+        val totalDurationMs: Long,
+    )
 }

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -144,6 +144,7 @@ val platformModule: Module =
                 progressTracker = get(),
                 bookRepository = get(),
                 playbackPreferences = get(),
+                sleepTimerManager = get(),
             )
         }
 

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
@@ -153,6 +153,9 @@ class DesktopPlayerViewModel(
         )
 
     init {
+        // Note: DesktopPlaybackController.acquire/release are no-ops, so we don't call them
+        // here (Android does). If Desktop ever grows session lifecycle, mirror Android's pattern.
+
         // Load default playback speed (drives surfaceMetadataFlow)
         viewModelScope.launch {
             defaultPlaybackSpeedFlow.value = playbackPreferences.getDefaultPlaybackSpeed()
@@ -321,6 +324,7 @@ class DesktopPlayerViewModel(
         }
 
         playbackManager.clearPlayback()
+        sleepTimerManager.cancelTimer()
     }
 
     fun getChapters(): List<Chapter> = playbackManager.chapters.value

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
@@ -1,19 +1,27 @@
-@file:Suppress("MagicNumber")
+@file:Suppress("MagicNumber", "TooManyFunctions")
 
 package com.calypsan.listenup.client.playback
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
@@ -22,9 +30,18 @@ private val logger = KotlinLogging.logger {}
 /**
  * Desktop playback ViewModel.
  *
- * Thin bridge between UI and PlaybackManager/AudioPlayer.
- * Observes PlaybackManager state flows and forwards user actions to AudioPlayer.
- * Handles ProgressTracker integration for pause/resume events.
+ * Composes [PlaybackManager] flows + book metadata + UI ephemera into a single
+ * [NowPlayingScreenState] via layered `combine().stateIn(WhileSubscribed)`. Mirrors
+ * the Android `NowPlayingViewModel` shape — the heavy upstream pipeline is independent
+ * of overlay/expand ephemera, which join only at the screen-state boundary.
+ *
+ * Side-effect collectors (ProgressTracker pause/resume notifications + 30 s ticker +
+ * GStreamer error reporting) live in separate `viewModelScope.launch { collect }` blocks,
+ * not in the state-deriving combines.
+ *
+ * Desktop currently has no UI for overlays / expanded mode / sleep timer, but the screen
+ * state still tail-combines those flows for shape parity with Android (and to enable
+ * future Desktop UI without re-plumbing).
  */
 class DesktopPlayerViewModel(
     private val playbackManager: PlaybackManager,
@@ -33,32 +50,117 @@ class DesktopPlayerViewModel(
     private val progressTracker: ProgressTracker,
     private val bookRepository: BookRepository,
     private val playbackPreferences: PlaybackPreferences,
+    private val sleepTimerManager: SleepTimerManager,
 ) : ViewModel() {
-    val state: StateFlow<NowPlayingState>
-        field = MutableStateFlow(NowPlayingState())
+    private companion object {
+        const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
+        const val PROGRESS_TICK_MS = 30_000L
+    }
+
+    private val overlayFlow = MutableStateFlow<NowPlayingOverlay>(NowPlayingOverlay.None)
+    private val isExpandedFlow = MutableStateFlow(false)
+    private val defaultPlaybackSpeedFlow = MutableStateFlow(1.0f)
 
     private var periodicUpdateJob: Job? = null
 
-    init {
-        observePlayback()
-    }
-
-    private fun observePlayback() {
-        // Observe current book
-        viewModelScope.launch {
-            playbackManager.currentBookId.collect { bookId ->
-                if (bookId != null) {
-                    loadBookInfo(bookId)
-                } else {
-                    state.update { it.copy(isVisible = false) }
-                }
+    /** Reactive book metadata for the current book id. One-shot fetch on bookId change via flatMapLatest. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val bookFlow: Flow<BookListItem?> =
+        playbackManager.currentBookId.flatMapLatest { bookId ->
+            flow {
+                emit(loadBook(bookId))
             }
         }
 
-        // Observe playback state
+    /** Aggregated playback dynamics (4 flows joined into one). */
+    private val dynamicsRawFlow: Flow<DynamicsRaw> =
+        combine(
+            playbackManager.isPlaying,
+            playbackManager.isBuffering,
+            playbackManager.currentPositionMs,
+            playbackManager.totalDurationMs,
+        ) { isPlaying, isBuffering, position, duration ->
+            DynamicsRaw(
+                isPlaying = isPlaying,
+                isBuffering = isBuffering,
+                currentPositionMs = position,
+                totalDurationMs = duration,
+            )
+        }
+
+    /** Aggregated surface metadata (chapter info + prepare progress + error + default speed). */
+    private val surfaceMetadataFlow: Flow<SurfaceMetadata> =
+        combine(
+            playbackManager.currentChapter,
+            playbackManager.prepareProgress,
+            playbackManager.playbackError,
+            defaultPlaybackSpeedFlow,
+        ) { chapter, prepare, error, defaultSpeed ->
+            SurfaceMetadata(
+                currentChapter = chapter,
+                prepareProgress = prepare,
+                error = error,
+                defaultPlaybackSpeed = defaultSpeed,
+            )
+        }
+
+    /** Sealed playback state derived from book + dynamics + metadata via the pure mapper. */
+    private val nowPlayingState: Flow<NowPlayingState> =
+        combine(
+            bookFlow,
+            dynamicsRawFlow,
+            playbackManager.playbackSpeed,
+            surfaceMetadataFlow,
+        ) { book, dynamicsRaw, speed, metadata ->
+            mapToNowPlayingState(
+                book = book,
+                dynamics =
+                    PlaybackDynamics(
+                        isPlaying = dynamicsRaw.isPlaying,
+                        isBuffering = dynamicsRaw.isBuffering,
+                        currentPositionMs = dynamicsRaw.currentPositionMs,
+                        totalDurationMs = dynamicsRaw.totalDurationMs,
+                        playbackSpeed = speed,
+                    ),
+                metadata = metadata,
+            )
+        }
+
+    /** Tail-combined screen state; the only flow the UI subscribes to. */
+    val screenState: StateFlow<NowPlayingScreenState> =
+        combine(
+            nowPlayingState,
+            overlayFlow,
+            isExpandedFlow,
+            sleepTimerManager.state,
+        ) { state, overlay, isExpanded, sleepTimer ->
+            NowPlayingScreenState(
+                state = state,
+                overlay = overlay,
+                isExpanded = isExpanded,
+                sleepTimerState = sleepTimer,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
+            initialValue =
+                NowPlayingScreenState(
+                    state = NowPlayingState.Idle,
+                    overlay = NowPlayingOverlay.None,
+                    isExpanded = false,
+                    sleepTimerState = sleepTimerManager.state.value,
+                ),
+        )
+
+    init {
+        // Load default playback speed (drives surfaceMetadataFlow)
+        viewModelScope.launch {
+            defaultPlaybackSpeedFlow.value = playbackPreferences.getDefaultPlaybackSpeed()
+        }
+
+        // Side effect: drive periodic ProgressTracker ticks while playing
         viewModelScope.launch {
             playbackManager.isPlaying.collect { isPlaying ->
-                state.update { it.copy(isPlaying = isPlaying) }
                 if (isPlaying) {
                     startPeriodicUpdates()
                 } else {
@@ -67,67 +169,31 @@ class DesktopPlayerViewModel(
             }
         }
 
-        // Observe position
-        viewModelScope.launch {
-            playbackManager.currentPositionMs.collect { positionMs ->
-                updatePosition(positionMs)
-            }
-        }
-
-        // Observe chapter
-        viewModelScope.launch {
-            playbackManager.currentChapter.collect { chapterInfo ->
-                if (chapterInfo != null) {
-                    state.update {
-                        it.copy(
-                            chapterIndex = chapterInfo.index,
-                            chapterTitle = chapterInfo.title,
-                            totalChapters = chapterInfo.totalChapters,
-                            chapterDurationMs = chapterInfo.endMs - chapterInfo.startMs,
-                        )
-                    }
-                }
-            }
-        }
-
-        // Observe speed
-        viewModelScope.launch {
-            playbackManager.playbackSpeed.collect { speed ->
-                state.update { it.copy(playbackSpeed = speed) }
-            }
-        }
-
-        // Observe total duration
-        viewModelScope.launch {
-            playbackManager.totalDurationMs.collect { durationMs ->
-                state.update { it.copy(bookDurationMs = durationMs) }
-            }
-        }
-
-        // Observe prepare progress
-        viewModelScope.launch {
-            playbackManager.prepareProgress.collect { progress ->
-                state.update {
-                    it.copy(
-                        isPreparing = progress != null,
-                        prepareProgress = progress?.progress ?: 0,
-                        prepareMessage = progress?.message,
-                    )
-                }
-            }
-        }
-
-        // Observe audio player errors
+        // Side effect: surface GStreamer / FFmpeg playback errors through the canonical
+        // playbackError flow so the mapper produces NowPlayingState.Error.
         viewModelScope.launch {
             playbackManager.playbackState.collect { playbackState ->
                 if (playbackState == PlaybackState.Error) {
-                    state.update {
-                        it.copy(errorMessage = "Playback error. Check GStreamer installation.")
-                    }
+                    playbackManager.reportError(
+                        message = "Playback error. Check GStreamer installation.",
+                        isRecoverable = false,
+                    )
                 } else if (playbackState == PlaybackState.Playing) {
-                    state.update { it.copy(errorMessage = null) }
+                    playbackManager.clearError()
                 }
             }
+        }
+    }
+
+    private suspend fun loadBook(bookId: BookId?): BookListItem? {
+        if (bookId == null) return null
+        return try {
+            bookRepository.getBookListItem(bookId.value)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "getBookListItem failed for ${bookId.value}" }
+            null
         }
     }
 
@@ -136,16 +202,15 @@ class DesktopPlayerViewModel(
      */
     fun playBook(bookId: BookId) {
         viewModelScope.launch {
-            state.update { it.copy(isPreparing = true, errorMessage = null) }
-
             val result = playbackManager.prepareForPlayback(bookId)
             if (result == null) {
-                state.update { it.copy(isPreparing = false, errorMessage = "Failed to prepare playback") }
+                playbackManager.reportError(
+                    message = "Failed to prepare playback",
+                    isRecoverable = true,
+                )
                 logger.error { "Failed to prepare playback for $bookId" }
                 return@launch
             }
-
-            state.update { it.copy(isPreparing = false) }
 
             playbackManager.startPlayback(
                 player = audioPlayer,
@@ -153,13 +218,12 @@ class DesktopPlayerViewModel(
                 resumeSpeed = result.resumeSpeed,
             )
 
-            // Check if playback actually started
+            // Check if playback actually started; reportError if not
             if (playbackManager.playbackState.value == PlaybackState.Error) {
-                state.update {
-                    it.copy(
-                        errorMessage = "Playback failed. Check that GStreamer plugins are installed correctly.",
-                    )
-                }
+                playbackManager.reportError(
+                    message = "Playback failed. Check that GStreamer plugins are installed correctly.",
+                    isRecoverable = false,
+                )
             }
         }
     }
@@ -185,14 +249,16 @@ class DesktopPlayerViewModel(
 
     fun skipBack(seconds: Int = 10) {
         val currentPos = playbackManager.currentPositionMs.value
-        val newPos = (currentPos - (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtLeast(0)
+        val speed = playbackManager.playbackSpeed.value
+        val newPos = (currentPos - (seconds * speed * 1000).toLong()).coerceAtLeast(0)
         playbackController.seekTo(newPos)
     }
 
     fun skipForward(seconds: Int = 30) {
         val currentPos = playbackManager.currentPositionMs.value
         val totalDuration = playbackManager.totalDurationMs.value
-        val newPos = (currentPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(totalDuration)
+        val speed = playbackManager.playbackSpeed.value
+        val newPos = (currentPos + (seconds * speed * 1000).toLong()).coerceAtMost(totalDuration)
         playbackController.seekTo(newPos)
     }
 
@@ -204,7 +270,8 @@ class DesktopPlayerViewModel(
 
     fun seekWithinChapter(progress: Float) {
         val chapters = playbackManager.chapters.value
-        val currentChapter = chapters.getOrNull(state.value.chapterIndex) ?: return
+        val currentIndex = playbackManager.currentChapter.value?.index ?: 0
+        val currentChapter = chapters.getOrNull(currentIndex) ?: return
         val targetPosition = currentChapter.startTime + (currentChapter.duration * progress).toLong()
         playbackController.seekTo(targetPosition)
     }
@@ -217,6 +284,7 @@ class DesktopPlayerViewModel(
     fun resetSpeedToDefault() {
         viewModelScope.launch {
             val defaultSpeed = playbackPreferences.getDefaultPlaybackSpeed()
+            defaultPlaybackSpeedFlow.value = defaultSpeed
             playbackController.setPlaybackSpeed(defaultSpeed)
             playbackManager.onSpeedReset(defaultSpeed)
         }
@@ -224,20 +292,22 @@ class DesktopPlayerViewModel(
 
     fun cycleSpeed() {
         val speeds = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 2.5f, 3.0f)
-        val currentSpeed = state.value.playbackSpeed
+        val currentSpeed = playbackManager.playbackSpeed.value
         val currentIndex = speeds.indexOfFirst { it >= currentSpeed - 0.01f }
         val nextIndex = if (currentIndex == -1 || currentIndex >= speeds.lastIndex) 0 else currentIndex + 1
         setSpeed(speeds[nextIndex])
     }
 
     fun previousChapter() {
-        val newIndex = (state.value.chapterIndex - 1).coerceAtLeast(0)
+        val currentIndex = playbackManager.currentChapter.value?.index ?: 0
+        val newIndex = (currentIndex - 1).coerceAtLeast(0)
         seekToChapter(newIndex)
     }
 
     fun nextChapter() {
         val chapters = playbackManager.chapters.value
-        val newIndex = (state.value.chapterIndex + 1).coerceAtMost(chapters.lastIndex.coerceAtLeast(0))
+        val currentIndex = playbackManager.currentChapter.value?.index ?: 0
+        val newIndex = (currentIndex + 1).coerceAtMost(chapters.lastIndex.coerceAtLeast(0))
         seekToChapter(newIndex)
     }
 
@@ -255,67 +325,46 @@ class DesktopPlayerViewModel(
 
     fun getChapters(): List<Chapter> = playbackManager.chapters.value
 
-    private suspend fun loadBookInfo(bookId: BookId) {
-        val book = bookRepository.getBookListItem(bookId.value) ?: return
-        val chapters = playbackManager.chapters.value
+    // === UI ephemera setters (mirror Android for shape parity) ===
 
-        state.update {
-            it.copy(
-                isVisible = true,
-                bookId = bookId.value,
-                title = book.title,
-                author = book.authorNames,
-                coverUrl = book.coverPath,
-                coverBlurHash = book.coverBlurHash,
-                authors = book.authors,
-                narrators = book.narrators,
-                seriesId = book.seriesId,
-                seriesName = book.seriesName,
-                bookDurationMs = book.duration,
-                totalChapters = chapters.size,
-                playbackSpeed = playbackManager.playbackSpeed.value,
-                isPlaying = playbackManager.isPlaying.value,
-            )
-        }
+    fun expand() {
+        isExpandedFlow.value = true
     }
 
-    private fun updatePosition(bookPositionMs: Long) {
-        val bookDurationMs = state.value.bookDurationMs
-        val bookProgress =
-            if (bookDurationMs > 0) {
-                bookPositionMs.toFloat() / bookDurationMs
-            } else {
-                0f
-            }
+    fun collapse() {
+        isExpandedFlow.value = false
+    }
 
-        val chapterInfo = playbackManager.currentChapter.value
-        val (chapterProgress, chapterPositionMs) =
-            if (chapterInfo != null) {
-                val posInChapter = bookPositionMs - chapterInfo.startMs
-                val chapterDuration = chapterInfo.endMs - chapterInfo.startMs
-                val progress =
-                    if (chapterDuration > 0) {
-                        posInChapter.toFloat() / chapterDuration
-                    } else {
-                        0f
-                    }
-                progress.coerceIn(0f, 1f) to posInChapter.coerceAtLeast(0)
-            } else {
-                0f to 0L
-            }
+    fun showChapterPicker() {
+        overlayFlow.value = NowPlayingOverlay.ChapterPicker
+    }
 
-        // Debounce: skip tiny changes
-        val positionDeltaMs = kotlin.math.abs(bookPositionMs - state.value.bookPositionMs)
-        if (positionDeltaMs < 200) return
+    fun hideChapterPicker() {
+        overlayFlow.value = NowPlayingOverlay.None
+    }
 
-        state.update {
-            it.copy(
-                bookProgress = bookProgress.coerceIn(0f, 1f),
-                bookPositionMs = bookPositionMs,
-                chapterProgress = chapterProgress,
-                chapterPositionMs = chapterPositionMs,
-            )
-        }
+    fun showSpeedPicker() {
+        overlayFlow.value = NowPlayingOverlay.SpeedPicker
+    }
+
+    fun hideSpeedPicker() {
+        overlayFlow.value = NowPlayingOverlay.None
+    }
+
+    fun showSleepTimer() {
+        overlayFlow.value = NowPlayingOverlay.SleepTimer
+    }
+
+    fun hideSleepTimer() {
+        overlayFlow.value = NowPlayingOverlay.None
+    }
+
+    fun showContributorPicker(type: ContributorPickerType) {
+        overlayFlow.value = NowPlayingOverlay.ContributorPicker(type)
+    }
+
+    fun hideContributorPicker() {
+        overlayFlow.value = NowPlayingOverlay.None
     }
 
     /**
@@ -326,7 +375,7 @@ class DesktopPlayerViewModel(
         periodicUpdateJob =
             viewModelScope.launch {
                 while (isActive) {
-                    delay(30_000)
+                    delay(PROGRESS_TICK_MS)
                     val bookId = playbackManager.currentBookId.value ?: continue
                     val positionMs = playbackManager.currentPositionMs.value
                     val speed = playbackManager.playbackSpeed.value
@@ -344,4 +393,11 @@ class DesktopPlayerViewModel(
         super.onCleared()
         stopPeriodicUpdates()
     }
+
+    private data class DynamicsRaw(
+        val isPlaying: Boolean,
+        val isBuffering: Boolean,
+        val currentPositionMs: Long,
+        val totalDurationMs: Long,
+    )
 }

--- a/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
@@ -68,6 +68,7 @@ import com.calypsan.listenup.client.features.tagdetail.TagDetailScreen
 import com.calypsan.listenup.client.features.profile.UserProfileScreen
 import com.calypsan.listenup.client.navigation.AuthNavigation
 import com.calypsan.listenup.client.playback.DesktopPlayerViewModel
+import com.calypsan.listenup.client.playback.NowPlayingState
 import com.calypsan.listenup.client.presentation.search.SearchViewModel
 import com.calypsan.listenup.desktop.nowplaying.DesktopNowPlayingBar
 import com.calypsan.listenup.desktop.nowplaying.DesktopNowPlayingScreen
@@ -212,7 +213,8 @@ private fun DesktopAuthenticatedNavigation() {
     val playerViewModel: DesktopPlayerViewModel = koinInject()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val playerState by playerViewModel.state.collectAsStateWithLifecycle()
+    val playerScreenState by playerViewModel.screenState.collectAsStateWithLifecycle()
+    val playerState = playerScreenState.state
 
     var currentDestination by remember { mutableStateOf<ShellDestination>(ShellDestination.Home) }
     val backStack: SnapshotStateList<DetailDestination> =
@@ -287,8 +289,8 @@ private fun DesktopAuthenticatedNavigation() {
                 }
             }
 
-            // Persistent mini player (visible when playing, hidden on NowPlaying screen)
-            if (playerState.isVisible && !isShowingNowPlaying) {
+            // Persistent mini player (visible when a book is loaded, hidden on NowPlaying screen)
+            if (playerState !is NowPlayingState.Idle && !isShowingNowPlaying) {
                 DesktopNowPlayingBar(
                     state = playerState,
                     onPlayPause = { playerViewModel.playPause() },
@@ -477,7 +479,17 @@ private fun DetailScreen(
         }
 
         is DetailDestination.NowPlaying -> {
-            val state by playerViewModel.state.collectAsStateWithLifecycle()
+            val screenState by playerViewModel.screenState.collectAsStateWithLifecycle()
+            val state = screenState.state
+            // "Go to Book" only meaningful when there's a known bookId — Active or
+            // Preparing variants populate it; Error sometimes does; Idle never.
+            val activeBookId: String? =
+                when (state) {
+                    is NowPlayingState.Active -> state.bookId
+                    is NowPlayingState.Preparing -> state.bookId
+                    is NowPlayingState.Error -> state.bookId
+                    is NowPlayingState.Idle -> null
+                }
             DesktopNowPlayingScreen(
                 state = state,
                 onPlayPause = { playerViewModel.playPause() },
@@ -492,10 +504,13 @@ private fun DetailScreen(
                     navigateBack()
                 },
                 onBackClick = navigateBack,
-                onGoToBook = {
-                    navigateBack()
-                    navigateTo(DetailDestination.Book(state.bookId))
-                },
+                onGoToBook =
+                    activeBookId?.let { id ->
+                        {
+                            navigateBack()
+                            navigateTo(DetailDestination.Book(id))
+                        }
+                    },
                 onGoToSeries = { seriesId ->
                     navigateBack()
                     navigateTo(DetailDestination.Series(seriesId))

--- a/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/media/GlobalMediaKeyManager.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/media/GlobalMediaKeyManager.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.desktop.media
 
 import com.calypsan.listenup.client.playback.DesktopPlayerViewModel
+import com.calypsan.listenup.client.playback.NowPlayingState
 import com.github.kwhat.jnativehook.GlobalScreen
 import com.github.kwhat.jnativehook.NativeHookException
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent
@@ -27,7 +28,8 @@ class GlobalMediaKeyManager(
     private val keyListener =
         object : NativeKeyListener {
             override fun nativeKeyPressed(event: NativeKeyEvent) {
-                if (!playerViewModel.state.value.isVisible) return
+                // Only intercept global media keys when there's a book loaded.
+                if (playerViewModel.screenState.value.state is NowPlayingState.Idle) return
 
                 when (event.keyCode) {
                     NativeKeyEvent.VC_MEDIA_PLAY -> {

--- a/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/nowplaying/DesktopNowPlayingBar.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/nowplaying/DesktopNowPlayingBar.kt
@@ -35,7 +35,11 @@ import com.calypsan.listenup.client.playback.NowPlayingState
 /**
  * Mini player bar shown at the bottom of the desktop window during playback.
  *
- * Shows cover art, title/chapter info, playback controls, and a progress indicator.
+ * Renders the appropriate UI for the [NowPlayingState] sealed variant — full controls
+ * when [NowPlayingState.Active], a preparing indicator on [NowPlayingState.Preparing],
+ * an error band on [NowPlayingState.Error]. Caller is expected to skip rendering
+ * entirely on [NowPlayingState.Idle].
+ *
  * Clicking the bar (outside of controls) expands to the full now-playing screen.
  */
 @Composable
@@ -54,8 +58,13 @@ fun DesktopNowPlayingBar(
     ) {
         Column {
             // Progress indicator at top of bar
+            val progress =
+                when (state) {
+                    is NowPlayingState.Active -> state.bookProgress.coerceIn(0f, 1f)
+                    else -> 0f
+                }
             LinearProgressIndicator(
-                progress = { state.bookProgress.coerceIn(0f, 1f) },
+                progress = { progress },
                 modifier = Modifier.fillMaxWidth().height(3.dp),
                 color = MaterialTheme.colorScheme.primary,
                 trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -69,80 +78,138 @@ fun DesktopNowPlayingBar(
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // Cover art
-                Box(
-                    modifier =
-                        Modifier
-                            .size(48.dp)
-                            .clip(RoundedCornerShape(6.dp))
-                            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-                ) {
-                    BookCoverImage(
-                        bookId = state.bookId,
-                        coverPath = state.coverUrl,
-                        contentDescription = state.title,
-                        blurHash = state.coverBlurHash,
-                        modifier = Modifier.size(48.dp),
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(12.dp))
-
-                // Title and chapter/error info
-                Column(modifier = Modifier.weight(1f)) {
-                    val errorMessage = state.errorMessage
-                    if (errorMessage != null) {
-                        Text(
-                            text = errorMessage,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    } else {
-                        Text(
-                            text = state.title,
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            text = state.chapterTitle ?: state.author,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                when (state) {
+                    is NowPlayingState.Idle -> {
+                        Unit
                     }
-                }
 
-                Spacer(modifier = Modifier.width(8.dp))
+                    is NowPlayingState.Preparing -> {
+                        BarCover(
+                            bookId = state.bookId,
+                            coverPath = state.coverPath,
+                            blurHash = state.coverBlurHash,
+                            contentDescription = state.title,
+                        )
 
-                // Playback controls
-                IconButton(onClick = onSkipBack, modifier = Modifier.size(36.dp)) {
-                    Icon(
-                        Icons.Default.SkipPrevious,
-                        contentDescription = "Skip back",
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
+                        Spacer(modifier = Modifier.width(12.dp))
 
-                IconButton(onClick = onPlayPause, modifier = Modifier.size(44.dp)) {
-                    Icon(
-                        imageVector = if (state.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                        contentDescription = if (state.isPlaying) "Pause" else "Play",
-                        modifier = Modifier.size(28.dp),
-                    )
-                }
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = state.title,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = state.message ?: "Preparing…",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
 
-                IconButton(onClick = onSkipForward, modifier = Modifier.size(36.dp)) {
-                    Icon(
-                        Icons.Default.SkipNext,
-                        contentDescription = "Skip forward",
-                        modifier = Modifier.size(20.dp),
-                    )
+                    is NowPlayingState.Active -> {
+                        BarCover(
+                            bookId = state.bookId,
+                            coverPath = state.coverPath,
+                            blurHash = state.coverBlurHash,
+                            contentDescription = state.title,
+                        )
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = state.title,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = state.chapterTitle ?: state.author,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        // Playback controls
+                        IconButton(onClick = onSkipBack, modifier = Modifier.size(36.dp)) {
+                            Icon(
+                                Icons.Default.SkipPrevious,
+                                contentDescription = "Skip back",
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+
+                        IconButton(onClick = onPlayPause, modifier = Modifier.size(44.dp)) {
+                            Icon(
+                                imageVector = if (state.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                contentDescription = if (state.isPlaying) "Pause" else "Play",
+                                modifier = Modifier.size(28.dp),
+                            )
+                        }
+
+                        IconButton(onClick = onSkipForward, modifier = Modifier.size(36.dp)) {
+                            Icon(
+                                Icons.Default.SkipNext,
+                                contentDescription = "Skip forward",
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+
+                    is NowPlayingState.Error -> {
+                        Column(modifier = Modifier.weight(1f)) {
+                            val errorTitle = state.title
+                            if (errorTitle != null) {
+                                Text(
+                                    text = errorTitle,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            Text(
+                                text = state.message,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun BarCover(
+    bookId: String,
+    coverPath: String?,
+    blurHash: String?,
+    contentDescription: String,
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+    ) {
+        BookCoverImage(
+            bookId = bookId,
+            coverPath = coverPath,
+            contentDescription = contentDescription,
+            blurHash = blurHash,
+            modifier = Modifier.size(48.dp),
+        )
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/nowplaying/DesktopNowPlayingScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/nowplaying/DesktopNowPlayingScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -87,13 +88,13 @@ private val logger = KotlinLogging.logger {}
 /**
  * Full-screen now-playing view for desktop.
  *
- * Adaptive layout with M3 Expressive styling:
- * - Wide layout: cover on left, controls on right
- * - Tall layout: vertical arrangement (centered)
- * - Dynamic color glow from cover art via kmpalette
- * - M3 Expressive wavy seek bar
- * - M3 connected button group for transport controls
- * - Overflow menu with navigation to book/series/contributor
+ * Dispatches over the [NowPlayingState] sealed hierarchy: [NowPlayingState.Active]
+ * gets the full transport / wavy seek bar / overflow menu UI; [NowPlayingState.Preparing]
+ * shows a centred preparing card; [NowPlayingState.Error] shows an error card with retry
+ * affordances; [NowPlayingState.Idle] shows nothing meaningful (caller normally avoids
+ * routing here when Idle).
+ *
+ * Active layout adapts: wide → cover left / controls right; tall → vertical centre.
  */
 @Composable
 fun DesktopNowPlayingScreen(
@@ -112,12 +113,183 @@ fun DesktopNowPlayingScreen(
     onGoToContributor: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
+    Surface(modifier = modifier.fillMaxSize()) {
+        when (state) {
+            is NowPlayingState.Idle -> {
+                IdleScreen(onBackClick = onBackClick)
+            }
+
+            is NowPlayingState.Preparing -> {
+                PreparingScreen(
+                    state = state,
+                    onBackClick = onBackClick,
+                )
+            }
+
+            is NowPlayingState.Error -> {
+                ErrorScreen(
+                    state = state,
+                    onBackClick = onBackClick,
+                    onClose = onClose,
+                )
+            }
+
+            is NowPlayingState.Active -> {
+                ActiveScreen(
+                    state = state,
+                    onPlayPause = onPlayPause,
+                    onSkipBack = onSkipBack,
+                    onSkipForward = onSkipForward,
+                    onPreviousChapter = onPreviousChapter,
+                    onNextChapter = onNextChapter,
+                    onSeekWithinChapter = onSeekWithinChapter,
+                    onSetSpeed = onSetSpeed,
+                    onClose = onClose,
+                    onBackClick = onBackClick,
+                    onGoToBook = onGoToBook,
+                    onGoToSeries = onGoToSeries,
+                    onGoToContributor = onGoToContributor,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdleScreen(onBackClick: () -> Unit) {
+    Column(modifier = Modifier.fillMaxSize().padding(24.dp)) {
+        IconButton(onClick = onBackClick) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                text = "No book is currently playing",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreparingScreen(
+    state: NowPlayingState.Preparing,
+    onBackClick: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize().padding(24.dp)) {
+        IconButton(onClick = onBackClick) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Box(
+                modifier = Modifier.size(180.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CoverArt(
+                    bookId = state.bookId,
+                    coverUrl = state.coverPath,
+                    blurHash = state.coverBlurHash,
+                )
+            }
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = state.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = state.author,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(24.dp))
+            LinearProgressIndicator(
+                progress = { state.progress.coerceIn(0, 100) / 100f },
+                modifier = Modifier.width(240.dp),
+            )
+            val prepareMessage = state.message
+            if (prepareMessage != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = prepareMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorScreen(
+    state: NowPlayingState.Error,
+    onBackClick: () -> Unit,
+    onClose: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize().padding(24.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            IconButton(onClick = onBackClick) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            IconButton(onClick = onClose) {
+                Icon(Icons.Default.Close, contentDescription = "Close player")
+            }
+        }
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (state.title != null) {
+                Text(
+                    text = "Failed to play ${state.title}",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+            Text(
+                text = state.message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 400.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActiveScreen(
+    state: NowPlayingState.Active,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+    onPreviousChapter: () -> Unit,
+    onNextChapter: () -> Unit,
+    onSeekWithinChapter: (Float) -> Unit,
+    onSetSpeed: (Float) -> Unit,
+    onClose: () -> Unit,
+    onBackClick: () -> Unit,
+    onGoToBook: (() -> Unit)?,
+    onGoToSeries: ((String) -> Unit)?,
+    onGoToContributor: ((String) -> Unit)?,
+) {
     // Dynamic color from cover art
     var dominantColor by remember { mutableStateOf(Color.Transparent) }
 
-    // Extract color when cover URL changes
-    LaunchedEffect(state.coverUrl) {
-        val coverPath = state.coverUrl
+    LaunchedEffect(state.coverPath) {
+        val coverPath = state.coverPath
         if (coverPath != null) {
             val color = extractDominantColor(coverPath)
             if (color != null) {
@@ -126,93 +298,91 @@ fun DesktopNowPlayingScreen(
         }
     }
 
-    Surface(modifier = modifier.fillMaxSize()) {
-        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-            val isWideLayout = maxWidth > maxHeight
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val isWideLayout = maxWidth > maxHeight
 
-            // Glow background
-            if (dominantColor != Color.Transparent) {
-                if (isWideLayout) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxHeight()
-                                .width(maxWidth * 0.5f)
-                                .align(Alignment.CenterStart)
-                                .background(
-                                    brush =
-                                        Brush.horizontalGradient(
-                                            colorStops =
-                                                arrayOf(
-                                                    0.0f to dominantColor.copy(alpha = 0.5f),
-                                                    0.3f to dominantColor.copy(alpha = 0.4f),
-                                                    0.6f to dominantColor.copy(alpha = 0.2f),
-                                                    0.85f to dominantColor.copy(alpha = 0.05f),
-                                                    1.0f to Color.Transparent,
-                                                ),
-                                        ),
-                                ),
-                    )
-                } else {
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(550.dp)
-                                .offset(y = 80.dp)
-                                .align(Alignment.TopCenter)
-                                .background(
-                                    brush =
-                                        Brush.verticalGradient(
-                                            colorStops =
-                                                arrayOf(
-                                                    0.0f to Color.Transparent,
-                                                    0.15f to dominantColor.copy(alpha = 0.3f),
-                                                    0.35f to dominantColor.copy(alpha = 0.6f),
-                                                    0.5f to dominantColor.copy(alpha = 0.6f),
-                                                    0.65f to dominantColor.copy(alpha = 0.3f),
-                                                    0.85f to dominantColor.copy(alpha = 0.1f),
-                                                    1.0f to Color.Transparent,
-                                                ),
-                                        ),
-                                ),
-                    )
-                }
-            }
-
+        // Glow background
+        if (dominantColor != Color.Transparent) {
             if (isWideLayout) {
-                WideLayout(
-                    state = state,
-                    onPlayPause = onPlayPause,
-                    onSkipBack = onSkipBack,
-                    onSkipForward = onSkipForward,
-                    onPreviousChapter = onPreviousChapter,
-                    onNextChapter = onNextChapter,
-                    onSeek = onSeekWithinChapter,
-                    onSetSpeed = onSetSpeed,
-                    onClose = onClose,
-                    onBackClick = onBackClick,
-                    onGoToBook = onGoToBook,
-                    onGoToSeries = onGoToSeries,
-                    onGoToContributor = onGoToContributor,
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxHeight()
+                            .width(maxWidth * 0.5f)
+                            .align(Alignment.CenterStart)
+                            .background(
+                                brush =
+                                    Brush.horizontalGradient(
+                                        colorStops =
+                                            arrayOf(
+                                                0.0f to dominantColor.copy(alpha = 0.5f),
+                                                0.3f to dominantColor.copy(alpha = 0.4f),
+                                                0.6f to dominantColor.copy(alpha = 0.2f),
+                                                0.85f to dominantColor.copy(alpha = 0.05f),
+                                                1.0f to Color.Transparent,
+                                            ),
+                                    ),
+                            ),
                 )
             } else {
-                TallLayout(
-                    state = state,
-                    onPlayPause = onPlayPause,
-                    onSkipBack = onSkipBack,
-                    onSkipForward = onSkipForward,
-                    onPreviousChapter = onPreviousChapter,
-                    onNextChapter = onNextChapter,
-                    onSeek = onSeekWithinChapter,
-                    onSetSpeed = onSetSpeed,
-                    onClose = onClose,
-                    onBackClick = onBackClick,
-                    onGoToBook = onGoToBook,
-                    onGoToSeries = onGoToSeries,
-                    onGoToContributor = onGoToContributor,
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(550.dp)
+                            .offset(y = 80.dp)
+                            .align(Alignment.TopCenter)
+                            .background(
+                                brush =
+                                    Brush.verticalGradient(
+                                        colorStops =
+                                            arrayOf(
+                                                0.0f to Color.Transparent,
+                                                0.15f to dominantColor.copy(alpha = 0.3f),
+                                                0.35f to dominantColor.copy(alpha = 0.6f),
+                                                0.5f to dominantColor.copy(alpha = 0.6f),
+                                                0.65f to dominantColor.copy(alpha = 0.3f),
+                                                0.85f to dominantColor.copy(alpha = 0.1f),
+                                                1.0f to Color.Transparent,
+                                            ),
+                                    ),
+                            ),
                 )
             }
+        }
+
+        if (isWideLayout) {
+            WideLayout(
+                state = state,
+                onPlayPause = onPlayPause,
+                onSkipBack = onSkipBack,
+                onSkipForward = onSkipForward,
+                onPreviousChapter = onPreviousChapter,
+                onNextChapter = onNextChapter,
+                onSeek = onSeekWithinChapter,
+                onSetSpeed = onSetSpeed,
+                onClose = onClose,
+                onBackClick = onBackClick,
+                onGoToBook = onGoToBook,
+                onGoToSeries = onGoToSeries,
+                onGoToContributor = onGoToContributor,
+            )
+        } else {
+            TallLayout(
+                state = state,
+                onPlayPause = onPlayPause,
+                onSkipBack = onSkipBack,
+                onSkipForward = onSkipForward,
+                onPreviousChapter = onPreviousChapter,
+                onNextChapter = onNextChapter,
+                onSeek = onSeekWithinChapter,
+                onSetSpeed = onSetSpeed,
+                onClose = onClose,
+                onBackClick = onBackClick,
+                onGoToBook = onGoToBook,
+                onGoToSeries = onGoToSeries,
+                onGoToContributor = onGoToContributor,
+            )
         }
     }
 }
@@ -253,7 +423,7 @@ private suspend fun extractDominantColor(coverPath: String): Color? =
 
 @Composable
 private fun TallLayout(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
@@ -294,7 +464,7 @@ private fun TallLayout(
         ) {
             CoverArt(
                 bookId = state.bookId,
-                coverUrl = state.coverUrl,
+                coverUrl = state.coverPath,
                 blurHash = state.coverBlurHash,
             )
         }
@@ -349,7 +519,7 @@ private fun TallLayout(
 
 @Composable
 private fun WideLayout(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
@@ -380,7 +550,7 @@ private fun WideLayout(
         ) {
             CoverArt(
                 bookId = state.bookId,
-                coverUrl = state.coverUrl,
+                coverUrl = state.coverPath,
                 blurHash = state.coverBlurHash,
             )
         }
@@ -439,7 +609,7 @@ private fun WideLayout(
 
 @Composable
 private fun TopBar(
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     onBackClick: () -> Unit,
     onClose: () -> Unit,
     onGoToBook: (() -> Unit)?,
@@ -487,7 +657,7 @@ private fun TopBar(
 private fun OverflowMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
-    state: NowPlayingState,
+    state: NowPlayingState.Active,
     onGoToBook: (() -> Unit)?,
     onGoToSeries: ((String) -> Unit)?,
     onGoToContributor: ((String) -> Unit)?,
@@ -508,12 +678,13 @@ private fun OverflowMenu(
             )
         }
 
-        if (onGoToSeries != null && state.hasSeries) {
+        val seriesId = state.seriesId
+        if (onGoToSeries != null && seriesId != null) {
             DropdownMenuItem(
                 text = { Text("Go to Series") },
                 onClick = {
                     onDismiss()
-                    state.seriesId?.let { onGoToSeries(it) }
+                    onGoToSeries(seriesId)
                 },
                 leadingIcon = { Icon(Icons.AutoMirrored.Filled.LibraryBooks, contentDescription = null) },
             )

--- a/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/window/ListenUpWindow.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/calypsan/listenup/desktop/window/ListenUpWindow.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.design.theme.ListenUpTheme
 import com.calypsan.listenup.client.domain.model.ThemeMode
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.playback.DesktopPlayerViewModel
+import com.calypsan.listenup.client.playback.NowPlayingState
 import com.calypsan.listenup.desktop.DesktopApp
 import com.calypsan.listenup.desktop.tray.ListenUpTray
 import org.koin.compose.koinInject
@@ -98,7 +99,8 @@ private fun handleMediaKey(
     key: Key,
     playerViewModel: DesktopPlayerViewModel,
 ): Boolean {
-    if (!playerViewModel.state.value.isVisible) return false
+    // Only intercept media keys when there's a book loaded (any non-Idle variant).
+    if (playerViewModel.screenState.value.state is NowPlayingState.Idle) return false
 
     return when (key) {
         Key.MediaPlayPause, Key.Spacebar -> {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingOverlay.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.client.playback
+
+/**
+ * Picker / dialog overlay state. Mutually exclusive — at most one overlay open at a time.
+ * Held by the VM in a private `MutableStateFlow<NowPlayingOverlay>`; tail-combined with
+ * [NowPlayingState] into [NowPlayingScreenState].
+ *
+ * Replaces the pre-Phase-E2.2.1 boolean fields on the flat NowPlayingState
+ * (`showChapterPicker`, `showSpeedPicker`, `showSleepTimer`, `showContributorPicker`).
+ */
+sealed interface NowPlayingOverlay {
+    data object None : NowPlayingOverlay
+
+    data object ChapterPicker : NowPlayingOverlay
+
+    data object SpeedPicker : NowPlayingOverlay
+
+    data object SleepTimer : NowPlayingOverlay
+
+    data class ContributorPicker(
+        val type: ContributorPickerType,
+    ) : NowPlayingOverlay
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingScreenState.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingScreenState.kt
@@ -1,0 +1,17 @@
+package com.calypsan.listenup.client.playback
+
+/**
+ * Tail-combined screen state. The VM exposes a single `screenState: StateFlow<NowPlayingScreenState>`
+ * to the UI; combine produces this from independent flows of [state], [overlay], [isExpanded],
+ * and the existing `sleepTimerManager.state`.
+ *
+ * Composes the rubric's "tail-combine" pattern: the expensive book/playback flow ([state])
+ * combines with the cheap UI ephemera ([overlay], [isExpanded]) only at the screen-state
+ * boundary, so overlay emissions don't re-execute the upstream pipeline.
+ */
+data class NowPlayingScreenState(
+    val state: NowPlayingState,
+    val overlay: NowPlayingOverlay,
+    val isExpanded: Boolean,
+    val sleepTimerState: SleepTimerState,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingState.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingState.kt
@@ -5,69 +5,78 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * UI state for Now Playing components (mini player and full screen).
+ * UI state for now-playing surfaces (mini-player + full-screen player).
  *
- * Separates book-level progress (mini player) from chapter-level progress (full screen).
- * Designed for M3 Expressive UI with dynamic color and chapter-aware seek.
+ * Sealed hierarchy makes illegal state combinations unrepresentable:
+ * - [Idle] — no book loaded; mini-player hidden
+ * - [Preparing] — book is being prepared (transcoding/loading); shown with progress
+ * - [Active] — playback-ready; full UI state populated
+ * - [Error] — something failed; shown with optional book context for "Failed to play X"
+ *
+ * Replaces the pre-Phase-E2.2.1 flat data class with `isVisible`, `errorMessage`,
+ * `isPreparing`, etc. — the boolean / nullable fields are now expressed as variants.
+ *
+ * Per-variant UI ephemera (`isExpanded`, picker visibility) lives in [NowPlayingOverlay]
+ * and a separate `isExpanded: StateFlow<Boolean>`, both tail-combined into
+ * [NowPlayingScreenState] by the VM.
  */
-data class NowPlayingState(
-    // Visibility
-    val isVisible: Boolean = false,
-    // Book info
-    val bookId: String = "",
-    val title: String = "",
-    val author: String = "",
-    val coverUrl: String? = null,
-    val coverBlurHash: String? = null,
-    // Contributors (for navigation menu)
-    val authors: List<BookContributor> = emptyList(),
-    val narrators: List<BookContributor> = emptyList(),
-    // Series info (for navigation menu)
-    val seriesId: String? = null,
-    val seriesName: String? = null,
-    // Chapter info
-    val chapterTitle: String? = null,
-    val chapterIndex: Int = 0,
-    val totalChapters: Int = 0,
-    // Playback state
-    val isPlaying: Boolean = false,
-    val isBuffering: Boolean = false,
-    val playbackSpeed: Float = 1.0f,
-    val defaultPlaybackSpeed: Float = 1.0f, // Universal default from settings
-    // Transcode preparation state
-    val isPreparing: Boolean = false,
-    val prepareProgress: Int = 0, // 0-100
-    val prepareMessage: String? = null,
-    // Book-level progress (for mini player progress bar)
-    val bookProgress: Float = 0f, // 0.0 - 1.0
-    val bookPositionMs: Long = 0,
-    val bookDurationMs: Long = 0,
-    // Chapter-level progress (for full screen seek bar)
-    val chapterProgress: Float = 0f, // 0.0 - 1.0
-    val chapterPositionMs: Long = 0,
-    val chapterDurationMs: Long = 0,
-    // Error state
-    val errorMessage: String? = null,
-    // UI state
-    val isExpanded: Boolean = false,
-    val showChapterPicker: Boolean = false,
-    val showSpeedPicker: Boolean = false,
-    val showSleepTimer: Boolean = false,
-    val showContributorPicker: ContributorPickerType? = null,
-) {
-    val chapterPosition: Duration get() = chapterPositionMs.milliseconds
-    val chapterDuration: Duration get() = chapterDurationMs.milliseconds
+sealed interface NowPlayingState {
+    /** No active playback session. Default state. Mini-player hidden. */
+    data object Idle : NowPlayingState
 
-    val chapterLabel: String get() =
-        if (totalChapters > 0) {
-            "Chapter ${chapterIndex + 1} of $totalChapters"
-        } else {
-            ""
-        }
+    /** Book loaded; pre-playback transcoding / loading in flight. */
+    data class Preparing(
+        val bookId: String,
+        val title: String,
+        val author: String,
+        val coverPath: String?,
+        val progress: Int, // 0-100
+        val message: String?,
+    ) : NowPlayingState
 
-    val hasSeries: Boolean get() = seriesId != null
-    val hasMultipleAuthors: Boolean get() = authors.size > 1
-    val hasMultipleNarrators: Boolean get() = narrators.size > 1
+    /** Playback-ready. Full UI state populated. */
+    data class Active(
+        val bookId: String,
+        val title: String,
+        val author: String,
+        val coverPath: String?,
+        val coverBlurHash: String?,
+        val authors: List<BookContributor>,
+        val narrators: List<BookContributor>,
+        val seriesId: String?,
+        val seriesName: String?,
+        val chapterTitle: String?,
+        val chapterIndex: Int,
+        val totalChapters: Int,
+        val isPlaying: Boolean,
+        val isBuffering: Boolean,
+        val playbackSpeed: Float,
+        val defaultPlaybackSpeed: Float,
+        val bookProgress: Float, // 0.0-1.0
+        val bookPositionMs: Long,
+        val bookDurationMs: Long,
+        val chapterProgress: Float, // 0.0-1.0
+        val chapterPositionMs: Long,
+        val chapterDurationMs: Long,
+    ) : NowPlayingState {
+        val chapterPosition: Duration get() = chapterPositionMs.milliseconds
+        val chapterDuration: Duration get() = chapterDurationMs.milliseconds
+
+        val chapterLabel: String get() =
+            if (totalChapters > 0) "Chapter ${chapterIndex + 1} of $totalChapters" else ""
+
+        val hasSeries: Boolean get() = seriesId != null
+        val hasMultipleAuthors: Boolean get() = authors.size > 1
+        val hasMultipleNarrators: Boolean get() = narrators.size > 1
+    }
+
+    /** Error state. Optional book context for "Failed to play [title]". */
+    data class Error(
+        val bookId: String?,
+        val title: String?,
+        val message: String,
+        val isRecoverable: Boolean,
+    ) : NowPlayingState
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingState.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingState.kt
@@ -30,6 +30,7 @@ sealed interface NowPlayingState {
         val title: String,
         val author: String,
         val coverPath: String?,
+        val coverBlurHash: String?,
         val progress: Int, // 0-100
         val message: String?,
     ) : NowPlayingState
@@ -65,7 +66,6 @@ sealed interface NowPlayingState {
         val chapterLabel: String get() =
             if (totalChapters > 0) "Chapter ${chapterIndex + 1} of $totalChapters" else ""
 
-        val hasSeries: Boolean get() = seriesId != null
         val hasMultipleAuthors: Boolean get() = authors.size > 1
         val hasMultipleNarrators: Boolean get() = narrators.size > 1
     }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapper.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapper.kt
@@ -113,7 +113,6 @@ fun mapToNowPlayingState(
 data class PlaybackDynamics(
     val isPlaying: Boolean,
     val isBuffering: Boolean,
-    val playbackState: PlaybackState,
     val currentPositionMs: Long,
     val totalDurationMs: Long,
     val playbackSpeed: Float,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapper.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapper.kt
@@ -1,0 +1,130 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.domain.model.BookListItem
+
+/**
+ * Pure mapping: combines book identity + playback dynamics + surface metadata into
+ * the appropriate sealed [NowPlayingState] variant.
+ *
+ * Variant selection priority:
+ * 1. book == null && error == null      → [NowPlayingState.Idle]
+ * 2. book == null && error != null      → [NowPlayingState.Error] with null bookId/title
+ * 3. error != null                       → [NowPlayingState.Error] with book context
+ * 4. prepareProgress != null             → [NowPlayingState.Preparing]
+ * 5. otherwise (book != null)            → [NowPlayingState.Active]
+ *
+ * Pure function — same inputs always produce the same output. Unit-testable in
+ * isolation. The VM's combine chain calls this in its terminal `map { ... }` block.
+ */
+fun mapToNowPlayingState(
+    book: BookListItem?,
+    dynamics: PlaybackDynamics,
+    metadata: SurfaceMetadata,
+): NowPlayingState {
+    if (book == null) {
+        if (metadata.error != null) {
+            return NowPlayingState.Error(
+                bookId = null,
+                title = null,
+                message = metadata.error.message,
+                isRecoverable = metadata.error.isRecoverable,
+            )
+        }
+        return NowPlayingState.Idle
+    }
+
+    if (metadata.error != null) {
+        return NowPlayingState.Error(
+            bookId = book.id.value,
+            title = book.title,
+            message = metadata.error.message,
+            isRecoverable = metadata.error.isRecoverable,
+        )
+    }
+
+    val prepare = metadata.prepareProgress
+    if (prepare != null) {
+        return NowPlayingState.Preparing(
+            bookId = book.id.value,
+            title = book.title,
+            author = book.authorNames,
+            coverPath = book.coverPath,
+            coverBlurHash = book.coverBlurHash,
+            progress = prepare.progress,
+            message = prepare.message,
+        )
+    }
+
+    val chapter = metadata.currentChapter
+    val chapterDurationMs: Long =
+        if (chapter != null) {
+            (chapter.endMs - chapter.startMs).coerceAtLeast(0L)
+        } else {
+            0L
+        }
+    val chapterPositionMs: Long =
+        if (chapter != null) {
+            (dynamics.currentPositionMs - chapter.startMs).coerceAtLeast(0L)
+        } else {
+            0L
+        }
+    val chapterProgress: Float =
+        if (chapterDurationMs > 0L) {
+            (chapterPositionMs.toFloat() / chapterDurationMs).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+    val bookProgress: Float =
+        if (dynamics.totalDurationMs > 0L) {
+            (dynamics.currentPositionMs.toFloat() / dynamics.totalDurationMs).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+
+    return NowPlayingState.Active(
+        bookId = book.id.value,
+        title = book.title,
+        author = book.authorNames,
+        coverPath = book.coverPath,
+        coverBlurHash = book.coverBlurHash,
+        authors = book.authors,
+        narrators = book.narrators,
+        seriesId = book.seriesId,
+        seriesName = book.seriesName,
+        chapterTitle = chapter?.title,
+        chapterIndex = chapter?.index ?: 0,
+        totalChapters = chapter?.totalChapters ?: 0,
+        isPlaying = dynamics.isPlaying,
+        isBuffering = dynamics.isBuffering,
+        playbackSpeed = dynamics.playbackSpeed,
+        defaultPlaybackSpeed = metadata.defaultPlaybackSpeed,
+        bookProgress = bookProgress,
+        bookPositionMs = dynamics.currentPositionMs,
+        bookDurationMs = dynamics.totalDurationMs,
+        chapterProgress = chapterProgress,
+        chapterPositionMs = chapterPositionMs,
+        chapterDurationMs = chapterDurationMs,
+    )
+}
+
+/**
+ * Playback dynamics aggregated by the VM's `playbackDynamicsFlow` combine.
+ */
+data class PlaybackDynamics(
+    val isPlaying: Boolean,
+    val isBuffering: Boolean,
+    val playbackState: PlaybackState,
+    val currentPositionMs: Long,
+    val totalDurationMs: Long,
+    val playbackSpeed: Float,
+)
+
+/**
+ * Surface metadata aggregated by the VM's `surfaceMetadataFlow` combine.
+ */
+data class SurfaceMetadata(
+    val currentChapter: PlaybackManager.ChapterInfo?,
+    val prepareProgress: PlaybackManager.PrepareProgress?,
+    val error: PlaybackManager.PlaybackError?,
+    val defaultPlaybackSpeed: Float,
+)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapperTest.kt
@@ -15,7 +15,6 @@ class NowPlayingStateMapperTest {
         PlaybackDynamics(
             isPlaying = false,
             isBuffering = false,
-            playbackState = PlaybackState.Idle,
             currentPositionMs = 0L,
             totalDurationMs = 0L,
             playbackSpeed = 1.0f,
@@ -40,7 +39,8 @@ class NowPlayingStateMapperTest {
             authors = listOf(BookContributor(id = "author-1", name = "Test Author", roles = listOf("Author"))),
             narrators = listOf(BookContributor(id = "narrator-1", name = "Test Narrator", roles = listOf("Narrator"))),
             duration = duration,
-            coverPath = null,
+            coverPath = "/covers/sample.jpg",
+            coverBlurHash = "L6PZfSi_.AyE_3t7t7R**0o#DgR4",
             addedAt = Timestamp(epochMillis = 1_704_067_200_000L),
             updatedAt = Timestamp(epochMillis = 1_704_067_200_000L),
         )
@@ -107,6 +107,8 @@ class NowPlayingStateMapperTest {
         assertEquals("book-1", result.bookId)
         assertEquals("Sample Book", result.title)
         assertEquals("Test Author", result.author)
+        assertEquals("/covers/sample.jpg", result.coverPath)
+        assertEquals("L6PZfSi_.AyE_3t7t7R**0o#DgR4", result.coverBlurHash)
         assertEquals(42, result.progress)
         assertEquals("Transcoding...", result.message)
     }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/NowPlayingStateMapperTest.kt
@@ -1,0 +1,175 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.domain.model.BookContributor
+import com.calypsan.listenup.client.domain.model.BookListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NowPlayingStateMapperTest {
+    private val emptyDynamics =
+        PlaybackDynamics(
+            isPlaying = false,
+            isBuffering = false,
+            playbackState = PlaybackState.Idle,
+            currentPositionMs = 0L,
+            totalDurationMs = 0L,
+            playbackSpeed = 1.0f,
+        )
+
+    private val emptyMetadata =
+        SurfaceMetadata(
+            currentChapter = null,
+            prepareProgress = null,
+            error = null,
+            defaultPlaybackSpeed = 1.0f,
+        )
+
+    private fun sampleBook(
+        id: String = "book-1",
+        title: String = "Sample Book",
+        duration: Long = 100_000L,
+    ): BookListItem =
+        BookListItem(
+            id = BookId(id),
+            title = title,
+            authors = listOf(BookContributor(id = "author-1", name = "Test Author", roles = listOf("Author"))),
+            narrators = listOf(BookContributor(id = "narrator-1", name = "Test Narrator", roles = listOf("Narrator"))),
+            duration = duration,
+            coverPath = null,
+            addedAt = Timestamp(epochMillis = 1_704_067_200_000L),
+            updatedAt = Timestamp(epochMillis = 1_704_067_200_000L),
+        )
+
+    @Test
+    fun `mapToNowPlayingState returns Idle when book is null and no error`() {
+        val result = mapToNowPlayingState(book = null, dynamics = emptyDynamics, metadata = emptyMetadata)
+        assertEquals(NowPlayingState.Idle, result)
+    }
+
+    @Test
+    fun `mapToNowPlayingState returns Error with null bookId when book is null and error present`() {
+        val metadata =
+            emptyMetadata.copy(
+                error =
+                    PlaybackManager.PlaybackError(
+                        message = "Network failure",
+                        isRecoverable = true,
+                        timestampMs = 1_000L,
+                    ),
+            )
+        val result = mapToNowPlayingState(book = null, dynamics = emptyDynamics, metadata = metadata)
+        assertIs<NowPlayingState.Error>(result)
+        assertNull(result.bookId)
+        assertNull(result.title)
+        assertEquals("Network failure", result.message)
+        assertTrue(result.isRecoverable)
+    }
+
+    @Test
+    fun `mapToNowPlayingState returns Error with bookId when both book and error present`() {
+        val book = sampleBook()
+        val metadata =
+            emptyMetadata.copy(
+                error =
+                    PlaybackManager.PlaybackError(
+                        message = "Codec error",
+                        isRecoverable = false,
+                        timestampMs = 1_000L,
+                    ),
+            )
+        val result = mapToNowPlayingState(book = book, dynamics = emptyDynamics, metadata = metadata)
+        assertIs<NowPlayingState.Error>(result)
+        assertEquals("book-1", result.bookId)
+        assertEquals("Sample Book", result.title)
+        assertEquals("Codec error", result.message)
+        assertEquals(false, result.isRecoverable)
+    }
+
+    @Test
+    fun `mapToNowPlayingState returns Preparing when book present and prepareProgress non-null`() {
+        val book = sampleBook()
+        val metadata =
+            emptyMetadata.copy(
+                prepareProgress =
+                    PlaybackManager.PrepareProgress(
+                        audioFileId = "file-1",
+                        progress = 42,
+                        message = "Transcoding...",
+                    ),
+            )
+        val result = mapToNowPlayingState(book = book, dynamics = emptyDynamics, metadata = metadata)
+        assertIs<NowPlayingState.Preparing>(result)
+        assertEquals("book-1", result.bookId)
+        assertEquals("Sample Book", result.title)
+        assertEquals("Test Author", result.author)
+        assertEquals(42, result.progress)
+        assertEquals("Transcoding...", result.message)
+    }
+
+    @Test
+    fun `mapToNowPlayingState returns Active for normal playback`() {
+        val book = sampleBook(duration = 100_000L)
+        val dynamics =
+            emptyDynamics.copy(
+                isPlaying = true,
+                currentPositionMs = 50_000L,
+                totalDurationMs = 100_000L,
+                playbackSpeed = 1.5f,
+            )
+        val result = mapToNowPlayingState(book = book, dynamics = dynamics, metadata = emptyMetadata)
+        assertIs<NowPlayingState.Active>(result)
+        assertEquals("book-1", result.bookId)
+        assertEquals(true, result.isPlaying)
+        assertEquals(0.5f, result.bookProgress)
+        assertEquals(50_000L, result.bookPositionMs)
+        assertEquals(100_000L, result.bookDurationMs)
+        assertEquals(1.5f, result.playbackSpeed)
+    }
+
+    @Test
+    fun `mapToNowPlayingState Active chapterLabel is empty when totalChapters is 0`() {
+        val book = sampleBook()
+        val result = mapToNowPlayingState(book = book, dynamics = emptyDynamics, metadata = emptyMetadata)
+        assertIs<NowPlayingState.Active>(result)
+        assertEquals(0, result.totalChapters)
+        assertEquals("", result.chapterLabel)
+    }
+
+    @Test
+    fun `mapToNowPlayingState Active bookProgress clamps to 0_1f range`() {
+        val book = sampleBook(duration = 100_000L)
+        // Position past duration — progress should clamp to 1.0f
+        val dynamics = emptyDynamics.copy(currentPositionMs = 200_000L, totalDurationMs = 100_000L)
+        val result = mapToNowPlayingState(book = book, dynamics = dynamics, metadata = emptyMetadata)
+        assertIs<NowPlayingState.Active>(result)
+        assertEquals(1.0f, result.bookProgress)
+    }
+
+    @Test
+    fun `mapToNowPlayingState Active chapterPositionMs cannot be negative`() {
+        val book = sampleBook()
+        // Chapter starts at 60_000 but we are at position 30_000 (before chapter start)
+        val chapter =
+            PlaybackManager.ChapterInfo(
+                index = 1,
+                title = "Chapter 2",
+                startMs = 60_000L,
+                endMs = 90_000L,
+                remainingMs = 30_000L,
+                totalChapters = 3,
+                isGenericTitle = false,
+            )
+        val dynamics = emptyDynamics.copy(currentPositionMs = 30_000L, totalDurationMs = 100_000L)
+        val metadata = emptyMetadata.copy(currentChapter = chapter)
+        val result = mapToNowPlayingState(book = book, dynamics = dynamics, metadata = metadata)
+        assertIs<NowPlayingState.Active>(result)
+        assertEquals(0L, result.chapterPositionMs) // coerceAtLeast(0L) — cannot be negative
+        assertEquals(30_000L, result.chapterDurationMs) // endMs - startMs
+        assertEquals(3, result.totalChapters) // pulled from chapter.totalChapters
+    }
+}


### PR DESCRIPTION
## Summary

W7 Phase E2.2.1 redoes the now-playing surface state shape per Finding 10 Phase 6 / Q3.

- **Sealed `NowPlayingState`** with 4 variants (`Idle`, `Preparing`, `Active`, `Error`). Replaces the pre-E2.2.1 flat data class with `isVisible`/`errorMessage`/`isPreparing` boolean+nullable fields. Illegal state combinations no longer representable.
- **Sealed `NowPlayingOverlay`** with 5 variants (`None`, `ChapterPicker`, `SpeedPicker`, `SleepTimer`, `ContributorPicker(type)`). Replaces 4 picker booleans on the flat state — mutually exclusive at the type level.
- **`NowPlayingScreenState`** tail-combined wrapper: `(state, overlay, isExpanded, sleepTimerState)`. Single StateFlow consumed by the screen.
- **`mapToNowPlayingState`** pure helper + 8 unit tests covering Idle / Preparing / Active / Error variants + edge cases (book null with error, chapterLabel empty, bookProgress clamping, chapterPositionMs non-negative, coverPath/coverBlurHash propagation).
- **Android `NowPlayingViewModel`** restructured: 3 layered combines (book identity / playback dynamics / surface metadata) → terminal combine producing `nowPlayingState: Flow<NowPlayingState>` (no inner `.stateIn`) → tail-combined `screenState: StateFlow<NowPlayingScreenState>` via `.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initial)`. 14 picker booleans → 10 trivial overlay setters. 8+ `init { collect { state.update {} } }` blocks deleted; `loadBookInfo`/`loadDefaultPlaybackSpeed`/`updatePosition`/`observePlayback`/`observeSleepTimer` deleted. Imperative methods (`playPause`, `previousChapter`, `nextChapter`, `seekWithinChapter`, etc.) read `playbackManager.*.value` directly to avoid WhileSubscribed-cooldown staleness.
- **`DesktopPlayerViewModel`** restructured to the same shape with platform-specific differences (no `playbackController.acquire/release` since DesktopPlaybackController's are no-ops; GStreamer error path routed through `playbackManager.reportError`/`clearError` so `NowPlayingState.Error` flows through the canonical `playbackError` flow). `audioPlayer` ctor field preserved as passthrough.
- **8 Android Compose screens + 5 Desktop Compose/app files** migrated from flat-field reads (`state.isVisible`, `state.coverUrl`, `state.showChapterPicker`, ...) to sealed-when handling on `screenState`.

## Per-task §M1 fix-ups folded in

| Commit | Concern |
|---|---|
| `5c583fc6` | Add `coverBlurHash` to Preparing; drop redundant `hasSeries` getter |
| `9aa3270b` | Drop unused `PlaybackDynamics.playbackState`; assert cover fields in Preparing test |
| `846f4258` | Direct-read playback values in imperative VM methods; drop inner `.stateIn` (closes 10s WhileSubscribed staleness window) |
| `3aa5a214` | Cancel sleep timer in Desktop `closeBook`; document acquire/release omission |

§M1 final review: **APPROVED** (no blocking concerns).

## Drifts opened (6 rows: #27-#32)

| # | Status | Description |
|---|---|---|
| 27 | Open | Desktop NowPlaying UI inert because `playbackManager.activateBook(bookId)` is never called from any Desktop source. Pre-existing latent bug; new combine architecture makes it load-bearing. → Post-W7 Desktop reconciliation. |
| 28 | Open | Desktop seek/skip imperatives don't call `playbackManager.updatePosition`. Pre-existing. → Post-W7 Desktop reconciliation. |
| 29 | Open | `PlaybackState.Error` → `reportError` plumbing in Desktop VM. Should move to `PlaybackManager.startPlayback` for platform-agnostic coverage. → E2.2.2 / W7 Phase F. |
| 30 | Closed | SleepTimerManager wired into Desktop VM contrary to plan instruction. Ratified at §M1 — parity with Android benefits E2.2.2 consolidation. |
| 31 | Open | `defaultPlaybackSpeedFlow` doesn't observe upstream changes (both VMs). Pre-existing. → Post-W7 cleanup OR W7 Phase F. |
| 32 | Closed | Plan/spec drift on `PlaybackDynamics.playbackState` field — documentation-only. |

## Out of scope (deferred to E2.2.2)

- Moving VMs to `shared/commonMain/.../presentation/{nowplaying,player}/`
- Consolidating `DesktopPlayerViewModel` (deletion)
- `PlayerUiState` redo (Android command-side VM stays flat in E2.2.1)
- iOS Kotlin VM adoption
- VM integration tests (commonTest mapper tests are the only test additions in E2.2.1)

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-29-w7-e2-2-1-nowplaying-state-redo-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-w7-e2-2-1-nowplaying-state-redo.md`

## Test plan

- [x] `:shared:jvmTest spotlessCheck detekt` green at every commit (after Task 1 — Task 1 + Task 2 leave `:androidApp:assembleDebug` red; Tasks 3-4 restore green)
- [x] `:androidApp:assembleDebug` green at HEAD
- [x] `:composeApp:compileKotlinDesktop` green at HEAD
- [x] `:desktopApp:assemble` green at HEAD
- [x] `:composeApp:testAndroidHostTest` green at HEAD
- [x] §M1 final review APPROVED

## W7 status

**Phase E2.2.1 complete.** Phase E2.2.2 opens next as a separate PR — moves VMs to `shared/presentation/`, consolidates `DesktopPlayerViewModel`, addresses `PlayerUiState` flat-state redo, candidate for iOS Kotlin VM adoption.