### PR TITLE
W8 Phase Z3 — PlaybackPositionRepository BookId + AppResult retype

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorBooksScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorBooksScreen.kt
@@ -47,6 +47,7 @@ import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.features.contributoredit.components.ContributorColorScheme
 import com.calypsan.listenup.client.features.contributoredit.components.rememberContributorColorScheme
 import com.calypsan.listenup.client.features.library.BookCard
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.presentation.contributordetail.ContributorBooksUiState
 import com.calypsan.listenup.client.presentation.contributordetail.ContributorBooksViewModel
 import com.calypsan.listenup.client.presentation.contributordetail.SeriesGroup
@@ -245,7 +246,7 @@ private fun GridOnlyLayout(
                 onClick = { onBookClick(book.id.value) },
                 authorName = book.authorNames,
                 duration = book.formatDuration(),
-                progress = state.bookProgress[book.id.value],
+                progress = state.bookProgress[book.id],
             )
         }
     }
@@ -344,7 +345,7 @@ private fun CondensedHeader(
 @Composable
 private fun SeriesCarouselSection(
     seriesGroup: SeriesGroup,
-    bookProgress: Map<String, Float>,
+    bookProgress: Map<BookId, Float>,
     onBookClick: (String) -> Unit,
 ) {
     Column(
@@ -388,7 +389,7 @@ private fun SeriesCarouselSection(
                     onClick = { onBookClick(book.id.value) },
                     authorName = book.authorNames,
                     duration = book.formatDuration(),
-                    progress = bookProgress[book.id.value],
+                    progress = bookProgress[book.id],
                     cardWidth = 150.dp,
                 )
             }
@@ -403,7 +404,7 @@ private fun SeriesCarouselSection(
 @Composable
 private fun StandaloneBooksGrid(
     books: List<BookListItem>,
-    bookProgress: Map<String, Float>,
+    bookProgress: Map<BookId, Float>,
     onBookClick: (String) -> Unit,
 ) {
     Column(
@@ -452,7 +453,7 @@ private fun StandaloneBooksGrid(
                             onClick = { onBookClick(book.id.value) },
                             authorName = book.authorNames,
                             duration = book.formatDuration(),
-                            progress = bookProgress[book.id.value],
+                            progress = bookProgress[book.id],
                             modifier = Modifier.weight(1f),
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.design.components.ListenUpDestructiveDialog
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.getInitials
@@ -305,7 +306,7 @@ private fun WideContributorPortfolio(
                     onClick = { onBookClick(book.id.value) },
                     authorName = book.authorNames,
                     duration = book.formatDuration(),
-                    progress = state.bookProgress[book.id.value],
+                    progress = state.bookProgress[book.id],
                 )
             }
         }
@@ -665,7 +666,7 @@ private fun NarrowHeroHeader(
 @Composable
 private fun NarrowWorkSection(
     section: RoleSection,
-    bookProgress: Map<String, Float>,
+    bookProgress: Map<BookId, Float>,
     onBookClick: (String) -> Unit,
     onViewAllClick: () -> Unit,
 ) {
@@ -696,7 +697,7 @@ private fun NarrowWorkSection(
                     onClick = { onBookClick(book.id.value) },
                     authorName = book.authorNames,
                     duration = book.formatDuration(),
-                    progress = bookProgress[book.id.value],
+                    progress = bookProgress[book.id],
                     cardWidth = 150.dp,
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BooksContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BooksContent.kt
@@ -48,6 +48,7 @@ import com.calypsan.listenup.client.design.components.ListenUpButton
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicatorSmall
 import com.calypsan.listenup.client.design.components.SortSplitButton
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.SyncState
 import com.calypsan.listenup.client.features.library.BookCard
@@ -226,8 +227,8 @@ fun BooksContent(
     scanProgress: ScanProgressState? = null,
     sortState: SortState,
     ignoreTitleArticles: Boolean,
-    bookProgress: Map<String, Float>,
-    bookIsFinished: Map<String, Boolean> = emptyMap(),
+    bookProgress: Map<BookId, Float>,
+    bookIsFinished: Map<BookId, Boolean> = emptyMap(),
     isInSelectionMode: Boolean = false,
     selectedBookIds: Set<String> = emptySet(),
     onCategorySelected: (SortCategory) -> Unit,
@@ -304,8 +305,8 @@ private fun BookGrid(
     books: List<BookListItem>,
     sortState: SortState,
     ignoreTitleArticles: Boolean,
-    bookProgress: Map<String, Float>,
-    bookIsFinished: Map<String, Boolean>,
+    bookProgress: Map<BookId, Float>,
+    bookIsFinished: Map<BookId, Boolean>,
     isInSelectionMode: Boolean,
     selectedBookIds: Set<String>,
     onCategorySelected: (SortCategory) -> Unit,
@@ -415,8 +416,8 @@ private fun BookGrid(
                             onClick = { onBookClick(bookId) },
                             authorName = gridItem.book.authorNames,
                             duration = gridItem.book.formatDuration(),
-                            progress = bookProgress[bookId],
-                            isFinished = bookIsFinished[bookId] ?: false,
+                            progress = bookProgress[gridItem.book.id],
+                            isFinished = bookIsFinished[gridItem.book.id] ?: false,
                             isInSelectionMode = isInSelectionMode,
                             isSelected = bookId in selectedBookIds,
                             onLongPress =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -85,11 +85,9 @@ class PlaybackPositionRepositoryImpl(
             dao.get(bookId)
         }
 
-    override fun observe(bookId: String): Flow<PlaybackPosition?> = dao.observe(BookId(bookId)).map { it?.toDomain() }
-
-    override fun observeAll(): Flow<Map<String, PlaybackPosition>> =
+    override fun observeAll(): Flow<Map<BookId, PlaybackPosition>> =
         dao.observeAll().map { positions ->
-            positions.associate { it.bookId.value to it.toDomain() }
+            positions.associate { it.bookId to it.toDomain() }
         }
 
     override suspend fun getLastPlayedBook(): AppResult<LastPlayedInfo?> =
@@ -106,46 +104,22 @@ class PlaybackPositionRepositoryImpl(
 
     // ----- Write paths -----------------------------------------------------------------------
 
-    override suspend fun save(
-        bookId: String,
-        positionMs: Long,
-        playbackSpeed: Float,
-        hasCustomSpeed: Boolean,
-    ) {
-        val now = currentEpochMilliseconds()
-        val existing = dao.get(BookId(bookId))
-
-        val entity =
-            PlaybackPositionEntity(
-                bookId = BookId(bookId),
-                positionMs = positionMs,
-                playbackSpeed = playbackSpeed,
-                hasCustomSpeed = hasCustomSpeed,
-                updatedAt = now,
-                syncedAt = existing?.syncedAt,
-                lastPlayedAt = now,
-                isFinished = existing?.isFinished ?: false,
-                finishedAt = existing?.finishedAt,
-                startedAt = existing?.startedAt ?: now, // Set on first save
-            )
-        dao.save(entity)
-    }
-
-    override suspend fun delete(bookId: String) {
-        dao.delete(BookId(bookId))
-    }
+    override suspend fun delete(bookId: BookId): AppResult<Unit> =
+        suspendRunCatching {
+            dao.delete(bookId)
+        }
 
     override suspend fun markComplete(
-        bookId: String,
+        bookId: BookId,
         startedAt: Long?,
         finishedAt: Long?,
-    ): AppResult<Unit> = savePlaybackState(BookId(bookId), PlaybackUpdate.MarkComplete(startedAt, finishedAt))
+    ): AppResult<Unit> = savePlaybackState(bookId, PlaybackUpdate.MarkComplete(startedAt, finishedAt))
 
-    override suspend fun discardProgress(bookId: String): AppResult<Unit> =
-        savePlaybackState(BookId(bookId), PlaybackUpdate.DiscardProgress)
+    override suspend fun discardProgress(bookId: BookId): AppResult<Unit> =
+        savePlaybackState(bookId, PlaybackUpdate.DiscardProgress)
 
-    override suspend fun restartBook(bookId: String): AppResult<Unit> =
-        savePlaybackState(BookId(bookId), PlaybackUpdate.Restart)
+    override suspend fun restartBook(bookId: BookId): AppResult<Unit> =
+        savePlaybackState(bookId, PlaybackUpdate.Restart)
 
     // ----- Canonical entry point ------------------------------------------------------------
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPositionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPositionRepository.kt
@@ -36,43 +36,14 @@ interface PlaybackPositionRepository {
     suspend fun get(bookId: BookId): AppResult<PlaybackPosition?>
 
     /**
-     * Observe position changes for a specific book reactively.
-     *
-     * Emits whenever the position changes, enabling real-time
-     * progress indicators and resume UI updates.
-     *
-     * @param bookId The book to observe
-     * @return Flow emitting PlaybackPosition or null
-     */
-    fun observe(bookId: String): Flow<PlaybackPosition?>
-
-    /**
      * Observe all playback positions reactively.
      *
      * Used for displaying progress indicators across the library,
      * showing completion percentages on book cards.
      *
-     * @return Flow emitting map of bookId to PlaybackPosition
+     * @return Flow emitting map of [BookId] to PlaybackPosition
      */
-    fun observeAll(): Flow<Map<String, PlaybackPosition>>
-
-    /**
-     * Save a playback position.
-     *
-     * Instant local operation - syncs eventually.
-     * Position updates should never block on network.
-     *
-     * @param bookId The book to save position for
-     * @param positionMs Current position in milliseconds
-     * @param playbackSpeed Current playback speed
-     * @param hasCustomSpeed Whether user set a custom speed
-     */
-    suspend fun save(
-        bookId: String,
-        positionMs: Long,
-        playbackSpeed: Float,
-        hasCustomSpeed: Boolean,
-    )
+    fun observeAll(): Flow<Map<BookId, PlaybackPosition>>
 
     /**
      * Delete position for a book.
@@ -80,8 +51,9 @@ interface PlaybackPositionRepository {
      * Used when resetting progress or removing a book.
      *
      * @param bookId The book to clear position for
+     * @return [AppResult.Success] when the DAO write commits; [AppResult.Failure] only on local DB-write failure.
      */
-    suspend fun delete(bookId: String)
+    suspend fun delete(bookId: BookId): AppResult<Unit>
 
     /**
      * Mark a book as complete.
@@ -96,10 +68,10 @@ interface PlaybackPositionRepository {
      * @return Result with Unit on success, or Failure on error
      */
     suspend fun markComplete(
-        bookId: String,
+        bookId: BookId,
         startedAt: Long? = null,
         finishedAt: Long? = null,
-    ): com.calypsan.listenup.client.core.AppResult<Unit>
+    ): AppResult<Unit>
 
     /**
      * Discard all progress for a book.
@@ -109,10 +81,10 @@ interface PlaybackPositionRepository {
      * is processed asynchronously by [com.calypsan.listenup.client.data.sync.push.OperationExecutor].
      *
      * @param bookId The book to discard progress for
-     * @return [com.calypsan.listenup.client.core.AppResult.Success] when the local write + queue commit;
-     *   [com.calypsan.listenup.client.core.AppResult.Failure] only on local DB-write failure.
+     * @return [AppResult.Success] when the local write + queue commit;
+     *   [AppResult.Failure] only on local DB-write failure.
      */
-    suspend fun discardProgress(bookId: String): com.calypsan.listenup.client.core.AppResult<Unit>
+    suspend fun discardProgress(bookId: BookId): AppResult<Unit>
 
     /**
      * Restart a book from the beginning.
@@ -122,10 +94,10 @@ interface PlaybackPositionRepository {
      * is processed asynchronously by [com.calypsan.listenup.client.data.sync.push.OperationExecutor].
      *
      * @param bookId The book to restart
-     * @return [com.calypsan.listenup.client.core.AppResult.Success] when the local write + queue commit;
-     *   [com.calypsan.listenup.client.core.AppResult.Failure] only on local DB-write failure.
+     * @return [AppResult.Success] when the local write + queue commit;
+     *   [AppResult.Failure] only on local DB-write failure.
      */
-    suspend fun restartBook(bookId: String): com.calypsan.listenup.client.core.AppResult<Unit>
+    suspend fun restartBook(bookId: BookId): AppResult<Unit>
 
     /**
      * Read the persisted entity row for [bookId]. Returns null if the book has

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -597,7 +597,7 @@ open class ProgressTracker(
             // Mark book as complete (Issue #206)
             val finishedAt = Clock.System.now().toEpochMilliseconds()
             when (val r = positionRepository.markComplete(
-                bookId = bookId.value,
+                bookId = bookId,
                 startedAt = null,
                 finishedAt = finishedAt,
             )) {
@@ -613,8 +613,12 @@ open class ProgressTracker(
      * Clear progress for a book (reset to beginning).
      */
     suspend fun clearProgress(bookId: BookId) {
-        positionRepository.delete(bookId.value)
-        logger.info { "Progress cleared for book: ${bookId.value}" }
+        when (val r = positionRepository.delete(bookId)) {
+            is AppResult.Success -> logger.info { "Progress cleared for book: ${bookId.value}" }
+            is AppResult.Failure -> logger.warn {
+                "Failed to clear progress for book ${bookId.value}: ${r.error.message}"
+            }
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -347,7 +347,7 @@ class BookDetailViewModel(
         val bookId = (state.value as? BookDetailUiState.Ready)?.book?.id?.value ?: return
         viewModelScope.launch {
             updateReady { it.copy(isMarkingComplete = true) }
-            when (playbackPositionRepository.markComplete(bookId, startedAt, finishedAt)) {
+            when (playbackPositionRepository.markComplete(BookId(bookId), startedAt, finishedAt)) {
                 is Success -> {
                     updateReady { it.copy(isMarkingComplete = false, isComplete = true) }
                     logger.info { "Marked book $bookId as complete" }
@@ -368,7 +368,7 @@ class BookDetailViewModel(
         val bookId = (state.value as? BookDetailUiState.Ready)?.book?.id?.value ?: return
         viewModelScope.launch {
             updateReady { it.copy(isDiscardingProgress = true) }
-            when (playbackPositionRepository.discardProgress(bookId)) {
+            when (playbackPositionRepository.discardProgress(BookId(bookId))) {
                 is Success -> {
                     updateReady {
                         it.copy(
@@ -396,7 +396,7 @@ class BookDetailViewModel(
         val bookId = (state.value as? BookDetailUiState.Ready)?.book?.id?.value ?: return
         viewModelScope.launch {
             updateReady { it.copy(isRestarting = true) }
-            when (playbackPositionRepository.restartBook(bookId)) {
+            when (playbackPositionRepository.restartBook(BookId(bookId))) {
                 is Success -> {
                     updateReady {
                         it.copy(

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModel.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.presentation.contributordetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.repository.ContributorRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
@@ -134,7 +135,7 @@ sealed interface ContributorBooksUiState {
         val roleDisplayName: String,
         val seriesGroups: List<SeriesGroup>,
         val standaloneBooks: List<BookListItem>,
-        val bookProgress: Map<String, Float>,
+        val bookProgress: Map<BookId, Float>,
         /** Maps bookId to creditedAs name when different from contributor's name. */
         val bookCreditedAs: Map<String, String>,
     ) : ContributorBooksUiState {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.presentation.contributordetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.domain.model.BookListItem
@@ -222,7 +223,7 @@ sealed interface ContributorDetailUiState {
     data class Ready(
         val contributor: Contributor,
         val roleSections: List<RoleSection>,
-        val bookProgress: Map<String, Float>,
+        val bookProgress: Map<BookId, Float>,
         /** Maps bookId to creditedAs name when different from contributor's name. */
         val bookCreditedAs: Map<String, String>,
         /** True while a delete is in flight. Screen shows an overlay spinner. */

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryUiState.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryUiState.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.presentation.library
 
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.data.sync.sse.ScanProgressState
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.ContributorWithBookCount
@@ -43,8 +44,8 @@ sealed interface LibraryUiState {
         val authors: List<ContributorWithBookCount>,
         val narrators: List<ContributorWithBookCount>,
         // Progress derived from playback positions
-        val bookProgress: Map<String, Float>,
-        val bookIsFinished: Map<String, Boolean>,
+        val bookProgress: Map<BookId, Float>,
+        val bookIsFinished: Map<BookId, Boolean>,
         // Sync
         val syncState: SyncState,
         val isServerScanning: Boolean,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.presentation.library
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.data.sync.sse.ScanProgressState
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.ContributorRole
@@ -67,8 +68,8 @@ private data class SyncSnapshot(
 
 /** Progress maps derived from playback positions and book durations. */
 private data class ProgressSnapshot(
-    val progressMap: Map<String, Float>,
-    val finishedMap: Map<String, Boolean>,
+    val progressMap: Map<BookId, Float>,
+    val finishedMap: Map<BookId, Boolean>,
 )
 
 /**
@@ -410,11 +411,11 @@ class LibraryViewModel(
 
     private fun computeProgress(
         books: List<BookListItem>,
-        positions: Map<String, PlaybackPosition>,
+        positions: Map<BookId, PlaybackPosition>,
     ): ProgressSnapshot {
-        val bookDurations = books.associate { it.id.value to it.duration }
-        val progressMap = mutableMapOf<String, Float>()
-        val finishedMap = mutableMapOf<String, Boolean>()
+        val bookDurations = books.associate { it.id to it.duration }
+        val progressMap = mutableMapOf<BookId, Float>()
+        val finishedMap = mutableMapOf<BookId, Boolean>()
 
         for ((bookId, position) in positions) {
             // Track isFinished for all positions (authoritative from server)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/util/BookProgressCalculator.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/util/BookProgressCalculator.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.util
 
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -22,7 +23,7 @@ suspend fun PlaybackPositionRepository.calculateProgressMap(
     books: List<BookListItem>,
     excludeComplete: Boolean = true,
     excludeUnstarted: Boolean = true,
-): Map<String, Float> =
+): Map<BookId, Float> =
     books
         .mapNotNull { book ->
             val position =
@@ -41,7 +42,7 @@ suspend fun PlaybackPositionRepository.calculateProgressMap(
                 val isInProgress =
                     (!excludeUnstarted || progress > 0f) &&
                         (!excludeComplete || progress < 0.99f)
-                if (isInProgress) book.id.value to progress else null
+                if (isInProgress) book.id to progress else null
             } else {
                 null
             }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
@@ -153,61 +153,6 @@ class PlaybackPositionRepositoryImplTest {
             assertIs<AppResult.Failure>(result)
         }
 
-    // ========== observe() Tests ==========
-
-    @Test
-    fun `observe emits position when it exists`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            val entity = createPlaybackPositionEntity(bookId = "book-1", positionMs = 30000L)
-            every { dao.observe(BookId("book-1")) } returns flowOf(entity)
-            val repository = createRepo(dao = dao)
-
-            // When
-            val result = repository.observe("book-1").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("book-1", result.bookId)
-            assertEquals(30000L, result.positionMs)
-        }
-
-    @Test
-    fun `observe emits null when position does not exist`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observe(any()) } returns flowOf(null)
-            val repository = createRepo(dao = dao)
-
-            // When
-            val result = repository.observe("missing-book").first()
-
-            // Then
-            assertNull(result)
-        }
-
-    @Test
-    fun `observe emits changes when position updates`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            val entity1 = createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L)
-            val entity2 = createPlaybackPositionEntity(bookId = "book-1", positionMs = 2000L)
-            every { dao.observe(BookId("book-1")) } returns flowOf(null, entity1, entity2)
-            val repository = createRepo(dao = dao)
-
-            // When
-            val emissions = repository.observe("book-1").take(3).toList()
-
-            // Then
-            assertEquals(3, emissions.size)
-            assertNull(emissions[0])
-            assertEquals(1000L, emissions[1]?.positionMs)
-            assertEquals(2000L, emissions[2]?.positionMs)
-        }
-
     // ========== observeAll() Tests ==========
 
     @Test
@@ -229,9 +174,9 @@ class PlaybackPositionRepositoryImplTest {
 
             // Then
             assertEquals(3, result.size)
-            assertEquals(1000L, result["book-1"]?.positionMs)
-            assertEquals(2000L, result["book-2"]?.positionMs)
-            assertEquals(3000L, result["book-3"]?.positionMs)
+            assertEquals(1000L, result[BookId("book-1")]?.positionMs)
+            assertEquals(2000L, result[BookId("book-2")]?.positionMs)
+            assertEquals(3000L, result[BookId("book-3")]?.positionMs)
         }
 
     @Test
@@ -287,103 +232,8 @@ class PlaybackPositionRepositoryImplTest {
             val result = repository.observeAll().first()
 
             // Then
-            assertTrue(result.containsKey("unique-book-id-123"))
-            assertFalse(result.containsKey("wrong-key"))
-        }
-
-    // ========== save() Tests ==========
-
-    @Test
-    fun `save creates new position when none exists`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.get(BookId("new-book")) } returns null
-            val repository = createRepo(dao = dao)
-
-            // When
-            repository.save(
-                bookId = "new-book",
-                positionMs = 5000L,
-                playbackSpeed = 1.25f,
-                hasCustomSpeed = true,
-            )
-
-            // Then
-            verifySuspend {
-                dao.save(
-                    any(), // Entity with correct values
-                )
-            }
-        }
-
-    @Test
-    fun `save preserves syncedAt for existing position`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            val existingEntity =
-                createPlaybackPositionEntity(
-                    bookId = "book-1",
-                    positionMs = 1000L,
-                    syncedAt = 1704067200000L, // Previously synced
-                )
-            everySuspend { dao.get(BookId("book-1")) } returns existingEntity
-            val repository = createRepo(dao = dao)
-
-            // When
-            repository.save(
-                bookId = "book-1",
-                positionMs = 2000L,
-                playbackSpeed = 1.0f,
-                hasCustomSpeed = false,
-            )
-
-            // Then - verify dao.get was called to retrieve existing entity (which has syncedAt)
-            // and dao.save was called (the impl preserves syncedAt from existing entity)
-            verifySuspend { dao.get(BookId("book-1")) }
-            verifySuspend { dao.save(any()) }
-        }
-
-    @Test
-    fun `save sets syncedAt to null for new position`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.get(BookId("new-book")) } returns null
-            val repository = createRepo(dao = dao)
-
-            // When
-            repository.save(
-                bookId = "new-book",
-                positionMs = 5000L,
-                playbackSpeed = 1.0f,
-                hasCustomSpeed = false,
-            )
-
-            // Then - verify dao.save was called (syncedAt should be null since no existing entity)
-            verifySuspend { dao.save(any()) }
-            verifySuspend { dao.get(BookId("new-book")) }
-        }
-
-    @Test
-    fun `save calls dao with correct parameters`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.get(any()) } returns null
-            val repository = createRepo(dao = dao)
-
-            // When
-            repository.save(
-                bookId = "test-book",
-                positionMs = 12345L,
-                playbackSpeed = 1.75f,
-                hasCustomSpeed = true,
-            )
-
-            // Then
-            verifySuspend { dao.save(any()) }
+            assertTrue(result.containsKey(BookId("unique-book-id-123")))
+            assertFalse(result.containsKey(BookId("wrong-key")))
         }
 
     // ========== delete() Tests ==========
@@ -396,7 +246,7 @@ class PlaybackPositionRepositoryImplTest {
             val repository = createRepo(dao = dao)
 
             // When
-            repository.delete("book-to-delete")
+            repository.delete(BookId("book-to-delete"))
 
             // Then
             verifySuspend { dao.delete(BookId("book-to-delete")) }
@@ -410,10 +260,37 @@ class PlaybackPositionRepositoryImplTest {
             val repository = createRepo(dao = dao)
 
             // When/Then - should not throw
-            repository.delete("nonexistent-book")
+            repository.delete(BookId("nonexistent-book"))
 
             // Verify delete was still called
             verifySuspend { dao.delete(BookId("nonexistent-book")) }
+        }
+
+    @Test
+    fun `delete returns Success when dao succeeds`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-ok")
+            everySuspend { dao.delete(bookId) } returns Unit
+            val repository = createRepo(dao = dao)
+
+            val result = repository.delete(bookId)
+
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.exactly(1)) { dao.delete(bookId) }
+        }
+
+    @Test
+    fun `delete returns Failure when dao throws`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-fail")
+            everySuspend { dao.delete(bookId) } throws RuntimeException("dao boom")
+            val repository = createRepo(dao = dao)
+
+            val result = repository.delete(bookId)
+
+            assertIs<AppResult.Failure>(result)
         }
 
     // ========== Entity to Domain Conversion Tests ==========
@@ -661,7 +538,7 @@ class PlaybackPositionRepositoryImplTest {
 
             // Then - should have 1 entry, with the second position value
             assertEquals(1, result.size)
-            assertEquals(2000L, result["book-1"]?.positionMs)
+            assertEquals(2000L, result[BookId("book-1")]?.positionMs)
         }
 
     // ========== getEntity() Tests (Task 3) ==========
@@ -1205,7 +1082,7 @@ class PlaybackPositionRepositoryImplTest {
             }
             val repository = createRepo(dao = dao, pendingOps = pendingOps)
 
-            val result = repository.markComplete(bookId, startedAt, finishedAt)
+            val result = repository.markComplete(BookId(bookId), startedAt, finishedAt)
 
             assertIs<AppResult.Success<Unit>>(result)
             val saved = captured.single()
@@ -1236,7 +1113,7 @@ class PlaybackPositionRepositoryImplTest {
             everySuspend { dao.save(any()) } returns Unit
             val repository = createRepo(dao = dao, pendingOps = pendingOps)
 
-            val result = repository.discardProgress(bookId)
+            val result = repository.discardProgress(BookId(bookId))
 
             assertIs<AppResult.Success<Unit>>(result)
             verifySuspend(VerifyMode.exactly(1)) {
@@ -1263,7 +1140,7 @@ class PlaybackPositionRepositoryImplTest {
             everySuspend { dao.save(any()) } returns Unit
             val repository = createRepo(dao = dao, pendingOps = pendingOps)
 
-            val result = repository.restartBook(bookId)
+            val result = repository.restartBook(BookId(bookId))
 
             assertIs<AppResult.Success<Unit>>(result)
             verifySuspend(VerifyMode.exactly(1)) {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
@@ -573,13 +573,27 @@ class ProgressTrackerTest {
             // positionRepository.delete is the correct domain-layer entry point.
             val fixture = createFixture()
             val bookId = BookId("book-clear")
-            everySuspend { fixture.positionRepository.delete(bookId.value) } returns Unit
+            everySuspend { fixture.positionRepository.delete(bookId) } returns AppResult.Success(Unit)
 
             val tracker = fixture.build()
 
             tracker.clearProgress(bookId)
 
-            verifySuspend { fixture.positionRepository.delete(bookId.value) }
+            verifySuspend { fixture.positionRepository.delete(bookId) }
+        }
+
+    @Test
+    fun `clearProgress logs warning when delete returns Failure`() =
+        runTest {
+            val fixture = createFixture()
+            val bookId = BookId("book-1")
+            everySuspend { fixture.positionRepository.delete(bookId) } returns
+                AppResult.Failure(DataError("delete failure"))
+
+            // Should not throw — best-effort logging absorbs the failure.
+            fixture.build().clearProgress(bookId)
+
+            verifySuspend(VerifyMode.exactly(1)) { fixture.positionRepository.delete(bookId) }
         }
 
     // ========== write-path migration (Task 5) ==========
@@ -859,7 +873,7 @@ class ProgressTrackerTest {
 
             // No exception thrown. The Failure was logged and consumed.
             verifySuspend(VerifyMode.exactly(1)) {
-                fixture.positionRepository.markComplete("book-1", null, any())
+                fixture.positionRepository.markComplete(BookId("book-1"), null, any())
             }
         }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModelTest.kt
@@ -373,7 +373,7 @@ class ContributorBooksViewModelTest {
             advanceUntilIdle()
 
             val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals(0.5f, state.bookProgress["book-1"])
+            assertEquals(0.5f, state.bookProgress[BookId("book-1")])
         }
 
     @Test
@@ -392,7 +392,7 @@ class ContributorBooksViewModelTest {
             advanceUntilIdle()
 
             val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertFalse(state.bookProgress.containsKey("book-1"))
+            assertFalse(state.bookProgress.containsKey(BookId("book-1")))
         }
 
     // ========== Derived Properties ==========

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
@@ -297,7 +297,7 @@ class ContributorDetailViewModelTest {
             advanceUntilIdle()
 
             val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(0.5f, state.bookProgress["book-1"])
+            assertEquals(0.5f, state.bookProgress[BookId("book-1")])
         }
 
     @Test
@@ -322,7 +322,7 @@ class ContributorDetailViewModelTest {
             advanceUntilIdle()
 
             val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(state.bookProgress.containsKey("book-1"))
+            assertFalse(state.bookProgress.containsKey(BookId("book-1")))
         }
 
     @Test
@@ -346,7 +346,7 @@ class ContributorDetailViewModelTest {
             advanceUntilIdle()
 
             val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(state.bookProgress.containsKey("book-1"))
+            assertFalse(state.bookProgress.containsKey(BookId("book-1")))
         }
 
     // ========== View All Threshold ==========

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -880,7 +880,7 @@ class LibraryViewModelTest {
                 )
             val positions =
                 mapOf(
-                    "book-1" to
+                    BookId("book-1") to
                         PlaybackPosition(
                             bookId = "book-1",
                             positionMs = 5_000L, // 50% progress
@@ -890,7 +890,7 @@ class LibraryViewModelTest {
                             syncedAtMs = null,
                             lastPlayedAtMs = null,
                         ),
-                    "book-2" to
+                    BookId("book-2") to
                         PlaybackPosition(
                             bookId = "book-2",
                             positionMs = 10_000L, // 50% progress
@@ -909,8 +909,8 @@ class LibraryViewModelTest {
 
             // Then
             val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(0.5f, loaded.bookProgress["book-1"])
-            assertEquals(0.5f, loaded.bookProgress["book-2"])
+            assertEquals(0.5f, loaded.bookProgress[BookId("book-1")])
+            assertEquals(0.5f, loaded.bookProgress[BookId("book-2")])
         }
 
     @Test
@@ -924,7 +924,7 @@ class LibraryViewModelTest {
                 )
             val positions =
                 mapOf(
-                    "book-1" to
+                    BookId("book-1") to
                         PlaybackPosition(
                             bookId = "book-1",
                             positionMs = 9_950L, // 99.5% - should be included for completion badge
@@ -943,7 +943,7 @@ class LibraryViewModelTest {
 
             // Then - completed book is included with its progress (for completion badge)
             val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(0.995f, loaded.bookProgress["book-1"])
+            assertEquals(0.995f, loaded.bookProgress[BookId("book-1")])
         }
 
     // ========== Per-Upstream Catch Tests ==========

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepository.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.map
 
 /**
  * In-memory fake of [PlaybackPositionRepository] backed by a [MutableStateFlow] of
- * book-id → position. Emits on every write so reactive consumers (`observe`, `observeAll`)
+ * book-id → position. Emits on every write so reactive consumers (`observeAll`)
  * behave like the real Room-backed implementation.
  *
  * Why a fake instead of a Mokkery mock: the bugs this interface participates in (Bug 2 —
@@ -54,47 +54,26 @@ class FakePlaybackPositionRepository(
         )
     }
 
-    override fun observe(bookId: String): Flow<PlaybackPosition?> = state.asStateFlow().map { it[bookId] }
+    override fun observeAll(): Flow<Map<BookId, PlaybackPosition>> =
+        state.asStateFlow().map { stringKeyed ->
+            stringKeyed.mapKeys { (k, _) -> BookId(k) }
+        }
 
-    override fun observeAll(): Flow<Map<String, PlaybackPosition>> = state.asStateFlow()
-
-    override suspend fun save(
-        bookId: String,
-        positionMs: Long,
-        playbackSpeed: Float,
-        hasCustomSpeed: Boolean,
-    ) {
-        val now = nowMs()
-        state.value = state.value + (
-            bookId to
-                PlaybackPosition(
-                    bookId = bookId,
-                    positionMs = positionMs,
-                    playbackSpeed = playbackSpeed,
-                    hasCustomSpeed = hasCustomSpeed,
-                    updatedAtMs = now,
-                    syncedAtMs = null,
-                    lastPlayedAtMs = now,
-                    isFinished = state.value[bookId]?.isFinished ?: false,
-                    finishedAtMs = state.value[bookId]?.finishedAtMs,
-                    startedAtMs = state.value[bookId]?.startedAtMs,
-                )
-        )
-    }
-
-    override suspend fun delete(bookId: String) {
-        state.value = state.value - bookId
+    override suspend fun delete(bookId: BookId): AppResult<Unit> {
+        state.value = state.value - bookId.value
+        return Success(Unit)
     }
 
     override suspend fun markComplete(
-        bookId: String,
+        bookId: BookId,
         startedAt: Long?,
         finishedAt: Long?,
     ): AppResult<Unit> {
+        val key = bookId.value
         val now = nowMs()
         val existing =
-            state.value[bookId] ?: PlaybackPosition(
-                bookId = bookId,
+            state.value[key] ?: PlaybackPosition(
+                bookId = key,
                 positionMs = 0L,
                 playbackSpeed = 1.0f,
                 hasCustomSpeed = false,
@@ -103,7 +82,7 @@ class FakePlaybackPositionRepository(
                 lastPlayedAtMs = now,
             )
         state.value = state.value + (
-            bookId to
+            key to
                 existing.copy(
                     isFinished = true,
                     finishedAtMs = finishedAt ?: now,
@@ -114,15 +93,16 @@ class FakePlaybackPositionRepository(
         return Success(Unit)
     }
 
-    override suspend fun discardProgress(bookId: String): AppResult<Unit> {
-        state.value = state.value - bookId
+    override suspend fun discardProgress(bookId: BookId): AppResult<Unit> {
+        state.value = state.value - bookId.value
         return Success(Unit)
     }
 
-    override suspend fun restartBook(bookId: String): AppResult<Unit> {
-        val existing = state.value[bookId] ?: return Success(Unit)
+    override suspend fun restartBook(bookId: BookId): AppResult<Unit> {
+        val key = bookId.value
+        val existing = state.value[key] ?: return Success(Unit)
         state.value = state.value + (
-            bookId to
+            key to
                 existing.copy(
                     positionMs = 0L,
                     isFinished = false,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepositoryTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,11 +20,14 @@ import kotlin.test.assertTrue
  */
 class FakePlaybackPositionRepositoryTest {
     @Test
-    fun saveAndGet() =
+    fun savePlaybackStateAndGet() =
         runTest {
             val repo = FakePlaybackPositionRepository()
 
-            repo.save(bookId = "book-1", positionMs = 5_000L, playbackSpeed = 1.25f, hasCustomSpeed = true)
+            repo.savePlaybackState(
+                BookId("book-1"),
+                PlaybackUpdate.Position(positionMs = 5_000L, speed = 1.0f),
+            )
 
             val result =
                 assertIs<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>(
@@ -31,21 +35,22 @@ class FakePlaybackPositionRepositoryTest {
                 )
             val saved = assertNotNull(result.data)
             assertEquals(5_000L, saved.positionMs)
-            assertEquals(1.25f, saved.playbackSpeed)
-            assertTrue(saved.hasCustomSpeed)
         }
 
     @Test
-    fun observeEmitsOnWrite() =
+    fun observeAllEmitsOnWrite() =
         runTest {
             val repo = FakePlaybackPositionRepository()
 
-            repo.observe("book-1").test {
-                assertNull(awaitItem(), "initial emission must be null (nothing saved)")
-                repo.save("book-1", positionMs = 1_000L, playbackSpeed = 1.0f, hasCustomSpeed = false)
+            repo.observeAll().test {
+                val initial = awaitItem()
+                assertTrue(initial.isEmpty(), "initial emission must be empty (nothing saved)")
+
+                repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
+
                 val after = awaitItem()
-                assertNotNull(after)
-                assertEquals(1_000L, after.positionMs)
+                assertEquals(1, after.size)
+                assertEquals(1_000L, after[BookId("book-1")]?.positionMs)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -54,14 +59,15 @@ class FakePlaybackPositionRepositoryTest {
     fun observeAllReflectsAllBooks() =
         runTest {
             val repo = FakePlaybackPositionRepository()
-            repo.save("book-1", 100L, 1.0f, false)
-            repo.save("book-2", 200L, 1.5f, true)
+            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 100L, speed = 1.0f))
+            repo.savePlaybackState(BookId("book-2"), PlaybackUpdate.Position(positionMs = 200L, speed = 1.0f))
 
             repo.observeAll().test {
                 val all = awaitItem()
                 assertEquals(2, all.size)
-                assertEquals(100L, all["book-1"]?.positionMs)
-                assertEquals(200L, all["book-2"]?.positionMs)
+                assertEquals(setOf(BookId("book-1"), BookId("book-2")), all.keys)
+                assertEquals(100L, all[BookId("book-1")]?.positionMs)
+                assertEquals(200L, all[BookId("book-2")]?.positionMs)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -70,9 +76,9 @@ class FakePlaybackPositionRepositoryTest {
     fun markCompleteSetsIsFinishedAndFinishedAt() =
         runTest {
             val repo = FakePlaybackPositionRepository()
-            repo.save("book-1", 1_000L, 1.0f, false)
+            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
 
-            val result = repo.markComplete("book-1", startedAt = 100L, finishedAt = 999L)
+            val result = repo.markComplete(BookId("book-1"), startedAt = 100L, finishedAt = 999L)
 
             assertTrue(result is com.calypsan.listenup.client.core.Success)
             val after =
@@ -90,9 +96,9 @@ class FakePlaybackPositionRepositoryTest {
     fun discardProgressRemovesEntry() =
         runTest {
             val repo = FakePlaybackPositionRepository()
-            repo.save("book-1", 1_000L, 1.0f, false)
+            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
 
-            val result = repo.discardProgress("book-1")
+            val result = repo.discardProgress(BookId("book-1"))
 
             assertTrue(result is com.calypsan.listenup.client.core.Success)
             val afterDiscard = assertIs<AppResult.Success<*>>(repo.get(BookId("book-1")))
@@ -103,10 +109,10 @@ class FakePlaybackPositionRepositoryTest {
     fun restartBookResetsPositionAndClearsFinished() =
         runTest {
             val repo = FakePlaybackPositionRepository()
-            repo.save("book-1", 10_000L, 1.0f, false)
-            repo.markComplete("book-1")
+            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 10_000L, speed = 1.0f))
+            repo.markComplete(BookId("book-1"))
 
-            val result = repo.restartBook("book-1")
+            val result = repo.restartBook(BookId("book-1"))
 
             assertTrue(result is com.calypsan.listenup.client.core.Success)
             val after =
@@ -125,9 +131,9 @@ class FakePlaybackPositionRepositoryTest {
         runTest {
             var clock = 1_000L
             val repo = FakePlaybackPositionRepository(nowMs = { clock })
-            repo.save("oldest", positionMs = 100L, playbackSpeed = 1.0f, hasCustomSpeed = false)
+            repo.savePlaybackState(BookId("oldest"), PlaybackUpdate.Position(positionMs = 100L, speed = 1.0f))
             clock = 2_000L
-            repo.save("newest", positionMs = 5_000L, playbackSpeed = 1.5f, hasCustomSpeed = true)
+            repo.savePlaybackState(BookId("newest"), PlaybackUpdate.Speed(positionMs = 5_000L, speed = 1.5f, custom = true))
 
             val result = repo.getLastPlayedBook()
 


### PR DESCRIPTION
## Summary
Closes drift #24. **W8 closes when this PR merges.**

- Retyped `PlaybackPositionRepository`'s remaining `bookId: String` parameters to `BookId` on `delete`, `markComplete`, `discardProgress`, `restartBook`. Lifted `delete`'s return to `AppResult<Unit>` so every fallible suspend method on the interface now returns `AppResult<T>`.
- Retyped `observeAll`'s map key from `String` to `BookId`. Cascaded through `BookProgressCalculator.calculateProgressMap`, `LibraryViewModel`, `LibraryUiState`, `ContributorBooksViewModel`, `ContributorDetailViewModel`, both Contributor UI states, and the corresponding Compose screens (`BooksContent.kt`, `ContributorBooksScreen.kt`, `ContributorDetailScreen.kt`).
- Deleted `save(bookId: String, ...)` and `observe(bookId: String)` — both confirmed unreachable from production (and tests) since W7's `savePlaybackState` consolidation. Retyping unreachable code would have been wasted work.
- Updated `FakePlaybackPositionRepository` to match the new interface; deleted tests for the deleted methods (2 in fake test, 7 in impl test).
- Added 2 new `delete` tests (Success / Failure paths) to `PlaybackPositionRepositoryImplTest` to cover the new `AppResult<Unit>` lift; added 1 `clearProgress` Failure-path log test in `ProgressTrackerTest`.

## Spec / plan
- `docs/superpowers/specs/2026-05-01-w8-z3-position-repo-retype-design.md`
- `docs/superpowers/plans/2026-05-01-w8-z3-position-repo-retype.md`

## Verification
- 3× `:shared:jvmTest` consecutive passes.
- `spotlessCheck`, `detekt`, `:androidApp:assembleDebug` green.
- Compiler enumerated every consumer site; each was mechanically updated (`BookId(rawString)` wrap or `.value` drop or container swap).

## Cascade scope (slightly larger than spec estimate)
The spec estimated "about 4 files outside the repo itself" for the map-key cascade. Actual count was 8 commonMain files + 3 Compose screens + tests, because `Map<String, Float>` propagates through UI state types into Compose. Subagents discovered `ContributorBooksScreen.kt` (not in the original plan) had the same drift and absorbed the fix — required for the desktop compile to be green.

## Task 0 (rubric currency)
Inherited from W8 Phase Z2. Versions verified (Kotlin 2.3.20, Room 2.8.4, Ktor 3.4.3, Koin 4.2.1, detekt 1.23.8). No amendments.

## W8 closure
**W8 (Download Subsystem / Bug 4) closes when this PR merges.** All four phases (A, B, C, D, E, Z1, Z2, Z3) plus Bug 4 fix all shipped. W9 (Navigation) opens next.