### PR TITLE
♻️ W8 Phase B — repository unification + sealed BookDownloadStatus + AppResult<DownloadOutcome>

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -255,7 +255,7 @@ class ListenUp :
         // Must be done before verifyCriticalKoinBindings() because DownloadManager needs WorkManager.
         val workerFactory =
             ListenUpWorkerFactory(
-                downloadDao = get(),
+                downloadRepository = get(),
                 fileManager = get(),
                 tokenProvider = get<AndroidAudioTokenProvider>(),
                 serverConfig = get(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -207,6 +207,7 @@ val downloadModule =
                 workManager = WorkManager.getInstance(androidContext()),
                 fileManager = get(),
                 localPreferences = get<com.calypsan.listenup.client.domain.repository.LocalPreferences>(),
+                downloadRepository = get(),
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.remote.ABSImportApiContract
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.data.remote.BackupApiContract
 import com.calypsan.listenup.client.data.remote.PlaybackApi
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -22,7 +22,7 @@ import com.calypsan.listenup.client.upload.ABSUploadWorker
  * - [ABSUploadWorker] — Audiobookshelf backup upload and import
  */
 class ListenUpWorkerFactory(
-    private val downloadDao: DownloadDao,
+    private val downloadRepository: DownloadRepository,
     private val fileManager: DownloadFileManager,
     private val tokenProvider: AudioTokenProvider,
     private val serverConfig: ServerConfig,
@@ -42,7 +42,7 @@ class ListenUpWorkerFactory(
                 DownloadWorker(
                     appContext,
                     workerParameters,
-                    downloadDao,
+                    downloadRepository,
                     fileManager,
                     tokenProvider,
                     serverConfig,

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/bookdetail/AndroidBookDetailPlatformActions.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/bookdetail/AndroidBookDetailPlatformActions.kt
@@ -1,11 +1,12 @@
 package com.calypsan.listenup.client.features.bookdetail
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.download.DownloadManager
-import com.calypsan.listenup.client.download.DownloadResult
 import com.calypsan.listenup.client.playback.PlaybackManager
 import android.content.Context
 import android.content.Intent
@@ -28,7 +29,7 @@ class AndroidBookDetailPlatformActions(
 
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> = downloadManager.observeBookStatus(bookId)
 
-    override suspend fun downloadBook(bookId: BookId): DownloadResult = downloadManager.downloadBook(bookId)
+    override suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome> = downloadManager.downloadBook(bookId)
 
     override suspend fun cancelDownload(bookId: BookId) = downloadManager.cancelDownload(bookId)
 

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.client.features.bookdetail
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -20,7 +22,7 @@ interface BookDetailPlatformActions {
     fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>
 
     /** Start downloading a book */
-    suspend fun downloadBook(bookId: BookId): DownloadResult
+    suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome>
 
     /** Cancel an in-progress download */
     suspend fun cancelDownload(bookId: BookId)
@@ -56,8 +58,8 @@ class NoOpBookDetailPlatformActions : BookDetailPlatformActions {
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
         flowOf(BookDownloadStatus.NotDownloaded(bookId.value))
 
-    override suspend fun downloadBook(bookId: BookId): DownloadResult =
-        DownloadResult.Error("Not available on this platform")
+    override suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome> =
+        AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Not available on this platform"))
 
     override suspend fun cancelDownload(bookId: BookId) {}
 

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
@@ -54,7 +54,7 @@ class NoOpBookDetailPlatformActions : BookDetailPlatformActions {
     override val isPlaybackAvailable: Boolean = false
 
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
-        flowOf(BookDownloadStatus.notDownloaded(bookId.value))
+        flowOf(BookDownloadStatus.NotDownloaded(bookId.value))
 
     override suspend fun downloadBook(bookId: BookId): DownloadResult =
         DownloadResult.Error("Not available on this platform")

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -41,7 +41,6 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
 import com.calypsan.listenup.client.design.components.rememberCoverColors
-import com.calypsan.listenup.client.domain.model.BookDownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.download.DownloadResult
 import com.calypsan.listenup.client.features.library.ShelfPickerSheet
@@ -169,7 +168,7 @@ private fun BookDetailReadyContent(
 
     val downloadStatusFlow = remember(bookId) { platformActions.observeBookStatus(BookId(bookId)) }
     val downloadStatus by downloadStatusFlow
-        .collectAsStateWithLifecycle(initialValue = BookDownloadStatus.notDownloaded(bookId))
+        .collectAsStateWithLifecycle(initialValue = BookDownloadStatus.NotDownloaded(bookId))
 
     // WiFi-only download state detection
     val wifiOnlyFlow = remember { platformActions.observeWifiOnlyDownloads() }
@@ -182,28 +181,29 @@ private fun BookDetailReadyContent(
     // - WiFi-only is enabled AND
     // - Not currently on WiFi/unmetered network
     val isWaitingForWifi =
-        downloadStatus.state == BookDownloadState.QUEUED &&
+        downloadStatus.isQueued() &&
             wifiOnlyDownloads &&
             !isOnUnmeteredNetwork
 
     // Server reachability check - runs when screen loads
     var isServerReachable by remember { mutableStateOf<Boolean?>(null) }
-    LaunchedEffect(bookId, downloadStatus.isFullyDownloaded) {
+    val isFullyDownloaded = downloadStatus is BookDownloadStatus.Completed
+    LaunchedEffect(bookId, isFullyDownloaded) {
         // Only check if book isn't downloaded - downloaded books always play
-        if (!downloadStatus.isFullyDownloaded) {
+        if (!isFullyDownloaded) {
             isServerReachable = platformActions.checkServerReachable()
         }
     }
 
     // Playback availability: can play if book is downloaded OR server is confirmed reachable
     // While check is in progress (null), assume playable to avoid flicker for fast connections
-    val canPlay = downloadStatus.isFullyDownloaded || isServerReachable != false
+    val canPlay = isFullyDownloaded || isServerReachable != false
 
     // Downloads are always allowed — they queue locally and don't need the server to be reachable
     val canDownload = platformActions.isPlaybackAvailable
 
     // Show warning when server is unreachable and book isn't downloaded (informational only)
-    val showServerWarning = isServerReachable == false && !downloadStatus.isFullyDownloaded
+    val showServerWarning = isServerReachable == false && !isFullyDownloaded
 
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showMarkCompleteDialog by remember { mutableStateOf(false) }
@@ -300,7 +300,7 @@ private fun BookDetailReadyContent(
     if (showDeleteDialog) {
         DeleteDownloadDialog(
             bookTitle = book.title,
-            downloadSize = downloadStatus.downloadedBytes,
+            downloadSize = downloadStatus.downloadedOrTotalBytes(),
             onConfirm = {
                 scope.launch {
                     platformActions.deleteDownload(BookId(bookId))
@@ -665,6 +665,19 @@ private fun ImmersiveBookDetail(
         }
     }
 }
+
+/** True when a download is in the queue but no file is actively transferring yet. */
+private fun BookDownloadStatus.isQueued(): Boolean =
+    this is BookDownloadStatus.InProgress && downloadingFiles == 0 && completedFiles == 0
+
+/** Returns the best available byte count to display in the delete dialog. */
+private fun BookDownloadStatus.downloadedOrTotalBytes(): Long =
+    when (this) {
+        is BookDownloadStatus.Completed -> totalBytes
+        is BookDownloadStatus.InProgress -> downloadedBytes
+        is BookDownloadStatus.Paused -> downloadedBytes
+        else -> 0L
+    }
 
 @Composable
 private fun ServerUnreachableBanner(modifier: Modifier = Modifier) {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -42,7 +42,8 @@ import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
 import com.calypsan.listenup.client.design.components.rememberCoverColors
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.features.library.ShelfPickerSheet
 import com.calypsan.listenup.client.features.bookdetail.components.BookReadersSection
 import com.calypsan.listenup.client.features.bookdetail.components.ChapterListItem
@@ -265,25 +266,8 @@ private fun BookDetailReadyContent(
         onUserProfileClick = onUserProfileClick,
         onDownloadClick = {
             scope.launch {
-                when (val result = platformActions.downloadBook(BookId(bookId))) {
-                    is DownloadResult.Success -> { /* Download started */ }
-
-                    is DownloadResult.AlreadyDownloaded -> { /* Nothing to do */ }
-
-                    is DownloadResult.InsufficientStorage -> {
-                        val requiredMb = result.requiredBytes / 1_000_000
-                        val availableMb = result.availableBytes / 1_000_000
-                        snackbarHostState.showSnackbar(
-                            "Not enough storage. Need ${requiredMb}MB, have ${availableMb}MB available.",
-                        )
-                    }
-
-                    is DownloadResult.Error -> {
-                        snackbarHostState.showSnackbar(
-                            "Download failed: ${result.message}",
-                        )
-                    }
-                }
+                val result = platformActions.downloadBook(BookId(bookId))
+                handleDownloadResult(result) { message -> snackbarHostState.showSnackbar(message) }
             }
         },
         onCancelClick = {
@@ -705,4 +689,21 @@ private fun ServerUnreachableBanner(modifier: Modifier = Modifier) {
             )
         }
     }
+}
+
+private suspend fun handleDownloadResult(
+    result: AppResult<DownloadOutcome>,
+    showSnackbar: suspend (String) -> Unit,
+) {
+    if (result is AppResult.Failure) {
+        showSnackbar("Download failed: ${result.error.debugInfo ?: "Unknown error"}")
+        return
+    }
+    val outcome = (result as AppResult.Success).data
+    if (outcome is DownloadOutcome.InsufficientStorage) {
+        val requiredMb = outcome.requiredBytes / 1_000_000
+        val availableMb = outcome.availableBytes / 1_000_000
+        showSnackbar("Not enough storage. Need ${requiredMb}MB, have ${availableMb}MB available.")
+    }
+    // DownloadOutcome.Started and DownloadOutcome.AlreadyDownloaded: no UI action needed
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DownloadButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DownloadButton.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.calypsan.listenup.client.domain.model.BookDownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
@@ -51,7 +50,7 @@ import listenup.composeapp.generated.resources.book_detail_waiting_for_wifi
  * - Queued (waiting for WiFi): WiFi-off icon, tap to cancel
  * - Downloading: Progress circle with %, tap to cancel
  * - Downloaded: Trash icon, tap to delete
- * - Failed/Partial: Retry icon, tap to resume
+ * - Failed/Paused: Retry icon, tap to resume
  *
  * @param isWaitingForWifi True when download is queued but waiting for WiFi connection
  *                         (wifiOnlyDownloads enabled + not on WiFi). Shows WiFi-off icon.
@@ -88,8 +87,8 @@ fun DownloadButton(
             contentAlignment = Alignment.Center,
             modifier = Modifier.fillMaxSize(),
         ) {
-            when (status.state) {
-                BookDownloadState.NOT_DOWNLOADED -> {
+            when (status) {
+                is BookDownloadStatus.NotDownloaded -> {
                     IconButton(onClick = onDownloadClick) {
                         Icon(
                             Icons.Outlined.Download,
@@ -99,43 +98,43 @@ fun DownloadButton(
                     }
                 }
 
-                BookDownloadState.QUEUED -> {
+                is BookDownloadStatus.InProgress -> {
                     IconButton(onClick = onCancelClick) {
-                        if (isWaitingForWifi) {
-                            // Waiting for WiFi - show WiFi-off icon
-                            Icon(
-                                Icons.Default.WifiOff,
-                                contentDescription = stringResource(Res.string.book_detail_waiting_for_wifi),
-                                tint = contentColor.copy(alpha = 0.7f),
-                            )
-                        } else {
-                            // Normal queued state - show spinner
-                            ListenUpLoadingIndicatorSmall()
+                        when {
+                            status.downloadingFiles > 0 -> {
+                                Box(contentAlignment = Alignment.Center) {
+                                    CircularProgressIndicator(
+                                        progress = { status.progress },
+                                        modifier = Modifier.size(32.dp),
+                                        strokeWidth = 3.dp,
+                                        color = contentColor,
+                                        trackColor = contentColor.copy(alpha = 0.3f),
+                                    )
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = stringResource(Res.string.book_detail_cancel_download),
+                                        modifier = Modifier.size(12.dp),
+                                        tint = contentColor.copy(alpha = 0.6f),
+                                    )
+                                }
+                            }
+
+                            isWaitingForWifi -> {
+                                Icon(
+                                    Icons.Default.WifiOff,
+                                    contentDescription = stringResource(Res.string.book_detail_waiting_for_wifi),
+                                    tint = contentColor.copy(alpha = 0.7f),
+                                )
+                            }
+
+                            else -> {
+                                ListenUpLoadingIndicatorSmall()
+                            }
                         }
                     }
                 }
 
-                BookDownloadState.DOWNLOADING -> {
-                    IconButton(onClick = onCancelClick) {
-                        Box(contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator(
-                                progress = { status.progress },
-                                modifier = Modifier.size(32.dp),
-                                strokeWidth = 3.dp,
-                                color = contentColor,
-                                trackColor = contentColor.copy(alpha = 0.3f),
-                            )
-                            Icon(
-                                Icons.Default.Close,
-                                contentDescription = stringResource(Res.string.book_detail_cancel_download),
-                                modifier = Modifier.size(12.dp),
-                                tint = contentColor.copy(alpha = 0.6f),
-                            )
-                        }
-                    }
-                }
-
-                BookDownloadState.COMPLETED -> {
+                is BookDownloadStatus.Completed -> {
                     IconButton(onClick = onDeleteClick) {
                         Icon(
                             Icons.Outlined.Delete,
@@ -145,8 +144,8 @@ fun DownloadButton(
                     }
                 }
 
-                BookDownloadState.PARTIAL,
-                BookDownloadState.FAILED,
+                is BookDownloadStatus.Failed,
+                is BookDownloadStatus.Paused,
                 -> {
                     IconButton(onClick = onDownloadClick) {
                         Icon(
@@ -176,67 +175,71 @@ fun DownloadButtonExpanded(
     modifier: Modifier = Modifier,
     isWaitingForWifi: Boolean = false,
 ) {
-    val progressPercent = (status.progress * 100).toInt()
+    val onClick =
+        when (status) {
+            is BookDownloadStatus.NotDownloaded -> onDownloadClick
+            is BookDownloadStatus.InProgress -> onCancelClick
+            is BookDownloadStatus.Completed -> onDeleteClick
+            is BookDownloadStatus.Failed -> onDownloadClick
+            is BookDownloadStatus.Paused -> onDownloadClick
+        }
 
     OutlinedButton(
-        onClick =
-            when (status.state) {
-                BookDownloadState.NOT_DOWNLOADED -> onDownloadClick
-                BookDownloadState.QUEUED, BookDownloadState.DOWNLOADING -> onCancelClick
-                BookDownloadState.COMPLETED -> onDeleteClick
-                BookDownloadState.PARTIAL, BookDownloadState.FAILED -> onDownloadClick
-            },
+        onClick = onClick,
         modifier =
             modifier
                 .fillMaxWidth()
                 .height(52.dp),
         shape = RoundedCornerShape(26.dp),
     ) {
-        when (status.state) {
-            BookDownloadState.NOT_DOWNLOADED -> {
+        when (status) {
+            is BookDownloadStatus.NotDownloaded -> {
                 Icon(Icons.Outlined.Download, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource(Res.string.book_detail_download))
             }
 
-            BookDownloadState.QUEUED -> {
-                if (isWaitingForWifi) {
-                    // Waiting for WiFi - show WiFi-off icon with message
-                    Icon(
-                        Icons.Default.WifiOff,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(Res.string.book_detail_waiting_for_wifi))
-                } else {
-                    // Normal queued state
-                    ListenUpLoadingIndicatorSmall()
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(Res.string.book_detail_queued))
+            is BookDownloadStatus.InProgress -> {
+                when {
+                    status.downloadingFiles > 0 -> {
+                        val progressPercent = (status.progress * 100).toInt()
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularProgressIndicator(
+                                progress = { status.progress },
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(stringResource(Res.string.book_detail_progresspercent, progressPercent))
+                        }
+                    }
+
+                    isWaitingForWifi -> {
+                        Icon(
+                            Icons.Default.WifiOff,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(Res.string.book_detail_waiting_for_wifi))
+                    }
+
+                    else -> {
+                        ListenUpLoadingIndicatorSmall()
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(Res.string.book_detail_queued))
+                    }
                 }
             }
 
-            BookDownloadState.DOWNLOADING -> {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    CircularProgressIndicator(
-                        progress = { status.progress },
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(Res.string.book_detail_progresspercent, progressPercent))
-                }
-            }
-
-            BookDownloadState.COMPLETED -> {
+            is BookDownloadStatus.Completed -> {
                 Icon(Icons.Outlined.Delete, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource(Res.string.book_detail_downloaded))
             }
 
-            BookDownloadState.PARTIAL,
-            BookDownloadState.FAILED,
+            is BookDownloadStatus.Failed,
+            is BookDownloadStatus.Paused,
             -> {
                 Icon(
                     Icons.Default.Refresh,

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.client.features.bookdetail
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -21,8 +23,8 @@ class DesktopBookDetailPlatformActions(
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
         flowOf(BookDownloadStatus.NotDownloaded(bookId.value))
 
-    override suspend fun downloadBook(bookId: BookId): DownloadResult =
-        DownloadResult.Error("Downloads not yet available on desktop")
+    override suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome> =
+        AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Downloads not yet available on desktop"))
 
     override suspend fun cancelDownload(bookId: BookId) {}
 

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
@@ -19,7 +19,7 @@ class DesktopBookDetailPlatformActions(
     override val isPlaybackAvailable: Boolean = true
 
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
-        flowOf(BookDownloadStatus.notDownloaded(bookId.value))
+        flowOf(BookDownloadStatus.NotDownloaded(bookId.value))
 
     override suspend fun downloadBook(bookId: BookId): DownloadResult =
         DownloadResult.Error("Downloads not yet available on desktop")

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
@@ -1,11 +1,13 @@
 package com.calypsan.listenup.client.platform
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.download.DownloadService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import com.calypsan.listenup.client.download.DownloadResult
-import com.calypsan.listenup.client.download.DownloadService
 
 /**
  * Stub implementation of [DownloadService] for desktop.
@@ -20,8 +22,8 @@ class StubDownloadService : DownloadService {
 
     override suspend fun wasExplicitlyDeleted(bookId: BookId): Boolean = false
 
-    override suspend fun downloadBook(bookId: BookId): DownloadResult =
-        DownloadResult.Error("Downloads not yet supported on desktop")
+    override suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome> =
+        AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Downloads not yet supported on desktop"))
 
     override suspend fun cancelDownload(bookId: BookId) {
         // No-op: downloads not supported

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
@@ -32,7 +32,7 @@ class StubDownloadService : DownloadService {
     }
 
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
-        flowOf(BookDownloadStatus.notDownloaded(bookId.value))
+        flowOf(BookDownloadStatus.NotDownloaded(bookId.value))
 
     override suspend fun resumeIncompleteDownloads() {
         // No-op: downloads not supported on desktop

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -15,7 +15,6 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
-import com.calypsan.listenup.client.domain.model.BookDownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
@@ -74,18 +73,12 @@ class DownloadManager(
         downloads: List<DownloadEntity>,
     ): BookDownloadStatus {
         if (downloads.isEmpty()) {
-            return BookDownloadStatus.notDownloaded(bookId)
+            return BookDownloadStatus.NotDownloaded(bookId)
         }
 
-        // If all files are DELETED, treat as not downloaded (show download button)
-        if (downloads.all { it.state == DownloadState.DELETED }) {
-            return BookDownloadStatus.notDownloaded(bookId)
-        }
-
-        // Filter out DELETED entries for counting
         val activeDownloads = downloads.filter { it.state != DownloadState.DELETED }
         if (activeDownloads.isEmpty()) {
-            return BookDownloadStatus.notDownloaded(bookId)
+            return BookDownloadStatus.NotDownloaded(bookId)
         }
 
         val totalFiles = activeDownloads.size
@@ -93,24 +86,44 @@ class DownloadManager(
         val totalBytes = activeDownloads.sumOf { it.totalBytes }
         val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
 
-        val state =
-            when {
-                activeDownloads.all { it.state == DownloadState.COMPLETED } -> BookDownloadState.COMPLETED
-                activeDownloads.any { it.state == DownloadState.DOWNLOADING } -> BookDownloadState.DOWNLOADING
-                activeDownloads.any { it.state == DownloadState.QUEUED } -> BookDownloadState.QUEUED
-                activeDownloads.any { it.state == DownloadState.FAILED } -> BookDownloadState.FAILED
-                activeDownloads.any { it.state == DownloadState.COMPLETED } -> BookDownloadState.PARTIAL
-                else -> BookDownloadState.NOT_DOWNLOADED
+        return when {
+            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
+                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
             }
 
-        return BookDownloadStatus(
-            bookId = bookId,
-            state = state,
-            totalFiles = totalFiles,
-            completedFiles = completedFiles,
-            totalBytes = totalBytes,
-            downloadedBytes = downloadedBytes,
-        )
+            activeDownloads.any { it.state == DownloadState.FAILED } -> {
+                BookDownloadStatus.Failed(
+                    bookId = bookId,
+                    errorMessage =
+                        activeDownloads
+                            .firstOrNull { it.state == DownloadState.FAILED }
+                            ?.errorMessage
+                            ?: "Download failed",
+                    partiallyDownloadedFiles = completedFiles,
+                )
+            }
+
+            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
+                BookDownloadStatus.Paused(
+                    bookId = bookId,
+                    pausedFiles = activeDownloads.size,
+                    downloadedBytes = downloadedBytes,
+                    totalBytes = totalBytes,
+                )
+            }
+
+            else -> {
+                BookDownloadStatus.InProgress(
+                    bookId = bookId,
+                    totalFiles = totalFiles,
+                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
+                    waitingForServerFiles = 0, // Phase D adds DownloadState.WAITING_FOR_SERVER
+                    completedFiles = completedFiles,
+                    totalBytes = totalBytes,
+                    downloadedBytes = downloadedBytes,
+                )
+            }
+        }
     }
 
     /**

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -8,7 +8,9 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookDao
@@ -16,6 +18,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
@@ -64,26 +67,26 @@ class DownloadManager(
      * Download a book (queue all audio files).
      * Called when user taps download button OR starts streaming.
      *
-     * @return DownloadResult indicating success, failure reason, or if already downloaded
+     * @return AppResult indicating success, failure reason, or if already downloaded
      */
-    override suspend fun downloadBook(bookId: BookId): DownloadResult {
+    override suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome> {
         // Check if already downloading or downloaded
         val existing = downloadDao.getForBook(bookId.value)
         if (existing.isNotEmpty() && existing.all { it.state == DownloadState.COMPLETED }) {
             logger.info { "Book ${bookId.value} already downloaded" }
-            return DownloadResult.AlreadyDownloaded
+            return AppResult.Success(DownloadOutcome.AlreadyDownloaded)
         }
 
         // Verify book exists before attempting download
         if (bookDao.getById(bookId) == null) {
             logger.error { "Book not found: ${bookId.value}" }
-            return DownloadResult.Error("Book not found")
+            return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Book not found"))
         }
 
         val audioFiles: List<AudioFileEntity> = audioFileDao.getForBook(bookId.value)
         if (audioFiles.isEmpty()) {
             logger.warn { "No audio files for book ${bookId.value}" }
-            return DownloadResult.Error("No audio files available")
+            return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "No audio files available"))
         }
 
         // Create download entries for files not already completed
@@ -106,9 +109,11 @@ class DownloadManager(
                 "Insufficient storage for book ${bookId.value}: " +
                     "need ${requiredBytes / 1_000_000}MB, have ${availableBytes / 1_000_000}MB"
             }
-            return DownloadResult.InsufficientStorage(
-                requiredBytes = requiredBytes,
-                availableBytes = availableBytes,
+            return AppResult.Success(
+                DownloadOutcome.InsufficientStorage(
+                    requiredBytes = requiredBytes,
+                    availableBytes = availableBytes,
+                ),
             )
         }
 
@@ -172,7 +177,7 @@ class DownloadManager(
         }
 
         logger.info { "Queued ${toDownload.size} files for download: ${bookId.value}" }
-        return DownloadResult.Success
+        return AppResult.Success(DownloadOutcome.Started)
     }
 
     /**

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -16,9 +16,9 @@ import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 private val logger = KotlinLogging.logger {}
 
@@ -47,84 +47,18 @@ class DownloadManager(
     private val workManager: WorkManager,
     private val fileManager: DownloadFileManager,
     private val localPreferences: com.calypsan.listenup.client.domain.repository.LocalPreferences,
+    private val downloadRepository: DownloadRepository,
 ) : DownloadService {
     /**
      * Observe download status for a specific book.
      */
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
-        downloadDao
-            .observeForBook(bookId.value)
-            .map { downloads -> aggregateStatus(bookId.value, downloads) }
+        downloadRepository.observeBookStatus(bookId)
 
     /**
      * Observe download status for all books (for library indicators).
      */
-    fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> =
-        downloadDao
-            .observeAll()
-            .map { downloads ->
-                downloads
-                    .groupBy { it.bookId }
-                    .mapValues { (bookId, files) -> aggregateStatus(bookId, files) }
-            }
-
-    private fun aggregateStatus(
-        bookId: String,
-        downloads: List<DownloadEntity>,
-    ): BookDownloadStatus {
-        if (downloads.isEmpty()) {
-            return BookDownloadStatus.NotDownloaded(bookId)
-        }
-
-        val activeDownloads = downloads.filter { it.state != DownloadState.DELETED }
-        if (activeDownloads.isEmpty()) {
-            return BookDownloadStatus.NotDownloaded(bookId)
-        }
-
-        val totalFiles = activeDownloads.size
-        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
-        val totalBytes = activeDownloads.sumOf { it.totalBytes }
-        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
-
-        return when {
-            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
-                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
-            }
-
-            activeDownloads.any { it.state == DownloadState.FAILED } -> {
-                BookDownloadStatus.Failed(
-                    bookId = bookId,
-                    errorMessage =
-                        activeDownloads
-                            .firstOrNull { it.state == DownloadState.FAILED }
-                            ?.errorMessage
-                            ?: "Download failed",
-                    partiallyDownloadedFiles = completedFiles,
-                )
-            }
-
-            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
-                BookDownloadStatus.Paused(
-                    bookId = bookId,
-                    pausedFiles = activeDownloads.size,
-                    downloadedBytes = downloadedBytes,
-                    totalBytes = totalBytes,
-                )
-            }
-
-            else -> {
-                BookDownloadStatus.InProgress(
-                    bookId = bookId,
-                    totalFiles = totalFiles,
-                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
-                    waitingForServerFiles = 0, // Phase D adds DownloadState.WAITING_FOR_SERVER
-                    completedFiles = completedFiles,
-                    totalBytes = totalBytes,
-                    downloadedBytes = downloadedBytes,
-                )
-            }
-        }
-    }
+    fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> = downloadRepository.observeAllStatuses()
 
     /**
      * Download a book (queue all audio files).

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
@@ -114,9 +114,9 @@ class DownloadWorker(
     ): Result {
         ErrorBus.emit(DownloadError.DownloadFailed(debugInfo = e.message))
         logger.error(e) { "Download failed: $audioFileId" }
-        // markFailed via repository sets state=FAILED + writes errorMessage + increments retryCount.
-        // On retry, the next doWork() call's first action is markDownloading, which transitions
-        // back. State-machine churn is intentional — single repository call replaces split DAO writes.
+        // markFailed sets state=FAILED + writes errorMessage + increments retryCount in one call,
+        // collapsing the previous redundant updateError + updateState(FAILED) writes (the prior
+        // updateError already set state=FAILED via its underlying query — no behavior change).
         downloadRepository.markFailed(audioFileId, DownloadError.DownloadFailed(debugInfo = e.message))
 
         return if (runAttemptCount < MAX_RETRIES) {

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
@@ -9,9 +9,8 @@ import androidx.work.workDataOf
 import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.core.error.ErrorBus
 import com.calypsan.listenup.client.core.Success
-import com.calypsan.listenup.client.data.local.db.DownloadDao
-import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.data.remote.PlaybackApi
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.playback.AudioCapabilityDetector
@@ -44,7 +43,7 @@ private val logger = KotlinLogging.logger {}
 class DownloadWorker(
     context: Context,
     params: WorkerParameters,
-    private val downloadDao: DownloadDao,
+    private val downloadRepository: DownloadRepository,
     private val fileManager: DownloadFileManager,
     private val tokenProvider: AudioTokenProvider,
     private val serverConfig: ServerConfig,
@@ -71,7 +70,7 @@ class DownloadWorker(
 
         logger.info { "Starting download: $audioFileId ($filename)" }
 
-        downloadDao.updateState(audioFileId, DownloadState.DOWNLOADING, System.currentTimeMillis())
+        downloadRepository.markDownloading(audioFileId, System.currentTimeMillis())
 
         return try {
             downloadFile(audioFileId, bookId, filename, expectedSize)
@@ -79,12 +78,12 @@ class DownloadWorker(
             Result.success()
         } catch (e: CancellationException) {
             logger.info { "Download cancelled: $audioFileId" }
-            downloadDao.updateState(audioFileId, DownloadState.PAUSED)
+            downloadRepository.markPaused(audioFileId)
             Result.failure()
         } catch (e: AuthenticationException) {
             // Auth failure after token refresh — pause instead of wasting retry budget
             logger.warn(e) { "Download paused due to auth failure: $audioFileId" }
-            downloadDao.updateState(audioFileId, DownloadState.PAUSED)
+            downloadRepository.markPaused(audioFileId)
             Result.failure()
         } catch (e: IOException) {
             // Check if this is a storage-related error (no retry for these)
@@ -98,8 +97,7 @@ class DownloadWorker(
             if (isStorageError) {
                 ErrorBus.emit(DownloadError.InsufficientStorage(debugInfo = e.message))
                 logger.error { "Download failed due to insufficient storage: $audioFileId" }
-                downloadDao.updateError(audioFileId, "Insufficient storage space")
-                downloadDao.updateState(audioFileId, DownloadState.FAILED)
+                downloadRepository.markFailed(audioFileId, DownloadError.InsufficientStorage(debugInfo = e.message))
                 Result.failure()
             } else {
                 // Regular IO error - may be transient, allow retry
@@ -116,13 +114,15 @@ class DownloadWorker(
     ): Result {
         ErrorBus.emit(DownloadError.DownloadFailed(debugInfo = e.message))
         logger.error(e) { "Download failed: $audioFileId" }
-        downloadDao.updateError(audioFileId, e.message ?: "Unknown error")
+        // markFailed via repository sets state=FAILED + writes errorMessage + increments retryCount.
+        // On retry, the next doWork() call's first action is markDownloading, which transitions
+        // back. State-machine churn is intentional — single repository call replaces split DAO writes.
+        downloadRepository.markFailed(audioFileId, DownloadError.DownloadFailed(debugInfo = e.message))
 
         return if (runAttemptCount < MAX_RETRIES) {
             logger.info { "Will retry download: $audioFileId (attempt ${runAttemptCount + 1})" }
             Result.retry()
         } else {
-            downloadDao.updateState(audioFileId, DownloadState.FAILED)
             Result.failure()
         }
     }
@@ -221,7 +221,7 @@ class DownloadWorker(
 
             // Update total size in database
             if (totalSize > 0) {
-                downloadDao.updateProgress(audioFileId, startByte, totalSize)
+                downloadRepository.updateProgress(audioFileId, startByte, totalSize)
             }
 
             FileOutputStream(tempFile, startByte > 0).use { output ->
@@ -243,7 +243,7 @@ class DownloadWorker(
                         // Update progress periodically
                         val now = System.currentTimeMillis()
                         if (now - lastProgressUpdate > PROGRESS_INTERVAL_MS) {
-                            downloadDao.updateProgress(audioFileId, totalBytesRead, totalSize)
+                            downloadRepository.updateProgress(audioFileId, totalBytesRead, totalSize)
                             setProgress(
                                 workDataOf(
                                     "progress" to totalBytesRead,
@@ -268,7 +268,7 @@ class DownloadWorker(
             }
 
             // Mark complete in database
-            downloadDao.markCompleted(
+            downloadRepository.markCompleted(
                 audioFileId = audioFileId,
                 localPath = destPath.toString(),
                 completedAt = System.currentTimeMillis(),

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -48,11 +48,22 @@ import com.calypsan.listenup.client.core.Success
 private val logger = KotlinLogging.logger {}
 
 /**
- * iOS implementation of DownloadService.
+ * iOS implementation of [DownloadService] using NSURLSession background downloads.
  *
- * Uses NSURLSession with download tasks that stream directly to disk.
- * Each file download is a single coroutine that suspends until complete.
- * Progress is tracked via delegate callbacks and written to the database.
+ * **W10 carveout (W8 Phase B):** this class still writes directly to
+ * [com.calypsan.listenup.client.data.local.db.DownloadDao] via the `downloadDao` constructor
+ * parameter — Sync Engine Rule 5 violation, deferred to W10. The Android side migrated to inject
+ * [com.calypsan.listenup.client.domain.repository.DownloadRepository] in W8 Phase B, but iOS is
+ * part of W10 (iOS Player Adoption) which owns the iOS migration onto shared Kotlin VMs and
+ * shared repositories. See `docs/superpowers/specs/2026-05-01-w8-handoff-design.md` § Phase B
+ * "AppleDownloadService keeps its current DAO writes" and § Out of scope ("iOS download adoption
+ * — deferred to W10").
+ *
+ * For Phase B specifically, this class's interface compliance was updated:
+ * - [downloadBook] returns [com.calypsan.listenup.client.core.AppResult]<[com.calypsan.listenup.client.domain.model.DownloadOutcome]> instead of the legacy `DownloadResult`.
+ * - [observeBookStatus] aggregates via the new sealed [com.calypsan.listenup.client.domain.model.BookDownloadStatus] hierarchy.
+ *
+ * The internal DAO writes remain untouched.
  */
 @OptIn(ExperimentalTime::class)
 class AppleDownloadService(

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -3,7 +3,9 @@
 
 package com.calypsan.listenup.client.download
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookDao
@@ -11,6 +13,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.playback.AudioTokenProvider
@@ -90,21 +93,21 @@ class AppleDownloadService(
     override suspend fun wasExplicitlyDeleted(bookId: BookId): Boolean = downloadDao.hasDeletedRecords(bookId.value)
 
     @Suppress("ReturnCount")
-    override suspend fun downloadBook(bookId: BookId): DownloadResult {
+    override suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome> {
         val existing = downloadDao.getForBook(bookId.value)
         if (existing.isNotEmpty() && existing.all { it.state == DownloadState.COMPLETED }) {
-            return DownloadResult.AlreadyDownloaded
+            return AppResult.Success(DownloadOutcome.AlreadyDownloaded)
         }
 
         val bookEntity =
             bookDao.getById(bookId) ?: run {
                 logger.error { "Book not found: ${bookId.value}" }
-                return DownloadResult.Error("Book not found")
+                return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Book not found"))
             }
 
         val audioFileEntities = audioFileDao.getForBook(bookId.value)
         if (audioFileEntities.isEmpty()) {
-            return DownloadResult.Error("No audio files available")
+            return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "No audio files available"))
         }
         val audioFiles: List<AudioFileResponse> = audioFileEntities.map { it.toAudioFileResponse() }
 
@@ -119,14 +122,14 @@ class AppleDownloadService(
 
         if (toDownload.isEmpty()) {
             logger.info { "All files already downloading or completed for ${bookId.value}" }
-            return DownloadResult.AlreadyDownloaded
+            return AppResult.Success(DownloadOutcome.AlreadyDownloaded)
         }
 
         // Check storage
         val requiredBytes = toDownload.sumOf { it.size }
         val availableBytes = fileManager.getAvailableSpace()
         if (availableBytes < (requiredBytes * 1.1).toLong()) {
-            return DownloadResult.InsufficientStorage(requiredBytes, availableBytes)
+            return AppResult.Success(DownloadOutcome.InsufficientStorage(requiredBytes, availableBytes))
         }
 
         // Ensure fresh token
@@ -134,12 +137,12 @@ class AppleDownloadService(
         val token =
             tokenProvider.getToken() ?: run {
                 logger.error { "No auth token available" }
-                return DownloadResult.Error("Not authenticated")
+                return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Not authenticated"))
             }
 
         val serverUrl =
             serverConfig.getServerUrl()?.value ?: run {
-                return DownloadResult.Error("No server configured")
+                return AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "No server configured"))
             }
 
         // Create download entries
@@ -180,7 +183,7 @@ class AppleDownloadService(
         }
 
         logger.info { "Queued ${toDownload.size} files for download: ${bookId.value}" }
-        return DownloadResult.Success
+        return AppResult.Success(DownloadOutcome.Started)
     }
 
     /**

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -10,7 +10,6 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
-import com.calypsan.listenup.client.domain.model.BookDownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -331,34 +330,63 @@ class AppleDownloadService(
 
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
         downloadDao.observeForBook(bookId.value).map { entities ->
-            if (entities.isEmpty()) {
-                BookDownloadStatus.notDownloaded(bookId.value)
-            } else {
-                val totalFiles = entities.size
-                val completedFiles = entities.count { it.state == DownloadState.COMPLETED }
-                val totalBytes = entities.sumOf { it.totalBytes }
-                val downloadedBytes = entities.sumOf { it.downloadedBytes }
+            aggregateBookDownloadStatus(bookId.value, entities)
+        }
 
-                val state =
-                    when {
-                        entities.all { it.state == DownloadState.COMPLETED } -> BookDownloadState.COMPLETED
-                        entities.any { it.state == DownloadState.DOWNLOADING } -> BookDownloadState.DOWNLOADING
-                        entities.any { it.state == DownloadState.QUEUED } -> BookDownloadState.QUEUED
-                        entities.any { it.state == DownloadState.FAILED } -> BookDownloadState.FAILED
-                        entities.any { it.state == DownloadState.COMPLETED } -> BookDownloadState.PARTIAL
-                        else -> BookDownloadState.NOT_DOWNLOADED
-                    }
+    // Inline copy of DownloadManager.aggregateStatus until Task 8 moves the canonical version
+    // into DownloadRepository. iOS keeps its own copy through W10 (deferred carveout per W8 design).
+    private fun aggregateBookDownloadStatus(
+        bookId: String,
+        entities: List<DownloadEntity>,
+    ): BookDownloadStatus {
+        if (entities.isEmpty()) {
+            return BookDownloadStatus.NotDownloaded(bookId)
+        }
+        val activeDownloads = entities.filter { it.state != DownloadState.DELETED }
+        if (activeDownloads.isEmpty()) {
+            return BookDownloadStatus.NotDownloaded(bookId)
+        }
+        val totalFiles = activeDownloads.size
+        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
+        val totalBytes = activeDownloads.sumOf { it.totalBytes }
+        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
+        return when {
+            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
+                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
+            }
 
-                BookDownloadStatus(
-                    bookId = bookId.value,
-                    state = state,
+            activeDownloads.any { it.state == DownloadState.FAILED } -> {
+                BookDownloadStatus.Failed(
+                    bookId = bookId,
+                    errorMessage =
+                        activeDownloads.firstOrNull { it.state == DownloadState.FAILED }?.errorMessage
+                            ?: "Download failed",
+                    partiallyDownloadedFiles = completedFiles,
+                )
+            }
+
+            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
+                BookDownloadStatus.Paused(
+                    bookId = bookId,
+                    pausedFiles = activeDownloads.size,
+                    downloadedBytes = downloadedBytes,
+                    totalBytes = totalBytes,
+                )
+            }
+
+            else -> {
+                BookDownloadStatus.InProgress(
+                    bookId = bookId,
                     totalFiles = totalFiles,
+                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
+                    waitingForServerFiles = 0,
                     completedFiles = completedFiles,
                     totalBytes = totalBytes,
                     downloadedBytes = downloadedBytes,
                 )
             }
         }
+    }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -1,7 +1,14 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.local.db.DownloadDao
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
@@ -9,18 +16,37 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /**
- * Reads downloaded-book summaries from Room, enriched with book metadata from [BookRepository].
+ * Single seam for download state + aggregation. All download writes go through this class
+ * (Sync Engine Rule 5). Aggregation reducer lives here so platforms share the same state-machine.
  *
- * Uses the batched [BookRepository.getBookListItems] variant so the common case (N downloaded
- * books) is one DAO query + one Room relation query, not N+1 per-book lookups.
+ * **Phase B scope:** state transitions + aggregation + reads. Orchestration methods
+ * (`enqueueForBook`, `cancelForBook`, `resumeForAudioFile`, `resumeIncompleteDownloads`)
+ * throw [NotImplementedError] in Phase B — Phase C / Phase D move platform code onto them.
+ *
+ * Cross-phase aliases per W8 design:
+ * - [markCancelled] writes [DownloadState.PAUSED]; Phase D switches to a new `CANCELLED` entry.
+ * - [markWaitingForServer] is a no-op; Phase D writes a new `WAITING_FOR_SERVER` entry.
+ * - [recheckWaitingForServer] is a no-op; Phase D wires the SSE-reconnect hook.
  */
 class DownloadRepositoryImpl(
     private val downloadDao: DownloadDao,
     private val bookRepository: BookRepository,
 ) : DownloadRepository {
-    override suspend fun deleteForBook(bookId: String) {
-        downloadDao.deleteForBook(bookId)
-    }
+    // --- Reads ---
+
+    override fun observeForBook(bookId: BookId): Flow<List<DownloadEntity>> = downloadDao.observeForBook(bookId.value)
+
+    override fun observeAll(): Flow<List<DownloadEntity>> = downloadDao.observeAll()
+
+    override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
+        downloadDao.observeForBook(bookId.value).map { aggregate(bookId.value, it) }
+
+    override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> =
+        downloadDao.observeAll().map { downloads ->
+            downloads
+                .groupBy { it.bookId }
+                .mapValues { (bookId, files) -> aggregate(bookId, files) }
+        }
 
     override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> =
         downloadDao.observeAll().map { downloads ->
@@ -31,7 +57,6 @@ class DownloadRepositoryImpl(
 
             if (completedByBook.isEmpty()) return@map emptyList()
 
-            // BookListItem.id is a BookId value class — associate by .value to match String keys.
             val books =
                 bookRepository
                     .getBookListItems(completedByBook.keys.toList())
@@ -50,4 +75,152 @@ class DownloadRepositoryImpl(
                     )
                 }.sortedByDescending { it.sizeBytes }
         }
+
+    override suspend fun getLocalPath(audioFileId: String): String? = downloadDao.getLocalPath(audioFileId)
+
+    // --- State-transition writes ---
+
+    override suspend fun markDownloading(
+        audioFileId: String,
+        startedAt: Long,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.updateState(audioFileId, DownloadState.DOWNLOADING, startedAt)
+        }
+
+    override suspend fun updateProgress(
+        audioFileId: String,
+        downloadedBytes: Long,
+        totalBytes: Long,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.updateProgress(audioFileId, downloadedBytes, totalBytes)
+        }
+
+    override suspend fun markCompleted(
+        audioFileId: String,
+        localPath: String,
+        completedAt: Long,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.markCompleted(audioFileId, localPath, completedAt)
+        }
+
+    override suspend fun markPaused(audioFileId: String): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.updateState(audioFileId, DownloadState.PAUSED)
+        }
+
+    // Phase B alias: cancellation collapses into PAUSED. Phase D adds DownloadState.CANCELLED.
+    override suspend fun markCancelled(audioFileId: String): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.updateState(audioFileId, DownloadState.PAUSED)
+        }
+
+    override suspend fun markFailed(
+        audioFileId: String,
+        error: DownloadError,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.updateError(audioFileId, error.message)
+        }
+
+    // Phase B alias: no-op. Phase D writes DownloadState.WAITING_FOR_SERVER + persists transcodeJobId.
+    override suspend fun markWaitingForServer(
+        audioFileId: String,
+        transcodeJobId: String,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    // --- Orchestration (Phase B: stub; Phase C/D move platform code onto these) ---
+
+    @Suppress("NotImplementedDeclaration") // Phase C/D scope — intentional stub per W8 design
+    override suspend fun enqueueForBook(bookId: BookId): AppResult<DownloadOutcome> =
+        throw NotImplementedError(
+            "DownloadRepository.enqueueForBook is Phase C/D scope. Phase B keeps " +
+                "orchestration on DownloadManager (Android) and AppleDownloadService (iOS).",
+        )
+
+    @Suppress("NotImplementedDeclaration") // Phase C/D scope — intentional stub per W8 design
+    override suspend fun cancelForBook(bookId: BookId): AppResult<Unit> =
+        throw NotImplementedError(
+            "DownloadRepository.cancelForBook is Phase C/D scope. Phase B keeps cancellation " +
+                "on the DownloadService impls.",
+        )
+
+    override suspend fun deleteForBook(bookId: String) {
+        downloadDao.deleteForBook(bookId)
+    }
+
+    @Suppress("NotImplementedDeclaration") // Phase D scope — intentional stub per W8 design
+    override suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit> =
+        throw NotImplementedError(
+            "DownloadRepository.resumeForAudioFile is Phase D scope (Bug 4 SSE handler).",
+        )
+
+    @Suppress("NotImplementedDeclaration") // Phase C/D scope — intentional stub per W8 design
+    override suspend fun resumeIncompleteDownloads(): AppResult<Unit> =
+        throw NotImplementedError(
+            "DownloadRepository.resumeIncompleteDownloads is Phase C/D scope. Phase B keeps " +
+                "this on the DownloadService impls.",
+        )
+
+    // Phase B alias: no-op. Phase D wires the SSE-reconnect hook.
+    override suspend fun recheckWaitingForServer(): AppResult<Unit> = AppResult.Success(Unit)
+
+    // --- Aggregation reducer (shared across platforms) ---
+
+    private fun aggregate(
+        bookId: String,
+        downloads: List<DownloadEntity>,
+    ): BookDownloadStatus {
+        if (downloads.isEmpty()) {
+            return BookDownloadStatus.NotDownloaded(bookId)
+        }
+        val activeDownloads = downloads.filter { it.state != DownloadState.DELETED }
+        if (activeDownloads.isEmpty()) {
+            return BookDownloadStatus.NotDownloaded(bookId)
+        }
+        val totalFiles = activeDownloads.size
+        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
+        val totalBytes = activeDownloads.sumOf { it.totalBytes }
+        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
+        return when {
+            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
+                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
+            }
+
+            activeDownloads.any { it.state == DownloadState.FAILED } -> {
+                BookDownloadStatus.Failed(
+                    bookId = bookId,
+                    errorMessage =
+                        activeDownloads
+                            .firstOrNull { it.state == DownloadState.FAILED }
+                            ?.errorMessage
+                            ?: "Download failed",
+                    partiallyDownloadedFiles = completedFiles,
+                )
+            }
+
+            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
+                BookDownloadStatus.Paused(
+                    bookId = bookId,
+                    pausedFiles = activeDownloads.size,
+                    downloadedBytes = downloadedBytes,
+                    totalBytes = totalBytes,
+                )
+            }
+
+            else -> {
+                BookDownloadStatus.InProgress(
+                    bookId = bookId,
+                    totalFiles = totalFiles,
+                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
+                    waitingForServerFiles = 0,
+                    completedFiles = completedFiles,
+                    totalBytes = totalBytes,
+                    downloadedBytes = downloadedBytes,
+                )
+            }
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatus.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatus.kt
@@ -1,49 +1,64 @@
 package com.calypsan.listenup.client.domain.model
 
 /**
- * Aggregated download status for a book.
+ * Aggregated download status for a book, modeled as a sealed hierarchy so consumers
+ * can exhaustively match on the variant shape without illegal-state combinations.
  *
- * Domain model representing the current download state of a book's audio files.
- * Used by ViewModels to display download progress and state in the UI.
+ * Replaces the legacy flat `data class BookDownloadStatus(state: BookDownloadState, ...)` per
+ * W8 Phase B (W8 handoff design § "Refactor `BookDownloadStatus` from flat data class to sealed
+ * hierarchy"). Closes the rubric drift around "UI state is a per-screen sealed hierarchy, not a
+ * flat data class."
  */
-data class BookDownloadStatus(
-    val bookId: String,
-    val state: BookDownloadState,
-    val totalFiles: Int,
-    val completedFiles: Int,
-    val totalBytes: Long,
-    val downloadedBytes: Long,
-) {
-    val progress: Float
-        get() = if (totalBytes > 0) downloadedBytes.toFloat() / totalBytes else 0f
+sealed interface BookDownloadStatus {
+    val bookId: String
 
-    val isFullyDownloaded: Boolean
-        get() = state == BookDownloadState.COMPLETED
+    /** No download exists for this book (or all files were explicitly deleted). */
+    data class NotDownloaded(
+        override val bookId: String,
+    ) : BookDownloadStatus
 
-    val isDownloading: Boolean
-        get() = state == BookDownloadState.DOWNLOADING || state == BookDownloadState.QUEUED
-
-    companion object {
-        fun notDownloaded(bookId: String) =
-            BookDownloadStatus(
-                bookId = bookId,
-                state = BookDownloadState.NOT_DOWNLOADED,
-                totalFiles = 0,
-                completedFiles = 0,
-                totalBytes = 0,
-                downloadedBytes = 0,
-            )
+    /**
+     * One or more files in this book are mid-flight (downloading, waiting for server, queued).
+     *
+     * @property waitingForServerFiles Count of files currently in `WAITING_FOR_SERVER` state. Zero
+     * until Phase D adds the state. The field is on the type now so Phase C/D don't reshape the
+     * sealed hierarchy mid-stream.
+     */
+    data class InProgress(
+        override val bookId: String,
+        val totalFiles: Int,
+        val downloadingFiles: Int,
+        val waitingForServerFiles: Int,
+        val completedFiles: Int,
+        val totalBytes: Long,
+        val downloadedBytes: Long,
+    ) : BookDownloadStatus {
+        val progress: Float = if (totalBytes > 0) downloadedBytes.toFloat() / totalBytes else 0f
     }
-}
 
-/**
- * Download state enumeration for a book.
- */
-enum class BookDownloadState {
-    NOT_DOWNLOADED,
-    QUEUED,
-    DOWNLOADING,
-    PARTIAL,
-    COMPLETED,
-    FAILED,
+    /** All files for this book are downloaded. */
+    data class Completed(
+        override val bookId: String,
+        val totalBytes: Long,
+    ) : BookDownloadStatus
+
+    /**
+     * One or more files failed and the worker exhausted its retries.
+     *
+     * @property partiallyDownloadedFiles Files that completed successfully before the failure;
+     * lets the UI show "X of N files downloaded" alongside the retry CTA.
+     */
+    data class Failed(
+        override val bookId: String,
+        val errorMessage: String,
+        val partiallyDownloadedFiles: Int,
+    ) : BookDownloadStatus
+
+    /** User cancelled or system paused the download. */
+    data class Paused(
+        override val bookId: String,
+        val pausedFiles: Int,
+        val downloadedBytes: Long,
+        val totalBytes: Long,
+    ) : BookDownloadStatus
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/DownloadOutcome.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/DownloadOutcome.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.domain.model
+
+/**
+ * Successful outcomes of a download orchestration request.
+ *
+ * Wrapped in [com.calypsan.listenup.client.core.AppResult.Success] when the request succeeds.
+ * Failures use [com.calypsan.listenup.client.core.AppResult.Failure] with a
+ * [com.calypsan.listenup.client.core.error.DownloadError].
+ *
+ * Replaces the legacy `DownloadResult` sealed type per W8 Phase B
+ * (W8 handoff design § "Migrate `DownloadResult` → `AppResult<DownloadOutcome>`").
+ */
+sealed interface DownloadOutcome {
+    /** New download enqueued (one or more files queued for fetch). */
+    data object Started : DownloadOutcome
+
+    /** All files for this book are already in [com.calypsan.listenup.client.data.local.db.DownloadState.COMPLETED]; no work enqueued. */
+    data object AlreadyDownloaded : DownloadOutcome
+
+    /**
+     * Pre-flight storage check failed; no work enqueued.
+     *
+     * Carried as a success outcome (not a failure) because it's a deterministic, user-actionable
+     * branch — the caller decides whether to surface a "free up space" prompt or proceed without
+     * downloading. Modeling it as a failure would force every caller to special-case it out of
+     * the failure handler.
+     */
+    data class InsufficientStorage(
+        val requiredBytes: Long,
+        val availableBytes: Long,
+    ) : DownloadOutcome
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -1,28 +1,134 @@
 package com.calypsan.listenup.client.domain.repository
 
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Repository for queries about the user's downloaded books.
+ * Single seam for download state and orchestration. All writes to the download DAO route through
+ * this repository (Sync Engine Rule 5 compliance). Aggregation lives here so all platforms share
+ * the same state-machine reducer.
  *
- * This is the domain-level surface for download-state reads. The per-book download
- * commands (start, cancel, delete) continue to live on
- * [com.calypsan.listenup.client.download.DownloadService]. W8 will unify these into
- * one repository; for now, this interface exposes only the reads that
- * [com.calypsan.listenup.client.presentation.storage.StorageViewModel] needs.
+ * Per W8 Phase B (handoff design § "Expand `DownloadRepository` interface"). Replaces:
+ * - The narrow read-only interface that previously lived here (limited to `observeDownloadedBooks`
+ *   and `deleteForBook`, used by `StorageViewModel`).
+ * - Direct `DownloadDao` access from `DownloadWorker` and `DownloadManager` (those callers will
+ *   be migrated to route through this interface in Phase B Tasks 7 and 8).
+ *
+ * Cross-phase carveout: methods marked **(Phase B alias)** below have placeholder implementations
+ * until Phase D adds the corresponding `DownloadState` enum entries (`CANCELLED`,
+ * `WAITING_FOR_SERVER`). The alias preserves the interface so Phases C and D don't reshape it.
  */
 interface DownloadRepository {
-    /**
-     * Observe all fully-downloaded books as domain summaries, sorted largest first.
-     */
+    // --- Reads ---
+
+    /** Observe the raw entities for a book (most callers should prefer [observeBookStatus]). */
+    fun observeForBook(bookId: BookId): Flow<List<DownloadEntity>>
+
+    /** Observe all download entities across all books. */
+    fun observeAll(): Flow<List<DownloadEntity>>
+
+    /** Observe the aggregated [BookDownloadStatus] for a single book. */
+    fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>
+
+    /** Observe aggregated statuses keyed by bookId for cross-book UIs (e.g., library list). */
+    fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>>
+
+    /** Observe completed-and-known-to-the-book-repository downloads as domain summaries. */
     fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>>
 
+    /** Get local file path for an audio file if downloaded; null otherwise. */
+    suspend fun getLocalPath(audioFileId: String): String?
+
+    // --- State-transition writes (Sync Engine Rule 5 enforcement point) ---
+
+    suspend fun markDownloading(
+        audioFileId: String,
+        startedAt: Long,
+    ): AppResult<Unit>
+
+    suspend fun updateProgress(
+        audioFileId: String,
+        downloadedBytes: Long,
+        totalBytes: Long,
+    ): AppResult<Unit>
+
+    suspend fun markCompleted(
+        audioFileId: String,
+        localPath: String,
+        completedAt: Long,
+    ): AppResult<Unit>
+
+    suspend fun markPaused(audioFileId: String): AppResult<Unit>
+
     /**
-     * Delete all download records for the given book.
-     *
-     * Called when a book finishes playing so the next playback session
-     * auto-downloads again (the user's default behaviour).
+     * **(Phase B alias)** — marks the file as PAUSED. Phase D will switch this to write
+     * the new `DownloadState.CANCELLED` enum entry (distinct from PAUSED so a late
+     * `transcode.complete` SSE event can be silently dropped without confusion). Until then,
+     * cancellation collapses into PAUSED, matching the pre-W8 behavior.
      */
+    suspend fun markCancelled(audioFileId: String): AppResult<Unit>
+
+    suspend fun markFailed(
+        audioFileId: String,
+        error: DownloadError,
+    ): AppResult<Unit>
+
+    /**
+     * **(Phase B alias)** — no-op. Phase D adds the `DownloadState.WAITING_FOR_SERVER` enum entry
+     * and activates this method to write the new state + persist `transcodeJobId` for the SSE
+     * `transcode.complete` re-enqueue path. The `transcodeJobId` parameter is accepted and
+     * ignored in Phase B.
+     */
+    suspend fun markWaitingForServer(
+        audioFileId: String,
+        transcodeJobId: String,
+    ): AppResult<Unit>
+
+    // --- Orchestration ---
+
+    /**
+     * Pre-flight check + DB insert + worker enqueue for a book's audio files.
+     *
+     * **(Phase C/D scope)** — Phase B keeps orchestration on the `DownloadService` impls
+     * (`DownloadManager` for Android, `AppleDownloadService` for iOS). This method throws
+     * `NotImplementedError` until Phase C/D moves the platform code onto the repository.
+     */
+    suspend fun enqueueForBook(bookId: BookId): AppResult<DownloadOutcome>
+
+    /**
+     * Cancel all in-flight downloads for a book.
+     *
+     * **(Phase C/D scope)** — see [enqueueForBook] for the same carveout reasoning.
+     */
+    suspend fun cancelForBook(bookId: BookId): AppResult<Unit>
+
+    /** Delete all download records for a book (used post-playback completion). */
     suspend fun deleteForBook(bookId: String)
+
+    /**
+     * Re-enqueue a single audio file's download.
+     *
+     * **(Phase D scope)** — wired by the Bug 4 SSE `transcode.complete` handler.
+     */
+    suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit>
+
+    /**
+     * App-startup recovery: re-enqueue any incomplete downloads.
+     *
+     * **(Phase C/D scope)** — see [enqueueForBook].
+     */
+    suspend fun resumeIncompleteDownloads(): AppResult<Unit>
+
+    /**
+     * **(Phase B alias)** — no-op. Phase D wires this to the SSE-reconnect hook: re-issues
+     * `preparePlayback` for any rows in `WAITING_FOR_SERVER` to catch missed
+     * `transcode.complete` events.
+     */
+    suspend fun recheckWaitingForServer(): AppResult<Unit>
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -1,26 +1,10 @@
 package com.calypsan.listenup.client.download
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import kotlinx.coroutines.flow.Flow
-
-/**
- * Result of a download operation.
- */
-sealed interface DownloadResult {
-    data object Success : DownloadResult
-
-    data object AlreadyDownloaded : DownloadResult
-
-    data class InsufficientStorage(
-        val requiredBytes: Long,
-        val availableBytes: Long,
-    ) : DownloadResult
-
-    data class Error(
-        val message: String,
-    ) : DownloadResult
-}
 
 /**
  * Interface for download operations needed by PlaybackManager.
@@ -29,7 +13,8 @@ sealed interface DownloadResult {
  * the full download implementation remains platform-specific.
  *
  * Android: Implemented by DownloadManager (WorkManager-based)
- * iOS: Will use URLSession background downloads
+ * iOS: AppleDownloadService (NSURLSession background downloads)
+ * Desktop: StubDownloadService (no-op)
  */
 interface DownloadService {
     /**
@@ -47,25 +32,28 @@ interface DownloadService {
     /**
      * Trigger background download of a book's audio files.
      *
-     * @return Result indicating success, failure reason, or if already downloaded
+     * Returns [AppResult.Success] with one of:
+     * - [DownloadOutcome.Started] — fresh enqueue.
+     * - [DownloadOutcome.AlreadyDownloaded] — all files already complete; no work enqueued.
+     * - [DownloadOutcome.InsufficientStorage] — pre-flight storage check failed; no work enqueued.
+     *
+     * Returns [AppResult.Failure] with [com.calypsan.listenup.client.core.error.DownloadError]
+     * for unexpected errors (book not found, missing audio metadata, etc.).
      */
-    suspend fun downloadBook(bookId: BookId): DownloadResult
+    suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome>
 
     /**
      * Cancel active download for a book.
-     * Called when book access is revoked or user cancels download.
      */
     suspend fun cancelDownload(bookId: BookId)
 
     /**
      * Delete downloaded files for a book.
-     * Called when book is deleted (access revoked) to clean up local storage.
      */
     suspend fun deleteDownload(bookId: BookId)
 
     /**
      * Observe download status for a book as a Flow.
-     * Emits new status whenever download state changes.
      */
     fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -1,0 +1,201 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory fake implementing [DownloadRepository] for seam-level tests.
+ *
+ * Per project memory `feedback_fakes_for_seams.md` — validated test pattern is hand-rolled fakes
+ * implementing the seam interface. State lives in a [MutableStateFlow] so observers see updates.
+ *
+ * Optional [enqueueFailure] lambda lets tests inject failure for [enqueueForBook] (returns the
+ * lambda's value when set; `AppResult.Success(DownloadOutcome.Started)` when null).
+ *
+ * Phase B carveout: orchestration methods (`cancelForBook`, `resumeForAudioFile`,
+ * `resumeIncompleteDownloads`) are intentional no-ops in this fake — they're filled in
+ * meaningfully when Phase C/D move platform code onto the repository.
+ */
+open class FakeDownloadRepository(
+    initial: List<DownloadEntity> = emptyList(),
+    private val enqueueFailure: ((BookId) -> AppResult<DownloadOutcome>)? = null,
+) : DownloadRepository {
+    private val state = MutableStateFlow(initial.associateBy { it.audioFileId })
+
+    /** All entities currently in the fake (test-only inspection). */
+    val entities: List<DownloadEntity> get() = state.value.values.toList()
+
+    // --- Reads ---
+
+    override fun observeForBook(bookId: BookId): Flow<List<DownloadEntity>> =
+        state.asStateFlow().map { it.values.filter { e -> e.bookId == bookId.value } }
+
+    override fun observeAll(): Flow<List<DownloadEntity>> = state.asStateFlow().map { it.values.toList() }
+
+    override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
+        observeForBook(bookId).map { aggregate(bookId.value, it) }
+
+    override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> =
+        observeAll().map { downloads ->
+            downloads
+                .groupBy { it.bookId }
+                .mapValues { (bid, files) -> aggregate(bid, files) }
+        }
+
+    override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> = observeAll().map { _ -> emptyList() }
+
+    override suspend fun getLocalPath(audioFileId: String): String? =
+        state.value[audioFileId]?.takeIf { it.state == DownloadState.COMPLETED }?.localPath
+
+    // --- State-transition writes ---
+
+    override suspend fun markDownloading(
+        audioFileId: String,
+        startedAt: Long,
+    ): AppResult<Unit> {
+        update(audioFileId) { it.copy(state = DownloadState.DOWNLOADING, startedAt = startedAt) }
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun updateProgress(
+        audioFileId: String,
+        downloadedBytes: Long,
+        totalBytes: Long,
+    ): AppResult<Unit> {
+        update(audioFileId) { it.copy(downloadedBytes = downloadedBytes, totalBytes = totalBytes) }
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun markCompleted(
+        audioFileId: String,
+        localPath: String,
+        completedAt: Long,
+    ): AppResult<Unit> {
+        update(audioFileId) {
+            it.copy(
+                state = DownloadState.COMPLETED,
+                localPath = localPath,
+                completedAt = completedAt,
+                downloadedBytes = it.totalBytes,
+            )
+        }
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun markPaused(audioFileId: String): AppResult<Unit> {
+        update(audioFileId) { it.copy(state = DownloadState.PAUSED) }
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun markCancelled(audioFileId: String): AppResult<Unit> = markPaused(audioFileId)
+
+    override suspend fun markFailed(
+        audioFileId: String,
+        error: DownloadError,
+    ): AppResult<Unit> {
+        update(audioFileId) {
+            it.copy(state = DownloadState.FAILED, errorMessage = error.message)
+        }
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun markWaitingForServer(
+        audioFileId: String,
+        transcodeJobId: String,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    // --- Orchestration ---
+
+    override suspend fun enqueueForBook(bookId: BookId): AppResult<DownloadOutcome> =
+        enqueueFailure?.invoke(bookId) ?: AppResult.Success(DownloadOutcome.Started)
+
+    override suspend fun cancelForBook(bookId: BookId): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun deleteForBook(bookId: String) {
+        state.update { current -> current.filterValues { it.bookId != bookId } }
+    }
+
+    override suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun resumeIncompleteDownloads(): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun recheckWaitingForServer(): AppResult<Unit> = AppResult.Success(Unit)
+
+    // --- Test helpers ---
+
+    /** Seed an entity directly (test setup convenience). */
+    fun seed(entity: DownloadEntity) {
+        state.update { current -> current + (entity.audioFileId to entity) }
+    }
+
+    private fun update(
+        audioFileId: String,
+        transform: (DownloadEntity) -> DownloadEntity,
+    ) {
+        state.update { current ->
+            val existing = current[audioFileId] ?: return@update current
+            current + (audioFileId to transform(existing))
+        }
+    }
+
+    private fun aggregate(
+        bookId: String,
+        downloads: List<DownloadEntity>,
+    ): BookDownloadStatus {
+        if (downloads.isEmpty()) return BookDownloadStatus.NotDownloaded(bookId)
+        val activeDownloads = downloads.filter { it.state != DownloadState.DELETED }
+        if (activeDownloads.isEmpty()) return BookDownloadStatus.NotDownloaded(bookId)
+        val totalFiles = activeDownloads.size
+        val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }
+        val totalBytes = activeDownloads.sumOf { it.totalBytes }
+        val downloadedBytes = activeDownloads.sumOf { it.downloadedBytes }
+        return when {
+            activeDownloads.all { it.state == DownloadState.COMPLETED } -> {
+                BookDownloadStatus.Completed(bookId = bookId, totalBytes = totalBytes)
+            }
+
+            activeDownloads.any { it.state == DownloadState.FAILED } -> {
+                BookDownloadStatus.Failed(
+                    bookId = bookId,
+                    errorMessage =
+                        activeDownloads.firstOrNull { it.state == DownloadState.FAILED }?.errorMessage
+                            ?: "Download failed",
+                    partiallyDownloadedFiles = completedFiles,
+                )
+            }
+
+            activeDownloads.all { it.state == DownloadState.PAUSED } -> {
+                BookDownloadStatus.Paused(
+                    bookId = bookId,
+                    pausedFiles = activeDownloads.size,
+                    downloadedBytes = downloadedBytes,
+                    totalBytes = totalBytes,
+                )
+            }
+
+            else -> {
+                BookDownloadStatus.InProgress(
+                    bookId = bookId,
+                    totalFiles = totalFiles,
+                    downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
+                    waitingForServerFiles = 0,
+                    completedFiles = completedFiles,
+                    totalBytes = totalBytes,
+                    downloadedBytes = downloadedBytes,
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
@@ -1,0 +1,258 @@
+package com.calypsan.listenup.client.data.repository
+
+import app.cash.turbine.test
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FakeDownloadRepositoryTest {
+    private fun entity(
+        audioFileId: String,
+        bookId: String = "book-1",
+        state: DownloadState = DownloadState.QUEUED,
+        totalBytes: Long = 1000L,
+        downloadedBytes: Long = 0L,
+    ) = DownloadEntity(
+        audioFileId = audioFileId,
+        bookId = bookId,
+        filename = "$audioFileId.mp3",
+        fileIndex = 0,
+        state = state,
+        localPath = null,
+        totalBytes = totalBytes,
+        downloadedBytes = downloadedBytes,
+        queuedAt = 0L,
+        startedAt = null,
+        completedAt = null,
+        errorMessage = null,
+        retryCount = 0,
+    )
+
+    @Test
+    fun `markDownloading transitions state and emits update`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+            fake.observeForBook(BookId("book-1")).test {
+                assertEquals(DownloadState.QUEUED, awaitItem().single().state)
+                fake.markDownloading("file-1", startedAt = 100L)
+                val downloading = awaitItem().single()
+                assertEquals(DownloadState.DOWNLOADING, downloading.state)
+                assertEquals(100L, downloading.startedAt)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `updateProgress updates byte counts`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+            val result = fake.updateProgress("file-1", downloadedBytes = 250L, totalBytes = 1000L)
+            assertIs<AppResult.Success<Unit>>(result)
+            assertEquals(250L, fake.entities.single().downloadedBytes)
+        }
+
+    @Test
+    fun `markCompleted sets state and downloadedBytes equals totalBytes`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+            fake.markCompleted("file-1", localPath = "/tmp/file-1.mp3", completedAt = 500L)
+            val completed = fake.entities.single()
+            assertEquals(DownloadState.COMPLETED, completed.state)
+            assertEquals("/tmp/file-1.mp3", completed.localPath)
+            assertEquals(500L, completed.completedAt)
+            assertEquals(completed.totalBytes, completed.downloadedBytes)
+        }
+
+    @Test
+    fun `markCancelled aliases to PAUSED in Phase B`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)))
+            fake.markCancelled("file-1")
+            assertEquals(DownloadState.PAUSED, fake.entities.single().state)
+        }
+
+    @Test
+    fun `markFailed sets state and error message`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+            fake.markFailed("file-1", DownloadError.DownloadFailed(debugInfo = "test failure"))
+            val failed = fake.entities.single()
+            assertEquals(DownloadState.FAILED, failed.state)
+            assertTrue(failed.errorMessage?.contains("Download") == true)
+        }
+
+    @Test
+    fun `markWaitingForServer is a no-op in Phase B`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+            val before = fake.entities.single()
+            fake.markWaitingForServer("file-1", transcodeJobId = "job-abc")
+            assertEquals(before, fake.entities.single())
+        }
+
+    @Test
+    fun `recheckWaitingForServer is a no-op in Phase B`() =
+        runTest {
+            val fake = FakeDownloadRepository()
+            val result = fake.recheckWaitingForServer()
+            assertIs<AppResult.Success<Unit>>(result)
+        }
+
+    @Test
+    fun `enqueueForBook returns Started by default`() =
+        runTest {
+            val fake = FakeDownloadRepository()
+            val result = fake.enqueueForBook(BookId("book-1"))
+            assertIs<AppResult.Success<DownloadOutcome>>(result)
+            assertEquals(DownloadOutcome.Started, result.data)
+        }
+
+    @Test
+    fun `enqueueForBook respects injected failure`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    enqueueFailure = { _ ->
+                        AppResult.Success(DownloadOutcome.InsufficientStorage(requiredBytes = 1000, availableBytes = 500))
+                    },
+                )
+            val result = fake.enqueueForBook(BookId("book-1"))
+            assertIs<AppResult.Success<DownloadOutcome>>(result)
+            assertIs<DownloadOutcome.InsufficientStorage>(result.data)
+        }
+
+    @Test
+    fun `aggregator returns NotDownloaded for empty book`() =
+        runTest {
+            val fake = FakeDownloadRepository()
+            fake.observeBookStatus(BookId("book-1")).test {
+                assertIs<BookDownloadStatus.NotDownloaded>(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `aggregator returns Completed when all files complete`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.COMPLETED, downloadedBytes = 1000L),
+                            entity("file-2", state = DownloadState.COMPLETED, downloadedBytes = 1000L),
+                        ),
+                )
+            fake.observeBookStatus(BookId("book-1")).test {
+                val status = awaitItem()
+                assertIs<BookDownloadStatus.Completed>(status)
+                assertEquals(2000L, status.totalBytes)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `aggregator returns Failed when any file failed`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.COMPLETED),
+                            entity("file-2", state = DownloadState.FAILED),
+                        ),
+                )
+            fake.observeBookStatus(BookId("book-1")).test {
+                val status = awaitItem()
+                assertIs<BookDownloadStatus.Failed>(status)
+                assertEquals(1, status.partiallyDownloadedFiles)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `aggregator returns InProgress for mixed downloading and queued`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.DOWNLOADING, downloadedBytes = 500L),
+                            entity("file-2", state = DownloadState.QUEUED),
+                        ),
+                )
+            fake.observeBookStatus(BookId("book-1")).test {
+                val status = awaitItem()
+                assertIs<BookDownloadStatus.InProgress>(status)
+                assertEquals(1, status.downloadingFiles)
+                assertEquals(2, status.totalFiles)
+                assertEquals(500L, status.downloadedBytes)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `aggregator returns Paused when all files paused`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.PAUSED, downloadedBytes = 100L),
+                            entity("file-2", state = DownloadState.PAUSED, downloadedBytes = 200L),
+                        ),
+                )
+            fake.observeBookStatus(BookId("book-1")).test {
+                val status = awaitItem()
+                assertIs<BookDownloadStatus.Paused>(status)
+                assertEquals(2, status.pausedFiles)
+                assertEquals(300L, status.downloadedBytes)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `getLocalPath returns null for non-completed file`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)),
+                )
+            assertNull(fake.getLocalPath("file-1"))
+        }
+
+    @Test
+    fun `getLocalPath returns path for completed file`() =
+        runTest {
+            val fake = FakeDownloadRepository()
+            fake.seed(
+                entity("file-1", state = DownloadState.COMPLETED).copy(localPath = "/tmp/file-1.mp3"),
+            )
+            assertEquals("/tmp/file-1.mp3", fake.getLocalPath("file-1"))
+        }
+
+    @Test
+    fun `deleteForBook removes all entities for that book`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", bookId = "book-1"),
+                            entity("file-2", bookId = "book-2"),
+                        ),
+                )
+            fake.deleteForBook("book-1")
+            assertEquals(1, fake.entities.size)
+            assertEquals("book-2", fake.entities.single().bookId)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
@@ -52,7 +52,7 @@ import com.calypsan.listenup.client.data.sync.ProfilePayload
 import com.calypsan.listenup.client.data.sync.ScanCompletedPayload
 import com.calypsan.listenup.client.data.sync.ScanStartedPayload
 import com.calypsan.listenup.client.data.sync.SessionStartedPayload
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.download.DownloadService
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
@@ -219,7 +219,7 @@ class SSEEventProcessorTest {
             // DownloadService stubs
             everySuspend { downloadService.cancelDownload(any()) } returns Unit
             everySuspend { downloadService.deleteDownload(any()) } returns Unit
-            everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.Success
+            everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(com.calypsan.listenup.client.domain.model.DownloadOutcome.Started)
             everySuspend { downloadService.getLocalPath(any()) } returns null
             everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
         }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatusTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatusTest.kt
@@ -1,0 +1,90 @@
+package com.calypsan.listenup.client.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BookDownloadStatusTest {
+    @Test
+    fun `NotDownloaded carries only the bookId`() {
+        val status = BookDownloadStatus.NotDownloaded(bookId = "book-1")
+        assertEquals("book-1", status.bookId)
+    }
+
+    @Test
+    fun `InProgress progress computes from downloadedBytes and totalBytes`() {
+        val status =
+            BookDownloadStatus.InProgress(
+                bookId = "book-1",
+                totalFiles = 4,
+                downloadingFiles = 1,
+                waitingForServerFiles = 0,
+                completedFiles = 2,
+                totalBytes = 1000L,
+                downloadedBytes = 250L,
+            )
+        assertEquals(0.25f, status.progress)
+    }
+
+    @Test
+    fun `InProgress progress is zero when totalBytes is zero`() {
+        val status =
+            BookDownloadStatus.InProgress(
+                bookId = "book-1",
+                totalFiles = 1,
+                downloadingFiles = 1,
+                waitingForServerFiles = 0,
+                completedFiles = 0,
+                totalBytes = 0L,
+                downloadedBytes = 0L,
+            )
+        assertEquals(0f, status.progress)
+    }
+
+    @Test
+    fun `Completed carries totalBytes`() {
+        val status = BookDownloadStatus.Completed(bookId = "book-1", totalBytes = 5000L)
+        assertEquals("book-1", status.bookId)
+        assertEquals(5000L, status.totalBytes)
+    }
+
+    @Test
+    fun `Failed carries error message and partiallyDownloadedFiles count`() {
+        val status =
+            BookDownloadStatus.Failed(
+                bookId = "book-1",
+                errorMessage = "Network unreachable",
+                partiallyDownloadedFiles = 2,
+            )
+        assertEquals("Network unreachable", status.errorMessage)
+        assertEquals(2, status.partiallyDownloadedFiles)
+    }
+
+    @Test
+    fun `Paused carries paused file count and progress numbers`() {
+        val status =
+            BookDownloadStatus.Paused(
+                bookId = "book-1",
+                pausedFiles = 3,
+                downloadedBytes = 100L,
+                totalBytes = 500L,
+            )
+        assertEquals(3, status.pausedFiles)
+        assertEquals(100L, status.downloadedBytes)
+        assertEquals(500L, status.totalBytes)
+    }
+
+    @Test
+    fun `sealed hierarchy enables exhaustive when matching`() {
+        val status: BookDownloadStatus = BookDownloadStatus.NotDownloaded("book-1")
+        val description: String =
+            when (status) {
+                is BookDownloadStatus.NotDownloaded -> "not downloaded"
+                is BookDownloadStatus.InProgress -> "in progress"
+                is BookDownloadStatus.Completed -> "completed"
+                is BookDownloadStatus.Failed -> "failed"
+                is BookDownloadStatus.Paused -> "paused"
+            }
+        assertTrue(description.isNotEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
@@ -2,8 +2,8 @@ package com.calypsan.listenup.client.presentation.storage
 
 import app.cash.turbine.test
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
 import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
-import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.StorageSpaceProvider
 import dev.mokkery.answering.returns
@@ -32,14 +32,16 @@ import kotlin.test.assertTrue
 class StorageViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
-    private class FakeDownloadRepository(
+    /**
+     * Local fake that overrides [observeDownloadedBooks] with a controllable [MutableStateFlow].
+     * All other DownloadRepository methods are satisfied by [FakeDownloadRepository]'s defaults.
+     */
+    private class StorageViewModelFakeDownloadRepository(
         initial: List<DownloadedBookSummary> = emptyList(),
-    ) : DownloadRepository {
+    ) : FakeDownloadRepository() {
         val downloads = MutableStateFlow(initial)
 
         override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> = downloads
-
-        override suspend fun deleteForBook(bookId: String) = Unit
     }
 
     @BeforeTest
@@ -53,7 +55,7 @@ class StorageViewModelTest {
     }
 
     private class Fixture(
-        val downloadRepository: FakeDownloadRepository,
+        val downloadRepository: StorageViewModelFakeDownloadRepository,
         val downloadService: DownloadService,
         val storageSpaceProvider: StorageSpaceProvider,
     )
@@ -65,7 +67,7 @@ class StorageViewModelTest {
     ): Pair<StorageViewModel, Fixture> {
         val fixture =
             Fixture(
-                downloadRepository = FakeDownloadRepository(downloads),
+                downloadRepository = StorageViewModelFakeDownloadRepository(downloads),
                 downloadService = mock(),
                 storageSpaceProvider = mock(),
             )

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -13,7 +13,8 @@ import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlayer
@@ -344,7 +345,7 @@ class PlaybackManagerBufferingStateTest {
         val downloadService: DownloadService = mock()
         everySuspend { downloadService.getLocalPath(any()) } returns null
         everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
         val playbackPreferences: PlaybackPreferences = mock()
         everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -18,7 +18,8 @@ import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
@@ -162,7 +163,7 @@ class PlaybackManagerFallbackFetchTest {
         val downloadService: DownloadService = mock()
         everySuspend { downloadService.getLocalPath(any()) } returns null
         everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
         val playbackPreferences: PlaybackPreferences = mock()
         everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -13,7 +13,8 @@ import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
@@ -129,7 +130,7 @@ class PlaybackManagerPrepareTest {
         val downloadService: DownloadService = mock()
         everySuspend { downloadService.getLocalPath(any()) } returns null
         everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
         val playbackPreferences: PlaybackPreferences = mock()
         everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -15,7 +15,8 @@ import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import com.calypsan.listenup.client.domain.repository.ServerConfig
-import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
@@ -228,7 +229,7 @@ class PlaybackManagerSpeedTest {
         val downloadService: DownloadService = mock()
         everySuspend { downloadService.getLocalPath(any()) } returns null
         everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
         return PlaybackManagerImpl(
             serverConfig = serverConfig,


### PR DESCRIPTION
## Summary

Phase B of W8 (Download Subsystem). Architectural foundation for the rest of W8.

- **`DownloadRepository` becomes the single seam** for download state and aggregation. All state writes route through it (Sync Engine Rule 5). The aggregation reducer that previously lived in `DownloadManager.aggregateStatus` and a duplicated copy in `AppleDownloadService` now lives in `DownloadRepositoryImpl`. `DownloadManager.observeBookStatus` and `observeAllStatuses` delegate to the repository.
- **`DownloadWorker` injects `DownloadRepository` instead of `DownloadDao`** — restores Sync Engine Rule 5 compliance and unlocks commonTest-only worker logic tests for Phase C/D.
- **`BookDownloadStatus` migrated from flat data class to sealed hierarchy** (`NotDownloaded` / `InProgress` / `Completed` / `Failed` / `Paused`). Closes the rubric drift around "UI state is a per-screen sealed hierarchy". The `InProgress.waitingForServerFiles` field exists with value `0` until Phase D adds the new `DownloadState.WAITING_FOR_SERVER` enum entry — added now to avoid reshaping the sealed hierarchy mid-W8. Consumers migrated: `BookDetailScreen`, `DownloadButton` + `DownloadButtonExpanded`, `DesktopBookDetailPlatformActions` (caught by grep sweep, not in original plan list).
- **`DownloadResult` migrated to `AppResult<DownloadOutcome>`** on the `DownloadService` interface and all 3 platform implementations + `BookDetailPlatformActions` and 5 `PlaybackManager` test stubs + `SSEEventProcessorTest` (caught by grep sweep). Closes the Error Model carveout flagged in Finding 08.
- **`FakeDownloadRepository` added** in commonTest per project memory `feedback_fakes_for_seams.md` — hand-rolled in-memory fake that Phase C/D tests depend on. 17 contract-validation tests. Made `open` so `StorageViewModelTest` could subclass for the narrow `observeDownloadedBooks` override case (drift candidate flagged in review).
- **Cross-phase aliasing:** `DownloadRepository` exposes `markCancelled`, `markWaitingForServer`, and `recheckWaitingForServer` so the interface is stable for Phase C/D, but their implementations alias to existing states (`markCancelled` → PAUSED) or no-op until Phase D adds the new enum entries. KDoc on each aliased method explicitly says "Phase B alias — Phase D will switch this to ...".
- **`AppleDownloadService` interface compliance only.** Its direct DAO writes remain a documented W10 carveout per the W8 handoff design (iOS migration is W10 scope).
- **Orchestration methods** (`enqueueForBook`, `cancelForBook`, `resumeForAudioFile`, `resumeIncompleteDownloads`) are declared on the repository but throw `NotImplementedError` in Phase B — Phase C (Ktor migration) and Phase D (Bug 4 fix) move the platform code onto them.

Per the W8 handoff design at `docs/superpowers/specs/2026-05-01-w8-handoff-design.md` § Phase B.

## Test plan

- [x] `:shared:jvmTest` green (×3 sequential runs to surface drift #23 — flake didn't fire)
- [x] `:androidApp:assembleDebug` green
- [x] `spotlessCheck` + `detekt` green
- [x] `:desktopApp:compileKotlinJvm` green
- [ ] Manual smoke: open Android app, confirm download button + flow still work as before (start a download, observe progress, complete, delete)
- [ ] Manual smoke: open Desktop app, confirm download button is still hidden (Phase A regression check)

## Drift #23 reminder

If CI `:shared:jvmTest` fails on `BookRepositoryImplTest.observeBookDetail re-emits when genres change for the book[jvm]` — that's the known drift #23 flake (~67% failure rate per project memory). Re-run; not introduced by this PR.

## Successor

Phase C (Ktor migration of `DownloadWorker`). Plan to follow.