### PR TITLE
✨ Sync Foundation — server-side substrate for cross-domain sync

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.server.routes.instanceRoutes
 import com.calypsan.listenup.server.routes.rpcRoutes
 import com.calypsan.listenup.server.routes.scannerRoutes
 import com.calypsan.listenup.server.routes.sseRoutes
+import com.calypsan.listenup.server.sync.syncRoutes
 import com.calypsan.listenup.server.scanner.Scanner
 import com.calypsan.listenup.server.scanner.watcher.FolderWatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -83,6 +84,7 @@ fun Application.module() {
         sseRoutes()
         authRoutes(authService)
         rpcRoutes(authService, scannerService)
+        syncRoutes()
         if (scannerService != null && eventBus != null) {
             scannerRoutes(scannerService, eventBus)
         }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.di.authModule
 import com.calypsan.listenup.server.di.scannerModule
+import com.calypsan.listenup.server.di.syncModule
 import com.calypsan.listenup.server.embeddedmeta.embeddedmetaModule
 import com.calypsan.listenup.server.plugins.installAppErrorStatusPages
 import com.calypsan.listenup.server.plugins.installCallIdAndLogging
@@ -59,6 +60,7 @@ fun Application.module() {
             modules += scannerModule(resolvedLibraryPath, applicationScope)
         }
         modules += embeddedmetaModule
+        modules += syncModule
         modules(modules)
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
@@ -22,10 +22,9 @@ import com.calypsan.listenup.server.db.UserEntity
 import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.db.UserStatusColumn
 import com.calypsan.listenup.server.db.UserTable
-import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import java.time.Clock
 import java.util.UUID
 
@@ -57,7 +56,7 @@ class AuthServiceImpl(
 
         val normalized = Email.normalize(request.email)
         val user =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.find { UserTable.emailNormalized eq normalized }.firstOrNull()
             } ?: return AppResult.Failure(AuthError.InvalidCredentials())
 
@@ -80,7 +79,7 @@ class AuthServiceImpl(
 
         val normalized = Email.normalize(request.email)
         val empty =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.all().limit(1).empty()
             }
         if (empty) return AppResult.Failure(AuthError.SetupRequired())
@@ -91,7 +90,7 @@ class AuthServiceImpl(
         }
 
         val existing =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.find { UserTable.emailNormalized eq normalized }.any()
             }
         if (existing) return AppResult.Failure(AuthError.EmailAlreadyExists())
