### PR TITLE
🐛 fix(shared): acquire PlaybackController on NowPlayingViewModel init

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -51,8 +51,11 @@ private val logger = KotlinLogging.logger {}
  * All command-side operations route through [PlaybackController].
  *
  * Lifecycle: Bound as a Koin `single` (per W7 Phase E2.2.2) — survives recomposition
- * and lives for the process lifetime. `onCleared` will never fire and acquire/release
- * is unneeded; PlaybackController is itself a `single` with matching lifecycle.
+ * and lives for the process lifetime. `init { playbackController.acquire() }` establishes
+ * the MediaController connection on first resolution and holds it for the process;
+ * `onCleared` never fires, so a matching `release()` would be dead code. The
+ * PlaybackController object's Koin singleton lifetime does **not** establish the
+ * connection — only `acquire()` does.
  */
 class NowPlayingViewModel(
     private val playbackManager: PlaybackManager,
@@ -65,6 +68,10 @@ class NowPlayingViewModel(
     private companion object {
         const val FADE_DURATION_MS = 3000L
         const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
+    }
+
+    init {
+        playbackController.acquire()
     }
 
     private val overlayFlow = MutableStateFlow<NowPlayingOverlay>(NowPlayingOverlay.None)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -76,6 +76,10 @@ class NowPlayingViewModelTest {
             // Default: bookRepository.getBookListItem returns null (no metadata).
             // bookFlow tolerates null; pure mapToNowPlayingState handles it.
             everySuspend { bookRepository.getBookListItem(any()) } returns null
+            // NowPlayingViewModel's init block calls playbackController.acquire() to
+            // establish the MediaController connection. Mokkery is strict by default
+            // and would raise CallNotMockedException without this stub.
+            every { playbackController.acquire() } returns Unit
         }
 
         fun newVm(): NowPlayingViewModel =

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -99,6 +99,21 @@ class NowPlayingViewModelTest {
         Dispatchers.resetMain()
     }
 
+    // ========== lifecycle (W7 Phase E2.2.2 regression) ==========
+
+    @Test
+    fun `init acquires the PlaybackController so MediaController connects`() {
+        val fixture = TestFixture()
+
+        fixture.newVm()
+
+        // The W7 Phase E2.2.2 refactor mistakenly removed acquire/release from the
+        // VM under the assumption that Koin-singleton lifetime obviated the call.
+        // It does not — only acquire() triggers MediaControllerHolder.connect().
+        // Without this call, every in-app playback command is a silent no-op.
+        verify(VerifyMode.exactly(1)) { fixture.playbackController.acquire() }
+    }
+
     // ========== playBook ==========
 
     @Test


### PR DESCRIPTION
## Summary

Restore in-app playback commands. `NowPlayingViewModel` now calls `playbackController.acquire()` from its `init` block, which fires `MediaControllerHolder.connect()` and populates `_controller`. Without this call, every command on `AndroidPlaybackController` (`play`, `pause`, `seekTo`, `startPlayback`) silently no-ops with a warn-log because `holder.controller` stays null.

The bug was introduced by W7 Phase E2.2.2, which moved the VM to a Koin `single` and authored a KDoc claiming "acquire/release is unneeded; PlaybackController is itself a `single` with matching lifecycle." That comment conflated the Koin singleton lifetime (object reference lives for the process) with the MediaController connection lifetime (only `acquire()` triggers `connect()`). The fix also rewrites that KDoc so the next reader doesn't repeat the inference.

Spec: `docs/superpowers/specs/2026-05-14-playback-controller-acquire-fix-design.md`.

## Test plan

- [x] Local: `./gradlew :shared:jvmTest :server:test spotlessCheck detekt :androidApp:assembleDebug` — green
- [x] Unit: new regression test `NowPlayingViewModelTest.init acquires the PlaybackController so MediaController connects` fails before the fix, passes after. Two-commit history (red test → green fix) preserves the TDD shape.
- [ ] **Manual smoke (reviewer to run on API 33+ emulator or device):**
  1. Install this build over a previous version (or clean install).
  2. Open the app, navigate to a fresh book, tap **in-app** Play (not notification, not media button).
  3. Audio should start playing.
  4. Tap Pause — playback should pause.
  5. Tap seek bar / seek-back / seek-forward — position should move.
  
  Before this fix, in-app Play does nothing and the logcat shows `AndroidPlaybackController.play: controller not ready`. After the fix, playback responds normally.

## Phase 5 unblock

This PR unblocks **Phase 5 — Android 17 Readiness** (paused at Task 2). After merge, the \`phase-5-android-17\` worktree rebases onto the new main and Phase 5 resumes from the \`ACCESS_LOCAL_NETWORK\` permission wiring.

## Note on local-CI flake

\`SyncSseClientAuthRefreshTest\` (data/sync, unrelated to this fix) is currently flaky — \`expected:<2> but was:<N>\` race-condition assertions, fails ~2/3 runs. Not introduced by this PR (originated in PR #289 Sync Engine Hardening). Local gate eventually passed clean on \`--rerun-tasks\`. Captured as a follow-up in the workspace-level \`docs/superpowers/followups.md\` tracker.