### PR TITLE
🔒 Sync Engine Hardening — 7 high + selected medium fixes from PR #287 + #288 reviews (Books-A pre-phase)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -63,7 +63,7 @@ fun Application.module() {
             modules += scannerModule(resolvedLibraryPath, applicationScope)
         }
         modules += embeddedmetaModule
-        modules += syncModule
+        modules += syncModule()
         modules(modules)
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
@@ -1,18 +1,28 @@
 package com.calypsan.listenup.server.di
 
 import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.sync.TagRepository
+import org.koin.core.module.Module
 import org.koin.dsl.module
 
 /**
  * Sync Foundation DI bindings. `createdAtStart = true` is mandatory on every
  * [com.calypsan.listenup.server.sync.SyncableRepository] so the `init` block
- * (which calls `SyncRoutes.register(...)`) runs at application bootstrap
+ * (which calls `registry.register(this)`) runs at application bootstrap
  * rather than lazily on first use — that makes `/api/v1/sync/domains` correct
  * on the first request.
+ *
+ * Exposed as a **function** rather than a top-level `val` so each Koin container
+ * receives a fresh [Module] (and therefore a fresh `SingleInstanceFactory` per
+ * binding). Koin's `SingleInstanceFactory` caches its produced instance on the
+ * factory object itself — reusing one module across containers leaks the same
+ * `SyncRegistry` (and every other `single`) into both, which is exactly the
+ * cross-Koin contamination H3 is fixing.
  */
-val syncModule =
+fun syncModule(): Module =
     module {
+        single { SyncRegistry() }
         single(createdAtStart = true) { ChangeBus() }
-        single(createdAtStart = true) { TagRepository(get(), get()) }
+        single(createdAtStart = true) { TagRepository(get(), get(), get()) }
     }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -9,12 +9,21 @@ import kotlinx.coroutines.flow.asSharedFlow
 private const val LIVE_TAIL_BUFFER = 256
 
 /**
- * Bus payload pairing the originating domain name with the typed event.
- * The domain name is used by the SSE endpoint to set the correct `event:` line.
+ * Type-bound bus entry. The source repository travels alongside the event so
+ * the consumer (SSE firehose, REST catch-up listener) can encode the event
+ * using the repository's own serializer — no static-registry lookup required.
+ *
+ * The previous untyped shape (`BusEvent(domainName, event)`) relied on a
+ * static [SyncRoutes] registry to look up the right serializer at consumption
+ * time. That coupling allowed a misrouted publish (wrong domain string, or
+ * reflective misuse) to silently encode a payload through the wrong serializer,
+ * producing malformed SSE frames and reconnect storms. The typed shape makes
+ * the binding compile-checked: a `BusEvent<Tag>` literally cannot carry a
+ * `Book` payload.
  */
