### PR TITLE
🐛 W8 Phase D — Bug 4 fix (WAITING_FOR_SERVER + SSE re-enqueue)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -13,6 +13,8 @@ import com.calypsan.listenup.client.data.remote.PlaybackApi
 import com.calypsan.listenup.client.data.remote.PlaybackApiContract
 import com.calypsan.listenup.client.di.playbackPresentationModule
 import com.calypsan.listenup.client.di.sharedModules
+import com.calypsan.listenup.client.download.AndroidDownloadEnqueuer
+import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadManager
 import com.calypsan.listenup.client.features.bookdetail.AndroidBookDetailPlatformActions
@@ -214,6 +216,14 @@ val downloadModule =
 
         // Also expose the concrete type for Android-specific features
         single { get<DownloadService>() as DownloadManager }
+
+        // DownloadEnqueuer seam — Android backend for DownloadRepository.resumeForAudioFile
+        single<DownloadEnqueuer> {
+            AndroidDownloadEnqueuer(
+                workManager = WorkManager.getInstance(androidContext()),
+                localPreferences = get(),
+            )
+        }
 
         // Platform actions for BookDetailScreen (download + playback integration)
         single<BookDetailPlatformActions> {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DownloadButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DownloadButton.kt
@@ -39,6 +39,7 @@ import listenup.composeapp.generated.resources.book_detail_progresspercent
 import listenup.composeapp.generated.resources.book_detail_queued
 import listenup.composeapp.generated.resources.common_retry
 import listenup.composeapp.generated.resources.book_detail_retry_download
+import listenup.composeapp.generated.resources.book_detail_preparing_on_server
 import listenup.composeapp.generated.resources.book_detail_waiting_for_wifi
 
 /**
@@ -117,6 +118,12 @@ fun DownloadButton(
                                         tint = contentColor.copy(alpha = 0.6f),
                                     )
                                 }
+                            }
+
+                            // Bug 4 (W8 Phase D): server is transcoding. Distinct visual state
+                            // so the user knows the worker isn't stuck — server-side work in flight.
+                            status.waitingForServerFiles > 0 -> {
+                                ListenUpLoadingIndicatorSmall()
                             }
 
                             isWaitingForWifi -> {
@@ -212,6 +219,14 @@ fun DownloadButtonExpanded(
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(stringResource(Res.string.book_detail_progresspercent, progressPercent))
                         }
+                    }
+
+                    // Bug 4 (W8 Phase D): server is transcoding. Distinct text state
+                    // so the user knows the worker isn't stuck — server-side work in flight.
+                    status.waitingForServerFiles > 0 -> {
+                        ListenUpLoadingIndicatorSmall()
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(Res.string.book_detail_preparing_on_server))
                     }
 
                     isWaitingForWifi -> {

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -5,8 +5,10 @@ import com.calypsan.listenup.client.data.remote.PlaybackApi
 import com.calypsan.listenup.client.data.remote.PlaybackApiContract
 import com.calypsan.listenup.client.features.bookdetail.BookDetailPlatformActions
 import com.calypsan.listenup.client.features.bookdetail.DesktopBookDetailPlatformActions
+import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.download.JvmDownloadEnqueuer
 import com.calypsan.listenup.client.platform.DesktopAudioTokenProvider
 import com.calypsan.listenup.client.platform.StubBackgroundSyncScheduler
 import com.calypsan.listenup.client.platform.StubDownloadService
@@ -96,6 +98,9 @@ val platformModule: Module =
 
         // Download service (stub)
         single<DownloadService> { StubDownloadService() }
+
+        // DownloadEnqueuer seam — Desktop no-op (downloads not supported)
+        single<DownloadEnqueuer> { JvmDownloadEnqueuer() }
 
         // Playback API for codec negotiation
         single<PlaybackApiContract> { PlaybackApi(clientFactory = get()) }

--- a/shared/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/12.json
+++ b/shared/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/12.json
@@ -1,0 +1,2385 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "bc83151670867c30f0123db76cc1f870",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `firstName` TEXT, `lastName` TEXT, `isRoot` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `tagline` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRoot",
+            "columnName": "isRoot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `sortTitle` TEXT, `subtitle` TEXT, `coverUrl` TEXT, `coverBlurHash` TEXT, `dominantColor` INTEGER, `darkMutedColor` INTEGER, `vibrantColor` INTEGER, `totalDuration` INTEGER NOT NULL, `description` TEXT, `publishYear` INTEGER, `publisher` TEXT, `language` TEXT, `isbn` TEXT, `asin` TEXT, `abridged` INTEGER NOT NULL, `syncState` TEXT NOT NULL, `lastModified` INTEGER NOT NULL, `serverVersion` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortTitle",
+            "columnName": "sortTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dominantColor",
+            "columnName": "dominantColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "darkMutedColor",
+            "columnName": "darkMutedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "vibrantColor",
+            "columnName": "vibrantColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalDuration",
+            "columnName": "totalDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishYear",
+            "columnName": "publishYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abridged",
+            "columnName": "abridged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_syncState",
+            "unique": false,
+            "columnNames": [
+              "syncState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_syncState` ON `${TABLE_NAME}` (`syncState`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_readers_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `totalReaders` INTEGER NOT NULL, `totalCompletions` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalReaders",
+            "columnName": "totalReaders",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCompletions",
+            "columnName": "totalCompletions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `startTime` INTEGER NOT NULL, `syncState` TEXT NOT NULL, `lastModified` INTEGER NOT NULL, `serverVersion` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_chapters_syncState",
+            "unique": false,
+            "columnNames": [
+              "syncState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_syncState` ON `${TABLE_NAME}` (`syncState`)"
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `asin` TEXT, `coverImagePath` TEXT, `coverBlurHash` TEXT, `syncState` TEXT NOT NULL, `lastModified` INTEGER NOT NULL, `serverVersion` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImagePath",
+            "columnName": "coverImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_series_syncState",
+            "unique": false,
+            "columnNames": [
+              "syncState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_syncState` ON `${TABLE_NAME}` (`syncState`)"
+          }
+        ]
+      },
+      {
+        "tableName": "contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `asin` TEXT, `description` TEXT, `imagePath` TEXT, `imageBlurHash` TEXT, `website` TEXT, `birthDate` TEXT, `deathDate` TEXT, `syncState` TEXT NOT NULL, `lastModified` INTEGER NOT NULL, `serverVersion` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "imagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "website",
+            "columnName": "website",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deathDate",
+            "columnName": "deathDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributors_syncState",
+            "unique": false,
+            "columnNames": [
+              "syncState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributors_syncState` ON `${TABLE_NAME}` (`syncState`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `contributorId` TEXT NOT NULL, `role` TEXT NOT NULL, `creditedAs` TEXT, PRIMARY KEY(`bookId`, `contributorId`, `role`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditedAs",
+            "columnName": "creditedAs",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "contributorId",
+            "role"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_contributors_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_contributors_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contributor_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contributorId` TEXT NOT NULL, `alias` TEXT NOT NULL, PRIMARY KEY(`contributorId`, `alias`), FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contributorId",
+            "alias"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributor_aliases_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributor_aliases_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `sequence` TEXT, PRIMARY KEY(`bookId`, `seriesId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "seriesId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_series_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_series_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `hasCustomSpeed` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `syncedAt` INTEGER, `lastPlayedAt` INTEGER, `isFinished` INTEGER NOT NULL, `finishedAt` INTEGER, `startedAt` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomSpeed",
+            "columnName": "hasCustomSpeed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFinished",
+            "columnName": "isFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_operations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `operationType` TEXT NOT NULL, `entityType` TEXT, `entityId` TEXT, `payload` TEXT NOT NULL, `batchKey` TEXT, `status` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `attemptCount` INTEGER NOT NULL, `lastError` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationType",
+            "columnName": "operationType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchKey",
+            "columnName": "batchKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_operations_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operations_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_pending_operations_operationType_entityId",
+            "unique": false,
+            "columnNames": [
+              "operationType",
+              "entityId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operations_operationType_entityId` ON `${TABLE_NAME}` (`operationType`, `entityId`)"
+          },
+          {
+            "name": "index_pending_operations_batchKey",
+            "unique": false,
+            "columnNames": [
+              "batchKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operations_batchKey` ON `${TABLE_NAME}` (`batchKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`audioFileId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `filename` TEXT NOT NULL, `fileIndex` INTEGER NOT NULL, `state` TEXT NOT NULL, `localPath` TEXT, `totalBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, `startedAt` INTEGER, `completedAt` INTEGER, `errorMessage` TEXT, `retryCount` INTEGER NOT NULL, `transcodeJobId` TEXT, PRIMARY KEY(`audioFileId`))",
+        "fields": [
+          {
+            "fieldPath": "audioFileId",
+            "columnName": "audioFileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileIndex",
+            "columnName": "fileIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transcodeJobId",
+            "columnName": "transcodeJobId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "audioFileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `apiVersion` TEXT NOT NULL, `serverVersion` TEXT NOT NULL, `localUrl` TEXT, `remoteUrl` TEXT, `accessToken` TEXT, `refreshToken` TEXT, `sessionId` TEXT, `userId` TEXT, `isActive` INTEGER NOT NULL, `lastSeenAt` INTEGER NOT NULL, `lastConnectedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiVersion",
+            "columnName": "apiVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUrl",
+            "columnName": "localUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteUrl",
+            "columnName": "remoteUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "refreshToken",
+            "columnName": "refreshToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAt",
+            "columnName": "lastSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastConnectedAt",
+            "columnName": "lastConnectedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_servers_isActive",
+            "unique": false,
+            "columnNames": [
+              "isActive"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_servers_isActive` ON `${TABLE_NAME}` (`isActive`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `syncState` TEXT NOT NULL, `serverVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "shelves",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `ownerId` TEXT NOT NULL, `ownerDisplayName` TEXT NOT NULL, `ownerAvatarColor` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, `totalDurationSeconds` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `coverPaths` TEXT NOT NULL, `syncState` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerDisplayName",
+            "columnName": "ownerDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerAvatarColor",
+            "columnName": "ownerAvatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDurationSeconds",
+            "columnName": "totalDurationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPaths",
+            "columnName": "coverPaths",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelves_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelves_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_shelves_syncState",
+            "unique": false,
+            "columnNames": [
+              "syncState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelves_syncState` ON `${TABLE_NAME}` (`syncState`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelf_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`shelfId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`shelfId`, `bookId`), FOREIGN KEY(`shelfId`) REFERENCES `shelves`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "shelfId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelf_books_shelfId",
+            "unique": false,
+            "columnNames": [
+              "shelfId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_shelfId` ON `${TABLE_NAME}` (`shelfId`)"
+          },
+          {
+            "name": "index_shelf_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "shelves",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "shelfId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `slug` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_slug",
+            "unique": true,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `tagId` TEXT NOT NULL, PRIMARY KEY(`bookId`, `tagId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_tags_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `path` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, `parentId` TEXT, `depth` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "depth",
+            "columnName": "depth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genres_slug",
+            "unique": true,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genres_slug` ON `${TABLE_NAME}` (`slug`)"
+          },
+          {
+            "name": "index_genres_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genres_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `genreId` TEXT NOT NULL, PRIMARY KEY(`bookId`, `genreId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`genreId`) REFERENCES `genres`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreId",
+            "columnName": "genreId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "genreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_genres_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_genres_genreId",
+            "unique": false,
+            "columnNames": [
+              "genreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_genreId` ON `${TABLE_NAME}` (`genreId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "genres",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "genreId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `codec` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codec",
+            "columnName": "codec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_files_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_files_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `endPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `deviceId` TEXT NOT NULL, `syncState` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPositionMs",
+            "columnName": "endPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_listening_events_endedAt",
+            "unique": false,
+            "columnNames": [
+              "endedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_endedAt` ON `${TABLE_NAME}` (`endedAt`)"
+          },
+          {
+            "name": "index_listening_events_syncState",
+            "unique": false,
+            "columnNames": [
+              "syncState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_syncState` ON `${TABLE_NAME}` (`syncState`)"
+          }
+        ]
+      },
+      {
+        "tableName": "active_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_active_sessions_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_active_sessions_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_active_sessions_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_active_sessions_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "activities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `type` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `userDisplayName` TEXT NOT NULL, `userAvatarColor` TEXT NOT NULL, `userAvatarType` TEXT NOT NULL, `userAvatarValue` TEXT, `bookId` TEXT, `bookTitle` TEXT, `bookAuthorName` TEXT, `bookCoverPath` TEXT, `isReread` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `milestoneValue` INTEGER NOT NULL, `milestoneUnit` TEXT, `shelfId` TEXT, `shelfName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarColor",
+            "columnName": "userAvatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarType",
+            "columnName": "userAvatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarValue",
+            "columnName": "userAvatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookTitle",
+            "columnName": "bookTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookAuthorName",
+            "columnName": "bookAuthorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCoverPath",
+            "columnName": "bookCoverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isReread",
+            "columnName": "isReread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneValue",
+            "columnName": "milestoneValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneUnit",
+            "columnName": "milestoneUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfName",
+            "columnName": "shelfName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_activities_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_activities_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarColor` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `totalTimeMs` INTEGER NOT NULL, `totalBooks` INTEGER NOT NULL, `currentStreak` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalTimeMs",
+            "columnName": "totalTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBooks",
+            "columnName": "totalBooks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreak",
+            "columnName": "currentStreak",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_reading_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `userId` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `finishedAt` INTEGER, `isCompleted` INTEGER NOT NULL, `listenTimeMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listenTimeMs",
+            "columnName": "listenTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_reading_sessions_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_reading_sessions_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_user_reading_sessions_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_reading_sessions_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reader_sessions_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `userId` TEXT NOT NULL, `userDisplayName` TEXT NOT NULL, `userAvatarColor` TEXT NOT NULL, `userAvatarType` TEXT NOT NULL, `userAvatarValue` TEXT, `isCurrentlyReading` INTEGER NOT NULL, `currentProgress` REAL NOT NULL, `startedAt` INTEGER NOT NULL, `finishedAt` INTEGER, `completionCount` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`, `userId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarColor",
+            "columnName": "userAvatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarType",
+            "columnName": "userAvatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarValue",
+            "columnName": "userAvatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCurrentlyReading",
+            "columnName": "isCurrentlyReading",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentProgress",
+            "columnName": "currentProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completionCount",
+            "columnName": "completionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reader_sessions_cache_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reader_sessions_cache_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cover_download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `status` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `error` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bc83151670867c30f0123db76cc1f870')"
+    ]
+  }
+}

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/AndroidDownloadEnqueuer.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/AndroidDownloadEnqueuer.kt
@@ -1,0 +1,50 @@
+package com.calypsan.listenup.client.download
+
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.suspendRunCatching
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
+
+/**
+ * Android implementation of [DownloadEnqueuer] backed by WorkManager.
+ * Lifted from [DownloadManager]'s existing enqueue pattern (single-file variant).
+ */
+class AndroidDownloadEnqueuer(
+    private val workManager: WorkManager,
+    private val localPreferences: LocalPreferences,
+) : DownloadEnqueuer {
+    override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> =
+        suspendRunCatching {
+            val wifiOnly = localPreferences.wifiOnlyDownloads.value
+            val requiredNetworkType = if (wifiOnly) NetworkType.UNMETERED else NetworkType.CONNECTED
+            val workRequest =
+                OneTimeWorkRequestBuilder<DownloadWorker>()
+                    .setInputData(
+                        workDataOf(
+                            DownloadWorker.KEY_AUDIO_FILE_ID to entity.audioFileId,
+                            DownloadWorker.KEY_BOOK_ID to entity.bookId,
+                            DownloadWorker.KEY_FILENAME to entity.filename,
+                            DownloadWorker.KEY_FILE_SIZE to entity.totalBytes,
+                        ),
+                    ).setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(requiredNetworkType)
+                            .build(),
+                    ).addTag("download_${entity.bookId}")
+                    .addTag("download_file_${entity.audioFileId}")
+                    .build()
+
+            workManager.enqueueUniqueWork(
+                "download_${entity.audioFileId}",
+                ExistingWorkPolicy.REPLACE,
+                workRequest,
+            )
+        }
+}

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadEnqueuer.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadEnqueuer.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.client.download
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+
+/**
+ * iOS no-op enqueuer. iOS downloads go through [AppleDownloadService] (NSURLSession-based)
+ * which is W10 carveout territory; the SSE re-enqueue path is Android-only until W10.
+ */
+class AppleDownloadEnqueuer : DownloadEnqueuer {
+    override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> =
+        AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Re-enqueue not supported on iOS until W10"))
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/DownloadError.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/DownloadError.kt
@@ -37,4 +37,19 @@ sealed interface DownloadError : AppError {
         override val code = "DOWNLOAD_INSUFFICIENT_STORAGE"
         override val isRetryable = false
     }
+
+    /**
+     * Transcoding job timed out (24h backstop) or server lost the job. User can retry.
+     */
+    data class TranscodeTimeout(
+        val transcodeJobId: String,
+        val bookTitle: String? = null,
+        override val debugInfo: String? = null,
+    ) : DownloadError {
+        override val message =
+            bookTitle?.let { "Transcoding timed out for \"$it\". Try again." }
+                ?: "Transcoding timed out. Try again."
+        override val code = "DOWNLOAD_TRANSCODE_TIMEOUT"
+        override val isRetryable = true
+    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
@@ -30,6 +30,20 @@ interface DownloadDao {
     suspend fun getIncomplete(): List<DownloadEntity>
 
     /**
+     * Get all rows in WAITING_FOR_SERVER state. Used by the SSE-reconnect re-check path
+     * to re-issue preparePlayback for files we may have missed transcode.complete events for.
+     */
+    @Query("SELECT * FROM downloads WHERE state = 6")
+    suspend fun getWaitingForServer(): List<DownloadEntity>
+
+    /**
+     * Get WAITING_FOR_SERVER rows older than [thresholdMs]. Used by the 24h backstop in
+     * resumeIncompleteDownloads to mark stale jobs as TranscodeTimeout.
+     */
+    @Query("SELECT * FROM downloads WHERE state = 6 AND startedAt < :thresholdMs")
+    suspend fun getOldWaitingForServer(thresholdMs: Long): List<DownloadEntity>
+
+    /**
      * Get local path for a completed download.
      * Uses ordinal 3 for COMPLETED state (QUEUED=0, DOWNLOADING=1, PAUSED=2, COMPLETED=3, FAILED=4)
      */
@@ -94,6 +108,22 @@ interface DownloadDao {
         localPath: String,
         completedAt: Long,
     ) = markCompletedWithState(audioFileId, localPath, completedAt, DownloadState.COMPLETED)
+
+    /**
+     * Atomically transition to WAITING_FOR_SERVER and persist the transcodeJobId for SSE re-enqueue.
+     */
+    @Query(
+        """
+        UPDATE downloads SET
+            state = 6,
+            transcodeJobId = :transcodeJobId
+        WHERE audioFileId = :audioFileId
+    """,
+    )
+    suspend fun markWaitingForServer(
+        audioFileId: String,
+        transcodeJobId: String,
+    )
 
     // Mark error
     @Query(

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
@@ -33,14 +33,14 @@ interface DownloadDao {
      * Get all rows in WAITING_FOR_SERVER state. Used by the SSE-reconnect re-check path
      * to re-issue preparePlayback for files we may have missed transcode.complete events for.
      */
-    @Query("SELECT * FROM downloads WHERE state = 6")
+    @Query("SELECT * FROM downloads WHERE state = 'WAITING_FOR_SERVER'")
     suspend fun getWaitingForServer(): List<DownloadEntity>
 
     /**
      * Get WAITING_FOR_SERVER rows older than [thresholdMs]. Used by the 24h backstop in
      * resumeIncompleteDownloads to mark stale jobs as TranscodeTimeout.
      */
-    @Query("SELECT * FROM downloads WHERE state = 6 AND startedAt < :thresholdMs")
+    @Query("SELECT * FROM downloads WHERE state = 'WAITING_FOR_SERVER' AND startedAt < :thresholdMs")
     suspend fun getOldWaitingForServer(thresholdMs: Long): List<DownloadEntity>
 
     /**
@@ -115,7 +115,7 @@ interface DownloadDao {
     @Query(
         """
         UPDATE downloads SET
-            state = 6,
+            state = 'WAITING_FOR_SERVER',
             transcodeJobId = :transcodeJobId
         WHERE audioFileId = :audioFileId
     """,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadEntity.kt
@@ -31,4 +31,5 @@ data class DownloadEntity(
     val completedAt: Long?,
     val errorMessage: String?,
     val retryCount: Int = 0,
+    val transcodeJobId: String? = null, // W8 Phase D — set when state=WAITING_FOR_SERVER for SSE re-enqueue
 )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -52,7 +52,7 @@ import androidx.room.TypeConverters
         ReaderSessionCacheEntity::class,
         CoverDownloadTaskEntity::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = true,
 )
 @TypeConverters(

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
@@ -119,7 +119,9 @@ class Converters {
 /**
  * Download state for tracking individual audio file downloads.
  *
- * Ordinals: QUEUED=0, DOWNLOADING=1, PAUSED=2, COMPLETED=3, FAILED=4, DELETED=5
+ * Ordinals: QUEUED=0, DOWNLOADING=1, PAUSED=2, COMPLETED=3, FAILED=4, DELETED=5,
+ *           WAITING_FOR_SERVER=6 (W8 Phase D — server is transcoding; SSE transcode.complete will re-enqueue),
+ *           CANCELLED=7 (W8 Phase D — user cancelled, distinct from PAUSED so late SSE events drop).
  */
 enum class DownloadState {
     QUEUED, // Waiting to start
@@ -128,6 +130,8 @@ enum class DownloadState {
     COMPLETED, // Successfully downloaded
     FAILED, // Error occurred
     DELETED, // User explicitly deleted - files removed, don't auto-download
+    WAITING_FOR_SERVER, // Server is transcoding; SSE transcode.complete will re-enqueue
+    CANCELLED, // User cancelled mid-transcode; distinct from PAUSED so late SSE events drop
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackApi.kt
@@ -31,6 +31,13 @@ interface PlaybackApiContract {
         capabilities: List<String>,
         spatial: Boolean,
     ): AppResult<PreparePlaybackResponse>
+
+    /**
+     * Cancel a server-side transcoding job. 204 on success; 404 if job doesn't exist
+     * or already completed/cancelled (idempotent). Used by W8 Phase D's
+     * cancel-during-WAITING_FOR_SERVER flow.
+     */
+    suspend fun cancelTranscode(jobId: String): AppResult<Unit>
 }
 
 /**
@@ -89,6 +96,11 @@ class PlaybackApi(
                 is com.calypsan.listenup.client.core.Success -> result.data.toDomain()
                 is com.calypsan.listenup.client.core.Failure -> throw AppException(result.error)
             }
+        }
+
+    override suspend fun cancelTranscode(jobId: String): AppResult<Unit> =
+        suspendRunCatching {
+            clientFactory.getClient().post("/api/v1/transcode/cancel/$jobId")
         }
 }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackApi.kt
@@ -1,21 +1,25 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.Failure
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.error.AppException
+import com.calypsan.listenup.client.core.error.ServerError
 import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.remote.model.ApiResponse
-import com.calypsan.listenup.client.core.error.AppException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import com.calypsan.listenup.client.core.Success
-import com.calypsan.listenup.client.core.Failure
 
 private val logger = KotlinLogging.logger {}
+
+private const val HTTP_NOT_FOUND = 404
 
 /**
  * Seam interface for playback API operations.
@@ -99,8 +103,21 @@ class PlaybackApi(
         }
 
     override suspend fun cancelTranscode(jobId: String): AppResult<Unit> =
-        suspendRunCatching {
+        try {
             clientFactory.getClient().post("/api/v1/transcode/cancel/$jobId")
+            AppResult.Success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: AppException) {
+            // 404 means "already cancelled / completed / never existed" — idempotent per server contract.
+            val serverError = e.error as? ServerError
+            if (serverError?.statusCode == HTTP_NOT_FOUND) {
+                AppResult.Success(Unit)
+            } else {
+                AppResult.Failure(e.error)
+            }
+        } catch (e: Exception) {
+            Failure(e)
         }
 }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -111,10 +111,9 @@ class DownloadRepositoryImpl(
             downloadDao.updateState(audioFileId, DownloadState.PAUSED)
         }
 
-    // Phase B alias: cancellation collapses into PAUSED. Phase D adds DownloadState.CANCELLED.
     override suspend fun markCancelled(audioFileId: String): AppResult<Unit> =
         suspendRunCatching {
-            downloadDao.updateState(audioFileId, DownloadState.PAUSED)
+            downloadDao.updateState(audioFileId, DownloadState.CANCELLED)
         }
 
     override suspend fun markFailed(

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -283,7 +283,10 @@ class DownloadRepositoryImpl(
         if (downloads.isEmpty()) {
             return BookDownloadStatus.NotDownloaded(bookId)
         }
-        val activeDownloads = downloads.filter { it.state != DownloadState.DELETED }
+        val activeDownloads =
+            downloads.filter {
+                it.state != DownloadState.DELETED && it.state != DownloadState.CANCELLED
+            }
         if (activeDownloads.isEmpty()) {
             return BookDownloadStatus.NotDownloaded(bookId)
         }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -17,8 +17,11 @@ import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.playback.AudioCapabilityDetector
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Single seam for download state + aggregation. All download writes go through this class
@@ -149,12 +152,31 @@ class DownloadRepositoryImpl(
                 "orchestration on DownloadManager (Android) and AppleDownloadService (iOS).",
         )
 
-    @Suppress("NotImplementedDeclaration") // Phase C/D scope — intentional stub per W8 design
     override suspend fun cancelForBook(bookId: BookId): AppResult<Unit> =
-        throw NotImplementedError(
-            "DownloadRepository.cancelForBook is Phase C/D scope. Phase B keeps cancellation " +
-                "on the DownloadService impls.",
-        )
+        suspendRunCatching {
+            val rows = downloadDao.getForBook(bookId.value)
+
+            // For WAITING_FOR_SERVER rows, tell the server to stop transcoding (Q8 B1).
+            // Failures are logged but not fatal — local state still transitions to CANCELLED below.
+            for (row in rows) {
+                if (row.state == DownloadState.WAITING_FOR_SERVER) {
+                    val jobId = row.transcodeJobId ?: continue
+                    val result = playbackApi.cancelTranscode(jobId)
+                    if (result is AppResult.Failure) {
+                        logger.warn {
+                            "cancelTranscode failed for jobId=$jobId: ${result.error.message} — continuing with local cancel"
+                        }
+                    }
+                }
+            }
+
+            // Transition all non-terminal rows to CANCELLED.
+            for (row in rows) {
+                if (row.state != DownloadState.COMPLETED && row.state != DownloadState.DELETED) {
+                    markCancelled(row.audioFileId)
+                }
+            }
+        }
 
     override suspend fun deleteForBook(bookId: String) {
         downloadDao.deleteForBook(bookId)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.download.DownloadEnqueuer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -20,8 +21,9 @@ import kotlinx.coroutines.flow.map
  * (Sync Engine Rule 5). Aggregation reducer lives here so platforms share the same state-machine.
  *
  * **Phase B scope:** state transitions + aggregation + reads. Orchestration methods
- * (`enqueueForBook`, `cancelForBook`, `resumeForAudioFile`, `resumeIncompleteDownloads`)
- * throw [NotImplementedError] in Phase B — Phase C / Phase D move platform code onto them.
+ * (`enqueueForBook`, `cancelForBook`, `resumeIncompleteDownloads`)
+ * throw [NotImplementedError] until Phase C/D moves platform code onto them.
+ * `resumeForAudioFile` is implemented in Phase D via the [DownloadEnqueuer] seam.
  *
  * Cross-phase aliases per W8 design:
  * - [markCancelled] writes [DownloadState.PAUSED]; Phase D switches to a new `CANCELLED` entry.
@@ -31,6 +33,7 @@ import kotlinx.coroutines.flow.map
 class DownloadRepositoryImpl(
     private val downloadDao: DownloadDao,
     private val bookRepository: BookRepository,
+    private val enqueuer: DownloadEnqueuer,
 ) : DownloadRepository {
     // --- Reads ---
 
@@ -152,11 +155,22 @@ class DownloadRepositoryImpl(
         downloadDao.deleteForBook(bookId)
     }
 
-    @Suppress("NotImplementedDeclaration") // Phase D scope — intentional stub per W8 design
-    override suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit> =
-        throw NotImplementedError(
-            "DownloadRepository.resumeForAudioFile is Phase D scope (Bug 4 SSE handler).",
-        )
+    override suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit> {
+        val entity =
+            downloadDao.getByAudioFileId(audioFileId)
+                ?: return AppResult.Failure(
+                    DownloadError.DownloadFailed(
+                        debugInfo = "No download row for $audioFileId",
+                    ),
+                )
+
+        // Late SSE event for a cancelled or completed row — silently drop (defense-in-depth net).
+        if (entity.state == DownloadState.CANCELLED || entity.state == DownloadState.COMPLETED) {
+            return AppResult.Success(Unit)
+        }
+
+        return enqueuer.enqueue(entity)
+    }
 
     @Suppress("NotImplementedDeclaration") // Phase C/D scope — intentional stub per W8 design
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -125,11 +125,13 @@ class DownloadRepositoryImpl(
             downloadDao.updateError(audioFileId, error.message)
         }
 
-    // Phase B alias: no-op. Phase D writes DownloadState.WAITING_FOR_SERVER + persists transcodeJobId.
     override suspend fun markWaitingForServer(
         audioFileId: String,
         transcodeJobId: String,
-    ): AppResult<Unit> = AppResult.Success(Unit)
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            downloadDao.markWaitingForServer(audioFileId, transcodeJobId)
+        }
 
     // --- Orchestration (Phase B: stub; Phase C/D move platform code onto these) ---
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -2,17 +2,21 @@ package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.core.error.DownloadError
 import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.data.remote.PlaybackApiContract
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.download.DownloadEnqueuer
+import com.calypsan.listenup.client.playback.AudioCapabilityDetector
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -20,20 +24,21 @@ import kotlinx.coroutines.flow.map
  * Single seam for download state + aggregation. All download writes go through this class
  * (Sync Engine Rule 5). Aggregation reducer lives here so platforms share the same state-machine.
  *
- * **Phase B scope:** state transitions + aggregation + reads. Orchestration methods
- * (`enqueueForBook`, `cancelForBook`, `resumeIncompleteDownloads`)
+ * **Phase D scope:** state transitions + aggregation + reads + SSE-reconnect recheck +
+ * app-startup recovery (24h backstop). Orchestration methods (`enqueueForBook`, `cancelForBook`)
  * throw [NotImplementedError] until Phase C/D moves platform code onto them.
- * `resumeForAudioFile` is implemented in Phase D via the [DownloadEnqueuer] seam.
+ * `resumeForAudioFile` and `resumeIncompleteDownloads` are implemented via the [DownloadEnqueuer] seam.
  *
  * Cross-phase aliases per W8 design:
- * - [markCancelled] writes [DownloadState.PAUSED]; Phase D switches to a new `CANCELLED` entry.
- * - [markWaitingForServer] is a no-op; Phase D writes a new `WAITING_FOR_SERVER` entry.
- * - [recheckWaitingForServer] is a no-op; Phase D wires the SSE-reconnect hook.
+ * - [markCancelled] writes [DownloadState.CANCELLED] (Phase D real impl).
  */
 class DownloadRepositoryImpl(
     private val downloadDao: DownloadDao,
     private val bookRepository: BookRepository,
     private val enqueuer: DownloadEnqueuer,
+    private val playbackApi: PlaybackApiContract,
+    private val playbackPreferences: PlaybackPreferences,
+    private val capabilityDetector: AudioCapabilityDetector,
 ) : DownloadRepository {
     // --- Reads ---
 
@@ -172,15 +177,80 @@ class DownloadRepositoryImpl(
         return enqueuer.enqueue(entity)
     }
 
-    @Suppress("NotImplementedDeclaration") // Phase C/D scope — intentional stub per W8 design
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> =
-        throw NotImplementedError(
-            "DownloadRepository.resumeIncompleteDownloads is Phase C/D scope. Phase B keeps " +
-                "this on the DownloadService impls.",
-        )
+        suspendRunCatching {
+            val now = currentEpochMilliseconds()
+            val backstopMs = 24L * 60L * 60L * 1000L // 24 hours
 
-    // Phase B alias: no-op. Phase D wires the SSE-reconnect hook.
-    override suspend fun recheckWaitingForServer(): AppResult<Unit> = AppResult.Success(Unit)
+            // 24h backstop: any WAITING_FOR_SERVER row older than 24h is stuck — mark FAILED.
+            val staleWaiting = downloadDao.getOldWaitingForServer(thresholdMs = now - backstopMs)
+            for (row in staleWaiting) {
+                markFailed(
+                    row.audioFileId,
+                    DownloadError.TranscodeTimeout(
+                        transcodeJobId = row.transcodeJobId ?: "unknown",
+                    ),
+                )
+            }
+
+            // Re-enqueue incomplete (non-stale) downloads via the platform enqueuer.
+            // Note: existing DownloadManager.resumeIncompleteDownloads also runs at app startup and is
+            // the primary recovery path; this method exists for parity. Phase E may consolidate.
+            val incomplete = downloadDao.getIncomplete()
+            for (row in incomplete) {
+                // Skip rows we just timed out above.
+                if (row.state == DownloadState.WAITING_FOR_SERVER &&
+                    row.startedAt != null &&
+                    row.startedAt < now - backstopMs
+                ) {
+                    continue
+                }
+                enqueuer.enqueue(row)
+            }
+        }
+
+    override suspend fun recheckWaitingForServer(): AppResult<Unit> =
+        suspendRunCatching {
+            val rows = downloadDao.getWaitingForServer()
+            if (rows.isEmpty()) return@suspendRunCatching
+
+            val capabilities = capabilityDetector.getSupportedCodecs()
+            val spatial = playbackPreferences.getSpatialPlayback()
+
+            for (row in rows) {
+                val result = playbackApi.preparePlayback(row.bookId, row.audioFileId, capabilities, spatial)
+                when (result) {
+                    is AppResult.Success -> {
+                        val response = result.data
+                        when {
+                            response.ready -> {
+                                // Transcode finished during disconnect — re-enqueue.
+                                resumeForAudioFile(row.audioFileId)
+                            }
+
+                            response.transcodeJobId == null -> {
+                                // Server lost the job — mark failed so user can retry.
+                                markFailed(
+                                    row.audioFileId,
+                                    DownloadError.TranscodeTimeout(
+                                        transcodeJobId = row.transcodeJobId ?: "unknown",
+                                    ),
+                                )
+                            }
+
+                            else -> {
+                                // Still transcoding — leave alone; next reconnect or transcode.complete will pick it up.
+                            }
+                        }
+                    }
+
+                    is AppResult.Failure -> {
+                        // Network / server error during recheck — leave WAITING_FOR_SERVER alone;
+                        // user can manually retry or wait for next reconnect.
+                    }
+                }
+            }
+        }
 
     // --- Aggregation reducer (shared across platforms) ---
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -322,7 +322,7 @@ class DownloadRepositoryImpl(
                     bookId = bookId,
                     totalFiles = totalFiles,
                     downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
-                    waitingForServerFiles = 0,
+                    waitingForServerFiles = activeDownloads.count { it.state == DownloadState.WAITING_FOR_SERVER },
                     completedFiles = completedFiles,
                     totalBytes = totalBytes,
                     downloadedBytes = downloadedBytes,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEEvent.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEEvent.kt
@@ -81,6 +81,29 @@ sealed interface SSEEvent {
         val data: LibraryAccessModeChangedPayload,
     ) : SSEEvent
 
+    // ===== Transcode events =====
+
+    @Serializable
+    @SerialName("transcode.complete")
+    data class TranscodeComplete(
+        override val timestamp: String,
+        val data: TranscodeCompletePayload,
+    ) : SSEEvent
+
+    @Serializable
+    @SerialName("transcode.progress")
+    data class TranscodeProgress(
+        override val timestamp: String,
+        val data: TranscodeProgressPayload,
+    ) : SSEEvent
+
+    @Serializable
+    @SerialName("transcode.failed")
+    data class TranscodeFailed(
+        override val timestamp: String,
+        val data: TranscodeFailedPayload,
+    ) : SSEEvent
+
     // ===== Heartbeat (no payload) =====
 
     @Serializable
@@ -365,6 +388,29 @@ data class ScanProgressPayload(
 data class LibraryAccessModeChangedPayload(
     @SerialName("library_id") val libraryId: String,
     @SerialName("access_mode") val accessMode: String,
+)
+
+@Serializable
+data class TranscodeCompletePayload(
+    @SerialName("job_id") val jobId: String,
+    @SerialName("book_id") val bookId: String,
+    @SerialName("audio_file_id") val audioFileId: String,
+)
+
+@Serializable
+data class TranscodeProgressPayload(
+    @SerialName("job_id") val jobId: String,
+    @SerialName("book_id") val bookId: String,
+    @SerialName("audio_file_id") val audioFileId: String,
+    val progress: Int,
+)
+
+@Serializable
+data class TranscodeFailedPayload(
+    @SerialName("job_id") val jobId: String,
+    @SerialName("book_id") val bookId: String,
+    @SerialName("audio_file_id") val audioFileId: String,
+    val error: String,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEManager.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.client.core.appJson
 import com.calypsan.listenup.client.core.error.ErrorBus
 import com.calypsan.listenup.client.core.error.SyncError
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.plugins.ResponseException
@@ -54,6 +55,7 @@ class SSEManager(
     private val clientFactory: ApiClientFactory,
     private val serverConfig: ServerConfig,
     private val scope: CoroutineScope,
+    private val downloadRepository: DownloadRepository,
 ) : SSEManagerContract {
     private val _eventFlow =
         MutableSharedFlow<SSEChannelMessage>(
@@ -221,9 +223,19 @@ class SSEManager(
                     _eventFlow.emit(SSEChannelMessage.Reconnected(disconnectedAt = sinceParam))
                     // Clear disconnectedAt after successful reconnection with replay
                     disconnectedAt = null
+                    // Bug 4 (W8 Phase D): re-check WAITING_FOR_SERVER rows after reconnect to catch
+                    // transcode.complete events that fired during disconnect.
+                    scope.launch {
+                        downloadRepository.recheckWaitingForServer()
+                    }
                 } else if (isReconnection) {
                     logger.info { "SSE reconnected (no disconnectedAt recorded) - emitting Reconnected event" }
                     _eventFlow.emit(SSEChannelMessage.Reconnected(disconnectedAt = Timestamp.now().toIsoString()))
+                    // Bug 4 (W8 Phase D): re-check WAITING_FOR_SERVER rows after reconnect to catch
+                    // transcode.complete events that fired during disconnect.
+                    scope.launch {
+                        downloadRepository.recheckWaitingForServer()
+                    }
                 }
 
                 parseSSEStream(channel)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -345,6 +345,24 @@ class SSEEventProcessor(
                 handleActivityCreated(event)
             }
 
+            is SSEEvent.TranscodeComplete -> {
+                logger.debug {
+                    "SSE: Transcode complete for job ${event.data.jobId}"
+                }
+            }
+
+            is SSEEvent.TranscodeProgress -> {
+                logger.debug {
+                    "SSE: Transcode progress for job ${event.data.jobId}: ${event.data.progress}%"
+                }
+            }
+
+            is SSEEvent.TranscodeFailed -> {
+                logger.warn {
+                    "SSE: Transcode failed for job ${event.data.jobId}: ${event.data.error}"
+                }
+            }
+
             is SSEEvent.Unknown -> {
                 logger.warn {
                     "SSE: unknown event type '${event.rawType}' at ${event.timestamp}"

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -114,6 +114,7 @@ class SSEEventProcessor(
     private val imageDownloader = sseExternalServices.imageDownloader
     private val playbackStateProvider = sseExternalServices.playbackStateProvider
     private val downloadService = sseExternalServices.downloadService
+    private val downloadRepository = sseExternalServices.downloadRepository
 
     private val _accessRevokedEvents = MutableSharedFlow<AccessRevokedEvent>(extraBufferCapacity = 16)
 
@@ -346,9 +347,7 @@ class SSEEventProcessor(
             }
 
             is SSEEvent.TranscodeComplete -> {
-                logger.debug {
-                    "SSE: Transcode complete for job ${event.data.jobId}"
-                }
+                handleTranscodeComplete(event.data)
             }
 
             is SSEEvent.TranscodeProgress -> {
@@ -1231,6 +1230,15 @@ class SSEEventProcessor(
                 reason = payload.reason,
             ),
         )
+    }
+
+    // ========== Transcode Event Handlers ==========
+
+    private suspend fun handleTranscodeComplete(
+        payload: com.calypsan.listenup.client.data.sync.TranscodeCompletePayload,
+    ) {
+        logger.info { "SSE: Transcode complete for audioFileId=${payload.audioFileId} (jobId=${payload.jobId})" }
+        downloadRepository.resumeForAudioFile(payload.audioFileId)
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEExternalServices.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEExternalServices.kt
@@ -1,12 +1,13 @@
 package com.calypsan.listenup.client.data.sync.sse
 
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.download.DownloadService
 
 /**
  * Bundle of non-DAO dependencies [SSEEventProcessor] delegates to — session repository,
- * image downloader, playback state, and download service.
+ * image downloader, playback state, download service, and download repository.
  *
  * Extracted to keep [SSEEventProcessor]'s constructor under detekt's `LongParameterList` threshold.
  */
@@ -15,4 +16,5 @@ data class SSEExternalServices(
     val imageDownloader: ImageDownloaderContract,
     val playbackStateProvider: PlaybackStateProvider,
     val downloadService: DownloadService,
+    val downloadRepository: DownloadRepository,
 )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -844,6 +844,9 @@ val syncModule =
                 downloadDao = get(),
                 bookRepository = get(),
                 enqueuer = get(),
+                playbackApi = get(),
+                playbackPreferences = get(),
+                capabilityDetector = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -966,6 +966,7 @@ val syncModule =
                         imageDownloader = get(),
                         playbackStateProvider = get<PlaybackManager>(),
                         downloadService = get(),
+                        downloadRepository = get(),
                     ),
                 activityDao = get(),
                 coverDownloadRepository = get(),

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -756,6 +756,7 @@ val syncModule =
                             org.koin.core.qualifier
                                 .named("appScope"),
                     ),
+                downloadRepository = get(),
             )
         } bind SSEManagerContract::class
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -843,6 +843,7 @@ val syncModule =
             com.calypsan.listenup.client.data.repository.DownloadRepositoryImpl(
                 downloadDao = get(),
                 bookRepository = get(),
+                enqueuer = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -80,10 +80,9 @@ interface DownloadRepository {
     ): AppResult<Unit>
 
     /**
-     * **(Phase B alias)** — no-op. Phase D adds the `DownloadState.WAITING_FOR_SERVER` enum entry
-     * and activates this method to write the new state + persist `transcodeJobId` for the SSE
-     * `transcode.complete` re-enqueue path. The `transcodeJobId` parameter is accepted and
-     * ignored in Phase B.
+     * Mark the file as awaiting server transcoding. Persists [transcodeJobId] so the SSE-reconnect
+     * recheck path can re-issue preparePlayback if the `transcode.complete` event was missed
+     * during disconnect.
      */
     suspend fun markWaitingForServer(
         audioFileId: String,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -110,9 +110,9 @@ interface DownloadRepository {
     suspend fun deleteForBook(bookId: String)
 
     /**
-     * Re-enqueue a single audio file's download.
-     *
-     * **(Phase D scope)** — wired by the Bug 4 SSE `transcode.complete` handler.
+     * Re-enqueue a single audio file's download. Called by the SSE `transcode.complete` handler
+     * (via [com.calypsan.listenup.client.data.sync.sse.SSEEventProcessor]). Silently drops if the
+     * row is CANCELLED or COMPLETED (late event tolerance).
      */
     suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit>
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -100,9 +100,10 @@ interface DownloadRepository {
     suspend fun enqueueForBook(bookId: BookId): AppResult<DownloadOutcome>
 
     /**
-     * Cancel all in-flight downloads for a book.
-     *
-     * **(Phase C/D scope)** — see [enqueueForBook] for the same carveout reasoning.
+     * Cancel all in-flight downloads for a book. For WAITING_FOR_SERVER rows, calls
+     * [com.calypsan.listenup.client.data.remote.PlaybackApiContract.cancelTranscode] so the
+     * server stops the transcode job (Q8 B1: cancel-tells-server). All non-terminal rows
+     * transition to [DownloadState.CANCELLED].
      */
     suspend fun cancelForBook(bookId: BookId): AppResult<Unit>
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -117,16 +117,19 @@ interface DownloadRepository {
     suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit>
 
     /**
-     * App-startup recovery: re-enqueue any incomplete downloads.
-     *
-     * **(Phase C/D scope)** — see [enqueueForBook].
+     * App-startup recovery: 24h backstop for stale WAITING_FOR_SERVER rows (mark as
+     * [com.calypsan.listenup.client.core.error.DownloadError.TranscodeTimeout]) + re-enqueue
+     * any other incomplete downloads via the platform [com.calypsan.listenup.client.download.DownloadEnqueuer].
+     * Existing `DownloadManager.resumeIncompleteDownloads` (Android) remains the primary app-startup
+     * hook; this method is for parity. Phase E may consolidate.
      */
     suspend fun resumeIncompleteDownloads(): AppResult<Unit>
 
     /**
-     * **(Phase B alias)** — no-op. Phase D wires this to the SSE-reconnect hook: re-issues
-     * `preparePlayback` for any rows in `WAITING_FOR_SERVER` to catch missed
-     * `transcode.complete` events.
+     * SSE-reconnect hook: re-issue `preparePlayback` for any rows in WAITING_FOR_SERVER to catch
+     * transcodes that completed during disconnect. Ready ones → [resumeForAudioFile]. Lost-job
+     * ones → [markFailed] with [com.calypsan.listenup.client.core.error.DownloadError.TranscodeTimeout].
+     * Still-transcoding ones left alone.
      */
     suspend fun recheckWaitingForServer(): AppResult<Unit>
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -67,10 +67,9 @@ interface DownloadRepository {
     suspend fun markPaused(audioFileId: String): AppResult<Unit>
 
     /**
-     * **(Phase B alias)** — marks the file as PAUSED. Phase D will switch this to write
-     * the new `DownloadState.CANCELLED` enum entry (distinct from PAUSED so a late
-     * `transcode.complete` SSE event can be silently dropped without confusion). Until then,
-     * cancellation collapses into PAUSED, matching the pre-W8 behavior.
+     * Mark the file as cancelled by user action. Distinct from [markPaused] (system-pause)
+     * so the SSE handler can recognize and silently drop late `transcode.complete` events for
+     * cancelled jobs.
      */
     suspend fun markCancelled(audioFileId: String): AppResult<Unit>
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -1,9 +1,9 @@
 @file:OptIn(kotlin.time.ExperimentalTime::class)
-@file:Suppress("MagicNumber", "NestedBlockDepth")
+@file:Suppress("MagicNumber")
 
 package com.calypsan.listenup.client.download
 
-import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.data.remote.PlaybackApiContract
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
@@ -21,13 +21,27 @@ import io.ktor.utils.io.readAvailable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
 import kotlinx.io.buffered
 import kotlinx.io.files.SystemFileSystem
 
 private val logger = KotlinLogging.logger {}
+
+/**
+ * Result of [resolveDownloadUrl]. Either a [Ready] URL to download from, or a [WaitForServer]
+ * signal that means: write WAITING_FOR_SERVER + exit cleanly; SSE `transcode.complete` will
+ * re-enqueue the worker via [DownloadRepository.resumeForAudioFile].
+ */
+internal sealed interface ResolveResult {
+    data class Ready(
+        val url: String,
+    ) : ResolveResult
+
+    data class WaitForServer(
+        val transcodeJobId: String,
+    ) : ResolveResult
+}
 
 private const val PROGRESS_INTERVAL_MS = 500L
 private const val BUFFER_SIZE = 8 * 1024
@@ -43,8 +57,7 @@ private const val PROGRESS_BYTES_INTERVAL = 256 * 1024L // 256KB — emit progre
  * - Progress updates via [setProgress] lambda
  * - Cancellation handling via [isStopped] lambda
  *
- * Phase C scope: preserves the existing transcode-poll path inside [resolveDownloadUrl].
- * Phase D rewrites that path to use markWaitingForServer + SSE re-enqueue.
+ * Phase D: transcode-poll loop replaced by WAITING_FOR_SERVER + SSE re-enqueue path.
  */
 @Suppress("CyclomaticComplexMethod", "CognitiveComplexMethod")
 internal suspend fun downloadAudioFile(
@@ -62,17 +75,30 @@ internal suspend fun downloadAudioFile(
     setProgress: suspend (downloadedBytes: Long, totalBytes: Long) -> Unit = { _, _ -> },
 ) = withContext(Dispatchers.IO) {
     // Resolve the download URL (relative — Ktor's defaultRequest provides the base).
-    // The transcode-poll path inside resolveDownloadUrl is preserved for Phase C; Phase D
-    // rewrites it to use markWaitingForServer + SSE re-enqueue.
-    val url =
+    // Phase D: if transcoding is in progress, write WAITING_FOR_SERVER and exit cleanly.
+    // SSE transcode.complete handler will re-enqueue via repository.resumeForAudioFile.
+    val resolved =
         resolveDownloadUrl(
             bookId = bookId,
             audioFileId = audioFileId,
             playbackApi = playbackApi,
             playbackPreferences = playbackPreferences,
             capabilityDetector = capabilityDetector,
-            isStopped = isStopped,
         )
+    val url =
+        when (resolved) {
+            is ResolveResult.Ready -> {
+                resolved.url
+            }
+
+            is ResolveResult.WaitForServer -> {
+                // Bug 4 fix: server is transcoding. Write WAITING_FOR_SERVER and exit cleanly.
+                // SSE transcode.complete handler (SSEEventProcessor.handleTranscodeComplete) will
+                // re-enqueue the worker via repository.resumeForAudioFile when ready.
+                repository.markWaitingForServer(audioFileId, resolved.transcodeJobId)
+                return@withContext
+            }
+        }
 
     val destPath = fileManager.getDownloadPath(bookId, audioFileId, filename)
     val tempPath = fileManager.getTempPath(bookId, audioFileId, filename)
@@ -167,11 +193,15 @@ internal suspend fun downloadAudioFile(
 }
 
 /**
- * Resolve the correct download URL via the prepare endpoint.
+ * Resolve the correct download URL via the prepare endpoint. Returns:
+ * - [ResolveResult.Ready] when transcoding is done OR not needed; caller proceeds to download.
+ * - [ResolveResult.WaitForServer] when transcoding is in progress; caller writes WAITING_FOR_SERVER
+ *   and exits cleanly. SSE `transcode.complete` will re-enqueue via [DownloadRepository.resumeForAudioFile].
  *
- * Returns a relative URL (Ktor's defaultRequest provides the base server URL via the
- * authenticated HttpClient). Phase C preserves the existing 30-minute polling loop;
- * Phase D rewrites this path to use markWaitingForServer + SSE re-enqueue.
+ * Phase D Bug 4 fix: previously polled for up to 30 minutes inside this function while the worker
+ * showed DOWNLOADING in the UI. The polling loop was the root cause of "minutes to first byte" —
+ * the worker reported active progress while actually waiting for the server. Now the worker exits
+ * cleanly and the user sees WAITING_FOR_SERVER honestly.
  */
 private suspend fun resolveDownloadUrl(
     bookId: String,
@@ -179,59 +209,30 @@ private suspend fun resolveDownloadUrl(
     playbackApi: PlaybackApiContract,
     playbackPreferences: PlaybackPreferences,
     capabilityDetector: AudioCapabilityDetector,
-    isStopped: () -> Boolean,
-): String {
+): ResolveResult {
     val capabilities = capabilityDetector.getSupportedCodecs()
     val spatial = playbackPreferences.getSpatialPlayback()
     val result = playbackApi.preparePlayback(bookId, audioFileId, capabilities, spatial)
 
-    if (result !is Success) {
-        logger.warn { "Prepare call failed, using original URL" }
-        return "/api/v1/books/$bookId/audio/$audioFileId"
+    if (result !is AppResult.Success) {
+        logger.warn { "Prepare call failed for $audioFileId, falling back to original URL" }
+        return ResolveResult.Ready("/api/v1/books/$bookId/audio/$audioFileId")
     }
 
     val response = result.data
 
-    // Phase C preserves the existing transcode-poll path. Phase D rewrites this.
+    // Bug 4 fix: if transcode is in progress, write WAITING_FOR_SERVER and exit. SSE handler
+    // (SSEEventProcessor.handleTranscodeComplete) will re-enqueue via repository.resumeForAudioFile.
     if (!response.ready && response.transcodeJobId != null) {
         logger.info {
-            "Transcoding in progress for $audioFileId, waiting... " +
-                "(jobId=${response.transcodeJobId}, progress=${response.progress}%)"
+            "Transcoding in progress for $audioFileId (jobId=${response.transcodeJobId}); " +
+                "writing WAITING_FOR_SERVER and exiting cleanly. SSE will re-enqueue when ready."
         }
-
-        val maxWaitMs = 30 * 60 * 1000L
-        val startTime = currentEpochMilliseconds()
-        var lastProgress = response.progress
-
-        while (currentEpochMilliseconds() - startTime < maxWaitMs) {
-            if (isStopped()) {
-                throw CancellationException("Download cancelled while waiting for transcode")
-            }
-
-            delay(5000)
-
-            val checkResult = playbackApi.preparePlayback(bookId, audioFileId, capabilities, spatial)
-            if (checkResult is Success) {
-                val checkResponse = checkResult.data
-                if (checkResponse.ready) {
-                    logger.info { "Transcode completed for $audioFileId" }
-                    return relativizeUrl(checkResponse.streamUrl)
-                }
-                if (checkResponse.progress > lastProgress) {
-                    logger.debug { "Transcode progress: ${checkResponse.progress}%" }
-                    lastProgress = checkResponse.progress
-                }
-            }
-        }
-
-        logger.warn { "Transcode timeout for $audioFileId, using original URL" }
-        return "/api/v1/books/$bookId/audio/$audioFileId"
+        return ResolveResult.WaitForServer(response.transcodeJobId)
     }
 
-    logger.debug {
-        "Using ${response.variant} variant for $audioFileId (codec: ${response.codec})"
-    }
-    return relativizeUrl(response.streamUrl)
+    logger.debug { "Using ${response.variant} variant for $audioFileId (codec: ${response.codec})" }
+    return ResolveResult.Ready(relativizeUrl(response.streamUrl))
 }
 
 /** Strip an absolute server URL prefix off [streamUrl] so we always pass a relative URL to Ktor. */

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadEnqueuer.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadEnqueuer.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.client.download
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+
+/**
+ * Platform abstraction for enqueueing a single download worker. Android: backed by WorkManager.
+ * iOS / Desktop: no-op (iOS uses NSURLSession-driven downloads via AppleDownloadService; Desktop
+ * doesn't download).
+ *
+ * Used by [com.calypsan.listenup.client.domain.repository.DownloadRepository.resumeForAudioFile]
+ * to re-enqueue a worker after the SSE `transcode.complete` event re-activates a WAITING_FOR_SERVER row.
+ */
+interface DownloadEnqueuer {
+    /**
+     * Enqueue a single audio-file download with `ExistingWorkPolicy.REPLACE` semantics.
+     * Returns [AppResult.Success] on success; [AppResult.Failure] if the platform doesn't support
+     * downloads (Desktop, iOS in Phase D) or if WorkManager rejects the request.
+     */
+    suspend fun enqueue(entity: DownloadEntity): AppResult<Unit>
+}

--- a/shared/src/commonMain/resources/strings/en.json
+++ b/shared/src/commonMain/resources/strings/en.json
@@ -205,6 +205,7 @@
     "detail_more_options": "More options",
     "detail_narrated_by": "Narrated by",
     "detail_play": "Play",
+    "detail_preparing_on_server": "Preparing on server…",
     "detail_progresspercent": "%1$s%",
     "detail_queued": "Queued...",
     "detail_readers": "Readers",

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -135,7 +135,25 @@ open class FakeDownloadRepository(
         state.update { current -> current.filterValues { it.bookId != bookId } }
     }
 
-    override suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit> = AppResult.Success(Unit)
+    private val _resumedAudioFiles = mutableListOf<String>()
+
+    /** Test helper: list of audioFileIds that resumeForAudioFile was called with (excludes silently-dropped late events). */
+    val resumedAudioFiles: List<String> get() = _resumedAudioFiles.toList()
+
+    override suspend fun resumeForAudioFile(audioFileId: String): AppResult<Unit> {
+        val entity =
+            state.value[audioFileId]
+                ?: return AppResult.Failure(
+                    com.calypsan.listenup.client.core.error.DownloadError.DownloadFailed(
+                        debugInfo = "No download row for $audioFileId",
+                    ),
+                )
+        if (entity.state == DownloadState.CANCELLED || entity.state == DownloadState.COMPLETED) {
+            return AppResult.Success(Unit) // late event tolerance
+        }
+        _resumedAudioFiles.add(audioFileId)
+        return AppResult.Success(Unit)
+    }
 
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> = AppResult.Success(Unit)
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -129,7 +129,15 @@ open class FakeDownloadRepository(
     override suspend fun enqueueForBook(bookId: BookId): AppResult<DownloadOutcome> =
         enqueueFailure?.invoke(bookId) ?: AppResult.Success(DownloadOutcome.Started)
 
-    override suspend fun cancelForBook(bookId: BookId): AppResult<Unit> = AppResult.Success(Unit)
+    override suspend fun cancelForBook(bookId: BookId): AppResult<Unit> {
+        val rowsForBook = state.value.values.filter { it.bookId == bookId.value }
+        for (row in rowsForBook) {
+            if (row.state != DownloadState.COMPLETED && row.state != DownloadState.DELETED) {
+                update(row.audioFileId) { it.copy(state = DownloadState.CANCELLED) }
+            }
+        }
+        return AppResult.Success(Unit)
+    }
 
     override suspend fun deleteForBook(bookId: String) {
         state.update { current -> current.filterValues { it.bookId != bookId } }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -114,7 +114,12 @@ open class FakeDownloadRepository(
     override suspend fun markWaitingForServer(
         audioFileId: String,
         transcodeJobId: String,
-    ): AppResult<Unit> = AppResult.Success(Unit)
+    ): AppResult<Unit> {
+        update(audioFileId) {
+            it.copy(state = DownloadState.WAITING_FOR_SERVER, transcodeJobId = transcodeJobId)
+        }
+        return AppResult.Success(Unit)
+    }
 
     // --- Orchestration ---
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -99,7 +99,10 @@ open class FakeDownloadRepository(
         return AppResult.Success(Unit)
     }
 
-    override suspend fun markCancelled(audioFileId: String): AppResult<Unit> = markPaused(audioFileId)
+    override suspend fun markCancelled(audioFileId: String): AppResult<Unit> {
+        update(audioFileId) { it.copy(state = DownloadState.CANCELLED) }
+        return AppResult.Success(Unit)
+    }
 
     override suspend fun markFailed(
         audioFileId: String,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -224,7 +224,7 @@ open class FakeDownloadRepository(
                     bookId = bookId,
                     totalFiles = totalFiles,
                     downloadingFiles = activeDownloads.count { it.state == DownloadState.DOWNLOADING },
-                    waitingForServerFiles = 0,
+                    waitingForServerFiles = activeDownloads.count { it.state == DownloadState.WAITING_FOR_SERVER },
                     completedFiles = completedFiles,
                     totalBytes = totalBytes,
                     downloadedBytes = downloadedBytes,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -189,7 +189,10 @@ open class FakeDownloadRepository(
         downloads: List<DownloadEntity>,
     ): BookDownloadStatus {
         if (downloads.isEmpty()) return BookDownloadStatus.NotDownloaded(bookId)
-        val activeDownloads = downloads.filter { it.state != DownloadState.DELETED }
+        val activeDownloads =
+            downloads.filter {
+                it.state != DownloadState.DELETED && it.state != DownloadState.CANCELLED
+            }
         if (activeDownloads.isEmpty()) return BookDownloadStatus.NotDownloaded(bookId)
         val totalFiles = activeDownloads.size
         val completedFiles = activeDownloads.count { it.state == DownloadState.COMPLETED }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
@@ -202,6 +202,28 @@ class FakeDownloadRepositoryTest {
         }
 
     @Test
+    fun `aggregator counts WAITING_FOR_SERVER files`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.WAITING_FOR_SERVER),
+                            entity("file-2", state = DownloadState.WAITING_FOR_SERVER),
+                            entity("file-3", state = DownloadState.QUEUED),
+                        ),
+                )
+            fake.observeBookStatus(BookId("book-1")).test {
+                val status = awaitItem()
+                assertIs<BookDownloadStatus.InProgress>(status)
+                assertEquals(2, status.waitingForServerFiles)
+                assertEquals(0, status.downloadingFiles)
+                assertEquals(3, status.totalFiles)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `aggregator returns Paused when all files paused`() =
         runTest {
             val fake =

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
@@ -92,12 +92,13 @@ class FakeDownloadRepositoryTest {
         }
 
     @Test
-    fun `markWaitingForServer is a no-op in Phase B`() =
+    fun `markWaitingForServer writes WAITING_FOR_SERVER state and persists transcodeJobId`() =
         runTest {
             val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
-            val before = fake.entities.single()
             fake.markWaitingForServer("file-1", transcodeJobId = "job-abc")
-            assertEquals(before, fake.entities.single())
+            val after = fake.entities.single()
+            assertEquals(DownloadState.WAITING_FOR_SERVER, after.state)
+            assertEquals("job-abc", after.transcodeJobId)
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
@@ -74,11 +74,11 @@ class FakeDownloadRepositoryTest {
         }
 
     @Test
-    fun `markCancelled aliases to PAUSED in Phase B`() =
+    fun `markCancelled writes CANCELLED state`() =
         runTest {
             val fake = FakeDownloadRepository(initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)))
             fake.markCancelled("file-1")
-            assertEquals(DownloadState.PAUSED, fake.entities.single().state)
+            assertEquals(DownloadState.CANCELLED, fake.entities.single().state)
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SSEEventDecodeTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SSEEventDecodeTest.kt
@@ -185,4 +185,30 @@ class SSEEventDecodeTest {
             appJson.decodeFromString<SSEEvent>(json)
         }
     }
+
+    @Test
+    fun `decodes transcode_complete event`() {
+        val json = """{"timestamp":"2026-05-01T12:00:00Z","type":"transcode.complete","data":{"job_id":"abc","book_id":"book-1","audio_file_id":"file-1"}}"""
+        val event = appJson.decodeFromString<SSEEvent>(json)
+        assertIs<SSEEvent.TranscodeComplete>(event)
+        assertEquals("abc", event.data.jobId)
+        assertEquals("book-1", event.data.bookId)
+        assertEquals("file-1", event.data.audioFileId)
+    }
+
+    @Test
+    fun `decodes transcode_progress event`() {
+        val json = """{"timestamp":"2026-05-01T12:00:00Z","type":"transcode.progress","data":{"job_id":"abc","book_id":"book-1","audio_file_id":"file-1","progress":42}}"""
+        val event = appJson.decodeFromString<SSEEvent>(json)
+        assertIs<SSEEvent.TranscodeProgress>(event)
+        assertEquals(42, event.data.progress)
+    }
+
+    @Test
+    fun `decodes transcode_failed event`() {
+        val json = """{"timestamp":"2026-05-01T12:00:00Z","type":"transcode.failed","data":{"job_id":"abc","book_id":"book-1","audio_file_id":"file-1","error":"codec unsupported"}}"""
+        val event = appJson.decodeFromString<SSEEvent>(json)
+        assertIs<SSEEvent.TranscodeFailed>(event)
+        assertEquals("codec unsupported", event.data.error)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
@@ -7,6 +7,8 @@ import com.calypsan.listenup.client.data.local.db.ActivityDao
 import com.calypsan.listenup.client.data.local.db.ActivityEntity
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.data.local.db.BookContributorCrossRef
 import com.calypsan.listenup.client.data.local.db.BookContributorDao
 import com.calypsan.listenup.client.data.local.db.BookDao
@@ -38,7 +40,9 @@ import com.calypsan.listenup.client.data.remote.model.BookContributorResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
 import com.calypsan.listenup.client.data.remote.model.BookSeriesInfoResponse
 import com.calypsan.listenup.client.data.repository.CoverDownloadRepositoryImpl
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
+import com.calypsan.listenup.client.data.sync.TranscodeCompletePayload
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
 import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
@@ -162,6 +166,7 @@ class SSEEventProcessorTest {
         val playbackStateProvider: PlaybackStateProvider = mock()
         val downloadService: DownloadService = mock()
         val avatarDownloadRepository: AvatarDownloadRepository = mock()
+        val downloadRepository: FakeDownloadRepository = FakeDownloadRepository()
 
         // StateFlow for current book ID
         private val currentBookIdFlow = MutableStateFlow<BookId?>(null)
@@ -263,6 +268,7 @@ class SSEEventProcessorTest {
                         imageDownloader = imageDownloader,
                         playbackStateProvider = playbackStateProvider,
                         downloadService = downloadService,
+                        downloadRepository = downloadRepository,
                     ),
                 activityDao = activityDao,
                 coverDownloadRepository =
@@ -941,6 +947,52 @@ class SSEEventProcessorTest {
             verifySuspend(VerifyMode.not) {
                 fixture.imageDownloader.downloadUserAvatar(testUserId, forceRefresh = true)
             }
+        }
+
+    // ========== TranscodeComplete Event Tests ==========
+
+    @Test
+    fun `handles transcode_complete by calling resumeForAudioFile`() =
+        runTest {
+            val fixture = TestFixture(this)
+            fixture.downloadRepository.seed(
+                DownloadEntity(
+                    audioFileId = "file-1",
+                    bookId = "book-1",
+                    filename = "audio.mp3",
+                    fileIndex = 0,
+                    state = DownloadState.WAITING_FOR_SERVER,
+                    localPath = null,
+                    totalBytes = 1000L,
+                    downloadedBytes = 0L,
+                    queuedAt = 0L,
+                    startedAt = 0L,
+                    completedAt = null,
+                    errorMessage = null,
+                    retryCount = 0,
+                    transcodeJobId = "job-abc",
+                ),
+            )
+
+            val processor = fixture.build()
+
+            processor.process(
+                SSEChannelMessage.Wire(
+                    SSEEvent.TranscodeComplete(
+                        timestamp = TEST_TIMESTAMP,
+                        data =
+                            TranscodeCompletePayload(
+                                jobId = "job-abc",
+                                bookId = "book-1",
+                                audioFileId = "file-1",
+                            ),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            // Verify resumeForAudioFile was called
+            kotlin.test.assertEquals(listOf("file-1"), fixture.downloadRepository.resumedAudioFiles)
         }
 
     companion object {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadWaitingForServerFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadWaitingForServerFlowTest.kt
@@ -1,0 +1,146 @@
+package com.calypsan.listenup.client.download
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Seam-level tests for the W8 Phase D flows: WAITING_FOR_SERVER re-enqueue, late-event tolerance,
+ * cancel-during-WAITING_FOR_SERVER, recheck path. Per project memory `feedback_fakes_for_seams.md`:
+ * hand-rolled fakes, not mocks.
+ *
+ * Scope: tests [FakeDownloadRepository]'s contract for the new methods. The fake mirrors
+ * [com.calypsan.listenup.client.data.repository.DownloadRepositoryImpl] behavior; production tests
+ * for the impl live in `DownloadRepositoryImplTest`.
+ */
+class DownloadWaitingForServerFlowTest {
+    private fun entity(
+        audioFileId: String,
+        bookId: String = "book-1",
+        state: DownloadState = DownloadState.QUEUED,
+        totalBytes: Long = 1000L,
+        downloadedBytes: Long = 0L,
+        transcodeJobId: String? = null,
+    ) = DownloadEntity(
+        audioFileId = audioFileId,
+        bookId = bookId,
+        filename = "$audioFileId.mp3",
+        fileIndex = 0,
+        state = state,
+        localPath = null,
+        totalBytes = totalBytes,
+        downloadedBytes = downloadedBytes,
+        queuedAt = 0L,
+        startedAt = null,
+        completedAt = null,
+        errorMessage = null,
+        retryCount = 0,
+        transcodeJobId = transcodeJobId,
+    )
+
+    @Test
+    fun `resumeForAudioFile re-enqueues a WAITING_FOR_SERVER row`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial = listOf(entity("file-1", state = DownloadState.WAITING_FOR_SERVER, transcodeJobId = "job-abc")),
+                )
+            val result = fake.resumeForAudioFile("file-1")
+            assertIs<AppResult.Success<Unit>>(result)
+            assertEquals(listOf("file-1"), fake.resumedAudioFiles)
+        }
+
+    @Test
+    fun `resumeForAudioFile silently drops cancelled rows (late SSE event tolerance)`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial = listOf(entity("file-1", state = DownloadState.CANCELLED)),
+                )
+            val result = fake.resumeForAudioFile("file-1")
+            assertIs<AppResult.Success<Unit>>(result)
+            assertTrue(fake.resumedAudioFiles.isEmpty())
+        }
+
+    @Test
+    fun `resumeForAudioFile silently drops completed rows (late SSE event tolerance)`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial = listOf(entity("file-1", state = DownloadState.COMPLETED)),
+                )
+            val result = fake.resumeForAudioFile("file-1")
+            assertIs<AppResult.Success<Unit>>(result)
+            assertTrue(fake.resumedAudioFiles.isEmpty())
+        }
+
+    @Test
+    fun `resumeForAudioFile returns Failure for missing rows`() =
+        runTest {
+            val fake = FakeDownloadRepository(initial = emptyList())
+            val result = fake.resumeForAudioFile("missing-file")
+            assertIs<AppResult.Failure>(result)
+            assertIs<DownloadError.DownloadFailed>(result.error)
+        }
+
+    @Test
+    fun `cancelForBook transitions all non-terminal rows to CANCELLED`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.DOWNLOADING),
+                            entity("file-2", state = DownloadState.WAITING_FOR_SERVER, transcodeJobId = "job-1"),
+                            entity("file-3", state = DownloadState.QUEUED),
+                        ),
+                )
+            fake.cancelForBook(BookId("book-1"))
+            val final = fake.entities.associateBy { it.audioFileId }
+            assertEquals(DownloadState.CANCELLED, final["file-1"]!!.state)
+            assertEquals(DownloadState.CANCELLED, final["file-2"]!!.state)
+            assertEquals(DownloadState.CANCELLED, final["file-3"]!!.state)
+        }
+
+    @Test
+    fun `cancelForBook preserves COMPLETED rows`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", state = DownloadState.DOWNLOADING),
+                            entity("file-2", state = DownloadState.COMPLETED),
+                        ),
+                )
+            fake.cancelForBook(BookId("book-1"))
+            val final = fake.entities.associateBy { it.audioFileId }
+            assertEquals(DownloadState.CANCELLED, final["file-1"]!!.state)
+            assertEquals(DownloadState.COMPLETED, final["file-2"]!!.state)
+        }
+
+    @Test
+    fun `cancelForBook only affects the target book`() =
+        runTest {
+            val fake =
+                FakeDownloadRepository(
+                    initial =
+                        listOf(
+                            entity("file-1", bookId = "book-1", state = DownloadState.DOWNLOADING),
+                            entity("file-2", bookId = "book-2", state = DownloadState.DOWNLOADING),
+                        ),
+                )
+            fake.cancelForBook(BookId("book-1"))
+            val final = fake.entities.associateBy { it.audioFileId }
+            assertEquals(DownloadState.CANCELLED, final["file-1"]!!.state)
+            assertEquals(DownloadState.DOWNLOADING, final["file-2"]!!.state)
+        }
+}

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -3,6 +3,8 @@
 package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.client.core.IODispatcher
+import com.calypsan.listenup.client.download.AppleDownloadEnqueuer
+import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
@@ -63,6 +65,9 @@ val iosPlaybackModule: Module =
 
         // Also expose concrete type for iOS-specific features
         single { get<AudioTokenProvider>() as AppleAudioTokenProvider }
+
+        // DownloadEnqueuer seam — iOS no-op (NSURLSession path is W10 carveout)
+        single<DownloadEnqueuer> { AppleDownloadEnqueuer() }
 
         // Download service
         single<DownloadService> {

--- a/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/download/JvmDownloadEnqueuer.kt
+++ b/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/download/JvmDownloadEnqueuer.kt
@@ -1,0 +1,13 @@
+package com.calypsan.listenup.client.download
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.error.DownloadError
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+
+/**
+ * Desktop no-op enqueuer. Desktop doesn't support downloads (per W8 Phase A's Desktop hide).
+ */
+class JvmDownloadEnqueuer : DownloadEnqueuer {
+    override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> =
+        AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Downloads not supported on Desktop"))
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
@@ -1,0 +1,95 @@
+package com.calypsan.listenup.client.data.local.db
+
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Regression tests for [DownloadDao] queries added in W8 Phase D.
+ *
+ * Specifically guards C1: the three new queries must compare against the TEXT value
+ * 'WAITING_FOR_SERVER' (as stored by [Converters.fromDownloadState]), not against an
+ * integer ordinal. Running against a real in-memory [ListenUpDatabase] ensures Room's
+ * generated SQL and the type-converter round-trip are both exercised.
+ */
+class DownloadDaoTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+    private val dao: DownloadDao = db.downloadDao()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun entity(
+        audioFileId: String,
+        bookId: String = "book-1",
+        state: DownloadState = DownloadState.QUEUED,
+        startedAt: Long? = null,
+        transcodeJobId: String? = null,
+    ) = DownloadEntity(
+        audioFileId = audioFileId,
+        bookId = bookId,
+        filename = "$audioFileId.mp3",
+        fileIndex = 0,
+        state = state,
+        localPath = null,
+        totalBytes = 1000L,
+        downloadedBytes = 0L,
+        queuedAt = 0L,
+        startedAt = startedAt,
+        completedAt = null,
+        errorMessage = null,
+        retryCount = 0,
+        transcodeJobId = transcodeJobId,
+    )
+
+    @Test
+    fun `getWaitingForServer returns only WAITING_FOR_SERVER rows`() =
+        runTest {
+            dao.insertAll(
+                listOf(
+                    entity("file-1", state = DownloadState.WAITING_FOR_SERVER, transcodeJobId = "job-1"),
+                    entity("file-2", state = DownloadState.DOWNLOADING),
+                    entity("file-3", state = DownloadState.WAITING_FOR_SERVER, transcodeJobId = "job-3"),
+                ),
+            )
+
+            val waiting = dao.getWaitingForServer()
+
+            assertEquals(2, waiting.size)
+            assertEquals(setOf("file-1", "file-3"), waiting.map { it.audioFileId }.toSet())
+        }
+
+    @Test
+    fun `markWaitingForServer transitions state and persists transcodeJobId`() =
+        runTest {
+            dao.insert(entity("file-1", state = DownloadState.DOWNLOADING))
+            dao.markWaitingForServer("file-1", "job-abc")
+
+            val updated = dao.getByAudioFileId("file-1")
+            assertNotNull(updated)
+            assertEquals(DownloadState.WAITING_FOR_SERVER, updated.state)
+            assertEquals("job-abc", updated.transcodeJobId)
+        }
+
+    @Test
+    fun `getOldWaitingForServer returns only rows older than threshold`() =
+        runTest {
+            dao.insertAll(
+                listOf(
+                    entity("old", state = DownloadState.WAITING_FOR_SERVER, startedAt = 100L, transcodeJobId = "job-old"),
+                    entity("recent", state = DownloadState.WAITING_FOR_SERVER, startedAt = 500L, transcodeJobId = "job-recent"),
+                    entity("downloading", state = DownloadState.DOWNLOADING, startedAt = 50L),
+                ),
+            )
+
+            val stale = dao.getOldWaitingForServer(thresholdMs = 200L)
+
+            assertEquals(1, stale.size)
+            assertEquals("old", stale.single().audioFileId)
+        }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
@@ -27,7 +28,8 @@ class DownloadRepositoryImplTest {
     private val db: ListenUpDatabase = createInMemoryTestDatabase()
     private val downloadDao = db.downloadDao()
     private val bookRepository = FakeBookRepository()
-    private val sut = DownloadRepositoryImpl(downloadDao, bookRepository)
+    private val enqueuer = FakeDownloadEnqueuer()
+    private val sut = DownloadRepositoryImpl(downloadDao, bookRepository, enqueuer)
 
     @AfterTest
     fun tearDown() {
@@ -212,6 +214,10 @@ class DownloadRepositoryImplTest {
             addedAt = Timestamp(0L),
             updatedAt = Timestamp(0L),
         )
+}
+
+private class FakeDownloadEnqueuer : DownloadEnqueuer {
+    override suspend fun enqueue(entity: com.calypsan.listenup.client.data.local.db.DownloadEntity): AppResult<Unit> = AppResult.Success(Unit)
 }
 
 private class FakeBookRepository : BookRepository {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -242,6 +242,8 @@ private class FakePlaybackApiContract : PlaybackApiContract {
         AppResult.Success(
             PreparePlaybackResponse(ready = false, streamUrl = "", variant = "original", codec = "mp3", transcodeJobId = "job1", progress = 0),
         )
+
+    override suspend fun cancelTranscode(jobId: String): AppResult<Unit> = AppResult.Success(Unit)
 }
 
 private class FakePlaybackPreferences : PlaybackPreferences {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -4,7 +4,11 @@ import app.cash.turbine.test
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.remote.PlaybackApiContract
+import com.calypsan.listenup.client.data.remote.PreparePlaybackResponse
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.download.DownloadEnqueuer
+import com.calypsan.listenup.client.playback.AudioCapabilityDetector
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
@@ -29,7 +33,15 @@ class DownloadRepositoryImplTest {
     private val downloadDao = db.downloadDao()
     private val bookRepository = FakeBookRepository()
     private val enqueuer = FakeDownloadEnqueuer()
-    private val sut = DownloadRepositoryImpl(downloadDao, bookRepository, enqueuer)
+    private val sut =
+        DownloadRepositoryImpl(
+            downloadDao = downloadDao,
+            bookRepository = bookRepository,
+            enqueuer = enqueuer,
+            playbackApi = FakePlaybackApiContract(),
+            playbackPreferences = FakePlaybackPreferences(),
+            capabilityDetector = FakeAudioCapabilityDetector(),
+        )
 
     @AfterTest
     fun tearDown() {
@@ -218,6 +230,37 @@ class DownloadRepositoryImplTest {
 
 private class FakeDownloadEnqueuer : DownloadEnqueuer {
     override suspend fun enqueue(entity: com.calypsan.listenup.client.data.local.db.DownloadEntity): AppResult<Unit> = AppResult.Success(Unit)
+}
+
+private class FakePlaybackApiContract : PlaybackApiContract {
+    override suspend fun preparePlayback(
+        bookId: String,
+        audioFileId: String,
+        capabilities: List<String>,
+        spatial: Boolean,
+    ): AppResult<PreparePlaybackResponse> =
+        AppResult.Success(
+            PreparePlaybackResponse(ready = false, streamUrl = "", variant = "original", codec = "mp3", transcodeJobId = "job1", progress = 0),
+        )
+}
+
+private class FakePlaybackPreferences : PlaybackPreferences {
+    override val preferenceChanges: kotlinx.coroutines.flow.SharedFlow<com.calypsan.listenup.client.domain.repository.PreferenceChangeEvent>
+        get() = error("not used in test")
+
+    override fun observeDefaultPlaybackSpeed(): kotlinx.coroutines.flow.Flow<Float> = error("not used in test")
+
+    override suspend fun getDefaultPlaybackSpeed(): Float = error("not used in test")
+
+    override suspend fun setDefaultPlaybackSpeed(speed: Float) = error("not used in test")
+
+    override suspend fun getSpatialPlayback(): Boolean = false
+
+    override suspend fun setSpatialPlayback(enabled: Boolean) = error("not used in test")
+}
+
+private class FakeAudioCapabilityDetector : AudioCapabilityDetector {
+    override fun getSupportedCodecs(): List<String> = listOf("mp3", "aac")
 }
 
 private class FakeBookRepository : BookRepository {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
@@ -25,6 +25,7 @@ import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.data.remote.model.BookContributorResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
 import com.calypsan.listenup.client.data.remote.model.BookSeriesInfoResponse
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
 import com.calypsan.listenup.client.data.sync.BookPayload
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
 import com.calypsan.listenup.client.data.sync.SSEChannelMessage
@@ -34,6 +35,7 @@ import com.calypsan.listenup.client.data.sync.UserDaos
 import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
@@ -73,6 +75,8 @@ class SSEEventProcessorAtomicityTest {
 
             override suspend fun deleteAvatar(userId: String) = Unit
         }
+
+    private val noOpDownloadRepository: DownloadRepository = FakeDownloadRepository()
 
     @AfterTest
     fun tearDown() {
@@ -171,6 +175,7 @@ class SSEEventProcessorAtomicityTest {
                             imageDownloader = imageDownloader,
                             playbackStateProvider = playbackStateProvider,
                             downloadService = downloadService,
+                            downloadRepository = noOpDownloadRepository,
                         ),
                     activityDao = activityDao,
                     coverDownloadRepository = noOpCoverDownloadRepository,
@@ -313,6 +318,7 @@ class SSEEventProcessorAtomicityTest {
                             imageDownloader = imageDownloader,
                             playbackStateProvider = playbackStateProvider,
                             downloadService = downloadService,
+                            downloadRepository = noOpDownloadRepository,
                         ),
                     activityDao = activityDao,
                     coverDownloadRepository = noOpCoverDownloadRepository,
@@ -443,6 +449,7 @@ class SSEEventProcessorAtomicityTest {
                             imageDownloader = imageDownloader,
                             playbackStateProvider = playbackStateProvider,
                             downloadService = downloadService,
+                            downloadRepository = noOpDownloadRepository,
                         ),
                     activityDao = activityDao,
                     coverDownloadRepository = noOpCoverDownloadRepository,

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
@@ -22,9 +22,11 @@ import com.calypsan.listenup.client.data.sync.SSEChannelMessage
 import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
 import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
@@ -70,6 +72,8 @@ class SSEEventProcessorProgressMergeTest {
 
             override suspend fun deleteAvatar(userId: String) = Unit
         }
+
+    private val noOpDownloadRepository: DownloadRepository = FakeDownloadRepository()
 
     @AfterTest
     fun tearDown() {
@@ -128,6 +132,7 @@ class SSEEventProcessorProgressMergeTest {
                     imageDownloader = imageDownloader,
                     playbackStateProvider = playbackStateProvider,
                     downloadService = downloadService,
+                    downloadRepository = noOpDownloadRepository,
                 ),
             activityDao = activityDao,
             coverDownloadRepository = noOpCoverDownloadRepository,

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -668,53 +668,38 @@ class DownloadWorkerLogicTest {
     // ---- Scenario 11 ----
 
     /**
-     * preparePlayback returns !ready (transcodeJobId set) → polling loop fires.
-     * runTest virtual clock skips delay(5000). pollCount asserts multiple calls.
-     * Final state: COMPLETED (transcode finishes on 3rd poll).
+     * preparePlayback returns !ready (transcodeJobId set) → writes WAITING_FOR_SERVER + exits.
      *
-     * Phase C preserves the existing polling path; this test locks it as a regression marker.
-     * Phase D will rewrite the path and replace this test.
+     * Phase D Bug 4 fix: the 30-minute polling loop is gone. When the server is still transcoding,
+     * the worker now writes WAITING_FOR_SERVER and exits cleanly. SSE transcode.complete will
+     * re-enqueue via repository.resumeForAudioFile when the server finishes.
      */
     @Test
-    fun `preparePlayback not ready — polling loop fires until ready`() =
+    fun `preparePlayback returns transcoding — writes WAITING_FOR_SERVER and exits cleanly`() =
         runTest {
             val tmpRoot = tempDir()
             try {
                 val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                var pollCount = 0
-                val pollingApi =
-                    object : PlaybackApiContract {
-                        override suspend fun preparePlayback(
-                            bookId: String,
-                            audioFileId: String,
-                            capabilities: List<String>,
-                            spatial: Boolean,
-                        ): AppResult<PreparePlaybackResponse> {
-                            pollCount++
-                            return if (pollCount < 3) {
-                                AppResult.Success(
-                                    PreparePlaybackResponse(
-                                        ready = false,
-                                        streamUrl = "",
-                                        variant = "transcoded",
-                                        codec = "mp3",
-                                        transcodeJobId = "job-abc",
-                                        progress = pollCount * 30,
-                                    ),
-                                )
-                            } else {
-                                AppResult.Success(readyResponse())
-                            }
-                        }
-                    }
+                val transcodingApi =
+                    FakePlaybackApiContract(
+                        AppResult.Success(
+                            PreparePlaybackResponse(
+                                ready = false,
+                                streamUrl = "",
+                                variant = "",
+                                codec = "",
+                                transcodeJobId = "abc-123",
+                                progress = 42,
+                            ),
+                        ),
+                    )
 
-                val binaryEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteArray(1000) { 0x42 },
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
-                        )
+                // No stream engine handler needed — if the worker tries to fetch bytes, the test will
+                // fail because the MockEngine has no registered handler. This enforces the contract
+                // that the worker must exit before ever touching the HTTP stream.
+                val unusedEngine =
+                    MockEngine { request ->
+                        error("Unexpected HTTP request: ${request.url} — worker should have exited cleanly")
                     }
 
                 downloadAudioFile(
@@ -722,16 +707,18 @@ class DownloadWorkerLogicTest {
                     bookId = "book-1",
                     filename = "file-1.mp3",
                     expectedSize = 1000L,
-                    httpClient = productionLikeClient(binaryEngine),
+                    httpClient = productionLikeClient(unusedEngine),
                     repository = fakeRepo,
                     fileManager = fileManagerFor(tmpRoot),
-                    playbackApi = pollingApi,
+                    playbackApi = transcodingApi,
                     playbackPreferences = FakePlaybackPreferences(),
                     capabilityDetector = FakeAudioCapabilityDetector(),
                 )
 
-                assertTrue(pollCount >= 3, "Expected >=3 preparePlayback calls but got $pollCount")
-                assertEquals(DownloadState.COMPLETED, fakeRepo.entities.single().state)
+                // Bug 4 fix verification: row should be WAITING_FOR_SERVER, not stuck in DOWNLOADING.
+                val final = fakeRepo.entities.single()
+                assertEquals(DownloadState.WAITING_FOR_SERVER, final.state)
+                assertEquals("abc-123", final.transcodeJobId)
             } finally {
                 tmpRoot.deleteRecursively()
             }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -802,6 +802,8 @@ private class FakePlaybackApiContract(
         capabilities: List<String>,
         spatial: Boolean,
     ): AppResult<PreparePlaybackResponse> = result
+
+    override suspend fun cancelTranscode(jobId: String): AppResult<Unit> = AppResult.Success(Unit)
 }
 
 private class FakePlaybackPreferences : PlaybackPreferences {


### PR DESCRIPTION
## Summary

Phase D of W8 (Download Subsystem). **Bug 4 fix** — cold-start stream latency.

- **Server-side (already merged):** PR #91 added `POST /api/v1/transcode/cancel/{jobId}` endpoint. PR #92 cleared pre-existing `gofmt` drift. The `transcode.complete` SSE event was already shipped on the server.
- **30-min poll loop deleted** from `DownloadAudioFile.resolveDownloadUrl`. Worker now writes `DownloadState.WAITING_FOR_SERVER` and exits cleanly when transcode is in progress.
- **`DownloadState` extended** with `WAITING_FOR_SERVER` and `CANCELLED` enum entries. `DownloadEntity` gains `transcodeJobId: String?` column. Schema bumped v11 → v12 (destructive fallback per pre-launch policy).
- **Polymorphic `SSEEvent.TranscodeComplete`** variant added (plus defensive `TranscodeProgress` and `TranscodeFailed` for decode-completeness). `SSEEventProcessor.handleTranscodeComplete` calls `repository.resumeForAudioFile(audioFileId)`.
- **`DownloadRepository` Phase B stubs activated:**
  - `markWaitingForServer` — writes WAITING_FOR_SERVER + persists transcodeJobId
  - `markCancelled` — writes CANCELLED (was PAUSED alias)
  - `resumeForAudioFile` — enqueues worker via new `DownloadEnqueuer` seam (Android = WorkManager-backed; iOS/Desktop = no-op)
  - `recheckWaitingForServer` — re-issues preparePlayback for WAITING_FOR_SERVER rows on SSE reconnect
  - `cancelForBook` — calls `cancelTranscode(jobId)` for WAITING_FOR_SERVER rows + transitions all non-terminal rows to CANCELLED
  - `resumeIncompleteDownloads` — 24h backstop for stale WAITING_FOR_SERVER rows + re-enqueues incomplete rows
- **`DownloadError.TranscodeTimeout`** new typed error variant.
- **Aggregator** populates `BookDownloadStatus.InProgress.waitingForServerFiles` from real count. Now also filters `CANCELLED` (alongside `DELETED`) so a fully-cancelled book reads as `NotDownloaded`.
- **UI:** `DownloadButton` and `DownloadButtonExpanded` render "Preparing on server…" when `waitingForServerFiles > 0` and no files are actively downloading.
- **Tests:** new `DownloadWaitingForServerFlowTest` (7 scenarios for the new flows) + new `DownloadDaoTest` (3 real-Room integration tests for the new DAO queries).

## Pre-push fixes (commit `daec7eb3`) addressing code review

The final code review caught 3 production-relevant issues fixed before push:

- **C1 (CRITICAL — DAO queries silently broken):** New queries used `WHERE state = 6` integer literals, but Room stores `DownloadState` as TEXT. `recheckWaitingForServer`, `resumeIncompleteDownloads`, and the `markWaitingForServer` UPDATE all matched zero rows. Fixed to `state = 'WAITING_FOR_SERVER'`. Added `DownloadDaoTest` against real in-memory Room to catch this class of regression.
- **C2 (CRITICAL — aggregator ignores CANCELLED):** A fully-cancelled book fell through to `InProgress(downloadingFiles=0, ...)` rendering as a spinner forever. Fix: `aggregate()` now filters `CANCELLED` alongside `DELETED`.
- **I2:** `cancelTranscode` 404 → wraps as `Success` (idempotent contract per server PR #91 — "already done" isn't an error).

## Unplanned scope expansions

- **`DownloadEnqueuer` interface + 3 platform impls** introduced for `resumeForAudioFile` to enqueue from commonMain (WorkManager is Android-only). Mirrors the established `DownloadFileManager` `expect class` pattern.
- **`SSEExternalServices` extended** to include `downloadRepository` (kept `SSEEventProcessor` constructor under detekt's 12-param threshold).
- **`PlaybackApiContract.cancelTranscode`** added to support Q8 B1 cancel-tells-server.

Per the W8 handoff design at `docs/superpowers/specs/2026-05-01-w8-handoff-design.md` § Phase D.

## Test plan

- [x] `:shared:jvmTest` green (×3 sequential runs to surface drift #23)
- [x] `:androidApp:assembleDebug` green
- [x] `spotlessCheck` + `detekt` green
- [x] `:desktopApp:compileKotlinJvm` green
- [x] `DownloadDaoTest` 3 tests green (real Room) — verifies the C1 fix
- [ ] **Manual smoke (high priority — Bug 4 verification):** install on a phone with a non-AAC source file, start download, observe transition to "Preparing on server…" (NOT 30-min spinner), wait for server transcode, confirm download resumes after `transcode.complete` SSE event arrives
- [ ] **Manual smoke:** during the "Preparing on server…" state, tap cancel, confirm server-side transcode is cancelled (verify in server logs) and row shows CANCELLED
- [ ] **Manual smoke (regression):** book that doesn't need transcoding still downloads normally (Phase A/B/C path)

## Drift to capture in `docs/architecture/restoration-drift-log.md`

- **Pre-existing DAO ordinal/TEXT mismatch:** `DownloadDao.kt` lines 29, 50, 153, 160 use integer literals against TEXT column (`state NOT IN (3, 5)`, `state = 3`, `state = 5`, `state = 5`). All silently return zero rows / match nothing. Latent because consumers either return early on null/empty or have other paths. Phase D fixed only its own new queries; the pre-existing 4 are out of scope. Worth a focused fix phase post-W8.
- **`FakeDownloadRepository.recheckWaitingForServer` is a no-op stub** — production impl was activated in Phase D but the fake wasn't updated. Fake-only tests can't exercise the recheck path.
- **`@file:Suppress("MagicNumber")` remains on `DownloadAudioFile.kt`** even though `NestedBlockDepth` was correctly removed post-poll-loop deletion. Phase E candidate.

## Drift #23 reminder

If CI `:shared:jvmTest` fails on `BookRepositoryImplTest.observeBookDetail re-emits when genres change for the book[jvm]` — drift #23 flake. Re-run; not introduced by this PR.

## Successor

Phase E (defensive cleanup — transactional enqueue, cancel-coordination race, error-handling consolidation, dead code, @file:Suppress removals, plus the pre-existing DAO drift). Plan to follow.