### PR TITLE
W8 Phase Z2 — defensive sweep

### DIFF
--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.client.data.local.db.GenreEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.local.db.TagEntity
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.GenreApiContract
 import com.calypsan.listenup.client.data.remote.TagApiContract
@@ -175,9 +176,18 @@ class BookRepositoryImplTest {
                 assertNotNull(initial)
                 assertTrue(initial.genres.isEmpty())
 
-                // Insert a genre + cross-ref.
-                genreDao.upsert(makeGenreEntity(id = "g-1", name = "Fantasy"))
-                genreDao.insertBookGenre(BookGenreCrossRef(bookId = BookId("book-1"), genreId = "g-1"))
+                // Insert genre + cross-ref atomically so Room's invalidation tracker
+                // fires once at commit, after both rows are present. Without the
+                // transaction, two separate invalidations expose an intermediate
+                // state (genre row inserted, cross-ref row not yet) where the
+                // observer re-emits with empty genres — the cause of drift #23's
+                // intermittent flake. Real Room transaction is required; the
+                // class-field passthrough TransactionRunner does not invoke Room's
+                // invalidation-batching machinery.
+                RoomTransactionRunner(db).atomically {
+                    genreDao.upsert(makeGenreEntity(id = "g-1", name = "Fantasy"))
+                    genreDao.insertBookGenre(BookGenreCrossRef(bookId = BookId("book-1"), genreId = "g-1"))
+                }
 
                 val updated = turbine.awaitItem()
                 assertNotNull(updated)
@@ -199,8 +209,11 @@ class BookRepositoryImplTest {
                 assertNotNull(initial)
                 assertTrue(initial.tags.isEmpty())
 
-                tagDao.upsert(makeTagEntity(id = "t-1", slug = "epic"))
-                tagDao.insertBookTag(BookTagCrossRef(bookId = BookId("book-1"), tagId = "t-1"))
+                // See genres-test note above — same atomic-write rationale.
+                RoomTransactionRunner(db).atomically {
+                    tagDao.upsert(makeTagEntity(id = "t-1", slug = "epic"))
+                    tagDao.insertBookTag(BookTagCrossRef(bookId = BookId("book-1"), tagId = "t-1"))
+                }
 
                 val updated = turbine.awaitItem()
                 assertNotNull(updated)


### PR DESCRIPTION
## Summary
- **Drift #23 fix:** wrap the cross-ref test writes in `BookRepositoryImplTest`'s `observeBookDetail re-emits when genres change` and `... when tags change` tests with a real `RoomTransactionRunner(db).atomically { ... }` block so Room's invalidation tracker fires once at commit instead of twice.
- **Drift-log accuracy:** drifts #1 (W6 Phase F PR #257 commit `dec007d2`), #27/#28 (W7 Phase E2.2.3 PR #268 commit `232f214d`), #33 (PR #268 commit `2fa07a71`), #35 (PR #268 commit `e932d8e3`) retroactively marked Closed. Same pattern as Z1's #5/#6/#7 log-accuracy fix.

## Root cause analysis
Initial hypothesis (in the spec) was a `Dispatchers.IO` vs `runTest` virtual-time mismatch in `createInMemoryTestDatabase()`. **That hypothesis was wrong** — switching to `Dispatchers.Unconfined` made the flake 100% reproducible (vs. the previous ~67%). The actual root cause: the tests issued two non-atomic writes (`dao.upsert(entity)` then `dao.insertCrossRef(...)`), each triggering its own Room invalidation. The first invalidation re-fired the `genres ⨝ book_genres` JOIN with the cross-ref row still missing, emitting `Ready(genres=[])` — which `awaitItem()` then captured. Wrapping the two writes in a single Room transaction batches invalidations to one commit-time fire, so the observer sees only the final state with both rows present.

The `Dispatchers.Unconfined` change was reverted; only `BookRepositoryImplTest.kt` is touched.

## Verification
- 20× consecutive passes on the previously-flaky tests post-fix (original 67% failure rate ⇒ p(20 in a row) ≈ 10⁻¹⁰).
- Standard 3× `:shared:jvmTest` pre-push gate: green.
- `spotlessCheck`, `detekt`, `:androidApp:assembleDebug`: green.

## Spec / plan
- `docs/superpowers/specs/2026-05-01-w8-z2-defensive-sweep-design.md`
- `docs/superpowers/plans/2026-05-01-w8-z2-defensive-sweep.md`

## Task 0 (rubric currency)
Inherited from W8 Phase Z1. Versions verified (Kotlin 2.3.20, Room 2.8.4, Ktor 3.4.3, Koin 4.2.1, detekt 1.23.8). No amendments.

## Successor
W8 Phase Z3 (`PlaybackPositionRepository` String→BookId + AppResult retype — drift #24). Closing Z3 closes W8.