-data class BusEvent(
-    val domainName: String,
-    val event: SyncEvent<*>,
+data class BusEvent<T : Any>(
+    val repo: SyncableRepository<T, *>,
+    val event: SyncEvent<T>,
 )
 
 /**
@@ -34,17 +43,26 @@ data class BusEvent(
  */
 class ChangeBus {
     private val flow =
-        MutableSharedFlow<BusEvent>(
+        MutableSharedFlow<BusEvent<*>>(
             replay = LIVE_TAIL_BUFFER,
             extraBufferCapacity = 0,
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
 
-    suspend fun publish(busEvent: BusEvent) {
-        flow.emit(busEvent)
+    /**
+     * Publishes [event] onto the bus, paired with the source [repo] so consumers
+     * can encode the payload through the repo's own serializer. The `<T>` binding
+     * statically prevents publishing an event whose payload type doesn't match
+     * the repo's element type.
+     */
+    suspend fun <T : Any> publish(
+        repo: SyncableRepository<T, *>,
+        event: SyncEvent<T>,
+    ) {
+        flow.emit(BusEvent(repo, event))
     }
 
-    fun subscribe(): SharedFlow<BusEvent> = flow.asSharedFlow()
+    fun subscribe(): SharedFlow<BusEvent<*>> = flow.asSharedFlow()
 
     /**
      * Best-effort lower bound on the oldest revision still in the live-tail

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -14,7 +14,7 @@ private const val LIVE_TAIL_BUFFER = 256
  * using the repository's own serializer — no static-registry lookup required.
  *
  * The previous untyped shape (`BusEvent(domainName, event)`) relied on a
- * static [SyncRoutes] registry to look up the right serializer at consumption
+ * static registry to look up the right serializer at consumption
  * time. That coupling allowed a misrouted publish (wrong domain string, or
  * reflective misuse) to silently encode a payload through the wrong serializer,
  * producing malformed SSE frames and reconnect storms. The typed shape makes

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncMeta.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncMeta.kt
@@ -1,10 +1,9 @@
 package com.calypsan.listenup.server.sync
 
 import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.TextColumnType
+import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.update
 
 /** Single-row counter table for the global sync revision space. */
 internal object SyncMetaTable : Table("sync_meta") {
@@ -16,20 +15,31 @@ internal object SyncMetaTable : Table("sync_meta") {
 private const val COUNTER_KEY = "revision_counter"
 
 /**
- * Bumps and returns the next global revision. Must be called from within an
- * open transaction — the single-row UPDATE serializes concurrent writes,
- * which is the desired behavior — every syncable write gets a unique,
- * monotonic revision.
+ * Atomically increment the revision counter and return the new value.
+ *
+ * Implemented via SQLite's `RETURNING` clause (3.35+) so the SELECT-then-UPDATE
+ * race is collapsed into a single statement holding the row's write lock for
+ * its full duration. Concurrent callers serialize behind that lock and each
+ * receives a unique, monotonic value — no SQLITE_BUSY exceptions surface for
+ * realistic write fan-in on the same `sync_meta` row.
+ *
+ * Must be called inside a transaction (compile-enforced via the [JdbcTransaction]
+ * receiver). Composes inside the parent transaction so the revision bump is
+ * atomic with the row write that consumes it.
+ *
+ * `explicitStatementType = EXEC` forces Exposed to read the `RETURNING` result
+ * via `executeQuery()` — without it, Exposed routes `UPDATE` through
+ * `executeUpdate()` which discards the result set on most JDBC drivers.
  */
 internal fun JdbcTransaction.nextRevision(): Long {
-    val current =
-        SyncMetaTable
-            .selectAll()
-            .where { SyncMetaTable.key eq COUNTER_KEY }
-            .single()[SyncMetaTable.value]
-    val next = current + 1
-    SyncMetaTable.update({ SyncMetaTable.key eq COUNTER_KEY }) {
-        it[value] = next
-    }
-    return next
+    val result =
+        exec(
+            stmt = "UPDATE sync_meta SET value = value + 1 WHERE key = ? RETURNING value",
+            args = listOf(TextColumnType() to COUNTER_KEY),
+            explicitStatementType = StatementType.EXEC,
+        ) { rs ->
+            check(rs.next()) { "sync_meta missing $COUNTER_KEY row" }
+            rs.getLong(1)
+        }
+    return checkNotNull(result) { "RETURNING clause produced no result set" }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRegistry.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRegistry.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.server.sync
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-Koin registry of syncable repositories, keyed by `domainName`.
+ *
+ * Replaces the prior `internal object SyncRoutes` static singleton. Tests
+ * that construct independent Koin containers now see independent registries
+ * — no cross-container leakage when `kotest.parallelism > 1`. Production
+ * uses exactly one Koin container, so the registry is effectively still a
+ * singleton — just one scoped to the application lifecycle rather than the
+ * JVM.
+ *
+ * Registration is performed by [SyncableRepository.init] via constructor
+ * injection. Lookups happen in the SSE catch-up routes (REST `?since=`)
+ * and the domain-discovery endpoint.
+ */
+class SyncRegistry {
+    private val byDomain = ConcurrentHashMap<String, SyncableRepository<*, *>>()
+
+    fun register(repo: SyncableRepository<*, *>) {
+        val existing = byDomain.putIfAbsent(repo.domainName, repo)
+        require(existing == null) {
+            "domainName '${repo.domainName}' already registered with " +
+                "${existing!!::class.simpleName}; registering ${repo::class.simpleName} " +
+                "would overwrite (per-Koin registry should be 1:1)"
+        }
+    }
+
+    fun lookup(domainName: String): SyncableRepository<*, *>? = byDomain[domainName]
+
+    fun knownDomains(): List<String> = byDomain.keys.sorted()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRegistry.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRegistry.kt
@@ -21,10 +21,12 @@ class SyncRegistry {
 
     fun register(repo: SyncableRepository<*, *>) {
         val existing = byDomain.putIfAbsent(repo.domainName, repo)
-        require(existing == null) {
-            "domainName '${repo.domainName}' already registered with " +
-                "${existing!!::class.simpleName}; registering ${repo::class.simpleName} " +
-                "would overwrite (per-Koin registry should be 1:1)"
+        if (existing != null) {
+            error(
+                "domainName '${repo.domainName}' already registered with " +
+                    "${existing::class.simpleName}; registering ${repo::class.simpleName} " +
+                    "would overwrite (per-Koin registry should be 1:1)",
+            )
         }
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -15,7 +15,6 @@ import io.ktor.server.routing.get
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -23,29 +22,6 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.ktor.ext.inject
-
-/**
- * Per-domain registry populated by [SyncableRepository] init blocks.
- * REST + digest + domain-list routes look up repositories by name here.
- *
- * This is the static-registry style used in the RPC Exception Guard's
- * `RpcGuard.dispatch()` — small startup wart, but explicit: every
- * repository announces itself.
- */
-internal object SyncRoutes {
-    private val registry = ConcurrentHashMap<String, SyncableRepository<*, *>>()
-
-    fun register(
-        domainName: String,
-        repository: SyncableRepository<*, *>,
-    ) {
-        registry[domainName] = repository
-    }
-
-    fun lookup(domainName: String): SyncableRepository<*, *>? = registry[domainName]
-
-    fun knownDomains(): List<String> = registry.keys.sorted()
-}
 
 private val log = KotlinLogging.logger("rpc.SyncFirehose")
 
@@ -62,6 +38,7 @@ private val log = KotlinLogging.logger("rpc.SyncFirehose")
  */
 fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
     val bus by inject<ChangeBus>()
+    val registry by inject<SyncRegistry>()
 
     // SSE firehose — streams every domain's BusEvents in real time.
     // event: line carries the domain name; id: line carries the revision (for Last-Event-Id).
@@ -161,7 +138,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
                 ?.coerceIn(1, 5000) ?: 500
 
         val repo =
-            SyncRoutes.lookup(domainName)
+            registry.lookup(domainName)
                 ?: return@get call.respond(HttpStatusCode.NotFound, "unknown domain: $domainName")
 
         @Suppress("UNCHECKED_CAST")
@@ -181,7 +158,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
             call.request.queryParameters["cursor"]?.toLongOrNull()
                 ?: return@get call.respond(HttpStatusCode.BadRequest, "cursor must be a Long")
         val repo =
-            SyncRoutes.lookup(domainName)
+            registry.lookup(domainName)
                 ?: return@get call.respond(HttpStatusCode.NotFound, "unknown domain: $domainName")
 
         @Suppress("UNCHECKED_CAST")
@@ -191,6 +168,6 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
     }
 
     get("/api/v1/sync/domains") {
-        call.respond(DomainList(domains = SyncRoutes.knownDomains()))
+        call.respond(DomainList(domains = registry.knownDomains()))
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -25,6 +25,10 @@ import org.koin.ktor.ext.inject
 
 private val log = KotlinLogging.logger("rpc.SyncFirehose")
 
+// SSE `event:` line for out-of-band SyncControl frames (CursorStale, StreamError).
+// Distinct from the per-domain `event: <domainName>` lines used for SyncEvent payloads.
+private const val SSE_EVENT_CONTROL = "control"
+
 /**
  * Mounts the Sync Foundation REST endpoints under `/api/v1/sync`:
  *  - `GET /api/v1/sync/events` — SSE firehose with `Last-Event-Id` resume
@@ -45,7 +49,25 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
     // Cursor-stale detection: if the client provides a Last-Event-Id newer than anything in
     // the bus's live-tail buffer, emit SyncControl.CursorStale and close.
     sse("/api/v1/sync/events") {
-        val lastEventId = call.request.headers["Last-Event-ID"]?.toLongOrNull()
+        // Malformed cursor (non-numeric) is treated identically to a stale cursor:
+        // a corrupted Room cell or client-side bug must force REST catch-up rather
+        // than silently subscribe to the live tail and diverge from server state.
+        val lastEventId: Long? =
+            call.request.headers["Last-Event-ID"]?.let { raw ->
+                raw.toLongOrNull() ?: run {
+                    send(
+                        data =
+                            contractJson.encodeToString(
+                                SyncControl.serializer(),
+                                SyncControl.CursorStale(
+                                    lastKnownRevision = bus.oldestRetainedRevision() ?: 0L,
+                                ),
+                            ),
+                        event = SSE_EVENT_CONTROL,
+                    )
+                    return@sse
+                }
+            }
         val oldestRetained = bus.oldestRetainedRevision()
 
         // Stale if client cursor is older than the bus's replay-buffer floor:
@@ -60,7 +82,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
                         SyncControl.serializer(),
                         SyncControl.CursorStale(lastKnownRevision = oldestRetained),
                     ),
-                event = "control",
+                event = SSE_EVENT_CONTROL,
             )
             return@sse
         }
@@ -118,7 +140,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
                                 ),
                         ),
                     ),
-                event = "control",
+                event = SSE_EVENT_CONTROL,
             )
         } finally {
             heartbeatJob.cancel()

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -115,14 +115,12 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
                 // processed in a previous session.
                 .filter { it.event.revision > (lastEventId ?: 0L) }
                 .collect { busEvent ->
-                    val repo = SyncRoutes.lookup(busEvent.domainName) ?: return@collect
-
-                    @Suppress("UNCHECKED_CAST")
-                    val typedRepo = repo as SyncableRepository<Any, Any>
+                    // Type-bound: repo and event match by construction, so the repo's
+                    // serializer is guaranteed to fit the event's payload type.
                     send(
                         id = busEvent.event.revision.toString(),
-                        event = busEvent.domainName,
-                        data = typedRepo.encodeSyncEventAsJson(busEvent.event),
+                        event = busEvent.repo.domainName,
+                        data = busEvent.repo.encodeSyncEventAsJson(busEvent.event),
                     )
                 }
         } catch (e: CancellationException) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -151,31 +151,27 @@ abstract class SyncableRepository<T : Any, ID : Any>(
 
             if (existed) {
                 bus.publish(
-                    BusEvent(
-                        domainName = domainName,
-                        event =
-                            SyncEvent.Updated(
-                                id = idStr,
-                                revision = rev,
-                                occurredAt = now,
-                                clientOpId = clientOpId,
-                                payload = saved,
-                            ),
-                    ),
+                    repo = this@SyncableRepository,
+                    event =
+                        SyncEvent.Updated(
+                            id = idStr,
+                            revision = rev,
+                            occurredAt = now,
+                            clientOpId = clientOpId,
+                            payload = saved,
+                        ),
                 )
             } else {
                 bus.publish(
-                    BusEvent(
-                        domainName = domainName,
-                        event =
-                            SyncEvent.Created(
-                                id = idStr,
-                                revision = rev,
-                                occurredAt = now,
-                                clientOpId = clientOpId,
-                                payload = saved,
-                            ),
-                    ),
+                    repo = this@SyncableRepository,
+                    event =
+                        SyncEvent.Created(
+                            id = idStr,
+                            revision = rev,
+                            occurredAt = now,
+                            clientOpId = clientOpId,
+                            payload = saved,
+                        ),
                 )
             }
 
@@ -241,16 +237,14 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                 )
             } else {
                 bus.publish(
-                    BusEvent(
-                        domainName = domainName,
-                        event =
-                            SyncEvent.Deleted(
-                                id = idStr,
-                                revision = rev,
-                                occurredAt = now,
-                                clientOpId = clientOpId,
-                            ),
-                    ),
+                    repo = this@SyncableRepository,
+                    event =
+                        SyncEvent.Deleted(
+                            id = idStr,
+                            revision = rev,
+                            occurredAt = now,
+                            clientOpId = clientOpId,
+                        ),
                 )
                 AppResult.Success(Unit)
             }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -114,7 +114,7 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         suspendTransaction(db) {
             val rev = nextRevision()
             val now = clock.now().toEpochMilliseconds()
-            val idStr = value.id.toString()
+            val idStr = idAsString(value.id)
 
             val existed =
                 table
@@ -183,6 +183,22 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         }
 
     /**
+     * Serializes a domain id to its raw string representation for WHERE clauses,
+     * UPDATE statements, and [SyncEvent] entity ids. Defaults to `id.toString()`,
+     * which is correct for `String` ids (e.g., Tags).
+     *
+     * **MUST be overridden for `@JvmInline value class` ids.** Kotlin's default
+     * `toString()` on a value class returns `"WrapperName(value=foo)"`, which would
+     * corrupt every column the id is written to (primary key, WHERE clauses,
+     * `SyncEvent.id`). Override to return the raw underlying string — e.g.,
+     * `override fun idAsString(id: BookId) = id.value`.
+     *
+     * The Konsist rule `IdAsStringRequiredForValueClassIdsRule` enforces this
+     * override at build time.
+     */
+    protected open fun idAsString(id: ID): String = id.toString()
+
+    /**
      * Exposes the table's primary-key column for use in WHERE clauses.
      * Default assumes a `text("id")` column — the canonical syncable-table
      * convention. Domains using a non-`id` PK column override this.
@@ -208,8 +224,9 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         suspendTransaction(db) {
             val rev = nextRevision()
             val now = clock.now().toEpochMilliseconds()
+            val idStr = idAsString(id)
             val rowsAffected =
-                table.update({ idColumn() eq id.toString() }) { stmt ->
+                table.update({ idColumn() eq idStr }) { stmt ->
                     stmt[table.revision] = rev
                     stmt[table.updatedAt] = now
                     stmt[table.deletedAt] = now
@@ -219,7 +236,7 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                 AppResult.Failure(
                     SyncError.NotFound(
                         domain = domainName,
-                        entityId = id.toString(),
+                        entityId = idStr,
                     ),
                 )
             } else {
@@ -228,7 +245,7 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                         domainName = domainName,
                         event =
                             SyncEvent.Deleted(
-                                id = id.toString(),
+                                id = idStr,
                                 revision = rev,
                                 occurredAt = now,
                                 clientOpId = clientOpId,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -37,18 +37,20 @@ import org.jetbrains.exposed.v1.jdbc.update
  *
  * The base provides `upsert`, `softDelete`, `pullSince`, `digest` operating
  * on the global revision counter and publishing to [ChangeBus] on every write.
- * Self-registers with [SyncRoutes] in its `init` block — Koin must use
- * `createdAtStart = true` so registration happens at application bootstrap.
+ * Self-registers with the injected [SyncRegistry] in its `init` block — Koin
+ * must use `createdAtStart = true` so registration happens at application
+ * bootstrap.
  */
 abstract class SyncableRepository<T : Any, ID : Any>(
     protected val db: Database,
     protected val table: SyncableTable,
     protected val bus: ChangeBus,
+    registry: SyncRegistry,
     val domainName: String,
     protected val clock: Clock = Clock.System,
 ) {
     init {
-        SyncRoutes.register(domainName, this)
+        registry.register(this)
     }
 
     protected abstract fun ResultRow.toDto(): T

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/TagRepository.kt
@@ -15,8 +15,9 @@ import org.jetbrains.exposed.v1.jdbc.Database
 class TagRepository(
     db: Database,
     bus: ChangeBus,
+    registry: SyncRegistry,
     clock: Clock = Clock.System,
-) : SyncableRepository<Tag, String>(db, TagTable, bus, "tags", clock) {
+) : SyncableRepository<Tag, String>(db, TagTable, bus, registry, "tags", clock) {
     override val elementSerializer: KSerializer<Tag> = Tag.serializer()
 
     override fun ResultRow.toDto(): Tag =

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/BusEventTypedTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/BusEventTypedTest.kt
@@ -1,0 +1,48 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Verifies the type-binding invariant of [BusEvent]: the source repository
+ * travels with the event so the SSE firehose can encode the payload through
+ * the matching serializer without a static-registry lookup.
+ */
+class BusEventTypedTest :
+    FunSpec({
+
+        test("BusEvent.repo provides the serializer needed to encode the event payload") {
+            withInMemoryDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = this, bus = bus)
+
+                runTest {
+                    val deferredBusEvent = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    repo.upsert(Tag(id = "t1", name = "sci-fi", revision = 0, updatedAt = 0))
+
+                    val busEvent = deferredBusEvent.await()
+
+                    // Type-binding invariant: the repo travels with the event.
+                    busEvent.repo.shouldNotBeNull()
+                    busEvent.repo.domainName shouldBe "tags"
+
+                    // The repo's own serializer can encode the matching event.
+                    val json = busEvent.repo.encodeSyncEventAsJson(busEvent.event)
+                    json shouldContain """"id":"t1""""
+                    json shouldContain "Created"
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/BusEventTypedTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/BusEventTypedTest.kt
@@ -24,7 +24,7 @@ class BusEventTypedTest :
         test("BusEvent.repo provides the serializer needed to encode the event payload") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
 
                 runTest {
                     val deferredBusEvent = async { bus.subscribe().first() }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
@@ -26,7 +26,7 @@ class ChangeBusTest :
         test("publish then subscribe receives the event") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
                 runTest {
                     val deferred = async { bus.subscribe().first() }
                     advanceUntilIdle()
@@ -41,7 +41,7 @@ class ChangeBusTest :
         test("multiple subscribers each receive every event") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
                 runTest {
                     val sub1 = async { bus.subscribe().take(2).toList() }
                     val sub2 = async { bus.subscribe().take(2).toList() }
@@ -62,7 +62,7 @@ class ChangeBusTest :
         test("oldestRetainedRevision tracks the lowest in-buffer event") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
                 runTest {
                     bus.oldestRetainedRevision() shouldBe null
                     repo.upsert(Tag(id = "a", name = "x", revision = 0, updatedAt = 0))
@@ -75,7 +75,7 @@ class ChangeBusTest :
         test("BusEvent is type-bound to its source repository") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
                 runTest {
                     val deferred = async { bus.subscribe().first() }
                     advanceUntilIdle()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/ChangeBusTest.kt
@@ -2,11 +2,13 @@
 
 package com.calypsan.listenup.server.sync
 
-import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -14,45 +16,74 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
+/**
+ * Bus mechanics, driven through a real [TagRepository] so events carry the
+ * type-bound [BusEvent.repo] reference produced by the canonical publish path.
+ */
 class ChangeBusTest :
     FunSpec({
 
         test("publish then subscribe receives the event") {
-            runTest {
+            withInMemoryDatabase {
                 val bus = ChangeBus()
-                val syncEvent = SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x")
-                val busEvent = BusEvent(domainName = "tags", event = syncEvent)
-                val deferred = async { bus.subscribe().first() }
-                // Yield so the subscriber coroutine can register on the SharedFlow before publish.
-                advanceUntilIdle()
-                bus.publish(busEvent)
-                deferred.await() shouldBe busEvent
+                val repo = TagRepository(db = this, bus = bus)
+                runTest {
+                    val deferred = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+                    repo.upsert(Tag(id = "a", name = "n", revision = 0, updatedAt = 0))
+                    val busEvent = deferred.await()
+                    busEvent.repo.domainName shouldBe "tags"
+                    busEvent.event.id shouldBe "a"
+                }
             }
         }
 
         test("multiple subscribers each receive every event") {
-            runTest {
+            withInMemoryDatabase {
                 val bus = ChangeBus()
-                val ev1 = BusEvent("tags", SyncEvent.Created(id = "a", revision = 1, occurredAt = 100, payload = "x"))
-                val ev2 = BusEvent("tags", SyncEvent.Updated<String>(id = "a", revision = 2, occurredAt = 101, payload = "y"))
-                val sub1 = async { bus.subscribe().take(2).toList() }
-                val sub2 = async { bus.subscribe().take(2).toList() }
-                // Yield so both subscribers register before events are published.
-                advanceUntilIdle()
-                bus.publish(ev1)
-                bus.publish(ev2)
-                sub1.await() shouldContainExactly listOf(ev1, ev2)
-                sub2.await() shouldContainExactly listOf(ev1, ev2)
+                val repo = TagRepository(db = this, bus = bus)
+                runTest {
+                    val sub1 = async { bus.subscribe().take(2).toList() }
+                    val sub2 = async { bus.subscribe().take(2).toList() }
+                    advanceUntilIdle()
+                    repo.upsert(Tag(id = "a", name = "n1", revision = 0, updatedAt = 0))
+                    repo.upsert(Tag(id = "b", name = "n2", revision = 0, updatedAt = 0))
+
+                    val r1 = sub1.await()
+                    val r2 = sub2.await()
+                    r1 shouldHaveSize 2
+                    r2 shouldHaveSize 2
+                    r1.map { it.event.id } shouldBe listOf("a", "b")
+                    r2.map { it.event.id } shouldBe listOf("a", "b")
+                }
             }
         }
 
         test("oldestRetainedRevision tracks the lowest in-buffer event") {
-            runTest {
+            withInMemoryDatabase {
                 val bus = ChangeBus()
-                bus.oldestRetainedRevision() shouldBe null
-                bus.publish(BusEvent("tags", SyncEvent.Created(id = "a", revision = 5, occurredAt = 100, payload = "x")))
-                bus.publish(BusEvent("tags", SyncEvent.Created(id = "b", revision = 7, occurredAt = 101, payload = "y")))
-                bus.oldestRetainedRevision()!! shouldBeGreaterThanOrEqual 5L
+                val repo = TagRepository(db = this, bus = bus)
+                runTest {
+                    bus.oldestRetainedRevision() shouldBe null
+                    repo.upsert(Tag(id = "a", name = "x", revision = 0, updatedAt = 0))
+                    repo.upsert(Tag(id = "b", name = "y", revision = 0, updatedAt = 0))
+                    bus.oldestRetainedRevision()!! shouldBeGreaterThanOrEqual 1L
+                }
+            }
+        }
+
+        test("BusEvent is type-bound to its source repository") {
+            withInMemoryDatabase {
+                val bus = ChangeBus()
+                val repo = TagRepository(db = this, bus = bus)
+                runTest {
+                    val deferred = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+                    repo.upsert(Tag(id = "a", name = "n", revision = 0, updatedAt = 0))
+                    val busEvent = deferred.await()
+                    busEvent.repo.shouldBeInstanceOf<TagRepository>()
+                    busEvent.repo shouldBe repo
+                }
             }
         }
     })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncMetaTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncMetaTest.kt
@@ -3,6 +3,11 @@ package com.calypsan.listenup.server.sync
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 
@@ -19,14 +24,28 @@ class SyncMetaTest :
             }
         }
 
-        test("nextRevision() is strictly monotonic across concurrent calls") {
+        test("nextRevision is strictly monotonic and never collides under 50 concurrent writers") {
             withInMemoryDatabase {
                 val db = this
-                runTest {
-                    val results = (1..50).map { suspendTransaction(db) { nextRevision() } }
-                    results.toSet().size shouldBe 50
-                    results shouldBe results.sorted()
-                }
+                // runBlocking (not runTest) — we need real Dispatchers.IO threads so
+                // the 50 transactions race on actual SQLite connections. runTest's
+                // virtual time would serialise them and miss the race.
+                val revisions =
+                    runBlocking {
+                        coroutineScope {
+                            (1..50)
+                                .map {
+                                    async(Dispatchers.IO) {
+                                        suspendTransaction(db) { nextRevision() }
+                                    }
+                                }.awaitAll()
+                        }
+                    }
+
+                // Every value unique AND strictly covering 1..50.
+                revisions.toSet().size shouldBe 50
+                revisions.min() shouldBe 1L
+                revisions.max() shouldBe 50L
             }
         }
     })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRegistryPerKoinTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRegistryPerKoinTest.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.server.di.syncModule
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
@@ -74,6 +75,17 @@ class SyncRegistryPerKoinTest :
                     registry.knownDomains() shouldBe listOf("tags")
                 } finally {
                     koin.close()
+                }
+            }
+        }
+
+        test("registering two repositories with the same domainName throws IllegalStateException") {
+            withInMemoryDatabase {
+                val db = this
+                val registry = SyncRegistry()
+                TagRepository(db, ChangeBus(), registry) // first registration succeeds
+                shouldThrow<IllegalStateException> {
+                    TagRepository(db, ChangeBus(), registry) // duplicate domainName → throws
                 }
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRegistryPerKoinTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRegistryPerKoinTest.kt
@@ -1,0 +1,80 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.server.di.syncModule
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+/**
+ * Pins the per-Koin scoping of [SyncRegistry] — two independent Koin containers
+ * must yield independent registries, so parallel `withTestApplication { }` blocks
+ * (and Books-A's cross-domain Tags+Books tests) can't trample each other's
+ * registrations.
+ *
+ * Before this task, [SyncRoutes] was a process-wide `internal object` holding a
+ * static `ConcurrentHashMap`. The second `register("tags", …)` in a JVM run
+ * would silently overwrite the first — invisible under serial test execution,
+ * flaky under `kotest.parallelism > 1`. This test would have caught it.
+ */
+class SyncRegistryPerKoinTest :
+    FunSpec({
+
+        test("two Koin containers each have their own SyncRegistry") {
+            withInMemoryDatabase {
+                val dbA: Database = this
+                withInMemoryDatabase {
+                    val dbB: Database = this
+
+                    val koinA =
+                        koinApplication {
+                            modules(
+                                module { single<Database> { dbA } },
+                                syncModule(),
+                            )
+                        }
+                    val koinB =
+                        koinApplication {
+                            modules(
+                                module { single<Database> { dbB } },
+                                syncModule(),
+                            )
+                        }
+
+                    try {
+                        val registryA = koinA.koin.get<SyncRegistry>()
+                        val registryB = koinB.koin.get<SyncRegistry>()
+
+                        registryA shouldNotBeSameInstanceAs registryB
+                        registryA.lookup("tags") shouldNotBeSameInstanceAs registryB.lookup("tags")
+                    } finally {
+                        koinA.close()
+                        koinB.close()
+                    }
+                }
+            }
+        }
+
+        test("single Koin container has one SyncRegistry with all registered repositories") {
+            withInMemoryDatabase {
+                val db: Database = this
+                val koin =
+                    koinApplication {
+                        modules(
+                            module { single<Database> { db } },
+                            syncModule(),
+                        )
+                    }
+
+                try {
+                    val registry: SyncRegistry = koin.koin.get()
+                    registry.knownDomains() shouldBe listOf("tags")
+                } finally {
+                    koin.close()
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRoutesMalformedCursorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRoutesMalformedCursorTest.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.testing.withTestApplication
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.headers
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+
+/**
+ * Pins the malformed-cursor branch of the SSE firehose: a non-numeric
+ * `Last-Event-ID` is treated identically to a stale cursor, forcing the client
+ * into REST catch-up rather than silently subscribing to the live tail and
+ * diverging from server state (corrupted Room cell, client-side bug, etc.).
+ */
+class SyncRoutesMalformedCursorTest :
+    FunSpec({
+
+        test("SSE with non-numeric Last-Event-ID emits CursorStale and closes") {
+            withTestApplication {
+                client.sse(
+                    urlString = "/api/v1/sync/events",
+                    request = {
+                        headers { append(HttpHeaders.LastEventID, "garbage-not-a-number") }
+                    },
+                ) {
+                    val event = incoming.first()
+                    event.event shouldBe "control"
+                    event.data!! shouldContain """"type":"SyncControl.CursorStale""""
+                    event.data!! shouldContain """"lastKnownRevision":"""
+                }
+            }
+        }
+
+        test("SSE with missing Last-Event-ID subscribes normally (no CursorStale)") {
+            withTestApplication {
+                client.sse("/api/v1/sync/events") {
+                    coroutineScope {
+                        val deferred = async { incoming.first() }
+                        // Drive a write so the firehose has something to emit; if the route
+                        // were misclassifying a missing header as malformed, the first frame
+                        // would be a control/CursorStale instead of a tags event.
+                        tagRepo.upsert(Tag("a", "alpha", 0, 0))
+                        val event = deferred.await()
+                        event.event shouldBe "tags"
+                        event.data!! shouldContain """"type":"SyncEvent.Created""""
+                    }
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRoutesStreamErrorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncRoutesStreamErrorTest.kt
@@ -1,0 +1,209 @@
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.sync.Tombstoned
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.sse.sse
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE as ServerSSE
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+import org.koin.dsl.module
+import org.koin.ktor.plugin.Koin
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
+
+/**
+ * Pins the spec §189 invariant: when the SSE firehose's emit pipeline throws,
+ * the server emits a `SyncControl.StreamError(InternalError(correlationId, cause))`
+ * frame where `cause` is the THROWABLE'S CLASS NAME only — never a full
+ * stacktrace, package path, or `Caused by:` chain.
+ *
+ * Stacktraces never cross the wire. Operators trace the correlation id to a
+ * server-side log entry that holds the full detail; the client only sees the
+ * sanitized class-name string. This test guards the contract; a regression that
+ * leaks `stackTraceToString()` or wraps the throwable's `toString()` into the
+ * frame would fail every `shouldNotContain` assertion below.
+ *
+ * The fixture installs a [ThrowingRepository] whose [ThrowingPayload.serializer]
+ * deliberately throws on encode. The SSE consumer's `Flow.collect { ... }`
+ * lambda calls `busEvent.repo.encodeSyncEventAsJson(busEvent.event)`, which
+ * delegates to that serializer — so a single `upsert` triggers the catch
+ * branch in [com.calypsan.listenup.server.sync.syncRoutes].
+ */
+class SyncRoutesStreamErrorTest :
+    FunSpec({
+
+        test("StreamError frame carries class-name cause + correlationId; never a stacktrace") {
+            withThrowingTestApplication {
+                client.sse("/api/v1/sync/events") {
+                    coroutineScope {
+                        val deferred = async { incoming.first { it.event == "control" } }
+                        // Triggers bus.publish → SSE collect → encodeSyncEventAsJson → throw
+                        repo.upsert(
+                            ThrowingPayload(id = "boom", revision = 0, updatedAt = 0),
+                        )
+                        val event = deferred.await()
+
+                        event.event shouldBe "control"
+                        val data = event.data!!
+
+                        // Wire shape: SyncControl.StreamError wrapping AppError.InternalError,
+                        // with a non-empty correlationId and a class-name-only cause.
+                        data shouldContain """"type":"SyncControl.StreamError""""
+                        data shouldContain """"type":"AppError.InternalError""""
+                        data shouldContain """"correlationId":"""
+                        // The cause is the simpleName of the thrown class, not the FQN.
+                        data shouldContain """"cause":"BrokenSerializerException""""
+
+                        // Invariant: stacktraces never cross the wire. None of these tokens
+                        // may appear in any field of the frame.
+                        data shouldNotContain "at com.calypsan."
+                        data shouldNotContain "Caused by:"
+                        data shouldNotContain ".java:"
+                        data shouldNotContain ".kt:"
+                    }
+                }
+            }
+        }
+    })
+
+/**
+ * Mirrors `withTestApplication` but wires a [ThrowingRepository] in place of
+ * `TagRepository`. Kept private to this test — the only consumer of the
+ * deliberately-broken serializer.
+ */
+private fun withThrowingTestApplication(block: suspend ThrowingTestScope.() -> Unit) {
+    testApplication {
+        val tmp =
+            Files.createTempFile("listenup-streamerror-test-", ".db").toFile().apply { deleteOnExit() }
+        val db =
+            DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
+        val bus = ChangeBus()
+        val registry = SyncRegistry()
+        val throwingRepo = ThrowingRepository(db, bus, registry)
+
+        // Materialise the table once before the SSE handler subscribes; otherwise
+        // the first upsert hits a missing-table error before reaching the bus.
+        suspendTransaction(db) { SchemaUtils.create(ThrowingTable) }
+
+        application {
+            install(ServerContentNegotiation) { json(contractJson) }
+            install(ServerSSE)
+            install(Koin) {
+                modules(
+                    module {
+                        single { db }
+                        single { bus }
+                        single { registry }
+                        single(createdAtStart = true) { throwingRepo }
+                    },
+                )
+            }
+            routing { syncRoutes() }
+        }
+
+        val jsonClient =
+            createClient {
+                install(ContentNegotiation) { json(contractJson) }
+                install(SSE)
+            }
+
+        ThrowingTestScope(client = jsonClient, repo = throwingRepo).block()
+    }
+}
+
+private data class ThrowingTestScope(
+    val client: io.ktor.client.HttpClient,
+    val repo: ThrowingRepository,
+)
+
+// ---------- Fixture types ----------
+
+/**
+ * Distinct simpleName ("BrokenSerializerException") so the wire-cause assertion
+ * is unambiguous — no other class in the stacktrace shares this name.
+ */
+private class BrokenSerializerException : RuntimeException("deliberately-broken serializer for stream-error test")
+
+@Serializable(with = ThrowingPayloadSerializer::class)
+@SerialName("ThrowingPayload")
+private data class ThrowingPayload(
+    val id: String,
+    val revision: Long,
+    val updatedAt: Long,
+    override val deletedAt: Long? = null,
+) : Tombstoned
+
+/**
+ * Throws on encode; decode is unused by the SSE path but implemented for
+ * completeness so `KSerializer` is honest.
+ */
+private object ThrowingPayloadSerializer : KSerializer<ThrowingPayload> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ThrowingPayload", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: ThrowingPayload,
+    ) {
+        boom()
+    }
+
+    override fun deserialize(decoder: Decoder): ThrowingPayload = boom()
+
+    private fun boom(): Nothing = throw BrokenSerializerException()
+}
+
+private object ThrowingTable : SyncableTable("throwing_streamerror_test") {
+    val id = text("id")
+    override val primaryKey = PrimaryKey(id)
+}
+
+private class ThrowingRepository(
+    db: Database,
+    bus: ChangeBus,
+    registry: SyncRegistry,
+) : SyncableRepository<ThrowingPayload, String>(db, ThrowingTable, bus, registry, "throwing") {
+    override val elementSerializer: KSerializer<ThrowingPayload> = ThrowingPayloadSerializer
+
+    override fun ResultRow.toDto(): ThrowingPayload =
+        ThrowingPayload(
+            id = this[ThrowingTable.id],
+            revision = this[ThrowingTable.revision],
+            updatedAt = this[ThrowingTable.updatedAt],
+            deletedAt = this[ThrowingTable.deletedAt],
+        )
+
+    override fun ThrowingPayload.writeTo(stmt: UpdateBuilder<*>) {
+        stmt[ThrowingTable.id] = id
+    }
+
+    override val ThrowingPayload.id: String get() = id
+
+    override fun ThrowingPayload.revisionOf(): Long = revision
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
@@ -47,7 +47,7 @@ class SyncableRepositoryIdAsStringTest :
             withInMemoryDatabase {
                 val db = this
                 val bus = ChangeBus()
-                val repo = FixtureRepository(db, bus)
+                val repo = FixtureRepository(db, bus, SyncRegistry())
 
                 runTest {
                     suspendTransaction(db) { SchemaUtils.create(FixtureTestTable) }
@@ -134,7 +134,8 @@ internal object FixtureTestTable : SyncableTable("fixture_idAsString_test") {
 internal class FixtureRepository(
     db: Database,
     bus: ChangeBus,
-) : SyncableRepository<FixturePayload, FixtureId>(db, FixtureTestTable, bus, "fixtures") {
+    registry: SyncRegistry,
+) : SyncableRepository<FixturePayload, FixtureId>(db, FixtureTestTable, bus, registry, "fixtures") {
     override val elementSerializer: KSerializer<FixturePayload> = FixturePayload.serializer()
 
     override fun ResultRow.toDto(): FixturePayload =

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
@@ -79,7 +79,7 @@ class SyncableRepositoryIdAsStringTest :
 
                     // Assertion 3: emitted SyncEvent.Created carries the raw id "abc".
                     val busEvent = deferredCreated.await()
-                    busEvent.domainName shouldBe "fixtures"
+                    busEvent.repo.domainName shouldBe "fixtures"
                     val createdEvent = busEvent.event
                     createdEvent.shouldBeInstanceOf<SyncEvent.Created<FixturePayload>>()
                     createdEvent.id shouldBe "abc"

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryIdAsStringTest.kt
@@ -1,0 +1,159 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tombstoned
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.jvm.JvmInline
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+
+/**
+ * Inline-fixture test that pins the `idAsString` template-hook contract:
+ *
+ * `SyncableRepository` MUST serialize the domain id to its raw string value
+ * for every WHERE clause, UPDATE statement, and `SyncEvent` entity id —
+ * never via Kotlin's default `toString()`, which on a `@JvmInline value class`
+ * emits `"WrapperName(value=foo)"` and would corrupt every column.
+ *
+ * The fixture uses [FixtureId] — a `@JvmInline value class` whose default
+ * `toString()` is `"FixtureId(value=abc)"`. Three assertions cover the three
+ * call sites (`upsert` WHERE, `softDelete` WHERE, emitted event `id`):
+ *  - upsertFromPayload stores `"abc"` (not `"FixtureId(value=abc)"`) in the id column.
+ *  - softDelete(FixtureId("abc")) finds the row and sets deletedAt.
+ *  - Emitted SyncEvent.Created.id is `"abc"`, not `"FixtureId(value=abc)"`.
+ */
+class SyncableRepositoryIdAsStringTest :
+    FunSpec({
+
+        test("idAsString override is honoured by upsert, softDelete, and event entityId") {
+            withInMemoryDatabase {
+                val db = this
+                val bus = ChangeBus()
+                val repo = FixtureRepository(db, bus)
+
+                runTest {
+                    suspendTransaction(db) { SchemaUtils.create(FixtureTestTable) }
+
+                    val deferredCreated = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    val payload =
+                        FixturePayload(
+                            id = FixtureId("abc"),
+                            label = "fixture",
+                            revision = 0,
+                            updatedAt = 0,
+                        )
+
+                    // Assertion 1: upsert stores the raw value "abc" in the id column,
+                    // not the wrapped "FixtureId(value=abc)" default-toString form.
+                    val upsertResult = repo.upsert(payload, clientOpId = "op-1")
+                    upsertResult.shouldBeInstanceOf<AppResult.Success<FixturePayload>>()
+
+                    val storedId =
+                        suspendTransaction(db) {
+                            FixtureTestTable
+                                .selectAll()
+                                .map { it[FixtureTestTable.id] }
+                                .single()
+                        }
+                    storedId shouldBe "abc"
+
+                    // Assertion 3: emitted SyncEvent.Created carries the raw id "abc".
+                    val busEvent = deferredCreated.await()
+                    busEvent.domainName shouldBe "fixtures"
+                    val createdEvent = busEvent.event
+                    createdEvent.shouldBeInstanceOf<SyncEvent.Created<FixturePayload>>()
+                    createdEvent.id shouldBe "abc"
+
+                    // Assertion 2: softDelete finds the row (it only finds it if
+                    // idAsString unwraps the value class — otherwise the WHERE
+                    // clause mismatches the stored "abc" and rowsAffected stays 0).
+                    val deleteResult = repo.softDelete(FixtureId("abc"), clientOpId = "op-2")
+                    deleteResult.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    val deletedAt =
+                        suspendTransaction(db) {
+                            FixtureTestTable
+                                .selectAll()
+                                .where { FixtureTestTable.id eq "abc" }
+                                .map { it[FixtureTestTable.deletedAt] }
+                                .single()
+                        }
+                    (deletedAt != null) shouldBe true
+                }
+            }
+        }
+    })
+
+/**
+ * Value class whose default `toString()` is `"FixtureId(value=abc)"` — the
+ * bug shape we're guarding against. The fixture proves `idAsString` strips
+ * the wrapper and writes the raw string everywhere it matters.
+ */
+@JvmInline
+@Serializable
+internal value class FixtureId(
+    val value: String,
+)
+
+@Serializable
+@SerialName("FixturePayload")
+internal data class FixturePayload(
+    val id: FixtureId,
+    val label: String,
+    val revision: Long,
+    val updatedAt: Long,
+    override val deletedAt: Long? = null,
+) : Tombstoned
+
+internal object FixtureTestTable : SyncableTable("fixture_idAsString_test") {
+    val id = text("id")
+    val label = text("label")
+    override val primaryKey = PrimaryKey(id)
+}
+
+internal class FixtureRepository(
+    db: Database,
+    bus: ChangeBus,
+) : SyncableRepository<FixturePayload, FixtureId>(db, FixtureTestTable, bus, "fixtures") {
+    override val elementSerializer: KSerializer<FixturePayload> = FixturePayload.serializer()
+
+    override fun ResultRow.toDto(): FixturePayload =
+        FixturePayload(
+            id = FixtureId(this[FixtureTestTable.id]),
+            label = this[FixtureTestTable.label],
+            revision = this[FixtureTestTable.revision],
+            updatedAt = this[FixtureTestTable.updatedAt],
+            deletedAt = this[FixtureTestTable.deletedAt],
+        )
+
+    override fun FixturePayload.writeTo(stmt: UpdateBuilder<*>) {
+        stmt[FixtureTestTable.id] = id.value
+        stmt[FixtureTestTable.label] = label
+    }
+
+    override val FixturePayload.id: FixtureId get() = this.id
+
+    override fun FixturePayload.revisionOf(): Long = revision
+
+    override fun idAsString(id: FixtureId): String = id.value
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
@@ -13,7 +13,7 @@ class TagRepositoryDigestTest :
         test("empty domain digest is count=0, hash=empty") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     val d = repo.digest(cursor = Long.MAX_VALUE)
                     d.cursor shouldBe Long.MAX_VALUE
@@ -26,7 +26,7 @@ class TagRepositoryDigestTest :
         test("digest is deterministic and sha256-prefixed") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0))
                     repo.upsert(Tag("b", "beta", 0, 0))
@@ -43,7 +43,7 @@ class TagRepositoryDigestTest :
         test("digest changes when a row is updated") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0))
                     val before = repo.digest(cursor = Long.MAX_VALUE)
@@ -58,7 +58,7 @@ class TagRepositoryDigestTest :
         test("digest scopes by cursor") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0)) // rev 1
                     repo.upsert(Tag("b", "beta", 0, 0)) // rev 2
@@ -72,7 +72,7 @@ class TagRepositoryDigestTest :
         test("digest includes soft-deleted rows") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0))
                     repo.softDelete("a")
@@ -85,7 +85,7 @@ class TagRepositoryDigestTest :
         test("digest byte format is the canonical wire contract") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0)) // revision 1
                     repo.upsert(Tag("b", "beta", 0, 0)) // revision 2

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryPullSinceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryPullSinceTest.kt
@@ -14,7 +14,7 @@ class TagRepositoryPullSinceTest :
         test("pullSince(0) returns all rows ordered by revision asc") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0))
                     repo.upsert(Tag("b", "beta", 0, 0))
@@ -31,7 +31,7 @@ class TagRepositoryPullSinceTest :
         test("pullSince filters by cursor strictly greater than") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0)) // revision 1
                     repo.upsert(Tag("b", "beta", 0, 0)) // revision 2
@@ -45,7 +45,7 @@ class TagRepositoryPullSinceTest :
         test("pullSince paginates with hasMore = true when limit reached") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     (1..5).forEach { repo.upsert(Tag(id = "id-$it", name = "n$it", revision = 0, updatedAt = 0)) }
                     val first = repo.pullSince(cursor = 0L, limit = 2)
@@ -67,7 +67,7 @@ class TagRepositoryPullSinceTest :
         test("pullSince includes soft-deleted rows with deletedAt populated") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", 0, 0))
                     repo.softDelete("a")
@@ -81,7 +81,7 @@ class TagRepositoryPullSinceTest :
         test("empty pullSince returns Page(items=[], cursor=null, hasMore=false)") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     val page = repo.pullSince(cursor = 0L, limit = 100)
                     page.items shouldHaveSize 0

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
@@ -23,7 +23,7 @@ class TagRepositorySoftDeleteTest :
             withInMemoryDatabase {
                 val db = this
                 val bus = ChangeBus()
-                val repo = TagRepository(db, bus)
+                val repo = TagRepository(db, bus, SyncRegistry())
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
                     // With replay=256, the subscriber sees the cached Created event first.
@@ -48,7 +48,7 @@ class TagRepositorySoftDeleteTest :
         test("softDelete of non-existent id returns SyncError.NotFound") {
             withInMemoryDatabase {
                 val db = this
-                val repo = TagRepository(db, ChangeBus())
+                val repo = TagRepository(db, ChangeBus(), SyncRegistry())
                 runTest {
                     val result = repo.softDelete("does-not-exist")
                     result.shouldBeInstanceOf<AppResult.Failure>()
@@ -64,7 +64,7 @@ class TagRepositorySoftDeleteTest :
             withInMemoryDatabase {
                 val db = this
                 val bus = ChangeBus()
-                val repo = TagRepository(db, bus)
+                val repo = TagRepository(db, bus, SyncRegistry())
                 runTest {
                     repo.upsert(Tag("t1", "sci-fi", 0, 0))
                     repo.softDelete("t1")

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositorySoftDeleteTest.kt
@@ -35,7 +35,7 @@ class TagRepositorySoftDeleteTest :
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                     val busEvent = deferredBusEvent.await()
-                    busEvent.domainName shouldBe "tags"
+                    busEvent.repo.domainName shouldBe "tags"
                     val event = busEvent.event
                     event.shouldBeInstanceOf<SyncEvent.Deleted>()
                     event.id shouldBe "t1"

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
@@ -49,7 +49,7 @@ class TagRepositoryUpsertTest :
                     saved.updatedAt shouldBe 1_730_000_000_000L
 
                     val busEvent = deferredBusEvent.await()
-                    busEvent.domainName shouldBe "tags"
+                    busEvent.repo.domainName shouldBe "tags"
                     val event = busEvent.event
                     event.shouldBeInstanceOf<SyncEvent.Created<Tag>>()
                     event.id shouldBe "t1"
@@ -78,7 +78,7 @@ class TagRepositoryUpsertTest :
                     repo.upsert(updated, clientOpId = "op-2")
 
                     val busEvent = sub.await()
-                    busEvent.domainName shouldBe "tags"
+                    busEvent.repo.domainName shouldBe "tags"
                     busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<Tag>>()
                     busEvent.event.clientOpId shouldBe "op-2"
                 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/TagRepositoryUpsertTest.kt
@@ -28,6 +28,7 @@ class TagRepositoryUpsertTest :
                     TagRepository(
                         db = this,
                         bus = bus,
+                        registry = SyncRegistry(),
                         clock =
                             object : Clock {
                                 override fun now() = fixedTime
@@ -63,7 +64,7 @@ class TagRepositoryUpsertTest :
         test("upsert of an existing row publishes Updated") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
 
                 runTest {
                     val initial = Tag(id = "t1", name = "sci-fi", revision = 0, updatedAt = 0)
@@ -88,7 +89,7 @@ class TagRepositoryUpsertTest :
         test("upsert with null clientOpId publishes event with null clientOpId") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
 
                 runTest {
                     val deferredBusEvent = async { bus.subscribe().first() }
@@ -105,7 +106,7 @@ class TagRepositoryUpsertTest :
         test("revisions are strictly monotonic across writes") {
             withInMemoryDatabase {
                 val bus = ChangeBus()
-                val repo = TagRepository(db = this, bus = bus)
+                val repo = TagRepository(db = this, bus = bus, registry = SyncRegistry())
 
                 runTest {
                     val r1 = (repo.upsert(Tag("a", "n1", 0, 0)) as AppResult.Success).data.revision

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.server.db.DatabaseConfig
 import com.calypsan.listenup.server.db.DatabaseFactory
 import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.sync.TagRepository
 import com.calypsan.listenup.server.sync.syncRoutes
 import io.ktor.client.HttpClient
@@ -50,7 +51,8 @@ internal fun withTestApplication(
         val db =
             DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
         val bus = ChangeBus()
-        val tagRepo = TagRepository(db, bus)
+        val registry = SyncRegistry()
+        val tagRepo = TagRepository(db, bus, registry)
 
         application {
             install(ServerContentNegotiation) { json(contractJson) }
@@ -60,6 +62,7 @@ internal fun withTestApplication(
                     module {
                         single { db }
                         single { bus }
+                        single { registry }
                         single(createdAtStart = true) { tagRepo }
                     },
                 )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -8,10 +8,35 @@ import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 private val logger = KotlinLogging.logger {}
 
 internal const val MAX_RETRYABLE_ATTEMPTS = 5
+
+/**
+ * What a single [PendingOperationQueue.drain] wave produced. The engine reads
+ * [retryableFailures] to decide whether to reschedule another drain on a
+ * backoff timer — `drain()` is one-wave-only and never loops internally, so
+ * recurring retry is the engine's responsibility.
+ *
+ * @property sent count of ops successfully ack'd by the server in this wave
+ * @property retryableFailures count of ops that failed retryably (still in queue,
+ *   `failureCount` incremented, will be picked up by a future drain)
+ * @property terminalFailures count of ops that failed non-retryably (flagged
+ *   past [MAX_RETRYABLE_ATTEMPTS] and will not be retried)
+ */
+data class DrainOutcome(
+    val sent: Int,
+    val retryableFailures: Int,
+    val terminalFailures: Int,
+) {
+    /** True when this wave produced at least one retryable failure that the engine should reschedule. */
+    val hasRetryableFailures: Boolean get() = retryableFailures > 0
+}
 
 /**
  * Per-entity FIFO queue of local-first writes awaiting server replay.
@@ -28,8 +53,10 @@ internal const val MAX_RETRYABLE_ATTEMPTS = 5
  *   it leaps past [MAX_RETRYABLE_ATTEMPTS] so it never retries.
  *
  * Drain is invoked by the engine on a coroutine — *not* a self-running loop.
- * The engine schedules drain on enqueue, on connection-up, and on retry
- * backoff timers.
+ * The engine schedules drain on three signals: [observeEnqueueSignal] (a new
+ * op landed), connection state transitioning to [ConnectionState.Connected],
+ * and a backoff timer it owns after a drain wave reports retryable failures
+ * via [DrainOutcome].
  */
 @OptIn(ExperimentalUuidApi::class)
 class PendingOperationQueue(
@@ -37,6 +64,24 @@ class PendingOperationQueue(
     private val sender: PendingOperationSender,
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
+    // The engine subscribes to this counter to schedule a drain whenever a new
+    // op lands. A monotonic-counter StateFlow rather than a unit SharedFlow
+    // because StateFlow's "new subscriber sees current value" semantics avoid
+    // the subscriber-race window that loses signals on a fresh subscription —
+    // the engine drops the initial value and reacts only to subsequent
+    // increments, which the engine treats as "an op was enqueued since you
+    // started listening."
+    private val enqueueCounter = MutableStateFlow(0L)
+
+    /**
+     * Monotonically increasing counter that ticks each time an op is enqueued.
+     * The engine collects increments to schedule a drain so local-first writes
+     * propagate without waiting for the next connection event. The initial
+     * value is unspecified; collectors should react to *changes* from whatever
+     * they observe on first attach.
+     */
+    fun observeEnqueueSignal(): StateFlow<Long> = enqueueCounter.asStateFlow()
+
     /** Enqueue a new op. Returns its generated `clientOpId`. */
     suspend fun enqueue(
         domainName: String,
@@ -60,6 +105,7 @@ class PendingOperationQueue(
                 ownerUserId = ownerUserId,
             ),
         )
+        enqueueCounter.update { it + 1 }
         return opId
     }
 
@@ -90,16 +136,21 @@ class PendingOperationQueue(
      * concurrent drain() calls do not contend on the same entity.
      *
      * One call = one wave. Caller schedules subsequent waves; drain() does not
-     * loop.
+     * loop. Returns a [DrainOutcome] so the engine can decide whether a retry
+     * backoff is warranted.
      */
-    suspend fun drain() {
+    suspend fun drain(): DrainOutcome {
         val ops = dao.nextDispatchable()
+        var sent = 0
+        var retryableFailures = 0
+        var terminalFailures = 0
         for (entity in ops) {
             val op = entity.toDomain()
             val result = sender.send(op)
             when (result) {
                 is AppResult.Success -> {
                     dao.delete(op.clientOpId)
+                    sent++
                 }
 
                 is AppResult.Failure -> {
@@ -118,6 +169,7 @@ class PendingOperationQueue(
                             lastError = result.error.code,
                         ),
                     )
+                    if (retryable) retryableFailures++ else terminalFailures++
                     logger.warn {
                         "Pending op ${op.clientOpId} failed: ${result.error.code} " +
                             "(retryable=$retryable, count=$newCount)"
@@ -125,6 +177,11 @@ class PendingOperationQueue(
                 }
             }
         }
+        return DrainOutcome(
+            sent = sent,
+            retryableFailures = retryableFailures,
+            terminalFailures = terminalFailures,
+        )
     }
 
     /** Live count of all queued ops. Engine forwards this to `SyncEngineState`. */

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SseClient.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SseClient.kt
@@ -14,4 +14,19 @@ interface SseClient {
     fun connect()
 
     fun disconnect()
+
+    /**
+     * Current `Last-Event-Id` the SSE client will resume from on the next
+     * reconnect. Read-only; visibility lets [SyncEngine.handleCursorStale]
+     * observe the cursor and tests assert reconnect behavior.
+     */
+    fun currentLastEventId(): Long?
+
+    /**
+     * Drop any active connection and reseed `lastEventId` from [newLastEventId].
+     * Called by [SyncEngine.handleCursorStale] after a recovery catch-up to
+     * ensure the next [connect] resumes from the new authoritative cursor
+     * rather than looping forever with the pre-stale value.
+     */
+    suspend fun reseed(newLastEventId: Long?)
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -63,11 +63,63 @@ class SyncEngine(
     // queue's SQL filter responsibility.
     private val drainMutex = Mutex()
 
+    // Serializes the start/stop handshake so concurrent re-entries (e.g.
+    // MainActivity.onResume firing twice in quick succession → two
+    // syncRepository.connectRealtime() → two engine.start()) can't race two
+    // catch-up loops or two SSE connect()s. The mutex protects only the
+    // bookkeeping (currentUser + engineJob assignment); the engineJob itself
+    // runs the long-lived startup body outside the mutex so a different-user
+    // start can cancel an in-flight startup without holding the lock across
+    // catch-up.
+    private val startMutex = Mutex()
+    private var currentUser: String? = null
+    private var engineJob: Job? = null
+
     /**
-     * Start the engine for [currentUserId]. Re-calling re-runs catch-up;
-     * proper idempotency arrives in D1 when frame collection is wired in.
+     * Start the engine for [currentUserId]. Idempotent under re-entry:
+     *
+     *  - Concurrent or sequential calls for the *same* user share a single
+     *    startup; the second caller observes "already starting/started" and
+     *    returns without re-running catch-up or re-connecting SSE.
+     *  - A call for a *different* user cancels the prior engine job (which
+     *    propagates cancellation into in-flight catch-up + frame collector +
+     *    drain schedulers) and rebuilds fresh for the new user.
+     *
+     * The caller is still suspended until the launched startup completes (or
+     * is cancelled) — the existing contract that `start()` returns *after*
+     * catch-up has run and SSE is connected is preserved. External
+     * cancellability comes from the engine job being a child of [scope].
      */
     suspend fun start(currentUserId: String) {
+        val job =
+            startMutex.withLock {
+                if (currentUser == currentUserId) {
+                    // Same user — either fully started or startup is in flight.
+                    // Either way: nothing for this caller to do.
+                    logger.debug { "start($currentUserId) — already active for this user; no-op" }
+                    return
+                }
+                // Different user (or first start): cancel any prior engine
+                // job so its in-flight catch-up / SSE work tears down before
+                // we claim ownership for the new user.
+                engineJob?.cancelAndJoin()
+                currentUser = currentUserId
+                scope.launch { runStart(currentUserId) }.also { engineJob = it }
+            }
+        // Wait for the launched startup to complete (or be cancelled by a
+        // subsequent different-user start). `join()` returns normally on
+        // cancellation, so the caller never observes a `CancellationException`
+        // from a different-user pre-emption — that's the new user's concern.
+        job.join()
+    }
+
+    /**
+     * The actual startup sequence, run inside the engine job so it's
+     * cancellable as a unit. Order matters and is documented in the class
+     * KDoc: queue ownership → catch-up → seed SSE cursor → collectors →
+     * drain scheduling → state observers → SSE connect.
+     */
+    private suspend fun runStart(currentUserId: String) {
         // Step 1: queue ownership.
         queue.clearForUserChange(currentUserId)
         // Step 2: catch-up across all registered domains.
@@ -93,6 +145,14 @@ class SyncEngine(
     }
 
     fun stop() {
+        // stop() is non-suspend so it can't take the startMutex — that's
+        // fine: cancellation is safe to race with a concurrent start(). The
+        // canceled engineJob will tear down its launched collectors; clearing
+        // currentUser means a subsequent start() for the same user will
+        // rebuild rather than no-op.
+        engineJob?.cancel()
+        engineJob = null
+        currentUser = null
         frameCollectorJob?.cancel()
         frameCollectorJob = null
         connectionUpDrainJob?.cancel()
@@ -143,22 +203,28 @@ class SyncEngine(
 
     /** Stop SSE and wait until the frame collector is fully cancelled. Used by tests and deterministic shutdown paths. */
     suspend fun stopAndJoin() {
-        val collector = frameCollectorJob
-        val connectionUp = connectionUpDrainJob
-        val enqueue = enqueueDrainJob
-        val depth = queueDepthJob
-        val failure = failureCountJob
-        frameCollectorJob = null
-        connectionUpDrainJob = null
-        enqueueDrainJob = null
-        queueDepthJob = null
-        failureCountJob = null
-        collector?.cancelAndJoin()
-        connectionUp?.cancelAndJoin()
-        enqueue?.cancelAndJoin()
-        depth?.cancelAndJoin()
-        failure?.cancelAndJoin()
-        sseClient.disconnect()
+        startMutex.withLock {
+            val engine = engineJob
+            val collector = frameCollectorJob
+            val connectionUp = connectionUpDrainJob
+            val enqueue = enqueueDrainJob
+            val depth = queueDepthJob
+            val failure = failureCountJob
+            engineJob = null
+            currentUser = null
+            frameCollectorJob = null
+            connectionUpDrainJob = null
+            enqueueDrainJob = null
+            queueDepthJob = null
+            failureCountJob = null
+            engine?.cancelAndJoin()
+            collector?.cancelAndJoin()
+            connectionUp?.cancelAndJoin()
+            enqueue?.cancelAndJoin()
+            depth?.cancelAndJoin()
+            failure?.cancelAndJoin()
+            sseClient.disconnect()
+        }
     }
 
     private fun ensureFrameCollector() {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -75,15 +75,35 @@ class SyncEngine(
     private var currentUser: String? = null
     private var engineJob: Job? = null
 
+    // Flips to true on the last line of [runStart] for the active user. If
+    // [runStart] throws before that line, the flag stays false even though
+    // engineJob has completed — that's the signal start() uses to retry
+    // instead of silently no-op'ing on a failed prior attempt. Reset to
+    // false at the top of every fresh start (different user OR retry).
+    private var currentUserStarted: Boolean = false
+
     /**
      * Start the engine for [currentUserId]. Idempotent under re-entry:
      *
      *  - Concurrent or sequential calls for the *same* user share a single
      *    startup; the second caller observes "already starting/started" and
-     *    returns without re-running catch-up or re-connecting SSE.
-     *  - A call for a *different* user cancels the prior engine job (which
-     *    propagates cancellation into in-flight catch-up + frame collector +
-     *    drain schedulers) and rebuilds fresh for the new user.
+     *    returns without re-running catch-up or re-connecting SSE — provided
+     *    the prior attempt is either still in flight (`engineJob.isActive`)
+     *    or has completed successfully (`currentUserStarted`). If it threw
+     *    before reaching the end of [runStart] the call retries the startup.
+     *  - A call for a *different* user cancels the prior engine job, which
+     *    propagates `CancellationException` through whatever step of
+     *    [runStart] is in flight (catch-up, suspended `ready.await()` inside
+     *    `ensure*` setup, `sseClient.connect()`). It does NOT tear down the
+     *    long-running collectors — `frameCollectorJob`, `connectionUpDrainJob`,
+     *    `enqueueDrainJob`, `queueDepthJob`, `failureCountJob` are launched
+     *    into [scope], not as children of `engineJob`, so they survive the
+     *    cancellation. That's intentional: they're user-agnostic (the queue
+     *    is wiped on user change via `clearForUserChange`, dispatcher and
+     *    sseClient are singletons), so leaving them in place avoids a
+     *    re-subscription stampede on every user switch. Hard shutdown that
+     *    must tear them down (tests, sign-out flows) goes through
+     *    [stopAndJoin], which cancels each collector job explicitly.
      *
      * The caller is still suspended until the launched startup completes (or
      * is cancelled) — the existing contract that `start()` returns *after*
@@ -93,17 +113,33 @@ class SyncEngine(
     suspend fun start(currentUserId: String) {
         val job =
             startMutex.withLock {
-                if (currentUser == currentUserId) {
-                    // Same user — either fully started or startup is in flight.
-                    // Either way: nothing for this caller to do.
+                if (currentUser == currentUserId &&
+                    (engineJob?.isActive == true || currentUserStarted)
+                ) {
+                    // Same user AND the prior startup is either still in flight
+                    // (engineJob.isActive) or has completed successfully
+                    // (currentUserStarted). Nothing for this caller to do.
+                    //
+                    // The currentUserStarted check is load-bearing: if the prior
+                    // runStart() threw (DB error in clearForUserChange, IO error in
+                    // sseClient.connect(), unexpected exception in any step), the
+                    // launched job completed exceptionally — isActive is false AND
+                    // currentUserStarted is false (because the flag-flip is the
+                    // last line of runStart, which never ran). currentUser is still
+                    // set, so without the currentUserStarted clause every subsequent
+                    // start() would silently no-op forever — the recovery path
+                    // SyncRepositoryImpl.forceFullResync() (which calls engine.start())
+                    // would be dead. With the clause, a failed start is retryable.
                     logger.debug { "start($currentUserId) — already active for this user; no-op" }
                     return
                 }
-                // Different user (or first start): cancel any prior engine
-                // job so its in-flight catch-up / SSE work tears down before
-                // we claim ownership for the new user.
+                // Different user (or first start, or retry-after-failure): cancel
+                // any prior engine job so its in-flight catch-up / SSE work (or
+                // its already-completed exceptional state) tears down before we
+                // claim ownership.
                 engineJob?.cancelAndJoin()
                 currentUser = currentUserId
+                currentUserStarted = false
                 scope.launch { runStart(currentUserId) }.also { engineJob = it }
             }
         // Wait for the launched startup to complete (or be cancelled by a
@@ -142,17 +178,38 @@ class SyncEngine(
         ensureStateObservers()
         // Step 7: connect SSE.
         sseClient.connect()
+        // All steps succeeded — flag the user's setup complete so a subsequent
+        // start() for the same user is a no-op. If any step above threw, this
+        // line is never reached, the flag stays false, and start() retries.
+        currentUserStarted = true
     }
 
     fun stop() {
-        // stop() is non-suspend so it can't take the startMutex — that's
-        // fine: cancellation is safe to race with a concurrent start(). The
-        // canceled engineJob will tear down its launched collectors; clearing
-        // currentUser means a subsequent start() for the same user will
-        // rebuild rather than no-op.
+        // stop() is non-suspend so it can't take the startMutex. That means
+        // the engineJob/currentUser writes below can race a concurrent start()
+        // and lose: if start() is inside withLock between assigning currentUser
+        // and assigning engineJob when stop() runs, stop's nulls land first and
+        // start's writes overwrite them — net result is engine continues running
+        // as if stop() never happened. This is acceptable because:
+        //
+        //   1. The dominant caller is MainActivity.onPause() racing onResume() →
+        //      start(). Android's lifecycle FSM serializes pause/resume per
+        //      Activity, so the race is structurally impossible at the call site.
+        //   2. Any caller that needs hard-shutdown semantics uses [stopAndJoin],
+        //      which takes startMutex and join()s every collector.
+        //
+        // If a non-Android caller is added later that depends on stop()'s race
+        // semantics, promote this to `suspend` + `startMutex.withLock { ... }`.
+        //
+        // Note: cancelling engineJob propagates CancellationException through
+        // an in-flight runStart() (catch-up, ensure* setup, sseClient.connect),
+        // but does NOT cancel the long-running collectors below — they're
+        // launched into [scope], not as children of engineJob. We cancel them
+        // explicitly here.
         engineJob?.cancel()
         engineJob = null
         currentUser = null
+        currentUserStarted = false
         frameCollectorJob?.cancel()
         frameCollectorJob = null
         connectionUpDrainJob?.cancel()
@@ -212,6 +269,7 @@ class SyncEngine(
             val failure = failureCountJob
             engineJob = null
             currentUser = null
+            currentUserStarted = false
             frameCollectorJob = null
             connectionUpDrainJob = null
             enqueueDrainJob = null

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -1,11 +1,15 @@
 package com.calypsan.listenup.client.data.sync
 
+import com.calypsan.listenup.client.core.AppResult
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Lifecycle composer for the client sync engine.
@@ -58,6 +62,41 @@ class SyncEngine(
         frameCollectorJob?.cancel()
         frameCollectorJob = null
         sseClient.disconnect()
+    }
+
+    /**
+     * Recover from a server-issued `SyncControl.CursorStale`. The dispatcher
+     * invokes this when the SSE firehose announces that the client's
+     * `Last-Event-Id` precedes the bus's live-tail replay floor.
+     *
+     * The recovery sequence is intentionally explicit at this layer so the
+     * ordering is auditable in one place:
+     *  1. Disconnect SSE so the catch-up REST pass cannot interleave with
+     *     a live-tail frame whose revision the cursor store hasn't recorded yet.
+     *  2. Run catch-up across every registered domain. Each domain's catch-up
+     *     advances [store] as it drains; per-domain failures are logged but do
+     *     not abort the loop — one slow domain shouldn't strand the rest.
+     *  3. Reseed the SSE client's `lastEventId` from the new high-water cursor.
+     *     Without this, the reconnect would re-issue the request with the
+     *     stale `Last-Event-Id`, the server would emit `CursorStale` again,
+     *     and the loop would spin forever (the H1 bug).
+     *  4. Reconnect SSE. Live tail resumes from the new cursor.
+     */
+    internal suspend fun handleCursorStale(lastKnown: Long?) {
+        logger.info { "CursorStale received; lastKnown=$lastKnown — disconnect → catchUp → reseed → reconnect" }
+        sseClient.disconnect()
+        when (val result = catchUp.catchUpAll(registry)) {
+            is AppResult.Success -> {}
+
+            is AppResult.Failure -> {
+                logger.warn {
+                    "Catch-up failed during CursorStale recovery: ${result.error.code}; continuing to reconnect"
+                }
+            }
+        }
+        val newCursor = store.highestCursor()
+        sseClient.reseed(newCursor)
+        sseClient.connect()
     }
 
     /** Stop SSE and wait until the frame collector is fully cancelled. Used by tests and deterministic shutdown paths. */

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -52,6 +53,8 @@ class SyncEngine(
     private var frameCollectorJob: Job? = null
     private var connectionUpDrainJob: Job? = null
     private var enqueueDrainJob: Job? = null
+    private var queueDepthJob: Job? = null
+    private var failureCountJob: Job? = null
 
     // Serializes drain waves so concurrent triggers (connection-up + enqueue +
     // retry) coalesce into one wave at a time. drain() reads from the DAO and
@@ -80,7 +83,12 @@ class SyncEngine(
         // replayed value at subscribe time gets dropped, and there's nothing
         // after it).
         ensureDrainScheduling()
-        // Step 6: connect SSE.
+        // Step 6: forward queue-depth and failure-count observers into
+        // SyncEngineState so the diagnostics surface reflects reality. Without
+        // this wire-up `pendingQueueDepth` / `pendingFailureCount` stay stuck
+        // at 0 forever even though the queue is doing work.
+        ensureStateObservers()
+        // Step 7: connect SSE.
         sseClient.connect()
     }
 
@@ -91,6 +99,10 @@ class SyncEngine(
         connectionUpDrainJob = null
         enqueueDrainJob?.cancel()
         enqueueDrainJob = null
+        queueDepthJob?.cancel()
+        queueDepthJob = null
+        failureCountJob?.cancel()
+        failureCountJob = null
         sseClient.disconnect()
     }
 
@@ -134,12 +146,18 @@ class SyncEngine(
         val collector = frameCollectorJob
         val connectionUp = connectionUpDrainJob
         val enqueue = enqueueDrainJob
+        val depth = queueDepthJob
+        val failure = failureCountJob
         frameCollectorJob = null
         connectionUpDrainJob = null
         enqueueDrainJob = null
+        queueDepthJob = null
+        failureCountJob = null
         collector?.cancelAndJoin()
         connectionUp?.cancelAndJoin()
         enqueue?.cancelAndJoin()
+        depth?.cancelAndJoin()
+        failure?.cancelAndJoin()
         sseClient.disconnect()
     }
 
@@ -209,6 +227,44 @@ class SyncEngine(
                         .drop(1) // ignore the StateFlow's replayed current value
                         .filter { state.value.connection is ConnectionState.Connected }
                         .collect { runDrain() }
+                }
+            ready.await()
+        }
+    }
+
+    /**
+     * Forward the queue's depth and failure-count flows into [SyncEngineState]
+     * so the diagnostics surface (Renovation §2.10) reflects reality. Without
+     * this wire-up, [SyncEngineState.setQueueDepth] and
+     * [SyncEngineState.setFailureCount] are dead writers — nothing invokes
+     * them, and the snapshot fields stay at 0 forever.
+     *
+     * Suspends until both collectors have begun collecting via [onStart] so
+     * callers observing state immediately after `start()` returns see the
+     * live values, not the initial zeros. Room's `Flow<Int>` is a cold flow,
+     * so `onStart` (not `onSubscription`, which is StateFlow/SharedFlow-only)
+     * is the right hook to signal "we're collecting now."
+     */
+    private suspend fun ensureStateObservers() {
+        if (queueDepthJob?.isActive != true) {
+            val ready = CompletableDeferred<Unit>()
+            queueDepthJob =
+                scope.launch {
+                    queue
+                        .observeQueueDepth()
+                        .onStart { ready.complete(Unit) }
+                        .collect { depth -> state.setQueueDepth(depth) }
+                }
+            ready.await()
+        }
+        if (failureCountJob?.isActive != true) {
+            val ready = CompletableDeferred<Unit>()
+            failureCountJob =
+                scope.launch {
+                    queue
+                        .observeFailureCount()
+                        .onStart { ready.complete(Unit) }
+                        .collect { count -> state.setFailureCount(count) }
                 }
             ready.await()
         }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -2,12 +2,21 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.client.core.AppResult
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private val logger = KotlinLogging.logger {}
 
@@ -32,14 +41,24 @@ private val logger = KotlinLogging.logger {}
 class SyncEngine(
     private val registry: ClientSyncDomainRegistry,
     private val queue: PendingOperationQueue,
-    @Suppress("UnusedPrivateProperty") private val state: SyncEngineState,
+    private val state: SyncEngineState,
     private val store: SyncCursorStore,
     private val catchUp: CatchUp,
     private val sseClient: SseClient,
     private val dispatcher: SyncEventDispatcher,
     private val scope: CoroutineScope,
+    private val retryBackoffMillis: Long = DEFAULT_RETRY_BACKOFF_MILLIS,
 ) {
     private var frameCollectorJob: Job? = null
+    private var connectionUpDrainJob: Job? = null
+    private var enqueueDrainJob: Job? = null
+
+    // Serializes drain waves so concurrent triggers (connection-up + enqueue +
+    // retry) coalesce into one wave at a time. drain() reads from the DAO and
+    // mutates rows; without a Mutex two concurrent drains would dispatch the
+    // same op twice. The Mutex is per-engine, not per-op — per-op FIFO is the
+    // queue's SQL filter responsibility.
+    private val drainMutex = Mutex()
 
     /**
      * Start the engine for [currentUserId]. Re-calling re-runs catch-up;
@@ -54,13 +73,24 @@ class SyncEngine(
         sseClient.seedLastEventId(store.highestCursor())
         // Step 4: collect frames before connecting so immediate frames are not dropped.
         ensureFrameCollector()
-        // Step 5: connect SSE.
+        // Step 5: schedule pending-queue drains before connecting so the
+        // connection-up transition is observed and any already-queued ops
+        // drain promptly. Suspend until both collectors are actively subscribed
+        // — otherwise an enqueue racing the launch would be lost (StateFlow's
+        // replayed value at subscribe time gets dropped, and there's nothing
+        // after it).
+        ensureDrainScheduling()
+        // Step 6: connect SSE.
         sseClient.connect()
     }
 
     fun stop() {
         frameCollectorJob?.cancel()
         frameCollectorJob = null
+        connectionUpDrainJob?.cancel()
+        connectionUpDrainJob = null
+        enqueueDrainJob?.cancel()
+        enqueueDrainJob = null
         sseClient.disconnect()
     }
 
@@ -102,8 +132,14 @@ class SyncEngine(
     /** Stop SSE and wait until the frame collector is fully cancelled. Used by tests and deterministic shutdown paths. */
     suspend fun stopAndJoin() {
         val collector = frameCollectorJob
+        val connectionUp = connectionUpDrainJob
+        val enqueue = enqueueDrainJob
         frameCollectorJob = null
+        connectionUpDrainJob = null
+        enqueueDrainJob = null
         collector?.cancelAndJoin()
+        connectionUp?.cancelAndJoin()
+        enqueue?.cancelAndJoin()
         sseClient.disconnect()
     }
 
@@ -115,5 +151,100 @@ class SyncEngine(
                     dispatcher.handle(frame)
                 }
             }
+    }
+
+    /**
+     * Wire the two reactive triggers for [PendingOperationQueue.drain]:
+     *
+     *  1. Connection state transitions to [ConnectionState.Connected]. The
+     *     queue may hold ops that landed while offline (or before sign-in
+     *     completed). Draining on connect is what makes "local-first writes
+     *     reach the server" actually work.
+     *  2. New op enqueued. If we're already connected, drain immediately;
+     *     otherwise the connection-up trigger will pick it up.
+     *
+     * The third trigger — backoff after retryable failure — lives inside
+     * [runDrain] itself, scheduled per wave.
+     *
+     * The enqueue trigger uses [PendingOperationQueue.observeEnqueueSignal]'s
+     * monotonic counter and `drop(1)` to ignore the replayed current value at
+     * subscription time — we only care about *new* enqueues from this point
+     * forward. The connection-up trigger uses [SyncEngineState.observe]'s
+     * StateFlow directly because the current connection state is itself the
+     * signal we want to react to.
+     *
+     * Suspends until both collectors are actively subscribed via
+     * [onSubscription] — so a caller that enqueues immediately after
+     * `start()` returns will reliably trigger a drain.
+     */
+    private suspend fun ensureDrainScheduling() {
+        if (connectionUpDrainJob?.isActive != true) {
+            val ready = CompletableDeferred<Unit>()
+            connectionUpDrainJob =
+                scope.launch {
+                    state
+                        .observe()
+                        .onSubscription { ready.complete(Unit) }
+                        .map { it.connection }
+                        .distinctUntilChanged()
+                        .collect { connection ->
+                            if (connection is ConnectionState.Connected) {
+                                runDrain()
+                            }
+                        }
+                }
+            ready.await()
+        }
+        if (enqueueDrainJob?.isActive != true) {
+            val ready = CompletableDeferred<Unit>()
+            enqueueDrainJob =
+                scope.launch {
+                    queue
+                        .observeEnqueueSignal()
+                        .onSubscription { ready.complete(Unit) }
+                        .drop(1) // ignore the StateFlow's replayed current value
+                        .filter { state.value.connection is ConnectionState.Connected }
+                        .collect { runDrain() }
+                }
+            ready.await()
+        }
+    }
+
+    /**
+     * Run one drain wave under [drainMutex] so concurrent triggers (connect-up,
+     * enqueue, retry) coalesce. If the wave produced retryable failures,
+     * schedule a backoff-delayed re-drain — that's the engine's retry timer.
+     * Non-retryable failures stay flagged past `MAX_RETRYABLE_ATTEMPTS` and
+     * are silently skipped on subsequent waves.
+     */
+    private suspend fun runDrain() {
+        val outcome =
+            drainMutex.withLock {
+                try {
+                    queue.drain()
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Re-throwing here would tear down the trigger collector
+                    // and silently stop all future drains. Log and continue —
+                    // a future trigger will re-attempt.
+                    logger.warn(e) { "Drain wave failed unexpectedly; will retry on next trigger" }
+                    return
+                }
+            }
+        if (outcome.hasRetryableFailures) {
+            scope.launch {
+                delay(retryBackoffMillis)
+                runDrain()
+            }
+        }
+    }
+
+    private companion object {
+        // Default retry backoff. Production wiring can override via constructor
+        // if the threat model changes; this value pairs with the queue's
+        // MAX_RETRYABLE_ATTEMPTS = 5 to bound total retry time to ~5s on
+        // transient failures without hammering the server.
+        const val DEFAULT_RETRY_BACKOFF_MILLIS = 1_000L
     }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -185,13 +185,17 @@ class SyncEngine(
                     state
                         .observe()
                         .onSubscription { ready.complete(Unit) }
-                        .map { it.connection }
+                        // Collapse to a Boolean transition before distinctUntilChanged.
+                        // Each parsed SSE frame produces a fresh `Connected(lastEventId=X)`
+                        // value; data-class equality treats `Connected(1)` and
+                        // `Connected(2)` as distinct, so `distinctUntilChanged` on the
+                        // raw connection would let every frame through and schedule a
+                        // drain per frame — a DB walk per SSE event. We only want to
+                        // fire on the Disconnected/Connecting → Connected edge.
+                        .map { it.connection is ConnectionState.Connected }
                         .distinctUntilChanged()
-                        .collect { connection ->
-                            if (connection is ConnectionState.Connected) {
-                                runDrain()
-                            }
-                        }
+                        .filter { it }
+                        .collect { runDrain() }
                 }
             ready.await()
         }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -20,7 +20,7 @@ class SyncEventDispatcher(
     private val queue: PendingOperationQueue,
     private val state: SyncEngineState,
     private val cursorAdvance: suspend (domainName: String, revision: Long) -> Unit,
-    private val onCursorStale: suspend () -> Unit = {},
+    private val onCursorStale: suspend (lastKnown: Long?) -> Unit = {},
 ) {
     /** Route a parsed SSE frame: control events, data events, or no-op for missing event lines. */
     suspend fun handle(frame: ParsedSseFrame) {
@@ -43,8 +43,10 @@ class SyncEventDispatcher(
             }
         when (control) {
             is SyncControl.CursorStale -> {
-                logger.info { "Cursor stale; falling back to REST catch-up" }
-                onCursorStale()
+                logger.info {
+                    "Cursor stale; signalling engine to orchestrate recovery (lastKnown=${control.lastKnownRevision})"
+                }
+                onCursorStale(control.lastKnownRevision)
             }
 
             is SyncControl.StreamError -> {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
@@ -127,6 +127,20 @@ class SyncSseClient(
         if (initial != null) lastEventId = initial
     }
 
+    /** Read-only accessor for [SyncEngine.handleCursorStale] and tests. */
+    override fun currentLastEventId(): Long? = lastEventId
+
+    /**
+     * Drop the current connection and reseed [lastEventId] from [newLastEventId].
+     * Caller is responsible for invoking [connect] afterwards once the new cursor
+     * is in place — keeps the disconnect/reseed/reconnect ordering visible at
+     * the orchestration site rather than hidden inside the SSE client.
+     */
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        lastEventId = newLastEventId
+    }
+
     /** Open an SSE connection (or no-op if one is already active). */
     override fun connect() {
         if (connectionJob?.isActive == true) return
@@ -141,8 +155,19 @@ class SyncSseClient(
                         }
 
                         ConnectAttempt.AuthFailed -> {
-                            state.setConnection(ConnectionState.Disconnected("auth"))
-                            return@launch
+                            // Treat 401/403 as transient: the Bearer Auth plugin refreshes
+                            // the token on the next outbound request, but it only gets to
+                            // try if we issue one. The pre-fix branch (return@launch) left
+                            // production users stranded every 15min (access-token TTL)
+                            // until app restart. Surface the disconnect with a distinct
+                            // reason so logs/state reflect what happened, then fall
+                            // through to the same backoff+retry as Reconnect.
+                            state.setConnection(ConnectionState.Disconnected("auth-transient"))
+                            state.recordError(SyncError.RealtimeDisconnected())
+                            val delayMs = reconnectDelayMillis(attempt)
+                            logger.debug { "SSE reconnect after auth-transient in ${delayMs}ms (attempt $attempt)" }
+                            attempt++
+                            delay(delayMs)
                         }
 
                         ConnectAttempt.Reconnect -> {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -80,7 +80,12 @@ val clientSyncRenovationModule =
                 queue = get(),
                 state = get(),
                 cursorAdvance = { domain, rev -> get<SyncCursorStore>().setCursor(domain, rev) },
-                onCursorStale = { get<CatchUp>().catchUpAll(get()) },
+                // Route stale-cursor recovery through the engine so the full
+                // disconnect → catchUp → reseed → reconnect lifecycle stays in
+                // one place. Resolving SyncEngine lazily breaks the Koin
+                // construction cycle (engine depends on dispatcher; dispatcher
+                // only needs engine at runtime, not at construction).
+                onCursorStale = { lastKnown -> get<SyncEngine>().handleCursorStale(lastKnown) },
             )
         }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModuleVerifyTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModuleVerifyTest.kt
@@ -20,9 +20,11 @@ import org.koin.test.verify.verify
  *  - [ServerConfig] — owned by `dataModule` (segregated interface bound to
  *    SettingsRepositoryImpl). SSE + catch-up clients use it for current-URL reads.
  *  - [CoroutineScope] (named `appScope`) — owned by `syncModule` until D2 cutover.
- *  - [Function1], [Function3] — Koin's verify treats constructor lambda params
- *    (`SyncEventDispatcher.cursorAdvance` / `onCursorStale`) as resolvable deps.
- *    They're satisfied at construction time by the module's `single { }` block.
+ *  - [Function2], [Function3] — Koin's verify treats constructor lambda params
+ *    (`SyncEventDispatcher.onCursorStale` is `suspend (Long?) -> Unit` =
+ *    Function2; `cursorAdvance` is `suspend (String, Long) -> Unit` = Function3)
+ *    as resolvable deps. They're satisfied at construction time by the
+ *    module's `single { }` block.
  */
 @OptIn(KoinExperimentalAPI::class)
 class ClientSyncRenovationModuleVerifyTest :
@@ -36,7 +38,7 @@ class ClientSyncRenovationModuleVerifyTest :
                         ApiClientFactory::class,
                         ServerConfig::class,
                         CoroutineScope::class,
-                        Function1::class,
+                        Function2::class,
                         Function3::class,
                     ),
             )

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/IdAsStringRequiredForValueClassIdsRule.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/IdAsStringRequiredForValueClassIdsRule.kt
@@ -1,0 +1,70 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.modifierprovider.withoutAbstractModifier
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Pin: any concrete `SyncableRepository<T, ID>` subclass whose `ID` type
+ * argument is a `@JvmInline value class` MUST override `idAsString(id: ID):
+ * String` to return the raw underlying value.
+ *
+ * Without the override, the default impl in [SyncableRepository] is
+ * `id.toString()` — which on a `@JvmInline value class` returns
+ * `"WrapperName(value=foo)"`. That string would land in the primary-key
+ * column, every WHERE clause, and the `SyncEvent.id` payload — corrupting
+ * the table and breaking every soft-delete and event-echo match.
+ *
+ * String-id domains (e.g., `TagRepository : SyncableRepository<Tag, String>`)
+ * are exempt: `String.toString()` is the identity, so the default impl is
+ * correct. The rule's predicate skips them.
+ *
+ * As of the initial roll-out, no production repository has a value-class id
+ * — the rule passes trivially. It exists to fire the moment Books-A introduces
+ * `BookRepository : SyncableRepository<Book, BookId>` and catches a missing
+ * override at build time.
+ */
+class IdAsStringRequiredForValueClassIdsRule :
+    FunSpec({
+
+        test("every concrete SyncableRepository with a @JvmInline value-class ID overrides idAsString") {
+            // Konsist 0.17.3 includes type arguments in `parent.name`, so a TagRepository's
+            // SyncableRepository<Tag, String> parent appears under the name
+            // "SyncableRepository<Tag, String>". Match by the type-argument-stripped name.
+            fun String.bareTypeName(): String = substringBefore('<')
+
+            val concreteRepositories =
+                Konsist
+                    .scopeFromProduction()
+                    .classes()
+                    .withoutAbstractModifier()
+                    .filter { cls ->
+                        cls.parents().any { it.name.bareTypeName() == "SyncableRepository" }
+                    }
+
+            val offenders =
+                concreteRepositories.mapNotNull { repo ->
+                    val parent = repo.parents().first { it.name.bareTypeName() == "SyncableRepository" }
+                    // SyncableRepository<T, ID> — ID is the 2nd type argument.
+                    val idArg = parent.typeArguments?.getOrNull(1) ?: return@mapNotNull null
+                    val idClass = idArg.sourceDeclaration?.asClassDeclaration() ?: return@mapNotNull null
+                    if (!idClass.hasValueModifier) {
+                        // String-id and other reference-type-id domains: default impl is fine.
+                        return@mapNotNull null
+                    }
+                    val hasOverride =
+                        repo.functions().any { fn ->
+                            fn.name == "idAsString" && fn.hasOverrideModifier
+                        }
+                    if (hasOverride) {
+                        null
+                    } else {
+                        "${repo.name} uses value-class id ${idClass.name} but does not override idAsString " +
+                            "(default `id.toString()` would write \"${idClass.name}(value=...)\" to every column)"
+                    }
+                }
+
+            offenders.shouldBeEmpty()
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRule.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRule.kt
@@ -15,9 +15,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
  * directory itself) for any of the Exposed write operators invoked on a token
  * that matches a `*Table` object known to extend `SyncableTable`.
  *
- * Detected write operators: `.upsert(`, `.update(`, `.insert(`, `.deleteWhere(`,
- * `.batchInsert(`, `.replace(`. Read-only operators (`.selectAll(`, `.select(`,
- * `.exists(`) are deliberately excluded.
+ * Detected write operators are listed in [WRITE_OPERATORS]. Read-only operators
+ * (`.selectAll(`, `.select(`, `.exists(`) are deliberately excluded.
  *
  * This is the load-bearing Konsist rule for the sync substrate — it structurally
  * guarantees that the bus sees every write rather than relying on discipline alone.
@@ -40,23 +39,13 @@ class SyncWritesGoThroughRepositoryRule :
             // empty codebase, but returns early rather than lying with an empty offender list).
             if (syncableTableNames.isEmpty()) return@test
 
-            val writeOperators =
-                listOf(
-                    ".upsert(",
-                    ".update(",
-                    ".insert(",
-                    ".deleteWhere(",
-                    ".batchInsert(",
-                    ".replace(",
-                )
-
             val offenders =
                 scope.files
                     .filter { it.path.contains("/server/") }
                     .filterNot { it.path.contains("/server/sync/") }
                     .flatMap { file ->
                         val stripped = stripComments(file.text)
-                        writeOperators.flatMap { op ->
+                        WRITE_OPERATORS.flatMap { op ->
                             syncableTableNames.mapNotNull { tableName ->
                                 if (stripped.contains("$tableName$op")) {
                                     "$tableName$op in ${file.path}"
@@ -69,7 +58,33 @@ class SyncWritesGoThroughRepositoryRule :
 
             offenders.shouldBeEmpty()
         }
-    })
+    }) {
+    companion object {
+        /**
+         * Every Exposed write operator that touches a `SyncableTable` outside the
+         * repository layer must appear here. Missing operators are silent-corruption
+         * risk — the rule will not catch a bypass that uses an operator absent from
+         * this set.
+         */
+        val WRITE_OPERATORS =
+            setOf(
+                ".upsert(",
+                ".update(",
+                ".insert(",
+                ".deleteWhere(",
+                ".batchInsert(",
+                ".replace(",
+                ".insertIgnore(",
+                ".deleteAll(",
+                ".deleteIgnoreWhere(",
+                ".batchReplace(",
+                ".upsertReturning(",
+                ".insertAndGetId(",
+                ".replaceFromQuery(",
+                ".updateReturning(",
+            )
+    }
+}
 
 private fun stripComments(source: String): String =
     source

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRuleFixtureTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRuleFixtureTest.kt
@@ -3,17 +3,28 @@ package com.calypsan.listenup.konsist
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class SyncWritesGoThroughRepositoryRuleFixtureTest : FunSpec({
-    test("the rule's write-operator set covers all Exposed write APIs that bypass DSL-level interception") {
-        // The constant must include every Exposed write operator that touches a SyncableTable
-        // outside the repository layer. Missing operators are silent-corruption risk.
-        val expected = setOf(
-            ".upsert(", ".update(", ".insert(",
-            ".deleteWhere(", ".batchInsert(", ".replace(",
-            ".insertIgnore(", ".deleteAll(", ".deleteIgnoreWhere(",
-            ".batchReplace(", ".upsertReturning(", ".insertAndGetId(",
-            ".replaceFromQuery(", ".updateReturning(",
-        )
-        SyncWritesGoThroughRepositoryRule.WRITE_OPERATORS shouldBe expected
-    }
-})
+class SyncWritesGoThroughRepositoryRuleFixtureTest :
+    FunSpec({
+        test("the rule's write-operator set covers all Exposed write APIs that bypass DSL-level interception") {
+            // The constant must include every Exposed write operator that touches a SyncableTable
+            // outside the repository layer. Missing operators are silent-corruption risk.
+            val expected =
+                setOf(
+                    ".upsert(",
+                    ".update(",
+                    ".insert(",
+                    ".deleteWhere(",
+                    ".batchInsert(",
+                    ".replace(",
+                    ".insertIgnore(",
+                    ".deleteAll(",
+                    ".deleteIgnoreWhere(",
+                    ".batchReplace(",
+                    ".upsertReturning(",
+                    ".insertAndGetId(",
+                    ".replaceFromQuery(",
+                    ".updateReturning(",
+                )
+            SyncWritesGoThroughRepositoryRule.WRITE_OPERATORS shouldBe expected
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRuleFixtureTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/SyncWritesGoThroughRepositoryRuleFixtureTest.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.konsist
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SyncWritesGoThroughRepositoryRuleFixtureTest : FunSpec({
+    test("the rule's write-operator set covers all Exposed write APIs that bypass DSL-level interception") {
+        // The constant must include every Exposed write operator that touches a SyncableTable
+        // outside the repository layer. Missing operators are silent-corruption risk.
+        val expected = setOf(
+            ".upsert(", ".update(", ".insert(",
+            ".deleteWhere(", ".batchInsert(", ".replace(",
+            ".insertIgnore(", ".deleteAll(", ".deleteIgnoreWhere(",
+            ".batchReplace(", ".upsertReturning(", ".insertAndGetId(",
+            ".replaceFromQuery(", ".updateReturning(",
+        )
+        SyncWritesGoThroughRepositoryRule.WRITE_OPERATORS shouldBe expected
+    }
+})

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleLifecycleTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleLifecycleTest.kt
@@ -1,0 +1,111 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.client.data.sync.testing.withClientSyncEngineAgainstServer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
+
+private const val SEEDED_COUNT = 300
+private const val OPERATION_TIMEOUT_SECONDS = 30L
+
+/**
+ * Tier 3 e2e for the `CursorStale` lifecycle (review H1 + M1).
+ *
+ * Verifies that `SyncEngine.handleCursorStale` orchestrates the recovery
+ * sequence end-to-end against a real `:server`:
+ *
+ *   1. disconnect SSE — prevents catch-up from interleaving with live tail
+ *   2. catch-up across every registered domain
+ *   3. reseed the SSE client's `lastEventId` from the cursor store
+ *   4. reconnect SSE
+ *
+ * Pre-fix: `lastEventId` was set only at start + per frame, so a CursorStale
+ * cycle advanced the cursor store but not the SSE client; reconnect looped
+ * with the same stale cursor forever.
+ *
+ * Post-fix: after `handleCursorStale`, `sseClient.currentLastEventId()`
+ * reflects the highest cursor and reconnect succeeds without re-tripping
+ * the stale check.
+ */
+class CursorStaleLifecycleTest :
+    FunSpec({
+
+        test("handleCursorStale: disconnect → catchUp → reseed lastEventId → reconnect") {
+            withClientSyncEngineAgainstServer {
+                // Pre-populate the server with SEEDED_COUNT tags. With a 256-entry
+                // replay buffer, anything earlier than (SEEDED_COUNT - 256) is evicted —
+                // realistically reproducing the production stale-cursor condition.
+                repeat(SEEDED_COUNT) { i ->
+                    tagRepo.upsert(Tag(id = "t$i", name = "name-$i", revision = 0L, updatedAt = 0L))
+                }
+
+                val collectorScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                try {
+                    // Subscribe before start so emissions during catch-up reach the
+                    // collector (the recording handler's flow has bounded replay).
+                    val firstCatchUpDeferred =
+                        collectorScope.async {
+                            recording.catchUpObserved.take(SEEDED_COUNT).toList()
+                        }
+
+                    engine.start(currentUserId = "u1")
+
+                    val firstCatchUp =
+                        withTimeout(OPERATION_TIMEOUT_SECONDS.seconds) { firstCatchUpDeferred.await() }
+                    firstCatchUp shouldHaveSize SEEDED_COUNT
+
+                    // SSE connects asynchronously after catch-up; wait for the state
+                    // to reach Connected rather than asserting on the immediate value.
+                    withTimeout(OPERATION_TIMEOUT_SECONDS.seconds) {
+                        state.observe().filter { it.connection is ConnectionState.Connected }.first()
+                    }
+                    state.value.connection.shouldBeInstanceOf<ConnectionState.Connected>()
+                    val cursorAfterInitial = sseClient.currentLastEventId()
+                    cursorAfterInitial.shouldNotBeNull()
+                    cursorAfterInitial shouldBeGreaterThan 0L
+
+                    // Simulate the production stale-cursor condition: the SSE client
+                    // is holding a lastEventId that the server's bus has already
+                    // evicted past. We reseed it to 0 to make the next SSE response
+                    // a `SyncControl.CursorStale` if the lifecycle were to run again.
+                    // Then drive handleCursorStale directly — the dispatcher path on
+                    // a real CursorStale frame.
+                    sseClient.reseed(0L)
+
+                    engine.handleCursorStale(lastKnown = 0L)
+
+                    // Lifecycle invariants post-handling:
+                    //  - SSE is reconnected, not in permanent Disconnected.
+                    //  - The SSE client's lastEventId was reseeded from the cursor store
+                    //    (which still holds the post-initial-catch-up high-water mark),
+                    //    not left at the stale 0L we forced moments ago. This is the
+                    //    H1 fix: without `sseClient.reseed(newCursor)` inside
+                    //    handleCursorStale, the reconnect would loop forever with 0L.
+                    withTimeout(OPERATION_TIMEOUT_SECONDS.seconds) {
+                        state.observe().filter { it.connection is ConnectionState.Connected }.first()
+                    }
+                    state.value.connection.shouldBeInstanceOf<ConnectionState.Connected>()
+                    val cursorAfterRecovery = sseClient.currentLastEventId()
+                    cursorAfterRecovery.shouldNotBeNull()
+                    cursorAfterRecovery shouldBe cursorAfterInitial
+                } finally {
+                    collectorScope.cancel()
+                }
+            }
+        }
+    })

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -1,0 +1,287 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+private const val TIMEOUT_SECONDS = 5L
+private const val RETRY_TIMEOUT_SECONDS = 10L
+private const val MIN_RETRY_ATTEMPTS = 2
+private const val POLL_DELAY_MILLIS = 20L
+
+/**
+ * Verifies `SyncEngine` schedules `PendingOperationQueue.drain()` on the three
+ * triggers the queue's KDoc promises:
+ *
+ *  1. Connection state transitions to [ConnectionState.Connected].
+ *  2. A new op is enqueued while the engine is already connected.
+ *  3. After a drain that produced retryable failures, the engine reschedules
+ *     a drain on a backoff so transient failures don't strand the op.
+ *
+ * Pre-fix: `drain()` existed but the engine never scheduled it. Local-first
+ * writes scaffolded by the Renovation could never reach the server.
+ */
+class PendingQueueDrainSchedulingTest :
+    FunSpec({
+
+        test("drain is scheduled when connection transitions to Connected") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    // replay = 64 so a late `sent.first { ... }` after the drain
+                    // emit still sees the value; without replay, the emit could
+                    // happen before the test's first() subscribes and be lost.
+                    val sent = MutableSharedFlow<String>(replay = 64)
+                    val sender =
+                        PendingOperationSender { op ->
+                            sent.tryEmit(op.clientOpId)
+                            AppResult.Success(Unit)
+                        }
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                        )
+                    val state = SyncEngineState()
+                    val sse = FakeSseClient(state)
+                    val engine = buildEngine(db, queue, state, sse, scope)
+
+                    // Op already enqueued before engine.start — so the only thing
+                    // that can drain it is the connection-up trigger.
+                    val opId = queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+
+                    engine.start(currentUserId = "u1")
+
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        sent.first { it == opId }
+                    }
+                } finally {
+                    // Order matters: cancel-and-join the scope BEFORE closing
+                    // the DB. Closing the DB while a runDrain is mid-transaction
+                    // crashes the native SQLite driver (SIGSEGV inside
+                    // sqlite3Close).
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("drain is scheduled when an op is enqueued while already connected") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    // replay = 64 so a late `sent.first { ... }` after the drain
+                    // emit still sees the value; without replay, the emit could
+                    // happen before the test's first() subscribes and be lost.
+                    val sent = MutableSharedFlow<String>(replay = 64)
+                    val sender =
+                        PendingOperationSender { op ->
+                            sent.tryEmit(op.clientOpId)
+                            AppResult.Success(Unit)
+                        }
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                        )
+                    val state = SyncEngineState()
+                    val sse = FakeSseClient(state)
+                    val engine = buildEngine(db, queue, state, sse, scope)
+
+                    engine.start(currentUserId = "u1")
+
+                    // Wait until the engine is observably Connected before enqueuing,
+                    // so the assertion is "enqueue-while-connected triggers drain"
+                    // and not "connection-up trigger happens to fire."
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        state.observe().first { it.connection is ConnectionState.Connected }
+                    }
+
+                    val opId = queue.enqueue("tags", "t-late", "upsert", "{}", "u1")
+
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        sent.first { it == opId }
+                    }
+                } finally {
+                    // Order matters: cancel-and-join the scope BEFORE closing
+                    // the DB. Closing the DB while a runDrain is mid-transaction
+                    // crashes the native SQLite driver (SIGSEGV inside
+                    // sqlite3Close).
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("drain is rescheduled after retry backoff when a send fails retryably") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val attempts = AtomicInteger(0)
+                    val attemptIds = mutableListOf<String>()
+                    val attemptsMutex = kotlinx.coroutines.sync.Mutex()
+                    val sender =
+                        PendingOperationSender { op ->
+                            val n = attempts.incrementAndGet()
+                            attemptsMutex.lock()
+                            try {
+                                attemptIds += op.clientOpId
+                            } finally {
+                                attemptsMutex.unlock()
+                            }
+                            if (n == 1) {
+                                AppResult.Failure(TransportError.NetworkUnavailable())
+                            } else {
+                                AppResult.Success(Unit)
+                            }
+                        }
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                        )
+                    val state = SyncEngineState()
+                    val sse = FakeSseClient(state)
+                    // Short backoff so the test doesn't have to wait long.
+                    val engine =
+                        buildEngine(db, queue, state, sse, scope, retryBackoffMillis = 50L)
+
+                    val opId = queue.enqueue("tags", "t-retry", "upsert", "{}", "u1")
+
+                    engine.start(currentUserId = "u1")
+
+                    withTimeout(RETRY_TIMEOUT_SECONDS.seconds) {
+                        while (attempts.get() < MIN_RETRY_ATTEMPTS) {
+                            delay(POLL_DELAY_MILLIS)
+                        }
+                    }
+                    attempts.get() shouldBeGreaterThanOrEqualTo MIN_RETRY_ATTEMPTS
+                    attemptIds shouldContain opId
+                    // The op was successfully sent on the retry, so the row is gone.
+                    db.pendingOperationV2Dao().get(opId) shouldBe null
+                } finally {
+                    // Order matters: cancel-and-join the scope BEFORE closing
+                    // the DB. Closing the DB while a runDrain is mid-transaction
+                    // crashes the native SQLite driver (SIGSEGV inside
+                    // sqlite3Close).
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+    })
+
+private fun buildEngine(
+    db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+    queue: PendingOperationQueue,
+    state: SyncEngineState,
+    sse: SseClient,
+    scope: CoroutineScope,
+    retryBackoffMillis: Long = 1_000L,
+): SyncEngine {
+    val registry = ClientSyncDomainRegistry()
+    registry.register(NoopTagHandler)
+    val store = SyncCursorStore(db.syncCursorDao())
+    val dispatcher =
+        SyncEventDispatcher(
+            registry = registry,
+            queue = queue,
+            state = state,
+            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+        )
+    return SyncEngine(
+        registry = registry,
+        queue = queue,
+        state = state,
+        store = store,
+        catchUp = NoopCatchUp,
+        sseClient = sse,
+        dispatcher = dispatcher,
+        scope = scope,
+        retryBackoffMillis = retryBackoffMillis,
+    )
+}
+
+private object NoopCatchUp : CatchUp {
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+private object NoopTagHandler : SyncDomainHandler<Tag> {
+    override val domainName = "tags"
+    override val payloadSerializer = Tag.serializer()
+
+    override suspend fun onEvent(
+        event: com.calypsan.listenup.api.sync.SyncEvent<Tag>,
+        isOwnEcho: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun onCatchUpItem(
+        item: Tag,
+        isTombstone: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+}
+
+/**
+ * Fake SSE client that mirrors production's `SyncSseClient.connect()` semantics:
+ * `connect()` transitions [state] to [ConnectionState.Connected], which is what
+ * the engine's connection-up trigger listens for.
+ */
+private class FakeSseClient(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seeded = newLastEventId
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -138,6 +138,67 @@ class PendingQueueDrainSchedulingTest :
             }
         }
 
+        test("drain fires once per Connected transition, not per Connected re-emission with different lastEventId") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    // Wrap the DAO so we can count `nextDispatchable()` calls —
+                    // each call corresponds 1:1 with a `runDrain()` wave inside
+                    // the engine. Counting sends doesn't distinguish the bug
+                    // (re-emissions only walk an empty queue and produce zero
+                    // sends), so we count drain waves directly.
+                    val dispatchCalls = AtomicInteger(0)
+                    val dao = CountingDao(db.pendingOperationV2Dao(), dispatchCalls)
+                    val sender = PendingOperationSender { AppResult.Success(Unit) }
+                    val queue = PendingOperationQueue(dao = dao, sender = sender)
+                    val state = SyncEngineState()
+                    val sse = FakeSseClient(state)
+                    val engine = buildEngine(db, queue, state, sse, scope)
+
+                    engine.start(currentUserId = "u1")
+
+                    // Wait until the engine is observably Connected and the
+                    // first connection-up drain wave has executed. After this,
+                    // dispatchCalls == 1.
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        state.observe().first { it.connection is ConnectionState.Connected }
+                        while (dispatchCalls.get() < 1) {
+                            delay(POLL_DELAY_MILLIS)
+                        }
+                    }
+                    val baseline = dispatchCalls.get()
+
+                    // Emit two more `Connected(lastEventId=X)` snapshots with
+                    // different lastEventId values — simulating SSE frame arrivals
+                    // that bump the cursor. Data-class equality treats these as
+                    // distinct from the previous `Connected`, so a naive
+                    // distinctUntilChanged on the raw connection lets them
+                    // through and the engine schedules a drain per frame —
+                    // a DB query per SSE frame on a busy firehose.
+                    state.setConnection(ConnectionState.Connected(lastEventId = 1L))
+                    state.setConnection(ConnectionState.Connected(lastEventId = 2L))
+
+                    // Give the engine plenty of time to (incorrectly) re-fire drain.
+                    delay(POLL_DELAY_MILLIS * 10)
+
+                    // The two re-emissions must NOT trigger additional drain
+                    // waves: the trigger fires once per transition into
+                    // Connected, not per Connected snapshot.
+                    dispatchCalls.get() shouldBe baseline
+                } finally {
+                    // Order matters: cancel-and-join the scope BEFORE closing
+                    // the DB. Closing the DB while a runDrain is mid-transaction
+                    // crashes the native SQLite driver (SIGSEGV inside
+                    // sqlite3Close).
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
         test("drain is rescheduled after retry backoff when a send fails retryably") {
             runBlocking {
                 val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -251,6 +312,37 @@ private object NoopTagHandler : SyncDomainHandler<Tag> {
         item: Tag,
         isTombstone: Boolean,
     ): AppResult<Unit> = AppResult.Success(Unit)
+}
+
+/**
+ * DAO decorator that counts calls to [nextDispatchable] so a test can assert
+ * how many drain waves the engine fired — each `runDrain()` invocation calls
+ * `nextDispatchable()` exactly once.
+ */
+private class CountingDao(
+    private val delegate: com.calypsan.listenup.client.data.local.db.PendingOperationV2Dao,
+    private val dispatchCalls: AtomicInteger,
+) : com.calypsan.listenup.client.data.local.db.PendingOperationV2Dao {
+    override suspend fun insert(op: com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity) = delegate.insert(op)
+
+    override suspend fun get(clientOpId: String) = delegate.get(clientOpId)
+
+    override suspend fun delete(clientOpId: String) = delegate.delete(clientOpId)
+
+    override suspend fun update(op: com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity) = delegate.update(op)
+
+    override suspend fun nextDispatchable(maxAttempts: Int): List<com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity> {
+        dispatchCalls.incrementAndGet()
+        return delegate.nextDispatchable(maxAttempts)
+    }
+
+    override fun observeQueueDepth() = delegate.observeQueueDepth()
+
+    override fun observeFailureCount(maxAttempts: Int) = delegate.observeFailureCount(maxAttempts)
+
+    override suspend fun deleteAllExcept(keepUserId: String) = delegate.deleteAllExcept(keepUserId)
+
+    override suspend fun deleteAll() = delegate.deleteAll()
 }
 
 /**

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleTest.kt
@@ -347,6 +347,13 @@ private class FakeSse : SseClient {
         connected = false
     }
 
+    override fun currentLastEventId(): Long? = seededLastEventId
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seededLastEventId = newLastEventId
+    }
+
     suspend fun emit(frame: ParsedSseFrame) {
         flow.emit(frame)
     }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
@@ -1,0 +1,217 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Verifies `SyncEngine.start()` is idempotent under re-entry.
+ *
+ * Pre-fix: `MainActivity.onResume` calls `connectRealtime()` → `engine.start()` on
+ * every resume. Two quick resumes race two concurrent `catchUpAll` invocations
+ * with duplicate `onCatchUpItem` calls and cursor-advance races. The "should I
+ * re-fire" logic lives inside `start()` so callers don't need to guard.
+ *
+ * Contract:
+ *  1. Concurrent calls for the same user run catch-up exactly once.
+ *  2. A sequential second call for the same user is a no-op (no second catch-up).
+ *  3. A call with a different user cancels the prior engine and rebuilds — two
+ *     catch-up invocations, the new user is the live one.
+ */
+class SyncEngineStartIdempotencyTest :
+    FunSpec({
+
+        test("two concurrent start() calls with same user don't run two catch-up loops") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val catchUp = CountingCatchUp()
+                    val state = SyncEngineState()
+                    val sse = FakeIdempotencySseClient(state)
+                    val engine = buildEngine(db, state, catchUp, sse, scope)
+
+                    coroutineScope {
+                        launch { engine.start(currentUserId = "user-a") }
+                        launch { engine.start(currentUserId = "user-a") }
+                    }
+
+                    catchUp.invocations.get() shouldBe 1
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("start() after a previous start() with the same user is a no-op (no second catch-up)") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val catchUp = CountingCatchUp()
+                    val state = SyncEngineState()
+                    val sse = FakeIdempotencySseClient(state)
+                    val engine = buildEngine(db, state, catchUp, sse, scope)
+
+                    engine.start(currentUserId = "user-a")
+                    engine.start(currentUserId = "user-a")
+
+                    catchUp.invocations.get() shouldBe 1
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("start() with a different user cancels prior and restarts (two catch-ups)") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val catchUp = CountingCatchUp()
+                    val state = SyncEngineState()
+                    val sse = FakeIdempotencySseClient(state)
+                    val engine = buildEngine(db, state, catchUp, sse, scope)
+
+                    engine.start(currentUserId = "user-a")
+                    engine.start(currentUserId = "user-b")
+
+                    catchUp.invocations.get() shouldBe 2
+                    // queue.clearForUserChange("user-b") would have wiped any user-a ops.
+                    // Enqueue under user-a, then start under user-b — the engine's
+                    // second start should clear user-a's queued op.
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+    })
+
+private fun buildEngine(
+    db: ListenUpDatabase,
+    state: SyncEngineState,
+    catchUp: CatchUp,
+    sse: SseClient,
+    scope: CoroutineScope,
+): SyncEngine {
+    val registry = ClientSyncDomainRegistry()
+    registry.register(IdempotencyNoopTagHandler)
+    val store = SyncCursorStore(db.syncCursorDao())
+    val queue =
+        PendingOperationQueue(
+            dao = db.pendingOperationV2Dao(),
+            sender =
+                PendingOperationSender {
+                    // Non-retryable failure keeps queue activity minimal and avoids
+                    // race noise during start() — the idempotency contract is what
+                    // we're isolating, not drain wiring.
+                    AppResult.Failure(SyncError.NotFound(domain = "tags", entityId = "t1"))
+                },
+        )
+    val dispatcher =
+        SyncEventDispatcher(
+            registry = registry,
+            queue = queue,
+            state = state,
+            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+        )
+    return SyncEngine(
+        registry = registry,
+        queue = queue,
+        state = state,
+        store = store,
+        catchUp = catchUp,
+        sseClient = sse,
+        dispatcher = dispatcher,
+        scope = scope,
+    )
+}
+
+/**
+ * Recording fake that counts `catchUpAll` invocations — the canonical signal
+ * for "did start() run a catch-up loop?"
+ */
+private class CountingCatchUp : CatchUp {
+    val invocations = AtomicInteger(0)
+
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
+        invocations.incrementAndGet()
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+private object IdempotencyNoopTagHandler : SyncDomainHandler<Tag> {
+    override val domainName = "tags"
+    override val payloadSerializer = Tag.serializer()
+
+    override suspend fun onEvent(
+        event: com.calypsan.listenup.api.sync.SyncEvent<Tag>,
+        isOwnEcho: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun onCatchUpItem(
+        item: Tag,
+        isTombstone: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+}
+
+/**
+ * Fake SSE client mirroring production's `connect()`-flips-state semantics.
+ * Local to this test so fakes don't leak between files.
+ */
+private class FakeIdempotencySseClient(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seeded = newLastEventId
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
@@ -128,7 +128,9 @@ class SyncEngineStartIdempotencyTest :
                 // via the JVM's default handler. The test only cares about the
                 // retry behavior; the exception itself is intentional.
                 val swallow =
-                    CoroutineExceptionHandler { _, _ -> /* expected — simulated failure */ }
+                    CoroutineExceptionHandler { _, _ ->
+                        // expected — simulated failure
+                    }
                 val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default + swallow)
                 val db = createInMemoryTestDatabase()
                 try {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -33,6 +34,8 @@ import kotlinx.coroutines.runBlocking
  *  2. A sequential second call for the same user is a no-op (no second catch-up).
  *  3. A call with a different user cancels the prior engine and rebuilds — two
  *     catch-up invocations, the new user is the live one.
+ *  4. A call after a previous failed runStart() retries — not a silent no-op,
+ *     so the documented recovery path (forceFullResync) actually works.
  */
 class SyncEngineStartIdempotencyTest :
     FunSpec({
@@ -110,6 +113,47 @@ class SyncEngineStartIdempotencyTest :
                 }
             }
         }
+
+        test("start() after a failed runStart() retries — not a silent no-op forever") {
+            // Regression guard for the same-user no-op recovery gap:
+            // if the prior runStart() threw, engineJob completed exceptionally
+            // and currentUserStarted is false, but currentUser is still set.
+            // Without the `currentUserStarted` clause in start()'s no-op check,
+            // every subsequent start("user-a") would be a silent no-op forever,
+            // stranding SyncRepositoryImpl.forceFullResync(). With the guard,
+            // the second start retries.
+            runBlocking {
+                // Swallow the simulated catch-up failure at the scope level so
+                // it doesn't surface as an "uncaught exception before next test"
+                // via the JVM's default handler. The test only cares about the
+                // retry behavior; the exception itself is intentional.
+                val swallow =
+                    CoroutineExceptionHandler { _, _ -> /* expected — simulated failure */ }
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default + swallow)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val catchUp = FailingThenSucceedingCatchUp()
+                    val state = SyncEngineState()
+                    val sse = FakeIdempotencySseClient(state)
+                    val engine = buildEngine(db, state, catchUp, sse, scope)
+
+                    // First start: runStart throws inside the launched job.
+                    // engineJob completes exceptionally; start() itself returns
+                    // normally because job.join() doesn't rethrow.
+                    engine.start(currentUserId = "user-a")
+                    catchUp.invocations.get() shouldBe 1
+
+                    // Second start for the same user: must retry, not no-op.
+                    engine.start(currentUserId = "user-a")
+                    catchUp.invocations.get() shouldBe 2
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
     })
 
 private fun buildEngine(
@@ -163,6 +207,28 @@ private class CountingCatchUp : CatchUp {
 
     override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
         invocations.incrementAndGet()
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+/**
+ * Fake that throws on its first `catchUpAll` invocation and succeeds afterwards.
+ * Drives the "engineJob completes exceptionally → retry must work" path —
+ * runStart() doesn't catch, so the throw propagates out of the launched job
+ * and into engineJob's failure state.
+ */
+private class FailingThenSucceedingCatchUp : CatchUp {
+    val invocations = AtomicInteger(0)
+
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
+        val attempt = invocations.incrementAndGet()
+        if (attempt == 1) {
+            error("simulated catch-up failure on first attempt")
+        }
         return AppResult.Success(Unit)
     }
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
@@ -1,0 +1,200 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+private const val TIMEOUT_SECONDS = 5L
+
+/**
+ * Verifies `SyncEngine` forwards `PendingOperationQueue.observeQueueDepth()` and
+ * `observeFailureCount()` into [SyncEngineState] so the diagnostics surface
+ * reflects reality. Pre-fix: `setQueueDepth`/`setFailureCount` were dead writers
+ * — nothing ever invoked them, so `pendingQueueDepth` / `pendingFailureCount`
+ * were stuck at 0 forever.
+ */
+class SyncEngineStateObserversTest :
+    FunSpec({
+
+        test("SyncEngineState.pendingQueueDepth reflects PendingOperationQueue.observeQueueDepth") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    // Non-retryable failure keeps ops in the queue (flagged past MAX,
+                    // never re-drained). Using a Success sender would drain-and-delete
+                    // the op the moment the engine sees the enqueue signal, racing the
+                    // assertion. observeQueueDepth counts ALL rows regardless of
+                    // failure status, so non-retryable failure is the right tool to
+                    // pin the row in place while the depth observer fires.
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender =
+                                PendingOperationSender {
+                                    AppResult.Failure(
+                                        com.calypsan.listenup.api.error.SyncError.NotFound(
+                                            domain = "tags",
+                                            entityId = "t1",
+                                        ),
+                                    )
+                                },
+                        )
+                    val state = SyncEngineState()
+                    val sse = FakeStateSseClient(state)
+                    val engine = buildEngine(db, queue, state, sse, scope)
+
+                    engine.start(currentUserId = "u1")
+
+                    state.value.pendingQueueDepth shouldBe 0
+
+                    queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                    queue.enqueue("tags", "t2", "upsert", "{}", "u1")
+
+                    val expectedDepth = 2
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        state.observe().first { it.pendingQueueDepth == expectedDepth }
+                    }
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("SyncEngineState.pendingFailureCount reflects PendingOperationQueue.observeFailureCount") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = PendingOperationSender { AppResult.Success(Unit) },
+                        )
+                    val state = SyncEngineState()
+                    val sse = FakeStateSseClient(state)
+                    val engine = buildEngine(db, queue, state, sse, scope)
+
+                    engine.start(currentUserId = "u1")
+
+                    // Insert a row directly via the DAO with failureCount already
+                    // past the retry budget — bypassing PendingOperationQueue.enqueue
+                    // (which would race the drain trigger and delete the op on the
+                    // success path before we could mutate it). The DAO row is the
+                    // invariant the failure-count flow watches, so writing to it
+                    // directly is the canonical way to assert the observer wire-up.
+                    val pastMax = 99
+                    db
+                        .pendingOperationV2Dao()
+                        .insert(
+                            com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity(
+                                clientOpId = "failed-op",
+                                domainName = "tags",
+                                entityId = "t1",
+                                opType = "upsert",
+                                payload = "{}",
+                                enqueuedAt = 1_000L,
+                                lastAttemptAt = 1_000L,
+                                failureCount = pastMax,
+                                lastError = "test",
+                                ownerUserId = "u1",
+                            ),
+                        )
+
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        state.observe().first { it.pendingFailureCount == 1 }
+                    }
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+    })
+
+private fun buildEngine(
+    db: ListenUpDatabase,
+    queue: PendingOperationQueue,
+    state: SyncEngineState,
+    sse: SseClient,
+    scope: CoroutineScope,
+): SyncEngine {
+    val registry = ClientSyncDomainRegistry()
+    val store = SyncCursorStore(db.syncCursorDao())
+    val dispatcher =
+        SyncEventDispatcher(
+            registry = registry,
+            queue = queue,
+            state = state,
+            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+        )
+    return SyncEngine(
+        registry = registry,
+        queue = queue,
+        state = state,
+        store = store,
+        catchUp = NoopStateCatchUp,
+        sseClient = sse,
+        dispatcher = dispatcher,
+        scope = scope,
+    )
+}
+
+private object NoopStateCatchUp : CatchUp {
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+/**
+ * Fake SSE client mirroring production's `connect()`-flips-state semantics.
+ * Local to this test so test fakes don't leak between files.
+ */
+private class FakeStateSseClient(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seeded = newLastEventId
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
@@ -149,10 +149,10 @@ class SyncEventDispatcherTest :
             }
         }
 
-        test("control: SyncControl.CursorStale sets state and triggers callback") {
+        test("control: SyncControl.CursorStale sets state and triggers callback with lastKnown") {
             runTest {
                 val db = createInMemoryTestDatabase()
-                var staleSeen = false
+                var seenLastKnown: Long? = null
                 val dispatcher =
                     SyncEventDispatcher(
                         registry = ClientSyncDomainRegistry(),
@@ -163,7 +163,7 @@ class SyncEventDispatcherTest :
                             ),
                         state = SyncEngineState(),
                         cursorAdvance = { _, _ -> },
-                        onCursorStale = { staleSeen = true },
+                        onCursorStale = { lastKnown -> seenLastKnown = lastKnown },
                     )
                 val lastKnownRevision = 1_000L
                 val control = SyncControl.CursorStale(lastKnownRevision = lastKnownRevision)
@@ -174,7 +174,7 @@ class SyncEventDispatcherTest :
                         data = contractJson.encodeToString(SyncControl.serializer(), control),
                     )
                 dispatcher.handle(frame)
-                staleSeen shouldBe true
+                seenLastKnown shouldBe lastKnownRevision
                 db.close()
             }
         }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientAuthRefreshTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientAuthRefreshTest.kt
@@ -1,0 +1,180 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Locks in Task 8's fix that treats mid-stream 401/403 as transient rather than
+ * terminal, so the Ktor Bearer Auth plugin can refresh the access token on the
+ * next reconnect.
+ *
+ * Pre-fix (the regression this test prevents): `runOnce()` returned
+ * `AuthFailed` and the outer reconnect loop called `return@launch`, stranding
+ * production Books-A users every 15 minutes (access-token TTL) until app
+ * restart. Post-fix: `AuthFailed` records the disconnect reason and falls
+ * through to the same backoff+retry path as a transient network error.
+ *
+ * The contract being pinned: a single 401 must NOT leave the SSE client in a
+ * permanent terminal state. The reconnect path must run so the auth plugin
+ * gets another outbound request to attach a refreshed token to.
+ *
+ * Tested at the [SyncSseClient] level with a `MockEngine`-backed `HttpClient`
+ * configured with `installListenUpErrorHandling()` (mirroring production's
+ * `expectSuccess = true`). This decouples the regression test from the real
+ * server's auth implementation, matches the test style of
+ * `SyncCatchUpClientTest`, and runs without spinning up `:server` for a pure
+ * client-side invariant.
+ */
+class SyncSseClientAuthRefreshTest :
+    FunSpec({
+
+        test("401 mid-stream surfaces Disconnected(\"auth-transient\") then reconnects to Connected — not permanent terminal") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val attempts = AtomicInteger(0)
+                val client =
+                    HttpClient(
+                        MockEngine { _ ->
+                            if (attempts.incrementAndGet() == 1) {
+                                respondError(HttpStatusCode.Unauthorized)
+                            } else {
+                                respondSse(SSE_FRAME_ID_1)
+                            }
+                        },
+                    ) {
+                        installListenUpErrorHandling()
+                    }
+
+                try {
+                    val state = SyncEngineState()
+                    val sse =
+                        SyncSseClient(
+                            serverUrlProvider = { "" },
+                            streamingClientProvider = { client },
+                            state = state,
+                            scope = scope,
+                        )
+
+                    sse.connect()
+
+                    // Counterfactual proof we exercised the AuthFailed branch: the
+                    // state must pass through Disconnected with reason AUTH_TRANSIENT
+                    // at some point. With the pre-fix `return@launch`, the outer loop
+                    // would have exited *before* setting that reason, OR (if it set
+                    // Disconnected("closed") in `disconnect()`) we'd see a different
+                    // reason — either way, AUTH_TRANSIENT only appears on the new
+                    // transient path.
+                    withTimeout(AUTH_TRANSIENT_TIMEOUT) {
+                        state
+                            .observe()
+                            .filter {
+                                (it.connection as? ConnectionState.Disconnected)?.reason == AUTH_TRANSIENT
+                            }.first()
+                    }
+
+                    // After backoff (1s for attempt 0), the second attempt 200s and
+                    // we reach Connected. With the pre-fix terminal `return@launch`,
+                    // this would time out: the outer loop never made a second attempt.
+                    withTimeout(RECONNECT_TIMEOUT) {
+                        state.observe().filter { it.connection is ConnectionState.Connected }.first()
+                    }
+                    state.value.connection.shouldBeInstanceOf<ConnectionState.Connected>()
+                    attempts.get() shouldBe 2
+                } finally {
+                    scope.cancel()
+                    client.close()
+                }
+            }
+        }
+
+        test("403 (Forbidden) is treated as auth-transient — same recovery path as 401") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val attempts = AtomicInteger(0)
+                val client =
+                    HttpClient(
+                        MockEngine { _ ->
+                            if (attempts.incrementAndGet() == 1) {
+                                respondError(HttpStatusCode.Forbidden)
+                            } else {
+                                respondSse(SSE_FRAME_ID_1)
+                            }
+                        },
+                    ) {
+                        installListenUpErrorHandling()
+                    }
+
+                try {
+                    val state = SyncEngineState()
+                    val sse =
+                        SyncSseClient(
+                            serverUrlProvider = { "" },
+                            streamingClientProvider = { client },
+                            state = state,
+                            scope = scope,
+                        )
+
+                    sse.connect()
+
+                    withTimeout(AUTH_TRANSIENT_TIMEOUT) {
+                        state
+                            .observe()
+                            .filter {
+                                (it.connection as? ConnectionState.Disconnected)?.reason == AUTH_TRANSIENT
+                            }.first()
+                    }
+                    withTimeout(RECONNECT_TIMEOUT) {
+                        state.observe().filter { it.connection is ConnectionState.Connected }.first()
+                    }
+                    attempts.get() shouldBe 2
+                } finally {
+                    scope.cancel()
+                    client.close()
+                }
+            }
+        }
+    })
+
+private const val SSE_FRAME_ID_1 = 1L
+private const val AUTH_TRANSIENT = "auth-transient"
+private val AUTH_TRANSIENT_TIMEOUT = 10.seconds
+private val RECONNECT_TIMEOUT = 15.seconds
+
+/**
+ * Single SSE frame, terminated by the blank line the parser needs to commit the
+ * frame. The content body shape doesn't matter for this test — only that the
+ * connection succeeds, the parser commits, and `lastEventId` advances.
+ */
+private fun io.ktor.client.engine.mock.MockRequestHandleScope.respondSse(eventId: Long) =
+    respond(
+        content =
+            """
+            id: $eventId
+            event: heartbeat
+            data: {}
+
+
+            """.trimIndent(),
+        status = HttpStatusCode.OK,
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Text.EventStream.toString()),
+    )

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -15,6 +15,7 @@ import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.server.db.DatabaseConfig
 import com.calypsan.listenup.server.db.DatabaseFactory
 import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.sync.TagRepository
 import com.calypsan.listenup.server.sync.syncRoutes
 import io.ktor.client.HttpClient
@@ -80,7 +81,8 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
         val serverDb =
             DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
         val bus = ChangeBus()
-        val tagRepo = TagRepository(serverDb, bus)
+        val registry = SyncRegistry()
+        val tagRepo = TagRepository(serverDb, bus, registry)
 
         application {
             install(ServerContentNegotiation) { json(contractJson) }
@@ -90,6 +92,7 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
                     module {
                         single { serverDb }
                         single { bus }
+                        single { registry }
                         single(createdAtStart = true) { tagRepo }
                     },
                 )
@@ -169,10 +172,10 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
         } finally {
             clientScope.cancel()
             clientDb.close()
-            // Stop Koin so the next test starts fresh. (`SyncRoutes` is a
-            // process-global registry but each test's `TagRepository` init replaces
-            // the "tags" entry, so cross-test leakage is bounded to `tags` and
-            // harmless for this fixture.)
+            // Stop Koin so the next test starts fresh. Each test creates its own
+            // `SyncRegistry` instance (passed into the per-test `TagRepository`),
+            // so there's no process-wide state to clean up — `GlobalContext` is
+            // only stopped because Ktor's Koin plugin starts it eagerly.
             if (GlobalContext.getKoinApplicationOrNull() != null) {
                 GlobalContext.stopKoin()
             }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -55,6 +55,7 @@ data class ClientEngineScope(
     val state: SyncEngineState,
     val dispatcher: SyncEventDispatcher,
     val queue: PendingOperationQueue,
+    val sseClient: SyncSseClient,
 )
 
 /**
@@ -136,13 +137,21 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
                     scope = clientScope,
                 )
 
+            // Forward reference: dispatcher's onCursorStale callback needs to
+            // call engine.handleCursorStale, but the engine takes the dispatcher
+            // as a constructor dep. Production uses Koin's lazy `get<SyncEngine>()`
+            // for this; here a single-slot holder serves the same role.
+            var engineRef: SyncEngine? = null
             val dispatcher =
                 SyncEventDispatcher(
                     registry = registry,
                     queue = queue,
                     state = state,
                     cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
-                    onCursorStale = { catchUp.catchUpAll(registry) },
+                    onCursorStale = { lastKnown ->
+                        checkNotNull(engineRef) { "SyncEngine not yet constructed" }
+                            .handleCursorStale(lastKnown)
+                    },
                 )
 
             val engine =
@@ -156,6 +165,7 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
                     dispatcher = dispatcher,
                     scope = clientScope,
                 )
+            engineRef = engine
 
             try {
                 ClientEngineScope(
@@ -165,6 +175,7 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
                     state = state,
                     dispatcher = dispatcher,
                     queue = queue,
+                    sseClient = sseClient,
                 ).block()
             } finally {
                 engine.stopAndJoin()


### PR DESCRIPTION
## Summary

Server-side fixes (Books-A blockers):
- **H1:** `SyncableRepository.idAsString` template — prevents value-class WHERE-clause corruption.
- **H2:** atomic `nextRevision` via `UPDATE … RETURNING value` — eliminates SQLITE_BUSY under concurrent writes.
- **H3:** `SyncRegistry` per-Koin instead of static singleton — eliminates parallel-test flake.
- **H4:** typed `BusEvent<T>` carrying source repository — prevents cross-domain serializer drift.
- **M2:** malformed `Last-Event-ID` → `CursorStale` instead of silent live-tail subscription.
- **M7:** test pinning the "no stacktraces over the wire" invariant.
- **M8:** complete `SyncWritesGoThroughRepositoryRule` write-operator list.

Client-side fixes:
- **H1+M1+M2:** CursorStale lifecycle in `SyncEngine` — disconnect → catchUp → reseed → reconnect; `AuthFailed` treated as transient.
- **H2:** `SyncEngine` schedules `queue.drain()` on connect + enqueue + retry backoff.
- **H3:** `SyncEngine` wires `PendingOperationQueue` observers into `SyncEngineState`.
- **M5:** `SyncEngine.start()` idempotent under re-entry.

Findings docs:
- `docs/superpowers/findings/2026-05-12-sync-foundation-review.md`
- `docs/superpowers/findings/2026-05-12-client-sync-renovation-review.md`

This unblocks Books-A.

## Test plan
- [x] `:server:test` green
- [x] `:shared:jvmTest` green
- [x] `:androidApp:assembleDebug` green
- [x] `spotlessCheck` + `detekt` green
- [x] All commits follow gitmoji + Conventional format; no Claude attribution footer

## Followups
~19 items appended to `docs/superpowers/followups.md` under "From Sync Engine Hardening (2026-05-14)".
