### PR TITLE
♻️ refactor(shared): extract PlaybackPreparer from PlaybackManagerImpl

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncCursor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncCursor.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.api.sync
 
+import kotlin.jvm.JvmInline
 import kotlinx.serialization.Serializable
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -8,24 +8,15 @@
 
 package com.calypsan.listenup.client.playback
 
-import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
-import com.calypsan.listenup.client.core.Failure
-import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
-import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ChapterDao
 import com.calypsan.listenup.client.data.remote.PlaybackApiContract
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
-import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
-import com.calypsan.listenup.client.data.remote.model.toEntity
-import com.calypsan.listenup.client.domain.model.AudioFile
 import com.calypsan.listenup.client.domain.model.Chapter
-import com.calypsan.listenup.client.domain.model.ContributorRole
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
-import com.calypsan.listenup.client.domain.playback.StreamPrepareResult
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -66,6 +57,25 @@ class PlaybackManagerImpl(
     private val scope: CoroutineScope,
     private val bookRepository: BookRepository,
 ) : PlaybackManager {
+    private val preparer =
+        PlaybackPreparer(
+            serverConfig = serverConfig,
+            playbackPreferences = playbackPreferences,
+            bookDao = bookDao,
+            audioFileDao = audioFileDao,
+            chapterDao = chapterDao,
+            imageStorage = imageStorage,
+            progressTracker = progressTracker,
+            tokenProvider = tokenProvider,
+            deviceContext = deviceContext,
+            downloadService = downloadService,
+            playbackApi = playbackApi,
+            capabilityDetector = capabilityDetector,
+            syncApi = syncApi,
+            scope = scope,
+            bookRepository = bookRepository,
+        )
+
     private val _currentBookId = MutableStateFlow<BookId?>(null)
     override val currentBookId: StateFlow<BookId?> = _currentBookId
 
@@ -136,201 +146,22 @@ class PlaybackManagerImpl(
      * @return PrepareResult with timeline and resume position, or null on failure
      */
     override suspend fun prepareForPlayback(bookId: BookId): PlaybackManager.PrepareResult? {
-        logger.info { "Preparing playback for book: ${bookId.value}" }
+        val prepared = preparer.prepare(bookId) { _prepareProgress.value = it } ?: return null
 
-        // 1. Ensure fresh auth token
-        tokenProvider.prepareForPlayback()
-
-        // 2. Get server URL
-        val serverUrl = serverConfig.getServerUrl()?.value
-        if (serverUrl == null) {
-            logger.error { "No server URL configured" }
-            return null
-        }
-
-        // 3. Get book with contributors from database
-        val bookWithContributors = bookDao.getByIdWithContributors(bookId)
-        if (bookWithContributors == null) {
-            logger.error { "Book not found: ${bookId.value}" }
-            return null
-        }
-        val book = bookWithContributors.book
-
-        // Extract author names (use creditedAs when available for proper attribution)
-        val contributorsById = bookWithContributors.contributors.associateBy { it.id }
-        val authorNames =
-            bookWithContributors.contributorRoles
-                .filter { it.role == ContributorRole.AUTHOR.apiValue }
-                .mapNotNull { crossRef ->
-                    contributorsById[crossRef.contributorId]?.let { entity ->
-                        crossRef.creditedAs ?: entity.name
-                    }
-                }.distinct()
-        val bookAuthor = authorNames.joinToString(", ").ifEmpty { "Unknown Author" }
-
-        // Get series name (first series if multiple)
-        val seriesName = bookWithContributors.series.firstOrNull()?.name
-
-        // Get cover path (if exists on disk)
-        val coverPath =
-            if (imageStorage.exists(bookId)) {
-                imageStorage.getCoverPath(bookId)
-            } else {
-                null
-            }
-
-        // 4. Load audio files from the junction. Fallback-fetch if empty locally.
-        var audioFileEntities = audioFileDao.getForBook(bookId.value)
-        if (audioFileEntities.isEmpty()) {
-            logger.info { "No audio files for book: ${bookId.value}, fetching from server..." }
-
-            val fetched = fetchBookFromServer(bookId)
-            if (!fetched) {
-                logger.error { "Failed to fetch book from server: ${bookId.value}" }
-                return null
-            }
-            audioFileEntities = audioFileDao.getForBook(bookId.value)
-            if (audioFileEntities.isEmpty()) {
-                logger.error { "Audio files still empty after fallback fetch for ${bookId.value}" }
-                return null
-            }
-        }
-
-        val audioFiles: List<AudioFileResponse> = audioFileEntities.map { it.toAudioFileResponse() }
-
-        // Log detailed audio file info for diagnostics
-        logger.debug { "=== Audio Files for book ${bookId.value} ===" }
-        var totalDuration = 0L
-        audioFiles.forEachIndexed { index, file ->
-            logger.debug {
-                "  File[$index]: id=${file.id}, filename=${file.filename}, " +
-                    "duration=${file.duration}ms (${file.duration / 1000}s), " +
-                    "size=${file.size}, format=${file.format}"
-            }
-            // Check for problematic values
-            if (file.duration <= 0) {
-                logger.warn { "  ⚠️ WARNING: File[$index] has invalid duration: ${file.duration}" }
-            }
-            if (file.duration > 86_400_000) { // More than 24 hours - suspicious
-                logger.warn {
-                    "  ⚠️ WARNING: File[$index] has suspiciously large duration: " +
-                        "${file.duration}ms (${file.duration / 3_600_000}h)"
-                }
-            }
-            totalDuration += file.duration
-        }
-        logger.debug {
-            "=== Total calculated duration: ${totalDuration}ms (${totalDuration / 1000}s / ${totalDuration / 60000}min) ==="
-        }
-
-        // 5. Build PlaybackTimeline with codec negotiation (if available) or local path resolution
-        val domainAudioFiles = audioFileEntities.map { it.toDomain() }
-        val timeline =
-            if (playbackApi != null && capabilityDetector != null) {
-                // Use transcode-aware timeline building
-                val capabilities = capabilityDetector.getSupportedCodecs()
-                logger.debug { "Client codec capabilities: $capabilities" }
-
-                PlaybackTimeline.buildWithTranscodeSupport(
-                    bookId = bookId,
-                    audioFiles = domainAudioFiles,
-                    baseUrl = serverUrl,
-                    resolveLocalPath = { audioFileId -> downloadService.getLocalPath(audioFileId) },
-                    prepareStream = { audioFileId, codec ->
-                        prepareStreamForFile(bookId.value, audioFileId, codec, capabilities, serverUrl)
-                    },
-                )
-            } else {
-                // Fallback to basic local path resolution
-                PlaybackTimeline.buildWithLocalPaths(
-                    bookId = bookId,
-                    audioFiles = domainAudioFiles,
-                    baseUrl = serverUrl,
-                    resolveLocalPath = { audioFileId -> downloadService.getLocalPath(audioFileId) },
-                )
-            }
-        _currentTimeline.value = timeline
+        _currentTimeline.value = prepared.timeline
         // Note: currentBookId is set by caller after reachability checks pass
-        _totalDurationMs.value = timeline.totalDurationMs
-
-        // Load chapters for this book
-        loadChapters(bookId)
-
-        logger.info { "Built timeline: ${timeline.files.size} files, ${timeline.totalDurationMs}ms total" }
-
-        // 6. Get resume position and speed
-        val savedPosition = progressTracker.getResumePosition(bookId)
-
-        val resumePositionMs =
-            if (savedPosition?.isFinished == true) {
-                logger.info { "Book is finished - starting from beginning for re-read" }
-                0L
-            } else {
-                savedPosition?.positionMs ?: 0L
-            }
-
-        // Determine playback speed: use book's custom speed if set, otherwise use universal default
-        val resumeSpeed =
-            if (savedPosition != null && savedPosition.hasCustomSpeed) {
-                // Book has a custom speed set by user
-                savedPosition.playbackSpeed
-            } else {
-                // Use universal default speed (synced across devices)
-                playbackPreferences.getDefaultPlaybackSpeed()
-            }
-
-        logger.debug {
-            "Resume position: ${resumePositionMs}ms, speed: ${resumeSpeed}x (hasCustomSpeed=${savedPosition?.hasCustomSpeed})"
-        }
-
-        // Validate resume position
-        if (resumePositionMs < 0) {
-            logger.warn { "⚠️ WARNING: Negative resume position: $resumePositionMs" }
-        }
-        if (resumePositionMs > timeline.totalDurationMs) {
-            logger.warn {
-                "⚠️ WARNING: Resume position $resumePositionMs exceeds book duration ${timeline.totalDurationMs}"
-            }
-        }
-
-        // Test timeline.resolve() with resume position
-        val resolvedPosition = timeline.resolve(resumePositionMs)
-        logger.debug {
-            "Resolved resume position: " +
-                "mediaItemIndex=${resolvedPosition.mediaItemIndex}, " +
-                "positionInFileMs=${resolvedPosition.positionInFileMs}"
-        }
-
-        if (resolvedPosition.mediaItemIndex >= timeline.files.size) {
-            logger.warn {
-                "⚠️ WARNING: Invalid mediaItemIndex ${resolvedPosition.mediaItemIndex} >= ${timeline.files.size}"
-            }
-        }
-
-        // 7. Trigger background download if not fully downloaded
-        // Skip if user explicitly deleted - they chose to stream only
-        // Skip on devices that don't support downloads (TV, Auto) - stream only
-        // Result ignored intentionally - this is best-effort caching, user can still stream
-        if (!deviceContext.supportsDownloads) {
-            logger.info { "Device does not support downloads, streaming only" }
-        } else if (!timeline.isFullyDownloaded && !downloadService.wasExplicitlyDeleted(bookId)) {
-            logger.info { "Book not fully downloaded, triggering background download" }
-            scope.launch {
-                downloadService.downloadBook(bookId) // Result logged in DownloadManager
-            }
-        } else if (!timeline.isFullyDownloaded) {
-            logger.info { "Book was explicitly deleted, streaming only (no auto-download)" }
-        }
+        _totalDurationMs.value = prepared.timeline.totalDurationMs
+        _chapters.value = prepared.chapters
 
         return PlaybackManager.PrepareResult(
-            timeline = timeline,
-            bookTitle = book.title,
-            bookAuthor = bookAuthor,
-            seriesName = seriesName,
-            coverPath = coverPath,
-            totalChapters = _chapters.value.size,
-            resumePositionMs = resumePositionMs,
-            resumeSpeed = resumeSpeed,
+            timeline = prepared.timeline,
+            bookTitle = prepared.bookTitle,
+            bookAuthor = prepared.bookAuthor,
+            seriesName = prepared.seriesName,
+            coverPath = prepared.coverPath,
+            totalChapters = prepared.chapters.size,
+            resumePositionMs = prepared.resumePositionMs,
+            resumeSpeed = prepared.resumeSpeed,
         )
     }
 
@@ -635,174 +466,6 @@ class PlaybackManagerImpl(
     }
 
     /**
-     * Negotiate streaming URL for a single audio file.
-     *
-     * Calls the server's prepare endpoint to get the correct URL
-     * based on client capabilities. If transcoding is in progress,
-     * polls until ready or timeout, emitting progress updates.
-     */
-    private suspend fun prepareStreamForFile(
-        bookId: String,
-        audioFileId: String,
-        codec: String,
-        capabilities: List<String>,
-        baseUrl: String,
-    ): StreamPrepareResult {
-        val api = playbackApi ?: return fallbackStreamResult(bookId, audioFileId, baseUrl)
-
-        val maxRetries = 120 // ~10 minutes at 5 second intervals
-        val retryDelayMs = 5000L
-
-        // Get spatial audio setting from repository
-        val spatial = playbackPreferences.getSpatialPlayback()
-
-        repeat(maxRetries) { attempt ->
-            when (val result = api.preparePlayback(bookId, audioFileId, capabilities, spatial)) {
-                is Success -> {
-                    val response = result.data
-                    logger.debug {
-                        "Prepare result for $audioFileId (attempt ${attempt + 1}): " +
-                            "ready=${response.ready}, variant=${response.variant}, codec=${response.codec}"
-                    }
-
-                    if (response.ready) {
-                        // Clear progress when ready
-                        _prepareProgress.value = null
-                        return StreamPrepareResult(
-                            streamUrl = response.streamUrl,
-                            ready = true,
-                            transcodeJobId = response.transcodeJobId,
-                        )
-                    }
-
-                    // Transcoding in progress - emit progress and retry
-                    _prepareProgress.value =
-                        PlaybackManager.PrepareProgress(
-                            audioFileId = audioFileId,
-                            progress = response.progress,
-                            message = "Preparing audio... ${response.progress}%",
-                        )
-
-                    logger.info {
-                        "Transcoding in progress for $audioFileId: " +
-                            "jobId=${response.transcodeJobId}, progress=${response.progress}%, " +
-                            "waiting ${retryDelayMs}ms before retry..."
-                    }
-                    kotlinx.coroutines.delay(retryDelayMs)
-                }
-
-                is Failure -> {
-                    _prepareProgress.value = null
-                    logger.warn {
-                        "Failed to prepare stream for $audioFileId (attempt ${attempt + 1}), " +
-                            "using fallback URL"
-                    }
-                    return fallbackStreamResult(bookId, audioFileId, baseUrl)
-                }
-            }
-        }
-
-        // Timeout - return what we have (stream URL that may 202)
-        _prepareProgress.value = null
-        logger.warn { "Transcode polling timeout for $audioFileId after $maxRetries attempts" }
-        return fallbackStreamResult(bookId, audioFileId, baseUrl)
-    }
-
-    /**
-     * Fallback stream result when prepare endpoint fails.
-     */
-    private fun fallbackStreamResult(
-        bookId: String,
-        audioFileId: String,
-        baseUrl: String,
-    ): StreamPrepareResult =
-        StreamPrepareResult(
-            streamUrl = "$baseUrl/api/v1/books/$bookId/audio/$audioFileId",
-            ready = true,
-            transcodeJobId = null,
-        )
-
-    /**
-     * Fetch book data from server and persist locally.
-     *
-     * Used as a fallback when local book data is incomplete (e.g., book synced
-     * before audio files were indexed). Writes both the book entity AND its
-     * audio-file junction rows in a single atomically block, so a partial
-     * persistence failure doesn't leave the DB holding a book with stale or
-     * missing audio files.
-     *
-     * Internal visibility allows [PlaybackManagerFallbackFetchAtomicityTest] to
-     * invoke the method directly. Not part of the public API.
-     *
-     * @param bookId The book ID to fetch.
-     * @return true if the fetch + persist succeeded, false otherwise. Callers
-     *   re-query [audioFileDao] after a successful fetch to obtain the rows.
-     */
-    internal suspend fun fetchBookFromServer(bookId: BookId): Boolean {
-        val api = syncApi
-        if (api == null) {
-            logger.error { "SyncApi not available for fetching book" }
-            return false
-        }
-
-        return when (val result = api.getBook(bookId.value)) {
-            is Success -> {
-                val bookResponse = result.data
-                logger.info { "Fetched book from server: ${bookResponse.title}" }
-
-                val entity = bookResponse.toEntity()
-                val audioFileRows =
-                    bookResponse.audioFiles.mapIndexed { idx, af ->
-                        AudioFileEntity(
-                            bookId = bookId,
-                            index = idx,
-                            id = af.id,
-                            filename = af.filename,
-                            format = af.format,
-                            codec = af.codec,
-                            duration = af.duration,
-                            size = af.size,
-                        )
-                    }
-
-                when (val writeResult = bookRepository.upsertWithAudioFiles(entity, audioFileRows)) {
-                    is AppResult.Success -> {
-                        logger.debug { "Saved fetched book + ${audioFileRows.size} audio files to local database" }
-                        true
-                    }
-
-                    is AppResult.Failure -> {
-                        logger.error { "Failed to persist fetched book ${bookId.value}: ${writeResult.error.message}" }
-                        false
-                    }
-                }
-            }
-
-            is Failure -> {
-                logger.error { "Failed to fetch book from server: ${bookId.value}" }
-                false
-            }
-        }
-    }
-
-    /**
-     * Load chapters for a book.
-     */
-    private suspend fun loadChapters(bookId: BookId) {
-        val entities = chapterDao.getChaptersForBook(bookId)
-        _chapters.value =
-            entities.map { entity ->
-                Chapter(
-                    id = entity.id.value,
-                    title = entity.title,
-                    duration = entity.duration,
-                    startTime = entity.startTime,
-                )
-            }
-        logger.debug { "Loaded ${_chapters.value.size} chapters for book ${bookId.value}" }
-    }
-
-    /**
      * Update current chapter based on position.
      * Called from updatePosition() to track chapter changes.
      */
@@ -856,34 +519,3 @@ class PlaybackManagerImpl(
     }
 }
 
-// ========== Type Conversions ==========
-
-/**
- * Convert an [AudioFileEntity] to the domain [AudioFile], carrying the
- * [AudioFileEntity.index] ordering field so callers have an explicit play-order signal.
- */
-private fun AudioFileEntity.toDomain(): AudioFile =
-    AudioFile(
-        id = id,
-        index = index,
-        filename = filename,
-        format = format,
-        codec = codec,
-        duration = duration,
-        size = size,
-    )
-
-/**
- * Convert an [AudioFileEntity] to the API-shaped [AudioFileResponse] that
- * the diagnostic logging path consumes. The domain mapping path now goes
- * directly via [toDomain], which carries the [AudioFileEntity.index] field.
- */
-private fun AudioFileEntity.toAudioFileResponse(): AudioFileResponse =
-    AudioFileResponse(
-        id = id,
-        filename = filename,
-        format = format,
-        codec = codec,
-        duration = duration,
-        size = size,
-    )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -518,4 +518,3 @@ class PlaybackManagerImpl(
             normalized.matches(Regex("""^\d+$"""))
     }
 }
