### PR TITLE
Fix WorkManager init-ordering crash on app launch

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactoryLazyTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactoryLazyTest.kt
@@ -1,0 +1,51 @@
+package com.calypsan.listenup.client.download
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+/**
+ * Verifies that constructing [ListenUpWorkerFactory] does not force any of its
+ * [Lazy] dependencies.
+ *
+ * This pins the fix for the WorkManager init-ordering crash: before the fix,
+ * constructing the factory at DI-resolution time would eagerly resolve
+ * DownloadRepository → DownloadEnqueuer → WorkManager.getInstance(), which threw
+ * because WorkManager.initialize() had not yet been called.  After the fix, all
+ * nine dependencies are [Lazy]; none is accessed until [WorkerFactory.createWorker]
+ * runs at job-dispatch time.
+ */
+class ListenUpWorkerFactoryLazyTest {
+    /**
+     * Each dep is a [Lazy] whose [Lazy.value] throws.  If constructing the factory
+     * forces any dep, this test fails with that error.  If all deps are truly lazy,
+     * construction succeeds and [assertNotNull] confirms we got a valid instance.
+     */
+    @Test
+    fun `constructing ListenUpWorkerFactory does not force any dependency`() {
+        val factory =
+            ListenUpWorkerFactory(
+                downloadRepository = lazy { error("downloadRepository forced at construction") },
+                fileManager = lazy { error("fileManager forced at construction") },
+                apiClientFactory = lazy { error("apiClientFactory forced at construction") },
+                playbackPreferences = lazy { error("playbackPreferences forced at construction") },
+                playbackApi = lazy { error("playbackApi forced at construction") },
+                capabilityDetector = lazy { error("capabilityDetector forced at construction") },
+                backupApi = lazy { error("backupApi forced at construction") },
+                absImportApi = lazy { error("absImportApi forced at construction") },
+                errorBus = lazy { error("errorBus forced at construction") },
+            )
+        // If we reach here, no dep was forced — the factory was safely constructed.
+        assertNotNull(factory)
+    }
+
+    /**
+     * Sanity-check that the lazy sentinels above actually do throw when accessed,
+     * so we know a regression would not silently pass.
+     */
+    @Test
+    fun `lazy sentinel throws when its value is accessed`() {
+        val sentinel: Lazy<Unit> = lazy { error("sentinel forced") }
+        assertFailsWith<IllegalStateException> { sentinel.value }
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
@@ -142,7 +142,7 @@ private class FakeAuthSession : AuthSession {
         email: String,
     ) = Unit
 
-    override suspend fun getPendingRegistration(): Pair<String, String>? = null
+    override suspend fun getPendingRegistration(): com.calypsan.listenup.client.domain.repository.PendingRegistration? = null
 
     override suspend fun clearPendingRegistration() = Unit
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -263,18 +263,20 @@ class ListenUp :
         }
 
         // Configure WorkManager with custom factory for dependency injection.
-        // Must be done before verifyCriticalKoinBindings() because DownloadManager needs WorkManager.
+        // Dependencies are wrapped in lazy { get() } so constructing the factory does not
+        // resolve DownloadRepository → DownloadEnqueuer → WorkManager.getInstance() before
+        // WorkManager.initialize() is called below.
         val workerFactory =
             ListenUpWorkerFactory(
-                downloadRepository = get(),
-                fileManager = get(),
-                apiClientFactory = get(),
-                playbackPreferences = get(),
-                playbackApi = get(),
-                capabilityDetector = get(),
-                backupApi = get(),
-                absImportApi = get(),
-                errorBus = get(),
+                downloadRepository = lazy { get() },
+                fileManager = lazy { get() },
+                apiClientFactory = lazy { get() },
+                playbackPreferences = lazy { get() },
+                playbackApi = lazy { get() },
+                capabilityDetector = lazy { get() },
+                backupApi = lazy { get() },
+                absImportApi = lazy { get() },
+                errorBus = lazy { get() },
             )
 
         val workManagerConfig =

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
@@ -18,22 +18,26 @@ import kotlinx.coroutines.runBlocking
 /**
  * WorkerFactory for injecting dependencies into all ListenUp workers.
  *
+ * All dependencies are [Lazy] so that constructing the factory does not resolve the
+ * download/WorkManager graph. Resolution is deferred until [createWorker] is called at
+ * job-dispatch time — long after [WorkManager.initialize] has run during app startup.
+ *
  * Handles creation of:
  * - [DownloadWorker] — offline audiobook downloads
  * - [ABSUploadWorker] — Audiobookshelf backup upload and import
  */
 class ListenUpWorkerFactory(
-    private val downloadRepository: DownloadRepository,
-    private val fileManager: DownloadFileManager,
+    private val downloadRepository: Lazy<DownloadRepository>,
+    private val fileManager: Lazy<DownloadFileManager>,
     // Deferred to worker-creation time so getClient() is never called before onboarding
     // completes (i.e. before serverConfig.getActiveUrl() returns non-null).
-    private val apiClientFactory: ApiClientFactory,
-    private val playbackPreferences: PlaybackPreferences,
-    private val playbackApi: PlaybackApiContract,
-    private val capabilityDetector: AudioCapabilityDetector,
-    private val backupApi: BackupApiContract,
-    private val absImportApi: ABSImportApiContract,
-    private val errorBus: ErrorBus,
+    private val apiClientFactory: Lazy<ApiClientFactory>,
+    private val playbackPreferences: Lazy<PlaybackPreferences>,
+    private val playbackApi: Lazy<PlaybackApiContract>,
+    private val capabilityDetector: Lazy<AudioCapabilityDetector>,
+    private val backupApi: Lazy<BackupApiContract>,
+    private val absImportApi: Lazy<ABSImportApiContract>,
+    private val errorBus: Lazy<ErrorBus>,
 ) : WorkerFactory() {
     override fun createWorker(
         appContext: Context,
@@ -45,17 +49,17 @@ class ListenUpWorkerFactory(
                 // WorkerFactory.createWorker is non-suspending; runBlocking is required.
                 // By the time WorkManager dispatches a download, onboarding has completed
                 // and serverConfig.getActiveUrl() is non-null — no cold-start crash risk.
-                val httpClient = runBlocking { apiClientFactory.getClient() }
+                val httpClient = runBlocking { apiClientFactory.value.getClient() }
                 DownloadWorker(
                     appContext,
                     workerParameters,
-                    downloadRepository,
-                    fileManager,
+                    downloadRepository.value,
+                    fileManager.value,
                     httpClient,
-                    playbackPreferences,
-                    playbackApi,
-                    capabilityDetector,
-                    errorBus,
+                    playbackPreferences.value,
+                    playbackApi.value,
+                    capabilityDetector.value,
+                    errorBus.value,
                 )
             }
 
@@ -63,8 +67,8 @@ class ListenUpWorkerFactory(
                 ABSUploadWorker(
                     appContext,
                     workerParameters,
-                    backupApi,
-                    absImportApi,
+                    backupApi.value,
+                    absImportApi.value,
                 )
             }
 


### PR DESCRIPTION
## Summary

Second of the two pre-existing Android startup crashes (the first is #291). The app fails to launch with:

```
java.lang.IllegalStateException: WorkManager is not initialized properly. You have explicitly
disabled WorkManagerInitializer in your manifest, have not manually called WorkManager#initialize
at this point, and your Application does not implement Configuration.Provider.
```

**Root cause — DI ordering in `ListenUp.onCreate()`:** the method constructs `ListenUpWorkerFactory(downloadRepository = get(), ...)` *before* it calls `WorkManager.initialize()`. That `get()` resolves `DownloadRepository → DownloadEnqueuer → AndroidDownloadEnqueuer(workManager = WorkManager.getInstance(...))` — and `WorkManager.getInstance()` throws because `initialize()` hasn't run yet. Chicken-and-egg: the `WorkManager.Configuration` needs the worker factory → the factory needs `DownloadRepository` → `DownloadRepository` needs `WorkManager`.

This was masked by the Koin StackOverflow in #291 — it surfaces only once that crash is fixed.

## Fix

`ListenUpWorkerFactory` uses all 9 of its dependencies only inside `createWorker()` (job-dispatch time), never at construction. So inject them lazily: the 9 constructor params become `Lazy<T>`, dereferenced with `.value` in `createWorker()`. The `onCreate()` call site passes `lazy { get() }`. Constructing the factory no longer resolves the download graph, so `WorkManager.initialize()` runs before any `WorkManager.getInstance()` call. Same `Lazy<T>` pattern as #291.

`onCreate()` ordering after the fix: `startKoin` → build factory (no deps forced) → build `Configuration` → `WorkManager.initialize()` → `verifyCriticalKoinBindings()` (resolves only ServerConfig/AuthSession/SyncEngine/ProgressTracker/PlaybackManager — none touch `downloadModule`). The first `downloadModule` resolution now happens at `createWorker()` time, long after init.

Adds `ListenUpWorkerFactoryLazyTest` — pins the invariant that constructing the factory forces none of its dependencies (uses `kotlin.test`, consistent with the `androidHostTest` source set, which has no Kotest dependency).

Also fixes a one-line pre-existing compile error in `AndroidAudioTokenProviderTest.kt` (`getPendingRegistration()` return type was the stale `Pair<String, String>?`; the `AuthSession` interface now returns `PendingRegistration?`) — `androidHostTest` did not compile on `origin/main` without it, which blocked adding the new test.

## Verification

Built with **both** this fix and #291's fix applied, installed on an API 37 emulator: the app launches clean, renders its UI, and reaches the server-discovery screen (the system local-network picker appears). Both startup crashes are gone.

## Test plan

- [x] `./gradlew :shared:jvmTest :server:test spotlessCheck detekt :androidApp:assembleDebug`
- [x] `:composeApp:testAndroidHostTest` — new `ListenUpWorkerFactoryLazyTest` passes
- [x] Manual: app launches clean on API 37 emulator (with #291 also applied)

## Merge note

Independent of #291 — different files, no conflict. #291 should merge first (or either order); the app only fully launches once **both** are on `main`.
