### PR TITLE
Android App Quality — Checkpoint B: accessibility

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbarSemanticsTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbarSemanticsTest.kt
@@ -1,0 +1,109 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies that [AlphabetScrollbar] exposes the accessibility semantics required for
+ * TalkBack users to perceive the fast-scroll control.
+ *
+ * Two properties are asserted:
+ *  - `ContentDescription` — identifies the widget to screen readers as "Alphabet scrollbar".
+ *  - `StateDescription` — reflects the focused letter when one is active during touch
+ *    (e.g. "Letter A"), and is absent at rest.
+ *
+ * JUnit4 + Robolectric (consistent with [WavySeekBarTest]).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class AlphabetScrollbarSemanticsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val testAlphabetIndex =
+        AlphabetIndex(
+            letters = listOf('A', 'B', 'C'),
+            letterToIndex = mapOf('A' to 0, 'B' to 1, 'C' to 2),
+        )
+
+    @Test
+    fun `AlphabetScrollbar exposes contentDescription identifying it as alphabet scrollbar`() {
+        composeRule.setContent {
+            Box(Modifier.fillMaxSize()) {
+                AlphabetScrollbar(
+                    alphabetIndex = testAlphabetIndex,
+                    onLetterSelected = {},
+                    isScrolling = true,
+                    modifier = Modifier.testTag(TEST_TAG),
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .assert(
+                SemanticsMatcher("has contentDescription 'Alphabet scrollbar'") { node ->
+                    val descriptions = node.config.getOrNull(SemanticsProperties.ContentDescription)
+                    descriptions != null && descriptions.any { it == "Alphabet scrollbar" }
+                },
+            )
+    }
+
+    @Test
+    fun `AlphabetScrollbar stateDescription names active letter when one is focused`() {
+        composeRule.setContent {
+            Box(Modifier.fillMaxSize()) {
+                AlphabetScrollbar(
+                    alphabetIndex = testAlphabetIndex,
+                    onLetterSelected = {},
+                    isScrolling = true,
+                    modifier = Modifier.testTag(TEST_TAG),
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+
+        // Press and hold to activate letter selection (do not release — that clears selectedLetter)
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .performTouchInput { down(center) }
+
+        composeRule.waitForIdle()
+
+        // With a letter now selected, stateDescription should name it
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .assert(
+                SemanticsMatcher("stateDescription names a letter while touch is held") { node ->
+                    val description = node.config.getOrNull(SemanticsProperties.StateDescription)
+                    description != null && description.startsWith("Letter ")
+                },
+            )
+
+        // Release the touch to restore state
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .performTouchInput { up() }
+    }
+
+    private companion object {
+        const val TEST_TAG = "alphabet_scrollbar_test"
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/WavySeekBarTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/nowplaying/WavySeekBarTest.kt
@@ -1,0 +1,143 @@
+package com.calypsan.listenup.client.features.nowplaying
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.math.abs
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that [WavySeekBar] exposes the accessibility semantics required for
+ * TalkBack users to perceive and operate the scrubber.
+ *
+ * A seekbar in Compose Accessibility is signalled by two properties working
+ * together (there is no Role.Slider in Compose UI 1.11):
+ *
+ *  - `ProgressBarRangeInfo` — exposes the current position within the range;
+ *    TalkBack reads this aloud and uses it to derive the seekbar widget class.
+ *  - `SemanticsActions.SetProgress` — lets TalkBack move the thumb and fire the
+ *    `onSeek` callback.
+ *  - `StateDescription` — surfaces a human-readable position string.
+ *
+ * JUnit4 + Robolectric (consistent with [PhaseABoundarySuiteTest]).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class WavySeekBarTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `WavySeekBar exposes ProgressBarRangeInfo matching supplied progress`() {
+        val progress = 0.4f
+
+        composeRule.setContent {
+            WavySeekBar(
+                progress = progress,
+                onSeek = {},
+                modifier = Modifier.testTag(TEST_TAG),
+            )
+        }
+
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .assert(
+                SemanticsMatcher("ProgressBarRangeInfo.current ≈ $progress") { node ->
+                    val info: ProgressBarRangeInfo? =
+                        node.config.getOrNull(SemanticsProperties.ProgressBarRangeInfo)
+                    info != null && abs(info.current - progress) < 0.001f
+                },
+            )
+    }
+
+    @Test
+    fun `WavySeekBar has SetProgress action`() {
+        composeRule.setContent {
+            WavySeekBar(
+                progress = 0.3f,
+                onSeek = {},
+                modifier = Modifier.testTag(TEST_TAG),
+            )
+        }
+
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .assert(
+                SemanticsMatcher("has SetProgress action") { node ->
+                    node.config.getOrNull(SemanticsActions.SetProgress) != null
+                },
+            )
+    }
+
+    @Test
+    fun `WavySeekBar SetProgress action fires onSeek with target value`() {
+        var receivedValue = Float.NaN
+
+        composeRule.setContent {
+            WavySeekBar(
+                progress = 0.2f,
+                onSeek = { receivedValue = it },
+                modifier = Modifier.testTag(TEST_TAG),
+            )
+        }
+
+        val targetValue = 0.75f
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
+                assertTrue(
+                    setProgress(targetValue),
+                    "SetProgress action did not report success",
+                )
+            }
+
+        assertTrue(!receivedValue.isNaN(), "onSeek was not called after SetProgress action")
+        assertEquals(
+            targetValue,
+            receivedValue,
+            absoluteTolerance = 0.001f,
+            message = "SetProgress delivered wrong value to onSeek",
+        )
+    }
+
+    @Test
+    fun `WavySeekBar state description reflects supplied description`() {
+        val description = "3:30 of 42:00"
+
+        composeRule.setContent {
+            WavySeekBar(
+                progress = 0.1f,
+                onSeek = {},
+                stateDescription = description,
+                modifier = Modifier.testTag(TEST_TAG),
+            )
+        }
+
+        composeRule
+            .onNodeWithTag(TEST_TAG)
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    description,
+                ),
+            )
+    }
+
+    private companion object {
+        const val TEST_TAG = "wavy_seek_bar_test"
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
@@ -1154,6 +1154,7 @@ private fun ChapterSeekBar(
             onSeek = onSeek,
             modifier = Modifier.fillMaxWidth(),
             isPlaying = isPlaying,
+            stateDescription = "${currentTime.formatPlaybackTime()} of ${totalTime.formatPlaybackTime()}",
         )
 
         Row(

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbar.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -336,6 +337,10 @@ fun AlphabetScrollbar(
         Column(
             modifier =
                 Modifier
+                    // Enforce 48dp min-width so the touch target meets the a11y minimum
+                    // even on short letter lists. Visual appearance unchanged — the
+                    // letters are centred inside the wider clip area.
+                    .defaultMinSize(minWidth = 48.dp)
                     .clip(RoundedCornerShape(16.dp))
                     .background(
                         if (isInteracting) {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbar.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbar.kt
@@ -41,6 +41,9 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInParent
@@ -289,7 +292,12 @@ fun AlphabetScrollbar(
                 .fillMaxHeight()
                 .offset(x = slideOffset)
                 .alpha(alpha)
-                .onSizeChanged { size ->
+                .semantics {
+                    contentDescription = "Alphabet scrollbar"
+                    selectedLetter?.let { letter ->
+                        stateDescription = "Letter $letter"
+                    }
+                }.onSizeChanged { size ->
                     containerHeightPx = size.height.toFloat()
                 },
     ) {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ProfileAvatar.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ProfileAvatar.kt
@@ -16,13 +16,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import coil3.compose.LocalPlatformContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import com.calypsan.listenup.client.domain.repository.ImageStorage
@@ -57,7 +56,6 @@ import listenup.composeapp.generated.resources.common_displayname_avatar
  * @param avatarType Optional avatar type ("auto" or "image") - if provided, skips DAO lookup
  * @param avatarValue Optional avatar URL path for image avatars
  * @param size Size of the avatar circle
- * @param fontSize Font size for initials
  * @param modifier Optional modifier
  */
 @Composable
@@ -69,7 +67,6 @@ fun ProfileAvatar(
     avatarType: String? = null,
     avatarValue: String? = null,
     size: Dp = 36.dp,
-    fontSize: TextUnit = 14.sp,
 ) {
     val context = LocalPlatformContext.current
     val userProfileRepository: UserProfileRepository = koinInject()
@@ -146,10 +143,10 @@ fun ProfileAvatar(
         } else if (effectiveAvatarType == "image") {
             // Avatar type is image but file not yet downloaded - show placeholder
             // This handles the race condition where profile is updated before download completes
-            InitialsAvatar(initials = initials, color = color, size = size, fontSize = fontSize)
+            InitialsAvatar(initials = initials, color = color, size = size)
         } else {
             // Auto-generated avatar with initials
-            InitialsAvatar(initials = initials, color = color, size = size, fontSize = fontSize)
+            InitialsAvatar(initials = initials, color = color, size = size)
         }
     }
 }
@@ -175,15 +172,23 @@ private fun parseAvatarColor(hexColor: String): Color =
 
 /**
  * Simple initials avatar.
+ *
+ * Font size is derived from the physical circle size (dp → px → sp) so that it
+ * stays proportional to the circle at any user font-scale setting.  A raw `sp`
+ * value would scale with font scale and overflow the fixed-size circle at 200%.
  */
 @Composable
 private fun InitialsAvatar(
     initials: String,
     color: Color,
     size: Dp,
-    fontSize: TextUnit,
     modifier: Modifier = Modifier,
 ) {
+    // Derive font size from physical pixels so it stays inside the circle regardless
+    // of the user's font scale setting.  ~38% of the circle diameter is a good fit
+    // for two-character initials at all sizes.
+    val derivedFontSize = with(LocalDensity.current) { (size.toPx() * 0.38f).toSp() }
+
     Box(
         modifier =
             modifier
@@ -194,7 +199,7 @@ private fun InitialsAvatar(
         Text(
             text = initials,
             color = Color.White,
-            fontSize = fontSize,
+            fontSize = derivedFontSize,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
         )

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/WavySeekBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/WavySeekBar.kt
@@ -26,6 +26,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
@@ -47,6 +52,8 @@ import kotlin.math.roundToInt
  * @param enabled Whether seeking is enabled
  * @param color The color of the filled track (defaults to primary)
  * @param trackColor The color of the unfilled track (defaults to surfaceVariant)
+ * @param stateDescription Human-readable description of the current position for TalkBack,
+ *   e.g. "3:30 of 42:00". Provide this from the call site where Duration values are available.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -58,6 +65,7 @@ fun WavySeekBar(
     enabled: Boolean = true,
     color: Color = MaterialTheme.colorScheme.primary,
     trackColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    stateDescription: String = "",
 ) {
     val density = LocalDensity.current
 
@@ -80,7 +88,12 @@ fun WavySeekBar(
             modifier
                 .fillMaxWidth()
                 .height(48.dp) // Touch target height
-                .onSizeChanged { size ->
+                .seekBarSemantics(
+                    progress = progress,
+                    stateDescription = stateDescription,
+                    enabled = enabled,
+                    onSeek = onSeek,
+                ).onSizeChanged { size ->
                     trackWidth = size.width.toFloat()
                 }.pointerInput(enabled) {
                     if (!enabled) return@pointerInput
@@ -147,3 +160,34 @@ fun WavySeekBar(
         )
     }
 }
+
+/**
+ * Attaches screen-reader semantics to the seek bar:
+ * - [ProgressBarRangeInfo] exposes the current position; TalkBack uses this to announce
+ *   the widget class as a seekbar and read the current value aloud.
+ * - [stateDescription] surfaces the human-readable "3:30 of 42:00" string supplied by
+ *   the call site (which has Duration context).
+ * - [setProgress] lets TalkBack and Switch Access move the thumb programmatically.
+ */
+private fun Modifier.seekBarSemantics(
+    progress: Float,
+    stateDescription: String,
+    enabled: Boolean,
+    onSeek: (Float) -> Unit,
+): Modifier =
+    semantics {
+        progressBarRangeInfo =
+            ProgressBarRangeInfo(
+                current = progress.coerceIn(0f, 1f),
+                range = 0f..1f,
+            )
+        if (stateDescription.isNotEmpty()) {
+            this.stateDescription = stateDescription
+        }
+        if (enabled) {
+            setProgress(label = "Seek") { targetValue ->
+                onSeek(targetValue.coerceIn(0f, 1f))
+                true
+            }
+        }
+    }


### PR DESCRIPTION
## Summary

Checkpoint B of the **Android App Quality** phase — accessibility. For an audiobook app, screen-reader users are a core audience, and the headline fix here unblocks one.

- **`WavySeekBar` (the Now Playing scrubber) is now operable by screen readers.** It was an opaque custom composable — a blind user could not scrub their audiobook. It now exposes `ProgressBarRangeInfo`, a `SetProgress` accessibility action wired to the seek callback, and a human-readable `stateDescription` ("3:30 of 42:00"). (Compose has no `Role.Slider`; `ProgressBarRangeInfo` + `SetProgress` is the canonical slider-accessibility mechanism, the same one Compose's own `Slider` uses.)
- **`AlphabetScrollbar` exposes itself to screen readers** — a `contentDescription` identifying the control and a `stateDescription` naming the focused letter during interaction. It was previously an opaque `Box`.
- **`AlphabetScrollbar` touch target widened to the 48dp minimum** — the interactive strip was ~30–36dp; `defaultMinSize(minWidth = 48.dp)` fixes the touchable area with no visual change.
- **`ProfileAvatar` initials survive 200% font scale** — initials used a hardcoded `sp` size that overflowed the fixed circle at large font scales; the size is now derived from the circle's physical dimensions (font-scale-independent). The now-dead `fontSize` parameter was removed.

**Content-description audit:** independently verified — 96 `IconButton`s, zero with a missing description; all 199 `contentDescription = null` sites are genuinely decorative (icons beside text labels, placeholder images whose real siblings carry descriptions). The codebase already has solid content-description discipline; no fixes were needed there. One role-annotation nicety (`SyncIndicator` clickables lacking `Role.Button`) is logged as a followup.

New Compose-UI semantics tests (`WavySeekBarTest`, `AlphabetScrollbarSemanticsTest`) pin the slider/scrollbar accessibility.

Spec: `docs/superpowers/specs/2026-05-17-android-app-quality-phase-design.md` · findings: `docs/superpowers/findings/2026-05-17-android-a11y-verification.md`.

## Test plan

- [x] `./gradlew :shared:jvmTest :server:test spotlessCheck detekt :androidApp:assembleDebug :composeApp:testAndroidHostTest :composeApp:desktopTest` — green
- [x] Semantics tests: `WavySeekBar` (range info, SetProgress action, stateDescription) and `AlphabetScrollbar` (contentDescription, focused-letter stateDescription)
- [ ] Manual (pending populated-server / interactive-emulator pass): TalkBack walk-through of Now Playing + Library; full 200%-font-scale walk of content screens; dynamic-cover text-contrast check on real covers (`AuroraBackground` code-assessed AA-safe — ≤18% alpha over Material 3 surface tokens)
