### PR TITLE
Fix Koin constructor cycle crashing app on launch

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryImpl.kt
@@ -30,16 +30,25 @@ private val logger = KotlinLogging.logger {}
  * `AuthSessionStore` — Settings calls into it for the cross-system seams
  * (set/clear server URL must update auth state).
  *
+ * `authSession` is injected as `Lazy<AuthSession>` to break the
+ * construction-time cycle: `SettingsRepositoryImpl` → `AuthSession` →
+ * `AuthSessionStore(serverConfig)` → `ServerConfig` → `SettingsRepositoryImpl`.
+ * `authSession` is only dereferenced inside suspend methods, never at
+ * construction or in `init`, so the lazy wrapper is safe.
+ *
  * All sensitive values are stored via `SecureStorage` (encrypted at rest).
  */
 class SettingsRepositoryImpl(
     private val secureStorage: SecureStorage,
-    private val authSession: AuthSession,
+    authSession: Lazy<AuthSession>,
 ) : com.calypsan.listenup.client.domain.repository.ServerConfig,
     com.calypsan.listenup.client.domain.repository.LibrarySync,
     com.calypsan.listenup.client.domain.repository.LibraryPreferences,
     com.calypsan.listenup.client.domain.repository.PlaybackPreferences,
     com.calypsan.listenup.client.domain.repository.LocalPreferences {
+    // Deferred to first suspend-method use; never read at construction time.
+    private val authSession by authSession
+
     // Buffer of 1 ensures emit() doesn't suspend when no collectors are active.
     // This is appropriate for preference sync since we don't want settings changes
     // to block waiting for the sync layer.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/AuthModule.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/AuthModule.kt
@@ -51,9 +51,10 @@ val clientAuthModule: Module
             // Token storage + AuthState derivation. AuthSessionStore depends on
             // ServerConfig (to read the URL during state derivation); the settings
             // impl in `dataModule` depends back on AuthSession (set-URL/disconnect
-            // updates auth state). The cycle is real and resolved by Koin's lazy
-            // single mechanism — see the comments at the SettingsRepositoryImpl
-            // binding in Koin.kt.
+            // updates auth state). The cycle is broken by injecting AuthSession as
+            // Lazy<AuthSession> in the SettingsRepositoryImpl constructor, so the
+            // AuthSession reference is deferred until first suspend-method use.
+            // See the SettingsRepositoryImpl binding comment in Koin.kt.
             singleOf(::AuthSessionStore) bind AuthSession::class
 
             // kotlinx.rpc proxies for AuthServicePublic + AuthServiceAuthed.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -93,6 +93,7 @@ import com.calypsan.listenup.client.domain.repository.ActiveSessionRepository
 import com.calypsan.listenup.client.domain.repository.ActivityRepository
 import com.calypsan.listenup.client.domain.repository.AdminRepository
 import com.calypsan.listenup.client.domain.repository.AuthRepository
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ContributorEditRepository
@@ -212,16 +213,21 @@ val dataModule =
         single { ShortcutActionManager() }
 
         // AuthSession (tokens + AuthState flow) is provided by clientAuthModule.
-        // SettingsRepositoryImpl below depends on AuthSession; the cycle is resolved
-        // by Koin's lazy single mechanism.
+        // SettingsRepositoryImpl depends on AuthSession, but AuthSessionStore (the
+        // AuthSession impl) depends on ServerConfig, which resolves back to
+        // SettingsRepositoryImpl — a construction-time cycle. The cycle is broken by
+        // injecting AuthSession as Lazy<AuthSession>: the lambda body runs only on
+        // first suspend-method use, by which time SettingsRepositoryImpl is fully
+        // constructed and registered in the Koin graph.
 
         // Settings repository — everything *non-auth*: server-URL plumbing, library identity,
         // library + playback preferences, device-local UI preferences. Emits preference change
         // events for PreferencesSyncObserver (in syncModule) to consume without circular deps.
         single {
+            val scope = this
             SettingsRepositoryImpl(
                 secureStorage = get(),
-                authSession = get(),
+                authSession = lazy { scope.get<AuthSession>() },
             )
         }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryTest.kt
@@ -39,7 +39,7 @@ class SettingsRepositoryTest {
     private fun createRepository(
         storage: SecureStorage = createMockStorage(),
         authSession: AuthSession = createMockAuthSession(),
-    ): SettingsRepositoryImpl = SettingsRepositoryImpl(storage, authSession)
+    ): SettingsRepositoryImpl = SettingsRepositoryImpl(storage, lazyOf(authSession))
 
     @Test
     fun `setServerUrl persists the URL and triggers offline derive when already authenticated`() =

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/di/SettingsAuthCycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/di/SettingsAuthCycleTest.kt
@@ -1,0 +1,114 @@
+package com.calypsan.listenup.client.di
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.SecureStorage
+import com.calypsan.listenup.client.data.repository.AuthSessionStore
+import com.calypsan.listenup.client.data.repository.SettingsRepositoryImpl
+import com.calypsan.listenup.client.domain.model.Instance
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.domain.repository.VerifiedServer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldNotBe
+import org.koin.core.context.stopKoin
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+/**
+ * Regression test for the SettingsRepositoryImpl ↔ AuthSession Koin constructor cycle.
+ *
+ * Without the fix the graph resolves:
+ *   SettingsRepositoryImpl(authSession=get()) → AuthSessionStore(serverConfig=get())
+ *   → single<ServerConfig> { get<SettingsRepositoryImpl>() } → SettingsRepositoryImpl
+ *   → ... → StackOverflowError
+ *
+ * [module.verify()] cannot catch this because it never instantiates — it only
+ * checks that declarations exist. This test resolves the real instances, which
+ * WILL StackOverflow before the fix and succeed after it.
+ */
+class SettingsAuthCycleTest :
+    FunSpec({
+
+        afterEach { stopKoin() }
+
+        test("resolving ServerConfig does not StackOverflow — SettingsRepositoryImpl lazy AuthSession cycle") {
+            // Minimal in-memory fakes for leaf externals.
+            val fakeStorage = InMemorySecureStorage()
+            val fakeInstanceRepository = NoOpInstanceRepository()
+
+            val testModule =
+                module {
+                    // Leaf externals
+                    single<SecureStorage> { fakeStorage }
+                    single<InstanceRepository> { fakeInstanceRepository }
+
+                    // Real bindings that form the cycle — copied verbatim from the fixed
+                    // dataModule / clientAuthModule bindings. The lazy wrapper defers
+                    // AuthSession resolution until first suspend-method use, breaking the
+                    // SettingsRepositoryImpl → AuthSession → ServerConfig → SettingsRepositoryImpl
+                    // construction-time cycle.
+                    single {
+                        val scope = this
+                        SettingsRepositoryImpl(
+                            secureStorage = get(),
+                            authSession = lazy { scope.get<AuthSession>() },
+                        )
+                    }
+                    single<ServerConfig> { get<SettingsRepositoryImpl>() }
+
+                    singleOf(::AuthSessionStore) bind AuthSession::class
+                }
+
+            val koin = koinApplication { modules(testModule) }.koin
+
+            // This is the line that stack-overflows without the fix.
+            val serverConfig = koin.get<ServerConfig>()
+            serverConfig shouldNotBe null
+        }
+    })
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+private class InMemorySecureStorage : SecureStorage {
+    private val store = mutableMapOf<String, String>()
+
+    override suspend fun save(
+        key: String,
+        value: String,
+    ) {
+        store[key] = value
+    }
+
+    override suspend fun read(key: String): String? = store[key]
+
+    override suspend fun delete(key: String) {
+        store.remove(key)
+    }
+
+    override suspend fun clear() {
+        store.clear()
+    }
+}
+
+private class NoOpInstanceRepository : InstanceRepository {
+    override suspend fun findReachableUrl(urls: List<String>): String? = null
+
+    override suspend fun getInstance(forceRefresh: Boolean): AppResult<Instance> =
+        AppResult.Failure(
+            com.calypsan.listenup.api.error.TransportError.NetworkUnavailable(
+                debugInfo = "NoOpInstanceRepository",
+            ),
+        )
+
+    override suspend fun verifyServer(baseUrl: String): AppResult<VerifiedServer> =
+        AppResult.Failure(
+            com.calypsan.listenup.api.error.TransportError.NetworkUnavailable(
+                debugInfo = "NoOpInstanceRepository",
+            ),
+        )
+}


### PR DESCRIPTION
## Summary

The Android app crash-loops on launch with `java.lang.StackOverflowError` in `ListenUp.onCreate`. Root cause is a **circular Koin constructor dependency**:

- `SettingsRepositoryImpl` constructor takes `authSession: AuthSession`
- `AuthSessionStore` (the `AuthSession` impl) constructor takes `serverConfig: ServerConfig`
- `ServerConfig` is bound as `single<ServerConfig> { get<SettingsRepositoryImpl>() }`

Both are `single` with eager `get()` injection, so Koin recurses forever building the graph.

`AuthModule.kt` and the `dataModule` comment both claimed "the cycle is resolved by Koin's lazy single mechanism" — that claim was false; no such mechanism breaks a constructor cycle.

**Why CI missed it:** the CI gate runs `assembleDebug` (compiles, never launches). Koin `module.verify()` only checks declarations exist — it never instantiates, so it cannot catch a constructor cycle.

## Fix

`SettingsRepositoryImpl` dereferences `authSession` only inside suspend methods, never at construction — so inject it as `Lazy<AuthSession>`. The `dataModule` binding passes `lazy { get<AuthSession>() }`; the lazy is forced on first suspend-method call, by which time `SettingsRepositoryImpl` is fully constructed and registered. The two false comments are corrected.

Adds `SettingsAuthCycleTest` — a regression test that **actually instantiates** the Koin graph and resolves `ServerConfig` (which `module.verify()` cannot do). It StackOverflows before the fix, passes after.

## Scope note

This fixes the **first** of (at least) two independent pre-existing startup crashes. A second — `WorkManager is not initialized properly`, a DI-ordering bug in `ListenUp.onCreate` where `WorkManager.getInstance()` is resolved before `WorkManager.initialize()` runs — was masked by this StackOverflow and surfaces once it is fixed. That one is tracked separately; **this PR alone does not make the app fully launchable.**

## Test plan

- [x] `./gradlew :shared:jvmTest :server:test spotlessCheck detekt :androidApp:assembleDebug`
- [x] New `SettingsAuthCycleTest` fails with `StackOverflowError` before the fix, passes after
- [x] Verified on an API 37 emulator: the StackOverflow is gone (app now progresses past Koin graph construction to the separate WorkManager bug)
