### PR TITLE
Phase 2 — Scanner: pipeline + watcher + RPC/REST/SSE

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ flyway = "11.7.0"
 hikari = "6.3.0"
 password4j = "1.8.4"
 konsist = "0.17.3"
+kfswatch = "1.4.0"
 
 [libraries]
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
@@ -209,6 +210,8 @@ markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-
 kmpalette-core = { module = "com.kmpalette:kmpalette-core", version.ref = "kmpalette" }
 # Konsist — architectural assertions
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
+# kfswatch — KMP filesystem watcher (inotify / FSEvents / ReadDirectoryChangesW)
+kfswatch = { module = "io.github.irgaly.kfswatch:kfswatch", version.ref = "kfswatch" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -85,6 +85,9 @@ dependencies {
     testImplementation(libs.ktor.client.cio)
     testImplementation(libs.ktor.client.auth)
     testImplementation(libs.mokkery.runtime)
+
+    // Turbine — Flow assertions for the watcher tests.
+    testImplementation(libs.turbine)
 }
 
 kotlin {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -67,6 +67,9 @@ dependencies {
     implementation(libs.kotlinx.coroutines.slf4j)
     runtimeOnly(libs.janino) // enables logback.xml <if>/<condition> elements
 
+    // Phase 2 scanner — filesystem watching across Linux/macOS/Windows.
+    implementation(libs.kfswatch)
+
     // Test deps
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.client.content.negotiation)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -1,10 +1,13 @@
 package com.calypsan.listenup.server
 
+import com.calypsan.listenup.api.ScannerService
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.server.auth.AuthServiceImpl
 import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.di.authModule
+import com.calypsan.listenup.server.di.scannerModule
 import com.calypsan.listenup.server.plugins.installAppErrorStatusPages
 import com.calypsan.listenup.server.plugins.installCallIdAndLogging
 import com.calypsan.listenup.server.plugins.installJwtAuth
@@ -13,7 +16,11 @@ import com.calypsan.listenup.server.routes.authRoutes
 import com.calypsan.listenup.server.routes.healthRoutes
 import com.calypsan.listenup.server.routes.instanceRoutes
 import com.calypsan.listenup.server.routes.rpcRoutes
+import com.calypsan.listenup.server.routes.scannerRoutes
 import com.calypsan.listenup.server.routes.sseRoutes
+import com.calypsan.listenup.server.scanner.Scanner
+import com.calypsan.listenup.server.scanner.watcher.FolderWatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -22,9 +29,17 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.resources.Resources
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.rpc.krpc.ktor.server.Krpc
 import org.koin.ktor.ext.inject
 import org.koin.ktor.plugin.Koin
+import java.nio.file.Files
+import java.nio.file.Path
+
+private val logger = KotlinLogging.logger {}
 
 fun main(args: Array<String>) = EngineMain.main(args)
 
@@ -34,8 +49,15 @@ fun Application.module() {
     install(SSE)
     install(Krpc)
 
+    val resolvedLibraryPath = resolveLibraryPath()
+    val applicationScope = CoroutineScope(coroutineContext + SupervisorJob())
+
     install(Koin) {
-        modules(authModule(environment.config))
+        val modules = mutableListOf(authModule(environment.config))
+        if (resolvedLibraryPath != null) {
+            modules += scannerModule(resolvedLibraryPath, applicationScope)
+        }
+        modules(modules)
     }
 
     installCallIdAndLogging()
@@ -48,11 +70,75 @@ fun Application.module() {
 
     installJwtAuth(jwt, sessions)
 
+    val scannerService: ScannerService? = resolvedLibraryPath?.let { inject<ScannerService>().value }
+    val eventBus: SharedFlow<ScanEvent>? = resolvedLibraryPath?.let { inject<SharedFlow<ScanEvent>>().value }
+
     routing {
         healthRoutes()
         instanceRoutes()
         sseRoutes()
         authRoutes(authService)
-        rpcRoutes(authService)
+        rpcRoutes(authService, scannerService)
+        if (scannerService != null && eventBus != null) {
+            scannerRoutes(scannerService, eventBus)
+        }
+    }
+
+    if (resolvedLibraryPath != null) {
+        bootstrapScannerOnStartup(applicationScope)
+    } else {
+        logger.warn {
+            "scanner.libraryPath unset or invalid — server starts without scanning. " +
+                "Set LISTENUP_LIBRARY_PATH to enable."
+        }
+    }
+}
+
+/**
+ * Reads `scanner.libraryPath` from configuration. Returns null when unset,
+ * blank, or pointing at a non-directory — the server still starts in those
+ * cases, just without an active scanner.
+ */
+private fun Application.resolveLibraryPath(): Path? {
+    val raw =
+        environment.config
+            .propertyOrNull("scanner.libraryPath")
+            ?.getString()
+            .orEmpty()
+    if (raw.isBlank()) return null
+    val path = Path.of(raw)
+    if (!Files.isDirectory(path)) {
+        logger.warn { "scanner.libraryPath '$raw' does not point to a directory — scanner disabled" }
+        return null
+    }
+    return path
+}
+
+/**
+ * Kicks off the initial scan and starts the [FolderWatcher]. Runs on the
+ * supplied [scope] so cancellation flows through structured concurrency
+ * when the application shuts down.
+ *
+ * The initial scan failures don't bubble — we log and continue. The user
+ * can re-trigger via the scanner RPC surface.
+ */
+private fun Application.bootstrapScannerOnStartup(scope: CoroutineScope) {
+    val scanner by inject<Scanner>()
+    val watcher by inject<FolderWatcher>()
+
+    scope.launch {
+        runCatching { scanner.runFullScan() }
+            .onFailure { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger.error(e) { "initial scan failed — server keeps running" }
+            }
+    }
+
+    scope.launch {
+        runCatching { watcher.start() }
+            .onFailure { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger.error(e) { "folder watcher failed to start — real-time updates disabled" }
+            }
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
@@ -1,0 +1,89 @@
+package com.calypsan.listenup.server.di
+
+import com.calypsan.listenup.api.ScannerService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.scanner.ScanCoordinator
+import com.calypsan.listenup.server.scanner.Scanner
+import com.calypsan.listenup.server.scanner.ScannerServiceImpl
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.scanner.watcher.FolderWatcher
+import com.calypsan.listenup.server.scanner.watcher.StableSizeDebouncer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.nio.file.Path
+
+/**
+ * Koin module for the scanner slice. Wires:
+ *
+ *  - The [ScanEvent] event bus (writable [MutableSharedFlow] for the
+ *    Scanner; read-only [SharedFlow] view for the RPC service and SSE).
+ *  - [AbsMetadataReader], [Scanner], [ScanCoordinator], [ScannerServiceImpl].
+ *  - [FolderWatcher] for real-time updates.
+ *
+ * The [applicationScope] parameter is the long-lived coroutine scope
+ * (typically `Application.coroutineContext + SupervisorJob`) — owns the
+ * coordinator's worker and the watcher's event loop. Cancelling the scope
+ * cancels everything cleanly on app shutdown.
+ *
+ * The module is only installed when [libraryPath] is set; the caller
+ * (Application.module()) decides whether to skip installation when no
+ * library path is configured.
+ */
+fun scannerModule(
+    libraryPath: Path,
+    applicationScope: CoroutineScope,
+): Module =
+    module {
+        single { libraryPath }
+        single { applicationScope }
+
+        // Event bus: one MutableSharedFlow as the writable side, exposed both
+        // as MutableSharedFlow (for the Scanner to emit) and as SharedFlow
+        // (for ScannerServiceImpl to expose to clients without leaking emit).
+        single<MutableSharedFlow<ScanEvent>> {
+            MutableSharedFlow(replay = 0, extraBufferCapacity = 64)
+        }
+        single<SharedFlow<ScanEvent>> { get<MutableSharedFlow<ScanEvent>>().asSharedFlow() }
+
+        single { AbsMetadataReader(contractJson) }
+
+        single {
+            Scanner(
+                rootPath = get(),
+                metadataReader = get(),
+                eventBus = get<MutableSharedFlow<ScanEvent>>(),
+            )
+        }
+
+        single {
+            val scanner: Scanner = get()
+            ScanCoordinator(
+                runFullScan = { scanner.runFullScan() },
+                runIncremental = { scanner.runIncremental(it) },
+                scope = get(),
+            )
+        }
+
+        single<ScannerService> {
+            ScannerServiceImpl(
+                scanner = get(),
+                coordinator = get(),
+                eventBus = get<SharedFlow<ScanEvent>>(),
+            )
+        }
+
+        single { StableSizeDebouncer() }
+
+        single {
+            FolderWatcher(
+                libraryRoot = get(),
+                scope = get(),
+                debouncer = get(),
+            )
+        }
+    }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.plugins
 import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
+import com.calypsan.listenup.api.error.ScanError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.api.result.AppResult
 import io.ktor.http.HttpStatusCode
@@ -60,6 +61,12 @@ internal fun AppError.toHttpStatus(): HttpStatusCode =
         is AuthError.PermissionDenied -> HttpStatusCode.Forbidden
         is ValidationError -> HttpStatusCode.BadRequest
         is InternalError -> HttpStatusCode.InternalServerError
+        is ScanError.AlreadyRunning -> HttpStatusCode.Conflict
+        is ScanError.LibraryPathNotConfigured -> HttpStatusCode.ServiceUnavailable
+        is ScanError.LibraryPathNotFound -> HttpStatusCode.ServiceUnavailable
+        is ScanError.FileUnreadable -> HttpStatusCode.InternalServerError
+        is ScanError.MetadataParseError -> HttpStatusCode.InternalServerError
+        is ScanError.TitleInferenceError -> HttpStatusCode.InternalServerError
     }
 
 /** Stamp the request's correlation id onto a typed wire error. */
@@ -80,4 +87,10 @@ internal fun AppError.withCorrelationId(id: String?): AppError =
         is AuthError.PermissionDenied -> copy(correlationId = id)
         is ValidationError -> copy(correlationId = id)
         is InternalError -> copy(correlationId = id)
+        is ScanError.AlreadyRunning -> copy(correlationId = id)
+        is ScanError.LibraryPathNotConfigured -> copy(correlationId = id)
+        is ScanError.LibraryPathNotFound -> copy(correlationId = id)
+        is ScanError.FileUnreadable -> copy(correlationId = id)
+        is ScanError.MetadataParseError -> copy(correlationId = id)
+        is ScanError.TitleInferenceError -> copy(correlationId = id)
     }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -46,6 +46,23 @@ fun Application.installAppErrorStatusPages() {
 /** Status mapping for typed [AppError]. Used by both REST handlers and tests. */
 internal fun AppError.toHttpStatus(): HttpStatusCode =
     when (this) {
+        is AuthError -> toHttpStatus()
+        is ScanError -> toHttpStatus()
+        is ValidationError -> HttpStatusCode.BadRequest
+        is InternalError -> HttpStatusCode.InternalServerError
+    }
+
+/** Stamp the request's correlation id onto a typed wire error. */
+internal fun AppError.withCorrelationId(id: String?): AppError =
+    when (this) {
+        is AuthError -> withCorrelationId(id)
+        is ScanError -> withCorrelationId(id)
+        is ValidationError -> copy(correlationId = id)
+        is InternalError -> copy(correlationId = id)
+    }
+
+private fun AuthError.toHttpStatus(): HttpStatusCode =
+    when (this) {
         is AuthError.InvalidCredentials -> HttpStatusCode.Unauthorized
         is AuthError.EmailAlreadyExists -> HttpStatusCode.Conflict
         is AuthError.RegistrationDisabled -> HttpStatusCode.Forbidden
@@ -59,8 +76,10 @@ internal fun AppError.toHttpStatus(): HttpStatusCode =
         is AuthError.RateLimited -> HttpStatusCode.TooManyRequests
         is AuthError.WeakPassword -> HttpStatusCode.BadRequest
         is AuthError.PermissionDenied -> HttpStatusCode.Forbidden
-        is ValidationError -> HttpStatusCode.BadRequest
-        is InternalError -> HttpStatusCode.InternalServerError
+    }
+
+private fun ScanError.toHttpStatus(): HttpStatusCode =
+    when (this) {
         is ScanError.AlreadyRunning -> HttpStatusCode.Conflict
         is ScanError.LibraryPathNotConfigured -> HttpStatusCode.ServiceUnavailable
         is ScanError.LibraryPathNotFound -> HttpStatusCode.ServiceUnavailable
@@ -69,8 +88,7 @@ internal fun AppError.toHttpStatus(): HttpStatusCode =
         is ScanError.TitleInferenceError -> HttpStatusCode.InternalServerError
     }
 
-/** Stamp the request's correlation id onto a typed wire error. */
-internal fun AppError.withCorrelationId(id: String?): AppError =
+private fun AuthError.withCorrelationId(id: String?): AuthError =
     when (this) {
         is AuthError.InvalidCredentials -> copy(correlationId = id)
         is AuthError.EmailAlreadyExists -> copy(correlationId = id)
@@ -85,8 +103,10 @@ internal fun AppError.withCorrelationId(id: String?): AppError =
         is AuthError.RateLimited -> copy(correlationId = id)
         is AuthError.WeakPassword -> copy(correlationId = id)
         is AuthError.PermissionDenied -> copy(correlationId = id)
-        is ValidationError -> copy(correlationId = id)
-        is InternalError -> copy(correlationId = id)
+    }
+
+private fun ScanError.withCorrelationId(id: String?): ScanError =
+    when (this) {
         is ScanError.AlreadyRunning -> copy(correlationId = id)
         is ScanError.LibraryPathNotConfigured -> copy(correlationId = id)
         is ScanError.LibraryPathNotFound -> copy(correlationId = id)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.routes
 import com.calypsan.listenup.api.AuthServiceAuthed
 import com.calypsan.listenup.api.AuthServicePublic
 import com.calypsan.listenup.api.PingService
+import com.calypsan.listenup.api.ScannerService
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.server.auth.AuthServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider
@@ -36,11 +37,17 @@ private class PingServiceImpl : PingService {
  * the client; RPC-side typed-error recovery awaits either a kotlinx.rpc
  * interceptor API or a migration to `AppResult<T>` return shapes.
  */
-fun Route.rpcRoutes(authService: AuthServiceImpl) {
+fun Route.rpcRoutes(
+    authService: AuthServiceImpl,
+    scannerService: ScannerService? = null,
+) {
     rpc("/api/rpc/public") {
         rpcConfig { serialization { json(contractJson) } }
         registerService<PingService> { PingServiceImpl() }
         registerService<AuthServicePublic> { authService }
+        if (scannerService != null) {
+            registerService<ScannerService> { scannerService }
+        }
     }
 
     authenticate(JWT_PROVIDER) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
@@ -1,0 +1,77 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.ScannerService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.resources.ScannerResources
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.plugins.toHttpStatus
+import com.calypsan.listenup.server.plugins.withCorrelationId
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.resources.get
+import io.ktor.server.resources.post
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.sse.sse
+import io.ktor.sse.ServerSentEvent
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * REST + SSE surface for the scanner. Three endpoints:
+ *
+ *  - `POST /api/v1/scan` — triggers a full scan. Returns an
+ *    [AppResult]<[ScanResultSummary]>; concurrent calls receive
+ *    `Failure(AlreadyRunning)`.
+ *  - `GET /api/v1/scan/last` — returns the most recent
+ *    [AppResult]<[ScanResult]>. Failure when no scan has run yet.
+ *  - `GET /sse/scan` — server-sent events; emits every [ScanEvent]
+ *    serialized as JSON in the SSE `data` field.
+ *
+ * The kotlinx.rpc surface for the same service is mounted separately by
+ * [rpcRoutes].
+ */
+fun Route.scannerRoutes(
+    scannerService: ScannerService,
+    events: Flow<ScanEvent>,
+) {
+    post<ScannerResources> {
+        call.respondAppResult<ScanResultSummary>(scannerService.scanFull())
+    }
+    get<ScannerResources.Last> {
+        call.respondAppResult<ScanResult>(scannerService.lastScanResult())
+    }
+
+    sse("/sse/scan") {
+        events.collect { event ->
+            send(
+                ServerSentEvent(
+                    event = event::class.simpleName,
+                    data = contractJson.encodeToString(ScanEvent.serializer(), event),
+                ),
+            )
+        }
+    }
+}
+
+private suspend inline fun <reified T : Any> ApplicationCall.respondAppResult(result: AppResult<T>) {
+    val status: HttpStatusCode
+    val body: AppResult<T>
+    when (result) {
+        is AppResult.Success -> {
+            status = HttpStatusCode.OK
+            body = result
+        }
+
+        is AppResult.Failure -> {
+            val typed = result.error.withCorrelationId(callId)
+            status = typed.toHttpStatus()
+            body = AppResult.Failure(typed)
+        }
+    }
+    respond(status, body)
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
@@ -1,0 +1,95 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.result.AppResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Single-flight coordinator for full scans and incremental re-analysis.
+ *
+ * One [Mutex] serialises every scan operation — a full scan and an
+ * incremental re-analysis cannot overlap, because both mutate the
+ * Scanner's `lastResult` state.
+ *
+ * **Full scans.** [scanFull] returns [ScanError.AlreadyRunning] immediately
+ * when another scan is in flight (mutex unavailable). The caller chooses
+ * whether to retry; by design we never queue full scans.
+ *
+ * **Incremental re-analysis.** [reanalyze] is fire-and-forget and
+ * non-suspending so the file watcher can call it freely. Per-path
+ * coalescing keeps a hot folder from flooding the queue: a path that is
+ * already pending will not be enqueued twice. A worker coroutine launched
+ * by the constructor drains the queue, taking the mutex for each item.
+ *
+ * **Plan deviation:** the plan literal sketched `Channel.CONFLATED` for the
+ * incremental queue. That collapses *all* traffic globally — when two
+ * distinct book roots fire in quick succession the second clobbers the
+ * first. We use [ConcurrentHashMap.newKeySet] for per-path dedup with an
+ * unbounded queue, which gives the test-stated semantics ("100 triggers
+ * for the same path collapse to ≤ 1") *without* dropping events for
+ * unrelated paths.
+ *
+ * **Cancellation.** Cancelling [scope] cancels the worker coroutine and
+ * propagates into any in-flight scan via structured concurrency.
+ * `CancellationException` is always re-raised — the coordinator never
+ * swallows it.
+ */
+class ScanCoordinator(
+    private val runFullScan: suspend () -> ScanResult,
+    private val runIncremental: suspend (Path) -> Unit,
+    scope: CoroutineScope,
+) {
+    private val mutex = Mutex()
+    private val pendingPaths: MutableSet<Path> = ConcurrentHashMap.newKeySet()
+    private val incrementalChannel = Channel<Path>(Channel.UNLIMITED)
+
+    init {
+        scope.launch {
+            for (path in incrementalChannel) {
+                // Remove BEFORE processing so a subsequent reanalyze(path)
+                // arriving during this run is re-enqueued — the file may
+                // have changed again while we were working on it.
+                pendingPaths.remove(path)
+                try {
+                    mutex.withLock { runIncremental(path) }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.warn(e) { "incremental analysis failed for $path — continuing" }
+                }
+            }
+        }
+    }
+
+    suspend fun scanFull(): AppResult<ScanResult> {
+        if (!mutex.tryLock()) {
+            return AppResult.Failure(ScanError.AlreadyRunning())
+        }
+        return try {
+            AppResult.Success(runFullScan())
+        } finally {
+            mutex.unlock()
+        }
+    }
+
+    fun reanalyze(bookRoot: Path) {
+        if (pendingPaths.add(bookRoot)) {
+            // trySend on UNLIMITED never fails for legitimate sends; the
+            // only failure mode is a closed channel, in which case we've
+            // been cancelled and dropping is correct.
+            val sent = incrementalChannel.trySend(bookRoot).isSuccess
+            if (!sent) pendingPaths.remove(bookRoot)
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -1,0 +1,229 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.scanner.pipeline.Analyzer
+import com.calypsan.listenup.server.scanner.pipeline.Differ
+import com.calypsan.listenup.server.scanner.pipeline.Grouper
+import com.calypsan.listenup.server.scanner.pipeline.Walker
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import java.nio.file.Path
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Top-level scanner orchestrator. Wires the four pipeline stages
+ * (Walker → Grouper → Analyzer → Differ) and tracks the most recent scan
+ * result in memory for cross-scan diffing.
+ *
+ * The Scanner exposes two work methods:
+ *
+ *  - [runFullScan] — walks the entire library, analyzes every book,
+ *    diffs against the previous full scan's snapshot, and updates
+ *    [lastResult]. Emits `Started → Progress* → Change* → Completed`
+ *    events on the [eventBus].
+ *  - [runIncremental] — walks just one book-root subtree, analyzes only
+ *    those books, diffs against the matching subset of the previous
+ *    snapshot, and patches the affected entries in [lastResult] in place.
+ *    Lets the watcher trigger fast per-book updates without paying for a
+ *    full library walk.
+ *
+ * **Concurrency.** Both work methods assume they're called serially — the
+ * single-flight guarantee comes from [ScanCoordinator]. The Scanner does
+ * NOT take its own lock; calling either method concurrently from outside
+ * the coordinator is a programming error.
+ *
+ * **`@Volatile lastResult`.** Read by `lastResult()` from arbitrary
+ * threads; written only from inside the coordinator's mutex.
+ */
+class Scanner(
+    private val rootPath: Path,
+    private val metadataReader: AbsMetadataReader,
+    private val eventBus: MutableSharedFlow<ScanEvent>,
+    private val parseSubtitle: Boolean = false,
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val correlationIdFactory: () -> String = { UUID.randomUUID().toString() },
+) {
+    @Volatile
+    private var lastResult: ScanResult? = null
+
+    fun lastResult(): ScanResult? = lastResult
+
+    suspend fun runFullScan(): ScanResult {
+        val correlationId = correlationIdFactory()
+        val started = clock()
+        eventBus.emit(ScanEvent.Started(correlationId, rootPath.toString()))
+
+        val (books, errors, filesWalked) = analyzeSubtree(bookRoot = rootPath, correlationId = correlationId)
+
+        emitProgress(correlationId, ScanPhase.DIFFING, filesWalked, books.size, errors.size)
+        val previous = lastResult?.books.orEmpty()
+        val changes = Differ().diff(books.asFlow(), previous).toList()
+        changes.forEach { eventBus.emit(ScanEvent.Change(correlationId, it)) }
+
+        val result =
+            ScanResult(
+                correlationId = correlationId,
+                rootPath = rootPath.toString(),
+                books = books,
+                changes = changes,
+                errors = errors,
+                durationMs = clock() - started,
+                filesWalked = filesWalked,
+                filesSkipped = 0,
+            )
+        lastResult = result
+        eventBus.emit(ScanEvent.Completed(correlationId, result.toSummary()))
+        logger.info {
+            "scan complete: ${books.size} books, ${changes.size} changes, ${errors.size} errors in ${result.durationMs}ms"
+        }
+        return result
+    }
+
+    /**
+     * Re-walks just [bookRoot] and patches the affected entries in
+     * [lastResult]. The [Differ] runs against the subset of the previous
+     * snapshot whose books fall under [bookRoot], so [ChangeEventDto]
+     * emissions are correctly scoped — a previously-analyzed book that
+     * disappeared during the incremental shows up as `Removed`.
+     *
+     * If the bookRoot directory no longer exists, all previously-known
+     * books at or under that path are emitted as Removed.
+     */
+    suspend fun runIncremental(bookRoot: Path) {
+        val correlationId = correlationIdFactory()
+        val started = clock()
+        eventBus.emit(ScanEvent.Started(correlationId, bookRoot.toString()))
+
+        val (books, errors, filesWalked) = analyzeSubtree(bookRoot = bookRoot, correlationId = correlationId)
+
+        val (previousAffected, previousUntouched) = partitionBooksUnder(bookRoot, lastResult?.books.orEmpty())
+        val changes = Differ().diff(books.asFlow(), previousAffected).toList()
+        changes.forEach { eventBus.emit(ScanEvent.Change(correlationId, it)) }
+
+        val patched = previousUntouched + books
+        val durationMs = clock() - started
+        lastResult =
+            lastResult?.copy(
+                books = patched,
+                changes = changes,
+                errors = errors,
+                durationMs = durationMs,
+                filesWalked = filesWalked,
+            ) ?: ScanResult(
+                correlationId = correlationId,
+                rootPath = rootPath.toString(),
+                books = patched,
+                changes = changes,
+                errors = errors,
+                durationMs = durationMs,
+                filesWalked = filesWalked,
+                filesSkipped = 0,
+            )
+        eventBus.emit(ScanEvent.Completed(correlationId, lastResult!!.toSummary()))
+    }
+
+    private suspend fun analyzeSubtree(
+        bookRoot: Path,
+        correlationId: String,
+    ): SubtreeAnalysis {
+        val prefix = rootPath.relativize(bookRoot).toString().replace('\\', '/')
+        val walker = Walker()
+        val grouper = Grouper()
+        val analyzer = Analyzer(rootPath, metadataReader, parseSubtitle)
+
+        emitProgress(correlationId, ScanPhase.WALKING, 0, 0, 0)
+        val rebasedFiles =
+            walker
+                .walk(bookRoot)
+                .map { entry ->
+                    if (prefix.isEmpty()) {
+                        entry
+                    } else {
+                        entry.copy(relPath = "$prefix/${entry.relPath}")
+                    }
+                }.toList()
+
+        emitProgress(correlationId, ScanPhase.GROUPING, rebasedFiles.size, 0, 0)
+        val candidates = grouper.group(rebasedFiles.asFlow()).toList()
+
+        emitProgress(correlationId, ScanPhase.ANALYZING, rebasedFiles.size, 0, 0)
+        val books = mutableListOf<AnalyzedBook>()
+        val errors = mutableListOf<ScanError>()
+        analyzer.analyze(candidates.asFlow()).toList().forEach { result ->
+            result
+                .onSuccess { books += it }
+                .onFailure { errors += toScanError(it) }
+        }
+        return SubtreeAnalysis(books = books, errors = errors, filesWalked = rebasedFiles.size)
+    }
+
+    private fun partitionBooksUnder(
+        bookRoot: Path,
+        books: List<AnalyzedBook>,
+    ): Pair<List<AnalyzedBook>, List<AnalyzedBook>> {
+        val rootPrefix = rootPath.relativize(bookRoot).toString().replace('\\', '/')
+        return books.partition { book ->
+            val rel = book.candidate.rootRelPath
+            if (rootPrefix.isEmpty()) {
+                true // bookRoot is the library root → all books are affected (a full reanalysis was triggered)
+            } else {
+                rel == rootPrefix || rel.startsWith("$rootPrefix/")
+            }
+        }
+    }
+
+    private suspend fun emitProgress(
+        correlationId: String,
+        phase: ScanPhase,
+        filesWalked: Int,
+        booksAnalyzed: Int,
+        errors: Int,
+    ) {
+        eventBus.emit(
+            ScanEvent.Progress(
+                correlationId = correlationId,
+                phase = phase,
+                filesWalked = filesWalked,
+                booksAnalyzed = booksAnalyzed,
+                errors = errors,
+            ),
+        )
+    }
+
+    private fun toScanError(t: Throwable): ScanError =
+        ScanError.FileUnreadable(
+            path = rootPath.toString(),
+            message = t.message ?: t::class.simpleName ?: "unknown error",
+        )
+}
+
+private data class SubtreeAnalysis(
+    val books: List<AnalyzedBook>,
+    val errors: List<ScanError>,
+    val filesWalked: Int,
+)
+
+internal fun ScanResult.toSummary(): ScanResultSummary =
+    ScanResultSummary(
+        correlationId = correlationId,
+        totalBooks = books.size,
+        added = changes.count { it is ChangeEventDto.Added },
+        modified = changes.count { it is ChangeEventDto.Modified },
+        removed = changes.count { it is ChangeEventDto.Removed },
+        moved = changes.count { it is ChangeEventDto.Moved },
+        errors = errors.size,
+        durationMs = durationMs,
+        filesWalked = filesWalked,
+    )

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.ScannerService
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.map
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Thin [ScannerService] implementation. The work lives in [Scanner];
+ * the coordinator enforces single-flight; this class just translates
+ * between the wire contract and the internal types.
+ *
+ * `lastScanResult()` returns [ScanError.LibraryPathNotConfigured] when no
+ * scan has run yet — a slightly stretched semantic, but the existing
+ * [ScanError] hierarchy doesn't have a "no scan yet" variant and adding
+ * one purely for this call site is overkill. Callers checking
+ * `lastScanResult` already have to handle the configuration failure mode;
+ * lumping "not yet" in is acceptable.
+ */
+class ScannerServiceImpl(
+    private val scanner: Scanner,
+    private val coordinator: ScanCoordinator,
+    private val eventBus: SharedFlow<ScanEvent>,
+) : ScannerService {
+    override suspend fun scanFull(): AppResult<ScanResultSummary> = coordinator.scanFull().map { it.toSummary() }
+
+    override suspend fun lastScanResult(): AppResult<ScanResult> =
+        scanner.lastResult()?.let { AppResult.Success(it) }
+            ?: AppResult.Failure(ScanError.LibraryPathNotConfigured())
+
+    override fun observeProgress(): Flow<ScanEvent> = eventBus
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParser.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParser.kt
@@ -115,9 +115,10 @@ object AbsTitleParser {
             // Empty sequence (regex allows `\d{0,3}`) — bail on this part too.
             if (sequence.isEmpty()) continue
             // Normalize: "06" → "6", "1.5" stays "1.5", "0.5" stays "0.5".
-            val normalized = sequence.toDoubleOrNull()?.let { d ->
-                if (d == d.toLong().toDouble()) d.toLong().toString() else sequence
-            } ?: sequence
+            val normalized =
+                sequence.toDoubleOrNull()?.let { d ->
+                    if (d == d.toLong().toDouble()) d.toLong().toString() else sequence
+                } ?: sequence
 
             parts[i] = suffix.orEmpty()
             if (parts[i].isEmpty()) parts.removeAt(i)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParser.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParser.kt
@@ -1,0 +1,139 @@
+package com.calypsan.listenup.server.scanner.inference
+
+/**
+ * Result of parsing a single title-folder name. Every annotation that ABS
+ * can encode in a title folder ends up here; the consumer (Analyzer)
+ * decides which fields to keep based on context (e.g. `sequence` is only
+ * meaningful when a series folder is present).
+ */
+data class ParsedTitle(
+    val title: String,
+    val subtitle: String? = null,
+    val asin: String? = null,
+    val narrators: List<String> = emptyList(),
+    val publishedYear: Int? = null,
+    val sequence: String? = null,
+)
+
+/**
+ * Title-folder name parser, ported byte-for-byte from
+ * `audiobookshelf/server/utils/scandir.js` (`getBookDataFromDir`,
+ * `getASIN`, `getNarrator`, `getSequence`, `getPublishedYear`,
+ * `getSubtitle`).
+ *
+ * The order of operations matters: ASIN → narrators → sequence (when a
+ * series folder is present) → year → subtitle. Each stage strips the
+ * matched portion from the working folder string before the next stage
+ * runs, so a folder like `(2010) - Book 2 - The Way of Kings [B0015T963C] {Kramer}`
+ * decomposes cleanly without regex collisions.
+ *
+ * **Compatibility note on narrator splitting.** ABS uses `parseNameString`
+ * which understands `&`, ` and `, `;`, and `Last, First` formats. Phase 2
+ * splits on the simple separators (`,`, `;`, `&`, ` and `) and trims;
+ * full ABS parity for `Last, First` recombination is deferred to Phase 4
+ * when name normalization gets a real implementation. For the typical
+ * `{Michael Kramer; Kate Reading}` form, the simple split is correct.
+ */
+object AbsTitleParser {
+    private val asinPattern = Regex("""(?: |^)\[([A-Z0-9]{10})](?= |$)""")
+    private val narratorPattern = Regex("""^(?<title>.*) \{(?<narrators>.*)}$""")
+    private val sequencePattern =
+        Regex(
+            """^(?<volumeLabel>vol\.? |volume |book )?(?<sequence>\d{0,3}(?:\.\d{1,2})?)(?<trailingDot>\.?)(?: (?<suffix>.*))?$""",
+            RegexOption.IGNORE_CASE,
+        )
+    private val yearPattern = Regex("""^ *\(?([0-9]{4})\)? * - *(.+)""")
+    private val nameSeparators = Regex("""\s*(?:,|;|&| and )\s*""")
+
+    fun parse(
+        folder: String,
+        hasSeriesFolder: Boolean = false,
+        parseSubtitle: Boolean = false,
+    ): ParsedTitle {
+        var working = folder.trim()
+
+        val (afterAsin, asin) = extractAsin(working)
+        working = afterAsin
+
+        val (afterNarrator, narrators) = extractNarrators(working)
+        working = afterNarrator
+
+        val sequence =
+            if (hasSeriesFolder) {
+                val (afterSequence, seq) = extractSequence(working)
+                working = afterSequence
+                seq
+            } else {
+                null
+            }
+
+        val (afterYear, year) = extractYear(working)
+        working = afterYear
+
+        val (title, subtitle) =
+            if (parseSubtitle) {
+                extractSubtitle(working)
+            } else {
+                working to null
+            }
+
+        return ParsedTitle(
+            title = title.trim(),
+            subtitle = subtitle?.trim()?.takeUnless { it.isEmpty() },
+            asin = asin,
+            narrators = narrators,
+            publishedYear = year,
+            sequence = sequence,
+        )
+    }
+
+    private fun extractAsin(folder: String): Pair<String, String?> {
+        val match = asinPattern.find(folder) ?: return folder to null
+        val cleaned = folder.replace(match.value, "").replace("  ", " ").trim()
+        return cleaned to match.groupValues[1]
+    }
+
+    private fun extractNarrators(folder: String): Pair<String, List<String>> {
+        val match = narratorPattern.matchEntire(folder) ?: return folder to emptyList()
+        val title = match.groups["title"]!!.value
+        val raw = match.groups["narrators"]!!.value
+        val names = raw.split(nameSeparators).map { it.trim() }.filter { it.isNotEmpty() }
+        return title to names
+    }
+
+    private fun extractSequence(folder: String): Pair<String, String?> {
+        val parts = folder.split(" - ").toMutableList()
+        for (i in parts.indices) {
+            val match = sequencePattern.matchEntire(parts[i]) ?: continue
+            val volumeLabel = match.groups["volumeLabel"]?.value
+            val sequence = match.groups["sequence"]?.value.orEmpty()
+            val trailingDot = match.groups["trailingDot"]?.value.orEmpty()
+            val suffix = match.groups["suffix"]?.value
+            // ABS exclusion: a part with a suffix but no volume label and no
+            // trailing dot is not a sequence (e.g. "101 Dalmations").
+            if (suffix != null && volumeLabel == null && trailingDot.isEmpty()) continue
+            // Empty sequence (regex allows `\d{0,3}`) — bail on this part too.
+            if (sequence.isEmpty()) continue
+            // Normalize: "06" → "6", "1.5" stays "1.5", "0.5" stays "0.5".
+            val normalized = sequence.toDoubleOrNull()?.let { d ->
+                if (d == d.toLong().toDouble()) d.toLong().toString() else sequence
+            } ?: sequence
+
+            parts[i] = suffix.orEmpty()
+            if (parts[i].isEmpty()) parts.removeAt(i)
+            return parts.joinToString(" - ") to normalized
+        }
+        return folder to null
+    }
+
+    private fun extractYear(folder: String): Pair<String, Int?> {
+        val match = yearPattern.matchEntire(folder) ?: return folder to null
+        return match.groupValues[2] to match.groupValues[1].toIntOrNull()
+    }
+
+    private fun extractSubtitle(folder: String): Pair<String, String?> {
+        val parts = folder.split(" - ")
+        if (parts.size < 2) return folder to null
+        return parts.first() to parts.drop(1).joinToString(" - ")
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/FileTypeRules.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/FileTypeRules.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import com.calypsan.listenup.api.dto.scanner.FileType
+
+/**
+ * Maps a filename to its [FileType] using the same extension sets as ABS
+ * (`audiobookshelf/server/utils/globals.js`). Classification happens once
+ * at the Walker; downstream stages filter by [FileType] without re-parsing
+ * the filename.
+ *
+ * Extensions are matched case-insensitively. Files with no extension or an
+ * unrecognised extension are [FileType.UNKNOWN] — not skipped, just
+ * unclassified, so the Analyzer can see them if it cares.
+ */
+object FileTypeRules {
+    private val audioExt =
+        setOf(
+            "m4b",
+            "mp3",
+            "m4a",
+            "flac",
+            "opus",
+            "ogg",
+            "oga",
+            "mp4",
+            "aac",
+            "wma",
+            "aiff",
+            "aif",
+            "wav",
+            "webm",
+            "webma",
+            "mka",
+            "awb",
+            "caf",
+            "mpg",
+            "mpeg",
+        )
+    private val imageExt = setOf("png", "jpg", "jpeg", "webp")
+    private val ebookExt = setOf("epub", "pdf", "mobi", "azw3", "cbr", "cbz")
+    private val textExt = setOf("txt", "nfo")
+    private val metadataExt = setOf("opf", "abs", "xml", "json")
+
+    fun classify(filename: String): FileType {
+        val ext = filename.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+        if (ext.isEmpty()) return FileType.UNKNOWN
+        return when (ext) {
+            in audioExt -> FileType.AUDIO
+            in imageExt -> FileType.IMAGE
+            in ebookExt -> FileType.EBOOK
+            in textExt -> FileType.TEXT
+            in metadataExt -> FileType.METADATA
+            else -> FileType.UNKNOWN
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/FolderShape.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/FolderShape.kt
@@ -1,0 +1,41 @@
+package com.calypsan.listenup.server.scanner.inference
+
+/**
+ * What ABS calls "folder structure" — the bottom three components of a
+ * relative path map to `<author>/<series>/<title>`, with author and series
+ * optional. Ported from
+ * `audiobookshelf/server/utils/scandir.js:149-173`.
+ *
+ * Components above the bottom three are ignored. A single-level path
+ * (a file or folder directly in the library root) yields a title-only
+ * shape.
+ */
+data class FolderShape(
+    val titleFolder: String,
+    val seriesFolder: String? = null,
+    val authorFolder: String? = null,
+) {
+    companion object {
+        fun parse(relPathToBook: String): FolderShape {
+            val parts =
+                relPathToBook
+                    .replace('\\', '/')
+                    .trim('/')
+                    .split('/')
+                    .filter { it.isNotEmpty() }
+                    .toMutableList()
+
+            if (parts.isEmpty()) return FolderShape(titleFolder = "")
+
+            val title = parts.removeLast()
+            val series = if (parts.size >= 2) parts.removeLast() else null
+            val author = if (parts.isNotEmpty()) parts.removeLast() else null
+
+            return FolderShape(
+                titleFolder = title,
+                seriesFolder = series,
+                authorFolder = author,
+            )
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/MultiDiscPattern.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/MultiDiscPattern.kt
@@ -1,0 +1,30 @@
+package com.calypsan.listenup.server.scanner.inference
+
+/**
+ * The ABS multi-disc folder convention: a directory whose name matches
+ * `^(cd|dis[ck])\s*\d{1,3}$` (case-insensitive) is treated as a disc
+ * subdirectory of its parent book, not a book root in its own right.
+ *
+ * Source: `audiobookshelf/server/utils/scandir.js:93-97`.
+ *
+ * Two stages need this rule:
+ *  - the [com.calypsan.listenup.server.scanner.pipeline.Grouper] uses
+ *    [matches] to roll a disc folder up to its parent book;
+ *  - [TrackInference] uses [discNumber] to extract the disc number when a
+ *    file's parent folder is a disc subdirectory.
+ *
+ * Keeping one regex avoids the two stages drifting apart on what counts
+ * as "a disc folder."
+ */
+object MultiDiscPattern {
+    private val pattern = Regex("""^(cd|dis[ck])\s*(\d{1,3})$""", RegexOption.IGNORE_CASE)
+
+    fun matches(folderName: String): Boolean = pattern.matches(folderName)
+
+    fun discNumber(folderName: String): Int? =
+        pattern
+            .matchEntire(folderName)
+            ?.groupValues
+            ?.get(2)
+            ?.toIntOrNull()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/SkipRules.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/SkipRules.kt
@@ -15,8 +15,14 @@ import java.nio.file.Path
 object SkipRules {
     private val tempExtensions =
         setOf(
-            ".part", ".tmp", ".crdownload", ".download",
-            ".bak", ".old", ".temp", ".tempfile",
+            ".part",
+            ".tmp",
+            ".crdownload",
+            ".download",
+            ".bak",
+            ".old",
+            ".temp",
+            ".tempfile",
         )
 
     fun shouldSkip(path: Path): Boolean {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/SkipRules.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/SkipRules.kt
@@ -1,0 +1,43 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Files and directories the Walker must skip. The rules are sourced from
+ * ABS's `server/utils/fileUtils.js:140-166` so an ABS library and a
+ * ListenUp library agree on what's invisible.
+ *
+ * The same predicate is also used by the watcher when deciding whether a
+ * filesystem event warrants a re-scan — keeping a single source of truth
+ * means a file ABS hides can never accidentally surface in our pipeline.
+ */
+object SkipRules {
+    private val tempExtensions =
+        setOf(
+            ".part", ".tmp", ".crdownload", ".download",
+            ".bak", ".old", ".temp", ".tempfile",
+        )
+
+    fun shouldSkip(path: Path): Boolean {
+        val name = path.fileName?.toString() ?: return false
+
+        // Dotfiles. ABS skips any path component starting with `.`; we apply the
+        // rule per entry so the Walker can prune subtrees as it descends.
+        if (name.startsWith(".")) return true
+
+        // Vendor junk — Synology indexer dirs.
+        val asString = path.toString()
+        if (asString.contains("/@eaDir/") || asString.contains("\\@eaDir\\")) return true
+
+        // Temp / partial-download extensions. Casefold; not all OSes preserve case.
+        if (tempExtensions.any { name.endsWith(it, ignoreCase = true) }) return true
+
+        // `.ignore` sentinel — presence of a `.ignore` sibling file marks the
+        // containing directory (and everything beneath) as skipped.
+        val parent = path.parent
+        if (parent != null && Files.exists(parent.resolve(".ignore"))) return true
+
+        return false
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
@@ -33,6 +33,7 @@ data class TrackInfo(
 object TrackInference {
     private val discInFilename = Regex("""\b(disc|cd) ?(\d{1,2})\b""", RegexOption.IGNORE_CASE)
     private val discInFolder = Regex("""^(cd|dis[ck])\s*(\d{1,3})$""", RegexOption.IGNORE_CASE)
+
     // No `\b` boundaries: filenames like `track01` don't have a word boundary
     // between `k` and `0`, since both classes are "word" characters. Greedy
     // `\d{1,4}` matches the longest 1-4 digit run and bounds 5+ digit numbers
@@ -65,7 +66,7 @@ object TrackInference {
 
         val trackMatch = trackPattern.find(trackHaystack)
         val trackNumber = trackMatch?.groupValues?.get(1)?.toIntOrNull()
-        val trackSource = if (trackNumber != null) TrackNumberSource.FILENAME else null
+        val trackSource = trackNumber?.let { TrackNumberSource.FILENAME }
 
         return TrackInfo(
             trackNumber = trackNumber,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
@@ -32,7 +32,6 @@ data class TrackInfo(
  */
 object TrackInference {
     private val discInFilename = Regex("""\b(disc|cd) ?(\d{1,2})\b""", RegexOption.IGNORE_CASE)
-    private val discInFolder = Regex("""^(cd|dis[ck])\s*(\d{1,3})$""", RegexOption.IGNORE_CASE)
 
     // No `\b` boundaries: filenames like `track01` don't have a word boundary
     // between `k` and `0`, since both classes are "word" characters. Greedy
@@ -57,9 +56,9 @@ object TrackInference {
             discSource = TrackNumberSource.FILENAME
             trackHaystack = nameWithoutExt.removeRange(discFilenameMatch.range)
         } else if (parentFolderName != null) {
-            val discFolderMatch = discInFolder.matchEntire(parentFolderName)
-            if (discFolderMatch != null) {
-                discNumber = discFolderMatch.groupValues[2].toIntOrNull()
+            val folderDisc = MultiDiscPattern.discNumber(parentFolderName)
+            if (folderDisc != null) {
+                discNumber = folderDisc
                 discSource = TrackNumberSource.FOLDER
             }
         }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
@@ -1,0 +1,77 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import com.calypsan.listenup.api.dto.scanner.TrackNumberSource
+
+/**
+ * Inferred track and disc numbers for one audio file. Either field can be
+ * null when no signal is found; consumers use original filesystem order as
+ * the fallback.
+ */
+data class TrackInfo(
+    val trackNumber: Int? = null,
+    val discNumber: Int? = null,
+    val trackSource: TrackNumberSource? = null,
+    val discSource: TrackNumberSource? = null,
+)
+
+/**
+ * Track and disc inference from a filename and its parent folder name.
+ * Ported from ABS `server/scanner/AudioFileScanner.js:111-147`
+ * (`getTrackAndDiscNumberFromFilename`).
+ *
+ * Disc number is sourced from (in priority order):
+ *  1. `\b(disc|cd) ?(\d{1,2})\b` matched anywhere in the filename.
+ *  2. `^(cd|dis[ck])\s*(\d{1,3})$` matched against the parent folder name
+ *     (the multi-disc subdirectory convention).
+ *
+ * Track number is the first 1–4 digit run remaining in the filename after
+ * stripping any matched disc prefix. Strict heuristic: ABS additionally
+ * strips title/author/series/year text before this match, but Phase 2
+ * skips that — embedded-tag-driven track inference is the right fix and
+ * lands in Phase 3 (`TrackNumberSource.METADATA`).
+ */
+object TrackInference {
+    private val discInFilename = Regex("""\b(disc|cd) ?(\d{1,2})\b""", RegexOption.IGNORE_CASE)
+    private val discInFolder = Regex("""^(cd|dis[ck])\s*(\d{1,3})$""", RegexOption.IGNORE_CASE)
+    // No `\b` boundaries: filenames like `track01` don't have a word boundary
+    // between `k` and `0`, since both classes are "word" characters. Greedy
+    // `\d{1,4}` matches the longest 1-4 digit run and bounds 5+ digit numbers
+    // (e.g. `12345.mp3` → 1234, leaving `5` unmatched).
+    private val trackPattern = Regex("""(\d{1,4})""")
+
+    fun infer(
+        filename: String,
+        parentFolderName: String?,
+    ): TrackInfo {
+        val nameWithoutExt = filename.substringBeforeLast('.', filename)
+
+        var discNumber: Int? = null
+        var discSource: TrackNumberSource? = null
+        var trackHaystack = nameWithoutExt
+
+        // Disc from filename first.
+        val discFilenameMatch = discInFilename.find(nameWithoutExt)
+        if (discFilenameMatch != null) {
+            discNumber = discFilenameMatch.groupValues[2].toIntOrNull()
+            discSource = TrackNumberSource.FILENAME
+            trackHaystack = nameWithoutExt.removeRange(discFilenameMatch.range)
+        } else if (parentFolderName != null) {
+            val discFolderMatch = discInFolder.matchEntire(parentFolderName)
+            if (discFolderMatch != null) {
+                discNumber = discFolderMatch.groupValues[2].toIntOrNull()
+                discSource = TrackNumberSource.FOLDER
+            }
+        }
+
+        val trackMatch = trackPattern.find(trackHaystack)
+        val trackNumber = trackMatch?.groupValues?.get(1)?.toIntOrNull()
+        val trackSource = if (trackNumber != null) TrackNumberSource.FILENAME else null
+
+        return TrackInfo(
+            trackNumber = trackNumber,
+            discNumber = discNumber,
+            trackSource = trackSource,
+            discSource = discSource,
+        )
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReader.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReader.kt
@@ -1,0 +1,63 @@
+package com.calypsan.listenup.server.scanner.metadata
+
+import com.calypsan.listenup.api.dto.scanner.SeriesEntry
+import com.calypsan.listenup.api.external.abs.AbsMetadata
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import java.nio.file.Files
+import java.nio.file.Path
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Reads ABS-authored `metadata.json` sidecar files. Two-step parse:
+ *
+ *  1. Read raw JSON. If the top-level object has a `metadata` field that is
+ *     itself an object, unwrap it (legacy ABS schema; the modern schema is
+ *     flat). See `audiobookshelf/server/utils/parsers/abmetadataGenerator.js:9-20`.
+ *  2. Decode the (potentially flattened) JSON into [AbsMetadata].
+ *
+ * Failures are logged at warn level and return null so the scan continues
+ * without the overlay — partial data beats a failed scan.
+ *
+ * `parseSeriesEntries` converts ABS's `["Series Name #1.5"]` string format
+ * into structured [SeriesEntry] values.
+ */
+class AbsMetadataReader(
+    private val json: Json,
+) {
+    suspend fun read(file: Path): AbsMetadata? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                if (!Files.isRegularFile(file)) return@runCatching null
+                val raw = Files.readString(file, Charsets.UTF_8)
+                val element = json.parseToJsonElement(raw)
+                val flattened =
+                    (element as? JsonObject)?.get("metadata")?.let { it as? JsonObject } ?: element
+                json.decodeFromJsonElement<AbsMetadata>(flattened)
+            }.onFailure { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger.warn(e) { "metadata.json parse failed at $file — skipping overlay" }
+            }.getOrNull()
+        }
+
+    fun parseSeriesEntries(rawSeries: List<String>): List<SeriesEntry> =
+        rawSeries.mapNotNull { raw ->
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) return@mapNotNull null
+            // ABS encodes sequence with `#` — `"Series Name #1.5"` → name="Series Name", sequence="1.5".
+            val hashIndex = trimmed.lastIndexOf('#')
+            if (hashIndex == -1) {
+                SeriesEntry(name = trimmed)
+            } else {
+                val name = trimmed.substring(0, hashIndex).trim()
+                val sequence = trimmed.substring(hashIndex + 1).trim().takeUnless { it.isEmpty() }
+                SeriesEntry(name = name, sequence = sequence)
+            }
+        }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReader.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReader.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
 import java.nio.file.Files
 import java.nio.file.Path
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -1,0 +1,202 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.MetadataSource
+import com.calypsan.listenup.api.dto.scanner.SeriesEntry
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.api.external.abs.AbsMetadata
+import com.calypsan.listenup.server.scanner.inference.AbsTitleParser
+import com.calypsan.listenup.server.scanner.inference.FolderShape
+import com.calypsan.listenup.server.scanner.inference.ParsedTitle
+import com.calypsan.listenup.server.scanner.inference.TrackInference
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.nio.file.Path
+
+/**
+ * Stage 3 of the scanner pipeline: turns each [CandidateBook] into an
+ * [AnalyzedBook] by combining three signal sources, in increasing precedence:
+ *
+ *  1. **Folder structure** — bottom-three components map to
+ *     `<author>/<series>/<title>`.
+ *  2. **Title-folder regex** — strips `[ASIN]`, `{Narrator}`, year prefix,
+ *     volume/sequence prefix, optional subtitle. See [AbsTitleParser].
+ *  3. **`metadata.json` overlay** — fields in a sidecar override
+ *     folder-derived values when present.
+ *
+ * Phase 3 will plug in embedded ID3/M4B tags as a fourth signal between
+ * filename and metadata.json. [AnalyzedBook]'s shape already accommodates
+ * those fields (every embedded-derivable field is nullable).
+ *
+ * Per-book failures (unexpected exceptions during analysis) surface as
+ * `Result.failure`; the upstream caller decides whether to log-and-continue
+ * or abort the scan. `CancellationException` is always re-raised so
+ * structured concurrency stays intact.
+ */
+class Analyzer(
+    private val rootPath: Path,
+    private val metadataReader: AbsMetadataReader,
+    private val parseSubtitle: Boolean = false,
+) {
+    fun analyze(candidates: Flow<CandidateBook>): Flow<Result<AnalyzedBook>> =
+        flow {
+            candidates.collect { c -> emit(analyzeOne(c)) }
+        }
+
+    private suspend fun analyzeOne(candidate: CandidateBook): Result<AnalyzedBook> =
+        safeRun {
+            val shape = FolderShape.parse(candidate.rootRelPath)
+            val parsed =
+                AbsTitleParser.parse(
+                    folder = shape.titleFolder,
+                    hasSeriesFolder = shape.seriesFolder != null,
+                    parseSubtitle = parseSubtitle,
+                )
+            val tracks = buildTracks(candidate)
+            val cover = pickCover(candidate.files)
+            val metadata = readMetadata(candidate)
+            compose(candidate, shape, parsed, tracks, cover, metadata)
+        }
+
+    private fun buildTracks(candidate: CandidateBook): List<TrackEntry> =
+        candidate.files
+            .filter { it.fileType == FileType.AUDIO }
+            .map { file ->
+                val parentFolder =
+                    file.relPath
+                        .split('/')
+                        .dropLast(1)
+                        .lastOrNull()
+                val info = TrackInference.infer(file.name, parentFolder)
+                TrackEntry(
+                    file = file,
+                    trackNumber = info.trackNumber,
+                    discNumber = info.discNumber,
+                    trackSource = info.trackSource,
+                    discSource = info.discSource,
+                )
+            }.sortedWith(NATURAL_TRACK_ORDER)
+
+    private fun pickCover(files: List<FileEntry>): FileEntry? {
+        val images = files.filter { it.fileType == FileType.IMAGE }
+        val coverByName =
+            images.firstOrNull {
+                it.name.substringBeforeLast('.').equals("cover", ignoreCase = true)
+            }
+        return coverByName ?: images.firstOrNull()
+    }
+
+    private suspend fun readMetadata(candidate: CandidateBook): AbsMetadata? {
+        val sidecar =
+            candidate.files.firstOrNull {
+                it.fileType == FileType.METADATA && it.name.equals("metadata.json", ignoreCase = true)
+            } ?: return null
+        return metadataReader.read(rootPath.resolve(sidecar.relPath))
+    }
+
+    private fun compose(
+        candidate: CandidateBook,
+        shape: FolderShape,
+        parsed: ParsedTitle,
+        tracks: List<TrackEntry>,
+        cover: FileEntry?,
+        metadata: AbsMetadata?,
+    ): AnalyzedBook =
+        AnalyzedBook(
+            candidate = candidate,
+            title = pickTitle(candidate, shape, parsed, metadata),
+            subtitle = metadata?.subtitle ?: parsed.subtitle,
+            authors = pickAuthors(shape, metadata),
+            narrators = pickNarrators(parsed, metadata),
+            series = pickSeries(shape, parsed, metadata),
+            publishedYear = metadata?.publishedYear ?: parsed.publishedYear,
+            asin = metadata?.asin ?: parsed.asin,
+            isbn = metadata?.isbn,
+            description = metadata?.description,
+            publisher = metadata?.publisher,
+            language = metadata?.language,
+            genres = metadata?.genres.orEmpty(),
+            tags = metadata?.tags.orEmpty(),
+            abridged = metadata?.abridged,
+            explicit = metadata?.explicit,
+            cover = cover,
+            tracks = tracks,
+            sources = collectSources(shape, parsed, metadata),
+        )
+
+    private fun pickTitle(
+        candidate: CandidateBook,
+        shape: FolderShape,
+        parsed: ParsedTitle,
+        metadata: AbsMetadata?,
+    ): String =
+        metadata?.title?.takeUnless { it.isBlank() }
+            ?: parsed.title.takeUnless { it.isBlank() }
+            ?: shape.titleFolder.takeUnless { it.isBlank() }
+            ?: candidate.rootRelPath
+
+    private fun pickAuthors(
+        shape: FolderShape,
+        metadata: AbsMetadata?,
+    ): List<String> =
+        metadata?.authors?.takeIf { it.isNotEmpty() }
+            ?: shape.authorFolder?.let { listOf(it) }
+            ?: emptyList()
+
+    private fun pickNarrators(
+        parsed: ParsedTitle,
+        metadata: AbsMetadata?,
+    ): List<String> = metadata?.narrators?.takeIf { it.isNotEmpty() } ?: parsed.narrators
+
+    private fun pickSeries(
+        shape: FolderShape,
+        parsed: ParsedTitle,
+        metadata: AbsMetadata?,
+    ): List<SeriesEntry> {
+        val fromMetadata = metadataReader.parseSeriesEntries(metadata?.series.orEmpty())
+        if (fromMetadata.isNotEmpty()) return fromMetadata
+        return shape.seriesFolder
+            ?.let { listOf(SeriesEntry(name = it, sequence = parsed.sequence)) }
+            ?: emptyList()
+    }
+
+    private fun collectSources(
+        shape: FolderShape,
+        parsed: ParsedTitle,
+        metadata: AbsMetadata?,
+    ): Set<MetadataSource> {
+        val sources = mutableSetOf<MetadataSource>()
+        if (shape.contributesAnything()) sources += MetadataSource.FOLDER_STRUCTURE
+        if (parsed.hasAnyFilenameAnnotation()) sources += MetadataSource.FILENAME
+        if (metadata != null) sources += MetadataSource.ABS_METADATA
+        return sources
+    }
+}
+
+private fun FolderShape.contributesAnything(): Boolean =
+    titleFolder.isNotEmpty() || seriesFolder != null || authorFolder != null
+
+private fun ParsedTitle.hasAnyFilenameAnnotation(): Boolean =
+    asin != null || narrators.isNotEmpty() || publishedYear != null ||
+        sequence != null || subtitle != null
+
+private val NATURAL_TRACK_ORDER =
+    compareBy<TrackEntry>(
+        { it.discNumber ?: 0 },
+        { it.trackNumber ?: Int.MAX_VALUE },
+        { it.file.name },
+    )
+
+private suspend fun <T> safeRun(block: suspend () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
@@ -1,0 +1,111 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.FileType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Stage 4 of the scanner pipeline: emits a [ChangeEventDto] per book that
+ * changed since the previous scan. Books unchanged from the prior snapshot
+ * emit nothing.
+ *
+ * Match algorithm, in priority order:
+ *  1. **Path match.** A book at `rootRelPath` X matches a previous book at
+ *     the same rootRelPath. The common case.
+ *  2. **Inode match.** Any audio file's inode in the current book matches
+ *     an audio file's inode in some previous book → treat as the same book
+ *     that moved. This is how cross-folder renames are detected.
+ *
+ * Outcomes:
+ *  - **No previous match** → [ChangeEventDto.Added].
+ *  - **Match by inode but rootRelPath differs** → [ChangeEventDto.Moved].
+ *  - **Match by path but content differs** → [ChangeEventDto.Modified].
+ *  - **Match and content equal** → no emission.
+ *  - **In previous but never matched in current** → [ChangeEventDto.Removed],
+ *    emitted after the current flow is exhausted.
+ *
+ * Inode-based move detection is best-effort: filesystems without stable file
+ * keys (Windows default, FAT, some SMB shares) leave `inode = null` in
+ * [com.calypsan.listenup.api.dto.scanner.FileEntry]; those moves degrade to
+ * a Removed + Added pair. Documented; not a bug.
+ *
+ * The "first scan" case (no prior state) is handled by passing
+ * `previous = emptyList()`; every current book is then [ChangeEventDto.Added].
+ */
+class Differ {
+    fun diff(
+        current: Flow<AnalyzedBook>,
+        previous: List<AnalyzedBook>,
+    ): Flow<ChangeEventDto> =
+        flow {
+            val previousByRoot = previous.associateBy { it.candidate.rootRelPath }
+            val previousByInode = inodeIndexFor(previous)
+            val matchedRoots = mutableSetOf<String>()
+
+            current.collect { book ->
+                val match = previousByRoot[book.candidate.rootRelPath] ?: book.findByInode(previousByInode)
+                val event = changeFor(book, match)
+                if (event != null) emit(event)
+                if (match != null) matchedRoots += match.candidate.rootRelPath
+            }
+
+            previous.forEach { previousBook ->
+                if (previousBook.candidate.rootRelPath !in matchedRoots) {
+                    emit(ChangeEventDto.Removed(previousBook.candidate.rootRelPath))
+                }
+            }
+        }
+
+    private fun changeFor(
+        current: AnalyzedBook,
+        previous: AnalyzedBook?,
+    ): ChangeEventDto? =
+        when {
+            previous == null -> {
+                ChangeEventDto.Added(current)
+            }
+
+            previous.candidate.rootRelPath != current.candidate.rootRelPath -> {
+                ChangeEventDto.Moved(
+                    from = previous.candidate.rootRelPath,
+                    to = current.candidate.rootRelPath,
+                    book = current,
+                )
+            }
+
+            previous != current -> {
+                ChangeEventDto.Modified(
+                    book = current,
+                    previousRootRelPath = previous.candidate.rootRelPath,
+                )
+            }
+
+            else -> {
+                null
+            }
+        }
+
+    private fun inodeIndexFor(books: List<AnalyzedBook>): Map<Long, AnalyzedBook> {
+        val index = mutableMapOf<Long, AnalyzedBook>()
+        books.forEach { book ->
+            book.candidate.files.forEach { file ->
+                val inode = file.inode
+                if (file.fileType == FileType.AUDIO && inode != null) {
+                    // First-write-wins: if two previous books somehow share an
+                    // inode (impossible on one filesystem, defensive here),
+                    // keep the first.
+                    index.putIfAbsent(inode, book)
+                }
+            }
+        }
+        return index
+    }
+
+    private fun AnalyzedBook.findByInode(index: Map<Long, AnalyzedBook>): AnalyzedBook? =
+        candidate.files.firstNotNullOfOrNull { file ->
+            val inode = file.inode
+            if (file.fileType == FileType.AUDIO && inode != null) index[inode] else null
+        }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Grouper.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Grouper.kt
@@ -1,0 +1,106 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.server.scanner.inference.MultiDiscPattern
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.fold
+
+/**
+ * Stage 2 of the scanner pipeline: groups [FileEntry]s into [CandidateBook]s
+ * by their book root.
+ *
+ * Two grouping rules:
+ *  1. **Multi-disc collapse.** When a file's immediate parent folder name
+ *     matches the [MultiDiscPattern] regex (`CD1`, `Disc 2`, `Disk 3`, …),
+ *     the book root rolls up to the disc folder's parent and the disc
+ *     folder's name is recorded in [CandidateBook.discFolders]. ABS allows
+ *     up to 3-digit disc numbers, case-insensitive, with optional whitespace.
+ *  2. **Single-file books.** An audio file directly in the library root
+ *     becomes its own [CandidateBook] with `isFile = true` and
+ *     `rootRelPath` set to the file's relative path. Each such audio file
+ *     is its own book; non-audio files at the library root are dropped.
+ *
+ * Books at deeper levels (`Author/Title`, `Author/Series/Title`) all use
+ * the file's parent directory as the book root.
+ *
+ * Order: emission preserves the order in which book roots are first seen
+ * in the upstream Walker flow. Walker is depth-first stable, so the order
+ * is reproducible across runs over the same filesystem snapshot.
+ */
+class Grouper {
+    fun group(files: Flow<FileEntry>): Flow<CandidateBook> =
+        flow {
+            // Single-file books emit immediately. Folder-rooted books accumulate
+            // until the upstream is exhausted, then emit in first-seen order.
+            val acc =
+                files.fold(GroupingAccumulator(emit = { emit(it) })) { acc, entry ->
+                    acc.apply { add(entry) }
+                }
+            acc.emitFolderBooks()
+        }
+}
+
+/**
+ * Mutable state for [Grouper.group]. Folder-rooted books collect into
+ * insertion-ordered maps keyed by book root; single-file books are emitted
+ * eagerly through [emit].
+ */
+private class GroupingAccumulator(
+    private val emit: suspend (CandidateBook) -> Unit,
+) {
+    private val filesByRoot = linkedMapOf<String, MutableList<FileEntry>>()
+    private val discsByRoot = linkedMapOf<String, MutableSet<String>>()
+    private val singleFileBooks = mutableListOf<CandidateBook>()
+
+    fun add(entry: FileEntry) {
+        val parentSegments = entry.relPath.split('/').dropLast(1)
+
+        if (parentSegments.isEmpty()) {
+            // File at the library root — single-file book if audio, else dropped.
+            if (entry.fileType == FileType.AUDIO) {
+                singleFileBooks +=
+                    CandidateBook(
+                        rootRelPath = entry.relPath,
+                        isFile = true,
+                        files = listOf(entry),
+                    )
+            }
+            return
+        }
+
+        val (bookRoot, discFolder) = bookRootAndDisc(parentSegments)
+        filesByRoot.getOrPut(bookRoot) { mutableListOf() } += entry
+        if (discFolder != null) {
+            discsByRoot.getOrPut(bookRoot) { linkedSetOf() } += discFolder
+        }
+    }
+
+    suspend fun emitFolderBooks() {
+        // Emit single-file books first (Walker visits them in depth-first
+        // order; root-level files come before subdirectory descents on most
+        // filesystems, but ordering between the two groups isn't contractual).
+        singleFileBooks.forEach { emit(it) }
+        filesByRoot.forEach { (root, files) ->
+            emit(
+                CandidateBook(
+                    rootRelPath = root,
+                    isFile = false,
+                    files = files.toList(),
+                    discFolders = discsByRoot[root]?.sorted().orEmpty(),
+                ),
+            )
+        }
+    }
+
+    private fun bookRootAndDisc(parentSegments: List<String>): Pair<String, String?> {
+        val last = parentSegments.last()
+        return if (MultiDiscPattern.matches(last)) {
+            parentSegments.dropLast(1).joinToString("/") to last
+        } else {
+            parentSegments.joinToString("/") to null
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Walker.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Walker.kt
@@ -1,0 +1,130 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.server.scanner.inference.FileTypeRules
+import com.calypsan.listenup.server.scanner.inference.SkipRules
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.io.IOException
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.EnumSet
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Stage 1 of the scanner pipeline: enumerates every file beneath a library
+ * root and emits one [FileEntry] per file the [SkipRules] don't filter out.
+ *
+ * Implementation notes:
+ *  - Built on `Files.walkFileTree` (NIO) — gives us subtree pruning for
+ *    `@eaDir` directories and `.ignore`-flagged subtrees, which `Files.walk`
+ *    can't express cleanly.
+ *  - Symlinks are **not** followed. This avoids cycles and accidental
+ *    enumeration of files outside the library root. The cost: a symlinked
+ *    audio collection isn't visible. Worth it for safety; users wanting
+ *    symlink support can request it later.
+ *  - Inode capture uses `BasicFileAttributes.fileKey()`. On POSIX this is a
+ *    `(dev, ino)` pair; we extract the ino half for the [FileEntry.inode]
+ *    field. On Windows default filesystems `fileKey()` returns null and
+ *    cross-folder move detection in the Differ degrades to name-only.
+ *  - Paths are emitted with POSIX separators in [FileEntry.relPath]
+ *    regardless of OS, so the wire format stays uniform.
+ *  - Walk is collected into a list before emission. Library sizes are bounded
+ *    (thousands of files, not gigabytes streamed); the simplicity beats the
+ *    backpressure precision of channelFlow for this use case.
+ */
+class Walker(
+    private val skipRules: (Path) -> Boolean = SkipRules::shouldSkip,
+) {
+    fun walk(root: Path): Flow<FileEntry> =
+        flow {
+            if (!Files.isDirectory(root)) return@flow
+
+            val collected = collectEntries(root)
+            collected.forEach { emit(it) }
+        }.flowOn(Dispatchers.IO)
+
+    private fun collectEntries(root: Path): List<FileEntry> {
+        val entries = mutableListOf<FileEntry>()
+        Files.walkFileTree(
+            root,
+            // Empty option set → do NOT follow symlinks. Cycles in symlinked
+            // libraries can't recurse into themselves.
+            EnumSet.noneOf(FileVisitOption::class.java),
+            Int.MAX_VALUE,
+            object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(
+                    dir: Path,
+                    attrs: BasicFileAttributes,
+                ): FileVisitResult =
+                    if (dir != root && skipRules(dir)) {
+                        FileVisitResult.SKIP_SUBTREE
+                    } else {
+                        FileVisitResult.CONTINUE
+                    }
+
+                override fun visitFile(
+                    file: Path,
+                    attrs: BasicFileAttributes,
+                ): FileVisitResult {
+                    if (skipRules(file)) return FileVisitResult.CONTINUE
+                    entries += toEntry(root, file, attrs)
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun visitFileFailed(
+                    file: Path,
+                    exc: IOException,
+                ): FileVisitResult {
+                    // Per the "never stranded" principle: log and continue.
+                    // A single unreadable file shouldn't fail the whole scan.
+                    logger.warn(exc) { "walk: failed to read $file — skipping" }
+                    return FileVisitResult.CONTINUE
+                }
+            },
+        )
+        return entries
+    }
+
+    private fun toEntry(
+        root: Path,
+        file: Path,
+        attrs: BasicFileAttributes,
+    ): FileEntry {
+        val name = file.fileName.toString()
+        val relPath = root.relativize(file).toString().replace('\\', '/')
+        val ext = name.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+        return FileEntry(
+            relPath = relPath,
+            name = name,
+            ext = ext,
+            size = attrs.size(),
+            mtimeMs = attrs.lastModifiedTime().toMillis(),
+            inode = extractInode(attrs.fileKey()),
+            fileType = FileTypeRules.classify(name),
+        )
+    }
+}
+
+// `UnixFileKey.toString()` has the format `(dev=N,ino=M)` since OpenJDK 8.
+// We only need the inode half — equality on `(dev, ino)` is what the Differ
+// uses, but two files in the same library always live on the same device,
+// so just the ino is enough to detect moves within a library.
+private val INODE_PATTERN = Regex("""ino=(\d+)""")
+
+private fun extractInode(fileKey: Any?): Long? =
+    fileKey?.toString()?.let {
+        INODE_PATTERN
+            .find(it)
+            ?.groupValues
+            ?.get(1)
+            ?.toLongOrNull()
+    }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
@@ -1,0 +1,159 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import com.calypsan.listenup.server.scanner.inference.MultiDiscPattern
+import com.calypsan.listenup.server.scanner.inference.SkipRules
+import io.github.irgaly.kfswatch.KfsDirectoryWatcher
+import io.github.irgaly.kfswatch.KfsDirectoryWatcherEvent
+import io.github.irgaly.kfswatch.KfsEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.ConcurrentHashMap
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Watches a library tree for filesystem changes and emits the
+ * [bookRoot][Flow] of any directory affected. Consumers (the Scanner
+ * orchestrator) then call `coordinator.reanalyze(bookRoot)`.
+ *
+ * Implementation notes:
+ *
+ *  - **Recursive watching is opt-in.** kfswatch's API watches a fixed list
+ *    of directories — it doesn't recurse on its own. We walk the library
+ *    tree at [start] and register every non-skipped directory. New
+ *    directories created during runtime are registered when their `Create`
+ *    event arrives.
+ *  - **Per-book coalescing.** Multiple events under the same book root
+ *    within the [debouncer]'s settle window collapse to a single emission.
+ *    Implementation: a map from book root → pending emission [Job]; a new
+ *    event for an already-pending book root cancels the prior job and
+ *    starts a fresh one. The "latest event wins" — its file is what we
+ *    debounce on.
+ *  - **Delete handling.** Delete events skip the debouncer (the file is
+ *    gone, polling it would just time out) and emit immediately for the
+ *    affected book root.
+ *  - **Skip rules.** [SkipRules] applied to every event path. Dotfiles,
+ *    `.ignore`-flagged subtrees, `@eaDir`, and temp extensions are
+ *    invisible to the watcher just as they are to the Walker.
+ *  - **Symlinks not followed** during initial registration (mirrors
+ *    Walker behavior).
+ *
+ * The watcher does not start listening until [start] is called; cleanup
+ * via [close] releases the inotify / FSEvents / RDC handles.
+ */
+class FolderWatcher(
+    private val libraryRoot: Path,
+    private val scope: CoroutineScope,
+    private val debouncer: StableSizeDebouncer = StableSizeDebouncer(),
+    private val skipRules: (Path) -> Boolean = SkipRules::shouldSkip,
+    private val watcher: KfsDirectoryWatcher = KfsDirectoryWatcher(scope),
+) {
+    private val emissions = MutableSharedFlow<Path>(extraBufferCapacity = 64)
+    val events: Flow<Path> = emissions.asSharedFlow()
+
+    private val pendingByBookRoot = ConcurrentHashMap<Path, Job>()
+
+    suspend fun start() {
+        registerExistingTree()
+        scope.launch {
+            watcher.onEventFlow.collect { event ->
+                try {
+                    handle(event)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.warn(e) { "watcher: failed to handle $event — continuing" }
+                }
+            }
+        }
+    }
+
+    suspend fun close() {
+        watcher.close()
+    }
+
+    private suspend fun registerExistingTree() {
+        // One add() per directory rather than a single varargs spread call.
+        // Avoids the array copy detekt's SpreadOperator rule warns about,
+        // and keeps each watch independent — a single bad path doesn't fail
+        // the whole registration batch.
+        collectWatchableDirectories().forEach { watcher.add(it) }
+    }
+
+    private fun collectWatchableDirectories(): List<String> {
+        val collected = mutableListOf<String>()
+        Files.walkFileTree(
+            libraryRoot,
+            object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(
+                    dir: Path,
+                    attrs: BasicFileAttributes,
+                ): FileVisitResult {
+                    if (dir != libraryRoot && skipRules(dir)) return FileVisitResult.SKIP_SUBTREE
+                    collected += dir.toString()
+                    return FileVisitResult.CONTINUE
+                }
+            },
+        )
+        return collected
+    }
+
+    private suspend fun handle(event: KfsDirectoryWatcherEvent) {
+        val fullPath = Path.of(event.targetDirectory).resolve(event.path)
+        if (skipRules(fullPath)) return
+
+        // A newly-created directory needs to be added to the watch set so
+        // events on its children surface. kfswatch does not recurse for us.
+        if (event.event == KfsEvent.Create && Files.isDirectory(fullPath)) {
+            watcher.add(fullPath.toString())
+        }
+
+        val bookRoot = computeBookRoot(fullPath)
+        scheduleEmission(bookRoot, fullPath, isDelete = event.event == KfsEvent.Delete)
+    }
+
+    private fun scheduleEmission(
+        bookRoot: Path,
+        triggerPath: Path,
+        isDelete: Boolean,
+    ) {
+        pendingByBookRoot.compute(bookRoot) { _, existing ->
+            existing?.cancel()
+            scope.launch {
+                if (!isDelete) {
+                    // Wait for the file to settle. If it never does (deleted
+                    // mid-wait), we still emit — the book root has changed.
+                    debouncer.awaitStable(triggerPath)
+                }
+                emissions.tryEmit(bookRoot)
+                pendingByBookRoot.remove(bookRoot)
+            }
+        }
+    }
+
+    /**
+     * Computes the book root for a file or directory path. The book root is
+     * the file's parent directory, or the parent's parent if the parent is
+     * a multi-disc folder (`CD1`, `Disc 2`, …) — matching the Grouper.
+     */
+    private fun computeBookRoot(path: Path): Path {
+        val parent = path.parent ?: return libraryRoot
+        val parentName = parent.fileName?.toString() ?: return parent
+        return if (MultiDiscPattern.matches(parentName)) {
+            parent.parent ?: libraryRoot
+        } else {
+            parent
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncer.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncer.kt
@@ -1,0 +1,115 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import kotlinx.coroutines.delay
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Uniform "done writing" detector across Linux/macOS/Windows.
+ *
+ * kfswatch translates platform events into a uniform Create/Modify/Delete
+ * model, but the *semantics* of those events differ:
+ *
+ *  - **Linux** (inotify): `IN_CLOSE_WRITE` fires once after the writer's
+ *    fd is closed — already a "done writing" signal.
+ *  - **macOS** (FSEvents) / **Windows** (ReadDirectoryChangesW): events
+ *    fire mid-write; consumers must poll for the file to settle.
+ *
+ * Rather than special-case per OS, we layer this debouncer on every
+ * platform: the file is "stable" when its size and mtime don't change
+ * for [settle] consecutive duration. A 2 s settle with 500 ms polling is
+ * the spec default — fast enough for human latency, slow enough to handle
+ * an SMB share's chattier events.
+ *
+ * Returns `false` if the file is deleted (or moved away) during the wait,
+ * so callers can treat the await as a signal: stable-and-present (true)
+ * or gone (false). Either outcome lets the watcher decide whether to
+ * trigger an analyze or a removal.
+ *
+ * The [SettleWindow] state machine is the testable core; [awaitStable] is
+ * the I/O-driven wrapper.
+ */
+class StableSizeDebouncer(
+    private val settle: Duration = 2.seconds,
+    private val poll: Duration = 500.milliseconds,
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+    suspend fun awaitStable(path: Path): Boolean {
+        var window = SettleWindow.initial()
+        while (true) {
+            val attrs = readAttributes(path) ?: return false
+            val tick =
+                window.tick(
+                    size = attrs.size(),
+                    mtime = attrs.lastModifiedTime().toMillis(),
+                    now = clock(),
+                    settleMs = settle.inWholeMilliseconds,
+                )
+            when (tick) {
+                is TickResult.Stable -> return true
+                is TickResult.Continue -> window = tick.next
+            }
+            delay(poll)
+        }
+    }
+
+    private fun readAttributes(path: Path): BasicFileAttributes? =
+        try {
+            Files.readAttributes(path, BasicFileAttributes::class.java)
+        } catch (_: NoSuchFileException) {
+            null
+        }
+}
+
+/**
+ * Pure state for the settle-window check. One [tick] per observation;
+ * each tick produces either a continuation state (with updated bookkeeping)
+ * or a [TickResult.Stable] signal when the file has been unchanged for
+ * the configured window.
+ */
+internal data class SettleWindow(
+    val lastSize: Long,
+    val lastMtime: Long,
+    val stableSince: Long,
+) {
+    fun tick(
+        size: Long,
+        mtime: Long,
+        now: Long,
+        settleMs: Long,
+    ): TickResult {
+        if (lastSize == UNINITIALIZED) {
+            // First observation — capture, but we have nothing to compare yet.
+            return TickResult.Continue(SettleWindow(size, mtime, now))
+        }
+        if (size != lastSize || mtime != lastMtime) {
+            // Changed — reset the settle window to "now."
+            return TickResult.Continue(SettleWindow(size, mtime, now))
+        }
+        // Unchanged — has the settle window elapsed?
+        return if (now - stableSince >= settleMs) {
+            TickResult.Stable
+        } else {
+            TickResult.Continue(this)
+        }
+    }
+
+    companion object {
+        const val UNINITIALIZED: Long = -1
+
+        fun initial(): SettleWindow = SettleWindow(UNINITIALIZED, UNINITIALIZED, 0)
+    }
+}
+
+internal sealed interface TickResult {
+    data class Continue(
+        val next: SettleWindow,
+    ) : TickResult
+
+    data object Stable : TickResult
+}

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -36,3 +36,11 @@ registration {
     policy = "OPEN"
     policy = ${?LISTENUP_REGISTRATION_POLICY}
 }
+
+scanner {
+    # Absolute path to the audiobook library root. If unset (empty), the server
+    # starts without scanning; clients can still configure a path later via the
+    # scanner RPC surface (Phase 4 — visual library setup).
+    libraryPath = ""
+    libraryPath = ${?LISTENUP_LIBRARY_PATH}
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/AudioLibraryFixture.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/AudioLibraryFixture.kt
@@ -1,0 +1,126 @@
+package com.calypsan.listenup.server.scanner
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.io.path.writeText
+
+/**
+ * A test-only DSL for assembling synthetic audiobook libraries on disk.
+ *
+ * Phase 2 doesn't read audio file content, so audio "tracks" are zero-byte
+ * placeholders with the correct extension. Phase 3 will add a separate
+ * fixture that emits real test audio for the audiometa port.
+ *
+ * Usage:
+ * ```
+ * audioLibrary {
+ *     book("Brandon Sanderson/Stormlight/The Way of Kings") {
+ *         tracks(count = 5)
+ *         cover()
+ *         metadataJson("""{"title":"The Way of Kings"}""")
+ *     }
+ *     book("Single File Book") { audio("audiobook.m4b") }
+ * }.use { fixture ->
+ *     // tests that consume fixture.root
+ * }
+ * ```
+ *
+ * The fixture is [AutoCloseable]; either wrap usage in `.use { }` or call
+ * [AudioLibraryFixture.close] in a `finally` block. Closing recursively
+ * deletes the temp directory.
+ */
+fun audioLibrary(
+    prefix: String = "listenup-audio-",
+    configure: AudioLibraryFixture.() -> Unit = {},
+): AudioLibraryFixture = AudioLibraryFixture(Files.createTempDirectory(prefix)).apply(configure)
+
+class AudioLibraryFixture(
+    val root: Path,
+) : AutoCloseable {
+    fun book(
+        relPath: String,
+        configure: BookScope.() -> Unit = {},
+    ): Path {
+        val bookRoot = (root / relPath).apply { createDirectories() }
+        BookScope(bookRoot).configure()
+        return bookRoot
+    }
+
+    fun raw(
+        relPath: String,
+        contents: String = "",
+    ): Path = (root / relPath).writeFile(contents)
+
+    fun audio(
+        relPath: String,
+        sizeBytes: Long = 0L,
+    ): Path = (root / relPath).placeholder(sizeBytes)
+
+    fun image(relPath: String): Path = (root / relPath).placeholder(0L)
+
+    /** Marks a directory subtree as skipped via the ABS `.ignore` sentinel. */
+    fun ignore(dirRelPath: String): Path {
+        val dir = (root / dirRelPath).apply { createDirectories() }
+        return (dir / ".ignore").placeholder(0L)
+    }
+
+    override fun close() {
+        root.toFile().deleteRecursively()
+    }
+}
+
+class BookScope(
+    val root: Path,
+) {
+    fun audio(
+        name: String,
+        sizeBytes: Long = 0L,
+    ): Path = (root / name).placeholder(sizeBytes)
+
+    fun cover(name: String = "cover.jpg"): Path = (root / name).placeholder(0L)
+
+    fun image(name: String): Path = (root / name).placeholder(0L)
+
+    fun text(
+        name: String,
+        contents: String = "",
+    ): Path = (root / name).writeFile(contents)
+
+    fun metadataJson(
+        contents: String,
+        name: String = "metadata.json",
+    ): Path = (root / name).writeFile(contents)
+
+    fun tracks(
+        count: Int,
+        namePattern: (Int) -> String = { i -> "%02d - Track.mp3".format(i) },
+    ): List<Path> = (1..count).map { audio(namePattern(it)) }
+
+    /** A multi-disc subdirectory (`CD1/`, `Disc 2/`, etc.). */
+    fun disc(
+        name: String,
+        configure: BookScope.() -> Unit,
+    ): Path {
+        val discRoot = (root / name).apply { createDirectories() }
+        BookScope(discRoot).configure()
+        return discRoot
+    }
+}
+
+private fun Path.placeholder(sizeBytes: Long): Path {
+    parent?.createDirectories()
+    if (sizeBytes == 0L) {
+        Files.createFile(this)
+    } else {
+        Files.write(this, ByteArray(sizeBytes.toInt()))
+    }
+    return this
+}
+
+private fun Path.writeFile(contents: String): Path {
+    parent?.createDirectories()
+    writeText(contents)
+    return this
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinatorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinatorTest.kt
@@ -1,0 +1,247 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.result.AppResult
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+class ScanCoordinatorTest :
+    FunSpec({
+
+        test("concurrent scanFull() — the second caller gets AlreadyRunning") {
+            runTest {
+                val gate = CompletableDeferred<Unit>()
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = {
+                            gate.await()
+                            emptyResult()
+                        },
+                        runIncremental = { /* unused */ },
+                        scope = backgroundScope,
+                    )
+
+                val first = async { coordinator.scanFull() }
+                runCurrent() // let `first` acquire the mutex and suspend on the gate
+
+                val second = coordinator.scanFull()
+                second.shouldBeInstanceOf<AppResult.Failure>()
+                second.error.shouldBeInstanceOf<ScanError.AlreadyRunning>()
+
+                gate.complete(Unit)
+                first.await().shouldBeInstanceOf<AppResult.Success<ScanResult>>()
+            }
+        }
+
+        test("incremental triggered during a full scan runs after the scan finishes") {
+            runTest {
+                val incrementalCalls = mutableListOf<Path>()
+                val gate = CompletableDeferred<Unit>()
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = {
+                            gate.await()
+                            emptyResult()
+                        },
+                        runIncremental = { p -> incrementalCalls.add(p) },
+                        scope = backgroundScope,
+                    )
+
+                val full = async { coordinator.scanFull() }
+                runCurrent() // full scan now holds the mutex
+
+                coordinator.reanalyze(Path.of("/library/Author/Title"))
+                runCurrent()
+                withClue("worker must not run while full scan holds the mutex") {
+                    incrementalCalls.shouldContainExactly(emptyList())
+                }
+
+                gate.complete(Unit)
+                full.await()
+                runCurrent()
+
+                incrementalCalls shouldContainExactly listOf(Path.of("/library/Author/Title"))
+            }
+        }
+
+        test("100 reanalyze() triggers for the same path coalesce to a single invocation") {
+            runTest {
+                val invocations = AtomicInteger(0)
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = { emptyResult() },
+                        runIncremental = { invocations.incrementAndGet() },
+                        scope = backgroundScope,
+                    )
+
+                val path = Path.of("/library/Author/Hot Folder")
+                repeat(100) { coordinator.reanalyze(path) }
+                runCurrent() // worker drains the queue
+
+                invocations.get() shouldBe 1
+            }
+        }
+
+        test("a path re-triggered after processing finishes runs again") {
+            runTest {
+                val invocations = AtomicInteger(0)
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = { emptyResult() },
+                        runIncremental = { invocations.incrementAndGet() },
+                        scope = backgroundScope,
+                    )
+
+                val path = Path.of("/library/Author/Title")
+                coordinator.reanalyze(path)
+                runCurrent()
+                invocations.get() shouldBe 1
+
+                // The first run completed, the path is no longer pending — the
+                // second trigger should re-enqueue it (the file may have changed
+                // again since the worker started).
+                coordinator.reanalyze(path)
+                runCurrent()
+                invocations.get() shouldBe 2
+            }
+        }
+
+        test("distinct paths fired concurrently are NOT coalesced") {
+            runTest {
+                val seen = mutableListOf<Path>()
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = { emptyResult() },
+                        runIncremental = { p -> seen.add(p) },
+                        scope = backgroundScope,
+                    )
+
+                val a = Path.of("/library/A")
+                val b = Path.of("/library/B")
+                val c = Path.of("/library/C")
+                coordinator.reanalyze(a)
+                coordinator.reanalyze(b)
+                coordinator.reanalyze(c)
+                runCurrent()
+
+                seen shouldContainExactly listOf(a, b, c)
+            }
+        }
+
+        test("an exception inside runIncremental is logged and the worker continues") {
+            runTest {
+                val seen = mutableListOf<Path>()
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = { emptyResult() },
+                        runIncremental = { p ->
+                            if (p == Path.of("/boom")) error("simulated failure")
+                            seen.add(p)
+                        },
+                        scope = backgroundScope,
+                    )
+
+                coordinator.reanalyze(Path.of("/before"))
+                coordinator.reanalyze(Path.of("/boom"))
+                coordinator.reanalyze(Path.of("/after"))
+                runCurrent()
+
+                seen shouldContainExactly listOf(Path.of("/before"), Path.of("/after"))
+            }
+        }
+
+        test("cancelling the calling job propagates into an in-flight full scan") {
+            runTest {
+                val cancellationCaught = AtomicReference<Throwable?>(null)
+                val started = CompletableDeferred<Unit>()
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = {
+                            started.complete(Unit)
+                            try {
+                                awaitCancellation()
+                            } catch (e: CancellationException) {
+                                cancellationCaught.set(e)
+                                throw e
+                            }
+                        },
+                        runIncremental = { /* unused */ },
+                        scope = backgroundScope,
+                    )
+
+                val job =
+                    launch {
+                        try {
+                            coordinator.scanFull()
+                        } catch (_: CancellationException) {
+                            // Expected — cancellation propagates out of scanFull.
+                        }
+                    }
+                started.await()
+                job.cancel()
+                job.join()
+
+                cancellationCaught.get().shouldBeInstanceOf<CancellationException>()
+            }
+        }
+
+        test("a busy reanalyze worker doesn't block scanFull from acquiring the mutex eventually") {
+            runTest {
+                val incrementalGate = CompletableDeferred<Unit>()
+                val coordinator =
+                    ScanCoordinator(
+                        runFullScan = { emptyResult() },
+                        runIncremental = { incrementalGate.await() },
+                        scope = backgroundScope,
+                    )
+
+                coordinator.reanalyze(Path.of("/slow"))
+                runCurrent() // worker takes mutex, suspends on gate
+
+                val full = async { coordinator.scanFull() }
+                runCurrent()
+
+                // While the incremental holds the mutex, scanFull tryLock fails.
+                full.isCompleted shouldBe true
+                full.await().shouldBeInstanceOf<AppResult.Failure>()
+
+                // Release the gate so the worker can finish.
+                incrementalGate.complete(Unit)
+
+                // After the worker releases the mutex, a fresh scanFull succeeds.
+                runCurrent()
+                delay(1)
+                val after = coordinator.scanFull()
+                after.shouldBeInstanceOf<AppResult.Success<ScanResult>>()
+            }
+        }
+    })
+
+private fun emptyResult(): ScanResult =
+    ScanResult(
+        correlationId = "test",
+        rootPath = "/library",
+        books = emptyList(),
+        changes = emptyList(),
+        errors = emptyList(),
+        durationMs = 0,
+        filesWalked = 0,
+        filesSkipped = 0,
+    )

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndFixture.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndFixture.kt
@@ -1,0 +1,107 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.server.module
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.cio.CIO as ServerCIO
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.EngineConnectorBuilder
+import io.ktor.server.engine.applicationEnvironment
+import io.ktor.server.engine.embeddedServer
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Fixture that boots a real `Application.module()` against a temp library
+ * directory, returning an [HttpClient] bound to the embedded server's
+ * resolved port. Mirrors the pattern from `AuthEndToEndFixture`: NO
+ * test-side overrides on the production graph — anything that breaks here
+ * breaks production identically.
+ *
+ * Use [populate] to seed the library before the server boots. The boot
+ * triggers an initial full scan via `bootstrapScannerOnStartup` so by the
+ * time the fixture is returned, [HttpClient] requests can race the
+ * bootstrap scan — tests should account for that (e.g. wait for the SSE
+ * `Completed` event, or call POST /api/v1/scan and accept that the first
+ * call may return `AlreadyRunning` while bootstrap is still running).
+ */
+internal class ScannerEndToEndFixture private constructor(
+    val libraryRoot: Path,
+    private val server: EmbeddedServer<*, *>,
+    val client: HttpClient,
+    val baseUrl: String,
+) : AutoCloseable {
+    override fun close() {
+        client.close()
+        @Suppress("MagicNumber")
+        server.stop(gracePeriodMillis = 100, timeoutMillis = 500)
+        libraryRoot.toFile().deleteRecursively()
+    }
+
+    companion object {
+        fun start(populate: AudioLibraryFixture.() -> Unit = {}): ScannerEndToEndFixture {
+            val tmpDb = Files.createTempFile("listenup-scanner-e2e-", ".db").toFile().apply { deleteOnExit() }
+            val libraryRoot = Files.createTempDirectory("listenup-scanner-e2e-lib-")
+            // Use AudioLibraryFixture to seed; we keep ownership of libraryRoot
+            // (closing the AudioLibraryFixture would delete it before the server
+            // even starts).
+            AudioLibraryFixture(libraryRoot).apply(populate)
+
+            val env =
+                applicationEnvironment {
+                    config =
+                        MapApplicationConfig(
+                            "database.jdbcUrl" to "jdbc:sqlite:${tmpDb.absolutePath}",
+                            "auth.refreshPepper" to "x".repeat(REFRESH_PEPPER_LENGTH),
+                            "jwt.secret" to "x".repeat(JWT_SECRET_LENGTH),
+                            "jwt.issuer" to "listenup",
+                            "jwt.audience" to "listenup-client",
+                            "registration.policy" to "OPEN",
+                            "scanner.libraryPath" to libraryRoot.toString(),
+                        )
+                }
+
+            val server =
+                embeddedServer(
+                    factory = ServerCIO,
+                    environment = env,
+                    configure = {
+                        connectors.add(
+                            EngineConnectorBuilder().apply {
+                                host = "127.0.0.1"
+                                port = 0
+                            },
+                        )
+                    },
+                ) {
+                    module()
+                }
+            server.start(wait = false)
+
+            val resolvedPort = runBlocking { server.engine.resolvedConnectors() }.first().port
+            val baseUrl = "http://127.0.0.1:$resolvedPort"
+
+            val client =
+                HttpClient(CIO) {
+                    install(ContentNegotiation) { json(contractJson) }
+                    install(SSE)
+                    install(HttpTimeout) {
+                        requestTimeoutMillis = REQUEST_TIMEOUT_MS
+                    }
+                }
+
+            return ScannerEndToEndFixture(libraryRoot, server, client, baseUrl)
+        }
+
+        private const val JWT_SECRET_LENGTH = 32
+        private const val REFRESH_PEPPER_LENGTH = 32
+        private const val REQUEST_TIMEOUT_MS = 10_000L
+    }
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndTest.kt
@@ -1,0 +1,137 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.result.AppResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end scanner tests — real `Application.module()` over a CIO embedded
+ * server, real DI graph, real Walker → Grouper → Analyzer → Differ pipeline,
+ * real REST + Resources surface. The contract boundary is exercised in full.
+ *
+ * Following Phase 1's F12 pattern: NO test-only overrides on the production
+ * graph — failures here mean the production wiring is broken.
+ *
+ * Coverage:
+ *  - Initial scan picks up every book at startup
+ *  - lastScanResult returns the latest result with all fields populated
+ *  - metadata.json overlay precedence end-to-end (server reads sidecar,
+ *    folder fields are overridden, wire round-trips correctly)
+ *  - Manual POST /api/v1/scan after bootstrap returns Success
+ *
+ * The `AlreadyRunning` failure mode is exercised at the unit level in
+ * `ScanCoordinatorTest`; reproducing it reliably here requires fragile
+ * timing against the bootstrap scan, so we don't bother — the wire-level
+ * concern (`AppResult.Failure(ScanError.AlreadyRunning)` round-trips
+ * through serialization) is covered by the contract tests in `:shared`.
+ */
+class ScannerEndToEndTest :
+    FunSpec({
+
+        test("initial scan picks up books and lastScanResult returns them") {
+            runTest(timeout = 30.seconds) {
+                val fix =
+                    autoClose(
+                        ScannerEndToEndFixture.start {
+                            book("Sanderson/Stormlight/The Way of Kings") {
+                                tracks(count = 2)
+                                cover()
+                            }
+                            book("Sanderson/Mistborn/The Final Empire") { tracks(count = 1) }
+                        },
+                    )
+
+                val result = waitForLastScanResult(fix)
+
+                result.books.size shouldBe 2
+                val titles = result.books.map { it.title }
+                titles.contains("The Way of Kings") shouldBe true
+                titles.contains("The Final Empire") shouldBe true
+            }
+        }
+
+        test("metadata.json overrides folder-derived fields end-to-end") {
+            runTest(timeout = 30.seconds) {
+                val fix =
+                    autoClose(
+                        ScannerEndToEndFixture.start {
+                            book("Author/Folder Title") {
+                                tracks(count = 1)
+                                metadataJson(
+                                    """
+                                    {
+                                      "title": "Override Title",
+                                      "authors": ["Brandon Sanderson"]
+                                    }
+                                    """.trimIndent(),
+                                )
+                            }
+                        },
+                    )
+
+                val result = waitForLastScanResult(fix)
+                val book = result.books.single()
+
+                book.title shouldBe "Override Title"
+                book.authors shouldBe listOf("Brandon Sanderson")
+            }
+        }
+
+        test("triggering a manual scan after bootstrap completes returns Success") {
+            runTest(timeout = 30.seconds) {
+                val fix =
+                    autoClose(
+                        ScannerEndToEndFixture.start {
+                            book("Author/Title") { tracks(count = 1) }
+                        },
+                    )
+
+                // Wait for bootstrap to finish so we have a stable state.
+                waitForLastScanResult(fix)
+
+                val response = fix.client.post("${fix.baseUrl}/api/v1/scan")
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.bodyAsAppResult<ScanResultSummary>()
+                val success = body.shouldBeInstanceOf<AppResult.Success<ScanResultSummary>>()
+                success.data.totalBooks shouldBe 1
+            }
+        }
+    })
+
+/**
+ * Polls `GET /api/v1/scan/last` until it returns Success — the bootstrap
+ * scan kicked off by `Application.module()` runs asynchronously and tests
+ * need to wait for it before asserting on results.
+ */
+private suspend fun waitForLastScanResult(
+    fix: ScannerEndToEndFixture,
+    timeoutMs: Long = 10_000,
+): ScanResult {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+        val response = fix.client.get("${fix.baseUrl}/api/v1/scan/last")
+        val body = response.bodyAsAppResult<ScanResult>()
+        if (body is AppResult.Success) return body.data
+        delay(50)
+    }
+    error("bootstrap scan did not complete within ${timeoutMs}ms")
+}
+
+private suspend inline fun <reified T : Any> HttpResponse.bodyAsAppResult(): AppResult<T> {
+    val text: String = body()
+    return contractJson.decodeFromString(AppResult.serializer(serializer<T>()), text)
+}
+
+private inline fun <reified T : Any> serializer(): kotlinx.serialization.KSerializer<T> = kotlinx.serialization.serializer()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImplTest.kt
@@ -1,0 +1,104 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+class ScannerServiceImplTest :
+    FunSpec({
+
+        test("scanFull returns Success with a summary built from the latest result") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 2) }
+                }.use { fixture ->
+                    val service = newService(fixture, scope = this)
+                    val result = service.scanFull()
+                    val success = result.shouldBeInstanceOf<AppResult.Success<ScanResultSummary>>()
+                    success.data.totalBooks shouldBe 1
+                    success.data.added shouldBe 1
+                    success.data.errors shouldBe 0
+                }
+            }
+        }
+
+        test("scanFull returns Failure(AlreadyRunning) on overlapping invocations") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 1) }
+                }.use { fixture ->
+                    val service = newService(fixture, scope = this)
+
+                    val first = async { service.scanFull() }
+                    runCurrent()
+
+                    val second = service.scanFull()
+                    val failure = second.shouldBeInstanceOf<AppResult.Failure>()
+                    failure.error.shouldBeInstanceOf<ScanError.AlreadyRunning>()
+
+                    first.await().shouldBeInstanceOf<AppResult.Success<ScanResultSummary>>()
+                }
+            }
+        }
+
+        test("lastScanResult returns LibraryPathNotConfigured before any scan has run") {
+            runTest {
+                audioLibrary {}.use { fixture ->
+                    val service = newService(fixture, scope = this)
+                    val result = service.lastScanResult()
+                    val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                    failure.error.shouldBeInstanceOf<ScanError.LibraryPathNotConfigured>()
+                }
+            }
+        }
+
+        test("lastScanResult returns Success after a scan completes") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 1) }
+                }.use { fixture ->
+                    val service = newService(fixture, scope = this)
+                    service.scanFull()
+
+                    val result = service.lastScanResult()
+                    val success = result.shouldBeInstanceOf<AppResult.Success<ScanResult>>()
+                    success.data.books.size shouldBe 1
+                }
+            }
+        }
+    })
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+private fun newService(
+    fixture: AudioLibraryFixture,
+    scope: TestScope,
+): ScannerServiceImpl {
+    val eventBus = MutableSharedFlow<ScanEvent>(replay = 0, extraBufferCapacity = 64)
+    val scanner =
+        Scanner(
+            rootPath = fixture.root,
+            metadataReader = AbsMetadataReader(contractJson),
+            eventBus = eventBus,
+        )
+    val coordinator =
+        ScanCoordinator(
+            runFullScan = { scanner.runFullScan() },
+            runIncremental = { scanner.runIncremental(it) },
+            scope = scope.backgroundScope,
+        )
+    return ScannerServiceImpl(scanner, coordinator, eventBus)
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerSseRouteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerSseRouteTest.kt
@@ -1,0 +1,116 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.result.AppResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Verifies the `GET /sse/scan` route specifically. Two contract concerns:
+ *
+ *  - **Frame format.** Each SSE frame's `data` field deserializes back to
+ *    a [ScanEvent] via the polymorphic `@SerialName` discriminator — no
+ *    silent type erosion.
+ *  - **Live stream.** A scan triggered via REST while a client is
+ *    subscribed produces the `Started → … → Completed` sequence on the
+ *    SSE stream.
+ */
+class ScannerSseRouteTest :
+    FunSpec({
+
+        test("SSE stream emits Started and Completed for a manual scan") {
+            // Real wall-clock — the SSE client runs on the Default dispatcher
+            // and uses real time; runTest's virtual time would dispatch
+            // `delay()` calls in the test body without actually waiting,
+            // which races the SSE subscription against the scan.
+            runBlocking {
+                val fix =
+                    autoClose(
+                        ScannerEndToEndFixture.start {
+                            book("Author/Title") { tracks(count = 1) }
+                        },
+                    )
+
+                // Wait for the bootstrap scan to finish so we have a stable
+                // mutex state — otherwise the manual scan we trigger below
+                // could race against bootstrap and return AlreadyRunning,
+                // generating no events for the SSE stream.
+                waitForBootstrap(fix)
+
+                // Subscribe to the SSE stream, collect events as they arrive.
+                val collected = mutableListOf<ScanEvent>()
+                val sseJob =
+                    async {
+                        withTimeoutOrNull(10.seconds) {
+                            fix.client.sse("${fix.baseUrl}/sse/scan") {
+                                incoming
+                                    .transformWhile { frame ->
+                                        val data = frame.data
+                                        if (data != null) {
+                                            val event =
+                                                runCatching {
+                                                    contractJson.decodeFromString(ScanEvent.serializer(), data)
+                                                }.getOrNull()
+                                            if (event != null) {
+                                                emit(event)
+                                                if (event is ScanEvent.Completed) return@transformWhile false
+                                            }
+                                        }
+                                        true
+                                    }.collect { collected.add(it) }
+                            }
+                        }
+                    }
+
+                // Pause so the SSE subscription is established before the scan
+                // fires — otherwise we miss the Started frame.
+                delay(500)
+
+                // Trigger a manual scan to generate fresh events.
+                fix.client.post("${fix.baseUrl}/api/v1/scan")
+
+                sseJob.await()
+
+                collected.size shouldBeGreaterThan 0
+                collected.any { it is ScanEvent.Started } shouldBe true
+                collected.any { it is ScanEvent.Completed } shouldBe true
+                // Polymorphic discriminator survived — every event has a
+                // non-empty correlationId.
+                collected.forEach { it.correlationId.isNotEmpty() shouldBe true }
+            }
+        }
+    })
+
+private suspend fun waitForBootstrap(fix: ScannerEndToEndFixture) {
+    val deadline = System.currentTimeMillis() + 10_000
+    while (System.currentTimeMillis() < deadline) {
+        val response = fix.client.get("${fix.baseUrl}/api/v1/scan/last")
+        val body: AppResult<ScanResult> =
+            contractJson.decodeFromString(
+                AppResult.serializer(ScanResult.serializer()),
+                response.body<String>(),
+            )
+        if (body is AppResult.Success) return
+        delay(50)
+    }
+    error("bootstrap scan did not complete within 10s")
+}
+
+@Suppress("unused")
+private suspend fun HttpResponse.discard() {
+    body<String>()
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
@@ -1,0 +1,201 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.atomic.AtomicLong
+
+class ScannerTest :
+    FunSpec({
+
+        test("first full scan emits Added for every book") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title-A") { tracks(count = 2) }
+                    book("Author/Title-B") { tracks(count = 1) }
+                }.use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+
+                    val result = scanner.runFullScan()
+                    result.books.size shouldBe 2
+                    result.changes.size shouldBe 2
+                    result.changes.all { it is ChangeEventDto.Added } shouldBe true
+
+                    val events = eventBus.replayCache
+                    events.first().shouldBeInstanceOf<ScanEvent.Started>()
+                    events.last().shouldBeInstanceOf<ScanEvent.Completed>()
+                    events.count { it is ScanEvent.Change } shouldBe 2
+                }
+            }
+        }
+
+        test("a second full scan with no changes emits zero Change events") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 2) }
+                }.use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+                    scanner.runFullScan() // first scan: 1 Added
+                    eventBus.resetReplayCache()
+
+                    val result = scanner.runFullScan()
+                    result.changes shouldBe emptyList()
+                    eventBus.replayCache.count { it is ScanEvent.Change } shouldBe 0
+                }
+            }
+        }
+
+        test("lastResult is updated after a full scan") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 1) }
+                }.use { fixture ->
+                    val (scanner, _) = newScanner(fixture)
+                    scanner.lastResult() shouldBe null
+
+                    scanner.runFullScan()
+                    val last = scanner.lastResult()
+                    last.shouldNotBeNull()
+                    last.books.size shouldBe 1
+                }
+            }
+        }
+
+        test("monotonic correlation IDs across scans") {
+            runTest {
+                audioLibrary { book("Author/Title") { tracks(count = 1) } }.use { fixture ->
+                    val counter = AtomicLong(0)
+                    val (scanner, _) =
+                        newScanner(
+                            fixture,
+                            correlationIdFactory = { "scan-${counter.incrementAndGet()}" },
+                        )
+                    scanner.runFullScan().correlationId shouldBe "scan-1"
+                    scanner.runFullScan().correlationId shouldBe "scan-2"
+                }
+            }
+        }
+
+        test("incremental analyzes only the targeted subtree and patches lastResult") {
+            runTest {
+                audioLibrary {
+                    book("Author/Stays") { tracks(count = 1) }
+                    book("Author/Updated") { tracks(count = 1) }
+                }.use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+                    scanner.runFullScan()
+                    eventBus.resetReplayCache()
+
+                    // Add a track to "Updated" only.
+                    fixture.book("Author/Updated") { audio("02 - New.mp3") }
+
+                    val targetRoot = fixture.root.resolve("Author/Updated")
+                    scanner.runIncremental(targetRoot)
+
+                    val last = scanner.lastResult().shouldNotBeNull()
+                    last.books.size shouldBe 2
+                    val updated = last.books.single { it.candidate.rootRelPath == "Author/Updated" }
+                    updated.candidate.files.size shouldBe 2
+
+                    // The Change event should be Modified for the updated book root,
+                    // and the unaffected book ("Stays") should NOT appear in changes.
+                    val changes = eventBus.replayCache.filterIsInstance<ScanEvent.Change>().map { it.event }
+                    changes.size shouldBe 1
+                    changes.single().shouldBeInstanceOf<ChangeEventDto.Modified>()
+                }
+            }
+        }
+
+        test("incremental against a deleted book root emits Removed") {
+            runTest {
+                audioLibrary {
+                    book("Author/Stays") { tracks(count = 1) }
+                    book("Author/Goes Away") { tracks(count = 1) }
+                }.use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+                    scanner.runFullScan()
+                    eventBus.resetReplayCache()
+
+                    // Delete the book directory entirely.
+                    val targetRoot = fixture.root.resolve("Author/Goes Away")
+                    targetRoot.toFile().deleteRecursively()
+
+                    scanner.runIncremental(targetRoot)
+
+                    val changes = eventBus.replayCache.filterIsInstance<ScanEvent.Change>().map { it.event }
+                    changes.size shouldBe 1
+                    val removed = changes.single().shouldBeInstanceOf<ChangeEventDto.Removed>()
+                    removed.rootRelPath shouldBe "Author/Goes Away"
+
+                    val last = scanner.lastResult().shouldNotBeNull()
+                    last.books.map { it.candidate.rootRelPath } shouldContain "Author/Stays"
+                    last.books.map { it.candidate.rootRelPath }.contains("Author/Goes Away") shouldBe false
+                }
+            }
+        }
+
+        test("ScanResult.toSummary counts Added/Modified/Removed/Moved correctly") {
+            runTest {
+                audioLibrary {
+                    book("Author/A") { tracks(count = 1) }
+                    book("Author/B") { tracks(count = 1) }
+                }.use { fixture ->
+                    val (scanner, _) = newScanner(fixture)
+                    val first = scanner.runFullScan()
+                    val summary = first.toSummary()
+                    summary.added shouldBe 2
+                    summary.modified shouldBe 0
+                    summary.removed shouldBe 0
+                    summary.moved shouldBe 0
+                    summary.totalBooks shouldBe 2
+                    summary.errors shouldBe 0
+                }
+            }
+        }
+
+        test("progress events are emitted across scan phases") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 1) }
+                }.use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+                    scanner.runFullScan()
+
+                    val phases = eventBus.replayCache.filterIsInstance<ScanEvent.Progress>().map { it.phase }
+                    phases shouldContainExactlyInAnyOrder
+                        listOf(
+                            com.calypsan.listenup.api.dto.scanner.ScanPhase.WALKING,
+                            com.calypsan.listenup.api.dto.scanner.ScanPhase.GROUPING,
+                            com.calypsan.listenup.api.dto.scanner.ScanPhase.ANALYZING,
+                            com.calypsan.listenup.api.dto.scanner.ScanPhase.DIFFING,
+                        )
+                }
+            }
+        }
+    })
+
+private fun newScanner(
+    fixture: AudioLibraryFixture,
+    correlationIdFactory: () -> String = { "test-correlation-id" },
+): Pair<Scanner, MutableSharedFlow<ScanEvent>> {
+    val eventBus = MutableSharedFlow<ScanEvent>(replay = 64, extraBufferCapacity = 64)
+    val scanner =
+        Scanner(
+            rootPath = fixture.root,
+            metadataReader = AbsMetadataReader(contractJson),
+            eventBus = eventBus,
+            correlationIdFactory = correlationIdFactory,
+        )
+    return scanner to eventBus
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParserTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParserTest.kt
@@ -1,0 +1,208 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Compatibility regression net for [AbsTitleParser]. Every case here is
+ * checked against the behavior of the equivalent function in ABS's
+ * `server/utils/scandir.js`. Drift fails the build.
+ */
+class AbsTitleParserTest :
+    FunSpec({
+
+        // ========== Plain titles ==========
+
+        test("plain title") {
+            AbsTitleParser.parse("The Way of Kings") shouldBe ParsedTitle(title = "The Way of Kings")
+        }
+
+        test("trims surrounding whitespace") {
+            AbsTitleParser.parse("   The Way of Kings   ") shouldBe ParsedTitle(title = "The Way of Kings")
+        }
+
+        // ========== ASIN ==========
+
+        test("ASIN at end") {
+            AbsTitleParser.parse("The Way of Kings [B0015T963C]") shouldBe
+                ParsedTitle(title = "The Way of Kings", asin = "B0015T963C")
+        }
+
+        test("ASIN with surrounding spaces is collapsed") {
+            AbsTitleParser.parse("Title [B0015T963C] Suffix") shouldBe
+                ParsedTitle(title = "Title Suffix", asin = "B0015T963C")
+        }
+
+        test("ASIN must be 10 chars uppercase alphanumeric — lowercase rejected") {
+            AbsTitleParser.parse("Title [b0015t963c]") shouldBe ParsedTitle(title = "Title [b0015t963c]")
+        }
+
+        test("ASIN must be 10 chars — 9 chars rejected") {
+            AbsTitleParser.parse("Title [B001ABCDEF]") shouldBe ParsedTitle(title = "Title", asin = "B001ABCDEF")
+            AbsTitleParser.parse("Title [B001ABCDE]") shouldBe ParsedTitle(title = "Title [B001ABCDE]")
+        }
+
+        // ========== Narrators ==========
+
+        test("single narrator") {
+            AbsTitleParser.parse("Title {Michael Kramer}") shouldBe
+                ParsedTitle(title = "Title", narrators = listOf("Michael Kramer"))
+        }
+
+        test("two narrators comma-separated") {
+            AbsTitleParser.parse("Title {Michael Kramer, Kate Reading}") shouldBe
+                ParsedTitle(title = "Title", narrators = listOf("Michael Kramer", "Kate Reading"))
+        }
+
+        test("two narrators semicolon-separated") {
+            AbsTitleParser.parse("Title {Michael Kramer; Kate Reading}") shouldBe
+                ParsedTitle(title = "Title", narrators = listOf("Michael Kramer", "Kate Reading"))
+        }
+
+        test("two narrators with ampersand") {
+            AbsTitleParser.parse("Title {Michael Kramer & Kate Reading}") shouldBe
+                ParsedTitle(title = "Title", narrators = listOf("Michael Kramer", "Kate Reading"))
+        }
+
+        test("narrators with 'and'") {
+            AbsTitleParser.parse("Title {Michael Kramer and Kate Reading}") shouldBe
+                ParsedTitle(title = "Title", narrators = listOf("Michael Kramer", "Kate Reading"))
+        }
+
+        // ========== Year ==========
+
+        test("year prefix with parentheses") {
+            AbsTitleParser.parse("(2010) - The Way of Kings") shouldBe
+                ParsedTitle(title = "The Way of Kings", publishedYear = 2010)
+        }
+
+        test("year prefix bare") {
+            AbsTitleParser.parse("2010 - The Way of Kings") shouldBe
+                ParsedTitle(title = "The Way of Kings", publishedYear = 2010)
+        }
+
+        // ========== Sequence (with series folder) ==========
+
+        test("sequence: Book 2 -") {
+            AbsTitleParser.parse("Book 2 - The Way of Kings", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "The Way of Kings", sequence = "2")
+        }
+
+        test("sequence: bare 2 -") {
+            AbsTitleParser.parse("2 - The Way of Kings", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "The Way of Kings", sequence = "2")
+        }
+
+        test("sequence: Vol. 3 -") {
+            AbsTitleParser.parse("Vol. 3 - Title Here", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Title Here", sequence = "3")
+        }
+
+        test("sequence: Volume 12. Title - Subtitle") {
+            AbsTitleParser.parse("Volume 12. Title - Subtitle", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Title - Subtitle", sequence = "12")
+        }
+
+        test("sequence: 1.5 -") {
+            AbsTitleParser.parse("1.5 - Novella", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Novella", sequence = "1.5")
+        }
+
+        test("sequence: 0.5 -") {
+            AbsTitleParser.parse("0.5 - Book Title", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Book Title", sequence = "0.5")
+        }
+
+        test("sequence: 100 -") {
+            AbsTitleParser.parse("100 - Book Title", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Book Title", sequence = "100")
+        }
+
+        test("sequence: 6. (with trailing dot)") {
+            AbsTitleParser.parse("6. Title", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Title", sequence = "6")
+        }
+
+        test("not a sequence: '101 Dalmations' (digits + suffix without volume label or trailing dot)") {
+            AbsTitleParser.parse("101 Dalmations", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "101 Dalmations")
+        }
+
+        test("sequence: '101. Dalmations' (trailing dot rescues it)") {
+            AbsTitleParser.parse("101. Dalmations", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Dalmations", sequence = "101")
+        }
+
+        test("sequence: 'Title - Subtitle - Vol 12' (sequence in trailing part)") {
+            AbsTitleParser.parse("Title - Subtitle - Vol 12", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Title - Subtitle", sequence = "12")
+        }
+
+        test("sequence ignored when no series folder") {
+            AbsTitleParser.parse("Book 2 - The Way of Kings", hasSeriesFolder = false) shouldBe
+                ParsedTitle(title = "Book 2 - The Way of Kings")
+        }
+
+        // ========== Subtitle ==========
+
+        test("subtitle split on first ' - ' when parseSubtitle=true") {
+            AbsTitleParser.parse("Title - Subtitle", parseSubtitle = true) shouldBe
+                ParsedTitle(title = "Title", subtitle = "Subtitle")
+        }
+
+        test("subtitle keeps trailing parts together") {
+            AbsTitleParser.parse("Title - Subtitle - More", parseSubtitle = true) shouldBe
+                ParsedTitle(title = "Title", subtitle = "Subtitle - More")
+        }
+
+        test("subtitle off: keeps full string") {
+            AbsTitleParser.parse("Title - Subtitle", parseSubtitle = false) shouldBe
+                ParsedTitle(title = "Title - Subtitle")
+        }
+
+        test("subtitle off: no subtitle field even with hyphen") {
+            AbsTitleParser.parse("Title - Subtitle").subtitle shouldBe null
+        }
+
+        // ========== Combinations ==========
+
+        test("year + sequence + asin + narrators all together") {
+            AbsTitleParser.parse(
+                "(2010) - Book 2 - The Way of Kings [B0015T963C] {Michael Kramer}",
+                hasSeriesFolder = true,
+            ) shouldBe
+                ParsedTitle(
+                    title = "The Way of Kings",
+                    publishedYear = 2010,
+                    sequence = "2",
+                    asin = "B0015T963C",
+                    narrators = listOf("Michael Kramer"),
+                )
+        }
+
+        test("year + sequence: '1980 - Book 2 - Title' (year is 4-digit, sequence regex's 0..3 digits skips it)") {
+            AbsTitleParser.parse("1980 - Book 2 - Title", hasSeriesFolder = true) shouldBe
+                ParsedTitle(title = "Title", publishedYear = 1980, sequence = "2")
+        }
+
+        // ========== Edge cases ==========
+
+        test("empty input") {
+            AbsTitleParser.parse("") shouldBe ParsedTitle(title = "")
+        }
+
+        test("just whitespace") {
+            AbsTitleParser.parse("   ") shouldBe ParsedTitle(title = "")
+        }
+
+        test("ASIN must be at end or have surrounding spaces, not glued") {
+            // The regex requires `(?: |^)` and `(?= |$)` — `[B0015T963C]Title` has no
+            // separating space at the end and shouldn't match.
+            AbsTitleParser.parse("[B0015T963C]Title") shouldBe ParsedTitle(title = "[B0015T963C]Title")
+        }
+
+        test("ASIN at very start") {
+            AbsTitleParser.parse("[B0015T963C] The Way of Kings") shouldBe
+                ParsedTitle(title = "The Way of Kings", asin = "B0015T963C")
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/FileTypeRulesTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/FileTypeRulesTest.kt
@@ -1,0 +1,68 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import com.calypsan.listenup.api.dto.scanner.FileType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FileTypeRulesTest :
+    FunSpec({
+
+        test("classifies all ABS audio extensions as AUDIO") {
+            listOf(
+                "track.m4b",
+                "track.mp3",
+                "track.m4a",
+                "track.flac",
+                "track.opus",
+                "track.ogg",
+                "track.oga",
+                "track.mp4",
+                "track.aac",
+                "track.wma",
+                "track.aiff",
+                "track.aif",
+                "track.wav",
+                "track.webm",
+                "track.webma",
+                "track.mka",
+                "track.awb",
+                "track.caf",
+                "track.mpg",
+                "track.mpeg",
+            ).forEach { FileTypeRules.classify(it) shouldBe FileType.AUDIO }
+        }
+
+        test("classifies image extensions as IMAGE") {
+            listOf("cover.jpg", "cover.jpeg", "cover.png", "cover.webp").forEach {
+                FileTypeRules.classify(it) shouldBe FileType.IMAGE
+            }
+        }
+
+        test("classifies ebook extensions as EBOOK") {
+            listOf("book.epub", "book.pdf", "book.mobi", "book.azw3", "comic.cbr", "comic.cbz").forEach {
+                FileTypeRules.classify(it) shouldBe FileType.EBOOK
+            }
+        }
+
+        test("classifies text extensions as TEXT") {
+            FileTypeRules.classify("desc.txt") shouldBe FileType.TEXT
+            FileTypeRules.classify("info.nfo") shouldBe FileType.TEXT
+        }
+
+        test("classifies metadata extensions as METADATA") {
+            listOf("metadata.json", "book.opf", "book.abs", "book.xml").forEach {
+                FileTypeRules.classify(it) shouldBe FileType.METADATA
+            }
+        }
+
+        test("uppercase extensions classify the same as lowercase") {
+            FileTypeRules.classify("TRACK.MP3") shouldBe FileType.AUDIO
+            FileTypeRules.classify("Cover.JPG") shouldBe FileType.IMAGE
+        }
+
+        test("unknown and missing extensions return UNKNOWN") {
+            FileTypeRules.classify("README") shouldBe FileType.UNKNOWN
+            FileTypeRules.classify("track.xyz") shouldBe FileType.UNKNOWN
+            FileTypeRules.classify("plain") shouldBe FileType.UNKNOWN
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/FolderShapeTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/FolderShapeTest.kt
@@ -1,0 +1,53 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FolderShapeTest :
+    FunSpec({
+
+        test("title only") {
+            FolderShape.parse("The Way of Kings") shouldBe FolderShape(titleFolder = "The Way of Kings")
+        }
+
+        test("author / title") {
+            FolderShape.parse("Brandon Sanderson/The Way of Kings") shouldBe
+                FolderShape(titleFolder = "The Way of Kings", authorFolder = "Brandon Sanderson")
+        }
+
+        test("author / series / title") {
+            FolderShape.parse("Brandon Sanderson/Stormlight Archive/The Way of Kings") shouldBe
+                FolderShape(
+                    titleFolder = "The Way of Kings",
+                    seriesFolder = "Stormlight Archive",
+                    authorFolder = "Brandon Sanderson",
+                )
+        }
+
+        test("deeper nesting — only bottom three components used") {
+            FolderShape.parse("library/extra/dirs/Brandon Sanderson/Stormlight Archive/The Way of Kings") shouldBe
+                FolderShape(
+                    titleFolder = "The Way of Kings",
+                    seriesFolder = "Stormlight Archive",
+                    authorFolder = "Brandon Sanderson",
+                )
+        }
+
+        test("Windows separators normalized") {
+            FolderShape.parse("Brandon Sanderson\\Stormlight Archive\\The Way of Kings") shouldBe
+                FolderShape(
+                    titleFolder = "The Way of Kings",
+                    seriesFolder = "Stormlight Archive",
+                    authorFolder = "Brandon Sanderson",
+                )
+        }
+
+        test("leading and trailing slashes dropped") {
+            FolderShape.parse("/Author/Title/") shouldBe
+                FolderShape(titleFolder = "Title", authorFolder = "Author")
+        }
+
+        test("empty path") {
+            FolderShape.parse("") shouldBe FolderShape(titleFolder = "")
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/SkipRulesTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/SkipRulesTest.kt
@@ -1,0 +1,49 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.div
+
+class SkipRulesTest :
+    FunSpec({
+
+        test("skips dotfiles") {
+            SkipRules.shouldSkip(Path.of("/library/.DS_Store")) shouldBe true
+            SkipRules.shouldSkip(Path.of("/library/.git")) shouldBe true
+        }
+
+        test("skips temp / partial-download extensions case-insensitively") {
+            SkipRules.shouldSkip(Path.of("/library/audiobook.part")) shouldBe true
+            SkipRules.shouldSkip(Path.of("/library/audiobook.TMP")) shouldBe true
+            SkipRules.shouldSkip(Path.of("/library/audiobook.crdownload")) shouldBe true
+            SkipRules.shouldSkip(Path.of("/library/cover.bak")) shouldBe true
+        }
+
+        test("skips Synology @eaDir junk on POSIX-style paths") {
+            SkipRules.shouldSkip(Path.of("/library/Author/Book/@eaDir/SYNOPHOTO_THUMB_M.jpg")) shouldBe true
+        }
+
+        test(".ignore sibling marks the directory as skipped") {
+            val tmp = Files.createTempDirectory("listenup-skip-")
+            try {
+                val bookDir = tmp / "BookFolder"
+                bookDir.createDirectories()
+                (bookDir / ".ignore").createFile()
+                val audio = bookDir / "track.mp3"
+                audio.createFile()
+                SkipRules.shouldSkip(audio) shouldBe true
+            } finally {
+                tmp.toFile().deleteRecursively()
+            }
+        }
+
+        test("does not skip ordinary audio files") {
+            SkipRules.shouldSkip(Path.of("/library/Author/Book/track.mp3")) shouldBe false
+            SkipRules.shouldSkip(Path.of("/library/Author/Book/cover.jpg")) shouldBe false
+            SkipRules.shouldSkip(Path.of("/library/Author/Book/metadata.json")) shouldBe false
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInferenceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInferenceTest.kt
@@ -1,0 +1,103 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import com.calypsan.listenup.api.dto.scanner.TrackNumberSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TrackInferenceTest :
+    FunSpec({
+
+        test("track number from leading digits") {
+            TrackInference.infer("01 - Chapter One.mp3", null) shouldBe
+                TrackInfo(trackNumber = 1, trackSource = TrackNumberSource.FILENAME)
+        }
+
+        test("track number with 'track' prefix") {
+            TrackInference.infer("track01.mp3", null) shouldBe
+                TrackInfo(trackNumber = 1, trackSource = TrackNumberSource.FILENAME)
+        }
+
+        test("disc from filename with 'CD' prefix") {
+            TrackInference.infer("CD2 track01.mp3", null) shouldBe
+                TrackInfo(
+                    trackNumber = 1,
+                    discNumber = 2,
+                    trackSource = TrackNumberSource.FILENAME,
+                    discSource = TrackNumberSource.FILENAME,
+                )
+        }
+
+        test("disc from filename with 'Disc' prefix — no track digits remain") {
+            // After stripping "Disc 1", " - Chapter Two" has no digits, so trackNumber stays null.
+            TrackInference.infer("Disc 1 - Chapter Two.mp3", null) shouldBe
+                TrackInfo(
+                    discNumber = 1,
+                    discSource = TrackNumberSource.FILENAME,
+                )
+        }
+
+        test("disc + track from filename when both present") {
+            TrackInference.infer("Disc 2 - 05 Chapter Five.mp3", null) shouldBe
+                TrackInfo(
+                    trackNumber = 5,
+                    discNumber = 2,
+                    trackSource = TrackNumberSource.FILENAME,
+                    discSource = TrackNumberSource.FILENAME,
+                )
+        }
+
+        test("disc from parent folder when filename lacks one") {
+            TrackInference.infer("01.mp3", "CD3") shouldBe
+                TrackInfo(
+                    trackNumber = 1,
+                    discNumber = 3,
+                    trackSource = TrackNumberSource.FILENAME,
+                    discSource = TrackNumberSource.FOLDER,
+                )
+        }
+
+        test("disc folder lowercase") {
+            TrackInference.infer("track42.mp3", "disc4") shouldBe
+                TrackInfo(
+                    trackNumber = 42,
+                    discNumber = 4,
+                    trackSource = TrackNumberSource.FILENAME,
+                    discSource = TrackNumberSource.FOLDER,
+                )
+        }
+
+        test("disc folder with disk variant") {
+            TrackInference.infer("01.mp3", "Disk 5") shouldBe
+                TrackInfo(
+                    trackNumber = 1,
+                    discNumber = 5,
+                    trackSource = TrackNumberSource.FILENAME,
+                    discSource = TrackNumberSource.FOLDER,
+                )
+        }
+
+        test("filename disc beats folder disc") {
+            TrackInference.infer("CD9 track01.mp3", "CD2") shouldBe
+                TrackInfo(
+                    trackNumber = 1,
+                    discNumber = 9,
+                    trackSource = TrackNumberSource.FILENAME,
+                    discSource = TrackNumberSource.FILENAME,
+                )
+        }
+
+        test("no track or disc — both null") {
+            TrackInference.infer("audiobook.m4b", null) shouldBe TrackInfo()
+        }
+
+        test("4-digit track number caps at the regex limit") {
+            TrackInference.infer("9999 - End.mp3", null) shouldBe
+                TrackInfo(trackNumber = 9999, trackSource = TrackNumberSource.FILENAME)
+        }
+
+        test("ignores 5-digit numbers (regex bounded 1-4 digits)") {
+            // 12345 contains "1234" as the first 4-digit match
+            TrackInference.infer("12345.mp3", null) shouldBe
+                TrackInfo(trackNumber = 1234, trackSource = TrackNumberSource.FILENAME)
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReaderTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReaderTest.kt
@@ -1,0 +1,137 @@
+package com.calypsan.listenup.server.scanner.metadata
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.SeriesEntry
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.io.path.writeText
+
+class AbsMetadataReaderTest :
+    FunSpec({
+
+        val reader = AbsMetadataReader(contractJson)
+
+        test("reads a flat metadata.json with the canonical ABS shape") {
+            runTest {
+                val tmp = Files.createTempDirectory("listenup-md-")
+                try {
+                    val file = tmp / "metadata.json"
+                    file.writeText(
+                        """
+                        {
+                          "title": "The Way of Kings",
+                          "subtitle": "Book One",
+                          "authors": ["Brandon Sanderson"],
+                          "narrators": ["Michael Kramer", "Kate Reading"],
+                          "series": ["Stormlight Archive #1"],
+                          "publishedYear": 2010,
+                          "asin": "B0015T963C"
+                        }
+                        """.trimIndent(),
+                    )
+
+                    val md = reader.read(file)
+
+                    md.shouldNotBeNull()
+                    md.title shouldBe "The Way of Kings"
+                    md.subtitle shouldBe "Book One"
+                    md.authors shouldBe listOf("Brandon Sanderson")
+                    md.narrators shouldBe listOf("Michael Kramer", "Kate Reading")
+                    md.series shouldBe listOf("Stormlight Archive #1")
+                    md.publishedYear shouldBe 2010
+                    md.asin shouldBe "B0015T963C"
+                } finally {
+                    tmp.toFile().deleteRecursively()
+                }
+            }
+        }
+
+        test("auto-flattens the legacy nested 'metadata' wrapper") {
+            runTest {
+                val tmp = Files.createTempDirectory("listenup-md-")
+                try {
+                    val file = tmp / "metadata.json"
+                    file.writeText("""{"metadata":{"title":"Legacy Title","authors":["Author"]}}""")
+
+                    val md = reader.read(file)
+
+                    md.shouldNotBeNull()
+                    md.title shouldBe "Legacy Title"
+                    md.authors shouldBe listOf("Author")
+                } finally {
+                    tmp.toFile().deleteRecursively()
+                }
+            }
+        }
+
+        test("returns null on malformed JSON without throwing") {
+            runTest {
+                val tmp = Files.createTempDirectory("listenup-md-")
+                try {
+                    val file = tmp / "metadata.json"
+                    file.writeText("{this is not valid json")
+
+                    reader.read(file).shouldBeNull()
+                } finally {
+                    tmp.toFile().deleteRecursively()
+                }
+            }
+        }
+
+        test("returns null when the file doesn't exist") {
+            runTest {
+                val tmp = Files.createTempDirectory("listenup-md-")
+                try {
+                    reader.read(tmp / "nope.json").shouldBeNull()
+                } finally {
+                    tmp.toFile().deleteRecursively()
+                }
+            }
+        }
+
+        test("returns null for a directory passed as a path") {
+            runTest {
+                val tmp = Files.createTempDirectory("listenup-md-")
+                try {
+                    (tmp / "sub").createDirectories()
+                    reader.read(tmp / "sub").shouldBeNull()
+                } finally {
+                    tmp.toFile().deleteRecursively()
+                }
+            }
+        }
+
+        test("parseSeriesEntries handles plain name (no #)") {
+            reader.parseSeriesEntries(listOf("Standalone")) shouldBe listOf(SeriesEntry("Standalone"))
+        }
+
+        test("parseSeriesEntries parses 'Name #seq' canonical form") {
+            reader.parseSeriesEntries(listOf("Stormlight Archive #1")) shouldBe
+                listOf(SeriesEntry("Stormlight Archive", "1"))
+        }
+
+        test("parseSeriesEntries preserves string sequences (1.5, 0a)") {
+            reader.parseSeriesEntries(listOf("Wheel of Time #5", "Mistborn #1.5", "Cosmere #0a")) shouldContainInOrder
+                listOf(
+                    SeriesEntry("Wheel of Time", "5"),
+                    SeriesEntry("Mistborn", "1.5"),
+                    SeriesEntry("Cosmere", "0a"),
+                )
+        }
+
+        test("parseSeriesEntries strips empty entries") {
+            reader.parseSeriesEntries(listOf("", "  ", "Real Series #1")) shouldBe
+                listOf(SeriesEntry("Real Series", "1"))
+        }
+
+        test("parseSeriesEntries with empty sequence (#) keeps name only") {
+            reader.parseSeriesEntries(listOf("Name #")) shouldBe listOf(SeriesEntry("Name"))
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerTest.kt
@@ -1,0 +1,427 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.MetadataSource
+import com.calypsan.listenup.api.dto.scanner.SeriesEntry
+import com.calypsan.listenup.api.dto.scanner.TrackNumberSource
+import com.calypsan.listenup.server.scanner.audioLibrary
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+
+class AnalyzerTest :
+    FunSpec({
+
+        val metadataReader = AbsMetadataReader(contractJson)
+
+        test("infers title, author, and series from folder shape alone") {
+            audioLibrary {
+                book("Sanderson/Stormlight/The Way of Kings") {
+                    tracks(count = 2)
+                }
+            }.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val candidate =
+                        candidateOf(
+                            "Sanderson/Stormlight/The Way of Kings",
+                            files =
+                                listOf(
+                                    fileEntry("Sanderson/Stormlight/The Way of Kings/01 - Track.mp3", FileType.AUDIO),
+                                    fileEntry("Sanderson/Stormlight/The Way of Kings/02 - Track.mp3", FileType.AUDIO),
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldBe "The Way of Kings"
+                    book.authors shouldContainExactly listOf("Sanderson")
+                    book.series shouldContainExactly listOf(SeriesEntry("Stormlight"))
+                    book.tracks.size shouldBe 2
+                    book.sources shouldBe setOf(MetadataSource.FOLDER_STRUCTURE)
+                }
+            }
+        }
+
+        test("extracts ASIN, narrators, year, sequence from title-folder annotations") {
+            audioLibrary {
+                book("Sanderson/Stormlight/(2010) - Book 1 - The Way of Kings [B0015T963C] {Michael Kramer; Kate Reading}") {
+                    tracks(count = 1)
+                }
+            }.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Sanderson/Stormlight/(2010) - Book 1 - The Way of Kings [B0015T963C] {Michael Kramer; Kate Reading}"
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files = listOf(fileEntry("$rel/01 - Track.mp3", FileType.AUDIO)),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldBe "The Way of Kings"
+                    book.asin shouldBe "B0015T963C"
+                    book.narrators shouldContainExactly listOf("Michael Kramer", "Kate Reading")
+                    book.publishedYear shouldBe 2010
+                    book.series shouldContainExactly listOf(SeriesEntry("Stormlight", "1"))
+                    book.sources shouldBe setOf(MetadataSource.FOLDER_STRUCTURE, MetadataSource.FILENAME)
+                }
+            }
+        }
+
+        test("metadata.json overrides folder-derived fields") {
+            audioLibrary {
+                book("Sanderson/Stormlight/Folder Title") {
+                    tracks(count = 1)
+                    metadataJson(
+                        """
+                        {
+                          "title": "Override Title",
+                          "subtitle": "From Sidecar",
+                          "authors": ["Brandon Sanderson"],
+                          "narrators": ["Michael Kramer"],
+                          "series": ["Stormlight Archive #1"],
+                          "publishedYear": 2010,
+                          "asin": "B0015T963C",
+                          "isbn": "9780765326355",
+                          "description": "Epic fantasy.",
+                          "publisher": "Tor Books",
+                          "language": "English",
+                          "genres": ["Fantasy"],
+                          "tags": ["epic"],
+                          "abridged": false,
+                          "explicit": false
+                        }
+                        """.trimIndent(),
+                    )
+                }
+            }.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Sanderson/Stormlight/Folder Title"
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files =
+                                listOf(
+                                    fileEntry("$rel/01 - Track.mp3", FileType.AUDIO),
+                                    fileEntry("$rel/metadata.json", FileType.METADATA),
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldBe "Override Title"
+                    book.subtitle shouldBe "From Sidecar"
+                    book.authors shouldContainExactly listOf("Brandon Sanderson")
+                    book.narrators shouldContainExactly listOf("Michael Kramer")
+                    book.series shouldContainExactly listOf(SeriesEntry("Stormlight Archive", "1"))
+                    book.publishedYear shouldBe 2010
+                    book.asin shouldBe "B0015T963C"
+                    book.isbn shouldBe "9780765326355"
+                    book.description shouldBe "Epic fantasy."
+                    book.publisher shouldBe "Tor Books"
+                    book.language shouldBe "English"
+                    book.genres shouldContainExactly listOf("Fantasy")
+                    book.tags shouldContainExactly listOf("epic")
+                    book.abridged shouldBe false
+                    book.explicit shouldBe false
+                    book.sources shouldBe setOf(MetadataSource.FOLDER_STRUCTURE, MetadataSource.ABS_METADATA)
+                }
+            }
+        }
+
+        test("falls back to folder-derived values when metadata.json is malformed") {
+            audioLibrary {
+                book("Author/Title") {
+                    tracks(count = 1)
+                    metadataJson("{not valid json", name = "metadata.json")
+                }
+            }.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val candidate =
+                        candidateOf(
+                            "Author/Title",
+                            files =
+                                listOf(
+                                    fileEntry("Author/Title/01 - Track.mp3", FileType.AUDIO),
+                                    fileEntry("Author/Title/metadata.json", FileType.METADATA),
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldBe "Title"
+                    book.authors shouldContainExactly listOf("Author")
+                    book.sources shouldBe setOf(MetadataSource.FOLDER_STRUCTURE)
+                }
+            }
+        }
+
+        test("picks cover.<ext> over other images") {
+            audioLibrary { /* paths only — no real files needed for this case */ }.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Author/Title"
+                    val firstImage = fileEntry("$rel/folder.png", FileType.IMAGE)
+                    val cover = fileEntry("$rel/cover.jpg", FileType.IMAGE)
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files =
+                                listOf(
+                                    firstImage,
+                                    fileEntry("$rel/01 - Track.mp3", FileType.AUDIO),
+                                    cover,
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.cover shouldBe cover
+                }
+            }
+        }
+
+        test("falls back to first image when no cover.<ext> is present") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Author/Title"
+                    val firstImage = fileEntry("$rel/folder.png", FileType.IMAGE)
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files =
+                                listOf(
+                                    firstImage,
+                                    fileEntry("$rel/01 - Track.mp3", FileType.AUDIO),
+                                    fileEntry("$rel/back.jpg", FileType.IMAGE),
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.cover shouldBe firstImage
+                }
+            }
+        }
+
+        test("emits null cover when there are no images") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Author/Title"
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files = listOf(fileEntry("$rel/01 - Track.mp3", FileType.AUDIO)),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.cover.shouldBeNull()
+                }
+            }
+        }
+
+        test("sorts tracks by disc then track number") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Author/Title"
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            isFile = false,
+                            discFolders = listOf("CD1", "CD2"),
+                            files =
+                                listOf(
+                                    // Walker would have surfaced these in arbitrary order;
+                                    // the Analyzer sorts them.
+                                    fileEntry("$rel/CD2/02.mp3", FileType.AUDIO),
+                                    fileEntry("$rel/CD1/02.mp3", FileType.AUDIO),
+                                    fileEntry("$rel/CD2/01.mp3", FileType.AUDIO),
+                                    fileEntry("$rel/CD1/01.mp3", FileType.AUDIO),
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.tracks.map { it.file.relPath } shouldContainExactly
+                        listOf(
+                            "$rel/CD1/01.mp3",
+                            "$rel/CD1/02.mp3",
+                            "$rel/CD2/01.mp3",
+                            "$rel/CD2/02.mp3",
+                        )
+                    book.tracks.first().discNumber shouldBe 1
+                    book.tracks.first().trackNumber shouldBe 1
+                    book.tracks.first().discSource shouldBe TrackNumberSource.FOLDER
+                }
+            }
+        }
+
+        test("title falls back to titleFolder when ABS regex strips everything") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    // Just an ASIN bracket, nothing else — parsed.title would be empty.
+                    val rel = "Author/[B0015T963C]"
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files = listOf(fileEntry("$rel/01.mp3", FileType.AUDIO)),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    // Title should never be blank.
+                    book.title.isNotBlank() shouldBe true
+                    book.asin shouldBe "B0015T963C"
+                }
+            }
+        }
+
+        test("single-file book at library root is analyzed without crashing") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val candidate =
+                        candidateOf(
+                            "standalone.m4b",
+                            isFile = true,
+                            files = listOf(fileEntry("standalone.m4b", FileType.AUDIO)),
+                        )
+                    val result = analyzer.analyze(flowOf(candidate)).toList().single()
+
+                    val book = result.getOrThrow()
+                    book.title.isNotBlank() shouldBe true
+                    book.tracks.size shouldBe 1
+                }
+            }
+        }
+
+        test("analyzer continues across multiple candidates") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val a =
+                        candidateOf(
+                            "Author/Book A",
+                            files = listOf(fileEntry("Author/Book A/01.mp3", FileType.AUDIO)),
+                        )
+                    val b =
+                        candidateOf(
+                            "Author/Book B",
+                            files = listOf(fileEntry("Author/Book B/01.mp3", FileType.AUDIO)),
+                        )
+                    val books = analyzer.analyze(flowOf(a, b)).toList().map { it.getOrThrow() }
+
+                    books.map { it.title } shouldContainExactly listOf("Book A", "Book B")
+                }
+            }
+        }
+
+        test("read returns the live cover FileEntry, not a copy") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val analyzer = Analyzer(fixture.root, metadataReader)
+                    val rel = "Author/Title"
+                    val cover = fileEntry("$rel/cover.jpg", FileType.IMAGE)
+                    val candidate =
+                        candidateOf(
+                            rel,
+                            files =
+                                listOf(
+                                    cover,
+                                    fileEntry("$rel/01.mp3", FileType.AUDIO),
+                                ),
+                        )
+                    val book =
+                        analyzer
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.cover.shouldNotBeNull()
+                    book.cover shouldBe cover
+                }
+            }
+        }
+    })
+
+private fun candidateOf(
+    rootRelPath: String,
+    files: List<FileEntry>,
+    isFile: Boolean = false,
+    discFolders: List<String> = emptyList(),
+): CandidateBook =
+    CandidateBook(
+        rootRelPath = rootRelPath,
+        isFile = isFile,
+        files = files,
+        discFolders = discFolders,
+    )
+
+private fun fileEntry(
+    relPath: String,
+    fileType: FileType,
+): FileEntry =
+    FileEntry(
+        relPath = relPath,
+        name = relPath.substringAfterLast('/'),
+        ext = relPath.substringAfterLast('.', "").lowercase(),
+        size = 0,
+        mtimeMs = 0,
+        inode = null,
+        fileType = fileType,
+    )

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/DifferTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/DifferTest.kt
@@ -1,0 +1,193 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+
+class DifferTest :
+    FunSpec({
+
+        val differ = Differ()
+
+        test("first scan emits Added for every current book") {
+            runTest {
+                val a = book("Author/Title-A", inode = 1)
+                val b = book("Author/Title-B", inode = 2)
+                val events = differ.diff(listOf(a, b).asFlow(), previous = emptyList()).toList()
+
+                events.size shouldBe 2
+                events.all { it is ChangeEventDto.Added } shouldBe true
+                events.map { (it as ChangeEventDto.Added).book.candidate.rootRelPath } shouldContainExactly
+                    listOf("Author/Title-A", "Author/Title-B")
+            }
+        }
+
+        test("identical scans emit no events") {
+            runTest {
+                val a = book("Author/Title", inode = 1)
+                val events = differ.diff(listOf(a).asFlow(), previous = listOf(a)).toList()
+                events shouldBe emptyList()
+            }
+        }
+
+        test("removed books emit Removed after current flow is exhausted") {
+            runTest {
+                val a = book("Author/Title-A", inode = 1)
+                val b = book("Author/Title-B", inode = 2)
+                val events = differ.diff(listOf(a).asFlow(), previous = listOf(a, b)).toList()
+
+                events.size shouldBe 1
+                events.single().shouldBeInstanceOf<ChangeEventDto.Removed>()
+                (events.single() as ChangeEventDto.Removed).rootRelPath shouldBe "Author/Title-B"
+            }
+        }
+
+        test("a content change at the same path emits Modified") {
+            runTest {
+                val before = book("Author/Title", inode = 1, trackCount = 3)
+                val after = book("Author/Title", inode = 1, trackCount = 4)
+                val events = differ.diff(listOf(after).asFlow(), previous = listOf(before)).toList()
+
+                events.size shouldBe 1
+                val mod = events.single().shouldBeInstanceOf<ChangeEventDto.Modified>()
+                mod.book.candidate.rootRelPath shouldBe "Author/Title"
+                mod.previousRootRelPath shouldBe "Author/Title"
+                mod.book.candidate.files.size shouldBe 4
+            }
+        }
+
+        test("a folder rename with stable inode emits Moved (not Removed + Added)") {
+            runTest {
+                val before = book("Author/Old Title", inode = 42)
+                val after = book("Author/New Title", inode = 42)
+                val events = differ.diff(listOf(after).asFlow(), previous = listOf(before)).toList()
+
+                events.size shouldBe 1
+                val moved = events.single().shouldBeInstanceOf<ChangeEventDto.Moved>()
+                moved.from shouldBe "Author/Old Title"
+                moved.to shouldBe "Author/New Title"
+                moved.book.candidate.rootRelPath shouldBe "Author/New Title"
+            }
+        }
+
+        test("a folder rename without inode degrades to Removed + Added") {
+            runTest {
+                val before = book("Author/Old Title", inode = null)
+                val after = book("Author/New Title", inode = null)
+                val events = differ.diff(listOf(after).asFlow(), previous = listOf(before)).toList()
+
+                events.size shouldBe 2
+                events.map { it::class.simpleName } shouldContainExactlyInAnyOrder
+                    listOf("Added", "Removed")
+            }
+        }
+
+        test("mixed Add + Modify + Remove in a single scan") {
+            runTest {
+                val unchanged = book("Author/Stays The Same", inode = 1)
+                val modifiedBefore = book("Author/Gets Modified", inode = 2, trackCount = 1)
+                val modifiedAfter = book("Author/Gets Modified", inode = 2, trackCount = 2)
+                val removed = book("Author/Disappears", inode = 3)
+                val added = book("Author/Newly Appears", inode = 4)
+
+                val events =
+                    differ
+                        .diff(
+                            current = listOf(unchanged, modifiedAfter, added).asFlow(),
+                            previous = listOf(unchanged, modifiedBefore, removed),
+                        ).toList()
+
+                events.map { it::class.simpleName } shouldContainExactlyInAnyOrder
+                    listOf("Modified", "Added", "Removed")
+            }
+        }
+
+        test("inode match wins over Removed when files are present in current") {
+            runTest {
+                // The book moved AND added a new file. Should emit Moved (with the
+                // updated content), not Removed+Added.
+                val before = book("Author/Old Title", inode = 7, trackCount = 2)
+                val after = book("Author/New Title", inode = 7, trackCount = 3)
+                val events = differ.diff(listOf(after).asFlow(), previous = listOf(before)).toList()
+
+                val moved = events.single().shouldBeInstanceOf<ChangeEventDto.Moved>()
+                moved.from shouldBe "Author/Old Title"
+                moved.to shouldBe "Author/New Title"
+                moved.book.candidate.files.size shouldBe 3
+            }
+        }
+
+        test("books with no audio files cannot be moved by inode") {
+            runTest {
+                // Only image files; no audio inode index entry.
+                val before = analyzedBook("Author/A", files = listOf(image("Author/A/cover.jpg", inode = 1)))
+                val after = analyzedBook("Author/B", files = listOf(image("Author/B/cover.jpg", inode = 1)))
+                val events = differ.diff(listOf(after).asFlow(), previous = listOf(before)).toList()
+
+                // Image inodes don't participate in move detection — degrades to Add+Remove.
+                events.map { it::class.simpleName } shouldContainExactlyInAnyOrder
+                    listOf("Added", "Removed")
+            }
+        }
+    })
+
+private fun book(
+    rootRelPath: String,
+    inode: Long?,
+    trackCount: Int = 1,
+): AnalyzedBook {
+    val files =
+        (1..trackCount).map { i ->
+            FileEntry(
+                relPath = "$rootRelPath/%02d.mp3".format(i),
+                name = "%02d.mp3".format(i),
+                ext = "mp3",
+                size = 0,
+                mtimeMs = 0,
+                // Use the same base inode for every track in a book so the test is
+                // deterministic; offsets prevent collisions between books.
+                inode = inode?.let { it * 100 + i },
+                fileType = FileType.AUDIO,
+            )
+        }
+    return analyzedBook(rootRelPath, files)
+}
+
+private fun image(
+    relPath: String,
+    inode: Long?,
+): FileEntry =
+    FileEntry(
+        relPath = relPath,
+        name = relPath.substringAfterLast('/'),
+        ext = relPath.substringAfterLast('.', "").lowercase(),
+        size = 0,
+        mtimeMs = 0,
+        inode = inode,
+        fileType = FileType.IMAGE,
+    )
+
+private fun analyzedBook(
+    rootRelPath: String,
+    files: List<FileEntry>,
+): AnalyzedBook =
+    AnalyzedBook(
+        candidate =
+            CandidateBook(
+                rootRelPath = rootRelPath,
+                isFile = false,
+                files = files,
+            ),
+        title = rootRelPath.substringAfterLast('/'),
+        tracks = emptyList(),
+    )

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/GrouperTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/GrouperTest.kt
@@ -1,0 +1,182 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+
+class GrouperTest :
+    FunSpec({
+
+        val grouper = Grouper()
+
+        test("groups files in a single book directory") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Author/Title/01.mp3", FileType.AUDIO),
+                        entry("Author/Title/02.mp3", FileType.AUDIO),
+                        entry("Author/Title/cover.jpg", FileType.IMAGE),
+                    )
+                val books = grouper.group(files.asFlow()).toList()
+                books shouldContainExactly
+                    listOf(
+                        CandidateBook(
+                            rootRelPath = "Author/Title",
+                            isFile = false,
+                            files = files,
+                            discFolders = emptyList(),
+                        ),
+                    )
+            }
+        }
+
+        test("groups files in author/series/title layout") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Sanderson/Stormlight/Way of Kings/01.mp3", FileType.AUDIO),
+                        entry("Sanderson/Stormlight/Way of Kings/02.mp3", FileType.AUDIO),
+                    )
+                val book = grouper.group(files.asFlow()).toList().single()
+                book.rootRelPath shouldBe "Sanderson/Stormlight/Way of Kings"
+                book.files shouldContainExactly files
+            }
+        }
+
+        test("collapses multi-disc subdirectories into the parent book") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Author/Title/CD1/01.mp3", FileType.AUDIO),
+                        entry("Author/Title/CD1/02.mp3", FileType.AUDIO),
+                        entry("Author/Title/CD2/01.mp3", FileType.AUDIO),
+                        entry("Author/Title/cover.jpg", FileType.IMAGE),
+                    )
+                val book = grouper.group(files.asFlow()).toList().single()
+                book.rootRelPath shouldBe "Author/Title"
+                book.files shouldContainExactlyInAnyOrder files
+                book.discFolders shouldContainExactly listOf("CD1", "CD2")
+            }
+        }
+
+        test("recognises CD/Disc/Disk variants case-insensitively") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Title/cd1/01.mp3", FileType.AUDIO),
+                        entry("Title/Disc 2/01.mp3", FileType.AUDIO),
+                        entry("Title/disk 3/01.mp3", FileType.AUDIO),
+                        entry("Title/DISC 99/01.mp3", FileType.AUDIO),
+                    )
+                val book = grouper.group(files.asFlow()).toList().single()
+                book.rootRelPath shouldBe "Title"
+                book.discFolders shouldContainExactly listOf("DISC 99", "Disc 2", "cd1", "disk 3")
+            }
+        }
+
+        test("does NOT roll up folders that look disc-like but exceed the digit cap") {
+            runTest {
+                // 4-digit numeric — outside ABS's 1-3 digit window. Treat as a
+                // regular folder (book root = the "CD1234" folder itself).
+                val files = listOf(entry("Author/CD1234/01.mp3", FileType.AUDIO))
+                val book = grouper.group(files.asFlow()).toList().single()
+                book.rootRelPath shouldBe "Author/CD1234"
+                book.discFolders shouldBe emptyList()
+            }
+        }
+
+        test("emits a single-file book when audio sits at the library root") {
+            runTest {
+                val files = listOf(entry("standalone.m4b", FileType.AUDIO))
+                val book = grouper.group(files.asFlow()).toList().single()
+                book.rootRelPath shouldBe "standalone.m4b"
+                book.isFile shouldBe true
+                book.files shouldContainExactly files
+            }
+        }
+
+        test("emits multiple single-file books when several audio files sit at root") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("a.m4b", FileType.AUDIO),
+                        entry("b.mp3", FileType.AUDIO),
+                    )
+                val books = grouper.group(files.asFlow()).toList()
+                books.size shouldBe 2
+                books.all { it.isFile } shouldBe true
+                books.map { it.rootRelPath } shouldContainExactlyInAnyOrder listOf("a.m4b", "b.mp3")
+            }
+        }
+
+        test("drops non-audio files at the library root (orphans)") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("orphan.jpg", FileType.IMAGE),
+                        entry("orphan.json", FileType.METADATA),
+                    )
+                grouper.group(files.asFlow()).toList() shouldBe emptyList()
+            }
+        }
+
+        test("emits two books for two adjacent title folders under one author") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Author/Title-A/01.mp3", FileType.AUDIO),
+                        entry("Author/Title-B/01.mp3", FileType.AUDIO),
+                    )
+                val books = grouper.group(files.asFlow()).toList()
+                books.map { it.rootRelPath } shouldContainExactly listOf("Author/Title-A", "Author/Title-B")
+            }
+        }
+
+        test("preserves first-seen order of book roots") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Z-author/01.mp3", FileType.AUDIO),
+                        entry("A-author/01.mp3", FileType.AUDIO),
+                        entry("M-author/01.mp3", FileType.AUDIO),
+                    )
+                val books = grouper.group(files.asFlow()).toList()
+                books.map { it.rootRelPath } shouldContainExactly listOf("Z-author", "A-author", "M-author")
+            }
+        }
+
+        test("collects audio + image + metadata files into one book") {
+            runTest {
+                val files =
+                    listOf(
+                        entry("Title/01.mp3", FileType.AUDIO),
+                        entry("Title/cover.jpg", FileType.IMAGE),
+                        entry("Title/metadata.json", FileType.METADATA),
+                        entry("Title/desc.txt", FileType.TEXT),
+                    )
+                val book = grouper.group(files.asFlow()).toList().single()
+                book.files shouldContainExactly files
+            }
+        }
+    })
+
+private fun entry(
+    relPath: String,
+    fileType: FileType,
+): FileEntry =
+    FileEntry(
+        relPath = relPath,
+        name = relPath.substringAfterLast('/'),
+        ext = relPath.substringAfterLast('.', "").lowercase(),
+        size = 0,
+        mtimeMs = 0,
+        inode = null,
+        fileType = fileType,
+    )

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/WalkerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/WalkerTest.kt
@@ -1,0 +1,156 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.server.scanner.audioLibrary
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import java.nio.file.Path
+
+class WalkerTest :
+    FunSpec({
+
+        val walker = Walker()
+
+        test("emits every file in a flat directory") {
+            audioLibrary {
+                audio("track-01.mp3")
+                audio("track-02.mp3")
+                image("cover.jpg")
+            }.use { fixture ->
+                runTest {
+                    val entries = walker.walk(fixture.root).toList()
+                    entries.map { it.relPath } shouldContainExactlyInAnyOrder
+                        listOf("track-01.mp3", "track-02.mp3", "cover.jpg")
+                }
+            }
+        }
+
+        test("descends into nested directories and uses POSIX separators in relPath") {
+            audioLibrary {
+                book("Author/Series/Title") {
+                    tracks(count = 2)
+                    cover()
+                }
+            }.use { fixture ->
+                runTest {
+                    val entries = walker.walk(fixture.root).toList()
+                    val paths = entries.map { it.relPath }
+                    paths shouldContainAll
+                        listOf(
+                            "Author/Series/Title/01 - Track.mp3",
+                            "Author/Series/Title/02 - Track.mp3",
+                            "Author/Series/Title/cover.jpg",
+                        )
+                    withClue("relPath must use POSIX separators on every OS") {
+                        paths.forEach { it shouldBe it.replace('\\', '/') }
+                    }
+                }
+            }
+        }
+
+        test("skips dotfiles, temp extensions, and .ignore-marked subtrees") {
+            audioLibrary {
+                audio("real-track.mp3")
+                raw(".DS_Store") // dotfile
+                audio("download.mp3.part") // temp ext
+                ignore("HiddenAuthor") // creates HiddenAuthor/.ignore
+                audio("HiddenAuthor/buried.mp3") // should be skipped
+            }.use { fixture ->
+                runTest {
+                    val entries = walker.walk(fixture.root).toList()
+                    val paths = entries.map { it.relPath }
+
+                    paths shouldContain "real-track.mp3"
+                    paths shouldNotContain ".DS_Store"
+                    paths shouldNotContain "download.mp3.part"
+                    paths shouldNotContain "HiddenAuthor/buried.mp3"
+                }
+            }
+        }
+
+        test("does not follow symlinks (cycles cannot crash the walk)") {
+            audioLibrary {
+                audio("real-track.mp3")
+            }.use { fixture ->
+                // Create a symlink loop: <root>/loop -> <root>
+                val loop = fixture.root.resolve("loop")
+                runCatching { Files.createSymbolicLink(loop, fixture.root) }
+                    .getOrElse { return@use }
+                runTest {
+                    val entries = walker.walk(fixture.root).toList()
+                    entries.map { it.relPath } shouldContain "real-track.mp3"
+                    // The symlink itself isn't followed; if visitFile reports it,
+                    // it'd appear as `loop` with no extension — UNKNOWN type.
+                    entries.none { it.relPath.startsWith("loop/") } shouldBe true
+                }
+            }
+        }
+
+        test("captures inode on POSIX filesystems") {
+            audioLibrary {
+                audio("track.mp3")
+            }.use { fixture ->
+                runTest {
+                    val entry = walker.walk(fixture.root).toList().single()
+                    if (System.getProperty("os.name").lowercase().contains("windows")) {
+                        // Windows default filesystem doesn't expose fileKey.
+                        entry.inode.shouldBeNull()
+                    } else {
+                        entry.inode.shouldNotBeNull()
+                    }
+                }
+            }
+        }
+
+        test("classifies files by extension") {
+            audioLibrary {
+                audio("track.mp3")
+                image("cover.png")
+                raw("metadata.json", contents = "{}")
+                raw("desc.txt", contents = "")
+                raw("README", contents = "")
+            }.use { fixture ->
+                runTest {
+                    val byName = walker.walk(fixture.root).toList().associateBy { it.name }
+                    byName.getValue("track.mp3").fileType shouldBe FileType.AUDIO
+                    byName.getValue("cover.png").fileType shouldBe FileType.IMAGE
+                    byName.getValue("metadata.json").fileType shouldBe FileType.METADATA
+                    byName.getValue("desc.txt").fileType shouldBe FileType.TEXT
+                    byName.getValue("README").fileType shouldBe FileType.UNKNOWN
+                }
+            }
+        }
+
+        test("returns empty flow when root is not a directory") {
+            runTest {
+                val notADir: Path = Files.createTempFile("listenup-not-a-dir-", ".txt")
+                try {
+                    walker.walk(notADir).toList() shouldBe emptyList()
+                } finally {
+                    Files.deleteIfExists(notADir)
+                }
+            }
+        }
+
+        test("captures size and mtime") {
+            audioLibrary {
+                audio("track.mp3", sizeBytes = 1024L)
+            }.use { fixture ->
+                runTest {
+                    val entry = walker.walk(fixture.root).toList().single()
+                    entry.size shouldBe 1024L
+                    (entry.mtimeMs > 0L) shouldBe true
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcherTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcherTest.kt
@@ -1,0 +1,161 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import app.cash.turbine.test
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.io.path.writeBytes
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Linux-flavored integration tests for FolderWatcher. CI runs on Linux so
+ * these exercise inotify; on macOS the same tests should pass against
+ * FSEvents but verifying that is a developer-machine task. The debouncer
+ * uses short settle/poll values (50 ms / 25 ms) to keep wall-clock cost
+ * per test under a second.
+ *
+ * **Test pattern:** the directory tree is created BEFORE the watcher is
+ * started, so the initial walk-and-register picks up every directory.
+ * Tests then write/modify files in the existing tree to trigger events.
+ * This sidesteps the inherent race between "newly-created directory" and
+ * "kfswatch finishes adding inotify watch on it".
+ */
+class FolderWatcherTest :
+    FunSpec({
+
+        val isLinux = System.getProperty("os.name").lowercase().contains("linux")
+
+        if (!isLinux) {
+            test("FolderWatcher integration tests are Linux-only — skipping suite") { /* no-op */ }
+        } else {
+            test("emits the book root after a file is created in a watched directory") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-watcher-")
+                    val bookDir = (tmp / "Author/Title").apply { createDirectories() }
+                    try {
+                        withWatcher(tmp) { watcher ->
+                            watcher.events.test(timeout = 5.seconds) {
+                                (bookDir / "track.mp3").writeBytes(byteArrayOf(1, 2, 3))
+                                awaitItem() shouldBe bookDir
+                                cancelAndIgnoreRemainingEvents()
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("multi-disc subdirectory emits the parent book root, not the disc folder") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-watcher-")
+                    val bookDir = (tmp / "Author/Multi-Disc Book").apply { createDirectories() }
+                    val cd1 = (bookDir / "CD1").apply { createDirectories() }
+                    try {
+                        withWatcher(tmp) { watcher ->
+                            watcher.events.test(timeout = 5.seconds) {
+                                (cd1 / "track.mp3").writeBytes(byteArrayOf(1, 2, 3))
+                                awaitItem() shouldBe bookDir
+                                cancelAndIgnoreRemainingEvents()
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("rapid bursts on the same book root coalesce to a single emission") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-watcher-")
+                    val bookDir = (tmp / "Author/Burst Book").apply { createDirectories() }
+                    try {
+                        withWatcher(tmp) { watcher ->
+                            val emissions = mutableListOf<Path>()
+                            val collectorJob =
+                                launch(start = CoroutineStart.UNDISPATCHED) {
+                                    watcher.events.collect { emissions.add(it) }
+                                }
+
+                            // Write 20 files in rapid succession. Per-book
+                            // coalescing should produce exactly one emission.
+                            repeat(20) { i ->
+                                (bookDir / "track-%02d.mp3".format(i)).writeBytes(byteArrayOf(i.toByte()))
+                            }
+
+                            delay(400) // settle window + buffer for all 20 writes
+                            collectorJob.cancel()
+
+                            withClue("emissions: $emissions") {
+                                emissions.count { it == bookDir } shouldBe 1
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("dotfiles do not trigger emissions") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-watcher-")
+                    val bookDir = (tmp / "Author/Title").apply { createDirectories() }
+                    try {
+                        withWatcher(tmp) { watcher ->
+                            val emissions = mutableListOf<Path>()
+                            val collectorJob =
+                                launch(start = CoroutineStart.UNDISPATCHED) {
+                                    watcher.events.collect { emissions.add(it) }
+                                }
+
+                            (bookDir / ".DS_Store").writeBytes(byteArrayOf(0))
+                            delay(150)
+
+                            withClue("dotfile must not produce any emission. emissions: $emissions") {
+                                emissions.size shouldBe 0
+                            }
+
+                            collectorJob.cancel()
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+        }
+    })
+
+private suspend fun withWatcher(
+    libraryRoot: Path,
+    block: suspend (FolderWatcher) -> Unit,
+) {
+    val supervisor = SupervisorJob()
+    val scope = CoroutineScope(supervisor + Dispatchers.Default)
+    val watcher =
+        FolderWatcher(
+            libraryRoot = libraryRoot,
+            scope = scope,
+            debouncer = StableSizeDebouncer(settle = 50.milliseconds, poll = 25.milliseconds),
+        )
+    try {
+        watcher.start()
+        delay(150) // give inotify time to attach watches across the tree
+        block(watcher)
+    } finally {
+        watcher.close()
+        scope.cancel()
+    }
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncerTest.kt
@@ -1,0 +1,155 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.io.path.div
+import kotlin.io.path.writeBytes
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class StableSizeDebouncerTest :
+    FunSpec({
+
+        // ---- Pure state-machine tests (no I/O, no coroutines) ----
+
+        test("first tick captures state and returns Continue") {
+            val tick = SettleWindow.initial().tick(size = 100, mtime = 1000, now = 0, settleMs = 2_000)
+            val cont = tick.shouldBeInstanceOf<TickResult.Continue>()
+            cont.next.lastSize shouldBe 100
+            cont.next.lastMtime shouldBe 1000
+            cont.next.stableSince shouldBe 0
+        }
+
+        test("Stable when size+mtime unchanged for the full settle window") {
+            val s0 =
+                SettleWindow
+                    .initial()
+                    .tick(100, 1000, now = 0, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            val s1 =
+                s0
+                    .tick(100, 1000, now = 1_000, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            s1.tick(100, 1000, now = 2_000, settleMs = 2_000) shouldBe TickResult.Stable
+        }
+
+        test("size change resets the settle window") {
+            val s0 =
+                SettleWindow
+                    .initial()
+                    .tick(100, 1000, now = 0, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            val s1 =
+                s0
+                    .tick(100, 1000, now = 1_000, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+
+            // File grows mid-wait — stableSince resets to the new "now."
+            val s2 =
+                s1
+                    .tick(200, 1500, now = 1_500, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            s2.lastSize shouldBe 200
+            s2.stableSince shouldBe 1_500
+
+            // Need another full settle window from the change.
+            s2.tick(200, 1500, now = 3_499, settleMs = 2_000).shouldBeInstanceOf<TickResult.Continue>()
+            s2.tick(200, 1500, now = 3_500, settleMs = 2_000) shouldBe TickResult.Stable
+        }
+
+        test("mtime change resets even when size is the same") {
+            val s0 =
+                SettleWindow
+                    .initial()
+                    .tick(100, 1000, now = 0, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            val s1 =
+                s0
+                    .tick(100, 2000, now = 1_500, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            s1.lastMtime shouldBe 2000
+            s1.stableSince shouldBe 1_500
+        }
+
+        test("settle boundary is inclusive at exactly settleMs") {
+            val s0 =
+                SettleWindow
+                    .initial()
+                    .tick(100, 1000, now = 0, settleMs = 2_000)
+                    .shouldBeInstanceOf<TickResult.Continue>()
+                    .next
+            // Exactly at the boundary.
+            s0.tick(100, 1000, now = 2_000, settleMs = 2_000) shouldBe TickResult.Stable
+        }
+
+        // ---- I/O-driven tests against the real filesystem ----
+        // These use real wall-clock with short settle so they're fast (~250 ms).
+
+        test("awaitStable returns true for a file that has been steady through the settle window") {
+            runBlocking {
+                val tmp = Files.createTempDirectory("listenup-stable-")
+                val file = tmp / "track.mp3"
+                file.writeBytes(byteArrayOf(1, 2, 3))
+                try {
+                    val debouncer =
+                        StableSizeDebouncer(
+                            settle = 200.milliseconds,
+                            poll = 50.milliseconds,
+                        )
+                    debouncer.awaitStable(file) shouldBe true
+                } finally {
+                    Files.deleteIfExists(file)
+                    Files.deleteIfExists(tmp)
+                }
+            }
+        }
+
+        test("awaitStable returns false when the file does not exist") {
+            runBlocking {
+                val tmp = Files.createTempDirectory("listenup-stable-")
+                try {
+                    val debouncer = StableSizeDebouncer(settle = 100.milliseconds, poll = 50.milliseconds)
+                    debouncer.awaitStable(tmp / "missing.mp3") shouldBe false
+                } finally {
+                    Files.deleteIfExists(tmp)
+                }
+            }
+        }
+
+        test("awaitStable returns false when the file is deleted mid-wait") {
+            runBlocking {
+                val tmp = Files.createTempDirectory("listenup-stable-")
+                val file = tmp / "track.mp3"
+                file.writeBytes(byteArrayOf(1, 2, 3))
+                try {
+                    val debouncer =
+                        StableSizeDebouncer(
+                            settle = 5.seconds, // long enough that we can delete first
+                            poll = 50.milliseconds,
+                        )
+                    val task =
+                        async(start = CoroutineStart.UNDISPATCHED) {
+                            debouncer.awaitStable(file)
+                        }
+                    // Delete after at least one poll cycle so the debouncer notices the disappearance.
+                    kotlinx.coroutines.delay(80)
+                    Files.deleteIfExists(file)
+                    task.await() shouldBe false
+                } finally {
+                    Files.deleteIfExists(tmp)
+                }
+            }
+        }
+    })

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/ScannerService.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/ScannerService.kt
@@ -1,0 +1,33 @@
+package com.calypsan.listenup.api
+
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.result.AppResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.rpc.annotations.Rpc
+
+/**
+ * Public scanner contract. Mounted at `/api/rpc/public` (no auth wall in
+ * Phase 2; admin-gating lands when the auth surface gets a role check in
+ * Phase 4).
+ *
+ * `observeProgress()` is a server-pushed [Flow] of [ScanEvent] —
+ * kotlinx.rpc opens a dedicated WebSocket frame stream for it. Multiple
+ * clients can subscribe simultaneously and they all see the same events
+ * (the scanner's event bus is a broadcast `SharedFlow`).
+ *
+ *  - `scanFull()` returns immediately with `Failure(AlreadyRunning)` if a
+ *    scan is in flight.
+ *  - `lastScanResult()` returns the most-recent completed scan's full
+ *    result — including the books list — for read-after-scan flows that
+ *    don't want to subscribe.
+ */
+@Rpc
+interface ScannerService {
+    suspend fun scanFull(): AppResult<ScanResultSummary>
+
+    suspend fun lastScanResult(): AppResult<ScanResult>
+
+    fun observeProgress(): Flow<ScanEvent>
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
@@ -1,0 +1,38 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The Analyzer's output: a [CandidateBook] enriched with everything we can
+ * infer from path components, filename annotations, and `metadata.json`.
+ *
+ * Phase 2 fills in path-derived fields (title/authors/series/sequence/
+ * narrators/asin/year) plus whatever an `metadata.json` overlay supplies.
+ * Phase 3 (audiometa Kotlin port) fills in embedded-tag fields without
+ * changing the shape — every embedded-only field is already nullable here.
+ *
+ * `sources` records the [MetadataSource]s that contributed at least one
+ * field, so consumers can debug precedence.
+ */
+@Serializable
+data class AnalyzedBook(
+    val candidate: CandidateBook,
+    val title: String,
+    val subtitle: String? = null,
+    val authors: List<String> = emptyList(),
+    val narrators: List<String> = emptyList(),
+    val series: List<SeriesEntry> = emptyList(),
+    val publishedYear: Int? = null,
+    val asin: String? = null,
+    val isbn: String? = null,
+    val description: String? = null,
+    val publisher: String? = null,
+    val language: String? = null,
+    val genres: List<String> = emptyList(),
+    val tags: List<String> = emptyList(),
+    val abridged: Boolean? = null,
+    val explicit: Boolean? = null,
+    val cover: FileEntry? = null,
+    val tracks: List<TrackEntry> = emptyList(),
+    val sources: Set<MetadataSource> = emptySet(),
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/CandidateBook.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/CandidateBook.kt
@@ -1,0 +1,20 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The Grouper's output: a set of files that belong to one logical book,
+ * before any metadata inference has run.
+ *
+ *  - `rootRelPath` is the relative directory (or single file path, when
+ *    `isFile = true`) that anchors the book.
+ *  - `discFolders` lists the matched `CD1/`, `Disc 2/` subdirectories
+ *    that were collapsed into this book — empty for non-multi-disc layouts.
+ */
+@Serializable
+data class CandidateBook(
+    val rootRelPath: String,
+    val isFile: Boolean,
+    val files: List<FileEntry>,
+    val discFolders: List<String> = emptyList(),
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ChangeEventDto.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ChangeEventDto.kt
@@ -12,7 +12,9 @@ import kotlinx.serialization.Serializable
 sealed interface ChangeEventDto {
     @Serializable
     @SerialName("added")
-    data class Added(val book: AnalyzedBook) : ChangeEventDto
+    data class Added(
+        val book: AnalyzedBook,
+    ) : ChangeEventDto
 
     @Serializable
     @SerialName("modified")
@@ -23,7 +25,9 @@ sealed interface ChangeEventDto {
 
     @Serializable
     @SerialName("removed")
-    data class Removed(val rootRelPath: String) : ChangeEventDto
+    data class Removed(
+        val rootRelPath: String,
+    ) : ChangeEventDto
 
     @Serializable
     @SerialName("moved")

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ChangeEventDto.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ChangeEventDto.kt
@@ -1,0 +1,35 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * What the Differ reports between scans. The wire-side mirror of the
+ * server-internal `ChangeEvent` — the contract is what crosses the wire,
+ * the internal type can be richer.
+ */
+@Serializable
+sealed interface ChangeEventDto {
+    @Serializable
+    @SerialName("added")
+    data class Added(val book: AnalyzedBook) : ChangeEventDto
+
+    @Serializable
+    @SerialName("modified")
+    data class Modified(
+        val book: AnalyzedBook,
+        val previousRootRelPath: String,
+    ) : ChangeEventDto
+
+    @Serializable
+    @SerialName("removed")
+    data class Removed(val rootRelPath: String) : ChangeEventDto
+
+    @Serializable
+    @SerialName("moved")
+    data class Moved(
+        val from: String,
+        val to: String,
+        val book: AnalyzedBook,
+    ) : ChangeEventDto
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/FileEntry.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/FileEntry.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One file the Walker discovered. Path is relative to the library root and
+ * uses POSIX separators regardless of the OS that produced it — clients on
+ * Linux, macOS, and Windows all see the same shape.
+ *
+ * `inode` is null when the underlying filesystem doesn't expose stable file
+ * keys (Windows default, FAT, some SMB mounts). The Differ degrades to
+ * path-only matching when inode is unavailable; cross-folder move detection
+ * is the feature that suffers.
+ */
+@Serializable
+data class FileEntry(
+    val relPath: String,
+    val name: String,
+    val ext: String,
+    val size: Long,
+    val mtimeMs: Long,
+    val inode: Long? = null,
+    val fileType: FileType,
+)
+
+@Serializable
+enum class FileType {
+    AUDIO,
+    IMAGE,
+    EBOOK,
+    METADATA,
+    TEXT,
+    UNKNOWN,
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/MetadataSource.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/MetadataSource.kt
@@ -1,0 +1,20 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Where a field on [AnalyzedBook] came from. The Analyzer records every
+ * source that contributed so consumers can reason about precedence — and
+ * so a debug UI can later show "this title came from `metadata.json`,
+ * this author came from the folder structure."
+ */
+@Serializable
+enum class MetadataSource {
+    FOLDER_STRUCTURE,
+    FILENAME,
+    ABS_METADATA,
+    OPF_FILE,
+    NFO_FILE,
+    TXT_FILES,
+    AUDIO_METATAGS,
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanPhase.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanPhase.kt
@@ -1,0 +1,13 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/** Where the scanner is in its pipeline. Reported in progress events. */
+@Serializable
+enum class ScanPhase {
+    WALKING,
+    GROUPING,
+    ANALYZING,
+    DIFFING,
+    COMPLETED,
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanResult.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanResult.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The aggregated output of one scan invocation. Phase 2 keeps this purely
+ * in-memory — no persistence yet. Phase 4's Books domain takes this as its
+ * input.
+ */
+@Serializable
+data class ScanResult(
+    val correlationId: String,
+    val rootPath: String,
+    val books: List<AnalyzedBook>,
+    val changes: List<ChangeEventDto>,
+    val errors: List<com.calypsan.listenup.api.error.ScanError>,
+    val durationMs: Long,
+    val filesWalked: Int,
+    val filesSkipped: Int,
+)
+
+/**
+ * Lightweight version of [ScanResult] returned by `scanFull()` over RPC and
+ * embedded in completion SSE events. The full books list is fetchable via
+ * `lastScanResult()` when needed — keeping it out of progress events keeps
+ * the wire small.
+ */
+@Serializable
+data class ScanResultSummary(
+    val correlationId: String,
+    val totalBooks: Int,
+    val added: Int,
+    val modified: Int,
+    val removed: Int,
+    val moved: Int,
+    val errors: Int,
+    val durationMs: Long,
+    val filesWalked: Int,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/SeriesEntry.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/SeriesEntry.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A book's membership in a series. `sequence` is intentionally a string —
+ * ABS treats `"1.5"` and `"0a"` as valid (matches `BookSeries.sequence` in
+ * the ABS schema). Numeric parsing is the consumer's job, never ours.
+ */
+@Serializable
+data class SeriesEntry(
+    val name: String,
+    val sequence: String? = null,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/TrackEntry.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/TrackEntry.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One audio file in playback order, with its derived position metadata.
+ * Phase 2 only fills track/disc from filename or parent folder; embedded-tag
+ * sources land in Phase 3 and use [TrackNumberSource.METADATA].
+ */
+@Serializable
+data class TrackEntry(
+    val file: FileEntry,
+    val trackNumber: Int? = null,
+    val discNumber: Int? = null,
+    val trackSource: TrackNumberSource? = null,
+    val discSource: TrackNumberSource? = null,
+)
+
+@Serializable
+enum class TrackNumberSource {
+    FILENAME,
+    FOLDER,
+    METADATA,
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/error/ScanError.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/error/ScanError.kt
@@ -1,0 +1,60 @@
+package com.calypsan.listenup.api.error
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Scanner-domain error variants. Modelled as values, not exceptions — same
+ * pattern as [AuthError]. Clients exhaustively `when` over the sealed shape
+ * and never string-match.
+ */
+@Serializable
+sealed interface ScanError : AppError {
+    /** Another scan (full or incremental) is currently running. */
+    @Serializable
+    @SerialName("ScanError.AlreadyRunning")
+    data class AlreadyRunning(
+        override val correlationId: String? = null,
+    ) : ScanError
+
+    /** No `scanner.libraryPath` is configured. */
+    @Serializable
+    @SerialName("ScanError.LibraryPathNotConfigured")
+    data class LibraryPathNotConfigured(
+        override val correlationId: String? = null,
+    ) : ScanError
+
+    /** `scanner.libraryPath` is set but the directory doesn't exist or isn't readable. */
+    @Serializable
+    @SerialName("ScanError.LibraryPathNotFound")
+    data class LibraryPathNotFound(
+        val path: String,
+        override val correlationId: String? = null,
+    ) : ScanError
+
+    /** Walker / Analyzer hit an unreadable file. The scan continues; this lands in `ScanResult.errors`. */
+    @Serializable
+    @SerialName("ScanError.FileUnreadable")
+    data class FileUnreadable(
+        val path: String,
+        val message: String,
+        override val correlationId: String? = null,
+    ) : ScanError
+
+    /** A `metadata.json` file failed to parse. The scan continues without the overlay. */
+    @Serializable
+    @SerialName("ScanError.MetadataParseError")
+    data class MetadataParseError(
+        val path: String,
+        val message: String,
+        override val correlationId: String? = null,
+    ) : ScanError
+
+    /** The Analyzer couldn't infer a usable title from the path or metadata. */
+    @Serializable
+    @SerialName("ScanError.TitleInferenceError")
+    data class TitleInferenceError(
+        val path: String,
+        override val correlationId: String? = null,
+    ) : ScanError
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/event/ScanEvent.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/event/ScanEvent.kt
@@ -1,0 +1,53 @@
+package com.calypsan.listenup.api.event
+
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Server-to-client streaming events emitted during and after a scan. Every
+ * event carries `correlationId` so a client can disambiguate concurrent
+ * server-side scans (a watcher-driven incremental can run after a manual
+ * full scan ends — the IDs differentiate the streams).
+ *
+ * Throughput: `Progress` is throttled at the scanner to at most one emit
+ * per ~200ms; `Change` and `Started`/`Completed` are emitted at their
+ * natural rate.
+ */
+@Serializable
+sealed interface ScanEvent {
+    val correlationId: String
+
+    @Serializable
+    @SerialName("started")
+    data class Started(
+        override val correlationId: String,
+        val rootPath: String,
+    ) : ScanEvent
+
+    @Serializable
+    @SerialName("progress")
+    data class Progress(
+        override val correlationId: String,
+        val phase: ScanPhase,
+        val filesWalked: Int,
+        val booksAnalyzed: Int,
+        val errors: Int,
+    ) : ScanEvent
+
+    @Serializable
+    @SerialName("change")
+    data class Change(
+        override val correlationId: String,
+        val event: ChangeEventDto,
+    ) : ScanEvent
+
+    @Serializable
+    @SerialName("completed")
+    data class Completed(
+        override val correlationId: String,
+        val result: ScanResultSummary,
+    ) : ScanEvent
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/external/abs/AbsChapter.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/external/abs/AbsChapter.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.api.external.abs
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One chapter as ABS encodes it in `metadata.json`. Times are in seconds.
+ * Phase 2 reads but does not use these — chapter inference lands in Phase 3
+ * once audiometa is ported.
+ */
+@Serializable
+data class AbsChapter(
+    val id: Int? = null,
+    val start: Double,
+    val end: Double,
+    val title: String,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/external/abs/AbsMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/external/abs/AbsMetadata.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.api.external.abs
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Schema for ABS-authored `metadata.json` sidecar files.
+ *
+ * ABS writes one of these in every book folder when `storeMetadataWithItem`
+ * is on (the common self-hoster setting). The schema is flat in current ABS
+ * versions; legacy ABS versions wrap fields in a nested `metadata` object —
+ * the reader auto-flattens both forms.
+ *
+ * `series` arrives as an array of `"Name #seq"` strings — this DTO keeps
+ * them as raw strings; the reader splits them into
+ * [com.calypsan.listenup.api.dto.scanner.SeriesEntry] downstream.
+ *
+ * Source: ABS `server/scanner/BookScanner.js:810-879` (`saveMetadataFile`)
+ * and `abmetadataGenerator.js:9-20` (legacy unwrap).
+ */
+@Serializable
+data class AbsMetadata(
+    val title: String? = null,
+    val subtitle: String? = null,
+    val authors: List<String> = emptyList(),
+    val narrators: List<String> = emptyList(),
+    val series: List<String> = emptyList(),
+    val genres: List<String> = emptyList(),
+    val tags: List<String> = emptyList(),
+    val publishedYear: Int? = null,
+    val publishedDate: String? = null,
+    val publisher: String? = null,
+    val description: String? = null,
+    val isbn: String? = null,
+    val asin: String? = null,
+    val language: String? = null,
+    val explicit: Boolean? = null,
+    val abridged: Boolean? = null,
+    val chapters: List<AbsChapter> = emptyList(),
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/resources/ScannerResources.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/resources/ScannerResources.kt
@@ -13,7 +13,10 @@ import io.ktor.resources.Resource
  *    route below for documentation.)
  */
 @Resource("/api/v1/scan")
-class Scan {
+class ScannerResources {
+    /** REST endpoint for ScannerService.lastScanResult — GET /api/v1/scan/last. */
     @Resource("last")
-    class Last(val parent: Scan = Scan())
+    class Last(
+        val parent: ScannerResources = ScannerResources(),
+    )
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/resources/ScannerResources.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/resources/ScannerResources.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.api.resources
+
+import io.ktor.resources.Resource
+
+/**
+ * REST mirror of [com.calypsan.listenup.api.ScannerService]. The two
+ * transports speak the same DTOs; clients pick the one they prefer.
+ *
+ *  - `POST /api/v1/scan` triggers a full scan.
+ *  - `GET /api/v1/scan/last` returns the most recent [ScanResult].
+ *  - `GET /sse/scan` streams [ScanEvent]s via Server-Sent Events.
+ *    (SSE doesn't fit the `@Resource` shape cleanly; kept as a separate
+ *    route below for documentation.)
+ */
+@Resource("/api/v1/scan")
+class Scan {
+    @Resource("last")
+    class Last(val parent: Scan = Scan())
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/ScannerDtoContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/ScannerDtoContractTest.kt
@@ -1,0 +1,230 @@
+package com.calypsan.listenup.api
+
+import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.MetadataSource
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.dto.scanner.SeriesEntry
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.api.dto.scanner.TrackNumberSource
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.ScanError
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.external.abs.AbsChapter
+import com.calypsan.listenup.api.external.abs.AbsMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+
+/**
+ * Round-trip every Phase 2 scanner DTO + sealed variant through `contractJson`.
+ * This is the contract regression net — any drift in polymorphic discriminator
+ * or default-value handling fails here before any pipeline code runs.
+ */
+class ScannerDtoContractTest :
+    FunSpec({
+
+        test("FileEntry survives JSON round-trip with all fields") {
+            val entry =
+                FileEntry(
+                    relPath = "Author/Series/Book/01 - Chapter.mp3",
+                    name = "01 - Chapter.mp3",
+                    ext = "mp3",
+                    size = 12_345_678L,
+                    mtimeMs = 1_714_694_400_000L,
+                    inode = 4242L,
+                    fileType = FileType.AUDIO,
+                )
+            roundTrip(entry) shouldBe entry
+        }
+
+        test("FileEntry tolerates a null inode (Windows / FAT / SMB)") {
+            val entry =
+                FileEntry(
+                    relPath = "x.mp3",
+                    name = "x.mp3",
+                    ext = "mp3",
+                    size = 0L,
+                    mtimeMs = 0L,
+                    inode = null,
+                    fileType = FileType.AUDIO,
+                )
+            roundTrip(entry) shouldBe entry
+        }
+
+        test("FileType variants round-trip") {
+            FileType.entries.forEach { roundTrip(it) shouldBe it }
+        }
+
+        test("SeriesEntry round-trips with string sequence (1.5, 0a allowed)") {
+            roundTrip(SeriesEntry("Stormlight Archive", "1")) shouldBe SeriesEntry("Stormlight Archive", "1")
+            roundTrip(SeriesEntry("Mistborn Era 2", "1.5")) shouldBe SeriesEntry("Mistborn Era 2", "1.5")
+            roundTrip(SeriesEntry("Cosmere", "0a")) shouldBe SeriesEntry("Cosmere", "0a")
+            roundTrip(SeriesEntry("Standalone")) shouldBe SeriesEntry("Standalone")
+        }
+
+        test("TrackEntry round-trips with all source variants") {
+            val file =
+                FileEntry(
+                    relPath = "track.mp3", name = "track.mp3", ext = "mp3",
+                    size = 0L, mtimeMs = 0L, fileType = FileType.AUDIO,
+                )
+            TrackNumberSource.entries.forEach { source ->
+                val entry = TrackEntry(file = file, trackNumber = 1, discNumber = 1, trackSource = source, discSource = source)
+                roundTrip(entry) shouldBe entry
+            }
+            // Nullable fields default cleanly.
+            roundTrip(TrackEntry(file = file)) shouldBe TrackEntry(file = file)
+        }
+
+        test("ScanPhase + MetadataSource enum variants round-trip") {
+            ScanPhase.entries.forEach { roundTrip(it) shouldBe it }
+            MetadataSource.entries.forEach { roundTrip(it) shouldBe it }
+        }
+
+        test("CandidateBook with multi-disc folders round-trips") {
+            val candidate =
+                CandidateBook(
+                    rootRelPath = "Author/Book",
+                    isFile = false,
+                    files = listOf(
+                        FileEntry("Author/Book/CD1/01.mp3", "01.mp3", "mp3", 0, 0, fileType = FileType.AUDIO),
+                        FileEntry("Author/Book/CD2/01.mp3", "01.mp3", "mp3", 0, 0, fileType = FileType.AUDIO),
+                    ),
+                    discFolders = listOf("Author/Book/CD1", "Author/Book/CD2"),
+                )
+            roundTrip(candidate) shouldBe candidate
+        }
+
+        test("AnalyzedBook with rich metadata round-trips") {
+            val candidate = CandidateBook("Author/Series/Book", false, emptyList())
+            val book =
+                AnalyzedBook(
+                    candidate = candidate,
+                    title = "The Way of Kings",
+                    subtitle = "Book One of the Stormlight Archive",
+                    authors = listOf("Brandon Sanderson"),
+                    narrators = listOf("Michael Kramer", "Kate Reading"),
+                    series = listOf(SeriesEntry("Stormlight Archive", "1")),
+                    publishedYear = 2010,
+                    asin = "B0015T963C",
+                    description = "A long book.",
+                    sources = setOf(MetadataSource.FOLDER_STRUCTURE, MetadataSource.ABS_METADATA),
+                )
+            roundTrip(book) shouldBe book
+        }
+
+        test("AnalyzedBook with only the required fields round-trips") {
+            val minimal =
+                AnalyzedBook(
+                    candidate = CandidateBook("Book", true, emptyList()),
+                    title = "Untitled",
+                    tracks = emptyList(),
+                )
+            roundTrip(minimal) shouldBe minimal
+        }
+
+        test("ChangeEventDto polymorphic discriminator survives all four variants") {
+            val book =
+                AnalyzedBook(
+                    candidate = CandidateBook("Book", false, emptyList()),
+                    title = "T",
+                )
+            val variants =
+                listOf<ChangeEventDto>(
+                    ChangeEventDto.Added(book),
+                    ChangeEventDto.Modified(book, "old/path"),
+                    ChangeEventDto.Removed("old/path"),
+                    ChangeEventDto.Moved("a/b", "c/d", book),
+                )
+            variants.forEach { original ->
+                val json = contractJson.encodeToString<ChangeEventDto>(original)
+                contractJson.decodeFromString<ChangeEventDto>(json) shouldBe original
+            }
+        }
+
+        test("ScanResult + ScanResultSummary round-trip") {
+            val summary =
+                ScanResultSummary(
+                    correlationId = "corr-1",
+                    totalBooks = 42, added = 10, modified = 5, removed = 1, moved = 0,
+                    errors = 0, durationMs = 1234, filesWalked = 200,
+                )
+            roundTrip(summary) shouldBe summary
+
+            val result =
+                ScanResult(
+                    correlationId = "corr-1",
+                    rootPath = "/library",
+                    books = emptyList(),
+                    changes = emptyList(),
+                    errors = emptyList(),
+                    durationMs = 1234, filesWalked = 200, filesSkipped = 5,
+                )
+            roundTrip(result) shouldBe result
+        }
+
+        test("ScanError variants survive round-trip via the AppError parent type") {
+            val variants =
+                listOf<ScanError>(
+                    ScanError.AlreadyRunning(correlationId = "c"),
+                    ScanError.LibraryPathNotConfigured(correlationId = "c"),
+                    ScanError.LibraryPathNotFound("/missing", correlationId = "c"),
+                    ScanError.FileUnreadable("/path", "perm denied", correlationId = "c"),
+                    ScanError.MetadataParseError("/path", "bad json", correlationId = "c"),
+                    ScanError.TitleInferenceError("/path", correlationId = "c"),
+                )
+            variants.forEach { original ->
+                val asAppError: AppError = original
+                val json = contractJson.encodeToString<AppError>(asAppError)
+                contractJson.decodeFromString<AppError>(json) shouldBe original
+            }
+        }
+
+        test("ScanEvent variants round-trip") {
+            val started: ScanEvent = ScanEvent.Started("c", "/library")
+            val progress: ScanEvent = ScanEvent.Progress("c", ScanPhase.ANALYZING, 100, 10, 0)
+            val change: ScanEvent =
+                ScanEvent.Change(
+                    "c",
+                    ChangeEventDto.Added(
+                        AnalyzedBook(CandidateBook("Book", false, emptyList()), "T"),
+                    ),
+                )
+            val completed: ScanEvent =
+                ScanEvent.Completed(
+                    "c",
+                    ScanResultSummary("c", 1, 1, 0, 0, 0, 0, 100, 10),
+                )
+            listOf(started, progress, change, completed).forEach {
+                val json = contractJson.encodeToString<ScanEvent>(it)
+                contractJson.decodeFromString<ScanEvent>(json) shouldBe it
+            }
+        }
+
+        test("AbsMetadata accepts the flat schema with all optional fields absent") {
+            val flat = """{"title":"Hello","authors":["Alice"]}"""
+            val parsed = contractJson.decodeFromString<AbsMetadata>(flat)
+            parsed.title shouldBe "Hello"
+            parsed.authors shouldBe listOf("Alice")
+            parsed.series shouldBe emptyList()
+        }
+
+        test("AbsMetadata round-trips with chapters") {
+            val md =
+                AbsMetadata(
+                    title = "Hello",
+                    authors = listOf("Alice"),
+                    series = listOf("Series #1"),
+                    chapters = listOf(AbsChapter(0, 0.0, 60.0, "Chapter 1")),
+                )
+            roundTrip(md) shouldBe md
+        }
+    })
+
+private inline fun <reified T : Any> roundTrip(value: T): T = contractJson.decodeFromString<T>(contractJson.encodeToString(value))

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/ScannerDtoContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/ScannerDtoContractTest.kt
@@ -71,8 +71,12 @@ class ScannerDtoContractTest :
         test("TrackEntry round-trips with all source variants") {
             val file =
                 FileEntry(
-                    relPath = "track.mp3", name = "track.mp3", ext = "mp3",
-                    size = 0L, mtimeMs = 0L, fileType = FileType.AUDIO,
+                    relPath = "track.mp3",
+                    name = "track.mp3",
+                    ext = "mp3",
+                    size = 0L,
+                    mtimeMs = 0L,
+                    fileType = FileType.AUDIO,
                 )
             TrackNumberSource.entries.forEach { source ->
                 val entry = TrackEntry(file = file, trackNumber = 1, discNumber = 1, trackSource = source, discSource = source)
@@ -92,10 +96,11 @@ class ScannerDtoContractTest :
                 CandidateBook(
                     rootRelPath = "Author/Book",
                     isFile = false,
-                    files = listOf(
-                        FileEntry("Author/Book/CD1/01.mp3", "01.mp3", "mp3", 0, 0, fileType = FileType.AUDIO),
-                        FileEntry("Author/Book/CD2/01.mp3", "01.mp3", "mp3", 0, 0, fileType = FileType.AUDIO),
-                    ),
+                    files =
+                        listOf(
+                            FileEntry("Author/Book/CD1/01.mp3", "01.mp3", "mp3", 0, 0, fileType = FileType.AUDIO),
+                            FileEntry("Author/Book/CD2/01.mp3", "01.mp3", "mp3", 0, 0, fileType = FileType.AUDIO),
+                        ),
                     discFolders = listOf("Author/Book/CD1", "Author/Book/CD2"),
                 )
             roundTrip(candidate) shouldBe candidate
@@ -152,8 +157,14 @@ class ScannerDtoContractTest :
             val summary =
                 ScanResultSummary(
                     correlationId = "corr-1",
-                    totalBooks = 42, added = 10, modified = 5, removed = 1, moved = 0,
-                    errors = 0, durationMs = 1234, filesWalked = 200,
+                    totalBooks = 42,
+                    added = 10,
+                    modified = 5,
+                    removed = 1,
+                    moved = 0,
+                    errors = 0,
+                    durationMs = 1234,
+                    filesWalked = 200,
                 )
             roundTrip(summary) shouldBe summary
 
@@ -164,7 +175,9 @@ class ScannerDtoContractTest :
                     books = emptyList(),
                     changes = emptyList(),
                     errors = emptyList(),
-                    durationMs = 1234, filesWalked = 200, filesSkipped = 5,
+                    durationMs = 1234,
+                    filesWalked = 200,
+                    filesSkipped = 5,
                 )
             roundTrip(result) shouldBe result
         }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
@@ -66,4 +66,29 @@ class ArchitectureTest :
                     file.imports.any { it.name.startsWith("com.calypsan.listenup.server.") }
                 }
         }
+
+        test("ScanEvent variants live in commonMain") {
+            Konsist
+                .scopeFromProject()
+                .classes()
+                .filter { it.resideInPackage("com.calypsan.listenup.api.event..") }
+                .withoutValueModifier()
+                .assertTrue { koClass ->
+                    "/shared/src/commonMain/" in koClass.containingFile.path
+                }
+        }
+
+        test("scanner package files in :server have no io.ktor imports") {
+            // The scanner core stays transport-agnostic. Ktor only enters via
+            // `routes/ScannerRoutes.kt` (REST + SSE) and `di/ScannerModule.kt`
+            // (Koin's ApplicationConfig binding) — both outside `scanner/`.
+            Konsist
+                .scopeFromProject()
+                .files
+                .filter { "/server/src/main/" in it.path }
+                .filter { it.packagee?.name?.startsWith("com.calypsan.listenup.server.scanner") == true }
+                .assertFalse { file ->
+                    file.imports.any { it.name.startsWith("io.ktor.") }
+                }
+        }
     })


### PR DESCRIPTION
## Summary

- 4-stage Flow pipeline (Walker → Grouper → Analyzer → Differ) emitting `Flow<ChangeEventDto>`; ABS-compatible folder/title/track inference + `metadata.json` overlay; cover precedence; inode-based cross-folder move detection.
- Real-time updates via `kfswatch` `FolderWatcher` with stable-size debounce + per-book coalescing; `ScanCoordinator` single-flights full scans and per-path-coalesced incremental re-analysis; `ScannerServiceImpl` over RPC + REST `/api/v1/scan{,/last}` + SSE `/sse/scan`; bootstrap-on-startup when `LISTENUP_LIBRARY_PATH` resolves.
- Two new Konsist rules pin `ScanEvent` in commonMain and keep the scanner core io.ktor-free.

Smoke-tested live against `/mnt/Igni/Audiobooks` (596 files / 448 books): boot scan in 96 ms, repeat scan in 22 ms with zero changes, zero errors.

## Test plan

- [x] `:shared:jvmTest` — contract round-trips, Konsist rules
- [x] `:server:test` — Walker, Grouper, Analyzer, Differ, ScanCoordinator, StableSizeDebouncer, FolderWatcher (Linux-only), Scanner orchestrator, ScannerServiceImpl, end-to-end + SSE
- [x] `:androidApp:assembleDebug`
- [x] `spotlessCheck` + `detekt`
- [x] Live smoke test against real library (boot scan + idempotent rescan)