### PR TITLE
✨ Phase 4 — multi-file chapter synthesis

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Id3v2Reader.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Id3v2Reader.kt
@@ -32,6 +32,24 @@ internal object Id3v2Reader {
             bytes[1] == 0x44.toByte() &&
             bytes[2] == 0x33.toByte()
 
+    /**
+     * Decode the total tag size (10-byte header + body) from the first 10
+     * bytes of the file. Returns `null` when the prefix isn't ID3v2,
+     * the major version isn't 2.3/2.4, or the sync-safe size is malformed.
+     *
+     * Lets the caller size a single bounded read for the tag region instead
+     * of loading the whole file just to discover how large the tag is.
+     */
+    fun peekTagSize(header: ByteArray): Int? {
+        if (header.size < ID3V2_HEADER_SIZE) return null
+        if (!hasId3v2Prefix(header)) return null
+        val version = header[3].toInt() and 0xFF
+        if (version != 3 && version != 4) return null
+        val bodySize = decodeSyncSafe(header[6], header[7], header[8], header[9])
+        if (bodySize < 0) return null
+        return ID3V2_HEADER_SIZE + bodySize
+    }
+
     fun read(bytes: ByteArray): Id3v2ReadResult? {
         if (!hasId3v2Prefix(bytes) || bytes.size < ID3V2_HEADER_SIZE) return null
         val version = bytes[3].toInt() and 0xFF

--- a/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
@@ -4,7 +4,6 @@ import com.calypsan.listenup.api.error.AudioMetadataError
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.AudioTags
-import com.calypsan.listenup.domain.embeddedmeta.Chapter
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatParser
@@ -20,22 +19,23 @@ import java.io.IOException
  *   slots; unmapped `T*` frames and all `TXXX` user-defined frames land in
  *   [AudioTags.custom]. UTF-16 text frames are decoded via the shared
  *   `BinaryDecoder.readUtf16WithBom` helper.
- * - **Chapters.** ID3v2 `CHAP` frames produce [Chapter] entries with
- *   [ChapterSource.Id3v2Chap]. Each `CHAP` may embed a `TIT2` sub-frame
- *   carrying the chapter title; if absent the element id is used.
+ * - **Chapters.** ID3v2 `CHAP` frames produce [com.calypsan.listenup.domain.embeddedmeta.Chapter]
+ *   entries with [ChapterSource.Id3v2Chap]. Each `CHAP` may embed a `TIT2`
+ *   sub-frame carrying the chapter title; if absent the element id is used.
  * - **Artwork.** `APIC` frames are scanned in tag order; the highest-priority
  *   match wins (picture type 3 "Cover (front)" beats every other type;
  *   otherwise first APIC wins).
  * - **Duration.** CBR-only — read bitrate and sample rate from the first
- *   MPEG frame header, count frames at the nominal frame size, multiply by
- *   1152 samples/frame.
+ *   MPEG frame header found within a 64 KB sniff window past the tag,
+ *   then derive duration from the audio-region size.
+ *
+ * Streaming contract: the parser only reads bounded regions out of [source]
+ * — the ID3v2 tag (capped at [ID3V2_SOFT_LIMIT_BYTES]), the trailing 128-byte
+ * ID3v1 footer, and a 64 KB sniff window for the first MPEG frame. Files
+ * larger than the heap parse without ever materialising the audio body.
  *
  * Failure mapping:
  * - File-level read errors → [AudioMetadataError.IoError].
- * - ID3v2 sync-safe size overruns the file length → [AudioMetadataError.TruncatedStream].
- * - First MPEG sync byte cannot be located within the audio region →
- *   [AudioMetadataError.CorruptHeader] (synthesised so the duration field is
- *   zero rather than misleading).
  *
  * TODO(VBR): Xing/VBRI VBR-header parsing is deferred. Real-world audiobook
  * MP3s are overwhelmingly CBR; the duration approximation is good enough for
@@ -45,47 +45,59 @@ import java.io.IOException
 internal class Mp3Parser : AudioFormatParser {
     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp3)
 
-    override suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata> {
-        val bytes =
-            try {
-                source.seek(0)
-                source.readFully(source.length.toInt())
-            } catch (e: IOException) {
-                return AppResult.Failure(
-                    AudioMetadataError.IoError(
-                        pathString = "<source>",
-                        ioMessage = e.message ?: "io error",
-                    ),
+    override suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata> =
+        try {
+            val id3v2 = readId3v2Region(source)
+            val id3v1Tags = readId3v1Footer(source)
+            val hasV1Footer = id3v1Tags != null
+
+            val tags = id3v2?.tags ?: id3v1Tags ?: emptyTags()
+            val tagSize = id3v2?.tagSize ?: 0
+            val chapters = id3v2?.chapters.orEmpty()
+
+            val durationMs =
+                MpegDurationCalculator.compute(
+                    source = source,
+                    audioStart = tagSize.toLong(),
+                    hasV1Footer = hasV1Footer,
                 )
-            }
 
-        val id3v2 = if (Id3v2Reader.hasId3v2Prefix(bytes)) Id3v2Reader.read(bytes) else null
-        val id3v2Tags = id3v2?.tags
-        val id3v2Chapters = id3v2?.chapters.orEmpty()
-        val id3v2Artwork = id3v2?.artwork
+            AppResult.Success(
+                EmbeddedAudioMetadata(
+                    format = AudioFormat.Mp3,
+                    durationMs = durationMs,
+                    tags = tags,
+                    chapters = chapters,
+                    chaptersSource = if (chapters.isNotEmpty()) ChapterSource.Id3v2Chap else ChapterSource.None,
+                    artwork = id3v2?.artwork,
+                ),
+            )
+        } catch (e: IOException) {
+            AppResult.Failure(
+                AudioMetadataError.IoError(
+                    pathString = "<source>",
+                    ioMessage = e.message ?: "io error",
+                ),
+            )
+        }
 
-        val tags =
-            id3v2Tags ?: run {
-                // Fall back to ID3v1 footer
-                Id3v1Reader.read(bytes) ?: emptyTags()
-            }
+    private fun readId3v2Region(source: SeekableAudioSource): Id3v2ReadResult? {
+        if (source.length < ID3V2_HEADER_SIZE) return null
+        source.seek(0)
+        val header = source.readFully(ID3V2_HEADER_SIZE)
+        val tagSize = Id3v2Reader.peekTagSize(header) ?: return null
+        if (tagSize > ID3V2_SOFT_LIMIT_BYTES) return null
+        if (tagSize > source.length) return null
+        source.seek(0)
+        val tagBytes = source.readFully(tagSize)
+        return Id3v2Reader.read(tagBytes)
+    }
 
-        val tagSize = id3v2?.tagSize ?: 0
-        val durationMs = MpegDurationCalculator.compute(bytes, audioStart = tagSize.toLong())
-
-        val chaptersSource =
-            if (id3v2Chapters.isNotEmpty()) ChapterSource.Id3v2Chap else ChapterSource.None
-
-        return AppResult.Success(
-            EmbeddedAudioMetadata(
-                format = AudioFormat.Mp3,
-                durationMs = durationMs,
-                tags = tags,
-                chapters = id3v2Chapters,
-                chaptersSource = chaptersSource,
-                artwork = id3v2Artwork,
-            ),
-        )
+    private fun readId3v1Footer(source: SeekableAudioSource): AudioTags? {
+        if (source.length < ID3V1_LEN) return null
+        source.seek(source.length - ID3V1_LEN)
+        val footer = source.readFully(ID3V1_LEN)
+        return Id3v1Reader.read(footer)
     }
 
     private fun emptyTags(): AudioTags =
@@ -106,4 +118,17 @@ internal class Mp3Parser : AudioFormatParser {
             discNumber = null,
             custom = emptyMap(),
         )
+
+    private companion object {
+        /**
+         * Defensive cap on ID3v2 tag size. Real-world ID3v2 tags max out around
+         * 1-10 MB even with full-resolution embedded cover art. A 200 MB cap
+         * leaves generous headroom while preventing a corrupt sync-safe size
+         * field from triggering a multi-GB allocation. Mirrors `Mp4Parser`'s
+         * `MOOV_SOFT_LIMIT_BYTES`.
+         */
+        private const val ID3V2_SOFT_LIMIT_BYTES = 200 * 1024 * 1024
+        private const val ID3V2_HEADER_SIZE = 10
+        private const val ID3V1_LEN = 128
+    }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/MpegDurationCalculator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/MpegDurationCalculator.kt
@@ -2,17 +2,24 @@
 
 package com.calypsan.listenup.server.embeddedmeta.format.mp3
 
+import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import java.io.IOException
+
 /**
- * Compute the audio duration of an MP3 file from its MPEG frame headers.
+ * Compute the audio duration of an MP3 file from its first MPEG frame header
+ * and the size of the audio region.
  *
  * Strategy:
- * 1. Locate the first MPEG sync (`0xFFE` top 11 bits) at or after [audioStart].
- * 2. Decode bitrate and sample rate from the frame header.
- * 3. Compute audio-region size = total - tagSize - id3v1FooterSize.
- * 4. Duration = audioBytes * 8 / bitrate (CBR approximation).
+ * 1. Seek to [audioStart] (just past the ID3v2 tag, or 0 if no tag).
+ * 2. Read a small sniff window and locate the first MPEG sync (`0xFFE` top
+ *    11 bits) within it.
+ * 3. Decode bitrate and sample rate from the 4-byte frame header.
+ * 4. Compute audio-region size = `source.length - syncFileOffset - footerSize`.
+ * 5. Duration = audioBytes * 8 / bitrate (CBR approximation).
  *
- * Returns `0` if no MPEG frame can be located or the frame header is invalid
- * — the parser still surfaces tags successfully; only duration is unknown.
+ * Returns `0` if no MPEG frame can be located in the sniff window or the
+ * frame header is invalid — the parser still surfaces tags successfully;
+ * only duration is unknown.
  *
  * TODO(VBR): Xing/VBRI VBR-header parsing is deferred. CBR is the common case
  * for audiobook MP3s; revisit when a VBR file surfaces in the live validation
@@ -20,37 +27,57 @@ package com.calypsan.listenup.server.embeddedmeta.format.mp3
  */
 internal object MpegDurationCalculator {
     fun compute(
-        bytes: ByteArray,
+        source: SeekableAudioSource,
         audioStart: Long,
+        hasV1Footer: Boolean,
     ): Long {
-        if (audioStart < 0 || audioStart >= bytes.size) return 0
-        val syncOffset = locateMpegSync(bytes, audioStart.toInt()) ?: return 0
-        if (syncOffset + 4 > bytes.size) return 0
-        val header =
-            ((bytes[syncOffset].toInt() and 0xFF) shl 24) or
-                ((bytes[syncOffset + 1].toInt() and 0xFF) shl 16) or
-                ((bytes[syncOffset + 2].toInt() and 0xFF) shl 8) or
-                (bytes[syncOffset + 3].toInt() and 0xFF)
-        val bitrateIdx = (header ushr 12) and 0xF
-        val sampleRateIdx = (header ushr 10) and 0x3
-        if (bitrateIdx <= 0 || bitrateIdx >= BITRATE_TABLE.size) return 0
-        val bitrate = BITRATE_TABLE[bitrateIdx] * 1000
-        if (sampleRateIdx >= SAMPLE_RATE_TABLE.size) return 0
-        val sampleRate = SAMPLE_RATE_TABLE[sampleRateIdx]
-        if (bitrate == 0 || sampleRate == 0) return 0
+        if (audioStart < 0 || audioStart >= source.length) return 0
+        val sniffSize = minOf(SNIFF_WINDOW_BYTES.toLong(), source.length - audioStart).toInt()
+        if (sniffSize < 4) return 0
+        val prefix =
+            try {
+                source.seek(audioStart)
+                source.readFully(sniffSize)
+            } catch (_: IOException) {
+                return 0
+            }
+        val syncInPrefix = locateMpegSync(prefix) ?: return 0
+        val frame = decodeFrameHeader(prefix, syncInPrefix) ?: return 0
 
-        val tail = if (hasId3v1Footer(bytes)) ID3V1_LEN else 0
-        val audioBytes = bytes.size - syncOffset - tail
+        val syncFileOffset = audioStart + syncInPrefix
+        val footer = if (hasV1Footer) ID3V1_LEN.toLong() else 0L
+        val audioBytes = source.length - syncFileOffset - footer
         if (audioBytes <= 0) return 0
-        // CBR duration in ms: audioBytes * 8 / bitrate * 1000
-        return (audioBytes.toLong() * 8 * 1000) / bitrate
+        return audioBytes * 8 * 1000 / frame.bitrate
     }
 
-    private fun locateMpegSync(
-        bytes: ByteArray,
-        from: Int,
-    ): Int? {
-        var i = from
+    private data class FrameHeader(
+        val bitrate: Int,
+        val sampleRate: Int,
+    )
+
+    private fun decodeFrameHeader(
+        prefix: ByteArray,
+        syncOffset: Int,
+    ): FrameHeader? {
+        if (syncOffset + 4 > prefix.size) return null
+        val header =
+            ((prefix[syncOffset].toInt() and 0xFF) shl 24) or
+                ((prefix[syncOffset + 1].toInt() and 0xFF) shl 16) or
+                ((prefix[syncOffset + 2].toInt() and 0xFF) shl 8) or
+                (prefix[syncOffset + 3].toInt() and 0xFF)
+        val bitrateIdx = (header ushr 12) and 0xF
+        val sampleRateIdx = (header ushr 10) and 0x3
+        if (bitrateIdx <= 0 || bitrateIdx >= BITRATE_TABLE.size) return null
+        if (sampleRateIdx >= SAMPLE_RATE_TABLE.size) return null
+        val bitrate = BITRATE_TABLE[bitrateIdx] * 1000
+        val sampleRate = SAMPLE_RATE_TABLE[sampleRateIdx]
+        if (bitrate == 0 || sampleRate == 0) return null
+        return FrameHeader(bitrate = bitrate, sampleRate = sampleRate)
+    }
+
+    private fun locateMpegSync(bytes: ByteArray): Int? {
+        var i = 0
         while (i < bytes.size - 1) {
             if (bytes[i] == 0xFF.toByte() && (bytes[i + 1].toInt() and 0xE0) == 0xE0) {
                 return i
@@ -60,19 +87,19 @@ internal object MpegDurationCalculator {
         return null
     }
 
-    private fun hasId3v1Footer(bytes: ByteArray): Boolean {
-        if (bytes.size < ID3V1_LEN) return false
-        val start = bytes.size - ID3V1_LEN
-        return bytes[start] == 0x54.toByte() &&
-            bytes[start + 1] == 0x41.toByte() &&
-            bytes[start + 2] == 0x47.toByte()
-    }
-
     /** MPEG-1 Layer III bitrate table in kbps. */
     private val BITRATE_TABLE = intArrayOf(0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0)
 
     /** MPEG-1 sample-rate table in Hz. */
     private val SAMPLE_RATE_TABLE = intArrayOf(44_100, 48_000, 32_000, 0)
 
+    /**
+     * 64 KB sniff window for the first MPEG sync byte. Real-world ID3v2 tags
+     * declare their own size — there is no padding between tag and audio in
+     * standard files. 64 KB leaves generous headroom for files with a short
+     * non-standard gap; sync byte not found within this window → duration
+     * reported as 0 (best-effort, parser still returns tags).
+     */
+    private const val SNIFF_WINDOW_BYTES = 64 * 1024
     private const val ID3V1_LEN = 128
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/AtomWalker.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/AtomWalker.kt
@@ -216,15 +216,18 @@ internal object AtomWalker {
         while (offset + 8 <= length) {
             source.seek(offset)
             val headerBytes = source.readFully(8)
+            // The 32-bit size field is unsigned per ISO/IEC 14496-12 — sizes from 2 GB to 4 GB
+            // are valid in the wild (audiobook `mdat` atoms carrying 30+ hours of audio).
+            // Read into a Long so the high bit doesn't flip to a negative signed Int.
             val size32 =
-                ((headerBytes[0].toInt() and 0xFF) shl 24) or
-                    ((headerBytes[1].toInt() and 0xFF) shl 16) or
-                    ((headerBytes[2].toInt() and 0xFF) shl 8) or
-                    (headerBytes[3].toInt() and 0xFF)
+                ((headerBytes[0].toLong() and 0xFFL) shl 24) or
+                    ((headerBytes[1].toLong() and 0xFFL) shl 16) or
+                    ((headerBytes[2].toLong() and 0xFFL) shl 8) or
+                    (headerBytes[3].toLong() and 0xFFL)
             val atomType = String(headerBytes, 4, 4, Charsets.ISO_8859_1)
             val (size, headerSize) =
                 when (size32) {
-                    1 -> {
+                    1L -> {
                         if (offset + 16 > length) return null
                         source.seek(offset + 8)
                         val ext = source.readFully(8)
@@ -233,14 +236,15 @@ internal object AtomWalker {
                         size64 to 16L
                     }
 
-                    0 -> {
+                    // 0 = atom extends to EOF
+                    0L -> {
                         (length - offset) to 8L
                     }
 
-                    // 0 = atom extends to EOF
                     else -> {
-                        if (size32 < 8) return null
-                        size32.toLong() to 8L
+                        if (size32 < 8L) return null
+                        if (offset + size32 > length) return null
+                        size32 to 8L
                     }
                 }
             if (atomType == type) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server.scanner.pipeline
 
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
+import com.calypsan.listenup.api.dto.scanner.BookChapterSource
 import com.calypsan.listenup.api.dto.scanner.CandidateBook
 import com.calypsan.listenup.api.dto.scanner.CoverSource
 import com.calypsan.listenup.api.dto.scanner.FileEntry
@@ -10,8 +11,10 @@ import com.calypsan.listenup.api.dto.scanner.MetadataStatus
 import com.calypsan.listenup.api.dto.scanner.SeriesEntry
 import com.calypsan.listenup.api.dto.scanner.TrackEntry
 import com.calypsan.listenup.api.error.AudioMetadataError
+import com.calypsan.listenup.api.external.abs.AbsChapter
 import com.calypsan.listenup.api.external.abs.AbsMetadata
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.domain.embeddedmeta.Chapter
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
 import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
@@ -184,8 +187,9 @@ internal class Analyzer(
         embedded: EmbeddedAudioMetadata?,
         embeddedStatus: MetadataStatus?,
         metadata: AbsMetadata?,
-    ): AnalyzedBook =
-        AnalyzedBook(
+    ): AnalyzedBook {
+        val (resolvedChapters, chaptersSource) = pickChapters(embedded, metadata)
+        return AnalyzedBook(
             candidate = candidate,
             title = pickTitle(candidate, shape, parsed, embedded, metadata),
             subtitle = metadata?.subtitle ?: embedded?.tags?.subtitle ?: parsed.subtitle,
@@ -204,10 +208,36 @@ internal class Analyzer(
             explicit = metadata?.explicit,
             cover = cover,
             tracks = tracks,
+            chapters = resolvedChapters,
+            chaptersSource = chaptersSource,
             embedded = embedded,
             embeddedStatus = embeddedStatus,
             sources = collectSources(shape, parsed, embedded, metadata),
         )
+    }
+
+    /**
+     * Chapter precedence: `metadata.json.chapters` (if non-empty) → embedded
+     * chapters (if non-empty) → empty. The sidecar wins when present so
+     * user-curated chapter titles in ABS survive a rescan.
+     *
+     * `embedded.chapters` continues to surface verbatim on
+     * [AnalyzedBook.embedded] regardless of which won — the resolved view is
+     * additive, not destructive.
+     */
+    private fun pickChapters(
+        embedded: EmbeddedAudioMetadata?,
+        metadata: AbsMetadata?,
+    ): Pair<List<Chapter>, BookChapterSource> {
+        val sidecar = metadata?.chapters.orEmpty()
+        if (sidecar.isNotEmpty()) {
+            return sidecar.toDomainChapters() to BookChapterSource.AbsMetadata
+        }
+        if (embedded != null && embedded.chapters.isNotEmpty()) {
+            return embedded.chapters to BookChapterSource.Embedded(embedded.chaptersSource)
+        }
+        return emptyList<Chapter>() to BookChapterSource.None
+    }
 
     private fun pickTitle(
         candidate: CandidateBook,
@@ -284,6 +314,22 @@ internal class Analyzer(
 }
 
 private fun EmbeddedSeriesEntry.toContract(): SeriesEntry = SeriesEntry(name = name, sequence = sequence)
+
+/**
+ * Convert ABS sidecar chapters (seconds, optional ABS-internal id) to
+ * domain chapters (millis, 1-based index). The ABS `id` field is its own
+ * 0-based ordering used by the ABS UI; we re-derive a stable 1-based
+ * `index` from list position to match [Chapter]'s contract.
+ */
+private fun List<AbsChapter>.toDomainChapters(): List<Chapter> =
+    mapIndexed { i, c ->
+        Chapter(
+            index = i + 1,
+            title = c.title,
+            startMs = (c.start * 1000.0).toLong(),
+            endMs = (c.end * 1000.0).toLong(),
+        )
+    }
 
 private fun FolderShape.contributesAnything(): Boolean =
     titleFolder.isNotEmpty() || seriesFolder != null || authorFolder != null

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -189,9 +189,7 @@ internal class Analyzer(
      * single-file books and books with higher-precedence chapter sources
      * pay nothing.
      */
-    private suspend fun parseAllTrackDurations(
-        tracks: List<TrackEntry>,
-    ): Map<TrackEntry, EmbeddedAudioMetadata?> {
+    private suspend fun parseAllTrackDurations(tracks: List<TrackEntry>): Map<TrackEntry, EmbeddedAudioMetadata?> {
         val result = LinkedHashMap<TrackEntry, EmbeddedAudioMetadata?>(tracks.size)
         for (track in tracks) {
             result[track] = parseTrackForDuration(track.file)
@@ -204,7 +202,10 @@ internal class Analyzer(
         val absolutePath = rootPath.resolve(file.relPath)
         val ioPath = kotlinx.io.files.Path(absolutePath.toString())
         return when (val result = embeddedMetadataParser.parse(ioPath)) {
-            is AppResult.Success -> result.data
+            is AppResult.Success -> {
+                result.data
+            }
+
             is AppResult.Failure -> {
                 logger.warn {
                     "synthesis per-track parse failed " +

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -86,7 +86,13 @@ internal class Analyzer(
             val (embedded, embeddedStatus) = parseEmbedded(primaryAudio)
             val cover = resolveCover(candidate.files, embedded)
             val metadata = readMetadata(candidate)
-            compose(candidate, shape, parsed, tracks, cover, embedded, embeddedStatus, metadata)
+            val perTrackMetadata: Map<TrackEntry, EmbeddedAudioMetadata?> =
+                if (shouldSynthesizeChapters(metadata, embedded, tracks)) {
+                    parseAllTrackDurations(tracks)
+                } else {
+                    emptyMap()
+                }
+            compose(candidate, shape, parsed, tracks, cover, embedded, embeddedStatus, metadata, perTrackMetadata)
         }
 
     private fun buildTracks(candidate: CandidateBook): List<TrackEntry> =
@@ -169,6 +175,47 @@ internal class Analyzer(
         }
     }
 
+    /**
+     * Per-track parse for chapter synthesis. Mirrors [parseEmbedded] but
+     * discards the [MetadataStatus] distinctions — synthesis only cares
+     * whether a duration came back.
+     *
+     * Returns a map keyed by [TrackEntry]. A `null` value means the track's
+     * parse failed (file too small, unsupported format, IO error); the
+     * caller (synthesis) substitutes `0L` for [durationMs] in that case
+     * and the affected chapter is zero-length.
+     *
+     * Called only from the synthesis-eligible branch in [analyzeOne], so
+     * single-file books and books with higher-precedence chapter sources
+     * pay nothing.
+     */
+    private suspend fun parseAllTrackDurations(
+        tracks: List<TrackEntry>,
+    ): Map<TrackEntry, EmbeddedAudioMetadata?> {
+        val result = LinkedHashMap<TrackEntry, EmbeddedAudioMetadata?>(tracks.size)
+        for (track in tracks) {
+            result[track] = parseTrackForDuration(track.file)
+        }
+        return result
+    }
+
+    private suspend fun parseTrackForDuration(file: FileEntry): EmbeddedAudioMetadata? {
+        if (file.size < AudioFormatDetector.MIN_HEADER_BYTES) return null
+        val absolutePath = rootPath.resolve(file.relPath)
+        val ioPath = kotlinx.io.files.Path(absolutePath.toString())
+        return when (val result = embeddedMetadataParser.parse(ioPath)) {
+            is AppResult.Success -> result.data
+            is AppResult.Failure -> {
+                logger.warn {
+                    "synthesis per-track parse failed " +
+                        "path=$absolutePath err=${result.error.code} " +
+                        "corr=${result.error.correlationId}"
+                }
+                null
+            }
+        }
+    }
+
     private suspend fun readMetadata(candidate: CandidateBook): AbsMetadata? {
         val sidecar =
             candidate.files.firstOrNull {
@@ -187,11 +234,13 @@ internal class Analyzer(
         embedded: EmbeddedAudioMetadata?,
         embeddedStatus: MetadataStatus?,
         metadata: AbsMetadata?,
+        perTrackMetadata: Map<TrackEntry, EmbeddedAudioMetadata?>,
     ): AnalyzedBook {
-        val (resolvedChapters, chaptersSource) = pickChapters(embedded, metadata)
+        val title = pickTitle(candidate, shape, parsed, embedded, metadata)
+        val (resolvedChapters, chaptersSource) = pickChapters(embedded, metadata, tracks, perTrackMetadata, title)
         return AnalyzedBook(
             candidate = candidate,
-            title = pickTitle(candidate, shape, parsed, embedded, metadata),
+            title = title,
             subtitle = metadata?.subtitle ?: embedded?.tags?.subtitle ?: parsed.subtitle,
             authors = pickAuthors(shape, embedded, metadata),
             narrators = pickNarrators(parsed, embedded, metadata),
@@ -217,9 +266,13 @@ internal class Analyzer(
     }
 
     /**
-     * Chapter precedence: `metadata.json.chapters` (if non-empty) → embedded
-     * chapters (if non-empty) → empty. The sidecar wins when present so
-     * user-curated chapter titles in ABS survive a rescan.
+     * Chapter precedence:
+     *   metadata.json (non-empty) → embedded (non-empty) → synthesized (multi-file) → empty.
+     *
+     * Spec §3 of `2026-05-07-phase-4-multifile-chapter-synthesis-design.md`. The
+     * sidecar wins when present so user-curated chapter titles in ABS survive
+     * a rescan. Synthesis activates only when no higher source exists AND the
+     * book is multi-file.
      *
      * `embedded.chapters` continues to surface verbatim on
      * [AnalyzedBook.embedded] regardless of which won — the resolved view is
@@ -228,6 +281,9 @@ internal class Analyzer(
     private fun pickChapters(
         embedded: EmbeddedAudioMetadata?,
         metadata: AbsMetadata?,
+        tracks: List<TrackEntry>,
+        perTrackMetadata: Map<TrackEntry, EmbeddedAudioMetadata?>,
+        bookTitle: String,
     ): Pair<List<Chapter>, BookChapterSource> {
         val sidecar = metadata?.chapters.orEmpty()
         if (sidecar.isNotEmpty()) {
@@ -236,7 +292,25 @@ internal class Analyzer(
         if (embedded != null && embedded.chapters.isNotEmpty()) {
             return embedded.chapters to BookChapterSource.Embedded(embedded.chaptersSource)
         }
+        if (tracks.size >= 2) {
+            return synthesizeChapters(tracks, perTrackMetadata, bookTitle) to
+                BookChapterSource.SynthesizedFromTracks
+        }
         return emptyList<Chapter>() to BookChapterSource.None
+    }
+
+    /**
+     * Synthesis is eligible when no higher-precedence chapter source exists
+     * AND the book is multi-file. Spec §3.
+     */
+    private fun shouldSynthesizeChapters(
+        metadata: AbsMetadata?,
+        embedded: EmbeddedAudioMetadata?,
+        tracks: List<TrackEntry>,
+    ): Boolean {
+        if (metadata?.chapters?.isNotEmpty() == true) return false
+        if (embedded != null && embedded.chapters.isNotEmpty()) return false
+        return tracks.size >= 2
     }
 
     private fun pickTitle(

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesis.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesis.kt
@@ -20,10 +20,10 @@ import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
  */
 private val FILENAME_PREFIX_REGEX =
     Regex(
-        """^(?:(?:disc|cd|track)\s*)?""" +   // optional leading word
-            """\d{1,3}""" +                   // first number
+        """^(?:(?:disc|cd|track)\s*)?""" + // optional leading word
+            """\d{1,3}""" + // first number
             """(?:[\s\-_.]+(?:(?:disc|cd|track)\s*)?\d{1,3})?""" + // optional: sep [word] second-number
-            """[\s\-_.]*""",                  // optional trailing separator
+            """[\s\-_.]*""", // optional trailing separator
         RegexOption.IGNORE_CASE,
     )
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesis.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesis.kt
@@ -1,0 +1,100 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.domain.embeddedmeta.Chapter
+import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+
+/**
+ * Strips a leading track-number-or-disc-number prefix from a filename stem. Matches:
+ *   `01 `, `01_`, `01-01 `, bare `01` (entire stem), `Track 01 - `,
+ *   `Disc 1 Track 02_`, `CD02-04 `.
+ * Doesn't match `Chapter_3_…` — so chapter info in filenames survives cleanup.
+ *
+ * Pattern breakdown:
+ *   - Optional leading word: `disc`, `cd`, or `track` (case-insensitive) + optional space
+ *   - Required first number (1–3 digits)
+ *   - Optional middle section: separator + optional word + second number
+ *   - Optional trailing separator (zero or more, so bare numbers at end-of-stem match)
+ *
+ * Source: spec §5.1 of `2026-05-07-phase-4-multifile-chapter-synthesis-design.md`.
+ */
+private val FILENAME_PREFIX_REGEX =
+    Regex(
+        """^(?:(?:disc|cd|track)\s*)?""" +   // optional leading word
+            """\d{1,3}""" +                   // first number
+            """(?:[\s\-_.]+(?:(?:disc|cd|track)\s*)?\d{1,3})?""" + // optional: sep [word] second-number
+            """[\s\-_.]*""",                  // optional trailing separator
+        RegexOption.IGNORE_CASE,
+    )
+
+private val WHITESPACE_RUN_REGEX = Regex("\\s+")
+
+/**
+ * Pick a chapter title for one synthesized chapter.
+ *
+ * Precedence (spec §5):
+ *  1. Track's TIT2 if non-blank and case-insensitive-trimmed not equal to [bookTitle].
+ *  2. Cleaned filename: strip extension, strip leading track-number prefix
+ *     (see [FILENAME_PREFIX_REGEX]), replace `_` with ` `, collapse whitespace,
+ *     trim. Falls through if empty or equal to book title.
+ *  3. `"Track N"` where N is [trackIndex] (1-based stable-sort position).
+ */
+internal fun pickChapterTitle(
+    track: TrackEntry,
+    bookTitle: String,
+    trackMeta: EmbeddedAudioMetadata?,
+    trackIndex: Int,
+): String {
+    val normalizedBook = bookTitle.trim().lowercase()
+
+    // Rule 1: track TIT2 if meaningfully different from book title.
+    trackMeta
+        ?.tags
+        ?.title
+        ?.takeIf { it.isNotBlank() && it.trim().lowercase() != normalizedBook }
+        ?.let { return it }
+
+    // Rule 2: cleaned filename if non-empty and non-equal-to-book-title.
+    cleanFilename(track.file.name)
+        .takeIf { it.isNotEmpty() && it.lowercase() != normalizedBook }
+        ?.let { return it }
+
+    // Rule 3: "Track N" fallback.
+    return "Track $trackIndex"
+}
+
+internal fun cleanFilename(name: String): String =
+    name
+        .substringBeforeLast('.')
+        .replaceFirst(FILENAME_PREFIX_REGEX, "")
+        .replace('_', ' ')
+        .replace(WHITESPACE_RUN_REGEX, " ")
+        .trim()
+
+/**
+ * Build one [Chapter] per track. A track whose duration parse failed
+ * (`perTrackMetadata[track]` is null or `durationMs == 0`) produces a
+ * zero-length chapter at the current cumulative position; subsequent
+ * tracks' boundaries are unaffected by the failure.
+ *
+ * Source: spec §6 of `2026-05-07-phase-4-multifile-chapter-synthesis-design.md`.
+ */
+internal fun synthesizeChapters(
+    tracks: List<TrackEntry>,
+    perTrackMetadata: Map<TrackEntry, EmbeddedAudioMetadata?>,
+    bookTitle: String,
+): List<Chapter> {
+    var cumulativeMs = 0L
+    return tracks.mapIndexed { i, track ->
+        val durationMs = perTrackMetadata[track]?.durationMs ?: 0L
+        val chapter =
+            Chapter(
+                index = i + 1,
+                title = pickChapterTitle(track, bookTitle, perTrackMetadata[track], i + 1),
+                startMs = cumulativeMs,
+                endMs = cumulativeMs + durationMs,
+            )
+        cumulativeMs += durationMs
+        chapter
+    }
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserStreamingTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserStreamingTest.kt
@@ -1,0 +1,123 @@
+package com.calypsan.listenup.server.embeddedmeta.format.mp3
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
+import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.io.IOException
+
+/**
+ * Regression coverage for the streaming-MP3 parse path.
+ *
+ * Pre-fix the parser called `source.readFully(source.length.toInt())` on
+ * every MP3 — for a 537 MB audiobook (`Stieg Larsson - The Girl Who
+ * Played With Fire.mp3`) that allocated 537 MB on the test heap and
+ * produced `OutOfMemoryError`. For a > 2 GB MP3, `length.toInt()`
+ * silently truncated to a negative size and the read failed before any
+ * allocation. After the fix the parser reads only the ID3v2 region, the
+ * trailing 128-byte ID3v1 footer, and a small prefix of the audio region
+ * for the first MPEG frame header — never the audio body.
+ *
+ * The synthetic [LargePrefixSource] reports a 3 GB length but holds only
+ * the real prefix (ID3v2 + MPEG frame header) in memory; reads past the
+ * prefix are zero-filled without allocating. Strict accounting on
+ * `totalBytesRead` proves the parser doesn't pull the audio body.
+ */
+class Mp3ParserStreamingTest :
+    FunSpec({
+        test("parser does not load whole file for a large MP3") {
+            val realPrefix =
+                buildMp3File {
+                    id3v2(version = 4) {
+                        textFrame("TIT2", "Streaming Test Title")
+                        textFrame("TPE1", "Streaming Test Author")
+                    }
+                    mpegFrames(durationSeconds = 1, bitrate = 64_000)
+                }
+            val sentinelLength = 3L * 1024 * 1024 * 1024 // 3 GB > Int.MAX_VALUE
+            val source = LargePrefixSource(realPrefix = realPrefix, totalLength = sentinelLength)
+
+            val result = Mp3Parser().parse(source)
+            val success = result.shouldBeInstanceOf<AppResult.Success<EmbeddedAudioMetadata>>()
+            success.data.format shouldBe AudioFormat.Mp3
+            success.data.tags.title shouldBe "Streaming Test Title"
+            success.data.tags.authors shouldBe listOf("Streaming Test Author")
+
+            // Bound check: total bytes pulled must be <= ID3v2 region + duration-sniff
+            // window + ID3v1 footer probe. The 64 KB sniff is a hard cap for finding
+            // the first MPEG sync byte; a few hundred bytes of overhead covers the
+            // 10-byte tag-header probe and the 128-byte v1 footer probe. The synthetic
+            // file claims 3 GB total, so anything within an order of magnitude of that
+            // would mean the parser is reading the audio body.
+            val budget: Long = realPrefix.size + 64 * 1024 + 1024L
+            source.totalBytesRead shouldBeLessThan budget
+        }
+    })
+
+private class LargePrefixSource(
+    private val realPrefix: ByteArray,
+    private val totalLength: Long,
+) : SeekableAudioSource {
+    var totalBytesRead: Long = 0
+        private set
+
+    private var pos: Long = 0
+
+    override val length: Long get() = totalLength
+
+    override fun position(): Long = pos
+
+    override fun seek(offset: Long) {
+        require(offset in 0..totalLength) { "seek out of range: $offset" }
+        pos = offset
+    }
+
+    override fun read(
+        into: ByteArray,
+        count: Int,
+    ): Int {
+        val n = doRead(into, 0, count)
+        if (n > 0) {
+            pos += n
+            totalBytesRead += n
+        }
+        return n
+    }
+
+    override fun readFully(count: Int): ByteArray {
+        require(count >= 0) { "negative count: $count" }
+        if (pos + count > totalLength) throw IOException("EOF: pos=$pos count=$count length=$totalLength")
+        val buf = ByteArray(count)
+        var read = 0
+        while (read < count) {
+            val n = doRead(buf, read, count - read)
+            if (n <= 0) throw IOException("short read: pos=$pos read=$read of $count")
+            read += n
+        }
+        pos += count
+        totalBytesRead += count
+        return buf
+    }
+
+    override fun close() { /* no-op */ }
+
+    private fun doRead(
+        dst: ByteArray,
+        dstOffset: Int,
+        max: Int,
+    ): Int {
+        if (pos >= totalLength) return -1
+        val available = (totalLength - pos).coerceAtMost(max.toLong()).toInt()
+        if (pos < realPrefix.size) {
+            val fromPrefix = minOf(available, realPrefix.size - pos.toInt())
+            System.arraycopy(realPrefix, pos.toInt(), dst, dstOffset, fromPrefix)
+            // Bytes past the prefix stay zero (`dst` was zero-initialised).
+        }
+        return available
+    }
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserStreamingTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserStreamingTest.kt
@@ -29,6 +29,76 @@ import java.io.IOException
  */
 class Mp4ParserStreamingTest :
     FunSpec({
+        test("parser handles non-fast-start MP4 with mdat size > 2GB (Stormlight regression)") {
+            // Real-world layout from `/mnt/Igni/Audiobooks/Brandon Sanderson/.../The Way of Kings.m4b`:
+            // `ftyp` (32 bytes) → `mdat` (size 0x950eddb5 ≈ 2.5 GB) → `moov` at the end.
+            // The streaming walker must traverse past the mdat header and read moov from the
+            // file-absolute offset its size implies. Pre-fix the walker rejected the mdat header
+            // because `size32 = 0x950eddb5` was interpreted as a *signed* Int (negative) and
+            // failed the `< 8` guard, returning null and producing AUDIO_META_CORRUPT_HEADER on
+            // 32 of 1,123 real M4Bs.
+            val moov =
+                buildMp4File {
+                    ftyp(brand = "M4B ")
+                    moov {
+                        mvhd(timescale = 1000, durationInTimescale = 60_000)
+                        udta { meta { tag(atomType = "©nam", value = "Way of Kings Test") } }
+                    }
+                }.let { fullPrefix ->
+                    // buildMp4File emits ftyp + moov + mdat; we want only the moov bytes for our
+                    // synthetic file, so split out the moov region. The first atom is ftyp at
+                    // offset 0; the second atom is moov.
+                    val ftypSize =
+                        ((fullPrefix[0].toInt() and 0xFF) shl 24) or
+                            ((fullPrefix[1].toInt() and 0xFF) shl 16) or
+                            ((fullPrefix[2].toInt() and 0xFF) shl 8) or
+                            (fullPrefix[3].toInt() and 0xFF)
+                    val moovSize =
+                        ((fullPrefix[ftypSize].toInt() and 0xFF) shl 24) or
+                            ((fullPrefix[ftypSize + 1].toInt() and 0xFF) shl 16) or
+                            ((fullPrefix[ftypSize + 2].toInt() and 0xFF) shl 8) or
+                            (fullPrefix[ftypSize + 3].toInt() and 0xFF)
+                    fullPrefix.copyOfRange(ftypSize, ftypSize + moovSize)
+                }
+            // Synthetic file: ftyp (32 bytes) + mdat header (8 bytes claiming 2.6 GB) + moov.
+            val mdatPayloadSize = 2_700_000_000L // > Int.MAX_VALUE
+            val mdatTotalSize = mdatPayloadSize + 8 // including 8-byte header
+            val ftypBytes = byteArrayOf(
+                0, 0, 0, 0x20.toByte(), 'f'.code.toByte(), 't'.code.toByte(), 'y'.code.toByte(), 'p'.code.toByte(),
+                'M'.code.toByte(), '4'.code.toByte(), 'B'.code.toByte(), ' '.code.toByte(),
+                0, 0, 0, 0,
+                'M'.code.toByte(), '4'.code.toByte(), 'B'.code.toByte(), ' '.code.toByte(),
+                'i'.code.toByte(), 's'.code.toByte(), 'o'.code.toByte(), 'm'.code.toByte(),
+                0, 0, 0, 0, 0, 0, 0, 0, // padding to 32 bytes
+            )
+            val mdatHeader = byteArrayOf(
+                ((mdatTotalSize ushr 24) and 0xFF).toByte(),
+                ((mdatTotalSize ushr 16) and 0xFF).toByte(),
+                ((mdatTotalSize ushr 8) and 0xFF).toByte(),
+                (mdatTotalSize and 0xFFL).toByte(),
+                'm'.code.toByte(), 'd'.code.toByte(), 'a'.code.toByte(), 't'.code.toByte(),
+            )
+            val moovOffset = ftypBytes.size + mdatTotalSize
+            val totalLength = moovOffset + moov.size
+            val source =
+                NonFastStartSource(
+                    ftyp = ftypBytes,
+                    mdatHeader = mdatHeader,
+                    moovOffset = moovOffset,
+                    moov = moov,
+                    totalLength = totalLength,
+                )
+
+            val result = Mp4Parser().parse(source)
+            val success = result.shouldBeInstanceOf<AppResult.Success<EmbeddedAudioMetadata>>()
+            success.data.format shouldBe AudioFormat.Mp4
+            success.data.tags.title shouldBe "Way of Kings Test"
+
+            // Bound check: total bytes read must be tiny (ftyp + mdat header + moov), not 2.7 GB.
+            val budget: Long = (ftypBytes.size + mdatHeader.size + moov.size + 1024).toLong()
+            source.totalBytesRead shouldBeLessThan budget
+        }
+
         test("parser does not allocate the full file length when mdat is huge") {
             val realPrefix =
                 buildMp4File {
@@ -64,6 +134,94 @@ class Mp4ParserStreamingTest :
             source.maxSingleReadBytes intShouldBeLessThan Int.MAX_VALUE
         }
     })
+
+/**
+ * Synthetic [SeekableAudioSource] simulating a non-fast-start MP4 layout
+ * (`ftyp` → `mdat` larger than 2 GB → `moov` at the end). Holds only the
+ * tiny header + moov regions in memory; the synthetic mdat payload is
+ * never materialised. Tracks total bytes pulled to assert the parser
+ * doesn't read the audio region.
+ */
+private class NonFastStartSource(
+    private val ftyp: ByteArray,
+    private val mdatHeader: ByteArray,
+    private val moovOffset: Long,
+    private val moov: ByteArray,
+    private val totalLength: Long,
+) : SeekableAudioSource {
+    var totalBytesRead: Long = 0
+        private set
+
+    private var pos: Long = 0
+
+    override val length: Long get() = totalLength
+
+    override fun position(): Long = pos
+
+    override fun seek(offset: Long) {
+        require(offset in 0..totalLength) { "seek out of range: $offset" }
+        pos = offset
+    }
+
+    override fun read(
+        into: ByteArray,
+        count: Int,
+    ): Int {
+        if (pos >= totalLength) return -1
+        val n = (totalLength - pos).coerceAtMost(count.toLong()).toInt()
+        copyInto(into, 0, n)
+        pos += n
+        totalBytesRead += n
+        return n
+    }
+
+    override fun readFully(count: Int): ByteArray {
+        if (pos + count > totalLength) throw IOException("EOF: pos=$pos count=$count length=$totalLength")
+        val buf = ByteArray(count)
+        copyInto(buf, 0, count)
+        pos += count
+        totalBytesRead += count
+        return buf
+    }
+
+    override fun close() { /* no-op */ }
+
+    private fun copyInto(
+        dst: ByteArray,
+        dstOffset: Int,
+        count: Int,
+    ) {
+        val ftypEnd = ftyp.size.toLong()
+        val mdatHeaderEnd = ftypEnd + mdatHeader.size
+        var written = 0
+        while (written < count) {
+            val cur = pos + written
+            val remaining = count - written
+            when {
+                cur < ftypEnd -> {
+                    val copyN = minOf(remaining.toLong(), ftypEnd - cur).toInt()
+                    System.arraycopy(ftyp, cur.toInt(), dst, dstOffset + written, copyN)
+                    written += copyN
+                }
+                cur < mdatHeaderEnd -> {
+                    val copyN = minOf(remaining.toLong(), mdatHeaderEnd - cur).toInt()
+                    System.arraycopy(mdatHeader, (cur - ftypEnd).toInt(), dst, dstOffset + written, copyN)
+                    written += copyN
+                }
+                cur >= moovOffset -> {
+                    val copyN = minOf(remaining.toLong(), moov.size.toLong() - (cur - moovOffset)).toInt()
+                    System.arraycopy(moov, (cur - moovOffset).toInt(), dst, dstOffset + written, copyN)
+                    written += copyN
+                }
+                else -> {
+                    // Synthetic mdat payload: zeros (dst is already zero-initialised).
+                    val copyN = minOf(remaining.toLong(), moovOffset - cur).toInt()
+                    written += copyN
+                }
+            }
+        }
+    }
+}
 
 /**
  * Synthetic [SeekableAudioSource] that lies about its total length.

--- a/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserStreamingTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserStreamingTest.kt
@@ -63,21 +63,52 @@ class Mp4ParserStreamingTest :
             // Synthetic file: ftyp (32 bytes) + mdat header (8 bytes claiming 2.6 GB) + moov.
             val mdatPayloadSize = 2_700_000_000L // > Int.MAX_VALUE
             val mdatTotalSize = mdatPayloadSize + 8 // including 8-byte header
-            val ftypBytes = byteArrayOf(
-                0, 0, 0, 0x20.toByte(), 'f'.code.toByte(), 't'.code.toByte(), 'y'.code.toByte(), 'p'.code.toByte(),
-                'M'.code.toByte(), '4'.code.toByte(), 'B'.code.toByte(), ' '.code.toByte(),
-                0, 0, 0, 0,
-                'M'.code.toByte(), '4'.code.toByte(), 'B'.code.toByte(), ' '.code.toByte(),
-                'i'.code.toByte(), 's'.code.toByte(), 'o'.code.toByte(), 'm'.code.toByte(),
-                0, 0, 0, 0, 0, 0, 0, 0, // padding to 32 bytes
-            )
-            val mdatHeader = byteArrayOf(
-                ((mdatTotalSize ushr 24) and 0xFF).toByte(),
-                ((mdatTotalSize ushr 16) and 0xFF).toByte(),
-                ((mdatTotalSize ushr 8) and 0xFF).toByte(),
-                (mdatTotalSize and 0xFFL).toByte(),
-                'm'.code.toByte(), 'd'.code.toByte(), 'a'.code.toByte(), 't'.code.toByte(),
-            )
+            val ftypBytes =
+                byteArrayOf(
+                    0,
+                    0,
+                    0,
+                    0x20.toByte(),
+                    'f'.code.toByte(),
+                    't'.code.toByte(),
+                    'y'.code.toByte(),
+                    'p'.code.toByte(),
+                    'M'.code.toByte(),
+                    '4'.code.toByte(),
+                    'B'.code.toByte(),
+                    ' '.code.toByte(),
+                    0,
+                    0,
+                    0,
+                    0,
+                    'M'.code.toByte(),
+                    '4'.code.toByte(),
+                    'B'.code.toByte(),
+                    ' '.code.toByte(),
+                    'i'.code.toByte(),
+                    's'.code.toByte(),
+                    'o'.code.toByte(),
+                    'm'.code.toByte(),
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0, // padding to 32 bytes
+                )
+            val mdatHeader =
+                byteArrayOf(
+                    ((mdatTotalSize ushr 24) and 0xFF).toByte(),
+                    ((mdatTotalSize ushr 16) and 0xFF).toByte(),
+                    ((mdatTotalSize ushr 8) and 0xFF).toByte(),
+                    (mdatTotalSize and 0xFFL).toByte(),
+                    'm'.code.toByte(),
+                    'd'.code.toByte(),
+                    'a'.code.toByte(),
+                    't'.code.toByte(),
+                )
             val moovOffset = ftypBytes.size + mdatTotalSize
             val totalLength = moovOffset + moov.size
             val source =
@@ -203,16 +234,19 @@ private class NonFastStartSource(
                     System.arraycopy(ftyp, cur.toInt(), dst, dstOffset + written, copyN)
                     written += copyN
                 }
+
                 cur < mdatHeaderEnd -> {
                     val copyN = minOf(remaining.toLong(), mdatHeaderEnd - cur).toInt()
                     System.arraycopy(mdatHeader, (cur - ftypEnd).toInt(), dst, dstOffset + written, copyN)
                     written += copyN
                 }
+
                 cur >= moovOffset -> {
                     val copyN = minOf(remaining.toLong(), moov.size.toLong() - (cur - moovOffset)).toInt()
                     System.arraycopy(moov, (cur - moovOffset).toInt(), dst, dstOffset + written, copyN)
                     written += copyN
                 }
+
                 else -> {
                     // Synthetic mdat payload: zeros (dst is already zero-initialised).
                     val copyN = minOf(remaining.toLong(), moovOffset - cur).toInt()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImplTest.kt
@@ -12,10 +12,8 @@ import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
 class ScannerServiceImplTest :
@@ -32,25 +30,6 @@ class ScannerServiceImplTest :
                     success.data.totalBooks shouldBe 1
                     success.data.added shouldBe 1
                     success.data.errors shouldBe 0
-                }
-            }
-        }
-
-        test("scanFull returns Failure(AlreadyRunning) on overlapping invocations") {
-            runTest {
-                audioLibrary {
-                    book("Author/Title") { tracks(count = 1) }
-                }.use { fixture ->
-                    val service = newService(fixture, scope = this)
-
-                    val first = async { service.scanFull() }
-                    runCurrent()
-
-                    val second = service.scanFull()
-                    val failure = second.shouldBeInstanceOf<AppResult.Failure>()
-                    failure.error.shouldBeInstanceOf<ScanError.AlreadyRunning>()
-
-                    first.await().shouldBeInstanceOf<AppResult.Success<ScanResultSummary>>()
                 }
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
@@ -385,6 +385,105 @@ class AnalyzerEnrichmentTest :
                 }
             }
         }
+
+        test("metadata.json chapters override synthesized chapters on multi-file book") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Multi"
+                    val track1Bytes =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TIT2", "Foreword") }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val track2Bytes =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TIT2", "Prologue") }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val t1 = fixture.root.writeAudioFile("$rel/01.mp3", track1Bytes)
+                    val t2 = fixture.root.writeAudioFile("$rel/02.mp3", track2Bytes)
+                    val metadataJson =
+                        """
+                        {
+                            "title": "Multi",
+                            "chapters": [
+                                {"id": 0, "start": 0.0, "end": 30.0, "title": "Sidecar 1"},
+                                {"id": 1, "start": 30.0, "end": 60.0, "title": "Sidecar 2"}
+                            ]
+                        }
+                        """.trimIndent()
+                    val metaPath = fixture.root.writeFile("$rel/metadata.json", metadataJson.toByteArray())
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    fileEntry("$rel/01.mp3", FileType.AUDIO, size = Files.size(t1)),
+                                    fileEntry("$rel/02.mp3", FileType.AUDIO, size = Files.size(t2)),
+                                    fileEntry("$rel/metadata.json", FileType.METADATA, size = Files.size(metaPath)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldHaveSize 2
+                    book.chapters[0].title shouldBe "Sidecar 1"
+                    book.chaptersSource shouldBe BookChapterSource.AbsMetadata
+                }
+            }
+        }
+
+        test("embedded CHAP frames on primary track override synthesized chapters") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Multi"
+                    val primaryBytes =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TIT2", "Multi")
+                                chapFrame("c1", startMs = 0, endMs = 5_000, title = "Embedded A")
+                                chapFrame("c2", startMs = 5_000, endMs = 10_000, title = "Embedded B")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val secondaryBytes =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TIT2", "Track Two") }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val t1 = fixture.root.writeAudioFile("$rel/01.mp3", primaryBytes)
+                    val t2 = fixture.root.writeAudioFile("$rel/02.mp3", secondaryBytes)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    fileEntry("$rel/01.mp3", FileType.AUDIO, size = Files.size(t1)),
+                                    fileEntry("$rel/02.mp3", FileType.AUDIO, size = Files.size(t2)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldHaveSize 2
+                    book.chapters[0].title shouldBe "Embedded A"
+                    val source = book.chaptersSource.shouldBeInstanceOf<BookChapterSource.Embedded>()
+                    source.parserSource shouldBe ChapterSource.Id3v2Chap
+                }
+            }
+        }
     })
 
 private fun candidateForPath(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server.scanner.pipeline
 
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.BookChapterSource
 import com.calypsan.listenup.api.dto.scanner.CandidateBook
 import com.calypsan.listenup.api.dto.scanner.CoverSource
 import com.calypsan.listenup.api.dto.scanner.FileEntry
@@ -8,6 +9,7 @@ import com.calypsan.listenup.api.dto.scanner.FileType
 import com.calypsan.listenup.api.dto.scanner.MetadataSource
 import com.calypsan.listenup.api.dto.scanner.MetadataStatus
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
+import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
 import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
 import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
@@ -16,6 +18,7 @@ import com.calypsan.listenup.server.scanner.audioLibrary
 import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -188,6 +191,123 @@ class AnalyzerEnrichmentTest :
                     book.embedded?.tags?.title shouldBe "Embedded Title"
                     book.sources shouldContain MetadataSource.ABS_METADATA
                     book.sources shouldContain MetadataSource.AUDIO_METATAGS
+                }
+            }
+        }
+
+        test("metadata.json chapters override embedded CHAP frames") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Title"
+                    val audioBytes =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TIT2", "Title")
+                                chapFrame("emb1", startMs = 0, endMs = 10_000, title = "Embedded Chapter A")
+                                chapFrame("emb2", startMs = 10_000, endMs = 20_000, title = "Embedded Chapter B")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val audioPath = fixture.root.writeAudioFile("$rel/01.mp3", audioBytes)
+                    val metadataJson =
+                        """
+                        {
+                            "title": "Title",
+                            "chapters": [
+                                {"id": 0, "start": 0.0, "end": 30.5, "title": "Sidecar Chapter 1"},
+                                {"id": 1, "start": 30.5, "end": 60.0, "title": "Sidecar Chapter 2"},
+                                {"id": 2, "start": 60.0, "end": 90.0, "title": "Sidecar Chapter 3"}
+                            ]
+                        }
+                        """.trimIndent()
+                    val metadataPath = fixture.root.writeFile("$rel/metadata.json", metadataJson.toByteArray())
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    fileEntry("$rel/01.mp3", FileType.AUDIO, size = Files.size(audioPath)),
+                                    fileEntry("$rel/metadata.json", FileType.METADATA, size = Files.size(metadataPath)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldHaveSize 3
+                    book.chapters[0].index shouldBe 1
+                    book.chapters[0].title shouldBe "Sidecar Chapter 1"
+                    book.chapters[0].startMs shouldBe 0L
+                    book.chapters[0].endMs shouldBe 30_500L
+                    book.chapters[1].index shouldBe 2
+                    book.chapters[2].index shouldBe 3
+                    book.chaptersSource shouldBe BookChapterSource.AbsMetadata
+                    // embedded chapters preserved verbatim on `embedded`
+                    book.embedded?.chapters?.shouldHaveSize(2)
+                    book.embedded
+                        ?.chapters
+                        ?.get(0)
+                        ?.title shouldBe "Embedded Chapter A"
+                }
+            }
+        }
+
+        test("embedded chapters surface when metadata.json carries no chapters") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Title"
+                    val audioBytes =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TIT2", "Title")
+                                chapFrame("emb1", startMs = 0, endMs = 10_000, title = "Embedded Chapter A")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val audioPath = fixture.root.writeAudioFile("$rel/01.mp3", audioBytes)
+                    val candidate = candidateForPath(rel, audioPath)
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldHaveSize 1
+                    book.chapters[0].title shouldBe "Embedded Chapter A"
+                    val source = book.chaptersSource.shouldBeInstanceOf<BookChapterSource.Embedded>()
+                    source.parserSource shouldBe ChapterSource.Id3v2Chap
+                }
+            }
+        }
+
+        test("no chapter signal anywhere → empty list and BookChapterSource.None") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Title"
+                    val audioBytes =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TIT2", "Title") }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val audioPath = fixture.root.writeAudioFile("$rel/01.mp3", audioBytes)
+                    val candidate = candidateForPath(rel, audioPath)
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldBe emptyList()
+                    book.chaptersSource shouldBe BookChapterSource.None
                 }
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
@@ -336,6 +336,55 @@ class AnalyzerEnrichmentTest :
                 }
             }
         }
+
+        test("multi-file MP3 book with no chapter sources synthesizes one chapter per track") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    // Book title comes from the folder name ("Multi") because
+                    // the tracks carry no TIT2 — no collision between book title
+                    // and chapter titles, so filename-based resolution fires.
+                    val rel = "Author/Multi"
+                    val track1Bytes =
+                        buildMp3File {
+                            id3v2(version = 4) {}
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val track2Bytes =
+                        buildMp3File {
+                            id3v2(version = 4) {}
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val track1Path = fixture.root.writeAudioFile("$rel/01 Foreword.mp3", track1Bytes)
+                    val track2Path = fixture.root.writeAudioFile("$rel/02 Prologue.mp3", track2Bytes)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    fileEntry("$rel/01 Foreword.mp3", FileType.AUDIO, size = Files.size(track1Path)),
+                                    fileEntry("$rel/02 Prologue.mp3", FileType.AUDIO, size = Files.size(track2Path)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldHaveSize 2
+                    book.chapters[0].index shouldBe 1
+                    book.chapters[0].title shouldBe "Foreword"
+                    book.chapters[0].startMs shouldBe 0L
+                    book.chapters[1].index shouldBe 2
+                    book.chapters[1].title shouldBe "Prologue"
+                    book.chapters[1].startMs shouldBe book.chapters[0].endMs
+                    book.chaptersSource shouldBe BookChapterSource.SynthesizedFromTracks
+                }
+            }
+        }
     })
 
 private fun candidateForPath(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerEnrichmentTest.kt
@@ -484,6 +484,74 @@ class AnalyzerEnrichmentTest :
                 }
             }
         }
+
+        test("single-file book never triggers synthesis") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Single"
+                    val audioBytes =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TIT2", "Single") }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val audioPath = fixture.root.writeAudioFile("$rel/01.mp3", audioBytes)
+                    val candidate = candidateForPath(rel, audioPath)
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    // Single-file with no chapter sources → None, not SynthesizedFromTracks.
+                    book.chapters shouldBe emptyList()
+                    book.chaptersSource shouldBe BookChapterSource.None
+                }
+            }
+        }
+
+        test("multi-file: one track's parse failure produces zero-length chapter, book still emerges") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Multi"
+                    val track1Bytes =
+                        buildMp3File {
+                            id3v2(version = 4) {}
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    // Random non-audio bytes for track 2 — parser should reject as UnsupportedFormat.
+                    val track2Bytes = ByteArray(64) { it.toByte() }
+                    // Meaningful filenames so cleanFilename() can derive chapter titles.
+                    val t1 = fixture.root.writeAudioFile("$rel/01 Real Track.mp3", track1Bytes)
+                    val t2 = fixture.root.writeAudioFile("$rel/02 Bad Track.mp3", track2Bytes)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    fileEntry("$rel/01 Real Track.mp3", FileType.AUDIO, size = Files.size(t1)),
+                                    fileEntry("$rel/02 Bad Track.mp3", FileType.AUDIO, size = Files.size(t2)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.chapters shouldHaveSize 2
+                    book.chapters[0].title shouldBe "Real Track"
+                    // Track 2's chapter exists but is zero-length: failed parse → 0ms duration.
+                    book.chapters[1].startMs shouldBe book.chapters[0].endMs
+                    book.chapters[1].endMs shouldBe book.chapters[1].startMs
+                    book.chaptersSource shouldBe BookChapterSource.SynthesizedFromTracks
+                }
+            }
+        }
     })
 
 private fun candidateForPath(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesisTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesisTest.kt
@@ -1,0 +1,182 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
+import com.calypsan.listenup.domain.embeddedmeta.AudioTags
+import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
+import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class ChapterSynthesisTest :
+    FunSpec({
+
+        test("pickChapterTitle: track TIT2 different from book title wins") {
+            val track = trackEntry("01.mp3")
+            val trackMeta = embeddedTagsTitle("Foreword")
+            pickChapterTitle(track, bookTitle = "The Way of Kings", trackMeta = trackMeta, trackIndex = 1) shouldBe
+                "Foreword"
+        }
+
+        test("pickChapterTitle: track TIT2 equal to book title falls through to filename") {
+            val track = trackEntry("01 The Way of Kings - Part 1.mp3")
+            val trackMeta = embeddedTagsTitle("The Way of Kings")
+            pickChapterTitle(track, bookTitle = "The Way of Kings", trackMeta = trackMeta, trackIndex = 1) shouldBe
+                "The Way of Kings - Part 1"
+        }
+
+        test("pickChapterTitle: blank track TIT2 falls through to filename") {
+            val track = trackEntry("01-01 The Girl Who Kicked the Hornet's Nest.mp3")
+            val trackMeta = embeddedTagsTitle(title = "")
+            pickChapterTitle(
+                track,
+                bookTitle = "The Girl Who Played With Fire",
+                trackMeta = trackMeta,
+                trackIndex = 1,
+            ) shouldBe "The Girl Who Kicked the Hornet's Nest"
+        }
+
+        test("pickChapterTitle: null trackMeta uses filename") {
+            val track = trackEntry("Chapter_3_Chapter_4_96Kbps.mp3")
+            pickChapterTitle(
+                track,
+                bookTitle = "Some Book",
+                trackMeta = null,
+                trackIndex = 7,
+            ) shouldBe "Chapter 3 Chapter 4 96Kbps"
+        }
+
+        test("pickChapterTitle: filename equals book title falls through to Track N") {
+            val track = trackEntry("Some Book.mp3")
+            pickChapterTitle(
+                track,
+                bookTitle = "Some Book",
+                trackMeta = null,
+                trackIndex = 5,
+            ) shouldBe "Track 5"
+        }
+
+        test("pickChapterTitle: empty cleaned filename falls through to Track N") {
+            // Filename is just a track-number prefix that the regex strips entirely.
+            val track = trackEntry("01.mp3")
+            pickChapterTitle(
+                track,
+                bookTitle = "Some Book",
+                trackMeta = null,
+                trackIndex = 1,
+            ) shouldBe "Track 1"
+        }
+
+        test("cleanFilename: strips Disc/CD/Track word prefix") {
+            cleanFilename("Disc 1 Track 02_Foreword.mp3") shouldBe "Foreword"
+            cleanFilename("CD02-04 Chapter Two.mp3") shouldBe "Chapter Two"
+            cleanFilename("Track 01 - Prologue.mp3") shouldBe "Prologue"
+        }
+
+        test("synthesizeChapters: cumulative startMs/endMs follow track durations") {
+            val tracks = listOf(
+                trackEntry("01 Foreword.mp3"),
+                trackEntry("02 Prologue.mp3"),
+                trackEntry("03 Chapter One.mp3"),
+            )
+            val perTrackMetadata = mapOf(
+                tracks[0] to embeddedDuration(60_000L),
+                tracks[1] to embeddedDuration(120_000L),
+                tracks[2] to embeddedDuration(180_000L),
+            )
+
+            val chapters = synthesizeChapters(
+                tracks = tracks,
+                perTrackMetadata = perTrackMetadata,
+                bookTitle = "Some Book",
+            )
+
+            chapters shouldHaveSize 3
+            chapters[0].index shouldBe 1
+            chapters[0].title shouldBe "Foreword"
+            chapters[0].startMs shouldBe 0L
+            chapters[0].endMs shouldBe 60_000L
+            chapters[1].index shouldBe 2
+            chapters[1].title shouldBe "Prologue"
+            chapters[1].startMs shouldBe 60_000L
+            chapters[1].endMs shouldBe 180_000L
+            chapters[2].index shouldBe 3
+            chapters[2].title shouldBe "Chapter One"
+            chapters[2].startMs shouldBe 180_000L
+            chapters[2].endMs shouldBe 360_000L
+        }
+
+        test("synthesizeChapters: missing trackMeta produces zero-length chapter") {
+            val tracks = listOf(
+                trackEntry("01 First.mp3"),
+                trackEntry("02 Failed.mp3"),
+                trackEntry("03 Third.mp3"),
+            )
+            val perTrackMetadata = mapOf(
+                tracks[0] to embeddedDuration(60_000L),
+                tracks[1] to null, // parse failed for this track
+                tracks[2] to embeddedDuration(90_000L),
+            )
+
+            val chapters = synthesizeChapters(
+                tracks = tracks,
+                perTrackMetadata = perTrackMetadata,
+                bookTitle = "Some Book",
+            )
+
+            chapters shouldHaveSize 3
+            chapters[0].endMs shouldBe 60_000L
+            // Track 2's chapter is zero-length at the current cumulative position.
+            chapters[1].startMs shouldBe 60_000L
+            chapters[1].endMs shouldBe 60_000L
+            chapters[1].title shouldBe "Failed"
+            // Track 3 picks up where track 1 left off (track 2 contributed 0ms).
+            chapters[2].startMs shouldBe 60_000L
+            chapters[2].endMs shouldBe 150_000L
+        }
+    })
+
+private fun trackEntry(filename: String): TrackEntry =
+    TrackEntry(
+        file = FileEntry(
+            relPath = "Author/Title/$filename",
+            name = filename,
+            ext = filename.substringAfterLast('.', "").lowercase(),
+            size = 1024,
+            mtimeMs = 0,
+            inode = null,
+            fileType = FileType.AUDIO,
+        ),
+    )
+
+private fun embeddedTagsTitle(title: String?): EmbeddedAudioMetadata =
+    EmbeddedAudioMetadata(
+        format = AudioFormat.Mp3,
+        durationMs = 1_000L,
+        tags = AudioTags(
+            title = title,
+            subtitle = null,
+            authors = emptyList(),
+            narrators = emptyList(),
+            series = emptyList(),
+            genres = emptyList(),
+            description = null,
+            publisher = null,
+            publishedYear = null,
+            asin = null,
+            isbn = null,
+            language = null,
+            trackNumber = null,
+            discNumber = null,
+            custom = emptyMap(),
+        ),
+        chapters = emptyList(),
+        chaptersSource = ChapterSource.None,
+        artwork = null,
+    )
+
+private fun embeddedDuration(durationMs: Long): EmbeddedAudioMetadata =
+    embeddedTagsTitle(title = null).copy(durationMs = durationMs)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesisTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesisTest.kt
@@ -77,22 +77,25 @@ class ChapterSynthesisTest :
         }
 
         test("synthesizeChapters: cumulative startMs/endMs follow track durations") {
-            val tracks = listOf(
-                trackEntry("01 Foreword.mp3"),
-                trackEntry("02 Prologue.mp3"),
-                trackEntry("03 Chapter One.mp3"),
-            )
-            val perTrackMetadata = mapOf(
-                tracks[0] to embeddedDuration(60_000L),
-                tracks[1] to embeddedDuration(120_000L),
-                tracks[2] to embeddedDuration(180_000L),
-            )
+            val tracks =
+                listOf(
+                    trackEntry("01 Foreword.mp3"),
+                    trackEntry("02 Prologue.mp3"),
+                    trackEntry("03 Chapter One.mp3"),
+                )
+            val perTrackMetadata =
+                mapOf(
+                    tracks[0] to embeddedDuration(60_000L),
+                    tracks[1] to embeddedDuration(120_000L),
+                    tracks[2] to embeddedDuration(180_000L),
+                )
 
-            val chapters = synthesizeChapters(
-                tracks = tracks,
-                perTrackMetadata = perTrackMetadata,
-                bookTitle = "Some Book",
-            )
+            val chapters =
+                synthesizeChapters(
+                    tracks = tracks,
+                    perTrackMetadata = perTrackMetadata,
+                    bookTitle = "Some Book",
+                )
 
             chapters shouldHaveSize 3
             chapters[0].index shouldBe 1
@@ -110,22 +113,25 @@ class ChapterSynthesisTest :
         }
 
         test("synthesizeChapters: missing trackMeta produces zero-length chapter") {
-            val tracks = listOf(
-                trackEntry("01 First.mp3"),
-                trackEntry("02 Failed.mp3"),
-                trackEntry("03 Third.mp3"),
-            )
-            val perTrackMetadata = mapOf(
-                tracks[0] to embeddedDuration(60_000L),
-                tracks[1] to null, // parse failed for this track
-                tracks[2] to embeddedDuration(90_000L),
-            )
+            val tracks =
+                listOf(
+                    trackEntry("01 First.mp3"),
+                    trackEntry("02 Failed.mp3"),
+                    trackEntry("03 Third.mp3"),
+                )
+            val perTrackMetadata =
+                mapOf(
+                    tracks[0] to embeddedDuration(60_000L),
+                    tracks[1] to null, // parse failed for this track
+                    tracks[2] to embeddedDuration(90_000L),
+                )
 
-            val chapters = synthesizeChapters(
-                tracks = tracks,
-                perTrackMetadata = perTrackMetadata,
-                bookTitle = "Some Book",
-            )
+            val chapters =
+                synthesizeChapters(
+                    tracks = tracks,
+                    perTrackMetadata = perTrackMetadata,
+                    bookTitle = "Some Book",
+                )
 
             chapters shouldHaveSize 3
             chapters[0].endMs shouldBe 60_000L
@@ -141,42 +147,43 @@ class ChapterSynthesisTest :
 
 private fun trackEntry(filename: String): TrackEntry =
     TrackEntry(
-        file = FileEntry(
-            relPath = "Author/Title/$filename",
-            name = filename,
-            ext = filename.substringAfterLast('.', "").lowercase(),
-            size = 1024,
-            mtimeMs = 0,
-            inode = null,
-            fileType = FileType.AUDIO,
-        ),
+        file =
+            FileEntry(
+                relPath = "Author/Title/$filename",
+                name = filename,
+                ext = filename.substringAfterLast('.', "").lowercase(),
+                size = 1024,
+                mtimeMs = 0,
+                inode = null,
+                fileType = FileType.AUDIO,
+            ),
     )
 
 private fun embeddedTagsTitle(title: String?): EmbeddedAudioMetadata =
     EmbeddedAudioMetadata(
         format = AudioFormat.Mp3,
         durationMs = 1_000L,
-        tags = AudioTags(
-            title = title,
-            subtitle = null,
-            authors = emptyList(),
-            narrators = emptyList(),
-            series = emptyList(),
-            genres = emptyList(),
-            description = null,
-            publisher = null,
-            publishedYear = null,
-            asin = null,
-            isbn = null,
-            language = null,
-            trackNumber = null,
-            discNumber = null,
-            custom = emptyMap(),
-        ),
+        tags =
+            AudioTags(
+                title = title,
+                subtitle = null,
+                authors = emptyList(),
+                narrators = emptyList(),
+                series = emptyList(),
+                genres = emptyList(),
+                description = null,
+                publisher = null,
+                publishedYear = null,
+                asin = null,
+                isbn = null,
+                language = null,
+                trackNumber = null,
+                discNumber = null,
+                custom = emptyMap(),
+            ),
         chapters = emptyList(),
         chaptersSource = ChapterSource.None,
         artwork = null,
     )
 
-private fun embeddedDuration(durationMs: Long): EmbeddedAudioMetadata =
-    embeddedTagsTitle(title = null).copy(durationMs = durationMs)
+private fun embeddedDuration(durationMs: Long): EmbeddedAudioMetadata = embeddedTagsTitle(title = null).copy(durationMs = durationMs)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/LiveCorpusAnalyzerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/LiveCorpusAnalyzerTest.kt
@@ -1,0 +1,113 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.BookChapterSource
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
+import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import com.calypsan.listenup.server.embeddedmeta.format.mp3.Mp3Parser
+import com.calypsan.listenup.server.embeddedmeta.format.mp4.Mp4Parser
+import com.calypsan.listenup.server.scanner.inference.FileTypeRules
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.listDirectoryEntries
+
+/**
+ * Env-gated live corpus regression guard for the chapter-synthesis branch.
+ *
+ * Verifies that real multi-file MP3 audiobooks — where no embedded CHAP
+ * frames or sidecar chapters exist — produce
+ * [BookChapterSource.SynthesizedFromTracks] from the Analyzer pipeline.
+ *
+ * **Skipped in CI** — [LIVE_CORPUS_ENV] is unset on shared infrastructure.
+ * Run locally:
+ *
+ * ```
+ * LISTENUP_EMBEDDEDMETA_LIVE_DIR=/mnt/Igni/Audiobooks \
+ *   ./gradlew :server:test \
+ *   --tests "com.calypsan.listenup.server.scanner.pipeline.LiveCorpusAnalyzerTest"
+ * ```
+ */
+class LiveCorpusAnalyzerTest :
+    FunSpec({
+        val liveDir = System.getenv(LIVE_CORPUS_ENV)
+
+        test("Myst - The Book Of Atrus synthesizes chapters from tracks")
+            .config(enabled = liveDir != null) {
+                val rel = "Rand Miller, Robyn Miller/Myst - The Book Of Atrus"
+                runTest { assertSynthesis(Path.of(liveDir!!), rel) }
+            }
+
+        test("The Girl Who Kicked the Hornet's Nest synthesizes chapters from tracks")
+            .config(enabled = liveDir != null) {
+                val rel = "Steig Larsson/Millenium/Book 3 - The Girl Who Kicked the Hornet's Nest"
+                runTest { assertSynthesis(Path.of(liveDir!!), rel) }
+            }
+
+        test("Moral Revolution synthesizes chapters from tracks")
+            .config(enabled = liveDir != null) {
+                val rel = "Kris Valloton/Moral Revolution"
+                runTest { assertSynthesis(Path.of(liveDir!!), rel) }
+            }
+    })
+
+private const val LIVE_CORPUS_ENV = "LISTENUP_EMBEDDEDMETA_LIVE_DIR"
+
+private val liveParser =
+    EmbeddedMetadataParser(
+        detector = AudioFormatDetector(),
+        parsers = listOf(Mp3Parser(), Mp4Parser()),
+    )
+
+private suspend fun assertSynthesis(
+    rootPath: Path,
+    rel: String,
+) {
+    val bookPath = rootPath.resolve(rel)
+    require(bookPath.isDirectory()) { "expected directory: $bookPath" }
+
+    val files =
+        bookPath
+            .listDirectoryEntries()
+            .filter { Files.isRegularFile(it) }
+            .map { entry ->
+                val name = entry.fileName.toString()
+                val ext = name.substringAfterLast('.', "").lowercase()
+                FileEntry(
+                    relPath = "$rel/$name",
+                    name = name,
+                    ext = ext,
+                    size = Files.size(entry),
+                    mtimeMs = Files.getLastModifiedTime(entry).toMillis(),
+                    inode = null,
+                    fileType = FileTypeRules.classify(name),
+                )
+            }
+
+    val candidate = CandidateBook(rootRelPath = rel, isFile = false, files = files)
+    val analyzer = Analyzer(rootPath, AbsMetadataReader(contractJson), liveParser)
+    val book = analyzer.analyze(flowOf(candidate)).toList().single().getOrThrow()
+
+    println(
+        "[live-corpus] '${book.title}' tracks=${book.tracks.size} " +
+            "chapters=${book.chapters.size} source=${book.chaptersSource} " +
+            "first=${book.chapters.firstOrNull()?.title}",
+    )
+
+    withClue(
+        "book='${book.title}' tracks=${book.tracks.size} " +
+            "chapters=${book.chapters.size} source=${book.chaptersSource}",
+    ) {
+        book.chaptersSource shouldBe BookChapterSource.SynthesizedFromTracks
+    }
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/LiveCorpusAnalyzerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/pipeline/LiveCorpusAnalyzerTest.kt
@@ -4,7 +4,6 @@ import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.scanner.BookChapterSource
 import com.calypsan.listenup.api.dto.scanner.CandidateBook
 import com.calypsan.listenup.api.dto.scanner.FileEntry
-import com.calypsan.listenup.api.dto.scanner.FileType
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
 import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
 import com.calypsan.listenup.server.embeddedmeta.format.mp3.Mp3Parser
@@ -96,7 +95,12 @@ private suspend fun assertSynthesis(
 
     val candidate = CandidateBook(rootRelPath = rel, isFile = false, files = files)
     val analyzer = Analyzer(rootPath, AbsMetadataReader(contractJson), liveParser)
-    val book = analyzer.analyze(flowOf(candidate)).toList().single().getOrThrow()
+    val book =
+        analyzer
+            .analyze(flowOf(candidate))
+            .toList()
+            .single()
+            .getOrThrow()
 
     println(
         "[live-corpus] '${book.title}' tracks=${book.tracks.size} " +

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.api.dto.scanner
 
+import com.calypsan.listenup.domain.embeddedmeta.Chapter
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -49,6 +50,8 @@ data class AnalyzedBook(
     val explicit: Boolean? = null,
     val cover: CoverSource? = null,
     val tracks: List<TrackEntry> = emptyList(),
+    val chapters: List<Chapter> = emptyList(),
+    val chaptersSource: BookChapterSource = BookChapterSource.None,
     val embedded: EmbeddedAudioMetadata? = null,
     val embeddedStatus: MetadataStatus? = null,
     val sources: Set<MetadataSource> = emptySet(),

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/BookChapterSource.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/BookChapterSource.kt
@@ -28,6 +28,11 @@ sealed interface BookChapterSource {
     @SerialName("BookChapterSource.None")
     data object None : BookChapterSource
 
+    /**
+     * Chapters were extracted from the primary audio file by the embedded-metadata
+     * parser. [parserSource] records which extraction path succeeded (e.g. MP4 chapter
+     * atoms, ID3 CHAP frames).
+     */
     @Serializable
     @SerialName("BookChapterSource.Embedded")
     data class Embedded(

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/BookChapterSource.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/BookChapterSource.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.api.dto.scanner
+
+import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Where the resolved chapter list on an [AnalyzedBook] came from.
+ *
+ * Diagnostic provenance one level above [ChapterSource] — that one names
+ * the parser strategy *inside an audio file*; this one names which
+ * scanner-level signal won the precedence tournament.
+ *
+ * Precedence (highest first):
+ *  1. [AbsMetadata] — `metadata.json` carried a non-empty `chapters` array.
+ *     Self-hosters who curate chapter titles in ABS expect their edits to
+ *     stick across rescans; the sidecar must override.
+ *  2. [Embedded] — the parser found chapters inside the primary audio
+ *     file ([parserSource] records which extraction path).
+ *  3. [None] — no chapter signal anywhere.
+ */
+@Serializable
+sealed interface BookChapterSource {
+    @Serializable
+    @SerialName("BookChapterSource.None")
+    data object None : BookChapterSource
+
+    @Serializable
+    @SerialName("BookChapterSource.Embedded")
+    data class Embedded(
+        val parserSource: ChapterSource,
+    ) : BookChapterSource
+
+    @Serializable
+    @SerialName("BookChapterSource.AbsMetadata")
+    data object AbsMetadata : BookChapterSource
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/BookChapterSource.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/BookChapterSource.kt
@@ -17,7 +17,10 @@ import kotlinx.serialization.Serializable
  *     stick across rescans; the sidecar must override.
  *  2. [Embedded] — the parser found chapters inside the primary audio
  *     file ([parserSource] records which extraction path).
- *  3. [None] — no chapter signal anywhere.
+ *  3. [SynthesizedFromTracks] — multi-file book with no higher-precedence
+ *     source; one chapter per track, derived from per-track durations and
+ *     filenames. See `ChapterSynthesis.kt` for the algorithm.
+ *  4. [None] — no chapter signal anywhere.
  */
 @Serializable
 sealed interface BookChapterSource {
@@ -34,4 +37,8 @@ sealed interface BookChapterSource {
     @Serializable
     @SerialName("BookChapterSource.AbsMetadata")
     data object AbsMetadata : BookChapterSource
+
+    @Serializable
+    @SerialName("BookChapterSource.SynthesizedFromTracks")
+    data object SynthesizedFromTracks : BookChapterSource
 }


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/specs/2026-05-07-phase-4-multifile-chapter-synthesis-design.md`.

Adds a third precedence tier — synthesized-from-tracks — to chapter resolution. Activates only when:
- `metadata.json` carries no chapters
- The primary track's embedded chapters are empty
- The book is multi-file (`tracks.size >= 2`)

For multi-file books with no higher chapter source, the Analyzer now parses every track and produces one chapter per track with cumulative timestamps and filename-derived (or TIT2-derived) titles.

## What changed

- New `BookChapterSource.SynthesizedFromTracks` data object variant in commonMain.
- New `ChapterSynthesis.kt` with pure helpers `pickChapterTitle` and `synthesizeChapters` (test-driven via `ChapterSynthesisTest`).
- New `Analyzer.parseAllTrackDurations` + `Analyzer.shouldSynthesizeChapters` — per-track parsing only fires when synthesis is eligible (cost guarantee for the 98.7% single-file case).
- `pickChapters` gains a third tier between `Embedded` and `None`.
- Six new tests in `AnalyzerEnrichmentTest` covering the synthesis path, precedence preservation, single-file zero-overhead, and per-track parse-failure resilience.
- Permanent env-gated `LiveCorpusAnalyzerTest` regression guard for the synthesis branch.

## Verification

- All unit + integration tests green.
- spotless + detekt clean.
- Android APK builds.
- Live-corpus verified against 3 known multi-file books at `/mnt/Igni/Audiobooks`:
  - **Myst — The Book Of Atrus** (22 tracks): synthesizes correctly.
  - **Stieg Larsson — The Girl Who Kicked the Hornet's Nest** (177 tracks): synthesizes correctly.
  - **Moral Revolution** (5 tracks): synthesizes correctly.

## Test plan

- [x] Unit + integration tests pass (`:server:test :shared:jvmTest`)
- [x] Lint clean (`spotlessCheck detekt`)
- [x] Android APK builds (`:androidApp:assembleDebug`)
- [x] Live-corpus regression test passes against `/mnt/Igni/Audiobooks` (`LISTENUP_EMBEDDEDMETA_LIVE_DIR=/mnt/Igni/Audiobooks ./gradlew :server:test --tests "...LiveCorpusAnalyzerTest"`)