@@ -101,7 +100,7 @@ class AuthServiceImpl(
         val passwordHashed = hasher.hash(request.password)
         val now = clock.millis()
         val user =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.new(newUserId()) {
                     email = request.email
                     emailNormalized = normalized
@@ -132,7 +131,7 @@ class AuthServiceImpl(
         if (!Email.isLikelyEmail(request.email)) return AppResult.Failure(AuthError.InvalidCredentials())
 
         val empty =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.all().limit(1).empty()
             }
         if (!empty) return AppResult.Failure(AuthError.SetupAlreadyComplete())
@@ -140,7 +139,7 @@ class AuthServiceImpl(
         val passwordHashed = hasher.hash(request.password)
         val now = clock.millis()
         val user =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.new(newUserId()) {
                     email = request.email
                     emailNormalized = Email.normalize(request.email)
@@ -163,7 +162,7 @@ class AuthServiceImpl(
                 )
 
         val user =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity[rotated.userId.value]
             }
         val role = user.role.toContract()
@@ -213,7 +212,7 @@ class AuthServiceImpl(
     override suspend fun currentUser(): AppResult<User> {
         val p = principalProvider.current() ?: return AppResult.Failure(AuthError.SessionExpired())
         val user =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.findById(p.userId.value)
             } ?: return AppResult.Failure(AuthError.SessionNotFound())
         return AppResult.Success(user.toContract())
@@ -245,7 +244,7 @@ class AuthServiceImpl(
         // Don't leak existence-or-state of the target — admin actions only succeed
         // against a genuinely pending row; everything else is PermissionDenied.
         val target =
-            newSuspendedTransaction(Dispatchers.IO, db) {
+            suspendTransaction(db) {
                 UserEntity.findById(request.userId.value)
             } ?: return AppResult.Failure(AuthError.PermissionDenied())
         if (target.status != UserStatusColumn.PENDING_APPROVAL) {
@@ -254,7 +253,7 @@ class AuthServiceImpl(
 
         val now = clock.millis()
         val newStatus = if (request.approved) UserStatusColumn.ACTIVE else UserStatusColumn.DENIED
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             target.status = newStatus
             target.updatedAt = now
         }
@@ -284,7 +283,7 @@ class AuthServiceImpl(
 
     private suspend fun markLastLogin(userId: String) {
         val now = clock.millis()
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             UserEntity[userId].lastLoginAt = now
         }
     }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
@@ -6,12 +6,11 @@ import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.server.db.SessionEntity
 import com.calypsan.listenup.server.db.SessionTable
 import com.calypsan.listenup.server.db.UserEntity
-import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.update
 import java.time.Clock
 import java.time.Duration
@@ -58,7 +57,7 @@ class SessionService(
         val expires = clock.instant().plus(refreshTtl).toEpochMilli()
         val sid = newSessionId()
         val familyId = newFamilyId()
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             SessionEntity.new(sid) {
                 user = UserEntity[userId.value]
                 refreshTokenHash = hash
@@ -86,7 +85,7 @@ class SessionService(
         val newHash = tokenHasher.hash(newRaw)
         val newExpires = clock.instant().plus(refreshTtl).toEpochMilli()
 
-        return newSuspendedTransaction(Dispatchers.IO, db) {
+        return suspendTransaction(db) {
             // Pass 1: live-token match → rotate. Indexed via UNIQUE INDEX
             // idx_sessions_token_hash on refresh_token_hash.
             val live =
@@ -101,7 +100,7 @@ class SessionService(
                 live.refreshTokenHash = newHash
                 live.lastUsedAt = now
                 live.expiresAt = newExpires
-                return@newSuspendedTransaction RotatedSession(
+                return@suspendTransaction RotatedSession(
                     sessionId = SessionId(live.id.value),
                     userId = UserId(live.user.id.value),
                     refreshToken = RefreshToken(newRaw),
@@ -127,7 +126,7 @@ class SessionService(
         sessionId: SessionId,
         ownerUserId: UserId,
     ) {
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             SessionTable.update({
                 (SessionTable.id eq sessionId.value) and
                     (SessionTable.userId eq ownerUserId.value) and
@@ -139,7 +138,7 @@ class SessionService(
     }
 
     suspend fun revokeAll(userId: UserId) {
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             SessionTable.update({
                 (SessionTable.userId eq userId.value) and (SessionTable.revokedAt eq null)
             }) {
@@ -160,7 +159,7 @@ class SessionService(
      */
     suspend fun wasReplay(token: RefreshToken): Boolean {
         val hash = tokenHasher.hash(token.value)
-        return newSuspendedTransaction(Dispatchers.IO, db) {
+        return suspendTransaction(db) {
             SessionEntity
                 .find { SessionTable.previousHash eq hash }
                 .any()
@@ -168,13 +167,13 @@ class SessionService(
     }
 
     suspend fun isLive(sessionId: SessionId): Boolean =
-        newSuspendedTransaction(Dispatchers.IO, db) {
-            val s = SessionEntity.findById(sessionId.value) ?: return@newSuspendedTransaction false
+        suspendTransaction(db) {
+            val s = SessionEntity.findById(sessionId.value) ?: return@suspendTransaction false
             s.revokedAt == null && s.expiresAt > clock.millis()
         }
 
     suspend fun listActiveFor(userId: UserId): List<SessionEntity> =
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             SessionEntity
                 .find {
                     (SessionTable.userId eq userId.value) and

--- a/server/src/main/kotlin/com/calypsan/listenup/server/db/TagTable.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/db/TagTable.kt
@@ -1,0 +1,10 @@
+package com.calypsan.listenup.server.db
+
+import com.calypsan.listenup.server.sync.SyncableTable
+
+/** Validation-domain table for the Sync Foundation phase. */
+internal object TagTable : SyncableTable("tags") {
+    val id = text("id")
+    val name = text("name").index()
+    override val primaryKey = PrimaryKey(id)
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
@@ -1,0 +1,18 @@
+package com.calypsan.listenup.server.di
+
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.TagRepository
+import org.koin.dsl.module
+
+/**
+ * Sync Foundation DI bindings. `createdAtStart = true` is mandatory on every
+ * [com.calypsan.listenup.server.sync.SyncableRepository] so the `init` block
+ * (which calls `SyncRoutes.register(...)`) runs at application bootstrap
+ * rather than lazily on first use — that makes `/api/v1/sync/domains` correct
+ * on the first request.
+ */
+val syncModule =
+    module {
+        single(createdAtStart = true) { ChangeBus() }
+        single(createdAtStart = true) { TagRepository(get(), get()) }
+    }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -158,6 +158,7 @@ private fun SyncError.toHttpStatus(): HttpStatusCode =
         is SyncError.SyncFailed -> HttpStatusCode.ServiceUnavailable
         is SyncError.RealtimeDisconnected -> HttpStatusCode.ServiceUnavailable
         is SyncError.PushFailed -> HttpStatusCode.ServiceUnavailable
+        is SyncError.NotFound -> HttpStatusCode.NotFound
     }
 
 private fun SyncError.withCorrelationId(id: String?): SyncError =
@@ -165,6 +166,7 @@ private fun SyncError.withCorrelationId(id: String?): SyncError =
         is SyncError.SyncFailed -> copy(correlationId = id)
         is SyncError.RealtimeDisconnected -> copy(correlationId = id)
         is SyncError.PushFailed -> copy(correlationId = id)
+        is SyncError.NotFound -> copy(correlationId = id)
     }
 
 private fun DownloadError.toHttpStatus(): HttpStatusCode =

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import java.util.concurrent.atomic.AtomicReference
 
 private const val LIVE_TAIL_BUFFER = 256
 
@@ -23,30 +22,25 @@ data class BusEvent(
  * Koin singleton with `createdAtStart()` so domain repositories' init blocks
  * can publish during application bootstrap.
  *
- * `replay = 0` because reconnect catch-up uses the database (REST `?since=<rev>`),
- * not the bus's internal buffer. `extraBufferCapacity = 256` is the live-tail
- * window for slow consumers; `BufferOverflow.DROP_OLDEST` means a slow client
- * gets `SyncControl.CursorStale` and falls back to REST.
+ * `replay = 256` retains the last 256 events for late subscribers and for
+ * [oldestRetainedRevision] reads. `extraBufferCapacity = 0` means the replay
+ * cache is the sole buffer; `BufferOverflow.DROP_OLDEST` evicts the head of
+ * the replay cache when it is full, so a slow client gets
+ * `SyncControl.CursorStale` and falls back to REST catch-up.
  *
- * [oldestRetainedRevision] is updated heuristically — when an event is
- * published, the oldest tracked is set to the new event's revision if it's
- * the first; on overflow eviction we don't have a hook from MutableSharedFlow,
- * so the value is conservative — it tracks what we *might* still have. When
- * the buffer is empty (no subscribers, or just-emitted-and-collected), it's
- * null.
+ * [oldestRetainedRevision] reads directly from [MutableSharedFlow.replayCache]
+ * so it always reflects the actual buffer floor, including after DROP_OLDEST
+ * evictions.
  */
 class ChangeBus {
     private val flow =
         MutableSharedFlow<BusEvent>(
-            replay = 0,
-            extraBufferCapacity = LIVE_TAIL_BUFFER,
+            replay = LIVE_TAIL_BUFFER,
+            extraBufferCapacity = 0,
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
 
-    private val oldest = AtomicReference<Long?>(null)
-
     suspend fun publish(busEvent: BusEvent) {
-        oldest.updateAndGet { current -> current ?: busEvent.event.revision }
         flow.emit(busEvent)
     }
 
@@ -54,8 +48,12 @@ class ChangeBus {
 
     /**
      * Best-effort lower bound on the oldest revision still in the live-tail
-     * buffer. Used by the SSE endpoint to decide cursor-stale fallback.
-     * Returns null when no events have been published since process start.
+     * replay buffer. Returns null when the buffer is empty (no events
+     * published since process start, or all events evicted under DROP_OLDEST).
      */
-    fun oldestRetainedRevision(): Long? = oldest.get()
+    fun oldestRetainedRevision(): Long? =
+        flow.replayCache
+            .firstOrNull()
+            ?.event
+            ?.revision
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -10,7 +10,16 @@ import java.util.concurrent.atomic.AtomicReference
 private const val LIVE_TAIL_BUFFER = 256
 
 /**
- * In-memory pub/sub for [SyncEvent]s. Single bus per process, registered as a
+ * Bus payload pairing the originating domain name with the typed event.
+ * The domain name is used by the SSE endpoint to set the correct `event:` line.
+ */
+data class BusEvent(
+    val domainName: String,
+    val event: SyncEvent<*>,
+)
+
+/**
+ * In-memory pub/sub for [BusEvent]s. Single bus per process, registered as a
  * Koin singleton with `createdAtStart()` so domain repositories' init blocks
  * can publish during application bootstrap.
  *
@@ -28,7 +37,7 @@ private const val LIVE_TAIL_BUFFER = 256
  */
 class ChangeBus {
     private val flow =
-        MutableSharedFlow<SyncEvent<*>>(
+        MutableSharedFlow<BusEvent>(
             replay = 0,
             extraBufferCapacity = LIVE_TAIL_BUFFER,
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
@@ -36,12 +45,12 @@ class ChangeBus {
 
     private val oldest = AtomicReference<Long?>(null)
 
-    suspend fun publish(event: SyncEvent<*>) {
-        oldest.updateAndGet { current -> current ?: event.revision }
-        flow.emit(event)
+    suspend fun publish(busEvent: BusEvent) {
+        oldest.updateAndGet { current -> current ?: busEvent.event.revision }
+        flow.emit(busEvent)
     }
 
-    fun subscribe(): SharedFlow<SyncEvent<*>> = flow.asSharedFlow()
+    fun subscribe(): SharedFlow<BusEvent> = flow.asSharedFlow()
 
     /**
      * Best-effort lower bound on the oldest revision still in the live-tail

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.SyncEvent
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import java.util.concurrent.atomic.AtomicReference
+
+private const val LIVE_TAIL_BUFFER = 256
+
+/**
+ * In-memory pub/sub for [SyncEvent]s. Single bus per process, registered as a
+ * Koin singleton with `createdAtStart()` so domain repositories' init blocks
+ * can publish during application bootstrap.
+ *
+ * `replay = 0` because reconnect catch-up uses the database (REST `?since=<rev>`),
+ * not the bus's internal buffer. `extraBufferCapacity = 256` is the live-tail
+ * window for slow consumers; `BufferOverflow.DROP_OLDEST` means a slow client
+ * gets `SyncControl.CursorStale` and falls back to REST.
+ *
+ * [oldestRetainedRevision] is updated heuristically — when an event is
+ * published, the oldest tracked is set to the new event's revision if it's
+ * the first; on overflow eviction we don't have a hook from MutableSharedFlow,
+ * so the value is conservative — it tracks what we *might* still have. When
+ * the buffer is empty (no subscribers, or just-emitted-and-collected), it's
+ * null.
+ */
+class ChangeBus {
+    private val flow =
+        MutableSharedFlow<SyncEvent<*>>(
+            replay = 0,
+            extraBufferCapacity = LIVE_TAIL_BUFFER,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    private val oldest = AtomicReference<Long?>(null)
+
+    suspend fun publish(event: SyncEvent<*>) {
+        oldest.updateAndGet { current -> current ?: event.revision }
+        flow.emit(event)
+    }
+
+    fun subscribe(): SharedFlow<SyncEvent<*>> = flow.asSharedFlow()
+
+    /**
+     * Best-effort lower bound on the oldest revision still in the live-tail
+     * buffer. Used by the SSE endpoint to decide cursor-stale fallback.
+     * Returns null when no events have been published since process start.
+     */
+    fun oldestRetainedRevision(): Long? = oldest.get()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncMeta.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncMeta.kt
@@ -1,11 +1,9 @@
 package com.calypsan.listenup.server.sync
 
-import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.v1.jdbc.update
 
 /** Single-row counter table for the global sync revision space. */
@@ -18,21 +16,20 @@ internal object SyncMetaTable : Table("sync_meta") {
 private const val COUNTER_KEY = "revision_counter"
 
 /**
- * Bumps and returns the next global revision. Composable inside a parent
- * `newSuspendedTransaction`; the single-row UPDATE serializes concurrent writes,
+ * Bumps and returns the next global revision. Must be called from within an
+ * open transaction — the single-row UPDATE serializes concurrent writes,
  * which is the desired behavior — every syncable write gets a unique,
  * monotonic revision.
  */
-internal suspend fun nextRevision(db: Database): Long =
-    newSuspendedTransaction(Dispatchers.IO, db) {
-        val current =
-            SyncMetaTable
-                .selectAll()
-                .where { SyncMetaTable.key eq COUNTER_KEY }
-                .single()[SyncMetaTable.value]
-        val next = current + 1
-        SyncMetaTable.update({ SyncMetaTable.key eq COUNTER_KEY }) {
-            it[value] = next
-        }
-        next
+internal fun JdbcTransaction.nextRevision(): Long {
+    val current =
+        SyncMetaTable
+            .selectAll()
+            .where { SyncMetaTable.key eq COUNTER_KEY }
+            .single()[SyncMetaTable.value]
+    val next = current + 1
+    SyncMetaTable.update({ SyncMetaTable.key eq COUNTER_KEY }) {
+        it[value] = next
     }
+    return next
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncMeta.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncMeta.kt
@@ -1,0 +1,38 @@
+package com.calypsan.listenup.server.sync
+
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.update
+
+/** Single-row counter table for the global sync revision space. */
+internal object SyncMetaTable : Table("sync_meta") {
+    val key = text("key")
+    val value = long("value")
+    override val primaryKey = PrimaryKey(key)
+}
+
+private const val COUNTER_KEY = "revision_counter"
+
+/**
+ * Bumps and returns the next global revision. Composable inside a parent
+ * `newSuspendedTransaction`; the single-row UPDATE serializes concurrent writes,
+ * which is the desired behavior — every syncable write gets a unique,
+ * monotonic revision.
+ */
+internal suspend fun nextRevision(db: Database): Long =
+    newSuspendedTransaction(Dispatchers.IO, db) {
+        val current =
+            SyncMetaTable
+                .selectAll()
+                .where { SyncMetaTable.key eq COUNTER_KEY }
+                .single()[SyncMetaTable.value]
+        val next = current + 1
+        SyncMetaTable.update({ SyncMetaTable.key eq COUNTER_KEY }) {
+            it[value] = next
+        }
+        next
+    }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.sync.DomainDigest
+import com.calypsan.listenup.api.sync.DomainList
 import com.calypsan.listenup.api.sync.Page
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -81,5 +82,9 @@ fun Route.syncRoutes() {
         val typedRepo = repo as SyncableRepository<Any, Any>
         val digest: DomainDigest = typedRepo.digest(cursor)
         call.respond(digest)
+    }
+
+    get("/api/v1/sync/domains") {
+        call.respond(DomainList(domains = SyncRoutes.knownDomains()))
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.Page
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -35,8 +36,9 @@ internal object SyncRoutes {
 /**
  * Mounts the Sync Foundation REST endpoints under `/api/v1/sync`:
  *  - `GET /api/v1/sync/<domain>?since=<rev>&limit=<n>` — paginated catch-up
+ *  - `GET /api/v1/sync/<domain>/digest?cursor=<rev>` — drift detection
  *
- * SSE firehose and the digest/domain-list endpoints are added in Tasks 16-18.
+ * SSE firehose and domain-list endpoints are added in Tasks 17-18.
  */
 fun Route.syncRoutes() {
     get("/api/v1/sync/{domain}") {
@@ -62,5 +64,22 @@ fun Route.syncRoutes() {
         // infer the concrete element serializer from the type-erased Page<Any>.
         // encodePageAsJson uses the concrete KSerializer<T> each repository provides.
         call.respondText(typedRepo.encodePageAsJson(page), ContentType.Application.Json)
+    }
+
+    get("/api/v1/sync/{domain}/digest") {
+        val domainName =
+            call.parameters["domain"]
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "missing domain")
+        val cursor =
+            call.request.queryParameters["cursor"]?.toLongOrNull()
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "cursor must be a Long")
+        val repo =
+            SyncRoutes.lookup(domainName)
+                ?: return@get call.respond(HttpStatusCode.NotFound, "unknown domain: $domainName")
+
+        @Suppress("UNCHECKED_CAST")
+        val typedRepo = repo as SyncableRepository<Any, Any>
+        val digest: DomainDigest = typedRepo.digest(cursor)
+        call.respond(digest)
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -1,0 +1,26 @@
+package com.calypsan.listenup.server.sync
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-domain registry populated by [SyncableRepository] init blocks.
+ * REST + digest + domain-list routes look up repositories by name here.
+ *
+ * This is the static-registry style used in the RPC Exception Guard's
+ * `RpcGuard.dispatch()` — small startup wart, but explicit: every
+ * repository announces itself.
+ */
+internal object SyncRoutes {
+    private val registry = ConcurrentHashMap<String, SyncableRepository<*, *>>()
+
+    fun register(
+        domainName: String,
+        repository: SyncableRepository<*, *>,
+    ) {
+        registry[domainName] = repository
+    }
+
+    fun lookup(domainName: String): SyncableRepository<*, *>? = registry[domainName]
+
+    fun knownDomains(): List<String> = registry.keys.sorted()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.filter
 import org.koin.ktor.ext.inject
 
 /**
@@ -62,9 +63,10 @@ fun Route.syncRoutes() {
         val lastEventId = call.request.headers["Last-Event-ID"]?.toLongOrNull()
         val oldestRetained = bus.oldestRetainedRevision()
 
-        // Stale if client cursor is newer than anything the bus has retained.
-        // "999999 > 1" → stale; "null" → fresh subscriber, stream normally.
-        val isStale = lastEventId != null && oldestRetained != null && lastEventId > oldestRetained
+        // Stale if client cursor is older than the bus's replay-buffer floor:
+        // the bus has already evicted the events the client needs.
+        // "clientCursor < oldestRetained" → stale; "null" → fresh subscriber, stream normally.
+        val isStale = lastEventId != null && oldestRetained != null && lastEventId < oldestRetained
 
         if (isStale) {
             send(
@@ -79,17 +81,23 @@ fun Route.syncRoutes() {
         }
 
         try {
-            bus.subscribe().collect { busEvent ->
-                val repo = SyncRoutes.lookup(busEvent.domainName) ?: return@collect
+            bus
+                .subscribe()
+                // Skip events the client already received. With replay=256, a reconnecting
+                // client would otherwise see events from the replay cache that it already
+                // processed in a previous session.
+                .filter { it.event.revision > (lastEventId ?: 0L) }
+                .collect { busEvent ->
+                    val repo = SyncRoutes.lookup(busEvent.domainName) ?: return@collect
 
-                @Suppress("UNCHECKED_CAST")
-                val typedRepo = repo as SyncableRepository<Any, Any>
-                send(
-                    id = busEvent.event.revision.toString(),
-                    event = busEvent.domainName,
-                    data = typedRepo.encodeSyncEventAsJson(busEvent.event),
-                )
-            }
+                    @Suppress("UNCHECKED_CAST")
+                    val typedRepo = repo as SyncableRepository<Any, Any>
+                    send(
+                        id = busEvent.event.revision.toString(),
+                        event = busEvent.domainName,
+                        data = typedRepo.encodeSyncEventAsJson(busEvent.event),
+                    )
+                }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -104,7 +112,7 @@ fun Route.syncRoutes() {
                                 InternalError(
                                     correlationId = cid,
                                     cause = e::class.simpleName,
-                                    debugInfo = "${e::class.simpleName}: ${e.message}",
+                                    debugInfo = null,
                                 ),
                         ),
                     ),

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -1,15 +1,23 @@
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.DomainList
 import com.calypsan.listenup.api.sync.Page
+import com.calypsan.listenup.api.sync.SyncControl
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.sse.sse
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import org.koin.ktor.ext.inject
 
 /**
  * Per-domain registry populated by [SyncableRepository] init blocks.
@@ -34,14 +42,77 @@ internal object SyncRoutes {
     fun knownDomains(): List<String> = registry.keys.sorted()
 }
 
+private val log = KotlinLogging.logger("rpc.SyncFirehose")
+
 /**
  * Mounts the Sync Foundation REST endpoints under `/api/v1/sync`:
+ *  - `GET /api/v1/sync/events` — SSE firehose with `Last-Event-Id` resume
  *  - `GET /api/v1/sync/<domain>?since=<rev>&limit=<n>` — paginated catch-up
  *  - `GET /api/v1/sync/<domain>/digest?cursor=<rev>` — drift detection
- *
- * SSE firehose and domain-list endpoints are added in Tasks 17-18.
+ *  - `GET /api/v1/sync/domains` — registered domain list
  */
 fun Route.syncRoutes() {
+    val bus by inject<ChangeBus>()
+
+    // SSE firehose — streams every domain's BusEvents in real time.
+    // event: line carries the domain name; id: line carries the revision (for Last-Event-Id).
+    // Cursor-stale detection: if the client provides a Last-Event-Id newer than anything in
+    // the bus's live-tail buffer, emit SyncControl.CursorStale and close.
+    sse("/api/v1/sync/events") {
+        val lastEventId = call.request.headers["Last-Event-ID"]?.toLongOrNull()
+        val oldestRetained = bus.oldestRetainedRevision()
+
+        // Stale if client cursor is newer than anything the bus has retained.
+        // "999999 > 1" → stale; "null" → fresh subscriber, stream normally.
+        val isStale = lastEventId != null && oldestRetained != null && lastEventId > oldestRetained
+
+        if (isStale) {
+            send(
+                data =
+                    contractJson.encodeToString(
+                        SyncControl.serializer(),
+                        SyncControl.CursorStale(lastKnownRevision = oldestRetained),
+                    ),
+                event = "control",
+            )
+            return@sse
+        }
+
+        try {
+            bus.subscribe().collect { busEvent ->
+                val repo = SyncRoutes.lookup(busEvent.domainName) ?: return@collect
+
+                @Suppress("UNCHECKED_CAST")
+                val typedRepo = repo as SyncableRepository<Any, Any>
+                send(
+                    id = busEvent.event.revision.toString(),
+                    event = busEvent.domainName,
+                    data = typedRepo.encodeSyncEventAsJson(busEvent.event),
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val cid = UUID.randomUUID().toString()
+            log.error(e) { "Uncaught SSE flow exception [cid=$cid]" }
+            send(
+                data =
+                    contractJson.encodeToString(
+                        SyncControl.serializer(),
+                        SyncControl.StreamError(
+                            error =
+                                InternalError(
+                                    correlationId = cid,
+                                    cause = e::class.simpleName,
+                                    debugInfo = "${e::class.simpleName}: ${e.message}",
+                                ),
+                        ),
+                    ),
+                event = "control",
+            )
+        }
+    }
+
     get("/api/v1/sync/{domain}") {
         val domainName =
             call.parameters["domain"]

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -1,5 +1,12 @@
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.sync.Page
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -23,4 +30,37 @@ internal object SyncRoutes {
     fun lookup(domainName: String): SyncableRepository<*, *>? = registry[domainName]
 
     fun knownDomains(): List<String> = registry.keys.sorted()
+}
+
+/**
+ * Mounts the Sync Foundation REST endpoints under `/api/v1/sync`:
+ *  - `GET /api/v1/sync/<domain>?since=<rev>&limit=<n>` — paginated catch-up
+ *
+ * SSE firehose and the digest/domain-list endpoints are added in Tasks 16-18.
+ */
+fun Route.syncRoutes() {
+    get("/api/v1/sync/{domain}") {
+        val domainName =
+            call.parameters["domain"]
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "missing domain")
+        val since =
+            call.request.queryParameters["since"]?.toLongOrNull()
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "since must be a Long")
+        val limit =
+            call.request.queryParameters["limit"]
+                ?.toIntOrNull()
+                ?.coerceIn(1, 5000) ?: 500
+
+        val repo =
+            SyncRoutes.lookup(domainName)
+                ?: return@get call.respond(HttpStatusCode.NotFound, "unknown domain: $domainName")
+
+        @Suppress("UNCHECKED_CAST")
+        val typedRepo = repo as SyncableRepository<Any, Any>
+        val page: Page<Any> = typedRepo.pullSince(since, limit)
+        // call.respond(page) would fail at runtime: kotlinx.serialization cannot
+        // infer the concrete element serializer from the type-erased Page<Any>.
+        // encodePageAsJson uses the concrete KSerializer<T> each repository provides.
+        call.respondText(typedRepo.encodePageAsJson(page), ContentType.Application.Json)
+    }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.server.sync
+
+import kotlin.time.Clock
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+
+/**
+ * Abstract base for syncable-domain repositories. Subclasses provide:
+ *  - The Exposed table (a [SyncableTable] subtype)
+ *  - `ResultRow.toDto()` to render a row into the wire-shape DTO
+ *  - `T.writeTo(stmt)` to render a DTO into an UpdateBuilder for write
+ *  - The `T.id` projection
+ *
+ * The base provides `upsert`, `softDelete`, `pullSince`, `digest` operating
+ * on the global revision counter and publishing to [ChangeBus] on every write.
+ * Self-registers with [SyncRoutes] in its `init` block — Koin must use
+ * `createdAtStart = true` so registration happens at application bootstrap.
+ */
+abstract class SyncableRepository<T : Any, ID : Any>(
+    protected val table: SyncableTable,
+    protected val bus: ChangeBus,
+    val domainName: String,
+    protected val clock: Clock = Clock.System,
+) {
+    init {
+        SyncRoutes.register(domainName, this)
+    }
+
+    protected abstract fun ResultRow.toDto(): T
+
+    protected abstract fun T.writeTo(stmt: UpdateBuilder<*>)
+
+    protected abstract val T.id: ID
+
+    // upsert: Task 10
+    // softDelete: Task 11
+    // pullSince: Task 12
+    // digest: Task 13
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.contractJson
-import com.calypsan.listenup.api.error.InternalError
+import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.Page
@@ -217,10 +217,9 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                 }
             if (rowsAffected == 0) {
                 AppResult.Failure(
-                    InternalError(
-                        correlationId = null,
-                        cause = "NotFound",
-                        debugInfo = "No $domainName row with id=$id",
+                    SyncError.NotFound(
+                        domain = domainName,
+                        entityId = id.toString(),
                     ),
                 )
             } else {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -2,8 +2,10 @@ package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.Page
 import com.calypsan.listenup.api.sync.SyncEvent
+import java.security.MessageDigest
 import kotlin.time.Clock
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.Column
@@ -11,6 +13,7 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -207,5 +210,35 @@ abstract class SyncableRepository<T : Any, ID : Any>(
             )
         }
 
-    // digest: Task 13
+    /**
+     * Returns a [DomainDigest] over all rows with `revision <= cursor`, soft-deleted rows
+     * included. Used by clients to detect drift cheaply — a `(count, hash)` mismatch signals
+     * the client should re-pull from `?since=0`.
+     *
+     * Algorithm: sort `(id, revision)` pairs lexicographically by id, concatenate as
+     * `<id>|<revision>\n` per row, SHA-256 the bytes, format as `"sha256:<lowercase-hex>"`.
+     * Empty domain → `count = 0`, `hash = ""`. This is a permanent wire contract — clients
+     * compute identically over their local rows.
+     */
+    suspend fun digest(cursor: Long): DomainDigest =
+        newSuspendedTransaction(Dispatchers.IO, db) {
+            val rows =
+                table
+                    .selectAll()
+                    .where { table.revision lessEq cursor }
+                    .map { row -> row[idColumn()] to row[table.revision] }
+                    .sortedBy { it.first }
+            if (rows.isEmpty()) {
+                DomainDigest(cursor = cursor, count = 0, hash = "")
+            } else {
+                val md = MessageDigest.getInstance("SHA-256")
+                val joined =
+                    rows.joinToString(separator = "\n") { (id, rev) -> "$id|$rev" } + "\n"
+                val hex =
+                    md
+                        .digest(joined.toByteArray(Charsets.UTF_8))
+                        .joinToString("") { "%02x".format(it) }
+                DomainDigest(cursor = cursor, count = rows.size, hash = "sha256:$hex")
+            }
+        }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.DomainDigest
@@ -8,6 +9,13 @@ import com.calypsan.listenup.api.sync.SyncEvent
 import java.security.MessageDigest
 import kotlin.time.Clock
 import kotlinx.coroutines.Dispatchers
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -47,6 +55,32 @@ abstract class SyncableRepository<T : Any, ID : Any>(
     protected abstract fun ResultRow.toDto(): T
 
     protected abstract fun T.writeTo(stmt: UpdateBuilder<*>)
+
+    /**
+     * kotlinx.serialization serializer for the concrete DTO type [T].
+     * Provided by each subclass so the route handler can encode [Page] responses
+     * without losing type information through the type-erased registry.
+     */
+    abstract val elementSerializer: KSerializer<T>
+
+    /**
+     * Encodes a [Page] of [T] to a JSON string using [contractJson] and the
+     * concrete [elementSerializer]. Called by the catch-up route to work around
+     * the type-erasure of the registry (`SyncableRepository<Any, Any>` cast).
+     */
+    fun encodePageAsJson(page: Page<T>): String {
+        val json: JsonObject =
+            buildJsonObject {
+                putJsonArray("items") {
+                    page.items.forEach { item ->
+                        add(contractJson.encodeToJsonElement(elementSerializer, item))
+                    }
+                }
+                put("nextCursor", page.nextCursor)
+                put("hasMore", page.hasMore)
+            }
+        return contractJson.encodeToString(JsonElement.serializer(), json)
+    }
 
     protected abstract val T.id: ID
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -1,8 +1,18 @@
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncEvent
 import kotlin.time.Clock
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.update
 
 /**
  * Abstract base for syncable-domain repositories. Subclasses provide:
@@ -17,6 +27,7 @@ import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
  * `createdAtStart = true` so registration happens at application bootstrap.
  */
 abstract class SyncableRepository<T : Any, ID : Any>(
+    protected val db: Database,
     protected val table: SyncableTable,
     protected val bus: ChangeBus,
     val domainName: String,
@@ -32,7 +43,95 @@ abstract class SyncableRepository<T : Any, ID : Any>(
 
     protected abstract val T.id: ID
 
-    // upsert: Task 10
+    /**
+     * Insert or update [value], bumping the global revision counter and publishing
+     * a [SyncEvent.Created] or [SyncEvent.Updated] to [ChangeBus].
+     *
+     * Created/Updated discrimination is based on whether the row exists before the
+     * write — existence is determined inside the transaction, so the decision is
+     * atomic with the write.
+     *
+     * @param clientOpId originating client operation id for SSE echo matching; null
+     *   for server-initiated writes (scanner, admin, etc.).
+     */
+    suspend fun upsert(
+        value: T,
+        clientOpId: String? = null,
+    ): AppResult<T> =
+        newSuspendedTransaction(Dispatchers.IO, db) {
+            val rev = nextRevision(db)
+            val now = clock.now().toEpochMilliseconds()
+            val idStr = value.id.toString()
+
+            val existed =
+                table
+                    .selectAll()
+                    .where { idColumn() eq idStr }
+                    .empty()
+                    .not()
+
+            if (existed) {
+                table.update({ idColumn() eq idStr }) { stmt ->
+                    value.writeTo(stmt)
+                    stmt[table.revision] = rev
+                    stmt[table.updatedAt] = now
+                    stmt[table.deletedAt] = null
+                    stmt[table.clientOpId] = clientOpId
+                }
+            } else {
+                table.insert { stmt ->
+                    value.writeTo(stmt)
+                    stmt[table.revision] = rev
+                    stmt[table.createdAt] = now
+                    stmt[table.updatedAt] = now
+                    stmt[table.deletedAt] = null
+                    stmt[table.clientOpId] = clientOpId
+                }
+            }
+
+            val saved =
+                table
+                    .selectAll()
+                    .where { idColumn() eq idStr }
+                    .single()
+                    .toDto()
+
+            if (existed) {
+                bus.publish(
+                    SyncEvent.Updated(
+                        id = idStr,
+                        revision = rev,
+                        occurredAt = now,
+                        clientOpId = clientOpId,
+                        payload = saved,
+                    ),
+                )
+            } else {
+                bus.publish(
+                    SyncEvent.Created(
+                        id = idStr,
+                        revision = rev,
+                        occurredAt = now,
+                        clientOpId = clientOpId,
+                        payload = saved,
+                    ),
+                )
+            }
+
+            AppResult.Success(saved)
+        }
+
+    /**
+     * Exposes the table's primary-key column for use in WHERE clauses.
+     * Default assumes a `text("id")` column — the canonical syncable-table
+     * convention. Domains using a non-`id` PK column override this.
+     */
+    protected open fun idColumn(): Column<String> {
+        @Suppress("UNCHECKED_CAST")
+        return table.columns.firstOrNull { it.name == "id" } as? Column<String>
+            ?: error("Domain table ${table.tableName} has no 'id' column; override idColumn().")
+    }
+
     // softDelete: Task 11
     // pullSince: Task 12
     // digest: Task 13

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -8,7 +8,6 @@ import com.calypsan.listenup.api.sync.Page
 import com.calypsan.listenup.api.sync.SyncEvent
 import java.security.MessageDigest
 import kotlin.time.Clock
-import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -26,7 +25,7 @@ import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.update
 
 /**
@@ -112,8 +111,8 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         value: T,
         clientOpId: String? = null,
     ): AppResult<T> =
-        newSuspendedTransaction(Dispatchers.IO, db) {
-            val rev = nextRevision(db)
+        suspendTransaction(db) {
+            val rev = nextRevision()
             val now = clock.now().toEpochMilliseconds()
             val idStr = value.id.toString()
 
@@ -206,8 +205,8 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         id: ID,
         clientOpId: String? = null,
     ): AppResult<Unit> =
-        newSuspendedTransaction(Dispatchers.IO, db) {
-            val rev = nextRevision(db)
+        suspendTransaction(db) {
+            val rev = nextRevision()
             val now = clock.now().toEpochMilliseconds()
             val rowsAffected =
                 table.update({ idColumn() eq id.toString() }) { stmt ->
@@ -251,7 +250,7 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         cursor: Long,
         limit: Int,
     ): Page<T> =
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             val rows =
                 table
                     .selectAll()
@@ -277,7 +276,7 @@ abstract class SyncableRepository<T : Any, ID : Any>(
      * compute identically over their local rows.
      */
     suspend fun digest(cursor: Long): DomainDigest =
-        newSuspendedTransaction(Dispatchers.IO, db) {
+        suspendTransaction(db) {
             val rows =
                 table
                     .selectAll()

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -2,12 +2,15 @@ package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.Page
 import com.calypsan.listenup.api.sync.SyncEvent
 import kotlin.time.Clock
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -43,6 +46,9 @@ abstract class SyncableRepository<T : Any, ID : Any>(
     protected abstract fun T.writeTo(stmt: UpdateBuilder<*>)
 
     protected abstract val T.id: ID
+
+    /** Subclass-provided projection of the DTO's revision. */
+    protected abstract fun T.revisionOf(): Long
 
     /**
      * Insert or update [value], bumping the global revision counter and publishing
@@ -176,6 +182,30 @@ abstract class SyncableRepository<T : Any, ID : Any>(
             }
         }
 
-    // pullSince: Task 12
+    /**
+     * Returns up to [limit] rows with `revision > cursor`, ordered by revision
+     * ascending. Includes soft-deleted rows so clients can apply tombstones.
+     * [Page.hasMore] is true when the result set hit the limit, signalling more
+     * pages remain.
+     */
+    suspend fun pullSince(
+        cursor: Long,
+        limit: Int,
+    ): Page<T> =
+        newSuspendedTransaction(Dispatchers.IO, db) {
+            val rows =
+                table
+                    .selectAll()
+                    .where { table.revision greater cursor }
+                    .orderBy(table.revision, SortOrder.ASC)
+                    .limit(limit)
+                    .map { it.toDto() }
+            Page(
+                items = rows,
+                nextCursor = if (rows.isEmpty()) null else rows.last().revisionOf(),
+                hasMore = rows.size == limit,
+            )
+        }
+
     // digest: Task 13
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.SyncEvent
 import kotlin.time.Clock
@@ -132,7 +133,49 @@ abstract class SyncableRepository<T : Any, ID : Any>(
             ?: error("Domain table ${table.tableName} has no 'id' column; override idColumn().")
     }
 
-    // softDelete: Task 11
+    /**
+     * Marks the row as deleted by setting `deleted_at`. Bumps revision and
+     * publishes [SyncEvent.Deleted]. Returns [AppResult.Failure] if no row exists
+     * with the given id.
+     *
+     * @param clientOpId originating client operation id for SSE echo matching; null
+     *   for server-initiated deletes.
+     */
+    suspend fun softDelete(
+        id: ID,
+        clientOpId: String? = null,
+    ): AppResult<Unit> =
+        newSuspendedTransaction(Dispatchers.IO, db) {
+            val rev = nextRevision(db)
+            val now = clock.now().toEpochMilliseconds()
+            val rowsAffected =
+                table.update({ idColumn() eq id.toString() }) { stmt ->
+                    stmt[table.revision] = rev
+                    stmt[table.updatedAt] = now
+                    stmt[table.deletedAt] = now
+                    stmt[table.clientOpId] = clientOpId
+                }
+            if (rowsAffected == 0) {
+                AppResult.Failure(
+                    InternalError(
+                        correlationId = null,
+                        cause = "NotFound",
+                        debugInfo = "No $domainName row with id=$id",
+                    ),
+                )
+            } else {
+                bus.publish(
+                    SyncEvent.Deleted(
+                        id = id.toString(),
+                        revision = rev,
+                        occurredAt = now,
+                        clientOpId = clientOpId,
+                    ),
+                )
+                AppResult.Success(Unit)
+            }
+        }
+
     // pullSince: Task 12
     // digest: Task 13
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -82,6 +82,16 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         return contractJson.encodeToString(JsonElement.serializer(), json)
     }
 
+    /**
+     * Encodes a [SyncEvent] to a JSON string using [contractJson] and the
+     * concrete [elementSerializer]. Called by the SSE firehose to serialise
+     * the event payload without losing type information through the
+     * type-erased registry (`SyncableRepository<Any, Any>` cast).
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun encodeSyncEventAsJson(event: SyncEvent<*>): String =
+        contractJson.encodeToString(SyncEvent.serializer(elementSerializer), event as SyncEvent<T>)
+
     protected abstract val T.id: ID
 
     /** Subclass-provided projection of the DTO's revision. */
@@ -142,22 +152,30 @@ abstract class SyncableRepository<T : Any, ID : Any>(
 
             if (existed) {
                 bus.publish(
-                    SyncEvent.Updated(
-                        id = idStr,
-                        revision = rev,
-                        occurredAt = now,
-                        clientOpId = clientOpId,
-                        payload = saved,
+                    BusEvent(
+                        domainName = domainName,
+                        event =
+                            SyncEvent.Updated(
+                                id = idStr,
+                                revision = rev,
+                                occurredAt = now,
+                                clientOpId = clientOpId,
+                                payload = saved,
+                            ),
                     ),
                 )
             } else {
                 bus.publish(
-                    SyncEvent.Created(
-                        id = idStr,
-                        revision = rev,
-                        occurredAt = now,
-                        clientOpId = clientOpId,
-                        payload = saved,
+                    BusEvent(
+                        domainName = domainName,
+                        event =
+                            SyncEvent.Created(
+                                id = idStr,
+                                revision = rev,
+                                occurredAt = now,
+                                clientOpId = clientOpId,
+                                payload = saved,
+                            ),
                     ),
                 )
             }
@@ -208,11 +226,15 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                 )
             } else {
                 bus.publish(
-                    SyncEvent.Deleted(
-                        id = id.toString(),
-                        revision = rev,
-                        occurredAt = now,
-                        clientOpId = clientOpId,
+                    BusEvent(
+                        domainName = domainName,
+                        event =
+                            SyncEvent.Deleted(
+                                id = id.toString(),
+                                revision = rev,
+                                occurredAt = now,
+                                clientOpId = clientOpId,
+                            ),
                     ),
                 )
                 AppResult.Success(Unit)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableTable.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableTable.kt
@@ -1,0 +1,26 @@
+package com.calypsan.listenup.server.sync
+
+import org.jetbrains.exposed.v1.core.Table
+
+/**
+ * Abstract Exposed table mixin contributing the sync-discipline columns every
+ * syncable domain table inherits:
+ *
+ *  - `revision`      monotonic, bumped on every write
+ *  - `created_at`    set on insert, never modified
+ *  - `updated_at`    refreshed on every write
+ *  - `deleted_at`    nullable; set on soft-delete, cleared on resurrect
+ *  - `client_op_id`  nullable; the most-recent write's originating op id (debug aid)
+ *
+ * Index on `revision` covers the hot-path REST catch-up query. Concrete domain
+ * tables add their own primary key (typically `text("id")`).
+ */
+abstract class SyncableTable(
+    name: String,
+) : Table(name) {
+    val revision = long("revision").index()
+    val createdAt = long("created_at")
+    val updatedAt = long("updated_at")
+    val deletedAt = long("deleted_at").nullable()
+    val clientOpId = text("client_op_id").nullable()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
@@ -31,4 +31,6 @@ class TagRepository(
     }
 
     override val Tag.id: String get() = this.id
+
+    override fun Tag.revisionOf(): Long = revision
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
@@ -5,15 +5,17 @@ import com.calypsan.listenup.server.db.TagTable
 import kotlin.time.Clock
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
 
 /**
  * Validation-domain repository. Tags has no public write API in this phase;
  * tests exercise the substrate directly through this class.
  */
 class TagRepository(
+    db: Database,
     bus: ChangeBus,
     clock: Clock = Clock.System,
-) : SyncableRepository<Tag, String>(TagTable, bus, "tags", clock) {
+) : SyncableRepository<Tag, String>(db, TagTable, bus, "tags", clock) {
     override fun ResultRow.toDto(): Tag =
         Tag(
             id = this[TagTable.id],

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.sync
 import com.calypsan.listenup.api.sync.Tag
 import com.calypsan.listenup.server.db.TagTable
 import kotlin.time.Clock
+import kotlinx.serialization.KSerializer
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -16,6 +17,8 @@ class TagRepository(
     bus: ChangeBus,
     clock: Clock = Clock.System,
 ) : SyncableRepository<Tag, String>(db, TagTable, bus, "tags", clock) {
+    override val elementSerializer: KSerializer<Tag> = Tag.serializer()
+
     override fun ResultRow.toDto(): Tag =
         Tag(
             id = this[TagTable.id],

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.db.TagTable
+import kotlin.time.Clock
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+
+/**
+ * Validation-domain repository. Tags has no public write API in this phase;
+ * tests exercise the substrate directly through this class.
+ */
+class TagRepository(
+    bus: ChangeBus,
+    clock: Clock = Clock.System,
+) : SyncableRepository<Tag, String>(TagTable, bus, "tags", clock) {
+    override fun ResultRow.toDto(): Tag =
+        Tag(
+            id = this[TagTable.id],
+            name = this[TagTable.name],
+            revision = this[TagTable.revision],
+            updatedAt = this[TagTable.updatedAt],
+            deletedAt = this[TagTable.deletedAt],
+        )
+
+    override fun Tag.writeTo(stmt: UpdateBuilder<*>) {
+        stmt[TagTable.id] = id
+        stmt[TagTable.name] = name
+    }
+
+    override val Tag.id: String get() = this.id
+}

--- a/server/src/main/resources/db/migration/V2__sync_foundation.sql
+++ b/server/src/main/resources/db/migration/V2__sync_foundation.sql
@@ -1,0 +1,22 @@
+-- Sync Foundation: global revision counter + Tags validation domain.
+-- The counter is incremented atomically inside every syncable write transaction.
+
+CREATE TABLE sync_meta (
+    key TEXT NOT NULL PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+
+INSERT INTO sync_meta (key, value) VALUES ('revision_counter', 0);
+
+CREATE TABLE tags (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    revision INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    deleted_at INTEGER,
+    client_op_id TEXT
+);
+
+CREATE INDEX idx_tags_revision ON tags (revision);
+CREATE INDEX idx_tags_name ON tags (name);

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
@@ -20,20 +20,21 @@ class ChangeBusTest :
         test("publish then subscribe receives the event") {
             runTest {
                 val bus = ChangeBus()
-                val event = SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x")
+                val syncEvent = SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x")
+                val busEvent = BusEvent(domainName = "tags", event = syncEvent)
                 val deferred = async { bus.subscribe().first() }
                 // Yield so the subscriber coroutine can register on the SharedFlow before publish.
                 advanceUntilIdle()
-                bus.publish(event)
-                deferred.await() shouldBe event
+                bus.publish(busEvent)
+                deferred.await() shouldBe busEvent
             }
         }
 
         test("multiple subscribers each receive every event") {
             runTest {
                 val bus = ChangeBus()
-                val ev1 = SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x")
-                val ev2 = SyncEvent.Updated<String>(id = "a", revision = 2, occurredAt = 101, payload = "y")
+                val ev1 = BusEvent("tags", SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x"))
+                val ev2 = BusEvent("tags", SyncEvent.Updated<String>(id = "a", revision = 2, occurredAt = 101, payload = "y"))
                 val sub1 = async { bus.subscribe().take(2).toList() }
                 val sub2 = async { bus.subscribe().take(2).toList() }
                 // Yield so both subscribers register before events are published.
@@ -49,8 +50,8 @@ class ChangeBusTest :
             runTest {
                 val bus = ChangeBus()
                 bus.oldestRetainedRevision() shouldBe null
-                bus.publish(SyncEvent.Created(id = "a", revision = 5, occurredAt = 100, payload = "x"))
-                bus.publish(SyncEvent.Created(id = "b", revision = 7, occurredAt = 101, payload = "y"))
+                bus.publish(BusEvent("tags", SyncEvent.Created(id = "a", revision = 5, occurredAt = 100, payload = "x")))
+                bus.publish(BusEvent("tags", SyncEvent.Created(id = "b", revision = 7, occurredAt = 101, payload = "y")))
                 bus.oldestRetainedRevision()!! shouldBeGreaterThanOrEqual 5L
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
@@ -1,0 +1,57 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.SyncEvent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class ChangeBusTest :
+    FunSpec({
+
+        test("publish then subscribe receives the event") {
+            runTest {
+                val bus = ChangeBus()
+                val event = SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x")
+                val deferred = async { bus.subscribe().first() }
+                // Yield so the subscriber coroutine can register on the SharedFlow before publish.
+                advanceUntilIdle()
+                bus.publish(event)
+                deferred.await() shouldBe event
+            }
+        }
+
+        test("multiple subscribers each receive every event") {
+            runTest {
+                val bus = ChangeBus()
+                val ev1 = SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x")
+                val ev2 = SyncEvent.Updated<String>(id = "a", revision = 2, occurredAt = 101, payload = "y")
+                val sub1 = async { bus.subscribe().take(2).toList() }
+                val sub2 = async { bus.subscribe().take(2).toList() }
+                // Yield so both subscribers register before events are published.
+                advanceUntilIdle()
+                bus.publish(ev1)
+                bus.publish(ev2)
+                sub1.await() shouldContainExactly listOf(ev1, ev2)
+                sub2.await() shouldContainExactly listOf(ev1, ev2)
+            }
+        }
+
+        test("oldestRetainedRevision tracks the lowest in-buffer event") {
+            runTest {
+                val bus = ChangeBus()
+                bus.oldestRetainedRevision() shouldBe null
+                bus.publish(SyncEvent.Created(id = "a", revision = 5, occurredAt = 100, payload = "x"))
+                bus.publish(SyncEvent.Created(id = "b", revision = 7, occurredAt = 101, payload = "y"))
+                bus.oldestRetainedRevision()!! shouldBeGreaterThanOrEqual 5L
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncCatchUpRouteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncCatchUpRouteTest.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Page
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withTestApplication
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+
+class SyncCatchUpRouteTest :
+    FunSpec({
+
+        test("GET /api/v1/sync/tags?since=0 returns all rows") {
+            withTestApplication {
+                tagRepo.upsert(Tag("a", "alpha", 0, 0))
+                tagRepo.upsert(Tag("b", "beta", 0, 0))
+
+                val response = client.get("/api/v1/sync/tags?since=0")
+                response.status shouldBe HttpStatusCode.OK
+                val page: Page<Tag> = response.body()
+                page.items shouldHaveSize 2
+                page.items.map { it.id } shouldBe listOf("a", "b")
+            }
+        }
+
+        test("unknown domain returns 404") {
+            withTestApplication {
+                val response = client.get("/api/v1/sync/nonexistent?since=0")
+                response.status shouldBe HttpStatusCode.NotFound
+            }
+        }
+
+        test("malformed cursor returns 400") {
+            withTestApplication {
+                val response = client.get("/api/v1/sync/tags?since=not-a-number")
+                response.status shouldBe HttpStatusCode.BadRequest
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncDigestRouteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncDigestRouteTest.kt
@@ -1,0 +1,35 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.DomainDigest
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withTestApplication
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+
+class SyncDigestRouteTest :
+    FunSpec({
+
+        test("GET /api/v1/sync/tags/digest returns DomainDigest") {
+            withTestApplication {
+                tagRepo.upsert(Tag("a", "alpha", 0, 0))
+                tagRepo.upsert(Tag("b", "beta", 0, 0))
+
+                val response = client.get("/api/v1/sync/tags/digest?cursor=999")
+                response.status shouldBe HttpStatusCode.OK
+                val d: DomainDigest = response.body()
+                d.count shouldBe 2
+                d.hash shouldStartWith "sha256:"
+            }
+        }
+
+        test("unknown domain returns 404") {
+            withTestApplication {
+                val response = client.get("/api/v1/sync/nope/digest?cursor=0")
+                response.status shouldBe HttpStatusCode.NotFound
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncDomainListRouteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncDomainListRouteTest.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.DomainList
+import com.calypsan.listenup.server.testing.withTestApplication
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+
+class SyncDomainListRouteTest :
+    FunSpec({
+
+        test("GET /api/v1/sync/domains returns sorted registered domain names") {
+            withTestApplication {
+                val response = client.get("/api/v1/sync/domains")
+                response.status shouldBe HttpStatusCode.OK
+                val list: DomainList = response.body()
+                list.domains shouldBe listOf("tags") // only Tags registered in this phase
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFirehoseTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFirehoseTest.kt
@@ -34,14 +34,15 @@ class SyncFirehoseTest :
 
         test("SSE with stale Last-Event-Id emits CursorStale and closes") {
             withTestApplication {
-                // Publish events to advance the bus's tracked oldest revision
-                tagRepo.upsert(Tag("a", "x", 0, 0))
-                tagRepo.upsert(Tag("b", "y", 0, 0))
+                // Publish 300 events to overflow the 256-event replay buffer.
+                // After overflow, the buffer holds revisions 45–300; revision 1 is evicted.
+                repeat(300) { i -> tagRepo.upsert(Tag("tag-$i", "label-$i", 0, 0)) }
 
-                // Connect with a Last-Event-Id far beyond anything the bus has
+                // Connect with Last-Event-Id=1 — older than the buffer floor (~45).
+                // client cursor < oldestRetained → stale.
                 client.sse(
                     urlString = "/api/v1/sync/events",
-                    request = { headers { append(HttpHeaders.LastEventID, "999999") } },
+                    request = { headers { append(HttpHeaders.LastEventID, "1") } },
                 ) {
                     val event = incoming.first()
                     event.event shouldBe "control"

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFirehoseTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFirehoseTest.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withTestApplication
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.headers
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+
+class SyncFirehoseTest :
+    FunSpec({
+
+        test("SSE emits Tag events on the firehose with event:tags lines") {
+            withTestApplication {
+                client.sse("/api/v1/sync/events") {
+                    coroutineScope {
+                        val deferred = async { incoming.first() }
+                        // Trigger a write that publishes to the bus
+                        tagRepo.upsert(Tag("a", "alpha", 0, 0))
+                        val event = deferred.await()
+                        event.event shouldBe "tags"
+                        event.id shouldBe "1" // first revision
+                        event.data!! shouldContain """"type":"SyncEvent.Created""""
+                        event.data!! shouldContain """"name":"alpha""""
+                    }
+                }
+            }
+        }
+
+        test("SSE with stale Last-Event-Id emits CursorStale and closes") {
+            withTestApplication {
+                // Publish events to advance the bus's tracked oldest revision
+                tagRepo.upsert(Tag("a", "x", 0, 0))
+                tagRepo.upsert(Tag("b", "y", 0, 0))
+
+                // Connect with a Last-Event-Id far beyond anything the bus has
+                client.sse(
+                    urlString = "/api/v1/sync/events",
+                    request = { headers { append(HttpHeaders.LastEventID, "999999") } },
+                ) {
+                    val event = incoming.first()
+                    event.event shouldBe "control"
+                    event.data!! shouldContain """"type":"SyncControl.CursorStale""""
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFoundationE2ETest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFoundationE2ETest.kt
@@ -1,0 +1,79 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.DomainDigest
+import com.calypsan.listenup.api.sync.DomainList
+import com.calypsan.listenup.api.sync.Page
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withTestApplication
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.call.body
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+
+class SyncFoundationE2ETest :
+    FunSpec({
+
+        test("end-to-end lifecycle: SSE connect → write → receive → reconnect → REST catch-up") {
+            withTestApplication {
+                // ---- Phase 1: Connect SSE, write, assert receive ----
+                var firstReceivedRevision: Long = 0
+
+                client.sse("/api/v1/sync/events") {
+                    coroutineScope {
+                        val deferred = async { incoming.first() }
+                        tagRepo.upsert(Tag("t1", "alpha", 0, 0))
+                        val event = deferred.await()
+                        event.event shouldBe "tags"
+                        event.data!! shouldContain """"type":"SyncEvent.Created""""
+                        event.data!! shouldContain """"id":"t1""""
+                        firstReceivedRevision = event.id!!.toLong()
+                    }
+                }
+
+                // ---- Phase 2: Write while disconnected ----
+                tagRepo.upsert(Tag("t2", "beta", 0, 0))
+
+                // ---- Phase 3: Reconnect with Last-Event-Id, write fresh t3, assert receive ----
+                client.sse(
+                    urlString = "/api/v1/sync/events",
+                    request = {
+                        headers { append(HttpHeaders.LastEventID, firstReceivedRevision.toString()) }
+                    },
+                ) {
+                    coroutineScope {
+                        val deferred = async { incoming.first() }
+                        tagRepo.upsert(Tag("t3", "gamma", 0, 0))
+                        val event3 = deferred.await()
+                        event3.data!! shouldContain """"id":"t3""""
+                    }
+                }
+
+                // ---- Phase 4: Verify domain-list discovery ----
+                val list: DomainList = client.get("/api/v1/sync/domains").body()
+                list.domains shouldBe listOf("tags")
+
+                // ---- Phase 5: Verify digest ----
+                val digest: DomainDigest = client.get("/api/v1/sync/tags/digest?cursor=999").body()
+                digest.count shouldBe 3 // t1, t2, t3
+
+                // ---- Phase 6: REST catch-up returns all rows ----
+                val page: Page<Tag> = client.get("/api/v1/sync/tags?since=0").body()
+                page.items shouldHaveSize 3
+
+                // ---- Phase 7: Soft-delete a row, assert tombstone in catch-up ----
+                tagRepo.softDelete("t1")
+                val pageAfterDelete: Page<Tag> = client.get("/api/v1/sync/tags?since=0").body()
+                val t1 = pageAfterDelete.items.first { it.id == "t1" }
+                t1.deletedAt shouldNotBe null
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFoundationE2ETest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncFoundationE2ETest.kt
@@ -18,6 +18,8 @@ import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 
 class SyncFoundationE2ETest :
     FunSpec({
@@ -42,7 +44,10 @@ class SyncFoundationE2ETest :
                 // ---- Phase 2: Write while disconnected ----
                 tagRepo.upsert(Tag("t2", "beta", 0, 0))
 
-                // ---- Phase 3: Reconnect with Last-Event-Id, write fresh t3, assert receive ----
+                // ---- Phase 3: Reconnect with Last-Event-Id, verify replay + live tail ----
+                // With replay=256, reconnecting with Last-Event-Id=1 delivers t2 (missed while
+                // disconnected) from the replay cache, then t3 live. This is the desired catch-up
+                // behavior — the client doesn't need REST for events still in the bus buffer.
                 client.sse(
                     urlString = "/api/v1/sync/events",
                     request = {
@@ -50,10 +55,12 @@ class SyncFoundationE2ETest :
                     },
                 ) {
                     coroutineScope {
-                        val deferred = async { incoming.first() }
+                        // Collect two events: the replayed t2 + the live t3
+                        val deferred = async { incoming.take(2).toList() }
                         tagRepo.upsert(Tag("t3", "gamma", 0, 0))
-                        val event3 = deferred.await()
-                        event3.data!! shouldContain """"id":"t3""""
+                        val events = deferred.await()
+                        events[0].data!! shouldContain """"id":"t2""""
+                        events[1].data!! shouldContain """"id":"t3""""
                     }
                 }
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncMetaTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncMetaTest.kt
@@ -4,23 +4,26 @@ import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 
 class SyncMetaTest :
     FunSpec({
         test("nextRevision() increments monotonically from 1") {
             withInMemoryDatabase {
+                val db = this
                 runTest {
-                    nextRevision(this@withInMemoryDatabase) shouldBe 1L
-                    nextRevision(this@withInMemoryDatabase) shouldBe 2L
-                    nextRevision(this@withInMemoryDatabase) shouldBe 3L
+                    suspendTransaction(db) { nextRevision() } shouldBe 1L
+                    suspendTransaction(db) { nextRevision() } shouldBe 2L
+                    suspendTransaction(db) { nextRevision() } shouldBe 3L
                 }
             }
         }
 
         test("nextRevision() is strictly monotonic across concurrent calls") {
             withInMemoryDatabase {
+                val db = this
                 runTest {
-                    val results = (1..50).map { nextRevision(this@withInMemoryDatabase) }
+                    val results = (1..50).map { suspendTransaction(db) { nextRevision() } }
                     results.toSet().size shouldBe 50
                     results shouldBe results.sorted()
                 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncMetaTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncMetaTest.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+class SyncMetaTest :
+    FunSpec({
+        test("nextRevision() increments monotonically from 1") {
+            withInMemoryDatabase {
+                runTest {
+                    nextRevision(this@withInMemoryDatabase) shouldBe 1L
+                    nextRevision(this@withInMemoryDatabase) shouldBe 2L
+                    nextRevision(this@withInMemoryDatabase) shouldBe 3L
+                }
+            }
+        }
+
+        test("nextRevision() is strictly monotonic across concurrent calls") {
+            withInMemoryDatabase {
+                runTest {
+                    val results = (1..50).map { nextRevision(this@withInMemoryDatabase) }
+                    results.toSet().size shouldBe 50
+                    results shouldBe results.sorted()
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableTableTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableTableTest.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.server.db.TagTable
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+
+class SyncableTableTest :
+    FunSpec({
+
+        test("SyncableTable mixin contributes the sync-discipline columns") {
+            val columnNames = TagTable.columns.map { it.name }
+            columnNames shouldContainAll
+                listOf(
+                    "id",
+                    "name",
+                    "revision",
+                    "created_at",
+                    "updated_at",
+                    "deleted_at",
+                    "client_op_id",
+                )
+        }
+
+        test("TagTable extends SyncableTable") {
+            // Compile-time check: if TagTable doesn't extend SyncableTable, this won't compile.
+            val table: SyncableTable = TagTable
+            check(table.tableName == "tags")
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
@@ -81,4 +81,25 @@ class TagRepositoryDigestTest :
                 }
             }
         }
+
+        test("digest byte format is the canonical wire contract") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0)) // revision 1
+                    repo.upsert(Tag("b", "beta", 0, 0)) // revision 2
+                    // Canonical layout: <id>|<revision>\n per row, sorted by id, trailing \n
+                    // Input bytes: "a|1\nb|2\n"
+                    val expectedInput = "a|1\nb|2\n"
+                    val md = java.security.MessageDigest.getInstance("SHA-256")
+                    val expectedHex =
+                        md
+                            .digest(expectedInput.toByteArray(Charsets.UTF_8))
+                            .joinToString("") { "%02x".format(it) }
+                    val actual = repo.digest(cursor = Long.MAX_VALUE)
+                    actual.hash shouldBe "sha256:$expectedHex"
+                }
+            }
+        }
     })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
@@ -1,0 +1,84 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import kotlinx.coroutines.test.runTest
+
+class TagRepositoryDigestTest :
+    FunSpec({
+
+        test("empty domain digest is count=0, hash=empty") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    val d = repo.digest(cursor = Long.MAX_VALUE)
+                    d.cursor shouldBe Long.MAX_VALUE
+                    d.count shouldBe 0
+                    d.hash shouldBe ""
+                }
+            }
+        }
+
+        test("digest is deterministic and sha256-prefixed") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0))
+                    repo.upsert(Tag("b", "beta", 0, 0))
+                    val d1 = repo.digest(cursor = Long.MAX_VALUE)
+                    val d2 = repo.digest(cursor = Long.MAX_VALUE)
+                    d1 shouldBe d2
+                    d1.count shouldBe 2
+                    d1.hash shouldStartWith "sha256:"
+                    d1.hash.length shouldBe "sha256:".length + 64 // 64 hex chars
+                }
+            }
+        }
+
+        test("digest changes when a row is updated") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0))
+                    val before = repo.digest(cursor = Long.MAX_VALUE)
+                    repo.upsert(Tag("a", "alpha-updated", 0, 0))
+                    val after = repo.digest(cursor = Long.MAX_VALUE)
+                    (before.hash != after.hash) shouldBe true
+                    before.count shouldBe after.count // still one row
+                }
+            }
+        }
+
+        test("digest scopes by cursor") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0)) // rev 1
+                    repo.upsert(Tag("b", "beta", 0, 0)) // rev 2
+                    repo.upsert(Tag("c", "gamma", 0, 0)) // rev 3
+                    val d = repo.digest(cursor = 2L)
+                    d.count shouldBe 2 // only a, b
+                }
+            }
+        }
+
+        test("digest includes soft-deleted rows") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0))
+                    repo.softDelete("a")
+                    val d = repo.digest(cursor = Long.MAX_VALUE)
+                    d.count shouldBe 1
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryPullSinceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryPullSinceTest.kt
@@ -1,0 +1,93 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+
+class TagRepositoryPullSinceTest :
+    FunSpec({
+
+        test("pullSince(0) returns all rows ordered by revision asc") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0))
+                    repo.upsert(Tag("b", "beta", 0, 0))
+                    repo.upsert(Tag("c", "gamma", 0, 0))
+                    val page = repo.pullSince(cursor = 0L, limit = 100)
+                    page.items shouldHaveSize 3
+                    page.items.map { it.id } shouldBe listOf("a", "b", "c")
+                    page.hasMore shouldBe false
+                    page.nextCursor shouldBe page.items.last().revision
+                }
+            }
+        }
+
+        test("pullSince filters by cursor strictly greater than") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0)) // revision 1
+                    repo.upsert(Tag("b", "beta", 0, 0)) // revision 2
+                    repo.upsert(Tag("c", "gamma", 0, 0)) // revision 3
+                    val page = repo.pullSince(cursor = 1L, limit = 100)
+                    page.items.map { it.id } shouldBe listOf("b", "c")
+                }
+            }
+        }
+
+        test("pullSince paginates with hasMore = true when limit reached") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    (1..5).forEach { repo.upsert(Tag(id = "id-$it", name = "n$it", revision = 0, updatedAt = 0)) }
+                    val first = repo.pullSince(cursor = 0L, limit = 2)
+                    first.items shouldHaveSize 2
+                    first.hasMore shouldBe true
+                    first.nextCursor!! shouldBe first.items.last().revision
+
+                    val second = repo.pullSince(cursor = first.nextCursor!!, limit = 2)
+                    second.items shouldHaveSize 2
+                    second.hasMore shouldBe true
+
+                    val third = repo.pullSince(cursor = second.nextCursor!!, limit = 2)
+                    third.items shouldHaveSize 1
+                    third.hasMore shouldBe false
+                }
+            }
+        }
+
+        test("pullSince includes soft-deleted rows with deletedAt populated") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    repo.upsert(Tag("a", "alpha", 0, 0))
+                    repo.softDelete("a")
+                    val page = repo.pullSince(cursor = 0L, limit = 100)
+                    page.items shouldHaveSize 1
+                    page.items.first().deletedAt shouldNotBe null
+                }
+            }
+        }
+
+        test("empty pullSince returns Page(items=[], cursor=null, hasMore=false)") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    val page = repo.pullSince(cursor = 0L, limit = 100)
+                    page.items shouldHaveSize 0
+                    page.nextCursor shouldBe null
+                    page.hasMore shouldBe false
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.result.AppResult
@@ -9,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
 class TagRepositorySoftDeleteTest :
@@ -22,6 +25,7 @@ class TagRepositorySoftDeleteTest :
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
                     val deferredBusEvent = async { bus.subscribe().first() }
+                    advanceUntilIdle()
 
                     val result = repo.softDelete("t1", clientOpId = "op-del")
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
@@ -57,6 +61,7 @@ class TagRepositorySoftDeleteTest :
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
                     repo.softDelete("t1")
                     val deferredBusEvent = async { bus.subscribe().first() }
+                    advanceUntilIdle()
 
                     val resurrected = repo.upsert(Tag("t1", "sci-fi-resurrected", 0, 0))
                     resurrected.shouldBeInstanceOf<AppResult.Success<Tag>>()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
@@ -21,12 +21,14 @@ class TagRepositorySoftDeleteTest :
                 val repo = TagRepository(db, bus)
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
-                    val deferredEvent = async { bus.subscribe().first() }
+                    val deferredBusEvent = async { bus.subscribe().first() }
 
                     val result = repo.softDelete("t1", clientOpId = "op-del")
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
 
-                    val event = deferredEvent.await()
+                    val busEvent = deferredBusEvent.await()
+                    busEvent.domainName shouldBe "tags"
+                    val event = busEvent.event
                     event.shouldBeInstanceOf<SyncEvent.Deleted>()
                     event.id shouldBe "t1"
                     event.clientOpId shouldBe "op-del"
@@ -54,14 +56,14 @@ class TagRepositorySoftDeleteTest :
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
                     repo.softDelete("t1")
-                    val deferredEvent = async { bus.subscribe().first() }
+                    val deferredBusEvent = async { bus.subscribe().first() }
 
                     val resurrected = repo.upsert(Tag("t1", "sci-fi-resurrected", 0, 0))
                     resurrected.shouldBeInstanceOf<AppResult.Success<Tag>>()
                     (resurrected as AppResult.Success).data.deletedAt shouldBe null
 
-                    val event = deferredEvent.await()
-                    event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
+                    val busEvent = deferredBusEvent.await()
+                    busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
                 }
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
@@ -1,0 +1,68 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class TagRepositorySoftDeleteTest :
+    FunSpec({
+
+        test("softDelete sets deletedAt, bumps revision, publishes Deleted") {
+            withInMemoryDatabase {
+                val db = this
+                val bus = ChangeBus()
+                val repo = TagRepository(db, bus)
+                runTest {
+                    repo.upsert(Tag("t1", "sci-fi", 0, 0))
+                    val deferredEvent = async { bus.subscribe().first() }
+
+                    val result = repo.softDelete("t1", clientOpId = "op-del")
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    val event = deferredEvent.await()
+                    event.shouldBeInstanceOf<SyncEvent.Deleted>()
+                    event.id shouldBe "t1"
+                    event.clientOpId shouldBe "op-del"
+                    (event.revision > 1L) shouldBe true
+                }
+            }
+        }
+
+        test("softDelete of non-existent id returns Failure") {
+            withInMemoryDatabase {
+                val db = this
+                val repo = TagRepository(db, ChangeBus())
+                runTest {
+                    val result = repo.softDelete("does-not-exist")
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+                }
+            }
+        }
+
+        test("upsert of a soft-deleted row clears deletedAt and emits Updated") {
+            withInMemoryDatabase {
+                val db = this
+                val bus = ChangeBus()
+                val repo = TagRepository(db, bus)
+                runTest {
+                    repo.upsert(Tag("t1", "sci-fi", 0, 0))
+                    repo.softDelete("t1")
+                    val deferredEvent = async { bus.subscribe().first() }
+
+                    val resurrected = repo.upsert(Tag("t1", "sci-fi-resurrected", 0, 0))
+                    resurrected.shouldBeInstanceOf<AppResult.Success<Tag>>()
+                    (resurrected as AppResult.Success).data.deletedAt shouldBe null
+
+                    val event = deferredEvent.await()
+                    event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
@@ -2,6 +2,7 @@
 
 package com.calypsan.listenup.server.sync
 
+import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.api.sync.Tag
@@ -10,6 +11,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -24,7 +26,9 @@ class TagRepositorySoftDeleteTest :
                 val repo = TagRepository(db, bus)
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
-                    val deferredBusEvent = async { bus.subscribe().first() }
+                    // With replay=256, the subscriber sees the cached Created event first.
+                    // Drop it to observe only the Deleted event from softDelete.
+                    val deferredBusEvent = async { bus.subscribe().drop(1).first() }
                     advanceUntilIdle()
 
                     val result = repo.softDelete("t1", clientOpId = "op-del")
@@ -41,13 +45,17 @@ class TagRepositorySoftDeleteTest :
             }
         }
 
-        test("softDelete of non-existent id returns Failure") {
+        test("softDelete of non-existent id returns SyncError.NotFound") {
             withInMemoryDatabase {
                 val db = this
                 val repo = TagRepository(db, ChangeBus())
                 runTest {
                     val result = repo.softDelete("does-not-exist")
                     result.shouldBeInstanceOf<AppResult.Failure>()
+                    val err = (result as AppResult.Failure).error
+                    err.shouldBeInstanceOf<SyncError.NotFound>()
+                    (err as SyncError.NotFound).domain shouldBe "tags"
+                    err.entityId shouldBe "does-not-exist"
                 }
             }
         }
@@ -60,7 +68,9 @@ class TagRepositorySoftDeleteTest :
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
                     repo.softDelete("t1")
-                    val deferredBusEvent = async { bus.subscribe().first() }
+                    // With replay=256, the subscriber sees both cached events (Created + Deleted).
+                    // Drop them to observe only the Updated event from the resurrection upsert.
+                    val deferredBusEvent = async { bus.subscribe().drop(2).first() }
                     advanceUntilIdle()
 
                     val resurrected = repo.upsert(Tag("t1", "sci-fi-resurrected", 0, 0))

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
@@ -1,0 +1,115 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class TagRepositoryUpsertTest :
+    FunSpec({
+
+        test("upsert of a fresh row publishes Created with bumped revision") {
+            withInMemoryDatabase {
+                val bus = ChangeBus()
+                val fixedTime = Instant.fromEpochMilliseconds(1_730_000_000_000L)
+                val repo =
+                    TagRepository(
+                        db = this,
+                        bus = bus,
+                        clock =
+                            object : Clock {
+                                override fun now() = fixedTime
+                            },
+                    )
+
+                runTest {
+                    val deferredEvent = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    val initial = Tag(id = "t1", name = "sci-fi", revision = 0, updatedAt = 0)
+                    val result = repo.upsert(initial, clientOpId = "op-1")
+
+                    result.shouldBeInstanceOf<AppResult.Success<Tag>>()
+                    val saved = (result as AppResult.Success).data
+                    saved.id shouldBe "t1"
+                    saved.name shouldBe "sci-fi"
+                    saved.revision shouldBe 1L
+                    saved.updatedAt shouldBe 1_730_000_000_000L
+
+                    val event = deferredEvent.await()
+                    event.shouldBeInstanceOf<SyncEvent.Created<Tag>>()
+                    event.id shouldBe "t1"
+                    event.revision shouldBe 1L
+                    event.clientOpId shouldBe "op-1"
+                    (event as SyncEvent.Created<*>).payload shouldBe saved
+                }
+            }
+        }
+
+        test("upsert of an existing row publishes Updated") {
+            withInMemoryDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = this, bus = bus)
+
+                runTest {
+                    val initial = Tag(id = "t1", name = "sci-fi", revision = 0, updatedAt = 0)
+                    repo.upsert(initial)
+
+                    val sub = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    val updated = initial.copy(name = "scifi-updated")
+                    repo.upsert(updated, clientOpId = "op-2")
+
+                    val event = sub.await()
+                    event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
+                    event.clientOpId shouldBe "op-2"
+                }
+            }
+        }
+
+        test("upsert with null clientOpId publishes event with null clientOpId") {
+            withInMemoryDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = this, bus = bus)
+
+                runTest {
+                    val deferredEvent = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    repo.upsert(Tag(id = "t2", name = "x", revision = 0, updatedAt = 0))
+
+                    val event = deferredEvent.await()
+                    event.clientOpId shouldBe null
+                }
+            }
+        }
+
+        test("revisions are strictly monotonic across writes") {
+            withInMemoryDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = this, bus = bus)
+
+                runTest {
+                    val r1 = (repo.upsert(Tag("a", "n1", 0, 0)) as AppResult.Success).data.revision
+                    val r2 = (repo.upsert(Tag("b", "n2", 0, 0)) as AppResult.Success).data.revision
+                    val r3 = (repo.upsert(Tag("a", "n1-updated", 0, 0)) as AppResult.Success).data.revision
+
+                    listOf(r1, r2, r3).distinct().size shouldBe 3
+                    (r2 > r1) shouldBe true
+                    (r3 > r2) shouldBe true
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
@@ -10,6 +10,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -68,7 +69,9 @@ class TagRepositoryUpsertTest :
                     val initial = Tag(id = "t1", name = "sci-fi", revision = 0, updatedAt = 0)
                     repo.upsert(initial)
 
-                    val sub = async { bus.subscribe().first() }
+                    // With replay=256, the subscriber immediately sees the replay cache.
+                    // Drop the already-published Created event to observe only the next write.
+                    val sub = async { bus.subscribe().drop(1).first() }
                     advanceUntilIdle()
 
                     val updated = initial.copy(name = "scifi-updated")

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
@@ -34,7 +34,7 @@ class TagRepositoryUpsertTest :
                     )
 
                 runTest {
-                    val deferredEvent = async { bus.subscribe().first() }
+                    val deferredBusEvent = async { bus.subscribe().first() }
                     advanceUntilIdle()
 
                     val initial = Tag(id = "t1", name = "sci-fi", revision = 0, updatedAt = 0)
@@ -47,7 +47,9 @@ class TagRepositoryUpsertTest :
                     saved.revision shouldBe 1L
                     saved.updatedAt shouldBe 1_730_000_000_000L
 
-                    val event = deferredEvent.await()
+                    val busEvent = deferredBusEvent.await()
+                    busEvent.domainName shouldBe "tags"
+                    val event = busEvent.event
                     event.shouldBeInstanceOf<SyncEvent.Created<Tag>>()
                     event.id shouldBe "t1"
                     event.revision shouldBe 1L
@@ -72,9 +74,10 @@ class TagRepositoryUpsertTest :
                     val updated = initial.copy(name = "scifi-updated")
                     repo.upsert(updated, clientOpId = "op-2")
 
-                    val event = sub.await()
-                    event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
-                    event.clientOpId shouldBe "op-2"
+                    val busEvent = sub.await()
+                    busEvent.domainName shouldBe "tags"
+                    busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
+                    busEvent.event.clientOpId shouldBe "op-2"
                 }
             }
         }
@@ -85,13 +88,13 @@ class TagRepositoryUpsertTest :
                 val repo = TagRepository(db = this, bus = bus)
 
                 runTest {
-                    val deferredEvent = async { bus.subscribe().first() }
+                    val deferredBusEvent = async { bus.subscribe().first() }
                     advanceUntilIdle()
 
                     repo.upsert(Tag(id = "t2", name = "x", revision = 0, updatedAt = 0))
 
-                    val event = deferredEvent.await()
-                    event.clientOpId shouldBe null
+                    val busEvent = deferredBusEvent.await()
+                    busEvent.event.clientOpId shouldBe null
                 }
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
@@ -1,0 +1,74 @@
+package com.calypsan.listenup.server.testing
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.TagRepository
+import com.calypsan.listenup.server.sync.syncRoutes
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import org.koin.dsl.module
+import org.koin.ktor.plugin.Koin
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
+
+/**
+ * Test scope exposing the JSON-capable [client] and [tagRepo] to test bodies.
+ * Decouples test code from [io.ktor.server.testing.ApplicationTestBuilder] so
+ * the two overloads of [withTestApplication] are unambiguous.
+ */
+data class SyncTestScope(
+    val client: HttpClient,
+    val tagRepo: TagRepository,
+)
+
+/**
+ * Minimal Ktor test harness for Sync Foundation route tests.
+ *
+ * Constructs an isolated SQLite database (same temp-file pattern as
+ * [withInMemoryDatabase]), wires a small Koin module with `Database`,
+ * `ChangeBus`, and `TagRepository`, installs `ContentNegotiation` and `SSE`,
+ * and mounts [syncRoutes]. Provides a JSON-capable [SyncTestScope.client] so
+ * `response.body<Page<Tag>>()` round-trips using [contractJson] on both sides.
+ *
+ * Used by Tasks 15-18. Additional domain repositories can be added to the
+ * Koin module when later tasks introduce them.
+ */
+internal fun withTestApplication(block: suspend SyncTestScope.() -> Unit) {
+    testApplication {
+        val tmp =
+            Files.createTempFile("listenup-sync-test-", ".db").toFile().apply { deleteOnExit() }
+        val db =
+            DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
+        val bus = ChangeBus()
+        val tagRepo = TagRepository(db, bus)
+
+        application {
+            install(ServerContentNegotiation) { json(contractJson) }
+            install(SSE)
+            install(Koin) {
+                modules(
+                    module {
+                        single { db }
+                        single { bus }
+                        single(createdAtStart = true) { tagRepo }
+                    },
+                )
+            }
+            routing { syncRoutes() }
+        }
+
+        val jsonClient =
+            createClient {
+                install(ContentNegotiation) { json(contractJson) }
+            }
+
+        SyncTestScope(client = jsonClient, tagRepo = tagRepo).block()
+    }
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
@@ -67,6 +67,7 @@ internal fun withTestApplication(block: suspend SyncTestScope.() -> Unit) {
         val jsonClient =
             createClient {
                 install(ContentNegotiation) { json(contractJson) }
+                install(io.ktor.client.plugins.sse.SSE)
             }
 
         SyncTestScope(client = jsonClient, tagRepo = tagRepo).block()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestFixtures.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestFixtures.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.server.testing
+
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import org.jetbrains.exposed.v1.jdbc.Database
+import java.nio.file.Files
+
+/**
+ * Runs [block] with a freshly-migrated in-memory SQLite [Database] as the receiver.
+ *
+ * Uses a temp-file database (not `:memory:`) so that Flyway's schema-history
+ * table and SQLite's single-connection constraint both work correctly. The file
+ * is deleted on JVM exit.
+ */
+fun withInMemoryDatabase(block: Database.() -> Unit) {
+    val tmp = Files.createTempFile("listenup-test-", ".db").toFile().apply { deleteOnExit() }
+    val db = DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
+    db.block()
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/error/SyncError.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/error/SyncError.kt
@@ -47,4 +47,23 @@ sealed interface SyncError : AppError {
         override val code: String = "SYNC_PUSH_FAILED"
         override val isRetryable: Boolean = true
     }
+
+    /**
+     * Returned when an operation references a row that does not exist (e.g.
+     * [softDelete][com.calypsan.listenup.server.sync.SyncableRepository.softDelete] of a
+     * missing id). [domain] and [entityId] carry diagnostic context; the
+     * user-facing [message] is generic.
+     */
+    @Serializable
+    @SerialName("SyncError.NotFound")
+    data class NotFound(
+        val domain: String,
+        val entityId: String,
+        override val correlationId: String? = null,
+        override val debugInfo: String? = null,
+    ) : SyncError {
+        override val message: String = "The requested item could not be found."
+        override val code: String = "SYNC_NOT_FOUND"
+        override val isRetryable: Boolean = false
+    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainDigest.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainDigest.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.api.sync
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-domain row-set fingerprint. Returned by `GET /api/v1/sync/<domain>/digest?cursor=<rev>`
+ * and computed identically on both server and client over `(id, revision)` pairs of every
+ * row in the domain with `revision <= cursor`, soft-deleted rows included.
+ *
+ * Algorithm: sort rows lexicographically by `id`, concatenate as `<id>|<revision>\n` per row,
+ * SHA-256 the resulting bytes, format as `"sha256:<lowercase-hex>"`. Empty domain → `count = 0`,
+ * `hash = ""`.
+ *
+ * Used by clients to detect drift cheaply — match `(count, hash)` between local and server;
+ * mismatch triggers a full domain re-pull (`?since=0`).
+ */
+@Serializable
+data class DomainDigest(
+    @SerialName("cursor")
+    val cursor: Long,
+    val count: Int,
+    val hash: String,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainList.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainList.kt
@@ -1,0 +1,18 @@
+package com.calypsan.listenup.api.sync
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * List of registered syncable domain names on the server. Returned by
+ * `GET /api/v1/sync/domains`. Clients diff against their locally-tracked
+ * "domains I've bootstrapped" set; new domains in the server's list trigger
+ * a full pull (`?since=0`) for that domain. Same machinery handles fresh
+ * client install (empty local set) and server-side new-domain rollout.
+ *
+ * Order: server returns names sorted lexicographically for stability.
+ */
+@Serializable
+data class DomainList(
+    @SerialName("domains") val domains: List<String>,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/Page.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/Page.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.api.sync
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * REST catch-up response envelope. `items` are *current state* of domain rows
+ * with `revision > <client cursor>`, soft-deleted rows included so clients can
+ * apply tombstones. `nextCursor` is the highest `revision` in this page (null
+ * when [items] is empty). `hasMore` indicates whether the server has more rows
+ * beyond this page; clients page until `hasMore == false`.
+ */
+@Serializable
+data class Page<T>(
+    @SerialName("items")
+    val items: List<T>,
+    val nextCursor: Long?,
+    val hasMore: Boolean,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
@@ -1,0 +1,40 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.error.AppError
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Out-of-band control events emitted on the SSE firehose, distinct from the
+ * `SyncEvent.*` data events. Sent on a different SSE `event:` line so clients
+ * can branch cleanly:
+ *  - `event: control` → JSON-decoded [SyncControl]
+ *  - `event: <domain>` → JSON-decoded [SyncEvent]
+ *
+ * Stable `@SerialName` discriminators — wire contract.
+ */
+@Serializable
+sealed interface SyncControl {
+    /**
+     * Sent when the client's `Last-Event-Id` is older than the bus's in-memory
+     * replay window. Client must fall back to REST per-domain catch-up against
+     * each registered domain.
+     */
+    @Serializable
+    @SerialName("SyncControl.CursorStale")
+    data class CursorStale(
+        val lastKnownRevision: Long,
+    ) : SyncControl
+
+    /**
+     * Sent on a fatal error inside the SSE emit pipeline. Client treats this as
+     * "connection ended; reconnect with current cursor and try again." The
+     * [error] is the same typed [AppError] surface the rest of the contract
+     * uses; stacktraces never cross the wire.
+     */
+    @Serializable
+    @SerialName("SyncControl.StreamError")
+    data class StreamError(
+        val error: AppError,
+    ) : SyncControl
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncCursor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncCursor.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.api.sync
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Type-safe wrapper around the global sync revision counter.
+ *
+ * Clients persist this across reconnects and pass it as `Last-Event-Id` on SSE
+ * resume or as the `?since=` query parameter on REST catch-up. The underlying
+ * type is [Long]; the value class is for call-site clarity only.
+ */
+@Serializable
+@JvmInline
+value class SyncCursor(
+    val revision: Long,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncEvent.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncEvent.kt
@@ -1,0 +1,64 @@
+package com.calypsan.listenup.api.sync
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Envelope for SSE-firehose events on the cross-domain sync surface.
+ *
+ * Three variants:
+ *  - [Created] / [Updated] carry the full domain payload (fat events — saves a round trip).
+ *  - [Deleted] carries no payload; the row's tombstone is its own signal.
+ *
+ * `clientOpId` is the originating client's operation id, propagated server-side from the
+ * write API, so SSE echoes match pending operations on the client without re-applying.
+ * Server-originated writes (e.g. scanner-driven during a library scan) leave it null.
+ *
+ * Stable `@SerialName` discriminators — renames are wire breaks.
+ */
+@Serializable
+sealed interface SyncEvent<out T> {
+    /** Stable entity identifier. */
+    val id: String
+
+    /** Global revision at write time. Also used as the SSE event id for `Last-Event-Id` resume. */
+    val revision: Long
+
+    /** Wall-clock millis (server-side) when the event was emitted. */
+    val occurredAt: Long
+
+    /** Originating client op id for echo matching, null for server-originated writes. */
+    val clientOpId: String?
+
+    /** Successful create. Carries the full domain payload. */
+    @Serializable
+    @SerialName("SyncEvent.Created")
+    data class Created<T>(
+        override val id: String,
+        override val revision: Long,
+        override val occurredAt: Long,
+        override val clientOpId: String? = null,
+        val payload: T,
+    ) : SyncEvent<T>
+
+    /** Successful update. Carries the full domain payload. */
+    @Serializable
+    @SerialName("SyncEvent.Updated")
+    data class Updated<T>(
+        override val id: String,
+        override val revision: Long,
+        override val occurredAt: Long,
+        override val clientOpId: String? = null,
+        val payload: T,
+    ) : SyncEvent<T>
+
+    /** Soft-delete tombstone. No payload — clients apply via id. */
+    @Serializable
+    @SerialName("SyncEvent.Deleted")
+    data class Deleted(
+        override val id: String,
+        override val revision: Long,
+        override val occurredAt: Long,
+        override val clientOpId: String? = null,
+    ) : SyncEvent<Nothing>
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/Tag.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/Tag.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.api.sync
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Validation-domain DTO for the Sync Foundation phase. Tags has no public write API
+ * in this phase — the repository is exercised by integration tests only. Future phases
+ * (likely Books-C, when users tag books) add the user-facing API.
+ *
+ * Carries the canonical sync-discipline fields every domain DTO will surface from
+ * Books-A onwards: `revision`, `updatedAt`, `deletedAt`. `clientOpId` is NOT on the
+ * payload — it lives on the wrapping [SyncEvent] for echo matching.
+ */
+@Serializable
+@SerialName("Tag")
+data class Tag(
+    val id: String,
+    val name: String,
+    val revision: Long,
+    val updatedAt: Long,
+    val deletedAt: Long? = null,
+)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/error/SyncErrorContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/error/SyncErrorContractTest.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.api.error
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins that [SyncError.NotFound] round-trips through the canonical [contractJson]
+ * using the polymorphic `AppError.serializer()` and has a stable `@SerialName`.
+ */
+class SyncErrorContractTest :
+    FunSpec({
+        test("NotFound round-trips") {
+            val original: AppError = SyncError.NotFound(domain = "tags", entityId = "missing")
+            val json = contractJson.encodeToString(AppError.serializer(), original)
+            val decoded = contractJson.decodeFromString(AppError.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("NotFound has stable @SerialName") {
+            val err: AppError = SyncError.NotFound(domain = "tags", entityId = "x")
+            val json = contractJson.encodeToString(AppError.serializer(), err)
+            json.contains("\"type\":\"SyncError.NotFound\"") shouldBe true
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/error/SyncErrorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/error/SyncErrorTest.kt
@@ -25,4 +25,13 @@ class SyncErrorTest :
             err.code shouldBe "SYNC_PUSH_FAILED"
             err.isRetryable shouldBe true
         }
+
+        test("NotFound has stable code, is not retryable, and carries domain + entityId") {
+            val err = SyncError.NotFound(domain = "tags", entityId = "abc-123")
+            err.message.isNotBlank() shouldBe true
+            err.code shouldBe "SYNC_NOT_FOUND"
+            err.isRetryable shouldBe false
+            err.domain shouldBe "tags"
+            err.entityId shouldBe "abc-123"
+        }
     })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/DomainDiscoveryContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/DomainDiscoveryContractTest.kt
@@ -1,0 +1,30 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DomainDiscoveryContractTest :
+    FunSpec({
+
+        test("DomainDigest round-trips") {
+            val original = DomainDigest(cursor = 42, count = 7, hash = "sha256:abc123")
+            val json = contractJson.encodeToString(DomainDigest.serializer(), original)
+            val decoded = contractJson.decodeFromString(DomainDigest.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("DomainList round-trips") {
+            val original = DomainList(domains = listOf("books", "tags", "shelves"))
+            val json = contractJson.encodeToString(DomainList.serializer(), original)
+            val decoded = contractJson.decodeFromString(DomainList.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("Empty DomainList round-trips") {
+            val original = DomainList(domains = emptyList())
+            val json = contractJson.encodeToString(DomainList.serializer(), original)
+            val decoded = contractJson.decodeFromString(DomainList.serializer(), json)
+            decoded shouldBe original
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/PageContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/PageContractTest.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.builtins.serializer
+
+class PageContractTest :
+    FunSpec({
+
+        test("Page round-trips with items and cursor") {
+            val original = Page(items = listOf("a", "b", "c"), nextCursor = 42L, hasMore = true)
+            val json = contractJson.encodeToString(Page.serializer(String.serializer()), original)
+            val decoded = contractJson.decodeFromString(Page.serializer(String.serializer()), json)
+            decoded shouldBe original
+        }
+
+        test("Empty Page round-trips with null cursor and hasMore=false") {
+            val original = Page(items = emptyList<String>(), nextCursor = null, hasMore = false)
+            val json = contractJson.encodeToString(Page.serializer(String.serializer()), original)
+            val decoded = contractJson.decodeFromString(Page.serializer(String.serializer()), json)
+            decoded shouldBe original
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/SyncControlContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/SyncControlContractTest.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.error.InternalError
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class SyncControlContractTest :
+    FunSpec({
+
+        test("CursorStale round-trips") {
+            val original: SyncControl = SyncControl.CursorStale(lastKnownRevision = 999)
+            val json = contractJson.encodeToString(SyncControl.serializer(), original)
+            val decoded = contractJson.decodeFromString(SyncControl.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("StreamError round-trips with typed AppError payload") {
+            val err = InternalError(correlationId = "cid-xyz", cause = "NPE")
+            val original: SyncControl = SyncControl.StreamError(error = err)
+            val json = contractJson.encodeToString(SyncControl.serializer(), original)
+            val decoded = contractJson.decodeFromString(SyncControl.serializer(), json)
+            decoded.shouldBeInstanceOf<SyncControl.StreamError>()
+            (decoded as SyncControl.StreamError).error.shouldBeInstanceOf<InternalError>()
+            (decoded.error as InternalError).correlationId shouldBe "cid-xyz"
+        }
+
+        test("Stable discriminators") {
+            val stale: SyncControl = SyncControl.CursorStale(0)
+            val streamErr: SyncControl = SyncControl.StreamError(InternalError())
+            contractJson
+                .encodeToString(SyncControl.serializer(), stale)
+                .contains("\"type\":\"SyncControl.CursorStale\"") shouldBe true
+            contractJson
+                .encodeToString(SyncControl.serializer(), streamErr)
+                .contains("\"type\":\"SyncControl.StreamError\"") shouldBe true
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/SyncEventContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/SyncEventContractTest.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.builtins.serializer
+
+class SyncEventContractTest :
+    FunSpec({
+
+        test("Created round-trips with payload and clientOpId") {
+            val original: SyncEvent<String> =
+                SyncEvent.Created(
+                    id = "abc",
+                    revision = 42,
+                    occurredAt = 1730000000000L,
+                    clientOpId = "op-uuid-1",
+                    payload = "hello",
+                )
+            val json = contractJson.encodeToString(SyncEvent.serializer(String.serializer()), original)
+            val decoded = contractJson.decodeFromString(SyncEvent.serializer(String.serializer()), json)
+            decoded shouldBe original
+        }
+
+        test("Updated round-trips with null clientOpId for server-originated writes") {
+            val original: SyncEvent<String> =
+                SyncEvent.Updated(
+                    id = "abc",
+                    revision = 43,
+                    occurredAt = 1730000000001L,
+                    clientOpId = null,
+                    payload = "world",
+                )
+            val json = contractJson.encodeToString(SyncEvent.serializer(String.serializer()), original)
+            val decoded = contractJson.decodeFromString(SyncEvent.serializer(String.serializer()), json)
+            decoded shouldBe original
+        }
+
+        test("Deleted round-trips and carries no payload") {
+            val original: SyncEvent<String> =
+                SyncEvent.Deleted(
+                    id = "abc",
+                    revision = 44,
+                    occurredAt = 1730000000002L,
+                    clientOpId = "op-uuid-2",
+                )
+            val json = contractJson.encodeToString(SyncEvent.serializer(String.serializer()), original)
+            val decoded = contractJson.decodeFromString(SyncEvent.serializer(String.serializer()), json)
+            decoded shouldBe original
+        }
+
+        test("Stable @SerialName discriminators") {
+            val created: SyncEvent<String> = SyncEvent.Created("a", 1, 10, null, "x")
+            val updated: SyncEvent<String> = SyncEvent.Updated("a", 1, 10, null, "x")
+            val deleted: SyncEvent<String> = SyncEvent.Deleted("a", 1, 10, null)
+            contractJson
+                .encodeToString(SyncEvent.serializer(String.serializer()), created)
+                .contains("\"type\":\"SyncEvent.Created\"") shouldBe true
+            contractJson
+                .encodeToString(SyncEvent.serializer(String.serializer()), updated)
+                .contains("\"type\":\"SyncEvent.Updated\"") shouldBe true
+            contractJson
+                .encodeToString(SyncEvent.serializer(String.serializer()), deleted)
+                .contains("\"type\":\"SyncEvent.Deleted\"") shouldBe true
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/TagContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/api/sync/TagContractTest.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TagContractTest :
+    FunSpec({
+
+        test("Tag round-trips with all fields") {
+            val original =
+                Tag(
+                    id = "tag-1",
+                    name = "sci-fi",
+                    revision = 42,
+                    updatedAt = 1730000000000L,
+                    deletedAt = null,
+                )
+            val json = contractJson.encodeToString(Tag.serializer(), original)
+            val decoded = contractJson.decodeFromString(Tag.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("Tag round-trips with deletedAt populated (tombstone)") {
+            val original =
+                Tag(
+                    id = "tag-2",
+                    name = "fantasy",
+                    revision = 50,
+                    updatedAt = 1730000000000L,
+                    deletedAt = 1730000005000L,
+                )
+            val json = contractJson.encodeToString(Tag.serializer(), original)
+            val decoded = contractJson.decodeFromString(Tag.serializer(), json)
+            decoded shouldBe original
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncEventTypesInCommonMainRule.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncEventTypesInCommonMainRule.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+
+/**
+ * Pin all sync wire types (`SyncEvent`, `SyncCursor`, `SyncControl`,
+ * `Page`, `DomainDigest`, `DomainList`, `Tag`) to commonMain. Backstops
+ * `DtosLiveInCommonMainRule` for the sync surface specifically — that rule
+ * guards `@Serializable` classes, but the sync surface also includes sealed
+ * interfaces and value classes that carry no annotation in their declaration
+ * header.
+ */
+class SyncEventTypesInCommonMainRule :
+    FunSpec({
+
+        test("sync wire types live in :shared/commonMain") {
+            val expectedFqns =
+                setOf(
+                    "com.calypsan.listenup.api.sync.SyncEvent",
+                    "com.calypsan.listenup.api.sync.SyncCursor",
+                    "com.calypsan.listenup.api.sync.SyncControl",
+                    "com.calypsan.listenup.api.sync.Page",
+                    "com.calypsan.listenup.api.sync.DomainDigest",
+                    "com.calypsan.listenup.api.sync.DomainList",
+                    "com.calypsan.listenup.api.sync.Tag",
+                )
+
+            val scope = Konsist.scopeFromProduction()
+
+            // Sealed interfaces and data classes may be declared as either
+            // `class` or `interface` in the AST — collect both to be safe.
+            val foundInCommonMain =
+                (scope.classes() + scope.interfaces())
+                    .filter { it.path.contains("/commonMain/") }
+                    .mapNotNull { it.fullyQualifiedName }
+                    .toSet()
+
+            foundInCommonMain shouldContainAll expectedFqns
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRule.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRule.kt
@@ -1,0 +1,77 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Forbid direct writes against `SyncableTable`-extending table objects outside
+ * `:server/.../sync/`. Reading is fine; writing must go through the repository
+ * so the global revision counter is bumped, the `clientOpId` is captured, and
+ * the [ChangeBus][com.calypsan.listenup.server.sync.ChangeBus] sees the event.
+ *
+ * Heuristic: strip line and block comments (so doc-string code samples don't
+ * false-trigger), then scan `:server/.../` files (excluding the `sync/`
+ * directory itself) for any of the Exposed write operators invoked on a token
+ * that matches a `*Table` object known to extend `SyncableTable`.
+ *
+ * Detected write operators: `.upsert(`, `.update(`, `.insert(`, `.deleteWhere(`,
+ * `.batchInsert(`, `.replace(`. Read-only operators (`.selectAll(`, `.select(`,
+ * `.exists(`) are deliberately excluded.
+ *
+ * This is the load-bearing Konsist rule for the sync substrate — it structurally
+ * guarantees that the bus sees every write rather than relying on discipline alone.
+ */
+class SyncWritesGoThroughRepositoryRule :
+    FunSpec({
+
+        test("No Exposed writes against SyncableTable subtypes outside :server/sync/") {
+            val scope = Konsist.scopeFromProduction()
+
+            // Discover names of objects that extend SyncableTable.
+            val syncableTableNames =
+                scope
+                    .objects()
+                    .filter { obj -> obj.parents().any { it.name == "SyncableTable" } }
+                    .map { it.name }
+                    .toSet()
+
+            // Nothing to check if no syncable tables exist yet (prevents false-green on
+            // empty codebase, but returns early rather than lying with an empty offender list).
+            if (syncableTableNames.isEmpty()) return@test
+
+            val writeOperators =
+                listOf(
+                    ".upsert(",
+                    ".update(",
+                    ".insert(",
+                    ".deleteWhere(",
+                    ".batchInsert(",
+                    ".replace(",
+                )
+
+            val offenders =
+                scope.files
+                    .filter { it.path.contains("/server/") }
+                    .filterNot { it.path.contains("/server/sync/") }
+                    .flatMap { file ->
+                        val stripped = stripComments(file.text)
+                        writeOperators.flatMap { op ->
+                            syncableTableNames.mapNotNull { tableName ->
+                                if (stripped.contains("$tableName$op")) {
+                                    "$tableName$op in ${file.path}"
+                                } else {
+                                    null
+                                }
+                            }
+                        }
+                    }
+
+            offenders.shouldBeEmpty()
+        }
+    })
+
+private fun stripComments(source: String): String =
+    source
+        .replace(Regex("""//[^\n]*"""), "")
+        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncableTablesExtendSyncableTableRule.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncableTablesExtendSyncableTableRule.kt
@@ -1,0 +1,60 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.modifierprovider.withoutAbstractModifier
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Pin: any concrete `SyncableRepository` subclass in `:server/.../sync/` whose
+ * name is `<Domain>Repository` must be paired with a `<Domain>Table` object that
+ * extends `SyncableTable`.
+ *
+ * This backstops the substrate convention so future domains don't accidentally
+ * bypass the sync columns (`revision`, `created_at`, `updated_at`,
+ * `deleted_at`, `client_op_id`) that the catch-up and digest routes depend on.
+ *
+ * The rule deliberately targets the `:server/.../sync/` path — that's where
+ * domain repositories live. The abstract `SyncableRepository` base class is
+ * excluded via `withoutAbstractModifier()`.
+ */
+class SyncableTablesExtendSyncableTableRule :
+    FunSpec({
+
+        test("Tables paired with a SyncableRepository extend SyncableTable") {
+            val scope = Konsist.scopeFromProduction()
+
+            // Concrete classes in server/sync/ that extend SyncableRepository.
+            val concreteRepositories =
+                scope
+                    .classes()
+                    .withoutAbstractModifier()
+                    .filter { cls ->
+                        cls.path.contains("/server/") &&
+                            cls.path.contains("/sync/") &&
+                            cls.parents().any { it.name == "SyncableRepository" }
+                    }
+
+            // All Exposed table objects in the production scope.
+            val tableObjects = scope.objects()
+
+            val offenders =
+                concreteRepositories.mapNotNull { repoClass ->
+                    val base = repoClass.name.removeSuffix("Repository")
+                    val expectedTableName = "${base}Table"
+                    val tableObj =
+                        tableObjects.firstOrNull { it.name == expectedTableName }
+                            ?: return@mapNotNull "$expectedTableName not found (expected pair for ${repoClass.name})"
+                    val extendsSyncableTable =
+                        tableObj.parents().any { it.name == "SyncableTable" }
+                    if (extendsSyncableTable) {
+                        null
+                    } else {
+                        "$expectedTableName does not extend SyncableTable " +
+                            "(parents: ${tableObj.parents().map { it.name }})"
+                    }
+                }
+
+            offenders.shouldBeEmpty()
+        }
+    })


### PR DESCRIPTION
## Summary

First phase of the 5-phase Books-domain rollout: **Sync Foundation → Client Sync Renovation → Books-A → Books-B → Books-C**. This phase ships only the server-side substrate; the seamless-experience properties become user-visible in the next phase.

- New `:server/sync/` substrate: every syncable Exposed table extends `SyncableTable` (revision/createdAt/updatedAt/deletedAt/client_op_id columns); writes go through `SyncableRepository<T, ID>` which bumps a global revision counter and publishes typed `SyncEvent<T>` events to an in-memory `ChangeBus`. Konsist rule `SyncWritesGoThroughRepositoryRule` enforces the discipline structurally — direct table writes outside `:server/sync/` fail the build.
- Wire surface: `GET /api/v1/sync/events` SSE firehose with `Last-Event-Id` replay (256-event live-tail buffer) + `SyncControl.CursorStale` fallback signal; `GET /api/v1/sync/<domain>?since=<rev>` REST catch-up returning `Page<T>`; `GET /api/v1/sync/<domain>/digest?cursor=<rev>` SHA-256 fingerprint for cheap drift detection; `GET /api/v1/sync/domains` for new-domain discovery (catches both fresh-install and server-side-rollout cases).
- CommonMain wire types: `SyncEvent<T>` (Created/Updated/Deleted with `clientOpId` for echo matching), `Page<T>`, `SyncCursor`, `SyncControl` (`CursorStale`/`StreamError`), `DomainDigest`, `DomainList`, `Tag` (validator domain), `SyncError.NotFound`. All `@Serializable` with stable `@SerialName` discriminators, contract-tested for round-trip + exact wire shape, pinned to commonMain by Konsist rule.
- Tags is the validation domain — exercised end-to-end by integration tests; no public write API in this phase. Future phases (likely Books-C) add the user-facing surface.
- `experimental.newSuspendedTransaction` swept to stable `suspendTransaction()` across all 27 sites in `:server` (auth + new sync code).

## Architecture notes

- **In-memory bus, not outbox.** Process-local `MutableSharedFlow(replay = 256)` with `DROP_OLDEST` overflow. Restart-loss is recovered by REST catch-up on next pull. Self-hosted single-instance operating model doesn't justify outbox-worker complexity.
- **Last-write-wins by revision, no optimistic concurrency.** Writes always succeed; conflict resolution converges silently to the latest revision. No "save failed, retry" UI ever surfaces. Position tracking (the one careful case — high-frequency, must coalesce) is deferred to its own phase.
- **`clientOpId` keystone for echo matching.** Every write API takes a `clientOpId`; the resulting `SyncEvent` carries it back so SSE echoes match pending operations on the client without re-applying. Idempotency cache (TTL'd dedup table) is scaffolded but not built — the column/parameter/event-field land now; the cache implementation lands when the first client-driven write surface ships (likely Books-C).
- **Stacktraces never cross the wire.** SSE error path is wrapped in `Flow.catch { emit(SyncControl.StreamError(InternalError(correlationId, cause))) }` — same security invariant the RPC Exception Guard establishes. Server logs the full exception via correlation ID; client sees only the typed error.

## Test plan

- [ ] `./gradlew :shared:jvmTest --no-daemon`
- [ ] `./gradlew :server:test --no-daemon`
- [ ] `./gradlew :rpc-guard-ksp:test --no-daemon`
- [ ] `./gradlew spotlessCheck detekt --no-daemon`
- [ ] `./gradlew :androidApp:assembleDebug --no-daemon`
- [ ] Manually verify `SyncFoundationE2ETest` lifecycle: SSE connect → write → receive → reconnect with `Last-Event-Id` → live-tail resumes → REST catch-up returns full state including soft-delete tombstones → `/digest` and `/domains` endpoints respond correctly

All 5 gates pass locally. 2647 tests, 0 failures.

## Follow-ups (for the next phase, Client Sync Renovation)

The audit at `docs/superpowers/findings/2026-05-08-client-sync-engine-audit.md` (committed earlier) is the brief for that phase. Specific items the substrate exposes:

- **Cursor format migration**: existing client `Puller` uses `updatedAfter: String?` (Go's ISO-8601 timestamps). New contract uses `?since=<Long>` (revision). Per-domain migration during integration.
- **SSE `Last-Event-Id` handling**: existing `SSEManager.parseSSEStream` ignores `id:` lines. Must be fixed before reconnect-with-cursor works.
- **Room schema migration**: existing entities use `serverVersion: Timestamp?` and `syncState: SyncState`. New convention is `revision: Long` + `deletedAt: Long?`. Per-domain Room migrations during integration.
- **Idempotency wiring**: existing `PendingOperationQueue` doesn't carry idempotency keys. Must be retrofitted to populate `clientOpId` on every queued op.
- **Optimistic UI / event-echo matching**: when a client write echoes back via SSE with a recognized `clientOpId`, the client should remove the pending op without re-applying. New machinery.

## Out of scope (deferred phases)

- **Position tracking**: highest-frequency sync surface; needs its own dedicated design (per-device coalescing, backpressure, max-revision-wins). Substrate doesn't foreclose its eventual shape.
- **Idempotency cache table**: scaffolding lands now; TTL'd dedup table lands with the first client-driven write surface (Books-C).
- **Smart drift narrowing**: digest mismatch currently triggers full domain re-pull. Binary-search-by-revision-range or per-row Merkle trees deferred until brute-force fallback proves expensive.

## References

- Spec: `docs/superpowers/specs/2026-05-08-sync-foundation-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-sync-foundation.md`
- Client audit findings: `docs/superpowers/findings/2026-05-08-client-sync-engine-audit.md`