-

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -194,7 +194,12 @@ class PlaybackPreparer(
                     resolveLocalPath = { audioFileId -> downloadService.getLocalPath(audioFileId) },
                     prepareStream = { audioFileId, codec ->
                         prepareStreamForFile(
-                            bookId.value, audioFileId, codec, capabilities, serverUrl, onPrepareProgress,
+                            bookId.value,
+                            audioFileId,
+                            codec,
+                            capabilities,
+                            serverUrl,
+                            onPrepareProgress,
                         )
                     },
                 )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -1,0 +1,464 @@
+@file:Suppress(
+    "MagicNumber",
+    "LongMethod",
+    "LongParameterList",
+    "CyclomaticComplexMethod",
+    "CognitiveComplexMethod",
+)
+
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Failure
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.data.local.db.ChapterDao
+import com.calypsan.listenup.client.data.remote.PlaybackApiContract
+import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
+import com.calypsan.listenup.client.data.remote.model.toEntity
+import com.calypsan.listenup.client.device.DeviceContext
+import com.calypsan.listenup.client.domain.model.AudioFile
+import com.calypsan.listenup.client.domain.model.Chapter
+import com.calypsan.listenup.client.domain.model.ContributorRole
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.domain.playback.StreamPrepareResult
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.download.DownloadService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Everything a player needs to begin playback of a book, as an immutable value.
+ *
+ * Unlike [PlaybackManager.PrepareResult] this also carries the resolved
+ * [chapters] list, so callers that do not hold a [PlaybackManager] — the iOS
+ * native player — get chapters without issuing a second query.
+ */
+data class PreparedPlayback(
+    val timeline: PlaybackTimeline,
+    val chapters: List<Chapter>,
+    val bookTitle: String,
+    val bookAuthor: String,
+    val seriesName: String?,
+    val coverPath: String?,
+    val resumePositionMs: Long,
+    val resumeSpeed: Float,
+)
+
+/**
+ * Stateless playback-preparation pipeline: turns a [BookId] into a
+ * [PreparedPlayback] value (auth token refresh, book + audio-file load with
+ * server fallback, timeline build, chapter load, resume-position resolution).
+ *
+ * Holds no mutable playback state. [PlaybackManagerImpl] constructs one
+ * internally and delegates [PlaybackManager.prepareForPlayback] to it; the iOS
+ * native player calls [prepare] directly via Koin.
+ */
+class PlaybackPreparer(
+    private val serverConfig: ServerConfig,
+    private val playbackPreferences: PlaybackPreferences,
+    private val bookDao: BookDao,
+    private val audioFileDao: AudioFileDao,
+    private val chapterDao: ChapterDao,
+    private val imageStorage: ImageStorage,
+    private val progressTracker: ProgressTracker,
+    private val tokenProvider: AudioTokenProvider,
+    private val deviceContext: DeviceContext,
+    private val downloadService: DownloadService,
+    private val playbackApi: PlaybackApiContract?,
+    private val capabilityDetector: AudioCapabilityDetector?,
+    private val syncApi: SyncApiContract?,
+    private val scope: CoroutineScope,
+    private val bookRepository: BookRepository,
+) {
+    /**
+     * Prepare playback for [bookId].
+     *
+     * @param onPrepareProgress invoked with transcode progress during the
+     *   (Android/Desktop-only) transcode-aware timeline build, and with `null`
+     *   when progress is cleared. iOS passes the no-op default.
+     * @return a [PreparedPlayback] value, or `null` on any failure (logged).
+     */
+    suspend fun prepare(
+        bookId: BookId,
+        onPrepareProgress: (PlaybackManager.PrepareProgress?) -> Unit = {},
+    ): PreparedPlayback? {
+        logger.info { "Preparing playback for book: ${bookId.value}" }
+
+        // 1. Ensure fresh auth token
+        tokenProvider.prepareForPlayback()
+
+        // 2. Get server URL
+        val serverUrl = serverConfig.getServerUrl()?.value
+        if (serverUrl == null) {
+            logger.error { "No server URL configured" }
+            return null
+        }
+
+        // 3. Get book with contributors from database
+        val bookWithContributors = bookDao.getByIdWithContributors(bookId)
+        if (bookWithContributors == null) {
+            logger.error { "Book not found: ${bookId.value}" }
+            return null
+        }
+        val book = bookWithContributors.book
+
+        // Extract author names (use creditedAs when available for proper attribution)
+        val contributorsById = bookWithContributors.contributors.associateBy { it.id }
+        val authorNames =
+            bookWithContributors.contributorRoles
+                .filter { it.role == ContributorRole.AUTHOR.apiValue }
+                .mapNotNull { crossRef ->
+                    contributorsById[crossRef.contributorId]?.let { entity ->
+                        crossRef.creditedAs ?: entity.name
+                    }
+                }.distinct()
+        val bookAuthor = authorNames.joinToString(", ").ifEmpty { "Unknown Author" }
+
+        // Get series name (first series if multiple)
+        val seriesName = bookWithContributors.series.firstOrNull()?.name
+
+        // Get cover path (if exists on disk)
+        val coverPath =
+            if (imageStorage.exists(bookId)) {
+                imageStorage.getCoverPath(bookId)
+            } else {
+                null
+            }
+
+        // 4. Load audio files from the junction. Fallback-fetch if empty locally.
+        var audioFileEntities = audioFileDao.getForBook(bookId.value)
+        if (audioFileEntities.isEmpty()) {
+            logger.info { "No audio files for book: ${bookId.value}, fetching from server..." }
+
+            val fetched = fetchBookFromServer(bookId)
+            if (!fetched) {
+                logger.error { "Failed to fetch book from server: ${bookId.value}" }
+                return null
+            }
+            audioFileEntities = audioFileDao.getForBook(bookId.value)
+            if (audioFileEntities.isEmpty()) {
+                logger.error { "Audio files still empty after fallback fetch for ${bookId.value}" }
+                return null
+            }
+        }
+
+        val audioFiles: List<AudioFileResponse> = audioFileEntities.map { it.toAudioFileResponse() }
+
+        // Log detailed audio file info for diagnostics
+        logger.debug { "=== Audio Files for book ${bookId.value} ===" }
+        var totalDuration = 0L
+        audioFiles.forEachIndexed { index, file ->
+            logger.debug {
+                "  File[$index]: id=${file.id}, filename=${file.filename}, " +
+                    "duration=${file.duration}ms (${file.duration / 1000}s), " +
+                    "size=${file.size}, format=${file.format}"
+            }
+            if (file.duration <= 0) {
+                logger.warn { "  ⚠️ WARNING: File[$index] has invalid duration: ${file.duration}" }
+            }
+            if (file.duration > 86_400_000) {
+                logger.warn {
+                    "  ⚠️ WARNING: File[$index] has suspiciously large duration: " +
+                        "${file.duration}ms (${file.duration / 3_600_000}h)"
+                }
+            }
+            totalDuration += file.duration
+        }
+        logger.debug {
+            "=== Total calculated duration: ${totalDuration}ms (${totalDuration / 1000}s / ${totalDuration / 60000}min) ==="
+        }
+
+        // 5. Build PlaybackTimeline with codec negotiation (if available) or local path resolution
+        val domainAudioFiles = audioFileEntities.map { it.toDomain() }
+        val timeline =
+            if (playbackApi != null && capabilityDetector != null) {
+                val capabilities = capabilityDetector.getSupportedCodecs()
+                logger.debug { "Client codec capabilities: $capabilities" }
+
+                PlaybackTimeline.buildWithTranscodeSupport(
+                    bookId = bookId,
+                    audioFiles = domainAudioFiles,
+                    baseUrl = serverUrl,
+                    resolveLocalPath = { audioFileId -> downloadService.getLocalPath(audioFileId) },
+                    prepareStream = { audioFileId, codec ->
+                        prepareStreamForFile(
+                            bookId.value, audioFileId, codec, capabilities, serverUrl, onPrepareProgress,
+                        )
+                    },
+                )
+            } else {
+                PlaybackTimeline.buildWithLocalPaths(
+                    bookId = bookId,
+                    audioFiles = domainAudioFiles,
+                    baseUrl = serverUrl,
+                    resolveLocalPath = { audioFileId -> downloadService.getLocalPath(audioFileId) },
+                )
+            }
+
+        // Load chapters for this book
+        val chapters = loadChapters(bookId)
+
+        logger.info { "Built timeline: ${timeline.files.size} files, ${timeline.totalDurationMs}ms total" }
+
+        // 6. Get resume position and speed
+        val savedPosition = progressTracker.getResumePosition(bookId)
+
+        val resumePositionMs =
+            if (savedPosition?.isFinished == true) {
+                logger.info { "Book is finished - starting from beginning for re-read" }
+                0L
+            } else {
+                savedPosition?.positionMs ?: 0L
+            }
+
+        val resumeSpeed =
+            if (savedPosition != null && savedPosition.hasCustomSpeed) {
+                savedPosition.playbackSpeed
+            } else {
+                playbackPreferences.getDefaultPlaybackSpeed()
+            }
+
+        logger.debug {
+            "Resume position: ${resumePositionMs}ms, speed: ${resumeSpeed}x (hasCustomSpeed=${savedPosition?.hasCustomSpeed})"
+        }
+
+        if (resumePositionMs < 0) {
+            logger.warn { "⚠️ WARNING: Negative resume position: $resumePositionMs" }
+        }
+        if (resumePositionMs > timeline.totalDurationMs) {
+            logger.warn {
+                "⚠️ WARNING: Resume position $resumePositionMs exceeds book duration ${timeline.totalDurationMs}"
+            }
+        }
+
+        val resolvedPosition = timeline.resolve(resumePositionMs)
+        logger.debug {
+            "Resolved resume position: " +
+                "mediaItemIndex=${resolvedPosition.mediaItemIndex}, " +
+                "positionInFileMs=${resolvedPosition.positionInFileMs}"
+        }
+
+        if (resolvedPosition.mediaItemIndex >= timeline.files.size) {
+            logger.warn {
+                "⚠️ WARNING: Invalid mediaItemIndex ${resolvedPosition.mediaItemIndex} >= ${timeline.files.size}"
+            }
+        }
+
+        // 7. Trigger background download if not fully downloaded (best-effort caching)
+        if (!deviceContext.supportsDownloads) {
+            logger.info { "Device does not support downloads, streaming only" }
+        } else if (!timeline.isFullyDownloaded && !downloadService.wasExplicitlyDeleted(bookId)) {
+            logger.info { "Book not fully downloaded, triggering background download" }
+            scope.launch {
+                downloadService.downloadBook(bookId)
+            }
+        } else if (!timeline.isFullyDownloaded) {
+            logger.info { "Book was explicitly deleted, streaming only (no auto-download)" }
+        }
+
+        return PreparedPlayback(
+            timeline = timeline,
+            chapters = chapters,
+            bookTitle = book.title,
+            bookAuthor = bookAuthor,
+            seriesName = seriesName,
+            coverPath = coverPath,
+            resumePositionMs = resumePositionMs,
+            resumeSpeed = resumeSpeed,
+        )
+    }
+
+    /**
+     * Negotiate streaming URL for a single audio file. Calls the server's
+     * prepare endpoint; if transcoding is in progress, polls until ready or
+     * timeout, reporting progress through [onPrepareProgress].
+     */
+    private suspend fun prepareStreamForFile(
+        bookId: String,
+        audioFileId: String,
+        codec: String,
+        capabilities: List<String>,
+        baseUrl: String,
+        onPrepareProgress: (PlaybackManager.PrepareProgress?) -> Unit,
+    ): StreamPrepareResult {
+        val api = playbackApi ?: return fallbackStreamResult(bookId, audioFileId, baseUrl)
+
+        val maxRetries = 120 // ~10 minutes at 5 second intervals
+        val retryDelayMs = 5000L
+
+        val spatial = playbackPreferences.getSpatialPlayback()
+
+        repeat(maxRetries) { attempt ->
+            when (val result = api.preparePlayback(bookId, audioFileId, capabilities, spatial)) {
+                is Success -> {
+                    val response = result.data
+                    logger.debug {
+                        "Prepare result for $audioFileId (attempt ${attempt + 1}): " +
+                            "ready=${response.ready}, variant=${response.variant}, codec=${response.codec}"
+                    }
+
+                    if (response.ready) {
+                        onPrepareProgress(null)
+                        return StreamPrepareResult(
+                            streamUrl = response.streamUrl,
+                            ready = true,
+                            transcodeJobId = response.transcodeJobId,
+                        )
+                    }
+
+                    onPrepareProgress(
+                        PlaybackManager.PrepareProgress(
+                            audioFileId = audioFileId,
+                            progress = response.progress,
+                            message = "Preparing audio... ${response.progress}%",
+                        ),
+                    )
+
+                    logger.info {
+                        "Transcoding in progress for $audioFileId: " +
+                            "jobId=${response.transcodeJobId}, progress=${response.progress}%, " +
+                            "waiting ${retryDelayMs}ms before retry..."
+                    }
+                    delay(retryDelayMs)
+                }
+
+                is Failure -> {
+                    onPrepareProgress(null)
+                    logger.warn {
+                        "Failed to prepare stream for $audioFileId (attempt ${attempt + 1}), using fallback URL"
+                    }
+                    return fallbackStreamResult(bookId, audioFileId, baseUrl)
+                }
+            }
+        }
+
+        onPrepareProgress(null)
+        logger.warn { "Transcode polling timeout for $audioFileId after $maxRetries attempts" }
+        return fallbackStreamResult(bookId, audioFileId, baseUrl)
+    }
+
+    /** Fallback stream result when the prepare endpoint fails. */
+    private fun fallbackStreamResult(
+        bookId: String,
+        audioFileId: String,
+        baseUrl: String,
+    ): StreamPrepareResult =
+        StreamPrepareResult(
+            streamUrl = "$baseUrl/api/v1/books/$bookId/audio/$audioFileId",
+            ready = true,
+            transcodeJobId = null,
+        )
+
+    /**
+     * Fetch book data from server and persist locally. Used as a fallback when
+     * local book data is incomplete. Writes book entity + audio-file junction
+     * rows atomically via [BookRepository.upsertWithAudioFiles].
+     *
+     * Internal visibility allows [PlaybackManagerFallbackFetchAtomicityTest] to
+     * invoke the method directly.
+     *
+     * @return true if fetch + persist succeeded.
+     */
+    internal suspend fun fetchBookFromServer(bookId: BookId): Boolean {
+        val api = syncApi
+        if (api == null) {
+            logger.error { "SyncApi not available for fetching book" }
+            return false
+        }
+
+        return when (val result = api.getBook(bookId.value)) {
+            is Success -> {
+                val bookResponse = result.data
+                logger.info { "Fetched book from server: ${bookResponse.title}" }
+
+                val entity = bookResponse.toEntity()
+                val audioFileRows =
+                    bookResponse.audioFiles.mapIndexed { idx, af ->
+                        AudioFileEntity(
+                            bookId = bookId,
+                            index = idx,
+                            id = af.id,
+                            filename = af.filename,
+                            format = af.format,
+                            codec = af.codec,
+                            duration = af.duration,
+                            size = af.size,
+                        )
+                    }
+
+                when (val writeResult = bookRepository.upsertWithAudioFiles(entity, audioFileRows)) {
+                    is AppResult.Success -> {
+                        logger.debug { "Saved fetched book + ${audioFileRows.size} audio files to local database" }
+                        true
+                    }
+
+                    is AppResult.Failure -> {
+                        logger.error { "Failed to persist fetched book ${bookId.value}: ${writeResult.error.message}" }
+                        false
+                    }
+                }
+            }
+
+            is Failure -> {
+                logger.error { "Failed to fetch book from server: ${bookId.value}" }
+                false
+            }
+        }
+    }
+
+    /** Load chapters for a book. */
+    private suspend fun loadChapters(bookId: BookId): List<Chapter> {
+        val entities = chapterDao.getChaptersForBook(bookId)
+        val chapters =
+            entities.map { entity ->
+                Chapter(
+                    id = entity.id.value,
+                    title = entity.title,
+                    duration = entity.duration,
+                    startTime = entity.startTime,
+                )
+            }
+        logger.debug { "Loaded ${chapters.size} chapters for book ${bookId.value}" }
+        return chapters
+    }
+}
+
+// ========== Type Conversions ==========
+
+/**
+ * Convert an [AudioFileEntity] to the domain [AudioFile], carrying the
+ * [AudioFileEntity.index] ordering field.
+ */
+private fun AudioFileEntity.toDomain(): AudioFile =
+    AudioFile(
+        id = id,
+        index = index,
+        filename = filename,
+        format = format,
+        codec = codec,
+        duration = duration,
+        size = size,
+    )
+
+/** Convert an [AudioFileEntity] to the API-shaped [AudioFileResponse] for diagnostic logging. */
+private fun AudioFileEntity.toAudioFileResponse(): AudioFileResponse =
+    AudioFileResponse(
+        id = id,
+        filename = filename,
+        format = format,
+        codec = codec,
+        duration = duration,
+        size = size,
+    )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.SyncStatusRepository
 import com.calypsan.listenup.client.util.sortableTitle
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.presentation.startup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.data.remote.SetupApiContract
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -61,7 +62,7 @@ class AppStartupViewModel(
 
     /** Call from MainActivity.onPause to record when the app left the foreground. */
     fun onAppBackgrounded() {
-        _state.value = _state.value.copy(backgroundedAtMs = System.currentTimeMillis())
+        _state.value = _state.value.copy(backgroundedAtMs = currentEpochMilliseconds())
     }
 
     /**
@@ -73,7 +74,7 @@ class AppStartupViewModel(
      */
     fun onAppForegrounded() {
         val backgroundedAt = _state.value.backgroundedAtMs ?: return
-        val elapsed = System.currentTimeMillis() - backgroundedAt
+        val elapsed = currentEpochMilliseconds() - backgroundedAt
         if (elapsed >= BACKGROUND_THRESHOLD_MS) {
             logger.info { "App was backgrounded for ${elapsed}ms (>= threshold) — re-checking library setup" }
             _state.value = AppStartupState(isChecking = true)

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
@@ -11,9 +11,10 @@ import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.bind
 import org.koin.dsl.module
-import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.playback.PlaybackManager
+import com.calypsan.listenup.client.playback.PlaybackPreparer
 import com.calypsan.listenup.client.playback.SleepTimerManager
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
@@ -144,6 +145,11 @@ object KoinHelper : KoinComponent {
 
     fun getSleepTimerManager(): SleepTimerManager {
         val instance: SleepTimerManager by inject()
+        return instance
+    }
+
+    fun getPlaybackPreparer(): PlaybackPreparer {
+        val instance: PlaybackPreparer by inject()
         return instance
     }
 }

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.client.playback.AvFoundationAudioPlayer
 import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.PlaybackManagerImpl
+import com.calypsan.listenup.client.playback.PlaybackPreparer
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
 import com.calypsan.listenup.client.sync.BackgroundSyncScheduler
@@ -87,6 +88,27 @@ val iosPlaybackModule: Module =
                 syncApi = get(),
                 positionRepository = get(),
                 scope = get(qualifier = named("playbackScope")),
+            )
+        }
+
+        // Stateless playback-preparation pipeline — consumed directly by the native iOS player
+        single {
+            PlaybackPreparer(
+                serverConfig = get(),
+                playbackPreferences = get(),
+                bookDao = get(),
+                audioFileDao = get(),
+                chapterDao = get(),
+                imageStorage = get(),
+                progressTracker = get(),
+                tokenProvider = get(),
+                deviceContext = get(),
+                downloadService = get(),
+                playbackApi = null,
+                capabilityDetector = null,
+                syncApi = get(),
+                scope = get(qualifier = named("playbackScope")),
+                bookRepository = get(),
             )
         }
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -29,7 +29,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Proves [PlaybackManager.fetchBookFromServer] delegates the write to
+ * Proves [PlaybackPreparer.fetchBookFromServer] delegates the write to
  * [BookRepository.upsertWithAudioFiles], which owns the atomicity guarantee.
  *
  * The actual rollback behaviour is exercised in [BookRepositoryImplTest].
@@ -74,8 +74,8 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                 )
 
             // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
