### PR TITLE
W8 Phase E — Defensive cleanup (Finding 08 D6/D9/D10/D11/D12 + DAO TEXT/ordinal fix)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -211,6 +211,7 @@ val downloadModule =
                 fileManager = get(),
                 localPreferences = get<com.calypsan.listenup.client.domain.repository.LocalPreferences>(),
                 downloadRepository = get(),
+                transactionRunner = get(),
             )
         }
 

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
@@ -36,6 +36,8 @@ class StubDownloadService : DownloadService {
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
         flowOf(BookDownloadStatus.NotDownloaded(bookId.value))
 
+    override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> = flowOf(emptyMap())
+
     override suspend fun resumeIncompleteDownloads() {
         // No-op: downloads not supported on desktop
     }

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.android.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.android.kt
@@ -27,26 +27,19 @@ actual class DownloadFileManager(
             return dir
         }
 
-    actual fun getDownloadPath(
+    actual fun getAudioFilePath(
         bookId: String,
         audioFileId: String,
         filename: String,
+        isTemp: Boolean,
     ): Path {
         val bookDir = Path(downloadDir.toString(), bookId)
         // Ensure book directory exists using kotlinx-io
         if (!SystemFileSystem.exists(bookDir)) {
             SystemFileSystem.createDirectories(bookDir)
         }
-        return Path(bookDir.toString(), "${audioFileId}_$filename")
-    }
-
-    actual fun getTempPath(
-        bookId: String,
-        audioFileId: String,
-        filename: String,
-    ): Path {
-        val destFile = getDownloadPath(bookId, audioFileId, filename)
-        return Path(destFile.parent!!.toString(), "${destFile.name}.tmp")
+        val finalName = if (isTemp) "${audioFileId}_$filename.tmp" else "${audioFileId}_$filename"
+        return Path(bookDir.toString(), finalName)
     }
 
     actual fun deleteBookFiles(bookId: String) {

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -18,6 +18,7 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
@@ -52,6 +53,7 @@ class DownloadManager(
     private val fileManager: DownloadFileManager,
     private val localPreferences: com.calypsan.listenup.client.domain.repository.LocalPreferences,
     private val downloadRepository: DownloadRepository,
+    private val transactionRunner: TransactionRunner,
 ) : DownloadService {
     /**
      * Observe download status for a specific book.
@@ -138,7 +140,11 @@ class DownloadManager(
                 )
             }
 
-        downloadDao.insertAll(entities)
+        // Persistence Rule 1: insert is transactional. resumeIncompleteDownloads is the
+        // documented recovery path for crash-between-commit-and-enqueue (Finding 08 D9).
+        transactionRunner.atomically {
+            downloadDao.insertAll(entities)
+        }
 
         // Determine network constraint based on WiFi-only preference
         // UNMETERED = WiFi/ethernet only, CONNECTED = any network (including cellular)
@@ -252,11 +258,7 @@ class DownloadManager(
         val requiredNetworkType = if (wifiOnly) NetworkType.UNMETERED else NetworkType.CONNECTED
 
         for (download in incomplete) {
-            // Only reset PAUSED state to QUEUED — do NOT reset DOWNLOADING.
-            // A DOWNLOADING entry means WorkManager may still have an active worker for it.
-            // Re-enqueueing with KEEP policy keeps that worker running, but if we reset the
-            // DB state to QUEUED the UI gets stuck on the spinner permanently because the
-            // worker only calls updateState(DOWNLOADING) once at the top of doWork().
+            // KEEP policy avoids displacing a worker that's already running for this row.
             if (download.state == DownloadState.PAUSED) {
                 downloadDao.updateState(download.audioFileId, DownloadState.QUEUED)
             }

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -61,9 +61,6 @@ class DownloadManager(
     override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
         downloadRepository.observeBookStatus(bookId)
 
-    /**
-     * Observe download status for all books (for library indicators).
-     */
     override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> = downloadRepository.observeAllStatuses()
 
     /**

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -55,7 +55,7 @@ class DownloadManager(
 ) : DownloadService {
     companion object {
         private const val STORAGE_BUFFER_MULTIPLIER = 1.1 // 10% buffer for download size estimates
-        private const val BYTES_PER_MB = 1_000_000L
+        private const val DECIMAL_BYTES_PER_MB = 1_000_000L
     }
 
     /**
@@ -110,7 +110,7 @@ class DownloadManager(
         if (availableBytes < requiredWithBuffer) {
             logger.warn {
                 "Insufficient storage for book ${bookId.value}: " +
-                    "need ${requiredBytes / BYTES_PER_MB}MB, have ${availableBytes / BYTES_PER_MB}MB"
+                    "need ${requiredBytes / DECIMAL_BYTES_PER_MB}MB, have ${availableBytes / DECIMAL_BYTES_PER_MB}MB"
             }
             return AppResult.Success(
                 DownloadOutcome.InsufficientStorage(
@@ -173,11 +173,11 @@ class DownloadManager(
                             .setRequiredNetworkType(requiredNetworkType)
                             .build(),
                     ).addTag(bookTag(bookId))
-                    .addTag(fileTag(file.id))
+                    .addTag(fileCancelTag(file.id))
                     .build()
 
             workManager.enqueueUniqueWork(
-                workName(file.id),
+                fileWorkName(file.id),
                 ExistingWorkPolicy.REPLACE,
                 workRequest,
             )
@@ -279,11 +279,11 @@ class DownloadManager(
                             .setRequiredNetworkType(requiredNetworkType)
                             .build(),
                     ).addTag(bookTag(download.bookId))
-                    .addTag(fileTag(download.audioFileId))
+                    .addTag(fileCancelTag(download.audioFileId))
                     .build()
 
             workManager.enqueueUniqueWork(
-                workName(download.audioFileId),
+                fileWorkName(download.audioFileId),
                 ExistingWorkPolicy.KEEP,
                 workRequest,
             )
@@ -315,11 +315,15 @@ class DownloadManager(
         logger.info { "Deleted all downloads" }
     }
 
+    // --- WorkManager string identifiers ---
+    // fileWorkName is the unique-work name for enqueueUniqueWork; fileCancelTag is for
+    // addTag/cancelAllWorkByTag. They produce different strings on purpose — do not consolidate.
+
     private fun bookTag(bookId: BookId): String = bookTag(bookId.value)
 
     private fun bookTag(bookIdValue: String): String = "download_$bookIdValue"
 
-    private fun fileTag(audioFileId: String): String = "download_file_$audioFileId"
+    private fun fileCancelTag(audioFileId: String): String = "download_file_$audioFileId"
 
-    private fun workName(audioFileId: String): String = "download_$audioFileId"
+    private fun fileWorkName(audioFileId: String): String = "download_$audioFileId"
 }

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -259,6 +259,7 @@ class DownloadManager(
 
         for (download in incomplete) {
             // KEEP policy avoids displacing a worker that's already running for this row.
+            // Only PAUSED is reset — DOWNLOADING rows belong to a worker that owns state transitions.
             if (download.state == DownloadState.PAUSED) {
                 downloadDao.updateState(download.audioFileId, DownloadState.QUEUED)
             }

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber", "StringLiteralDuplication")
-
 package com.calypsan.listenup.client.download
 
 import androidx.work.Constraints
@@ -55,6 +53,11 @@ class DownloadManager(
     private val downloadRepository: DownloadRepository,
     private val transactionRunner: TransactionRunner,
 ) : DownloadService {
+    companion object {
+        private const val STORAGE_BUFFER_MULTIPLIER = 1.1 // 10% buffer for download size estimates
+        private const val BYTES_PER_MB = 1_000_000L
+    }
+
     /**
      * Observe download status for a specific book.
      */
@@ -102,12 +105,12 @@ class DownloadManager(
         val requiredBytes = toDownload.sumOf { it.size }
         val availableBytes = fileManager.getAvailableSpace()
         // Add 10% buffer for safety
-        val requiredWithBuffer = (requiredBytes * 1.1).toLong()
+        val requiredWithBuffer = (requiredBytes * STORAGE_BUFFER_MULTIPLIER).toLong()
 
         if (availableBytes < requiredWithBuffer) {
             logger.warn {
                 "Insufficient storage for book ${bookId.value}: " +
-                    "need ${requiredBytes / 1_000_000}MB, have ${availableBytes / 1_000_000}MB"
+                    "need ${requiredBytes / BYTES_PER_MB}MB, have ${availableBytes / BYTES_PER_MB}MB"
             }
             return AppResult.Success(
                 DownloadOutcome.InsufficientStorage(
@@ -169,12 +172,12 @@ class DownloadManager(
                             .Builder()
                             .setRequiredNetworkType(requiredNetworkType)
                             .build(),
-                    ).addTag("download_${bookId.value}")
-                    .addTag("download_file_${file.id}")
+                    ).addTag(bookTag(bookId))
+                    .addTag(fileTag(file.id))
                     .build()
 
             workManager.enqueueUniqueWork(
-                "download_${file.id}",
+                workName(file.id),
                 ExistingWorkPolicy.REPLACE,
                 workRequest,
             )
@@ -191,7 +194,7 @@ class DownloadManager(
         // Await WorkManager cancellation completion before updating DB state. Closes the race
         // where a worker's final updateProgress write lands after cancelAllWorkByTag returns
         // but before the state update fires (Finding 08 D10).
-        workManager.cancelAllWorkByTag("download_${bookId.value}").await()
+        workManager.cancelAllWorkByTag(bookTag(bookId)).await()
         downloadDao.updateStateForBook(bookId.value, DownloadState.PAUSED)
         logger.info { "Cancelled download: ${bookId.value}" }
     }
@@ -206,7 +209,7 @@ class DownloadManager(
         // Await WorkManager cancellation completion before deleting files. Closes the race
         // where a worker's final updateProgress write lands after cancelAllWorkByTag returns
         // but before the deletion fires (Finding 08 D10).
-        workManager.cancelAllWorkByTag("download_${bookId.value}").await()
+        workManager.cancelAllWorkByTag(bookTag(bookId)).await()
 
         // Delete files from disk
         fileManager.deleteBookFiles(bookId.value)
@@ -275,12 +278,12 @@ class DownloadManager(
                             .Builder()
                             .setRequiredNetworkType(requiredNetworkType)
                             .build(),
-                    ).addTag("download_${download.bookId}")
-                    .addTag("download_file_${download.audioFileId}")
+                    ).addTag(bookTag(download.bookId))
+                    .addTag(fileTag(download.audioFileId))
                     .build()
 
             workManager.enqueueUniqueWork(
-                "download_${download.audioFileId}",
+                workName(download.audioFileId),
                 ExistingWorkPolicy.KEEP,
                 workRequest,
             )
@@ -311,4 +314,12 @@ class DownloadManager(
         downloadDao.deleteAll()
         logger.info { "Deleted all downloads" }
     }
+
+    private fun bookTag(bookId: BookId): String = bookTag(bookId.value)
+
+    private fun bookTag(bookIdValue: String): String = "download_$bookIdValue"
+
+    private fun fileTag(audioFileId: String): String = "download_file_$audioFileId"
+
+    private fun workName(audioFileId: String): String = "download_$audioFileId"
 }

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -64,7 +64,7 @@ class DownloadManager(
     /**
      * Observe download status for all books (for library indicators).
      */
-    fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> = downloadRepository.observeAllStatuses()
+    override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> = downloadRepository.observeAllStatuses()
 
     /**
      * Download a book (queue all audio files).

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -7,6 +7,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import androidx.work.await
 import androidx.work.workDataOf
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
@@ -184,7 +185,10 @@ class DownloadManager(
      * Cancel active download for a book.
      */
     override suspend fun cancelDownload(bookId: BookId) {
-        workManager.cancelAllWorkByTag("download_${bookId.value}")
+        // Await WorkManager cancellation completion before updating DB state. Closes the race
+        // where a worker's final updateProgress write lands after cancelAllWorkByTag returns
+        // but before the state update fires (Finding 08 D10).
+        workManager.cancelAllWorkByTag("download_${bookId.value}").await()
         downloadDao.updateStateForBook(bookId.value, DownloadState.PAUSED)
         logger.info { "Cancelled download: ${bookId.value}" }
     }
@@ -196,7 +200,10 @@ class DownloadManager(
      */
     override suspend fun deleteDownload(bookId: BookId) {
         // Cancel any active downloads first
-        workManager.cancelAllWorkByTag("download_${bookId.value}")
+        // Await WorkManager cancellation completion before deleting files. Closes the race
+        // where a worker's final updateProgress write lands after cancelAllWorkByTag returns
+        // but before the deletion fires (Finding 08 D10).
+        workManager.cancelAllWorkByTag("download_${bookId.value}").await()
 
         // Delete files from disk
         fileManager.deleteBookFiles(bookId.value)

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -364,6 +364,10 @@ class AppleDownloadService(
 
     // Inline copy of DownloadManager.aggregateStatus until Task 8 moves the canonical version
     // into DownloadRepository. iOS keeps its own copy through W10 (deferred carveout per W8 design).
+    // Known parity gaps with Android's aggregator: does NOT filter DownloadState.CANCELLED from
+    // activeDownloads, and hardcodes waitingForServerFiles = 0. These gaps now reach the interface
+    // via observeAllStatuses (W8 Phase E D11) — when a cross-book consumer arrives before W10
+    // closes this carveout, fix here first or it will mis-report aggregate status on iOS.
     private fun aggregateBookDownloadStatus(
         bookId: String,
         entities: List<DownloadEntity>,

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -64,6 +64,14 @@ private val logger = KotlinLogging.logger {}
  * - [observeBookStatus] aggregates via the new sealed [com.calypsan.listenup.client.domain.model.BookDownloadStatus] hierarchy.
  *
  * The internal DAO writes remain untouched.
+ *
+ * **Codec negotiation: intentionally absent on iOS.** Android's `DownloadWorker.resolveDownloadUrl`
+ * negotiates with the server's `preparePlayback` endpoint to pick a transcoded variant when the
+ * device doesn't support the source codec. iOS's native AVFoundation audio player supports every
+ * codec the server can serve (AAC, MP3, FLAC, ALAC, Opus), so negotiation is unnecessary — the
+ * download URL points directly at the original file. **If a future server adds a codec iOS does
+ * not natively support, this class requires codec negotiation matching the Android worker's
+ * pattern.** Closes Finding 08 D6 (principled asymmetry, not silent omission).
  */
 @OptIn(ExperimentalTime::class)
 class AppleDownloadService(

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -347,6 +347,13 @@ class AppleDownloadService(
             aggregateBookDownloadStatus(bookId.value, entities)
         }
 
+    override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> =
+        downloadDao.observeAll().map { downloads ->
+            downloads
+                .groupBy { it.bookId }
+                .mapValues { (bookId, files) -> aggregateBookDownloadStatus(bookId, files) }
+        }
+
     // Inline copy of DownloadManager.aggregateStatus until Task 8 moves the canonical version
     // into DownloadRepository. iOS keeps its own copy through W10 (deferred carveout per W8 design).
     private fun aggregateBookDownloadStatus(

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -226,7 +226,7 @@ class AppleDownloadService(
         logger.info { "Downloading: $filename (${audioFile.size / 1_000_000}MB)" }
 
         // Register this download so delegate can track it
-        val destPath = fileManager.getDownloadPath(bookId, audioFileId, filename)
+        val destPath = fileManager.getAudioFilePath(bookId, audioFileId, filename, isTemp = false)
 
         // Ensure parent directory exists
         val destUrl = NSURL.fileURLWithPath(destPath.toString())

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.apple.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.apple.kt
@@ -40,10 +40,11 @@ actual class DownloadFileManager {
             return path
         }
 
-    actual fun getDownloadPath(
+    actual fun getAudioFilePath(
         bookId: String,
         audioFileId: String,
         filename: String,
+        isTemp: Boolean,
     ): Path {
         val bookDirPath = Path(downloadDir, bookId)
 
@@ -56,16 +57,8 @@ actual class DownloadFileManager {
                 error = null,
             )
         }
-        return Path(bookDirPath, "${audioFileId}_$filename")
-    }
-
-    actual fun getTempPath(
-        bookId: String,
-        audioFileId: String,
-        filename: String,
-    ): Path {
-        val destFile = getDownloadPath(bookId, audioFileId, filename)
-        return Path(destFile.parent!!, "${destFile.name}.tmp")
+        val finalName = if (isTemp) "${audioFileId}_$filename.tmp" else "${audioFileId}_$filename"
+        return Path(bookDirPath, finalName)
     }
 
     actual fun deleteBookFiles(bookId: String) {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
@@ -23,10 +23,10 @@ interface DownloadDao {
     suspend fun getByAudioFileId(audioFileId: String): DownloadEntity?
 
     /**
-     * Get all downloads not in COMPLETED (ordinal 3) or DELETED (ordinal 5) state.
+     * Get all downloads not in COMPLETED or DELETED state.
      * Used to find stalled/interrupted downloads for resume.
      */
-    @Query("SELECT * FROM downloads WHERE state NOT IN (3, 5) ORDER BY bookId, fileIndex")
+    @Query("SELECT * FROM downloads WHERE state NOT IN ('COMPLETED', 'DELETED') ORDER BY bookId, fileIndex")
     suspend fun getIncomplete(): List<DownloadEntity>
 
     /**
@@ -45,9 +45,8 @@ interface DownloadDao {
 
     /**
      * Get local path for a completed download.
-     * Uses ordinal 3 for COMPLETED state (QUEUED=0, DOWNLOADING=1, PAUSED=2, COMPLETED=3, FAILED=4)
      */
-    @Query("SELECT localPath FROM downloads WHERE audioFileId = :audioFileId AND state = 3")
+    @Query("SELECT localPath FROM downloads WHERE audioFileId = :audioFileId AND state = 'COMPLETED'")
     suspend fun getLocalPath(audioFileId: String): String?
 
     // Insert
@@ -147,17 +146,17 @@ interface DownloadDao {
     ) = updateErrorWithState(audioFileId, error, DownloadState.FAILED)
 
     /**
-     * Mark all files for a book as DELETED (ordinal 5).
+     * Mark all files for a book as DELETED.
      * Used when user explicitly deletes a download - keeps records for tracking.
      */
-    @Query("UPDATE downloads SET state = 5, localPath = NULL WHERE bookId = :bookId")
+    @Query("UPDATE downloads SET state = 'DELETED', localPath = NULL WHERE bookId = :bookId")
     suspend fun markDeletedForBook(bookId: String)
 
     /**
      * Check if a book has any DELETED records (user explicitly deleted).
      * Used to determine if we should auto-download on playback.
      */
-    @Query("SELECT EXISTS(SELECT 1 FROM downloads WHERE bookId = :bookId AND state = 5)")
+    @Query("SELECT EXISTS(SELECT 1 FROM downloads WHERE bookId = :bookId AND state = 'DELETED')")
     suspend fun hasDeletedRecords(bookId: String): Boolean
 
     // Delete

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -1,5 +1,4 @@
 @file:OptIn(kotlin.time.ExperimentalTime::class)
-@file:Suppress("MagicNumber")
 
 package com.calypsan.listenup.client.download
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -100,8 +100,8 @@ internal suspend fun downloadAudioFile(
             }
         }
 
-    val destPath = fileManager.getDownloadPath(bookId, audioFileId, filename)
-    val tempPath = fileManager.getTempPath(bookId, audioFileId, filename)
+    val destPath = fileManager.getAudioFilePath(bookId, audioFileId, filename, isTemp = false)
+    val tempPath = fileManager.getAudioFilePath(bookId, audioFileId, filename, isTemp = true)
 
     // Resume support: if a partial tempFile exists, send Range header.
     val startByte =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.kt
@@ -14,21 +14,15 @@ import kotlinx.io.files.Path
  */
 expect class DownloadFileManager {
     /**
-     * Get the final destination path for a downloaded file.
+     * Get the path for a downloaded file. [isTemp]=true returns the in-progress temp path
+     * (supports resume); [isTemp]=false returns the final destination path. Single function
+     * eliminates format-divergence risk between the two paths (Finding 08 D12).
      */
-    fun getDownloadPath(
+    fun getAudioFilePath(
         bookId: String,
         audioFileId: String,
         filename: String,
-    ): Path
-
-    /**
-     * Get temp path for in-progress download (supports resume).
-     */
-    fun getTempPath(
-        bookId: String,
-        audioFileId: String,
-        filename: String,
+        isTemp: Boolean,
     ): Path
 
     /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -58,8 +58,9 @@ interface DownloadService {
     fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>
 
     /**
-     * Observe download status for all books, keyed by bookId. Used by cross-book UIs
-     * (library list indicators) to render download badges without N+1 per-book queries.
+     * Observe download status for all books, keyed by bookId. Reserved for cross-book UIs
+     * (e.g., library list download badges) — no current consumers; the method exists on the
+     * interface so callers don't need the platform-specific type when they arrive.
      */
     fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>>
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -58,6 +58,12 @@ interface DownloadService {
     fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>
 
     /**
+     * Observe download status for all books, keyed by bookId. Used by cross-book UIs
+     * (library list indicators) to render download badges without N+1 per-book queries.
+     */
+    fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>>
+
+    /**
      * Resume any incomplete downloads (e.g. after re-authentication or app restart).
      */
     suspend fun resumeIncompleteDownloads()

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -165,6 +165,13 @@ open class FakeDownloadRepository(
 
     override suspend fun resumeIncompleteDownloads(): AppResult<Unit> = AppResult.Success(Unit)
 
+    /**
+     * Phase D production impl re-issues `preparePlayback` for WAITING_FOR_SERVER rows. The fake
+     * leaves this as a no-op deliberately — mirroring would require injecting a fake
+     * `PlaybackApiContract` into the fake's constructor, cascading to every test that uses it.
+     * Tests that need recheck behavior should use `DownloadRepositoryImplTest` against the real
+     * impl with a `FakePlaybackApiContract`.
+     */
     override suspend fun recheckWaitingForServer(): AppResult<Unit> = AppResult.Success(Unit)
 
     // --- Test helpers ---

--- a/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.jvm.kt
@@ -30,26 +30,19 @@ actual open class DownloadFileManager(
             return dir
         }
 
-    actual fun getDownloadPath(
+    actual fun getAudioFilePath(
         bookId: String,
         audioFileId: String,
         filename: String,
+        isTemp: Boolean,
     ): Path {
         val bookDir = Path(downloadDir.toString(), bookId)
         // Ensure book directory exists using kotlinx-io
         if (!SystemFileSystem.exists(bookDir)) {
             SystemFileSystem.createDirectories(bookDir)
         }
-        return Path(bookDir.toString(), "${audioFileId}_$filename")
-    }
-
-    actual fun getTempPath(
-        bookId: String,
-        audioFileId: String,
-        filename: String,
-    ): Path {
-        val destFile = getDownloadPath(bookId, audioFileId, filename)
-        return Path(destFile.parent!!.toString(), "${destFile.name}.tmp")
+        val finalName = if (isTemp) "${audioFileId}_$filename.tmp" else "${audioFileId}_$filename"
+        return Path(bookDir.toString(), finalName)
     }
 
     actual fun deleteBookFiles(bookId: String) {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
@@ -1,11 +1,13 @@
 package com.calypsan.listenup.client.data.local.db
 
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 /**
  * Regression tests for [DownloadDao] queries added in W8 Phase D.
@@ -91,5 +93,71 @@ class DownloadDaoTest {
 
             assertEquals(1, stale.size)
             assertEquals("old", stale.single().audioFileId)
+        }
+
+    @Test
+    fun `getIncomplete returns rows not COMPLETED and not DELETED`() =
+        runTest {
+            dao.insertAll(
+                listOf(
+                    entity("file-1", state = DownloadState.QUEUED),
+                    entity("file-2", state = DownloadState.DOWNLOADING),
+                    entity("file-3", state = DownloadState.COMPLETED),
+                    entity("file-4", state = DownloadState.DELETED),
+                    entity("file-5", state = DownloadState.WAITING_FOR_SERVER, transcodeJobId = "j"),
+                ),
+            )
+            val incomplete = dao.getIncomplete()
+            // Expect: file-1, file-2, file-5 (QUEUED, DOWNLOADING, WAITING_FOR_SERVER)
+            // Reject: file-3 (COMPLETED), file-4 (DELETED)
+            assertEquals(3, incomplete.size)
+            assertEquals(setOf("file-1", "file-2", "file-5"), incomplete.map { it.audioFileId }.toSet())
+        }
+
+    @Test
+    fun `getLocalPath returns localPath for COMPLETED rows only`() =
+        runTest {
+            dao.insertAll(
+                listOf(
+                    entity("file-1", state = DownloadState.COMPLETED).copy(localPath = "/path/to/file-1"),
+                    entity("file-2", state = DownloadState.DOWNLOADING).copy(localPath = "/path/to/file-2"),
+                ),
+            )
+            assertEquals("/path/to/file-1", dao.getLocalPath("file-1"))
+            // For non-COMPLETED rows, query should return null even if localPath is set.
+            assertNull(dao.getLocalPath("file-2"))
+        }
+
+    @Test
+    fun `markDeletedForBook transitions all rows for a book to DELETED`() =
+        runTest {
+            dao.insertAll(
+                listOf(
+                    entity("file-1", bookId = "book-1", state = DownloadState.COMPLETED).copy(localPath = "/path"),
+                    entity("file-2", bookId = "book-1", state = DownloadState.DOWNLOADING),
+                    entity("file-3", bookId = "book-2", state = DownloadState.QUEUED), // different book
+                ),
+            )
+            dao.markDeletedForBook("book-1")
+            val all = dao.observeAll().first()
+            val byId = all.associateBy { it.audioFileId }
+            assertEquals(DownloadState.DELETED, byId["file-1"]!!.state)
+            assertEquals(DownloadState.DELETED, byId["file-2"]!!.state)
+            assertNull(byId["file-1"]!!.localPath) // should be cleared
+            assertEquals(DownloadState.QUEUED, byId["file-3"]!!.state) // book-2 unaffected
+        }
+
+    @Test
+    fun `hasDeletedRecords returns true if any DELETED row exists for a book`() =
+        runTest {
+            dao.insertAll(
+                listOf(
+                    entity("file-1", bookId = "book-1", state = DownloadState.DELETED),
+                    entity("file-2", bookId = "book-2", state = DownloadState.COMPLETED),
+                ),
+            )
+            assertEquals(true, dao.hasDeletedRecords("book-1"))
+            assertEquals(false, dao.hasDeletedRecords("book-2"))
+            assertEquals(false, dao.hasDeletedRecords("book-3")) // non-existent book
         }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -215,7 +215,7 @@ class DownloadWorkerLogicTest {
                 val fileManager = fileManagerFor(tmpRoot)
 
                 // Pre-write 400 bytes to the temp path so startByte = 400
-                val tempPath = fileManager.getTempPath("book-1", "file-1", "file-1.mp3")
+                val tempPath = fileManager.getAudioFilePath("book-1", "file-1", "file-1.mp3", isTemp = true)
                 SystemFileSystem.sink(tempPath).buffered().use { sink ->
                     sink.write(ByteArray(400) { 0x41 })
                 }


### PR DESCRIPTION
## Summary

Defensive cleanup phase of W8 — sweeps the remaining Finding 08 drifts that didn't fit Phases B/C/D, plus 4 pre-existing DAO bugs surfaced during Phase D's review. No user-visible behavior change; tightens correctness, removes latent bugs, and removes \`@file:Suppress\` annotations where the underlying complexity has shrunk.

**Finding 08 drifts closed:**
- **D6** — iOS codec-negotiation absence documented as principled asymmetry (KDoc on \`AppleDownloadService\`).
- **D9** — \`DownloadManager.downloadBook\` DB insert wrapped in \`transactionRunner.atomically { }\` per Persistence Rule 1; \`resumeIncompleteDownloads\` documented as the named recovery path for crash-between-commit-and-enqueue.
- **D10** — \`cancelDownload\`/\`deleteDownload\` now \`await()\` \`WorkManager.cancelAllWorkByTag(...)\` before the DB state write, closing the race window where a worker's final \`updateProgress\` could land after cancel returned.
- **D11** — \`observeAllStatuses(): Flow<Map<String, BookDownloadStatus>>\` lifted onto the \`DownloadService\` interface so cross-book consumers don't leak the platform-specific \`DownloadManager\` type. Android delegates to repository, iOS delegates via existing aggregator, Desktop returns \`flowOf(emptyMap())\`.
- **D12** — \`DownloadFileManager.getDownloadPath\` + \`getTempPath\` consolidated into \`getAudioFilePath(..., isTemp: Boolean)\` across \`expect\`/\`actual\`. Eliminates format-divergence risk between the two paths.

**Pre-existing DAO bugs (surfaced during Phase D, fixed here):**
- 4 queries in \`DownloadDao.kt\` compared integer literals against a TEXT column (Room stores \`DownloadState\` as \`enum.name\`). Fixed via string literals (\`'COMPLETED'\`, \`'DELETED'\`). All silently returned zero rows / matched nothing today; latent because consumers had fallback paths. Locked with new \`DownloadDaoTest\` scenarios.

**Cleanup:**
- \`@file:Suppress\` removed from \`DownloadAudioFile.kt\` (vestigial — Phase C already extracted the constants) and \`DownloadManager.kt\` (after extracting \`STORAGE_BUFFER_MULTIPLIER\`, \`DECIMAL_BYTES_PER_MB\`, and the \`bookTag\`/\`fileCancelTag\`/\`fileWorkName\` helpers).
- Forensic comment in \`resumeIncompleteDownloads\` shrunk to a 2-line invariant note (the bug class it described is materially reduced by the transactional insert).
- KDoc note added to \`FakeDownloadRepository.recheckWaitingForServer\` documenting why the fake stays a no-op (mirroring would cascade constructor surface across every test).

## Test plan

- [x] All 4 CI gates green locally before push (\`:shared:jvmTest\`, \`spotlessCheck\`, \`detekt\`, \`:androidApp:assembleDebug\`)
- [x] \`:shared:jvmTest\` run 3× per drift-#23 protocol — runs #1/#2 clean; run #3 surfaced known \`BookRepositoryImplTest.observeBookDetail\` flake (drift #23, not Phase E regression)
- [x] New \`DownloadDaoTest\` scenarios lock the 4 fixed DAO queries
- [ ] Manual smoke: download a book, confirm cancel/delete behave correctly under churn (post-merge)
- [ ] Manual smoke: confirm storage-insufficient log message still reads correctly (\`DECIMAL_BYTES_PER_MB\` rename is value-preserving)

## Out of scope

- iOS download adoption — deferred to W10 (carveout already documented on \`AppleDownloadService\`).
- \`FakeDownloadRepository\` open-class → interface conversion — Phase E would expand surface; deferred.
- Drifts #17 + #20 — Phase Z (sync drift sweep) closes W8.