### PR TITLE
composeApp/androidApp followup cleanup — 7 tracked items

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -81,16 +81,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
-            // Use the release signing config when available (CI), otherwise fall back to
-            // debug signing so the nonMinifiedRelease variant (used for Baseline Profile
-            // generation) can be packaged locally without a keystore.
-            val releaseSigningConfig = signingConfigs.getByName("release")
-            signingConfig =
-                if (releaseSigningConfig.storeFile != null) {
-                    releaseSigningConfig
-                } else {
-                    signingConfigs.getByName("debug")
-                }
+            // Always require the real release signing config. If KEYSTORE_FILE is not set the
+            // storeFile is null and AGP will fail loud during packaging — which is the correct
+            // behaviour for a production release build.
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 
@@ -106,6 +100,22 @@ android {
         htmlReport = true
         xmlReport = true
         sarifReport = true
+    }
+}
+
+// The Baseline Profile plugin generates an APK for the nonMinifiedRelease and benchmarkRelease
+// variants. These variants derive from "release" so they inherit the release signingConfig, but
+// they only run locally — there is no CI keystore available for them. Reassign those two variants
+// to the debug signing config so local profile generation works keyless, while the shippable
+// "release" variant (above) keeps the real config and fails loud if the keystore is absent.
+@Suppress("UnstableApiUsage")
+androidComponents {
+    val debugConfig = android.signingConfigs.getByName("debug")
+    onVariants(selector().withBuildType("nonMinifiedRelease")) { variant ->
+        variant.signingConfig?.setConfig(debugConfig)
+    }
+    onVariants(selector().withBuildType("benchmarkRelease")) { variant ->
+        variant.signingConfig?.setConfig(debugConfig)
     }
 }
 

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/foldable/PostureProviderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/foldable/PostureProviderTest.kt
@@ -1,0 +1,64 @@
+package com.calypsan.listenup.client.foldable
+
+import androidx.window.layout.FoldingFeature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [classifyPosture].
+ *
+ * [classifyPosture] is pure — it accepts already-extracted [FoldingFeature.State] and
+ * [FoldingFeature.Orientation] values (public constants) and returns a [Posture]. No Android
+ * framework or Robolectric is needed; the test runs on the JVM directly as a plain Kotest spec.
+ *
+ * The `null`-input branches cover the case where no [FoldingFeature] is present in the display
+ * features list — [posture] passes `null, null` in that case, so [classifyPosture] must handle
+ * it gracefully and return [Posture.NORMAL].
+ */
+class PostureProviderTest :
+    FunSpec({
+        // ── HALF_OPENED variants ──────────────────────────────────────────────
+
+        test("HALF_OPENED + HORIZONTAL yields TABLETOP") {
+            classifyPosture(
+                FoldingFeature.State.HALF_OPENED,
+                FoldingFeature.Orientation.HORIZONTAL,
+            ) shouldBe Posture.TABLETOP
+        }
+
+        test("HALF_OPENED + VERTICAL yields BOOK") {
+            classifyPosture(
+                FoldingFeature.State.HALF_OPENED,
+                FoldingFeature.Orientation.VERTICAL,
+            ) shouldBe Posture.BOOK
+        }
+
+        test("HALF_OPENED + null orientation yields NORMAL") {
+            classifyPosture(
+                FoldingFeature.State.HALF_OPENED,
+                orientation = null,
+            ) shouldBe Posture.NORMAL
+        }
+
+        // ── FLAT variants ─────────────────────────────────────────────────────
+
+        test("FLAT + HORIZONTAL yields NORMAL") {
+            classifyPosture(
+                FoldingFeature.State.FLAT,
+                FoldingFeature.Orientation.HORIZONTAL,
+            ) shouldBe Posture.NORMAL
+        }
+
+        test("FLAT + VERTICAL yields NORMAL") {
+            classifyPosture(
+                FoldingFeature.State.FLAT,
+                FoldingFeature.Orientation.VERTICAL,
+            ) shouldBe Posture.NORMAL
+        }
+
+        // ── No folding feature present ────────────────────────────────────────
+
+        test("null state yields NORMAL (no folding feature present)") {
+            classifyPosture(state = null, orientation = null) shouldBe Posture.NORMAL
+        }
+    })

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -102,13 +102,13 @@ class PlaybackErrorHandlerTest {
     @Test
     fun `classify returns Network for ERROR_CODE_IO_NETWORK_CONNECTION_FAILED`() {
         val error = PlaybackException("net", null, PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED)
-        assertIs<PlaybackErrorHandler.PlaybackError.Network>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Network>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns Network for ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT`() {
         val error = PlaybackException("timeout", null, PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT)
-        assertIs<PlaybackErrorHandler.PlaybackError.Network>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Network>(makeHandler().classify(error))
     }
 
     // ── classify — HTTP status codes ─────────────────────────────────────────
@@ -116,37 +116,37 @@ class PlaybackErrorHandlerTest {
     @Test
     fun `classify returns AuthExpired for HTTP 401`() {
         val error = makeHttpStatusException(401)
-        assertIs<PlaybackErrorHandler.PlaybackError.AuthExpired>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.AuthExpired>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns AuthExpired for HTTP 403`() {
         val error = makeHttpStatusException(403)
-        assertIs<PlaybackErrorHandler.PlaybackError.AuthExpired>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.AuthExpired>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns NotFound for HTTP 404`() {
         val error = makeHttpStatusException(404)
-        assertIs<PlaybackErrorHandler.PlaybackError.NotFound>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.NotFound>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns Network for HTTP 500`() {
         val error = makeHttpStatusException(500)
-        assertIs<PlaybackErrorHandler.PlaybackError.Network>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Network>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns Network for HTTP 599`() {
         val error = makeHttpStatusException(599)
-        assertIs<PlaybackErrorHandler.PlaybackError.Network>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Network>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns Unknown for HTTP 400 (unclassified)`() {
         val error = makeHttpStatusException(400)
-        assertIs<PlaybackErrorHandler.PlaybackError.Unknown>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Unknown>(makeHandler().classify(error))
     }
 
     /**
@@ -161,7 +161,7 @@ class PlaybackErrorHandlerTest {
                 RuntimeException("wrong cause type"),
                 PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
             )
-        assertIs<PlaybackErrorHandler.PlaybackError.Unknown>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Unknown>(makeHandler().classify(error))
     }
 
     /**
@@ -170,7 +170,7 @@ class PlaybackErrorHandlerTest {
     @Test
     fun `classify does not crash when cause is null for IO_BAD_HTTP_STATUS`() {
         val error = PlaybackException("bad http null cause", null, PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS)
-        assertIs<PlaybackErrorHandler.PlaybackError.Unknown>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Unknown>(makeHandler().classify(error))
     }
 
     // ── classify — Codec ──────────────────────────────────────────────────────
@@ -178,19 +178,19 @@ class PlaybackErrorHandlerTest {
     @Test
     fun `classify returns Codec for ERROR_CODE_DECODER_INIT_FAILED`() {
         val error = PlaybackException("decoder init", null, PlaybackException.ERROR_CODE_DECODER_INIT_FAILED)
-        assertIs<PlaybackErrorHandler.PlaybackError.Codec>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Codec>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns Codec for ERROR_CODE_DECODING_FAILED`() {
         val error = PlaybackException("decoding", null, PlaybackException.ERROR_CODE_DECODING_FAILED)
-        assertIs<PlaybackErrorHandler.PlaybackError.Codec>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Codec>(makeHandler().classify(error))
     }
 
     @Test
     fun `classify returns Codec for ERROR_CODE_AUDIO_TRACK_INIT_FAILED`() {
         val error = PlaybackException("audio track", null, PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED)
-        assertIs<PlaybackErrorHandler.PlaybackError.Codec>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Codec>(makeHandler().classify(error))
     }
 
     // ── classify — Stuck ──────────────────────────────────────────────────────
@@ -198,7 +198,7 @@ class PlaybackErrorHandlerTest {
     @Test
     fun `classify returns Stuck for ERROR_CODE_TIMEOUT`() {
         val error = PlaybackException("timeout", null, PlaybackException.ERROR_CODE_TIMEOUT)
-        assertIs<PlaybackErrorHandler.PlaybackError.Stuck>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Stuck>(makeHandler().classify(error))
     }
 
     // ── classify — Unknown ────────────────────────────────────────────────────
@@ -206,7 +206,7 @@ class PlaybackErrorHandlerTest {
     @Test
     fun `classify returns Unknown for unrecognised error code`() {
         val error = PlaybackException("other", null, PlaybackException.ERROR_CODE_UNSPECIFIED)
-        assertIs<PlaybackErrorHandler.PlaybackError.Unknown>(makeHandler().classify(error))
+        assertIs<PlaybackErrorHandler.ClassifiedError.Unknown>(makeHandler().classify(error))
     }
 
     // ── handle — Network ──────────────────────────────────────────────────────
@@ -220,7 +220,7 @@ class PlaybackErrorHandlerTest {
 
             val result =
                 makeHandler(tracker = tracker).handle(
-                    error = PlaybackErrorHandler.PlaybackError.Network("net"),
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
                     player = player,
                     currentBookId = BookId("book1"),
                     onShowError = { errors += it },
@@ -239,7 +239,7 @@ class PlaybackErrorHandlerTest {
             val tracker = FakeProgressTracker()
 
             makeHandler(tracker = tracker).handle(
-                error = PlaybackErrorHandler.PlaybackError.Network("net"),
+                error = PlaybackErrorHandler.ClassifiedError.Network("net"),
                 player = FakeExoPlayer(),
                 currentBookId = null,
                 onShowError = {},
@@ -259,7 +259,7 @@ class PlaybackErrorHandlerTest {
 
             val result =
                 makeHandler(tracker = tracker).handle(
-                    error = PlaybackErrorHandler.PlaybackError.NotFound("404"),
+                    error = PlaybackErrorHandler.ClassifiedError.NotFound("404"),
                     player = player,
                     currentBookId = BookId("book2"),
                     onShowError = { errors += it },
@@ -283,7 +283,7 @@ class PlaybackErrorHandlerTest {
 
             val result =
                 makeHandler().handle(
-                    error = PlaybackErrorHandler.PlaybackError.Codec("codec"),
+                    error = PlaybackErrorHandler.ClassifiedError.Codec("codec"),
                     player = player,
                     currentBookId = null,
                     onShowError = { errors += it },
@@ -305,7 +305,7 @@ class PlaybackErrorHandlerTest {
 
             val result =
                 makeHandler(tracker = tracker).handle(
-                    error = PlaybackErrorHandler.PlaybackError.Stuck("stuck"),
+                    error = PlaybackErrorHandler.ClassifiedError.Stuck("stuck"),
                     player = player,
                     currentBookId = BookId("book3"),
                     onShowError = { errors += it },
@@ -328,7 +328,7 @@ class PlaybackErrorHandlerTest {
             val player = FakeExoPlayer(stubbedPosition = 0L, stubbedMediaItemIndex = 0)
 
             makeHandler().handle(
-                error = PlaybackErrorHandler.PlaybackError.Stuck("stuck at zero"),
+                error = PlaybackErrorHandler.ClassifiedError.Stuck("stuck at zero"),
                 player = player,
                 currentBookId = null,
                 onShowError = {},
@@ -348,7 +348,7 @@ class PlaybackErrorHandlerTest {
 
             val result =
                 makeHandler(tracker = tracker).handle(
-                    error = PlaybackErrorHandler.PlaybackError.Unknown(RuntimeException("unexpected")),
+                    error = PlaybackErrorHandler.ClassifiedError.Unknown(RuntimeException("unexpected")),
                     player = player,
                     currentBookId = BookId("book4"),
                     onShowError = { errors += it },
@@ -368,12 +368,12 @@ class PlaybackErrorHandlerTest {
         val handler = makeHandler()
         val messages =
             listOf(
-                handler.getErrorMessage(PlaybackErrorHandler.PlaybackError.Network("n")),
-                handler.getErrorMessage(PlaybackErrorHandler.PlaybackError.AuthExpired("a")),
-                handler.getErrorMessage(PlaybackErrorHandler.PlaybackError.NotFound("nf")),
-                handler.getErrorMessage(PlaybackErrorHandler.PlaybackError.Codec("c")),
-                handler.getErrorMessage(PlaybackErrorHandler.PlaybackError.Stuck("s")),
-                handler.getErrorMessage(PlaybackErrorHandler.PlaybackError.Unknown(RuntimeException())),
+                handler.getErrorMessage(PlaybackErrorHandler.ClassifiedError.Network("n")),
+                handler.getErrorMessage(PlaybackErrorHandler.ClassifiedError.AuthExpired("a")),
+                handler.getErrorMessage(PlaybackErrorHandler.ClassifiedError.NotFound("nf")),
+                handler.getErrorMessage(PlaybackErrorHandler.ClassifiedError.Codec("c")),
+                handler.getErrorMessage(PlaybackErrorHandler.ClassifiedError.Stuck("s")),
+                handler.getErrorMessage(PlaybackErrorHandler.ClassifiedError.Unknown(RuntimeException())),
             )
 
         assertTrue(messages.all { it.isNotBlank() }, "All messages must be non-blank")

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -71,6 +71,33 @@ private val logger = KotlinLogging.logger {}
 /** Maximum number of historical exit records to inspect for memory-related causes. */
 private const val HISTORICAL_EXIT_LIMIT = 5
 
+/** Maps [ApplicationExitInfo.REASON_*] codes to human-readable names for log output. */
+@RequiresApi(Build.VERSION_CODES.R)
+private val exitReasonNames: Map<Int, String> =
+    mapOf(
+        ApplicationExitInfo.REASON_UNKNOWN to "UNKNOWN",
+        ApplicationExitInfo.REASON_EXIT_SELF to "EXIT_SELF",
+        ApplicationExitInfo.REASON_SIGNALED to "SIGNALED",
+        ApplicationExitInfo.REASON_LOW_MEMORY to "LOW_MEMORY",
+        ApplicationExitInfo.REASON_CRASH to "CRASH",
+        ApplicationExitInfo.REASON_CRASH_NATIVE to "CRASH_NATIVE",
+        ApplicationExitInfo.REASON_ANR to "ANR",
+        ApplicationExitInfo.REASON_INITIALIZATION_FAILURE to "INITIALIZATION_FAILURE",
+        ApplicationExitInfo.REASON_PERMISSION_CHANGE to "PERMISSION_CHANGE",
+        ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE to "EXCESSIVE_RESOURCE_USAGE",
+        ApplicationExitInfo.REASON_USER_REQUESTED to "USER_REQUESTED",
+        ApplicationExitInfo.REASON_USER_STOPPED to "USER_STOPPED",
+        ApplicationExitInfo.REASON_DEPENDENCY_DIED to "DEPENDENCY_DIED",
+        ApplicationExitInfo.REASON_OTHER to "OTHER",
+        ApplicationExitInfo.REASON_FREEZER to "FREEZER",
+        ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE to "PACKAGE_STATE_CHANGE",
+        ApplicationExitInfo.REASON_PACKAGE_UPDATED to "PACKAGE_UPDATED",
+    )
+
+/** Returns a readable name for [code] in the form `NAME(int)`, e.g. `LOW_MEMORY(3)`. */
+@RequiresApi(Build.VERSION_CODES.R)
+private fun exitReasonName(code: Int): String = "${exitReasonNames[code] ?: "UNKNOWN"}($code)"
+
 /**
  * Runs each named resolver and throws [IllegalStateException] on the first failure.
  *
@@ -419,7 +446,7 @@ class ListenUp :
                         description?.contains("memory", ignoreCase = true) == true
                 if (isMemoryRelated) {
                     logger.info {
-                        "Historical exit: reason=${record.reason} description=$description " +
+                        "Historical exit: reason=${exitReasonName(record.reason)} description=$description " +
                             "pss=${record.pss}kB rss=${record.rss}kB"
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
@@ -149,7 +149,13 @@ fun NowPlayingScreen(
 ) {
     // Predictive back: track gesture progress to animate dismissal (scale + alpha)
     val backProgress = remember { Animatable(0f) }
-    PlatformPredictiveBackHandler(enabled = true) { progressFlow ->
+    // Gate the handler until the screen has fully entered composition. The composable is
+    // reachable during the AnimatedVisibility enter-transition, so enabling immediately would
+    // let a back gesture fire before the screen is presented, creating a jarring mid-slide
+    // dismiss. Flipping `presented` on the first composition frame is the lightest safe guard.
+    var presented by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { presented = true }
+    PlatformPredictiveBackHandler(enabled = presented) { progressFlow ->
         try {
             progressFlow.collect { progress -> backProgress.snapTo(progress) }
             onCollapse()

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingScreen.kt
@@ -222,6 +222,13 @@ fun NowPlayingScreen(
 
     val dragOffset = remember { Animatable(0f) }
 
+    // When a predictive-back gesture begins, immediately clear any in-flight drag offset so the
+    // two transforms (translationY from drag + scale/alpha from back) never compound. snapTo is
+    // intentional — an animated clear would itself compound with the back animation.
+    LaunchedEffect(backProgress.value != 0f) {
+        if (backProgress.value != 0f && dragOffset.value != 0f) dragOffset.snapTo(0f)
+    }
+
     Surface(
         modifier =
             modifier

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/foldable/PostureProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/foldable/PostureProvider.kt
@@ -42,11 +42,27 @@ fun PostureProvider(content: @Composable () -> Unit) {
 }
 
 private fun posture(features: List<DisplayFeature>): Posture {
-    val folding =
-        features.filterIsInstance<FoldingFeature>().firstOrNull()
-            ?: return Posture.NORMAL
-    if (folding.state != FoldingFeature.State.HALF_OPENED) return Posture.NORMAL
-    return when (folding.orientation) {
+    val folding = features.filterIsInstance<FoldingFeature>().firstOrNull()
+    return classifyPosture(folding?.state, folding?.orientation)
+}
+
+/**
+ * Pure mapping from extracted [FoldingFeature] properties to a [Posture] value.
+ *
+ * Visible for testing — callers outside the `foldable` package should use [LocalPosture]
+ * rather than this helper directly.
+ *
+ * Rules:
+ * - [FoldingFeature.State.HALF_OPENED] + [FoldingFeature.Orientation.HORIZONTAL] → [Posture.TABLETOP]
+ * - [FoldingFeature.State.HALF_OPENED] + [FoldingFeature.Orientation.VERTICAL] → [Posture.BOOK]
+ * - Any other combination, or `null` inputs (no folding feature present) → [Posture.NORMAL]
+ */
+internal fun classifyPosture(
+    state: FoldingFeature.State?,
+    orientation: FoldingFeature.Orientation?,
+): Posture {
+    if (state != FoldingFeature.State.HALF_OPENED) return Posture.NORMAL
+    return when (orientation) {
         FoldingFeature.Orientation.HORIZONTAL -> Posture.TABLETOP
         FoldingFeature.Orientation.VERTICAL -> Posture.BOOK
         else -> Posture.NORMAL

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandler.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandler.kt
@@ -28,48 +28,48 @@ class PlaybackErrorHandler(
     /**
      * Classifies errors into actionable categories.
      */
-    sealed class PlaybackError {
+    sealed class ClassifiedError {
         // Retryable - ExoPlayer handles internally, we just wait
         data class Network(
             val message: String,
-        ) : PlaybackError()
+        ) : ClassifiedError()
 
         // Retryable once - refresh token, retry request
         data class AuthExpired(
             val message: String,
-        ) : PlaybackError()
+        ) : ClassifiedError()
 
         // Not retryable - user action required
         data class NotFound(
             val message: String,
-        ) : PlaybackError()
+        ) : ClassifiedError()
 
         data class Codec(
             val message: String,
-        ) : PlaybackError()
+        ) : ClassifiedError()
 
         // Stuck player - Media3 1.9.0 detects when playback is stuck
         // Triggers after 10 min buffering, 10s ready with no progress, etc.
         data class Stuck(
             val message: String,
-        ) : PlaybackError()
+        ) : ClassifiedError()
 
         data class Unknown(
             val cause: Throwable,
-        ) : PlaybackError()
+        ) : ClassifiedError()
     }
 
     /**
      * Maps ExoPlayer exceptions to our error types.
      */
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-    fun classify(error: PlaybackException): PlaybackError =
+    fun classify(error: PlaybackException): ClassifiedError =
         when (error.errorCode) {
             // Network errors - ExoPlayer will retry, we just observe
             PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
             PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
             -> {
-                PlaybackError.Network("Network connection lost")
+                ClassifiedError.Network("Network connection lost")
             }
 
             // HTTP errors - check status code
@@ -78,11 +78,11 @@ class PlaybackErrorHandler(
                 val statusCode = (cause as? HttpDataSource.InvalidResponseCodeException)?.responseCode
 
                 when (statusCode) {
-                    401 -> PlaybackError.AuthExpired("Session expired")
-                    403 -> PlaybackError.AuthExpired("Access denied")
-                    404 -> PlaybackError.NotFound("Audio file not found")
-                    in 500..599 -> PlaybackError.Network("Server error, retrying...")
-                    else -> PlaybackError.Unknown(error)
+                    401 -> ClassifiedError.AuthExpired("Session expired")
+                    403 -> ClassifiedError.AuthExpired("Access denied")
+                    404 -> ClassifiedError.NotFound("Audio file not found")
+                    in 500..599 -> ClassifiedError.Network("Server error, retrying...")
+                    else -> ClassifiedError.Unknown(error)
                 }
             }
 
@@ -91,17 +91,17 @@ class PlaybackErrorHandler(
             PlaybackException.ERROR_CODE_DECODING_FAILED,
             PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED,
             -> {
-                PlaybackError.Codec("Cannot play this audio format")
+                ClassifiedError.Codec("Cannot play this audio format")
             }
 
             // Stuck player detection (Media3 1.9.0)
             // Fires after 10 min buffering, 10s ready with no progress, etc.
             PlaybackException.ERROR_CODE_TIMEOUT -> {
-                PlaybackError.Stuck("Playback appears to be stuck")
+                ClassifiedError.Stuck("Playback appears to be stuck")
             }
 
             else -> {
-                PlaybackError.Unknown(error)
+                ClassifiedError.Unknown(error)
             }
         }
 
@@ -111,7 +111,7 @@ class PlaybackErrorHandler(
      */
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     suspend fun handle(
-        error: PlaybackError,
+        error: ClassifiedError,
         player: ExoPlayer,
         currentBookId: BookId?,
         onShowError: (String) -> Unit,
@@ -123,14 +123,14 @@ class PlaybackErrorHandler(
         }
 
         return when (error) {
-            is PlaybackError.Network -> {
+            is ClassifiedError.Network -> {
                 // ExoPlayer handles retry internally
                 // Just log and let it buffer
                 logger.info { "Network error, ExoPlayer buffering: ${error.message}" }
                 true // Continue, ExoPlayer is handling it
             }
 
-            is PlaybackError.AuthExpired -> {
+            is ClassifiedError.AuthExpired -> {
                 logger.warn { "Auth expired during playback" }
 
                 // Try token refresh
@@ -152,21 +152,21 @@ class PlaybackErrorHandler(
                 }
             }
 
-            is PlaybackError.NotFound -> {
+            is ClassifiedError.NotFound -> {
                 logger.error { "Audio file not found: ${error.message}" }
                 onShowError("This audio file is no longer available.")
                 player.pause()
                 false
             }
 
-            is PlaybackError.Codec -> {
+            is ClassifiedError.Codec -> {
                 logger.error { "Codec error: ${error.message}" }
                 onShowError("Cannot play this audio file. Format may be unsupported.")
                 player.pause()
                 false
             }
 
-            is PlaybackError.Stuck -> {
+            is ClassifiedError.Stuck -> {
                 // Media3 1.9.0 stuck player detection
                 // Player was buffering or ready but not making progress
                 logger.warn { "Stuck player detected: ${error.message}" }
@@ -189,7 +189,7 @@ class PlaybackErrorHandler(
                 true // Continue, we're attempting recovery
             }
 
-            is PlaybackError.Unknown -> {
+            is ClassifiedError.Unknown -> {
                 logger.error(error.cause) { "Unknown playback error" }
                 onShowError("Playback error. Please try again.")
                 player.pause()
@@ -201,13 +201,13 @@ class PlaybackErrorHandler(
     /**
      * Get a user-friendly message for an error.
      */
-    fun getErrorMessage(error: PlaybackError): String =
+    fun getErrorMessage(error: ClassifiedError): String =
         when (error) {
-            is PlaybackError.Network -> "Connection lost. Retrying..."
-            is PlaybackError.AuthExpired -> "Session expired. Please sign in."
-            is PlaybackError.NotFound -> "File not available."
-            is PlaybackError.Codec -> "Cannot play this format."
-            is PlaybackError.Stuck -> "Playback stuck. Retrying..."
-            is PlaybackError.Unknown -> "Playback error."
+            is ClassifiedError.Network -> "Connection lost. Retrying..."
+            is ClassifiedError.AuthExpired -> "Session expired. Please sign in."
+            is ClassifiedError.NotFound -> "File not available."
+            is ClassifiedError.Codec -> "Cannot play this format."
+            is ClassifiedError.Stuck -> "Playback stuck. Retrying..."
+            is ClassifiedError.Unknown -> "Playback error."
         }
 }

--- a/composeApp/src/androidMain/res/values/colors.xml
+++ b/composeApp/src/androidMain/res/values/colors.xml
@@ -2,4 +2,6 @@
 <resources>
     <!-- Splash screen background — matches the light theme surface (#FFFBFF) for a seamless cold-start transition -->
     <color name="splash_background">#FFFBFF</color>
+    <!-- Splash icon background disc — ListenUp brand orange, consistent in light and dark modes -->
+    <color name="splash_icon_background">#F05A3B</color>
 </resources>

--- a/composeApp/src/androidMain/res/values/themes.xml
+++ b/composeApp/src/androidMain/res/values/themes.xml
@@ -6,7 +6,8 @@
 
     <style name="Theme.ListenUp.SplashScreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
-        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_monochrome</item>
+        <item name="windowSplashScreenIconBackgroundColor">@color/splash_icon_background</item>
         <item name="windowSplashScreenAnimationDuration">300</item>
         <item name="postSplashScreenTheme">@style/Theme.ListenUp</item>
     </style>

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/components/AppTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/components/AppTopBar.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicatorSmall
@@ -44,6 +45,7 @@ import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.common_search
 import listenup.composeapp.generated.resources.shell_close_search
 import listenup.composeapp.generated.resources.shell_search_audiobooks
+import listenup.composeapp.generated.resources.shell_sync_details_action
 import listenup.composeapp.generated.resources.shell_sync_error
 import org.jetbrains.compose.resources.stringResource
 
@@ -254,8 +256,11 @@ private fun SyncIndicator(
                 ListenUpLoadingIndicatorSmall(
                     modifier =
                         Modifier
-                            .clickable(onClick = onClick)
-                            .padding(end = 4.dp),
+                            .clickable(
+                                onClickLabel = stringResource(Res.string.shell_sync_details_action),
+                                role = Role.Button,
+                                onClick = onClick,
+                            ).padding(end = 4.dp),
                 )
             }
 
@@ -266,8 +271,11 @@ private fun SyncIndicator(
                     tint = MaterialTheme.colorScheme.error,
                     modifier =
                         Modifier
-                            .clickable(onClick = onClick)
-                            .padding(end = 4.dp),
+                            .clickable(
+                                onClickLabel = stringResource(Res.string.shell_sync_details_action),
+                                role = Role.Button,
+                                onClick = onClick,
+                            ).padding(end = 4.dp),
                 )
             }
 

--- a/shared/src/commonMain/resources/strings/en.json
+++ b/shared/src/commonMain/resources/strings/en.json
@@ -386,6 +386,7 @@
     "pendingcount_pending": "%1$s pending",
     "retry_all": "Retry all",
     "search_audiobooks": "Search audiobooks...",
+    "sync_details_action": "Show sync details",
     "sync_error": "Sync error",
     "sync_status": "Sync Status",
     "syncing": "Syncing...",


### PR DESCRIPTION
## Summary

Clears the accumulated `composeApp` / `androidApp` followup backlog — seven small, independent items, none entangled with the in-flight Books-A work. Each is a tracked entry from `docs/superpowers/followups.md`.

**Build / diagnostics**
- **Scoped the release-signing debug fallback** — a keyless `assembleRelease` previously *silently* produced a debug-signed APK. The shippable `release` variant now uses the real release signing config and fails loud when no keystore is present; the debug fallback is scoped (via the AGP variant API) to only the Baseline-Profile generation variants (`nonMinifiedRelease`/`benchmarkRelease`), which still package keyless.
- **Readable exit reasons** — `logHistoricalMemoryExits` logged `ApplicationExitInfo.reason` as a bare int; now mapped to names (`reason=LOW_MEMORY(3)`), mirroring `JobReasonLogger`.

**Now Playing gestures**
- **Predictive-back gated until presented** — `PlatformPredictiveBackHandler` was hardcoded `enabled = true`, firing during the screen's enter animation; now gated on a presented/settled flag.
- **Drag + predictive-back no longer compound** — `dragOffset` is cleared (`snapTo(0f)`) when a predictive-back gesture starts, so the drag-to-dismiss and back transforms can't briefly stack in the shared `graphicsLayer`.

**Accessibility / clarity**
- **`SyncIndicator` announced as a button** — its clickable status indicator now carries `Role.Button` + an `onClickLabel` so TalkBack announces it correctly.
- **`PlaybackErrorHandler.PlaybackError` → `ClassifiedError`** — pure rename; the handler's internal classification model no longer name-collides with the wire-borne `api.error.PlaybackError`.

**Tests**
- **`FoldingFeature` → `Posture` mapping covered** — the mapping was extracted to a pure `internal classifyPosture(state, orientation)` helper and covered with a 6-branch Kotest test (it was the `foldable` package's only untested logic).

**Splash screen** (user-directed)
- The splash now uses the existing monochrome icon (`ic_launcher_monochrome`) on a brand-orange disc (`windowSplashScreenIconBackgroundColor` = `#F05A3B`, the `ListenUpOrange` brand color) — the Material You splash shape, instead of the heavier full adaptive launcher icon.

One note: the `SyncIndicator` `onClickLabel` required a single new string key in `shared/.../strings/en.json` — unavoidable for a resource-backed label (the file's convention). It is a one-key additive change; no other `:shared` file is touched.

## Test plan

- [x] `./gradlew :shared:jvmTest :server:test spotlessCheck detekt :androidApp:assembleDebug :composeApp:testAndroidHostTest :composeApp:desktopTest` — green
- [x] New `PostureProviderTest` (Kotest, 6 branches)
- [x] `PlaybackErrorHandlerTest` still green after the rename
- [ ] Manual (pending): visual check of the new splash icon/colour on an emulator