-            val playbackManager =
-                PlaybackManagerImpl(
+            val preparer =
+                PlaybackPreparer(
                     serverConfig = mock(),
                     playbackPreferences = mock(),
                     bookDao = db.bookDao(),
@@ -93,7 +93,7 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                     bookRepository = bookRepository,
                 )
 
-            val result = playbackManager.fetchBookFromServer(BookId("book-rollback"))
+            val result = preparer.fetchBookFromServer(BookId("book-rollback"))
 
             assertTrue(result, "fetchBookFromServer should return true on success")
             verifySuspend(VerifyMode.exactly(1)) {
@@ -129,8 +129,8 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                 )
 
             // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
-            val playbackManager =
-                PlaybackManagerImpl(
+            val preparer =
+                PlaybackPreparer(
                     serverConfig = mock(),
                     playbackPreferences = mock(),
                     bookDao = db.bookDao(),
@@ -148,7 +148,7 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                     bookRepository = bookRepository,
                 )
 
-            val result = playbackManager.fetchBookFromServer(BookId("book-fail"))
+            val result = preparer.fetchBookFromServer(BookId("book-fail"))
 
             assertFalse(result, "fetchBookFromServer should return false when persistence fails")
             verifySuspend(VerifyMode.exactly(1)) {


### PR DESCRIPTION
## Summary

- Extracts the playback-preparation pipeline out of `PlaybackManagerImpl` into a new stateless `PlaybackPreparer` (`commonMain`), which returns an immutable `PreparedPlayback` value. `PlaybackManagerImpl.prepareForPlayback` now delegates to it — public constructor and observable behaviour unchanged, so the Android/Desktop/macOS Koin modules are untouched.
- Wires `PlaybackPreparer` into the iOS Koin module so the upcoming native iOS player can consume it directly.
- Fixes a pre-existing failure: four `commonMain` files used JVM-only APIs (`System.currentTimeMillis()`, JVM `Volatile`, a missing `JvmInline` import), so the iOS Kotlin target did not compile. Swapped to multiplatform equivalents.

First plan of the iOS Playback Foundation effort (spec: `docs/superpowers/specs/2026-05-17-ios-playback-foundation-design.md`). Behaviour-preserving — no functional change to Android/Desktop playback.

## Test Plan

- [x] `:shared:jvmTest` — full suite green; the existing `PlaybackManager*Test` regression suite passes unchanged (behaviour preservation)
- [x] `spotlessCheck detekt` green
- [x] `:server:test` green
- [x] `:androidApp:assembleDebug` green
- [x] `compileKotlinIosSimulatorArm64` green — the iOS Kotlin target now compiles

## Follow-ups (tracked in docs/superpowers/followups.md)

- `PlaybackPreparer.prepare` returns nullable rather than `AppResult<T>` — typed prepare-errors deferred to the Swift player plan
- `iosPlaybackModule` has no `module.verify()` coverage
- `PlaybackPreparer.kt` carries `@file:Suppress` — decompose `prepare()` and parameter-object the constructor