### PR TITLE
✅ test(shared): migrate Books-domain tests to Kotest

### DIFF
--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImplTest.kt
@@ -17,14 +17,12 @@ import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for ContributorRepositoryImpl.
@@ -36,926 +34,928 @@ import kotlin.test.assertTrue
  * - Flow emissions for reactive queries
  * - Alias parsing from comma-separated string to list
  */
-class ContributorRepositoryImplTest {
-    // ========== Test Fixtures ==========
+class ContributorRepositoryImplTest :
+    FunSpec({
 
-    private fun createMockDao(): ContributorDao = mock<ContributorDao>(MockMode.autoUnit)
+        // ========== Test Fixtures ==========
 
-    private fun createRepository(dao: ContributorDao): ContributorRepositoryImpl =
-        ContributorRepositoryImpl(
-            contributorDao = dao,
-            bookDao = mock<BookDao>(MockMode.autoUnit),
-            searchDao = mock<SearchDao>(MockMode.autoUnit),
-            api = mock<ContributorApiContract>(),
-            metadataApi = mock<MetadataApiContract>(),
-            networkMonitor = mock<NetworkMonitor>(),
-            imageStorage = mock<ImageStorage>(),
-        )
+        fun createMockDao(): ContributorDao = mock<ContributorDao>(MockMode.autoUnit)
 
-    private fun createTestContributorEntity(
-        id: String = "contrib-1",
-        name: String = "Brandon Sanderson",
-        description: String? = null,
-        imagePath: String? = null,
-        imageBlurHash: String? = null,
-        website: String? = null,
-        birthDate: String? = null,
-        deathDate: String? = null,
-        createdAt: Long = 1000L,
-        updatedAt: Long = 1000L,
-    ): ContributorEntity =
-        ContributorEntity(
-            id =
-                com.calypsan.listenup.client.core
-                    .ContributorId(id),
-            name = name,
-            description = description,
-            imagePath = imagePath,
-            imageBlurHash = imageBlurHash,
-            website = website,
-            birthDate = birthDate,
-            deathDate = deathDate,
-            createdAt = Timestamp(createdAt),
-            updatedAt = Timestamp(updatedAt),
-        )
+        fun createRepository(dao: ContributorDao): ContributorRepositoryImpl =
+            ContributorRepositoryImpl(
+                contributorDao = dao,
+                bookDao = mock<BookDao>(MockMode.autoUnit),
+                searchDao = mock<SearchDao>(MockMode.autoUnit),
+                api = mock<ContributorApiContract>(),
+                metadataApi = mock<MetadataApiContract>(),
+                networkMonitor = mock<NetworkMonitor>(),
+                imageStorage = mock<ImageStorage>(),
+            )
 
-    private fun createTestContributorWithAliases(
-        entity: ContributorEntity = createTestContributorEntity(),
-        aliases: List<String> = emptyList(),
-    ): ContributorWithAliases = ContributorWithAliases(contributor = entity, aliases = aliases)
+        fun createTestContributorEntity(
+            id: String = "contrib-1",
+            name: String = "Brandon Sanderson",
+            description: String? = null,
+            imagePath: String? = null,
+            imageBlurHash: String? = null,
+            website: String? = null,
+            birthDate: String? = null,
+            deathDate: String? = null,
+            createdAt: Long = 1000L,
+            updatedAt: Long = 1000L,
+        ): ContributorEntity =
+            ContributorEntity(
+                id =
+                    com.calypsan.listenup.client.core
+                        .ContributorId(id),
+                name = name,
+                description = description,
+                imagePath = imagePath,
+                imageBlurHash = imageBlurHash,
+                website = website,
+                birthDate = birthDate,
+                deathDate = deathDate,
+                createdAt = Timestamp(createdAt),
+                updatedAt = Timestamp(updatedAt),
+            )
 
-    // ========== observeAll Tests ==========
+        fun createTestContributorWithAliases(
+            entity: ContributorEntity = createTestContributorEntity(),
+            aliases: List<String> = emptyList(),
+        ): ContributorWithAliases = ContributorWithAliases(contributor = entity, aliases = aliases)
 
-    @Test
-    fun `observeAll returns empty list when no contributors exist`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeAllWithAliases() } returns flowOf(emptyList())
-            val repository = createRepository(dao)
+        // ========== observeAll Tests ==========
 
-            // When
-            val result = repository.observeAll().first()
+        test("observeAll returns empty list when no contributors exist") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeAllWithAliases() } returns flowOf(emptyList())
+                val repository = createRepository(dao)
 
-            // Then
-            assertTrue(result.isEmpty())
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
         }
 
-    @Test
-    fun `observeAll transforms entities to domain models`() =
-        runTest {
-            // Given
-            val rows =
-                listOf(
+        test("observeAll transforms entities to domain models") {
+            runTest {
+                // Given
+                val rows =
+                    listOf(
+                        createTestContributorWithAliases(
+                            entity =
+                                createTestContributorEntity(
+                                    id = "contrib-1",
+                                    name = "Brandon Sanderson",
+                                    description = "Fantasy author",
+                                ),
+                        ),
+                        createTestContributorWithAliases(
+                            entity =
+                                createTestContributorEntity(
+                                    id = "contrib-2",
+                                    name = "Michael Kramer",
+                                    description = "Audiobook narrator",
+                                ),
+                        ),
+                    )
+                val dao = createMockDao()
+                every { dao.observeAllWithAliases() } returns flowOf(rows)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result.size shouldBe 2
+                result[0].id.value shouldBe "contrib-1"
+                result[0].name shouldBe "Brandon Sanderson"
+                result[0].description shouldBe "Fantasy author"
+                result[1].id.value shouldBe "contrib-2"
+                result[1].name shouldBe "Michael Kramer"
+                result[1].description shouldBe "Audiobook narrator"
+            }
+        }
+
+        test("observeAll preserves entity order from dao") {
+            runTest {
+                // Given - entities ordered by name
+                val rows =
+                    listOf(
+                        createTestContributorWithAliases(entity = createTestContributorEntity(id = "c1", name = "Aaron")),
+                        createTestContributorWithAliases(entity = createTestContributorEntity(id = "c2", name = "Brandon")),
+                        createTestContributorWithAliases(entity = createTestContributorEntity(id = "c3", name = "Cory")),
+                    )
+                val dao = createMockDao()
+                every { dao.observeAllWithAliases() } returns flowOf(rows)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result[0].name shouldBe "Aaron"
+                result[1].name shouldBe "Brandon"
+                result[2].name shouldBe "Cory"
+            }
+        }
+
+        test("observeAll delegates to dao observeAllWithAliases") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeAllWithAliases() } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                repository.observeAll().first()
+
+                // Then
+                verify { dao.observeAllWithAliases() }
+            }
+        }
+
+        // ========== observeById Tests ==========
+
+        test("observeById returns null when contributor not found") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeByIdWithAliases("nonexistent") } returns flowOf(null)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeById("nonexistent").first()
+
+                // Then
+                result shouldBe null
+            }
+        }
+
+        test("observeById returns contributor when found") {
+            runTest {
+                // Given
+                val row =
                     createTestContributorWithAliases(
                         entity =
                             createTestContributorEntity(
                                 id = "contrib-1",
-                                name = "Brandon Sanderson",
-                                description = "Fantasy author",
-                            ),
-                    ),
-                    createTestContributorWithAliases(
-                        entity =
-                            createTestContributorEntity(
-                                id = "contrib-2",
-                                name = "Michael Kramer",
-                                description = "Audiobook narrator",
-                            ),
-                    ),
-                )
-            val dao = createMockDao()
-            every { dao.observeAllWithAliases() } returns flowOf(rows)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeAll().first()
-
-            // Then
-            assertEquals(2, result.size)
-            assertEquals("contrib-1", result[0].id.value)
-            assertEquals("Brandon Sanderson", result[0].name)
-            assertEquals("Fantasy author", result[0].description)
-            assertEquals("contrib-2", result[1].id.value)
-            assertEquals("Michael Kramer", result[1].name)
-            assertEquals("Audiobook narrator", result[1].description)
-        }
-
-    @Test
-    fun `observeAll preserves entity order from dao`() =
-        runTest {
-            // Given - entities ordered by name
-            val rows =
-                listOf(
-                    createTestContributorWithAliases(entity = createTestContributorEntity(id = "c1", name = "Aaron")),
-                    createTestContributorWithAliases(entity = createTestContributorEntity(id = "c2", name = "Brandon")),
-                    createTestContributorWithAliases(entity = createTestContributorEntity(id = "c3", name = "Cory")),
-                )
-            val dao = createMockDao()
-            every { dao.observeAllWithAliases() } returns flowOf(rows)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeAll().first()
-
-            // Then
-            assertEquals("Aaron", result[0].name)
-            assertEquals("Brandon", result[1].name)
-            assertEquals("Cory", result[2].name)
-        }
-
-    @Test
-    fun `observeAll delegates to dao observeAllWithAliases`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeAllWithAliases() } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeAll().first()
-
-            // Then
-            verify { dao.observeAllWithAliases() }
-        }
-
-    // ========== observeById Tests ==========
-
-    @Test
-    fun `observeById returns null when contributor not found`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeByIdWithAliases("nonexistent") } returns flowOf(null)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeById("nonexistent").first()
-
-            // Then
-            assertNull(result)
-        }
-
-    @Test
-    fun `observeById returns contributor when found`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity =
-                        createTestContributorEntity(
-                            id = "contrib-1",
-                            name = "Stephen King",
-                            description = "Horror author",
-                            website = "https://stephenking.com",
-                        ),
-                )
-            val dao = createMockDao()
-            every { dao.observeByIdWithAliases("contrib-1") } returns flowOf(row)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeById("contrib-1").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("contrib-1", result.id.value)
-            assertEquals("Stephen King", result.name)
-            assertEquals("Horror author", result.description)
-            assertEquals("https://stephenking.com", result.website)
-        }
-
-    @Test
-    fun `observeById transforms entity correctly`() =
-        runTest {
-            // Given — aliases seeded in arbitrary order to prove repository-level sorting
-            val row =
-                createTestContributorWithAliases(
-                    entity =
-                        createTestContributorEntity(
-                            id = "contrib-42",
-                            name = "Test Author",
-                            description = "Test description",
-                            imagePath = "/images/author.jpg",
-                            imageBlurHash = "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
-                            website = "https://example.com",
-                            birthDate = "1947-09-21",
-                            deathDate = null,
-                        ),
-                    aliases = listOf("Richard Bachman", "John Swithen"),
-                )
-            val dao = createMockDao()
-            every { dao.observeByIdWithAliases("contrib-42") } returns flowOf(row)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeById("contrib-42").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("contrib-42", result.id.value)
-            assertEquals("Test Author", result.name)
-            assertEquals("Test description", result.description)
-            assertEquals("/images/author.jpg", result.imagePath)
-            assertEquals("LEHV6nWB2yk8pyo0adR*.7kCMdnj", result.imageBlurHash)
-            assertEquals("https://example.com", result.website)
-            assertEquals("1947-09-21", result.birthDate)
-            assertNull(result.deathDate)
-            // Sorted case-insensitively at the domain boundary
-            assertEquals(listOf("John Swithen", "Richard Bachman"), result.aliases)
-        }
-
-    @Test
-    fun `observeById delegates to dao with correct id`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeByIdWithAliases("target-id") } returns flowOf(null)
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeById("target-id").first()
-
-            // Then
-            verify { dao.observeByIdWithAliases("target-id") }
-        }
-
-    // ========== getById Tests ==========
-
-    @Test
-    fun `getById returns null when contributor not found`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("nonexistent") } returns null
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("nonexistent")
-
-            // Then
-            assertNull(result)
-        }
-
-    @Test
-    fun `getById returns contributor when found`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity =
-                        createTestContributorEntity(
-                            id = "contrib-1",
-                            name = "Neil Gaiman",
-                            description = "Fantasy/Horror author",
-                        ),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("contrib-1")
-
-            // Then
-            assertNotNull(result)
-            assertEquals("contrib-1", result.id.value)
-            assertEquals("Neil Gaiman", result.name)
-            assertEquals("Fantasy/Horror author", result.description)
-        }
-
-    @Test
-    fun `getById transforms all entity fields correctly`() =
-        runTest {
-            // Given — seed in arbitrary order to prove repository-level sorting
-            val row =
-                createTestContributorWithAliases(
-                    entity =
-                        createTestContributorEntity(
-                            id = "complete-contrib",
-                            name = "Complete Author",
-                            description = "Full biography here",
-                            imagePath = "/path/to/image.jpg",
-                            imageBlurHash = "ABC123",
-                            website = "https://author.com",
-                            birthDate = "1960-01-15",
-                            deathDate = "2020-12-31",
-                        ),
-                    aliases = listOf("Pen Name Two", "Pen Name One", "Pen Name Three"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("complete-contrib") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("complete-contrib")
-
-            // Then
-            assertNotNull(result)
-            assertEquals("complete-contrib", result.id.value)
-            assertEquals("Complete Author", result.name)
-            assertEquals("Full biography here", result.description)
-            assertEquals("/path/to/image.jpg", result.imagePath)
-            assertEquals("ABC123", result.imageBlurHash)
-            assertEquals("https://author.com", result.website)
-            assertEquals("1960-01-15", result.birthDate)
-            assertEquals("2020-12-31", result.deathDate)
-            // Sorted case-insensitively at the domain boundary:
-            // "Pen Name One" < "Pen Name Three" < "Pen Name Two" (O < Th < Tw)
-            assertEquals(3, result.aliases.size)
-            assertEquals("Pen Name One", result.aliases[0])
-            assertEquals("Pen Name Three", result.aliases[1])
-            assertEquals("Pen Name Two", result.aliases[2])
-        }
-
-    @Test
-    fun `getById passes correct id to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("target-id") } returns null
-            val repository = createRepository(dao)
-
-            // When
-            repository.getById("target-id")
-
-            // Then
-            verifySuspend { dao.getByIdWithAliases("target-id") }
-        }
-
-    // ========== observeByBookId Tests ==========
-
-    @Test
-    fun `observeByBookId returns empty list when book has no contributors`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeByBookId("book-1") } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeByBookId("book-1").first()
-
-            // Then
-            assertTrue(result.isEmpty())
-        }
-
-    @Test
-    fun `observeByBookId returns contributors for book`() =
-        runTest {
-            // Given
-            val entities =
-                listOf(
-                    createTestContributorEntity(id = "author-1", name = "Brandon Sanderson"),
-                    createTestContributorEntity(id = "narrator-1", name = "Michael Kramer"),
-                )
-            val dao = createMockDao()
-            every { dao.observeByBookId("book-1") } returns flowOf(entities)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeByBookId("book-1").first()
-
-            // Then
-            assertEquals(2, result.size)
-            assertEquals("Brandon Sanderson", result[0].name)
-            assertEquals("Michael Kramer", result[1].name)
-        }
-
-    @Test
-    fun `observeByBookId transforms entities to domain models`() =
-        runTest {
-            // Given
-            val entity =
-                createTestContributorEntity(
-                    id = "contrib-1",
-                    name = "Kate Reading",
-                    description = "Narrator",
-                )
-            val dao = createMockDao()
-            every { dao.observeByBookId("book-42") } returns flowOf(listOf(entity))
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeByBookId("book-42").first()
-
-            // Then — aliases come from the junction table and are not covered by this path;
-            // task 8 removes the entity field entirely. Scope this test to the non-alias fields.
-            assertEquals(1, result.size)
-            assertEquals("contrib-1", result[0].id.value)
-            assertEquals("Kate Reading", result[0].name)
-            assertEquals("Narrator", result[0].description)
-        }
-
-    @Test
-    fun `observeByBookId passes correct bookId to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeByBookId("my-book-id") } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeByBookId("my-book-id").first()
-
-            // Then
-            verify { dao.observeByBookId("my-book-id") }
-        }
-
-    // ========== getByBookId Tests ==========
-
-    @Test
-    fun `getByBookId returns empty list when book has no contributors`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getByBookId("book-1") } returns emptyList()
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getByBookId("book-1")
-
-            // Then
-            assertTrue(result.isEmpty())
-        }
-
-    @Test
-    fun `getByBookId returns contributors for book`() =
-        runTest {
-            // Given
-            val entities =
-                listOf(
-                    createTestContributorEntity(id = "c1", name = "Author One"),
-                    createTestContributorEntity(id = "c2", name = "Author Two"),
-                    createTestContributorEntity(id = "c3", name = "Narrator One"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByBookId("book-1") } returns entities
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getByBookId("book-1")
-
-            // Then
-            assertEquals(3, result.size)
-            assertEquals("Author One", result[0].name)
-            assertEquals("Author Two", result[1].name)
-            assertEquals("Narrator One", result[2].name)
-        }
-
-    @Test
-    fun `getByBookId transforms entities to domain models`() =
-        runTest {
-            // Given
-            val entity =
-                createTestContributorEntity(
-                    id = "contrib-5",
-                    name = "Tim Gerard Reynolds",
-                    description = "Audiobook narrator",
-                    imagePath = "/images/tgr.jpg",
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByBookId("book-1") } returns listOf(entity)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getByBookId("book-1")
-
-            // Then
-            assertEquals(1, result.size)
-            assertEquals("contrib-5", result[0].id.value)
-            assertEquals("Tim Gerard Reynolds", result[0].name)
-            assertEquals("Audiobook narrator", result[0].description)
-            assertEquals("/images/tgr.jpg", result[0].imagePath)
-        }
-
-    @Test
-    fun `getByBookId calls dao with correct bookId`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getByBookId("specific-book-id") } returns emptyList()
-            val repository = createRepository(dao)
-
-            // When
-            repository.getByBookId("specific-book-id")
-
-            // Then
-            verifySuspend { dao.getByBookId("specific-book-id") }
-        }
-
-    // ========== getBookIdsForContributor Tests ==========
-
-    @Test
-    fun `getBookIdsForContributor returns empty list when contributor has no books`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForContributor("contrib-1") } returns emptyList()
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getBookIdsForContributor("contrib-1")
-
-            // Then
-            assertTrue(result.isEmpty())
-        }
-
-    @Test
-    fun `getBookIdsForContributor returns book IDs for contributor`() =
-        runTest {
-            // Given
-            val bookIds = listOf("book-1", "book-2", "book-3")
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForContributor("contrib-1") } returns bookIds
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getBookIdsForContributor("contrib-1")
-
-            // Then
-            assertEquals(3, result.size)
-            assertEquals("book-1", result[0])
-            assertEquals("book-2", result[1])
-            assertEquals("book-3", result[2])
-        }
-
-    @Test
-    fun `getBookIdsForContributor passes correct contributorId to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForContributor("specific-contrib-id") } returns emptyList()
-            val repository = createRepository(dao)
-
-            // When
-            repository.getBookIdsForContributor("specific-contrib-id")
-
-            // Then
-            verifySuspend { dao.getBookIdsForContributor("specific-contrib-id") }
-        }
-
-    // ========== observeBookIdsForContributor Tests ==========
-
-    @Test
-    fun `observeBookIdsForContributor returns empty list when contributor has no books`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeBookIdsForContributor("contrib-1") } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeBookIdsForContributor("contrib-1").first()
-
-            // Then
-            assertTrue(result.isEmpty())
-        }
-
-    @Test
-    fun `observeBookIdsForContributor returns book IDs for contributor`() =
-        runTest {
-            // Given
-            val bookIds = listOf("book-a", "book-b")
-            val dao = createMockDao()
-            every { dao.observeBookIdsForContributor("contrib-1") } returns flowOf(bookIds)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeBookIdsForContributor("contrib-1").first()
-
-            // Then
-            assertEquals(2, result.size)
-            assertEquals("book-a", result[0])
-            assertEquals("book-b", result[1])
-        }
-
-    @Test
-    fun `observeBookIdsForContributor passes correct contributorId to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeBookIdsForContributor("target-contrib") } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeBookIdsForContributor("target-contrib").first()
-
-            // Then
-            verify { dao.observeBookIdsForContributor("target-contrib") }
-        }
-
-    // ========== Entity to Domain Conversion Tests ==========
-
-    @Test
-    fun `toDomain converts all entity fields correctly`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity =
-                        createTestContributorEntity(
-                            id = "conversion-test",
-                            name = "Full Name",
-                            description = "Full description",
-                            imagePath = "/full/path.jpg",
-                            imageBlurHash = "BLURHASH",
-                            website = "https://full.website.com",
-                            birthDate = "1980-06-15",
-                            deathDate = "2050-12-31",
-                        ),
-                    aliases = listOf("Alias Two", "Alias One"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("conversion-test") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("conversion-test")
-
-            // Then - verify all fields are mapped, aliases sorted case-insensitively
-            assertNotNull(result)
-            assertEquals("conversion-test", result.id.value)
-            assertEquals("Full Name", result.name)
-            assertEquals("Full description", result.description)
-            assertEquals("/full/path.jpg", result.imagePath)
-            assertEquals("BLURHASH", result.imageBlurHash)
-            assertEquals("https://full.website.com", result.website)
-            assertEquals("1980-06-15", result.birthDate)
-            assertEquals("2050-12-31", result.deathDate)
-            assertEquals(2, result.aliases.size)
-            assertEquals("Alias One", result.aliases[0])
-            assertEquals("Alias Two", result.aliases[1])
-        }
-
-    @Test
-    fun `toDomain handles null optional fields`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity =
-                        createTestContributorEntity(
-                            id = "minimal-contrib",
-                            name = "Minimal Author",
-                            description = null,
-                            imagePath = null,
-                            imageBlurHash = null,
-                            website = null,
-                            birthDate = null,
-                            deathDate = null,
-                        ),
-                    aliases = emptyList(),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("minimal-contrib") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("minimal-contrib")
-
-            // Then
-            assertNotNull(result)
-            assertEquals("minimal-contrib", result.id.value)
-            assertEquals("Minimal Author", result.name)
-            assertNull(result.description)
-            assertNull(result.imagePath)
-            assertNull(result.imageBlurHash)
-            assertNull(result.website)
-            assertNull(result.birthDate)
-            assertNull(result.deathDate)
-            assertTrue(result.aliases.isEmpty())
-        }
-
-    // ========== Alias Projection + Sorting Tests ==========
-    // Aliases are sourced from the `contributor_aliases` junction table (projected by
-    // ContributorWithAliases) and sorted case-insensitively at the domain boundary, since
-    // Room's @Relation does not support ORDER BY on the projected child collection.
-
-    @Test
-    fun `toDomain returns single alias unchanged`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(),
-                    aliases = listOf("Richard Bachman"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("contrib-1")
-
-            // Then
-            assertNotNull(result)
-            assertEquals(1, result.aliases.size)
-            assertEquals("Richard Bachman", result.aliases[0])
-        }
-
-    @Test
-    fun `toDomain sorts multiple aliases alphabetically`() =
-        runTest {
-            // Given — seed in arbitrary order
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(),
-                    aliases = listOf("Alias Three", "Alias One", "Alias Two"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("contrib-1")
-
-            // Then
-            assertNotNull(result)
-            assertEquals(3, result.aliases.size)
-            assertEquals("Alias One", result.aliases[0])
-            assertEquals("Alias Three", result.aliases[1])
-            assertEquals("Alias Two", result.aliases[2])
-        }
-
-    @Test
-    fun `toDomain sorts aliases case-insensitively`() =
-        runTest {
-            // Given — mixed case; case-insensitive sort must group regardless of case
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(),
-                    aliases = listOf("charlie", "Bravo", "alpha", "Delta"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("contrib-1")
-
-            // Then
-            assertNotNull(result)
-            assertEquals(listOf("alpha", "Bravo", "charlie", "Delta"), result.aliases)
-        }
-
-    @Test
-    fun `toDomain returns empty list when no aliases projected`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(),
-                    aliases = emptyList(),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("contrib-1")
-
-            // Then
-            assertNotNull(result)
-            assertTrue(result.aliases.isEmpty())
-        }
-
-    // ========== Multiple Items Tests ==========
-
-    @Test
-    fun `observeAll handles large number of contributors`() =
-        runTest {
-            // Given
-            val rows =
-                (1..100).map { i ->
-                    createTestContributorWithAliases(
-                        entity =
-                            createTestContributorEntity(
-                                id = "contrib-$i",
-                                name = "Contributor $i",
+                                name = "Stephen King",
+                                description = "Horror author",
+                                website = "https://stephenking.com",
                             ),
                     )
-                }
-            val dao = createMockDao()
-            every { dao.observeAllWithAliases() } returns flowOf(rows)
-            val repository = createRepository(dao)
+                val dao = createMockDao()
+                every { dao.observeByIdWithAliases("contrib-1") } returns flowOf(row)
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.observeAll().first()
+                // When
+                val result = repository.observeById("contrib-1").first()
 
-            // Then
-            assertEquals(100, result.size)
-            assertEquals("contrib-1", result[0].id.value)
-            assertEquals("contrib-100", result[99].id.value)
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "contrib-1"
+                result.name shouldBe "Stephen King"
+                result.description shouldBe "Horror author"
+                result.website shouldBe "https://stephenking.com"
+            }
         }
 
-    @Test
-    fun `getByBookId handles multiple contributors for book`() =
-        runTest {
-            // Given
-            val entities =
-                (1..10).map { i ->
+        test("observeById transforms entity correctly") {
+            runTest {
+                // Given — aliases seeded in arbitrary order to prove repository-level sorting
+                val row =
+                    createTestContributorWithAliases(
+                        entity =
+                            createTestContributorEntity(
+                                id = "contrib-42",
+                                name = "Test Author",
+                                description = "Test description",
+                                imagePath = "/images/author.jpg",
+                                imageBlurHash = "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+                                website = "https://example.com",
+                                birthDate = "1947-09-21",
+                                deathDate = null,
+                            ),
+                        aliases = listOf("Richard Bachman", "John Swithen"),
+                    )
+                val dao = createMockDao()
+                every { dao.observeByIdWithAliases("contrib-42") } returns flowOf(row)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeById("contrib-42").first()
+
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "contrib-42"
+                result.name shouldBe "Test Author"
+                result.description shouldBe "Test description"
+                result.imagePath shouldBe "/images/author.jpg"
+                result.imageBlurHash shouldBe "LEHV6nWB2yk8pyo0adR*.7kCMdnj"
+                result.website shouldBe "https://example.com"
+                result.birthDate shouldBe "1947-09-21"
+                result.deathDate shouldBe null
+                // Sorted case-insensitively at the domain boundary
+                result.aliases shouldBe listOf("John Swithen", "Richard Bachman")
+            }
+        }
+
+        test("observeById delegates to dao with correct id") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeByIdWithAliases("target-id") } returns flowOf(null)
+                val repository = createRepository(dao)
+
+                // When
+                repository.observeById("target-id").first()
+
+                // Then
+                verify { dao.observeByIdWithAliases("target-id") }
+            }
+        }
+
+        // ========== getById Tests ==========
+
+        test("getById returns null when contributor not found") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("nonexistent") } returns null
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("nonexistent")
+
+                // Then
+                result shouldBe null
+            }
+        }
+
+        test("getById returns contributor when found") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity =
+                            createTestContributorEntity(
+                                id = "contrib-1",
+                                name = "Neil Gaiman",
+                                description = "Fantasy/Horror author",
+                            ),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "contrib-1"
+                result.name shouldBe "Neil Gaiman"
+                result.description shouldBe "Fantasy/Horror author"
+            }
+        }
+
+        test("getById transforms all entity fields correctly") {
+            runTest {
+                // Given — seed in arbitrary order to prove repository-level sorting
+                val row =
+                    createTestContributorWithAliases(
+                        entity =
+                            createTestContributorEntity(
+                                id = "complete-contrib",
+                                name = "Complete Author",
+                                description = "Full biography here",
+                                imagePath = "/path/to/image.jpg",
+                                imageBlurHash = "ABC123",
+                                website = "https://author.com",
+                                birthDate = "1960-01-15",
+                                deathDate = "2020-12-31",
+                            ),
+                        aliases = listOf("Pen Name Two", "Pen Name One", "Pen Name Three"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("complete-contrib") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("complete-contrib")
+
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "complete-contrib"
+                result.name shouldBe "Complete Author"
+                result.description shouldBe "Full biography here"
+                result.imagePath shouldBe "/path/to/image.jpg"
+                result.imageBlurHash shouldBe "ABC123"
+                result.website shouldBe "https://author.com"
+                result.birthDate shouldBe "1960-01-15"
+                result.deathDate shouldBe "2020-12-31"
+                // Sorted case-insensitively at the domain boundary:
+                // "Pen Name One" < "Pen Name Three" < "Pen Name Two" (O < Th < Tw)
+                result.aliases.size shouldBe 3
+                result.aliases[0] shouldBe "Pen Name One"
+                result.aliases[1] shouldBe "Pen Name Three"
+                result.aliases[2] shouldBe "Pen Name Two"
+            }
+        }
+
+        test("getById passes correct id to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("target-id") } returns null
+                val repository = createRepository(dao)
+
+                // When
+                repository.getById("target-id")
+
+                // Then
+                verifySuspend { dao.getByIdWithAliases("target-id") }
+            }
+        }
+
+        // ========== observeByBookId Tests ==========
+
+        test("observeByBookId returns empty list when book has no contributors") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeByBookId("book-1") } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeByBookId("book-1").first()
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("observeByBookId returns contributors for book") {
+            runTest {
+                // Given
+                val entities =
+                    listOf(
+                        createTestContributorEntity(id = "author-1", name = "Brandon Sanderson"),
+                        createTestContributorEntity(id = "narrator-1", name = "Michael Kramer"),
+                    )
+                val dao = createMockDao()
+                every { dao.observeByBookId("book-1") } returns flowOf(entities)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeByBookId("book-1").first()
+
+                // Then
+                result.size shouldBe 2
+                result[0].name shouldBe "Brandon Sanderson"
+                result[1].name shouldBe "Michael Kramer"
+            }
+        }
+
+        test("observeByBookId transforms entities to domain models") {
+            runTest {
+                // Given
+                val entity =
                     createTestContributorEntity(
-                        id = "contrib-$i",
-                        name = "Contributor $i",
+                        id = "contrib-1",
+                        name = "Kate Reading",
+                        description = "Narrator",
                     )
-                }
-            val dao = createMockDao()
-            everySuspend { dao.getByBookId("book-1") } returns entities
-            val repository = createRepository(dao)
+                val dao = createMockDao()
+                every { dao.observeByBookId("book-42") } returns flowOf(listOf(entity))
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getByBookId("book-1")
+                // When
+                val result = repository.observeByBookId("book-42").first()
 
-            // Then
-            assertEquals(10, result.size)
+                // Then — aliases come from the junction table and are not covered by this path;
+                // task 8 removes the entity field entirely. Scope this test to the non-alias fields.
+                result.size shouldBe 1
+                result[0].id.value shouldBe "contrib-1"
+                result[0].name shouldBe "Kate Reading"
+                result[0].description shouldBe "Narrator"
+            }
         }
 
-    @Test
-    fun `getBookIdsForContributor handles large number of books`() =
-        runTest {
-            // Given
-            val bookIds = (1..200).map { "book-$it" }
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForContributor("prolific-author") } returns bookIds
-            val repository = createRepository(dao)
+        test("observeByBookId passes correct bookId to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeByBookId("my-book-id") } returns flowOf(emptyList())
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getBookIdsForContributor("prolific-author")
+                // When
+                repository.observeByBookId("my-book-id").first()
 
-            // Then
-            assertEquals(200, result.size)
-            assertEquals("book-1", result[0])
-            assertEquals("book-200", result[199])
+                // Then
+                verify { dao.observeByBookId("my-book-id") }
+            }
         }
 
-    // ========== Domain Model Behavior Tests ==========
+        // ========== getByBookId Tests ==========
 
-    @Test
-    fun `domain model matchesName matches primary name case-insensitively`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(name = "Stephen King"),
-                    aliases = emptyList(),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
+        test("getByBookId returns empty list when book has no contributors") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getByBookId("book-1") } returns emptyList()
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getById("contrib-1")
+                // When
+                val result = repository.getByBookId("book-1")
 
-            // Then
-            assertNotNull(result)
-            assertTrue(result.matchesName("Stephen King"))
-            assertTrue(result.matchesName("STEPHEN KING"))
-            assertTrue(result.matchesName("stephen king"))
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
         }
 
-    @Test
-    fun `domain model matchesName matches alias case-insensitively`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(name = "Stephen King"),
-                    aliases = listOf("Richard Bachman"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
+        test("getByBookId returns contributors for book") {
+            runTest {
+                // Given
+                val entities =
+                    listOf(
+                        createTestContributorEntity(id = "c1", name = "Author One"),
+                        createTestContributorEntity(id = "c2", name = "Author Two"),
+                        createTestContributorEntity(id = "c3", name = "Narrator One"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByBookId("book-1") } returns entities
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getById("contrib-1")
+                // When
+                val result = repository.getByBookId("book-1")
 
-            // Then
-            assertNotNull(result)
-            assertTrue(result.matchesName("Richard Bachman"))
-            assertTrue(result.matchesName("RICHARD BACHMAN"))
-            assertTrue(result.matchesName("richard bachman"))
+                // Then
+                result.size shouldBe 3
+                result[0].name shouldBe "Author One"
+                result[1].name shouldBe "Author Two"
+                result[2].name shouldBe "Narrator One"
+            }
         }
 
-    @Test
-    fun `domain model matchesName returns false for non-matching names`() =
-        runTest {
-            // Given
-            val row =
-                createTestContributorWithAliases(
-                    entity = createTestContributorEntity(name = "Stephen King"),
-                    aliases = listOf("Richard Bachman"),
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
-            val repository = createRepository(dao)
+        test("getByBookId transforms entities to domain models") {
+            runTest {
+                // Given
+                val entity =
+                    createTestContributorEntity(
+                        id = "contrib-5",
+                        name = "Tim Gerard Reynolds",
+                        description = "Audiobook narrator",
+                        imagePath = "/images/tgr.jpg",
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByBookId("book-1") } returns listOf(entity)
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getById("contrib-1")
+                // When
+                val result = repository.getByBookId("book-1")
 
-            // Then
-            assertNotNull(result)
-            assertTrue(!result.matchesName("Neil Gaiman"))
-            assertTrue(!result.matchesName("Random Name"))
+                // Then
+                result.size shouldBe 1
+                result[0].id.value shouldBe "contrib-5"
+                result[0].name shouldBe "Tim Gerard Reynolds"
+                result[0].description shouldBe "Audiobook narrator"
+                result[0].imagePath shouldBe "/images/tgr.jpg"
+            }
         }
-}
+
+        test("getByBookId calls dao with correct bookId") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getByBookId("specific-book-id") } returns emptyList()
+                val repository = createRepository(dao)
+
+                // When
+                repository.getByBookId("specific-book-id")
+
+                // Then
+                verifySuspend { dao.getByBookId("specific-book-id") }
+            }
+        }
+
+        // ========== getBookIdsForContributor Tests ==========
+
+        test("getBookIdsForContributor returns empty list when contributor has no books") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForContributor("contrib-1") } returns emptyList()
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForContributor("contrib-1")
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("getBookIdsForContributor returns book IDs for contributor") {
+            runTest {
+                // Given
+                val bookIds = listOf("book-1", "book-2", "book-3")
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForContributor("contrib-1") } returns bookIds
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForContributor("contrib-1")
+
+                // Then
+                result.size shouldBe 3
+                result[0] shouldBe "book-1"
+                result[1] shouldBe "book-2"
+                result[2] shouldBe "book-3"
+            }
+        }
+
+        test("getBookIdsForContributor passes correct contributorId to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForContributor("specific-contrib-id") } returns emptyList()
+                val repository = createRepository(dao)
+
+                // When
+                repository.getBookIdsForContributor("specific-contrib-id")
+
+                // Then
+                verifySuspend { dao.getBookIdsForContributor("specific-contrib-id") }
+            }
+        }
+
+        // ========== observeBookIdsForContributor Tests ==========
+
+        test("observeBookIdsForContributor returns empty list when contributor has no books") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeBookIdsForContributor("contrib-1") } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeBookIdsForContributor("contrib-1").first()
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("observeBookIdsForContributor returns book IDs for contributor") {
+            runTest {
+                // Given
+                val bookIds = listOf("book-a", "book-b")
+                val dao = createMockDao()
+                every { dao.observeBookIdsForContributor("contrib-1") } returns flowOf(bookIds)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeBookIdsForContributor("contrib-1").first()
+
+                // Then
+                result.size shouldBe 2
+                result[0] shouldBe "book-a"
+                result[1] shouldBe "book-b"
+            }
+        }
+
+        test("observeBookIdsForContributor passes correct contributorId to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeBookIdsForContributor("target-contrib") } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                repository.observeBookIdsForContributor("target-contrib").first()
+
+                // Then
+                verify { dao.observeBookIdsForContributor("target-contrib") }
+            }
+        }
+
+        // ========== Entity to Domain Conversion Tests ==========
+
+        test("toDomain converts all entity fields correctly") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity =
+                            createTestContributorEntity(
+                                id = "conversion-test",
+                                name = "Full Name",
+                                description = "Full description",
+                                imagePath = "/full/path.jpg",
+                                imageBlurHash = "BLURHASH",
+                                website = "https://full.website.com",
+                                birthDate = "1980-06-15",
+                                deathDate = "2050-12-31",
+                            ),
+                        aliases = listOf("Alias Two", "Alias One"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("conversion-test") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("conversion-test")
+
+                // Then - verify all fields are mapped, aliases sorted case-insensitively
+                result.shouldNotBeNull()
+                result.id.value shouldBe "conversion-test"
+                result.name shouldBe "Full Name"
+                result.description shouldBe "Full description"
+                result.imagePath shouldBe "/full/path.jpg"
+                result.imageBlurHash shouldBe "BLURHASH"
+                result.website shouldBe "https://full.website.com"
+                result.birthDate shouldBe "1980-06-15"
+                result.deathDate shouldBe "2050-12-31"
+                result.aliases.size shouldBe 2
+                result.aliases[0] shouldBe "Alias One"
+                result.aliases[1] shouldBe "Alias Two"
+            }
+        }
+
+        test("toDomain handles null optional fields") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity =
+                            createTestContributorEntity(
+                                id = "minimal-contrib",
+                                name = "Minimal Author",
+                                description = null,
+                                imagePath = null,
+                                imageBlurHash = null,
+                                website = null,
+                                birthDate = null,
+                                deathDate = null,
+                            ),
+                        aliases = emptyList(),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("minimal-contrib") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("minimal-contrib")
+
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "minimal-contrib"
+                result.name shouldBe "Minimal Author"
+                result.description shouldBe null
+                result.imagePath shouldBe null
+                result.imageBlurHash shouldBe null
+                result.website shouldBe null
+                result.birthDate shouldBe null
+                result.deathDate shouldBe null
+                (result.aliases.isEmpty()) shouldBe true
+            }
+        }
+
+        // ========== Alias Projection + Sorting Tests ==========
+        // Aliases are sourced from the `contributor_aliases` junction table (projected by
+        // ContributorWithAliases) and sorted case-insensitively at the domain boundary, since
+        // Room's @Relation does not support ORDER BY on the projected child collection.
+
+        test("toDomain returns single alias unchanged") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(),
+                        aliases = listOf("Richard Bachman"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                result.aliases.size shouldBe 1
+                result.aliases[0] shouldBe "Richard Bachman"
+            }
+        }
+
+        test("toDomain sorts multiple aliases alphabetically") {
+            runTest {
+                // Given — seed in arbitrary order
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(),
+                        aliases = listOf("Alias Three", "Alias One", "Alias Two"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                result.aliases.size shouldBe 3
+                result.aliases[0] shouldBe "Alias One"
+                result.aliases[1] shouldBe "Alias Three"
+                result.aliases[2] shouldBe "Alias Two"
+            }
+        }
+
+        test("toDomain sorts aliases case-insensitively") {
+            runTest {
+                // Given — mixed case; case-insensitive sort must group regardless of case
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(),
+                        aliases = listOf("charlie", "Bravo", "alpha", "Delta"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                result.aliases shouldBe listOf("alpha", "Bravo", "charlie", "Delta")
+            }
+        }
+
+        test("toDomain returns empty list when no aliases projected") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(),
+                        aliases = emptyList(),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                (result.aliases.isEmpty()) shouldBe true
+            }
+        }
+
+        // ========== Multiple Items Tests ==========
+
+        test("observeAll handles large number of contributors") {
+            runTest {
+                // Given
+                val rows =
+                    (1..100).map { i ->
+                        createTestContributorWithAliases(
+                            entity =
+                                createTestContributorEntity(
+                                    id = "contrib-$i",
+                                    name = "Contributor $i",
+                                ),
+                        )
+                    }
+                val dao = createMockDao()
+                every { dao.observeAllWithAliases() } returns flowOf(rows)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result.size shouldBe 100
+                result[0].id.value shouldBe "contrib-1"
+                result[99].id.value shouldBe "contrib-100"
+            }
+        }
+
+        test("getByBookId handles multiple contributors for book") {
+            runTest {
+                // Given
+                val entities =
+                    (1..10).map { i ->
+                        createTestContributorEntity(
+                            id = "contrib-$i",
+                            name = "Contributor $i",
+                        )
+                    }
+                val dao = createMockDao()
+                everySuspend { dao.getByBookId("book-1") } returns entities
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getByBookId("book-1")
+
+                // Then
+                result.size shouldBe 10
+            }
+        }
+
+        test("getBookIdsForContributor handles large number of books") {
+            runTest {
+                // Given
+                val bookIds = (1..200).map { "book-$it" }
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForContributor("prolific-author") } returns bookIds
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForContributor("prolific-author")
+
+                // Then
+                result.size shouldBe 200
+                result[0] shouldBe "book-1"
+                result[199] shouldBe "book-200"
+            }
+        }
+
+        // ========== Domain Model Behavior Tests ==========
+
+        test("domain model matchesName matches primary name case-insensitively") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(name = "Stephen King"),
+                        aliases = emptyList(),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                (result.matchesName("Stephen King")) shouldBe true
+                (result.matchesName("STEPHEN KING")) shouldBe true
+                (result.matchesName("stephen king")) shouldBe true
+            }
+        }
+
+        test("domain model matchesName matches alias case-insensitively") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(name = "Stephen King"),
+                        aliases = listOf("Richard Bachman"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                (result.matchesName("Richard Bachman")) shouldBe true
+                (result.matchesName("RICHARD BACHMAN")) shouldBe true
+                (result.matchesName("richard bachman")) shouldBe true
+            }
+        }
+
+        test("domain model matchesName returns false for non-matching names") {
+            runTest {
+                // Given
+                val row =
+                    createTestContributorWithAliases(
+                        entity = createTestContributorEntity(name = "Stephen King"),
+                        aliases = listOf("Richard Bachman"),
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getByIdWithAliases("contrib-1") } returns row
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("contrib-1")
+
+                // Then
+                result.shouldNotBeNull()
+                (!result.matchesName("Neil Gaiman")) shouldBe true
+                (!result.matchesName("Random Name")) shouldBe true
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryTest.kt
@@ -19,11 +19,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * Tests for ContributorRepository.
@@ -32,408 +30,410 @@ import kotlin.test.assertTrue
  * - Online: Use server Bleve search
  * - Offline or server failure: Fall back to local Room FTS5
  */
-class ContributorRepositoryTest {
-    // --- Helper functions for creating mocks ---
+class ContributorRepositoryTest :
+    FunSpec({
 
-    private fun createMockApi(): ContributorApiContract = mock<ContributorApiContract>()
+        // --- Helper functions for creating mocks ---
 
-    private fun createMockSearchDao(): SearchDao = mock<SearchDao>(MockMode.autoUnit)
+        fun createMockApi(): ContributorApiContract = mock<ContributorApiContract>()
 
-    private fun createMockContributorDao(): ContributorDao = mock<ContributorDao>(MockMode.autoUnit)
+        fun createMockSearchDao(): SearchDao = mock<SearchDao>(MockMode.autoUnit)
 
-    private fun createMockBookDao(): BookDao = mock<BookDao>(MockMode.autoUnit)
+        fun createMockContributorDao(): ContributorDao = mock<ContributorDao>(MockMode.autoUnit)
 
-    private fun createMockNetworkMonitor(): NetworkMonitor = mock<NetworkMonitor>()
+        fun createMockBookDao(): BookDao = mock<BookDao>(MockMode.autoUnit)
 
-    private fun createMockMetadataApi(): MetadataApiContract = mock<MetadataApiContract>()
+        fun createMockNetworkMonitor(): NetworkMonitor = mock<NetworkMonitor>()
 
-    private fun createMockImageStorage(): ImageStorage = mock<ImageStorage>()
+        fun createMockMetadataApi(): MetadataApiContract = mock<MetadataApiContract>()
 
-    private fun createTestContributorEntity(
-        id: String = "contrib-1",
-        name: String = "Brandon Sanderson",
-    ): ContributorEntity =
-        ContributorEntity(
-            id =
-                com.calypsan.listenup.client.core
-                    .ContributorId(id),
-            name = name,
-            description = null,
-            imagePath = null,
-            createdAt = Timestamp(0),
-            updatedAt = Timestamp(0),
-        )
+        fun createMockImageStorage(): ImageStorage = mock<ImageStorage>()
 
-    private fun createContributorSearchResult(
-        id: String = "contrib-1",
-        name: String = "Brandon Sanderson",
-        bookCount: Int = 5,
-    ): ContributorSearchResult =
-        ContributorSearchResult(
-            id = id,
-            name = name,
-            bookCount = bookCount,
-        )
+        fun createTestContributorEntity(
+            id: String = "contrib-1",
+            name: String = "Brandon Sanderson",
+        ): ContributorEntity =
+            ContributorEntity(
+                id =
+                    com.calypsan.listenup.client.core
+                        .ContributorId(id),
+                name = name,
+                description = null,
+                imagePath = null,
+                createdAt = Timestamp(0),
+                updatedAt = Timestamp(0),
+            )
 
-    // --- Empty/short query tests ---
+        fun createContributorSearchResult(
+            id: String = "contrib-1",
+            name: String = "Brandon Sanderson",
+            bookCount: Int = 5,
+        ): ContributorSearchResult =
+            ContributorSearchResult(
+                id = id,
+                name = name,
+                bookCount = bookCount,
+            )
 
-    @Test
-    fun `empty query returns empty result`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        // --- Empty/short query tests ---
 
-            // When
-            val result = repository.searchContributors("")
+        test("empty query returns empty result") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            // Then
-            assertTrue(result.contributors.isEmpty())
-            assertEquals(0, result.tookMs)
+                // When
+                val result = repository.searchContributors("")
+
+                // Then
+                (result.contributors.isEmpty()) shouldBe true
+                result.tookMs shouldBe 0
+            }
         }
 
-    @Test
-    fun `single character query returns empty result`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("single character query returns empty result") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            // When
-            val result = repository.searchContributors("b")
+                // When
+                val result = repository.searchContributors("b")
 
-            // Then
-            assertTrue(result.contributors.isEmpty())
+                // Then
+                (result.contributors.isEmpty()) shouldBe true
+            }
         }
 
-    @Test
-    fun `whitespace-only query returns empty result`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("whitespace-only query returns empty result") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            // When
-            val result = repository.searchContributors("   ")
+                // When
+                val result = repository.searchContributors("   ")
 
-            // Then
-            assertTrue(result.contributors.isEmpty())
+                // Then
+                (result.contributors.isEmpty()) shouldBe true
+            }
         }
 
-    // --- Online search tests ---
+        // --- Online search tests ---
 
-    @Test
-    fun `online search calls server API`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("online search calls server API") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns true
+                every { networkMonitor.isOnline() } returns true
 
-            val serverResults =
-                listOf(
-                    createContributorSearchResult(id = "c1", name = "Brandon Sanderson", bookCount = 10),
-                    createContributorSearchResult(id = "c2", name = "Brian McClellan", bookCount = 5),
-                )
-            everySuspend { api.searchContributors(any(), any()) } returns Success(serverResults)
+                val serverResults =
+                    listOf(
+                        createContributorSearchResult(id = "c1", name = "Brandon Sanderson", bookCount = 10),
+                        createContributorSearchResult(id = "c2", name = "Brian McClellan", bookCount = 5),
+                    )
+                everySuspend { api.searchContributors(any(), any()) } returns Success(serverResults)
 
-            // When
-            val result = repository.searchContributors("bran")
+                // When
+                val result = repository.searchContributors("bran")
 
-            // Then
-            assertEquals(2, result.contributors.size)
-            assertEquals("Brandon Sanderson", result.contributors[0].name)
-            assertEquals("Brian McClellan", result.contributors[1].name)
-            assertFalse(result.isOfflineResult)
+                // Then
+                result.contributors.size shouldBe 2
+                result.contributors[0].name shouldBe "Brandon Sanderson"
+                result.contributors[1].name shouldBe "Brian McClellan"
+                result.isOfflineResult shouldBe false
+            }
         }
 
-    @Test
-    fun `online search passes limit parameter`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("online search passes limit parameter") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns true
-            everySuspend { api.searchContributors(any(), any()) } returns Success(emptyList())
+                every { networkMonitor.isOnline() } returns true
+                everySuspend { api.searchContributors(any(), any()) } returns Success(emptyList())
 
-            // When
-            repository.searchContributors("test", limit = 5)
+                // When
+                repository.searchContributors("test", limit = 5)
 
-            // Then - verify API was called with correct limit
-            verifySuspend { api.searchContributors(any(), any()) }
+                // Then - verify API was called with correct limit
+                verifySuspend { api.searchContributors(any(), any()) }
+            }
         }
 
-    @Test
-    fun `online search returns book counts`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("online search returns book counts") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns true
+                every { networkMonitor.isOnline() } returns true
 
-            val serverResults =
-                listOf(
-                    createContributorSearchResult(id = "c1", name = "Brandon Sanderson", bookCount = 15),
-                )
-            everySuspend { api.searchContributors(any(), any()) } returns Success(serverResults)
+                val serverResults =
+                    listOf(
+                        createContributorSearchResult(id = "c1", name = "Brandon Sanderson", bookCount = 15),
+                    )
+                everySuspend { api.searchContributors(any(), any()) } returns Success(serverResults)
 
-            // When
-            val result = repository.searchContributors("sanderson")
+                // When
+                val result = repository.searchContributors("sanderson")
 
-            // Then
-            assertEquals(15, result.contributors[0].bookCount)
+                // Then
+                result.contributors[0].bookCount shouldBe 15
+            }
         }
 
-    // --- Offline fallback tests ---
+        // --- Offline fallback tests ---
 
-    @Test
-    fun `offline search uses local FTS`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("offline search uses local FTS") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns false
-            everySuspend { searchDao.searchContributors(any(), any()) } returns
-                listOf(createTestContributorEntity(id = "c1", name = "Local Author"))
+                every { networkMonitor.isOnline() } returns false
+                everySuspend { searchDao.searchContributors(any(), any()) } returns
+                    listOf(createTestContributorEntity(id = "c1", name = "Local Author"))
 
-            // When
-            val result = repository.searchContributors("local")
+                // When
+                val result = repository.searchContributors("local")
 
-            // Then
-            assertEquals(1, result.contributors.size)
-            assertEquals("Local Author", result.contributors[0].name)
-            assertTrue(result.isOfflineResult)
+                // Then
+                result.contributors.size shouldBe 1
+                result.contributors[0].name shouldBe "Local Author"
+                result.isOfflineResult shouldBe true
+            }
         }
 
-    @Test
-    fun `offline search sets book count to zero`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("offline search sets book count to zero") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns false
-            everySuspend { searchDao.searchContributors(any(), any()) } returns
-                listOf(createTestContributorEntity(id = "c1", name = "Author"))
+                every { networkMonitor.isOnline() } returns false
+                everySuspend { searchDao.searchContributors(any(), any()) } returns
+                    listOf(createTestContributorEntity(id = "c1", name = "Author"))
 
-            // When
-            val result = repository.searchContributors("author")
+                // When
+                val result = repository.searchContributors("author")
 
-            // Then
-            assertEquals(0, result.contributors[0].bookCount) // Not available offline
+                // Then
+                result.contributors[0].bookCount shouldBe 0 // Not available offline
+            }
         }
 
-    @Test
-    fun `server error falls back to local FTS`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("server error falls back to local FTS") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns true
-            everySuspend { api.searchContributors(any(), any()) } returns
-                Failure(Exception("Server error"))
-            everySuspend { searchDao.searchContributors(any(), any()) } returns
-                listOf(createTestContributorEntity(id = "c1", name = "Fallback Author"))
+                every { networkMonitor.isOnline() } returns true
+                everySuspend { api.searchContributors(any(), any()) } returns
+                    Failure(Exception("Server error"))
+                everySuspend { searchDao.searchContributors(any(), any()) } returns
+                    listOf(createTestContributorEntity(id = "c1", name = "Fallback Author"))
 
-            // When
-            val result = repository.searchContributors("fallback")
+                // When
+                val result = repository.searchContributors("fallback")
 
-            // Then
-            assertEquals(1, result.contributors.size)
-            assertEquals("Fallback Author", result.contributors[0].name)
-            assertTrue(result.isOfflineResult)
+                // Then
+                result.contributors.size shouldBe 1
+                result.contributors[0].name shouldBe "Fallback Author"
+                result.isOfflineResult shouldBe true
+            }
         }
 
-    // --- Query sanitization tests ---
+        // --- Query sanitization tests ---
 
-    @Test
-    fun `query with special characters is sanitized`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("query with special characters is sanitized") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns true
-            everySuspend { api.searchContributors(any(), any()) } returns Success(emptyList())
+                every { networkMonitor.isOnline() } returns true
+                everySuspend { api.searchContributors(any(), any()) } returns Success(emptyList())
 
-            // When - query with FTS special chars that should be stripped
-            val result = repository.searchContributors("test*()\":")
+                // When - query with FTS special chars that should be stripped
+                val result = repository.searchContributors("test*()\":")
 
-            // Then - should not throw, search executes
-            assertFalse(result.isOfflineResult)
+                // Then - should not throw, search executes
+                result.isOfflineResult shouldBe false
+            }
         }
 
-    @Test
-    fun `very long query is truncated`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("very long query is truncated") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns true
-            everySuspend { api.searchContributors(any(), any()) } returns Success(emptyList())
+                every { networkMonitor.isOnline() } returns true
+                everySuspend { api.searchContributors(any(), any()) } returns Success(emptyList())
 
-            // When - query longer than 100 chars
-            val longQuery = "ab" + "a".repeat(200)
-            val result = repository.searchContributors(longQuery)
+                // When - query longer than 100 chars
+                val longQuery = "ab" + "a".repeat(200)
+                val result = repository.searchContributors(longQuery)
 
-            // Then - should not throw, search executes with truncated query
-            assertFalse(result.isOfflineResult)
+                // Then - should not throw, search executes with truncated query
+                result.isOfflineResult shouldBe false
+            }
         }
 
-    // --- FTS query conversion tests ---
+        // --- FTS query conversion tests ---
 
-    @Test
-    fun `local search converts query to FTS format`() =
-        runTest {
-            // Given
-            val api = createMockApi()
-            val searchDao = createMockSearchDao()
-            val networkMonitor = createMockNetworkMonitor()
-            val repository =
-                ContributorRepositoryImpl(
-                    contributorDao = createMockContributorDao(),
-                    bookDao = createMockBookDao(),
-                    searchDao = searchDao,
-                    api = api,
-                    metadataApi = createMockMetadataApi(),
-                    networkMonitor = networkMonitor,
-                    imageStorage = createMockImageStorage(),
-                )
+        test("local search converts query to FTS format") {
+            runTest {
+                // Given
+                val api = createMockApi()
+                val searchDao = createMockSearchDao()
+                val networkMonitor = createMockNetworkMonitor()
+                val repository =
+                    ContributorRepositoryImpl(
+                        contributorDao = createMockContributorDao(),
+                        bookDao = createMockBookDao(),
+                        searchDao = searchDao,
+                        api = api,
+                        metadataApi = createMockMetadataApi(),
+                        networkMonitor = networkMonitor,
+                        imageStorage = createMockImageStorage(),
+                    )
 
-            every { networkMonitor.isOnline() } returns false
-            everySuspend { searchDao.searchContributors(any(), any()) } returns emptyList()
+                every { networkMonitor.isOnline() } returns false
+                everySuspend { searchDao.searchContributors(any(), any()) } returns emptyList()
 
-            // When - multi-word query
-            repository.searchContributors("brandon sanderson")
+                // When - multi-word query
+                repository.searchContributors("brandon sanderson")
 
-            // Then - should call searchDao (FTS query conversion happens internally)
-            verifySuspend { searchDao.searchContributors(any(), any()) }
+                // Then - should call searchDao (FTS query conversion happens internally)
+                verifySuspend { searchDao.searchContributors(any(), any()) }
+            }
         }
-}
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImplTest.kt
@@ -22,14 +22,12 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for SeriesRepositoryImpl.
@@ -40,803 +38,805 @@ import kotlin.test.assertTrue
  * - Proper handling of empty results and null cases
  * - Flow emissions for reactive queries
  */
-class SeriesRepositoryImplTest {
-    // ========== Test Fixtures ==========
+class SeriesRepositoryImplTest :
+    FunSpec({
 
-    private fun createMockDao(): SeriesDao = mock<SeriesDao>(MockMode.autoUnit)
+        // ========== Test Fixtures ==========
 
-    private fun createRepository(dao: SeriesDao): SeriesRepositoryImpl =
-        SeriesRepositoryImpl(
-            seriesDao = dao,
-            bookDao = mock<BookDao>(MockMode.autoUnit),
-            searchDao = mock<SearchDao>(MockMode.autoUnit),
-            api = mock<SeriesApiContract>(),
-            networkMonitor = mock<NetworkMonitor>(),
-            imageStorage = mock<ImageStorage>(),
-        )
+        fun createMockDao(): SeriesDao = mock<SeriesDao>(MockMode.autoUnit)
 
-    private fun createTestSeriesEntity(
-        id: String = "series-1",
-        name: String = "The Stormlight Archive",
-        description: String? = null,
-        createdAt: Long = 1000L,
-        updatedAt: Long = 1000L,
-    ): SeriesEntity =
-        SeriesEntity(
-            id =
-                com.calypsan.listenup.client.core
-                    .SeriesId(id),
-            name = name,
-            description = description,
-            createdAt = Timestamp(createdAt),
-            updatedAt = Timestamp(updatedAt),
-        )
+        fun createRepository(dao: SeriesDao): SeriesRepositoryImpl =
+            SeriesRepositoryImpl(
+                seriesDao = dao,
+                bookDao = mock<BookDao>(MockMode.autoUnit),
+                searchDao = mock<SearchDao>(MockMode.autoUnit),
+                api = mock<SeriesApiContract>(),
+                networkMonitor = mock<NetworkMonitor>(),
+                imageStorage = mock<ImageStorage>(),
+            )
 
-    // ========== observeAll Tests ==========
+        fun createTestSeriesEntity(
+            id: String = "series-1",
+            name: String = "The Stormlight Archive",
+            description: String? = null,
+            createdAt: Long = 1000L,
+            updatedAt: Long = 1000L,
+        ): SeriesEntity =
+            SeriesEntity(
+                id =
+                    com.calypsan.listenup.client.core
+                        .SeriesId(id),
+                name = name,
+                description = description,
+                createdAt = Timestamp(createdAt),
+                updatedAt = Timestamp(updatedAt),
+            )
 
-    @Test
-    fun `observeAll returns empty list when no series exist`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeAll() } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeAll().first()
-
-            // Then
-            assertTrue(result.isEmpty())
+        fun createRepositoryWithBookDao(
+            seriesDao: SeriesDao,
+            bookDao: BookDao,
+        ): SeriesRepositoryImpl {
+            val imageStorage = mock<ImageStorage>(MockMode.autoUnit)
+            every { imageStorage.exists(any()) } returns false
+            return SeriesRepositoryImpl(
+                seriesDao = seriesDao,
+                bookDao = bookDao,
+                searchDao = mock<SearchDao>(MockMode.autoUnit),
+                api = mock<SeriesApiContract>(),
+                networkMonitor = mock<NetworkMonitor>(),
+                imageStorage = imageStorage,
+            )
         }
 
-    @Test
-    fun `observeAll transforms entities to domain models`() =
-        runTest {
-            // Given
-            val entities =
-                listOf(
+        fun makeBookEntity(
+            id: String,
+            title: String,
+        ): BookEntity =
+            BookEntity(
+                id = BookId(id),
+                title = title,
+                sortTitle = title,
+                subtitle = null,
+                coverHash = null,
+                coverBlurHash = null,
+                dominantColor = null,
+                darkMutedColor = null,
+                vibrantColor = null,
+                totalDuration = 1_000L,
+                description = null,
+                publishYear = null,
+                publisher = null,
+                language = null,
+                isbn = null,
+                asin = null,
+                abridged = false,
+                createdAt = Timestamp(1_000L),
+                updatedAt = Timestamp(1_000L),
+            )
+
+        fun makeBookWithContributors(book: BookEntity): BookWithContributors =
+            BookWithContributors(
+                book = book,
+                contributors = emptyList(),
+                contributorRoles = emptyList(),
+                series = emptyList(),
+                seriesSequences = emptyList(),
+            )
+
+        // ========== observeAll Tests ==========
+
+        test("observeAll returns empty list when no series exist") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeAll() } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("observeAll transforms entities to domain models") {
+            runTest {
+                // Given
+                val entities =
+                    listOf(
+                        createTestSeriesEntity(
+                            id = "series-1",
+                            name = "The Stormlight Archive",
+                            description = "Epic fantasy series",
+                        ),
+                        createTestSeriesEntity(
+                            id = "series-2",
+                            name = "Mistborn",
+                            description = "Fantasy trilogy",
+                        ),
+                    )
+                val dao = createMockDao()
+                every { dao.observeAll() } returns flowOf(entities)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result.size shouldBe 2
+                result[0].id.value shouldBe "series-1"
+                result[0].name shouldBe "The Stormlight Archive"
+                result[0].description shouldBe "Epic fantasy series"
+                result[1].id.value shouldBe "series-2"
+                result[1].name shouldBe "Mistborn"
+                result[1].description shouldBe "Fantasy trilogy"
+            }
+        }
+
+        test("observeAll preserves entity order from dao") {
+            runTest {
+                // Given - entities ordered by name
+                val entities =
+                    listOf(
+                        createTestSeriesEntity(id = "s1", name = "Alpha Series"),
+                        createTestSeriesEntity(id = "s2", name = "Beta Series"),
+                        createTestSeriesEntity(id = "s3", name = "Gamma Series"),
+                    )
+                val dao = createMockDao()
+                every { dao.observeAll() } returns flowOf(entities)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result[0].name shouldBe "Alpha Series"
+                result[1].name shouldBe "Beta Series"
+                result[2].name shouldBe "Gamma Series"
+            }
+        }
+
+        test("observeAll delegates to dao observeAll") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeAll() } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                repository.observeAll().first()
+
+                // Then
+                verify { dao.observeAll() }
+            }
+        }
+
+        // ========== observeById Tests ==========
+
+        test("observeById returns null when series not found") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeById("nonexistent") } returns flowOf(null)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeById("nonexistent").first()
+
+                // Then
+                result shouldBe null
+            }
+        }
+
+        test("observeById returns series when found") {
+            runTest {
+                // Given
+                val entity =
                     createTestSeriesEntity(
                         id = "series-1",
-                        name = "The Stormlight Archive",
-                        description = "Epic fantasy series",
-                    ),
-                    createTestSeriesEntity(
-                        id = "series-2",
-                        name = "Mistborn",
-                        description = "Fantasy trilogy",
-                    ),
-                )
-            val dao = createMockDao()
-            every { dao.observeAll() } returns flowOf(entities)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeAll().first()
-
-            // Then
-            assertEquals(2, result.size)
-            assertEquals("series-1", result[0].id.value)
-            assertEquals("The Stormlight Archive", result[0].name)
-            assertEquals("Epic fantasy series", result[0].description)
-            assertEquals("series-2", result[1].id.value)
-            assertEquals("Mistborn", result[1].name)
-            assertEquals("Fantasy trilogy", result[1].description)
-        }
-
-    @Test
-    fun `observeAll preserves entity order from dao`() =
-        runTest {
-            // Given - entities ordered by name
-            val entities =
-                listOf(
-                    createTestSeriesEntity(id = "s1", name = "Alpha Series"),
-                    createTestSeriesEntity(id = "s2", name = "Beta Series"),
-                    createTestSeriesEntity(id = "s3", name = "Gamma Series"),
-                )
-            val dao = createMockDao()
-            every { dao.observeAll() } returns flowOf(entities)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeAll().first()
-
-            // Then
-            assertEquals("Alpha Series", result[0].name)
-            assertEquals("Beta Series", result[1].name)
-            assertEquals("Gamma Series", result[2].name)
-        }
-
-    @Test
-    fun `observeAll delegates to dao observeAll`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeAll() } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeAll().first()
-
-            // Then
-            verify { dao.observeAll() }
-        }
-
-    // ========== observeById Tests ==========
-
-    @Test
-    fun `observeById returns null when series not found`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeById("nonexistent") } returns flowOf(null)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeById("nonexistent").first()
-
-            // Then
-            assertNull(result)
-        }
-
-    @Test
-    fun `observeById returns series when found`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-1",
-                    name = "The Wheel of Time",
-                    description = "Epic fantasy series by Robert Jordan",
-                )
-            val dao = createMockDao()
-            every { dao.observeById("series-1") } returns flowOf(entity)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeById("series-1").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("series-1", result.id.value)
-            assertEquals("The Wheel of Time", result.name)
-            assertEquals("Epic fantasy series by Robert Jordan", result.description)
-        }
-
-    @Test
-    fun `observeById transforms entity correctly`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-42",
-                    name = "Test Series",
-                    description = "Test description",
-                )
-            val dao = createMockDao()
-            every { dao.observeById("series-42") } returns flowOf(entity)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeById("series-42").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("series-42", result.id.value)
-            assertEquals("Test Series", result.name)
-            assertEquals("Test description", result.description)
-        }
-
-    @Test
-    fun `observeById delegates to dao with correct id`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeById("target-id") } returns flowOf(null)
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeById("target-id").first()
-
-            // Then
-            verify { dao.observeById("target-id") }
-        }
-
-    // ========== getById Tests ==========
-
-    @Test
-    fun `getById returns null when series not found`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getById("nonexistent") } returns null
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("nonexistent")
-
-            // Then
-            assertNull(result)
-        }
-
-    @Test
-    fun `getById returns series when found`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-1",
-                    name = "Harry Potter",
-                    description = "Wizarding world",
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getById("series-1") } returns entity
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("series-1")
-
-            // Then
-            assertNotNull(result)
-            assertEquals("series-1", result.id.value)
-            assertEquals("Harry Potter", result.name)
-            assertEquals("Wizarding world", result.description)
-        }
-
-    @Test
-    fun `getById transforms all entity fields correctly`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "complete-series",
-                    name = "Complete Series Name",
-                    description = "Full description here",
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getById("complete-series") } returns entity
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("complete-series")
-
-            // Then
-            assertNotNull(result)
-            assertEquals("complete-series", result.id.value)
-            assertEquals("Complete Series Name", result.name)
-            assertEquals("Full description here", result.description)
-        }
-
-    @Test
-    fun `getById passes correct id to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getById("target-id") } returns null
-            val repository = createRepository(dao)
-
-            // When
-            repository.getById("target-id")
-
-            // Then
-            verifySuspend { dao.getById("target-id") }
-        }
-
-    // ========== observeByBookId Tests ==========
-
-    @Test
-    fun `observeByBookId returns null when book has no series`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeByBookId("book-1") } returns flowOf(null)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeByBookId("book-1").first()
-
-            // Then
-            assertNull(result)
-        }
-
-    @Test
-    fun `observeByBookId returns series for book`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-1",
-                    name = "The Cosmere",
-                    description = "Shared universe",
-                )
-            val dao = createMockDao()
-            every { dao.observeByBookId("book-1") } returns flowOf(entity)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeByBookId("book-1").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("series-1", result.id.value)
-            assertEquals("The Cosmere", result.name)
-            assertEquals("Shared universe", result.description)
-        }
-
-    @Test
-    fun `observeByBookId transforms entity to domain model`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-42",
-                    name = "Book Series",
-                    description = "Description",
-                )
-            val dao = createMockDao()
-            every { dao.observeByBookId("book-42") } returns flowOf(entity)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeByBookId("book-42").first()
-
-            // Then
-            assertNotNull(result)
-            assertEquals("series-42", result.id.value)
-            assertEquals("Book Series", result.name)
-            assertEquals("Description", result.description)
-        }
-
-    @Test
-    fun `observeByBookId passes correct bookId to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeByBookId("my-book-id") } returns flowOf(null)
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeByBookId("my-book-id").first()
-
-            // Then
-            verify { dao.observeByBookId("my-book-id") }
-        }
-
-    // ========== getBookIdsForSeries Tests ==========
-
-    @Test
-    fun `getBookIdsForSeries returns empty list when series has no books`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForSeries("series-1") } returns emptyList()
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getBookIdsForSeries("series-1")
-
-            // Then
-            assertTrue(result.isEmpty())
-        }
-
-    @Test
-    fun `getBookIdsForSeries returns book IDs for series`() =
-        runTest {
-            // Given
-            val bookIds = listOf("book-1", "book-2", "book-3")
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForSeries("series-1") } returns bookIds
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getBookIdsForSeries("series-1")
-
-            // Then
-            assertEquals(3, result.size)
-            assertEquals("book-1", result[0])
-            assertEquals("book-2", result[1])
-            assertEquals("book-3", result[2])
-        }
-
-    @Test
-    fun `getBookIdsForSeries passes correct seriesId to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForSeries("specific-series-id") } returns emptyList()
-            val repository = createRepository(dao)
-
-            // When
-            repository.getBookIdsForSeries("specific-series-id")
-
-            // Then
-            verifySuspend { dao.getBookIdsForSeries("specific-series-id") }
-        }
-
-    // ========== observeBookIdsForSeries Tests ==========
-
-    @Test
-    fun `observeBookIdsForSeries returns empty list when series has no books`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeBookIdsForSeries("series-1") } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeBookIdsForSeries("series-1").first()
-
-            // Then
-            assertTrue(result.isEmpty())
-        }
-
-    @Test
-    fun `observeBookIdsForSeries returns book IDs for series`() =
-        runTest {
-            // Given
-            val bookIds = listOf("book-a", "book-b")
-            val dao = createMockDao()
-            every { dao.observeBookIdsForSeries("series-1") } returns flowOf(bookIds)
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.observeBookIdsForSeries("series-1").first()
-
-            // Then
-            assertEquals(2, result.size)
-            assertEquals("book-a", result[0])
-            assertEquals("book-b", result[1])
-        }
-
-    @Test
-    fun `observeBookIdsForSeries passes correct seriesId to dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeBookIdsForSeries("target-series") } returns flowOf(emptyList())
-            val repository = createRepository(dao)
-
-            // When
-            repository.observeBookIdsForSeries("target-series").first()
-
-            // Then
-            verify { dao.observeBookIdsForSeries("target-series") }
-        }
-
-    // ========== Entity to Domain Conversion Tests ==========
-
-    @Test
-    fun `toDomain converts all entity fields correctly`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "conversion-test",
-                    name = "Full Name",
-                    description = "Full description",
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getById("conversion-test") } returns entity
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("conversion-test")
-
-            // Then - verify all fields are mapped
-            assertNotNull(result)
-            assertEquals("conversion-test", result.id.value)
-            assertEquals("Full Name", result.name)
-            assertEquals("Full description", result.description)
-        }
-
-    @Test
-    fun `toDomain handles null optional fields`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "minimal-series",
-                    name = "Minimal Series",
-                    description = null,
-                )
-            val dao = createMockDao()
-            everySuspend { dao.getById("minimal-series") } returns entity
-            val repository = createRepository(dao)
-
-            // When
-            val result = repository.getById("minimal-series")
-
-            // Then
-            assertNotNull(result)
-            assertEquals("minimal-series", result.id.value)
-            assertEquals("Minimal Series", result.name)
-            assertNull(result.description)
-        }
-
-    // ========== Multiple Items Tests ==========
-
-    @Test
-    fun `observeAll handles large number of series`() =
-        runTest {
-            // Given
-            val entities =
-                (1..100).map { i ->
-                    createTestSeriesEntity(
-                        id = "series-$i",
-                        name = "Series $i",
+                        name = "The Wheel of Time",
+                        description = "Epic fantasy series by Robert Jordan",
                     )
-                }
-            val dao = createMockDao()
-            every { dao.observeAll() } returns flowOf(entities)
-            val repository = createRepository(dao)
+                val dao = createMockDao()
+                every { dao.observeById("series-1") } returns flowOf(entity)
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.observeAll().first()
+                // When
+                val result = repository.observeById("series-1").first()
 
-            // Then
-            assertEquals(100, result.size)
-            assertEquals("series-1", result[0].id.value)
-            assertEquals("series-100", result[99].id.value)
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "series-1"
+                result.name shouldBe "The Wheel of Time"
+                result.description shouldBe "Epic fantasy series by Robert Jordan"
+            }
         }
 
-    @Test
-    fun `getBookIdsForSeries handles large number of books`() =
-        runTest {
-            // Given
-            val bookIds = (1..200).map { "book-$it" }
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForSeries("large-series") } returns bookIds
-            val repository = createRepository(dao)
+        test("observeById transforms entity correctly") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "series-42",
+                        name = "Test Series",
+                        description = "Test description",
+                    )
+                val dao = createMockDao()
+                every { dao.observeById("series-42") } returns flowOf(entity)
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getBookIdsForSeries("large-series")
+                // When
+                val result = repository.observeById("series-42").first()
 
-            // Then
-            assertEquals(200, result.size)
-            assertEquals("book-1", result[0])
-            assertEquals("book-200", result[199])
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "series-42"
+                result.name shouldBe "Test Series"
+                result.description shouldBe "Test description"
+            }
         }
 
-    // ========== Edge Cases Tests ==========
+        test("observeById delegates to dao with correct id") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeById("target-id") } returns flowOf(null)
+                val repository = createRepository(dao)
 
-    @Test
-    fun `observeAll handles series with empty description`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-1",
-                    name = "Series Name",
-                    description = "",
-                )
-            val dao = createMockDao()
-            every { dao.observeAll() } returns flowOf(listOf(entity))
-            val repository = createRepository(dao)
+                // When
+                repository.observeById("target-id").first()
 
-            // When
-            val result = repository.observeAll().first()
-
-            // Then
-            assertEquals(1, result.size)
-            assertEquals("", result[0].description)
+                // Then
+                verify { dao.observeById("target-id") }
+            }
         }
 
-    @Test
-    fun `observeById handles series with special characters in name`() =
-        runTest {
-            // Given
-            val entity =
-                createTestSeriesEntity(
-                    id = "series-special",
-                    name = "Series: The \"Special\" One (2024)",
-                    description = null,
-                )
-            val dao = createMockDao()
-            every { dao.observeById("series-special") } returns flowOf(entity)
-            val repository = createRepository(dao)
+        // ========== getById Tests ==========
 
-            // When
-            val result = repository.observeById("series-special").first()
+        test("getById returns null when series not found") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getById("nonexistent") } returns null
+                val repository = createRepository(dao)
 
-            // Then
-            assertNotNull(result)
-            assertEquals("Series: The \"Special\" One (2024)", result.name)
+                // When
+                val result = repository.getById("nonexistent")
+
+                // Then
+                result shouldBe null
+            }
         }
 
-    @Test
-    fun `getBookIdsForSeries returns single book ID`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getBookIdsForSeries("single-book-series") } returns listOf("only-book")
-            val repository = createRepository(dao)
+        test("getById returns series when found") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "series-1",
+                        name = "Harry Potter",
+                        description = "Wizarding world",
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getById("series-1") } returns entity
+                val repository = createRepository(dao)
 
-            // When
-            val result = repository.getBookIdsForSeries("single-book-series")
+                // When
+                val result = repository.getById("series-1")
 
-            // Then
-            assertEquals(1, result.size)
-            assertEquals("only-book", result[0])
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "series-1"
+                result.name shouldBe "Harry Potter"
+                result.description shouldBe "Wizarding world"
+            }
         }
 
-    // ========== observeAllWithBooks Tests (drift #16 closure) ==========
+        test("getById transforms all entity fields correctly") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "complete-series",
+                        name = "Complete Series Name",
+                        description = "Full description here",
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getById("complete-series") } returns entity
+                val repository = createRepository(dao)
 
-    private fun createRepositoryWithBookDao(
-        seriesDao: SeriesDao,
-        bookDao: BookDao,
-    ): SeriesRepositoryImpl {
-        val imageStorage = mock<ImageStorage>(MockMode.autoUnit)
-        every { imageStorage.exists(any()) } returns false
-        return SeriesRepositoryImpl(
-            seriesDao = seriesDao,
-            bookDao = bookDao,
-            searchDao = mock<SearchDao>(MockMode.autoUnit),
-            api = mock<SeriesApiContract>(),
-            networkMonitor = mock<NetworkMonitor>(),
-            imageStorage = imageStorage,
-        )
-    }
+                // When
+                val result = repository.getById("complete-series")
 
-    private fun makeBookEntity(
-        id: String,
-        title: String,
-    ): BookEntity =
-        BookEntity(
-            id = BookId(id),
-            title = title,
-            sortTitle = title,
-            subtitle = null,
-            coverHash = null,
-            coverBlurHash = null,
-            dominantColor = null,
-            darkMutedColor = null,
-            vibrantColor = null,
-            totalDuration = 1_000L,
-            description = null,
-            publishYear = null,
-            publisher = null,
-            language = null,
-            isbn = null,
-            asin = null,
-            abridged = false,
-            createdAt = Timestamp(1_000L),
-            updatedAt = Timestamp(1_000L),
-        )
-
-    private fun makeBookWithContributors(book: BookEntity): BookWithContributors =
-        BookWithContributors(
-            book = book,
-            contributors = emptyList(),
-            contributorRoles = emptyList(),
-            series = emptyList(),
-            seriesSequences = emptyList(),
-        )
-
-    @Test
-    fun `observeAllWithBooks returns empty list when no series exist`() =
-        runTest {
-            val seriesDao = createMockDao()
-            val bookDao = mock<BookDao>(MockMode.autoUnit)
-            every { seriesDao.observeAllWithBooks() } returns flowOf(emptyList())
-            every { bookDao.observeAllWithContributors() } returns flowOf(emptyList())
-            val repository = createRepositoryWithBookDao(seriesDao, bookDao)
-
-            val result = repository.observeAllWithBooks().first()
-
-            assertTrue(result.isEmpty())
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "complete-series"
+                result.name shouldBe "Complete Series Name"
+                result.description shouldBe "Full description here"
+            }
         }
 
-    @Test
-    fun `observeAllWithBooks joins series with books from book dao by id`() =
-        runTest {
-            val seriesEntity = createTestSeriesEntity(id = "series-1", name = "Stormlight")
-            val book1 = makeBookEntity("book-1", "Way of Kings")
-            val book2 = makeBookEntity("book-2", "Words of Radiance")
-            val seriesRelation =
-                SeriesWithBooksRelation(
-                    series = seriesEntity,
-                    books = listOf(book1, book2),
-                    bookSequences =
-                        listOf(
-                            BookSeriesCrossRef(BookId("book-1"), SeriesId("series-1"), "1"),
-                            BookSeriesCrossRef(BookId("book-2"), SeriesId("series-1"), "2"),
-                        ),
-                )
+        test("getById passes correct id to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getById("target-id") } returns null
+                val repository = createRepository(dao)
 
-            val seriesDao = createMockDao()
-            val bookDao = mock<BookDao>(MockMode.autoUnit)
-            every { seriesDao.observeAllWithBooks() } returns flowOf(listOf(seriesRelation))
-            every { bookDao.observeAllWithContributors() } returns
-                flowOf(listOf(makeBookWithContributors(book1), makeBookWithContributors(book2)))
-            val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+                // When
+                repository.getById("target-id")
 
-            val result = repository.observeAllWithBooks().first()
-
-            assertEquals(1, result.size)
-            assertEquals("series-1", result[0].series.id.value)
-            assertEquals(2, result[0].books.size)
-            assertEquals("book-1", result[0].books[0].id.value)
-            assertEquals("Way of Kings", result[0].books[0].title)
-            assertEquals("1", result[0].bookSequences["book-1"])
-            assertEquals("2", result[0].bookSequences["book-2"])
+                // Then
+                verifySuspend { dao.getById("target-id") }
+            }
         }
 
-    @Test
-    fun `observeAllWithBooks silently skips orphan book ids missing from book dao`() =
-        runTest {
-            // Series references two books, but bookDao only knows about one.
-            val seriesEntity = createTestSeriesEntity(id = "series-1", name = "Series")
-            val book1 = makeBookEntity("book-1", "Known Book")
-            val orphanBook = makeBookEntity("book-orphan", "Stale Reference")
-            val seriesRelation =
-                SeriesWithBooksRelation(
-                    series = seriesEntity,
-                    books = listOf(book1, orphanBook),
-                    bookSequences = emptyList(),
-                )
+        // ========== observeByBookId Tests ==========
 
-            val seriesDao = createMockDao()
-            val bookDao = mock<BookDao>(MockMode.autoUnit)
-            every { seriesDao.observeAllWithBooks() } returns flowOf(listOf(seriesRelation))
-            // Only book-1 is in bookDao's flow; book-orphan is missing.
-            every { bookDao.observeAllWithContributors() } returns
-                flowOf(listOf(makeBookWithContributors(book1)))
-            val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+        test("observeByBookId returns null when book has no series") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeByBookId("book-1") } returns flowOf(null)
+                val repository = createRepository(dao)
 
-            val result = repository.observeAllWithBooks().first()
+                // When
+                val result = repository.observeByBookId("book-1").first()
 
-            assertEquals(1, result.size)
-            assertEquals(1, result[0].books.size, "Orphan book should be silently dropped")
-            assertEquals("book-1", result[0].books[0].id.value)
+                // Then
+                result shouldBe null
+            }
         }
 
-    // ========== observeSeriesWithBooks Tests (drift #16 closure) ==========
+        test("observeByBookId returns series for book") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "series-1",
+                        name = "The Cosmere",
+                        description = "Shared universe",
+                    )
+                val dao = createMockDao()
+                every { dao.observeByBookId("book-1") } returns flowOf(entity)
+                val repository = createRepository(dao)
 
-    @Test
-    fun `observeSeriesWithBooks returns null when series relation is null`() =
-        runTest {
-            val seriesDao = createMockDao()
-            val bookDao = mock<BookDao>(MockMode.autoUnit)
-            every { seriesDao.observeByIdWithBooks("missing") } returns flowOf(null)
-            every { bookDao.observeBySeriesIdWithContributors("missing") } returns flowOf(emptyList())
-            val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+                // When
+                val result = repository.observeByBookId("book-1").first()
 
-            val result = repository.observeSeriesWithBooks("missing").first()
-
-            assertNull(result)
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "series-1"
+                result.name shouldBe "The Cosmere"
+                result.description shouldBe "Shared universe"
+            }
         }
 
-    @Test
-    fun `observeSeriesWithBooks combines series relation with contributor-enriched books`() =
-        runTest {
-            val seriesEntity = createTestSeriesEntity(id = "series-1", name = "Cosmere")
-            val book1 = makeBookEntity("book-1", "Book One")
-            val book2 = makeBookEntity("book-2", "Book Two")
-            val seriesRelation =
-                SeriesWithBooksRelation(
-                    series = seriesEntity,
-                    books = listOf(book1, book2),
-                    bookSequences =
-                        listOf(
-                            BookSeriesCrossRef(BookId("book-1"), SeriesId("series-1"), "1"),
-                            BookSeriesCrossRef(BookId("book-2"), SeriesId("series-1"), "2"),
-                        ),
-                )
+        test("observeByBookId transforms entity to domain model") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "series-42",
+                        name = "Book Series",
+                        description = "Description",
+                    )
+                val dao = createMockDao()
+                every { dao.observeByBookId("book-42") } returns flowOf(entity)
+                val repository = createRepository(dao)
 
-            val seriesDao = createMockDao()
-            val bookDao = mock<BookDao>(MockMode.autoUnit)
-            every { seriesDao.observeByIdWithBooks("series-1") } returns flowOf(seriesRelation)
-            every { bookDao.observeBySeriesIdWithContributors("series-1") } returns
-                flowOf(listOf(makeBookWithContributors(book1), makeBookWithContributors(book2)))
-            val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+                // When
+                val result = repository.observeByBookId("book-42").first()
 
-            val result = repository.observeSeriesWithBooks("series-1").first()
-
-            assertNotNull(result)
-            assertEquals("series-1", result.series.id.value)
-            assertEquals(2, result.books.size)
-            assertEquals("book-1", result.books[0].id.value)
-            assertEquals("book-2", result.books[1].id.value)
-            assertEquals("1", result.bookSequences["book-1"])
-            assertEquals("2", result.bookSequences["book-2"])
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "series-42"
+                result.name shouldBe "Book Series"
+                result.description shouldBe "Description"
+            }
         }
-}
+
+        test("observeByBookId passes correct bookId to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeByBookId("my-book-id") } returns flowOf(null)
+                val repository = createRepository(dao)
+
+                // When
+                repository.observeByBookId("my-book-id").first()
+
+                // Then
+                verify { dao.observeByBookId("my-book-id") }
+            }
+        }
+
+        // ========== getBookIdsForSeries Tests ==========
+
+        test("getBookIdsForSeries returns empty list when series has no books") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForSeries("series-1") } returns emptyList()
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForSeries("series-1")
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("getBookIdsForSeries returns book IDs for series") {
+            runTest {
+                // Given
+                val bookIds = listOf("book-1", "book-2", "book-3")
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForSeries("series-1") } returns bookIds
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForSeries("series-1")
+
+                // Then
+                result.size shouldBe 3
+                result[0] shouldBe "book-1"
+                result[1] shouldBe "book-2"
+                result[2] shouldBe "book-3"
+            }
+        }
+
+        test("getBookIdsForSeries passes correct seriesId to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForSeries("specific-series-id") } returns emptyList()
+                val repository = createRepository(dao)
+
+                // When
+                repository.getBookIdsForSeries("specific-series-id")
+
+                // Then
+                verifySuspend { dao.getBookIdsForSeries("specific-series-id") }
+            }
+        }
+
+        // ========== observeBookIdsForSeries Tests ==========
+
+        test("observeBookIdsForSeries returns empty list when series has no books") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeBookIdsForSeries("series-1") } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeBookIdsForSeries("series-1").first()
+
+                // Then
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("observeBookIdsForSeries returns book IDs for series") {
+            runTest {
+                // Given
+                val bookIds = listOf("book-a", "book-b")
+                val dao = createMockDao()
+                every { dao.observeBookIdsForSeries("series-1") } returns flowOf(bookIds)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeBookIdsForSeries("series-1").first()
+
+                // Then
+                result.size shouldBe 2
+                result[0] shouldBe "book-a"
+                result[1] shouldBe "book-b"
+            }
+        }
+
+        test("observeBookIdsForSeries passes correct seriesId to dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeBookIdsForSeries("target-series") } returns flowOf(emptyList())
+                val repository = createRepository(dao)
+
+                // When
+                repository.observeBookIdsForSeries("target-series").first()
+
+                // Then
+                verify { dao.observeBookIdsForSeries("target-series") }
+            }
+        }
+
+        // ========== Entity to Domain Conversion Tests ==========
+
+        test("toDomain converts all entity fields correctly") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "conversion-test",
+                        name = "Full Name",
+                        description = "Full description",
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getById("conversion-test") } returns entity
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("conversion-test")
+
+                // Then - verify all fields are mapped
+                result.shouldNotBeNull()
+                result.id.value shouldBe "conversion-test"
+                result.name shouldBe "Full Name"
+                result.description shouldBe "Full description"
+            }
+        }
+
+        test("toDomain handles null optional fields") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "minimal-series",
+                        name = "Minimal Series",
+                        description = null,
+                    )
+                val dao = createMockDao()
+                everySuspend { dao.getById("minimal-series") } returns entity
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getById("minimal-series")
+
+                // Then
+                result.shouldNotBeNull()
+                result.id.value shouldBe "minimal-series"
+                result.name shouldBe "Minimal Series"
+                result.description shouldBe null
+            }
+        }
+
+        // ========== Multiple Items Tests ==========
+
+        test("observeAll handles large number of series") {
+            runTest {
+                // Given
+                val entities =
+                    (1..100).map { i ->
+                        createTestSeriesEntity(
+                            id = "series-$i",
+                            name = "Series $i",
+                        )
+                    }
+                val dao = createMockDao()
+                every { dao.observeAll() } returns flowOf(entities)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result.size shouldBe 100
+                result[0].id.value shouldBe "series-1"
+                result[99].id.value shouldBe "series-100"
+            }
+        }
+
+        test("getBookIdsForSeries handles large number of books") {
+            runTest {
+                // Given
+                val bookIds = (1..200).map { "book-$it" }
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForSeries("large-series") } returns bookIds
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForSeries("large-series")
+
+                // Then
+                result.size shouldBe 200
+                result[0] shouldBe "book-1"
+                result[199] shouldBe "book-200"
+            }
+        }
+
+        // ========== Edge Cases Tests ==========
+
+        test("observeAll handles series with empty description") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "series-1",
+                        name = "Series Name",
+                        description = "",
+                    )
+                val dao = createMockDao()
+                every { dao.observeAll() } returns flowOf(listOf(entity))
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeAll().first()
+
+                // Then
+                result.size shouldBe 1
+                result[0].description shouldBe ""
+            }
+        }
+
+        test("observeById handles series with special characters in name") {
+            runTest {
+                // Given
+                val entity =
+                    createTestSeriesEntity(
+                        id = "series-special",
+                        name = "Series: The \"Special\" One (2024)",
+                        description = null,
+                    )
+                val dao = createMockDao()
+                every { dao.observeById("series-special") } returns flowOf(entity)
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.observeById("series-special").first()
+
+                // Then
+                result.shouldNotBeNull()
+                result.name shouldBe "Series: The \"Special\" One (2024)"
+            }
+        }
+
+        test("getBookIdsForSeries returns single book ID") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getBookIdsForSeries("single-book-series") } returns listOf("only-book")
+                val repository = createRepository(dao)
+
+                // When
+                val result = repository.getBookIdsForSeries("single-book-series")
+
+                // Then
+                result.size shouldBe 1
+                result[0] shouldBe "only-book"
+            }
+        }
+
+        // ========== observeAllWithBooks Tests (drift #16 closure) ==========
+
+        test("observeAllWithBooks returns empty list when no series exist") {
+            runTest {
+                val seriesDao = createMockDao()
+                val bookDao = mock<BookDao>(MockMode.autoUnit)
+                every { seriesDao.observeAllWithBooks() } returns flowOf(emptyList())
+                every { bookDao.observeAllWithContributors() } returns flowOf(emptyList())
+                val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+
+                val result = repository.observeAllWithBooks().first()
+
+                (result.isEmpty()) shouldBe true
+            }
+        }
+
+        test("observeAllWithBooks joins series with books from book dao by id") {
+            runTest {
+                val seriesEntity = createTestSeriesEntity(id = "series-1", name = "Stormlight")
+                val book1 = makeBookEntity("book-1", "Way of Kings")
+                val book2 = makeBookEntity("book-2", "Words of Radiance")
+                val seriesRelation =
+                    SeriesWithBooksRelation(
+                        series = seriesEntity,
+                        books = listOf(book1, book2),
+                        bookSequences =
+                            listOf(
+                                BookSeriesCrossRef(BookId("book-1"), SeriesId("series-1"), "1"),
+                                BookSeriesCrossRef(BookId("book-2"), SeriesId("series-1"), "2"),
+                            ),
+                    )
+
+                val seriesDao = createMockDao()
+                val bookDao = mock<BookDao>(MockMode.autoUnit)
+                every { seriesDao.observeAllWithBooks() } returns flowOf(listOf(seriesRelation))
+                every { bookDao.observeAllWithContributors() } returns
+                    flowOf(listOf(makeBookWithContributors(book1), makeBookWithContributors(book2)))
+                val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+
+                val result = repository.observeAllWithBooks().first()
+
+                result.size shouldBe 1
+                result[0].series.id.value shouldBe "series-1"
+                result[0].books.size shouldBe 2
+                result[0].books[0].id.value shouldBe "book-1"
+                result[0].books[0].title shouldBe "Way of Kings"
+                result[0].bookSequences["book-1"] shouldBe "1"
+                result[0].bookSequences["book-2"] shouldBe "2"
+            }
+        }
+
+        test("observeAllWithBooks silently skips orphan book ids missing from book dao") {
+            runTest {
+                // Series references two books, but bookDao only knows about one.
+                val seriesEntity = createTestSeriesEntity(id = "series-1", name = "Series")
+                val book1 = makeBookEntity("book-1", "Known Book")
+                val orphanBook = makeBookEntity("book-orphan", "Stale Reference")
+                val seriesRelation =
+                    SeriesWithBooksRelation(
+                        series = seriesEntity,
+                        books = listOf(book1, orphanBook),
+                        bookSequences = emptyList(),
+                    )
+
+                val seriesDao = createMockDao()
+                val bookDao = mock<BookDao>(MockMode.autoUnit)
+                every { seriesDao.observeAllWithBooks() } returns flowOf(listOf(seriesRelation))
+                // Only book-1 is in bookDao's flow; book-orphan is missing.
+                every { bookDao.observeAllWithContributors() } returns
+                    flowOf(listOf(makeBookWithContributors(book1)))
+                val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+
+                val result = repository.observeAllWithBooks().first()
+
+                result.size shouldBe 1
+                result[0].books.size shouldBe 1
+                result[0].books[0].id.value shouldBe "book-1"
+            }
+        }
+
+        // ========== observeSeriesWithBooks Tests (drift #16 closure) ==========
+
+        test("observeSeriesWithBooks returns null when series relation is null") {
+            runTest {
+                val seriesDao = createMockDao()
+                val bookDao = mock<BookDao>(MockMode.autoUnit)
+                every { seriesDao.observeByIdWithBooks("missing") } returns flowOf(null)
+                every { bookDao.observeBySeriesIdWithContributors("missing") } returns flowOf(emptyList())
+                val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+
+                val result = repository.observeSeriesWithBooks("missing").first()
+
+                result shouldBe null
+            }
+        }
+
+        test("observeSeriesWithBooks combines series relation with contributor-enriched books") {
+            runTest {
+                val seriesEntity = createTestSeriesEntity(id = "series-1", name = "Cosmere")
+                val book1 = makeBookEntity("book-1", "Book One")
+                val book2 = makeBookEntity("book-2", "Book Two")
+                val seriesRelation =
+                    SeriesWithBooksRelation(
+                        series = seriesEntity,
+                        books = listOf(book1, book2),
+                        bookSequences =
+                            listOf(
+                                BookSeriesCrossRef(BookId("book-1"), SeriesId("series-1"), "1"),
+                                BookSeriesCrossRef(BookId("book-2"), SeriesId("series-1"), "2"),
+                            ),
+                    )
+
+                val seriesDao = createMockDao()
+                val bookDao = mock<BookDao>(MockMode.autoUnit)
+                every { seriesDao.observeByIdWithBooks("series-1") } returns flowOf(seriesRelation)
+                every { bookDao.observeBySeriesIdWithContributors("series-1") } returns
+                    flowOf(listOf(makeBookWithContributors(book1), makeBookWithContributors(book2)))
+                val repository = createRepositoryWithBookDao(seriesDao, bookDao)
+
+                val result = repository.observeSeriesWithBooks("series-1").first()
+
+                result.shouldNotBeNull()
+                result.series.id.value shouldBe "series-1"
+                result.books.size shouldBe 2
+                result.books[0].id.value shouldBe "book-1"
+                result.books[1].id.value shouldBe "book-2"
+                result.bookSequences["book-1"] shouldBe "1"
+                result.bookSequences["book-2"] shouldBe "2"
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorkerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorkerTest.kt
@@ -13,57 +13,56 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CoverDownloadWorkerTest {
-    private fun createTask(id: String) =
-        CoverDownloadTaskEntity(
-            bookId = BookId(id),
-            status = CoverDownloadStatus.PENDING,
-            attempts = 0,
-            createdAt = Timestamp.now(),
-        )
+class CoverDownloadWorkerTest :
+    FunSpec({
 
-    @Test
-    fun `processQueue delays between each download`() =
-        runTest {
-            val dao: CoverDownloadDao = mock()
-            val downloader: ImageDownloaderContract = mock()
-
-            val tasks = listOf(createTask("a"), createTask("b"), createTask("c"))
-
-            // First call returns tasks, second returns empty to stop loop
-            everySuspend { dao.getNextBatch(limit = any(), maxRetries = any()) } sequentiallyReturns listOf(tasks, emptyList())
-            everySuspend { dao.markInProgress(any()) } returns Unit
-            everySuspend { dao.markCompleted(any(), any()) } returns Unit
-            every { dao.observeRemainingCount() } returns flowOf(0)
-            every { dao.observeCompletedCount() } returns flowOf(0)
-            every { dao.observeTotalCount() } returns flowOf(0)
-            everySuspend { downloader.downloadCover(any()) } returns Success(true)
-
-            val worker = CoverDownloadWorker(dao, downloader)
-
-            val startTime = currentTime
-            worker.processQueue()
-            val elapsed = currentTime - startTime
-
-            // 3 tasks * 500ms delay = 1500ms minimum
-            val expectedMinimum = 3 * 500L
-            assertTrue(
-                elapsed >= expectedMinimum,
-                "Expected at least ${expectedMinimum}ms but took ${elapsed}ms",
+        fun createTask(id: String) =
+            CoverDownloadTaskEntity(
+                bookId = BookId(id),
+                status = CoverDownloadStatus.PENDING,
+                attempts = 0,
+                createdAt = Timestamp.now(),
             )
 
-            // Verify each task was marked in-progress then completed
-            for (task in tasks) {
-                verifySuspend { dao.markInProgress(task.bookId) }
-                verifySuspend { dao.markCompleted(task.bookId, any()) }
+        test("processQueue delays between each download") {
+            runTest {
+                val dao: CoverDownloadDao = mock()
+                val downloader: ImageDownloaderContract = mock()
+
+                val tasks = listOf(createTask("a"), createTask("b"), createTask("c"))
+
+                // First call returns tasks, second returns empty to stop loop
+                everySuspend { dao.getNextBatch(limit = any(), maxRetries = any()) } sequentiallyReturns listOf(tasks, emptyList())
+                everySuspend { dao.markInProgress(any()) } returns Unit
+                everySuspend { dao.markCompleted(any(), any()) } returns Unit
+                every { dao.observeRemainingCount() } returns flowOf(0)
+                every { dao.observeCompletedCount() } returns flowOf(0)
+                every { dao.observeTotalCount() } returns flowOf(0)
+                everySuspend { downloader.downloadCover(any()) } returns Success(true)
+
+                val worker = CoverDownloadWorker(dao, downloader)
+
+                val startTime = currentTime
+                worker.processQueue()
+                val elapsed = currentTime - startTime
+
+                // 3 tasks * 500ms delay = 1500ms minimum
+                val expectedMinimum = 3 * 500L
+                (elapsed >= expectedMinimum) shouldBe true
+
+                // Verify each task was marked in-progress then completed
+                for (task in tasks) {
+                    verifySuspend { dao.markInProgress(task.bookId) }
+                    verifySuspend { dao.markCompleted(task.bookId, any()) }
+                }
             }
         }
-}
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatusTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatusTest.kt
@@ -1,90 +1,84 @@
 package com.calypsan.listenup.client.domain.model
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BookDownloadStatusTest {
-    @Test
-    fun `NotDownloaded carries only the bookId`() {
-        val status = BookDownloadStatus.NotDownloaded(bookId = "book-1")
-        assertEquals("book-1", status.bookId)
-    }
+class BookDownloadStatusTest :
+    FunSpec({
 
-    @Test
-    fun `InProgress progress computes from downloadedBytes and totalBytes`() {
-        val status =
-            BookDownloadStatus.InProgress(
-                bookId = "book-1",
-                totalFiles = 4,
-                downloadingFiles = 1,
-                waitingForServerFiles = 0,
-                completedFiles = 2,
-                totalBytes = 1000L,
-                downloadedBytes = 250L,
-            )
-        assertEquals(0.25f, status.progress)
-    }
+        test("NotDownloaded carries only the bookId") {
+            val status = BookDownloadStatus.NotDownloaded(bookId = "book-1")
+            status.bookId shouldBe "book-1"
+        }
 
-    @Test
-    fun `InProgress progress is zero when totalBytes is zero`() {
-        val status =
-            BookDownloadStatus.InProgress(
-                bookId = "book-1",
-                totalFiles = 1,
-                downloadingFiles = 1,
-                waitingForServerFiles = 0,
-                completedFiles = 0,
-                totalBytes = 0L,
-                downloadedBytes = 0L,
-            )
-        assertEquals(0f, status.progress)
-    }
+        test("InProgress progress computes from downloadedBytes and totalBytes") {
+            val status =
+                BookDownloadStatus.InProgress(
+                    bookId = "book-1",
+                    totalFiles = 4,
+                    downloadingFiles = 1,
+                    waitingForServerFiles = 0,
+                    completedFiles = 2,
+                    totalBytes = 1000L,
+                    downloadedBytes = 250L,
+                )
+            status.progress shouldBe 0.25f
+        }
 
-    @Test
-    fun `Completed carries totalBytes`() {
-        val status = BookDownloadStatus.Completed(bookId = "book-1", totalBytes = 5000L)
-        assertEquals("book-1", status.bookId)
-        assertEquals(5000L, status.totalBytes)
-    }
+        test("InProgress progress is zero when totalBytes is zero") {
+            val status =
+                BookDownloadStatus.InProgress(
+                    bookId = "book-1",
+                    totalFiles = 1,
+                    downloadingFiles = 1,
+                    waitingForServerFiles = 0,
+                    completedFiles = 0,
+                    totalBytes = 0L,
+                    downloadedBytes = 0L,
+                )
+            status.progress shouldBe 0f
+        }
 
-    @Test
-    fun `Failed carries error message and partiallyDownloadedFiles count`() {
-        val status =
-            BookDownloadStatus.Failed(
-                bookId = "book-1",
-                errorMessage = "Network unreachable",
-                partiallyDownloadedFiles = 2,
-            )
-        assertEquals("Network unreachable", status.errorMessage)
-        assertEquals(2, status.partiallyDownloadedFiles)
-    }
+        test("Completed carries totalBytes") {
+            val status = BookDownloadStatus.Completed(bookId = "book-1", totalBytes = 5000L)
+            status.bookId shouldBe "book-1"
+            status.totalBytes shouldBe 5000L
+        }
 
-    @Test
-    fun `Paused carries paused file count and progress numbers`() {
-        val status =
-            BookDownloadStatus.Paused(
-                bookId = "book-1",
-                pausedFiles = 3,
-                downloadedBytes = 100L,
-                totalBytes = 500L,
-            )
-        assertEquals(3, status.pausedFiles)
-        assertEquals(100L, status.downloadedBytes)
-        assertEquals(500L, status.totalBytes)
-    }
+        test("Failed carries error message and partiallyDownloadedFiles count") {
+            val status =
+                BookDownloadStatus.Failed(
+                    bookId = "book-1",
+                    errorMessage = "Network unreachable",
+                    partiallyDownloadedFiles = 2,
+                )
+            status.errorMessage shouldBe "Network unreachable"
+            status.partiallyDownloadedFiles shouldBe 2
+        }
 
-    @Test
-    fun `sealed hierarchy enables exhaustive when matching`() {
-        val status: BookDownloadStatus = BookDownloadStatus.NotDownloaded("book-1")
-        val description: String =
-            when (status) {
-                is BookDownloadStatus.NotDownloaded -> "not downloaded"
-                is BookDownloadStatus.InProgress -> "in progress"
-                is BookDownloadStatus.Completed -> "completed"
-                is BookDownloadStatus.Failed -> "failed"
-                is BookDownloadStatus.Paused -> "paused"
-            }
-        assertTrue(description.isNotEmpty())
-    }
-}
+        test("Paused carries paused file count and progress numbers") {
+            val status =
+                BookDownloadStatus.Paused(
+                    bookId = "book-1",
+                    pausedFiles = 3,
+                    downloadedBytes = 100L,
+                    totalBytes = 500L,
+                )
+            status.pausedFiles shouldBe 3
+            status.downloadedBytes shouldBe 100L
+            status.totalBytes shouldBe 500L
+        }
+
+        test("sealed hierarchy enables exhaustive when matching") {
+            val status: BookDownloadStatus = BookDownloadStatus.NotDownloaded("book-1")
+            val description: String =
+                when (status) {
+                    is BookDownloadStatus.NotDownloaded -> "not downloaded"
+                    is BookDownloadStatus.InProgress -> "in progress"
+                    is BookDownloadStatus.Completed -> "completed"
+                    is BookDownloadStatus.Failed -> "failed"
+                    is BookDownloadStatus.Paused -> "paused"
+                }
+            description.isNotEmpty() shouldBe true
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/BookListItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/BookListItemTest.kt
@@ -2,11 +2,9 @@ package com.calypsan.listenup.client.domain.model
 
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
 
 /**
  * Tests for [BookListItem] convenience properties.
@@ -20,167 +18,150 @@ import kotlin.test.assertTrue
  * [BookDetail] exposes the same convenience properties; if their behavior diverges
  * in the future, mirror these tests on [BookDetail].
  */
-class BookListItemTest {
-    private fun createTestBook(
-        duration: Long = 3600000L, // 1 hour
-        coverPath: String? = null,
-        authors: List<BookContributor> = emptyList(),
-        narrators: List<BookContributor> = emptyList(),
-        series: List<BookSeries> = emptyList(),
-    ): BookListItem =
-        BookListItem(
-            id = BookId("book-1"),
-            title = "Test Book",
-            subtitle = null,
-            authors = authors,
-            narrators = narrators,
-            duration = duration,
-            coverPath = coverPath,
-            addedAt = Timestamp.now(),
-            updatedAt = Timestamp.now(),
-            series = series,
-        )
+class BookListItemTest :
+    FunSpec({
 
-    // ========== Duration Formatting Tests ==========
-
-    @Test
-    fun `formatDuration returns hours and minutes for long duration`() {
-        val book = createTestBook(duration = 9_000_000L) // 2.5 hours (150 minutes)
-        assertEquals("2h 30m", book.formatDuration())
-    }
-
-    @Test
-    fun `formatDuration returns only minutes for short duration`() {
-        val book = createTestBook(duration = 2_700_000L) // 45 minutes
-        assertEquals("45m", book.formatDuration())
-    }
-
-    @Test
-    fun `formatDuration handles exactly one hour`() {
-        val book = createTestBook(duration = 3_600_000L) // 60 minutes
-        assertEquals("1h 0m", book.formatDuration())
-    }
-
-    @Test
-    fun `formatDuration handles zero duration`() {
-        val book = createTestBook(duration = 0L)
-        assertEquals("0m", book.formatDuration())
-    }
-
-    @Test
-    fun `formatDuration handles very long duration`() {
-        val book = createTestBook(duration = 86_400_000L) // 24 hours
-        assertEquals("24h 0m", book.formatDuration())
-    }
-
-    @Test
-    fun `formatDuration truncates partial minutes`() {
-        // 1 hour 30 minutes 45 seconds - should show 1h 30m (ignoring seconds)
-        val book = createTestBook(duration = 5_445_000L)
-        assertEquals("1h 30m", book.formatDuration())
-    }
-
-    // ========== Cover Path Tests ==========
-
-    @Test
-    fun `hasCover returns true when cover path is set`() {
-        val book = createTestBook(coverPath = "/path/to/cover.jpg")
-        assertTrue(book.hasCover)
-    }
-
-    @Test
-    fun `hasCover returns false when cover path is null`() {
-        val book = createTestBook(coverPath = null)
-        assertFalse(book.hasCover)
-    }
-
-    // ========== Series Title Tests ==========
-
-    @Test
-    fun `fullSeriesTitle returns name and sequence when both present`() {
-        val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Mistborn", sequence = "1")))
-        assertEquals("Mistborn #1", book.fullSeriesTitle)
-    }
-
-    @Test
-    fun `fullSeriesTitle handles decimal sequence numbers`() {
-        val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Stormlight Archive", sequence = "2.5")))
-        assertEquals("Stormlight Archive #2.5", book.fullSeriesTitle)
-    }
-
-    @Test
-    fun `fullSeriesTitle returns only name when sequence is null`() {
-        val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Wheel of Time", sequence = null)))
-        assertEquals("Wheel of Time", book.fullSeriesTitle)
-    }
-
-    @Test
-    fun `fullSeriesTitle returns only name when sequence is blank`() {
-        val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Wheel of Time", sequence = "  ")))
-        assertEquals("Wheel of Time", book.fullSeriesTitle)
-    }
-
-    @Test
-    fun `fullSeriesTitle returns null when no series`() {
-        val book = createTestBook(series = emptyList())
-        assertNull(book.fullSeriesTitle)
-    }
-
-    // ========== Contributor Names Tests ==========
-
-    @Test
-    fun `authorNames joins multiple authors with commas`() {
-        val book =
-            createTestBook(
-                authors =
-                    listOf(
-                        BookContributor("1", "Brandon Sanderson"),
-                        BookContributor("2", "Robert Jordan"),
-                    ),
+        fun createTestBook(
+            duration: Long = 3600000L, // 1 hour
+            coverPath: String? = null,
+            authors: List<BookContributor> = emptyList(),
+            narrators: List<BookContributor> = emptyList(),
+            series: List<BookSeries> = emptyList(),
+        ): BookListItem =
+            BookListItem(
+                id = BookId("book-1"),
+                title = "Test Book",
+                subtitle = null,
+                authors = authors,
+                narrators = narrators,
+                duration = duration,
+                coverPath = coverPath,
+                addedAt = Timestamp.now(),
+                updatedAt = Timestamp.now(),
+                series = series,
             )
-        assertEquals("Brandon Sanderson, Robert Jordan", book.authorNames)
-    }
 
-    @Test
-    fun `authorNames returns single author name`() {
-        val book =
-            createTestBook(
-                authors = listOf(BookContributor("1", "Brandon Sanderson")),
-            )
-        assertEquals("Brandon Sanderson", book.authorNames)
-    }
+        // ========== Duration Formatting Tests ==========
 
-    @Test
-    fun `authorNames returns empty string when no authors`() {
-        val book = createTestBook(authors = emptyList())
-        assertEquals("", book.authorNames)
-    }
+        test("formatDuration returns hours and minutes for long duration") {
+            val book = createTestBook(duration = 9_000_000L) // 2.5 hours (150 minutes)
+            book.formatDuration() shouldBe "2h 30m"
+        }
 
-    @Test
-    fun `narratorNames joins multiple narrators with commas`() {
-        val book =
-            createTestBook(
-                narrators =
-                    listOf(
-                        BookContributor("1", "Michael Kramer"),
-                        BookContributor("2", "Kate Reading"),
-                    ),
-            )
-        assertEquals("Michael Kramer, Kate Reading", book.narratorNames)
-    }
+        test("formatDuration returns only minutes for short duration") {
+            val book = createTestBook(duration = 2_700_000L) // 45 minutes
+            book.formatDuration() shouldBe "45m"
+        }
 
-    @Test
-    fun `narratorNames returns single narrator name`() {
-        val book =
-            createTestBook(
-                narrators = listOf(BookContributor("1", "Michael Kramer")),
-            )
-        assertEquals("Michael Kramer", book.narratorNames)
-    }
+        test("formatDuration handles exactly one hour") {
+            val book = createTestBook(duration = 3_600_000L) // 60 minutes
+            book.formatDuration() shouldBe "1h 0m"
+        }
 
-    @Test
-    fun `narratorNames returns empty string when no narrators`() {
-        val book = createTestBook(narrators = emptyList())
-        assertEquals("", book.narratorNames)
-    }
-}
+        test("formatDuration handles zero duration") {
+            val book = createTestBook(duration = 0L)
+            book.formatDuration() shouldBe "0m"
+        }
+
+        test("formatDuration handles very long duration") {
+            val book = createTestBook(duration = 86_400_000L) // 24 hours
+            book.formatDuration() shouldBe "24h 0m"
+        }
+
+        test("formatDuration truncates partial minutes") {
+            // 1 hour 30 minutes 45 seconds - should show 1h 30m (ignoring seconds)
+            val book = createTestBook(duration = 5_445_000L)
+            book.formatDuration() shouldBe "1h 30m"
+        }
+
+        // ========== Cover Path Tests ==========
+
+        test("hasCover returns true when cover path is set") {
+            val book = createTestBook(coverPath = "/path/to/cover.jpg")
+            book.hasCover shouldBe true
+        }
+
+        test("hasCover returns false when cover path is null") {
+            val book = createTestBook(coverPath = null)
+            book.hasCover shouldBe false
+        }
+
+        // ========== Series Title Tests ==========
+
+        test("fullSeriesTitle returns name and sequence when both present") {
+            val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Mistborn", sequence = "1")))
+            book.fullSeriesTitle shouldBe "Mistborn #1"
+        }
+
+        test("fullSeriesTitle handles decimal sequence numbers") {
+            val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Stormlight Archive", sequence = "2.5")))
+            book.fullSeriesTitle shouldBe "Stormlight Archive #2.5"
+        }
+
+        test("fullSeriesTitle returns only name when sequence is null") {
+            val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Wheel of Time", sequence = null)))
+            book.fullSeriesTitle shouldBe "Wheel of Time"
+        }
+
+        test("fullSeriesTitle returns only name when sequence is blank") {
+            val book = createTestBook(series = listOf(BookSeries(seriesId = "series-1", seriesName = "Wheel of Time", sequence = "  ")))
+            book.fullSeriesTitle shouldBe "Wheel of Time"
+        }
+
+        test("fullSeriesTitle returns null when no series") {
+            val book = createTestBook(series = emptyList())
+            book.fullSeriesTitle.shouldBeNull()
+        }
+
+        // ========== Contributor Names Tests ==========
+
+        test("authorNames joins multiple authors with commas") {
+            val book =
+                createTestBook(
+                    authors =
+                        listOf(
+                            BookContributor("1", "Brandon Sanderson"),
+                            BookContributor("2", "Robert Jordan"),
+                        ),
+                )
+            book.authorNames shouldBe "Brandon Sanderson, Robert Jordan"
+        }
+
+        test("authorNames returns single author name") {
+            val book =
+                createTestBook(
+                    authors = listOf(BookContributor("1", "Brandon Sanderson")),
+                )
+            book.authorNames shouldBe "Brandon Sanderson"
+        }
+
+        test("authorNames returns empty string when no authors") {
+            val book = createTestBook(authors = emptyList())
+            book.authorNames shouldBe ""
+        }
+
+        test("narratorNames joins multiple narrators with commas") {
+            val book =
+                createTestBook(
+                    narrators =
+                        listOf(
+                            BookContributor("1", "Michael Kramer"),
+                            BookContributor("2", "Kate Reading"),
+                        ),
+                )
+            book.narratorNames shouldBe "Michael Kramer, Kate Reading"
+        }
+
+        test("narratorNames returns single narrator name") {
+            val book =
+                createTestBook(
+                    narrators = listOf(BookContributor("1", "Michael Kramer")),
+                )
+            book.narratorNames shouldBe "Michael Kramer"
+        }
+
+        test("narratorNames returns empty string when no narrators") {
+            val book = createTestBook(narrators = emptyList())
+            book.narratorNames shouldBe ""
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/ChapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/ChapterTest.kt
@@ -1,72 +1,66 @@
 package com.calypsan.listenup.client.domain.model
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Tests for Chapter domain model.
  *
  * Covers duration formatting in MM:SS format.
  */
-class ChapterTest {
-    private fun createChapter(
-        duration: Long = 60_000L, // 1 minute
-    ): Chapter =
-        Chapter(
-            id = "chapter-1",
-            title = "Chapter 1",
-            duration = duration,
-            startTime = 0L,
-        )
+class ChapterTest :
+    FunSpec({
 
-    // ========== Duration Formatting Tests ==========
+        fun createChapter(
+            duration: Long = 60_000L, // 1 minute
+        ): Chapter =
+            Chapter(
+                id = "chapter-1",
+                title = "Chapter 1",
+                duration = duration,
+                startTime = 0L,
+            )
 
-    @Test
-    fun `formatDuration returns MM SS format`() {
-        val chapter = createChapter(duration = 125_000L) // 2 minutes 5 seconds
-        assertEquals("02:05", chapter.formatDuration())
-    }
+        // ========== Duration Formatting Tests ==========
 
-    @Test
-    fun `formatDuration pads single digit minutes`() {
-        val chapter = createChapter(duration = 300_000L) // 5 minutes
-        assertEquals("05:00", chapter.formatDuration())
-    }
+        test("formatDuration returns MM SS format") {
+            val chapter = createChapter(duration = 125_000L) // 2 minutes 5 seconds
+            chapter.formatDuration() shouldBe "02:05"
+        }
 
-    @Test
-    fun `formatDuration pads single digit seconds`() {
-        val chapter = createChapter(duration = 603_000L) // 10 minutes 3 seconds
-        assertEquals("10:03", chapter.formatDuration())
-    }
+        test("formatDuration pads single digit minutes") {
+            val chapter = createChapter(duration = 300_000L) // 5 minutes
+            chapter.formatDuration() shouldBe "05:00"
+        }
 
-    @Test
-    fun `formatDuration handles zero duration`() {
-        val chapter = createChapter(duration = 0L)
-        assertEquals("00:00", chapter.formatDuration())
-    }
+        test("formatDuration pads single digit seconds") {
+            val chapter = createChapter(duration = 603_000L) // 10 minutes 3 seconds
+            chapter.formatDuration() shouldBe "10:03"
+        }
 
-    @Test
-    fun `formatDuration handles exactly one minute`() {
-        val chapter = createChapter(duration = 60_000L)
-        assertEquals("01:00", chapter.formatDuration())
-    }
+        test("formatDuration handles zero duration") {
+            val chapter = createChapter(duration = 0L)
+            chapter.formatDuration() shouldBe "00:00"
+        }
 
-    @Test
-    fun `formatDuration handles long chapters`() {
-        val chapter = createChapter(duration = 3_661_000L) // 61 minutes 1 second
-        assertEquals("61:01", chapter.formatDuration())
-    }
+        test("formatDuration handles exactly one minute") {
+            val chapter = createChapter(duration = 60_000L)
+            chapter.formatDuration() shouldBe "01:00"
+        }
 
-    @Test
-    fun `formatDuration handles very long chapters`() {
-        val chapter = createChapter(duration = 7_200_000L) // 120 minutes (2 hours)
-        assertEquals("120:00", chapter.formatDuration())
-    }
+        test("formatDuration handles long chapters") {
+            val chapter = createChapter(duration = 3_661_000L) // 61 minutes 1 second
+            chapter.formatDuration() shouldBe "61:01"
+        }
 
-    @Test
-    fun `formatDuration ignores milliseconds`() {
-        // 1 minute, 30 seconds, 500 milliseconds - should show 01:30
-        val chapter = createChapter(duration = 90_500L)
-        assertEquals("01:30", chapter.formatDuration())
-    }
-}
+        test("formatDuration handles very long chapters") {
+            val chapter = createChapter(duration = 7_200_000L) // 120 minutes (2 hours)
+            chapter.formatDuration() shouldBe "120:00"
+        }
+
+        test("formatDuration ignores milliseconds") {
+            // 1 minute, 30 seconds, 500 milliseconds - should show 01:30
+            val chapter = createChapter(duration = 90_500L)
+            chapter.formatDuration() shouldBe "01:30"
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/SearchHitTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/SearchHitTest.kt
@@ -1,59 +1,55 @@
 package com.calypsan.listenup.client.domain.model
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
 
 /**
  * Tests for SearchHit domain model.
  *
  * Covers duration formatting with various edge cases.
  */
-class SearchHitTest {
-    private fun createSearchHit(duration: Long? = null): SearchHit =
-        SearchHit(
-            id = "hit-1",
-            type = SearchHitType.BOOK,
-            name = "Test Book",
-            duration = duration,
-        )
+class SearchHitTest :
+    FunSpec({
 
-    // ========== Duration Formatting Tests ==========
+        fun createSearchHit(duration: Long? = null): SearchHit =
+            SearchHit(
+                id = "hit-1",
+                type = SearchHitType.BOOK,
+                name = "Test Book",
+                duration = duration,
+            )
 
-    @Test
-    fun `formatDuration returns null when duration is null`() {
-        val hit = createSearchHit(duration = null)
-        assertNull(hit.formatDuration())
-    }
+        // ========== Duration Formatting Tests ==========
 
-    @Test
-    fun `formatDuration returns hours and minutes for long duration`() {
-        val hit = createSearchHit(duration = 7_200_000L) // 2 hours
-        assertEquals("2h 0m", hit.formatDuration())
-    }
+        test("formatDuration returns null when duration is null") {
+            val hit = createSearchHit(duration = null)
+            hit.formatDuration().shouldBeNull()
+        }
 
-    @Test
-    fun `formatDuration returns only minutes for short duration`() {
-        val hit = createSearchHit(duration = 1_800_000L) // 30 minutes
-        assertEquals("30m", hit.formatDuration())
-    }
+        test("formatDuration returns hours and minutes for long duration") {
+            val hit = createSearchHit(duration = 7_200_000L) // 2 hours
+            hit.formatDuration() shouldBe "2h 0m"
+        }
 
-    @Test
-    fun `formatDuration handles mixed hours and minutes`() {
-        val hit = createSearchHit(duration = 5_400_000L) // 1.5 hours (90 minutes)
-        assertEquals("1h 30m", hit.formatDuration())
-    }
+        test("formatDuration returns only minutes for short duration") {
+            val hit = createSearchHit(duration = 1_800_000L) // 30 minutes
+            hit.formatDuration() shouldBe "30m"
+        }
 
-    @Test
-    fun `formatDuration handles zero duration`() {
-        val hit = createSearchHit(duration = 0L)
-        assertEquals("0m", hit.formatDuration())
-    }
+        test("formatDuration handles mixed hours and minutes") {
+            val hit = createSearchHit(duration = 5_400_000L) // 1.5 hours (90 minutes)
+            hit.formatDuration() shouldBe "1h 30m"
+        }
 
-    @Test
-    fun `formatDuration ignores seconds`() {
-        // 1 hour, 30 minutes, 30 seconds - should show 1h 30m
-        val hit = createSearchHit(duration = 5_430_000L)
-        assertEquals("1h 30m", hit.formatDuration())
-    }
-}
+        test("formatDuration handles zero duration") {
+            val hit = createSearchHit(duration = 0L)
+            hit.formatDuration() shouldBe "0m"
+        }
+
+        test("formatDuration ignores seconds") {
+            // 1 hour, 30 minutes, 30 seconds - should show 1h 30m
+            val hit = createSearchHit(duration = 5_430_000L)
+            hit.formatDuration() shouldBe "1h 30m"
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/LoadBookForEditUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/LoadBookForEditUseCaseTest.kt
@@ -15,12 +15,11 @@ import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for LoadBookForEditUseCase.
@@ -34,525 +33,527 @@ import kotlin.test.assertTrue
  * - Tag loading (all and for book)
  * - Error handling for genre/tag loading failures
  */
-class LoadBookForEditUseCaseTest {
-    // ========== Test Fixtures ==========
+class LoadBookForEditUseCaseTest :
+    FunSpec({
 
-    private class TestFixture {
-        val bookRepository: BookRepository = mock()
-        val genreRepository: GenreRepository = mock()
-        val tagRepository: TagRepository = mock()
+        // ========== Test Fixtures ==========
 
-        fun build(): LoadBookForEditUseCase =
-            LoadBookForEditUseCase(
-                bookRepository = bookRepository,
-                genreRepository = genreRepository,
-                tagRepository = tagRepository,
-            )
-    }
+        class TestFixture {
+            val bookRepository: BookRepository = mock()
+            val genreRepository: GenreRepository = mock()
+            val tagRepository: TagRepository = mock()
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs for successful operations
-        everySuspend { fixture.genreRepository.getAll() } returns emptyList()
-        everySuspend { fixture.genreRepository.getGenresForBook(any()) } returns emptyList()
-        everySuspend { fixture.tagRepository.getAll() } returns emptyList()
-        everySuspend { fixture.tagRepository.getTagsForBook(any()) } returns emptyList()
-
-        return fixture
-    }
-
-    // ========== Book Not Found Tests ==========
-
-    @Test
-    fun `returns not found error when book does not exist`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("nonexistent") } returns null
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase("nonexistent")
-
-            // Then
-            val failure = assertIs<Failure>(result)
-            assertIs<com.calypsan.listenup.api.error.ValidationError>(failure.error)
-            assertTrue(failure.message.contains("not found", ignoreCase = true))
-        }
-
-    // ========== Metadata Transformation Tests ==========
-
-    @Test
-    fun `transforms book metadata correctly`() =
-        runTest {
-            // Given
-            val book =
-                TestData.bookDetail(
-                    id = "book-1",
-                    title = "The Great Gatsby",
-                    subtitle = "A Novel",
-                    description = "Jazz Age story",
-                    publishYear = 1925,
-                    publisher = "Scribner",
-                    language = "en",
-                    isbn = "978-0743273565",
-                    asin = "B000FC0PDA",
-                    abridged = false,
+            fun build(): LoadBookForEditUseCase =
+                LoadBookForEditUseCase(
+                    bookRepository = bookRepository,
+                    genreRepository = genreRepository,
+                    tagRepository = tagRepository,
                 )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase("book-1")
-
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
-
-            assertEquals("book-1", editData.bookId)
-            assertEquals("The Great Gatsby", editData.metadata.title)
-            assertEquals("A Novel", editData.metadata.subtitle)
-            assertEquals("Jazz Age story", editData.metadata.description)
-            assertEquals("1925", editData.metadata.publishYear)
-            assertEquals("Scribner", editData.metadata.publisher)
-            assertEquals("en", editData.metadata.language)
-            assertEquals("978-0743273565", editData.metadata.isbn)
-            assertEquals("B000FC0PDA", editData.metadata.asin)
-            assertEquals(false, editData.metadata.abridged)
         }
 
-    @Test
-    fun `handles null optional fields with empty strings`() =
-        runTest {
-            // Given
-            val book =
-                TestData.bookDetail(
-                    id = "book-1",
-                    title = "Minimal Book",
-                    subtitle = null,
-                    description = null,
-                    publishYear = null,
-                    publisher = null,
-                    language = null,
-                    isbn = null,
-                    asin = null,
-                )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
 
-            // When
-            val result = useCase("book-1")
+            // Default stubs for successful operations
+            everySuspend { fixture.genreRepository.getAll() } returns emptyList()
+            everySuspend { fixture.genreRepository.getGenresForBook(any()) } returns emptyList()
+            everySuspend { fixture.tagRepository.getAll() } returns emptyList()
+            everySuspend { fixture.tagRepository.getTagsForBook(any()) } returns emptyList()
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
-
-            assertEquals("", editData.metadata.subtitle)
-            assertEquals("", editData.metadata.description)
-            assertEquals("", editData.metadata.publishYear)
-            assertEquals("", editData.metadata.publisher)
-            assertEquals(null, editData.metadata.language)
-            assertEquals("", editData.metadata.isbn)
-            assertEquals("", editData.metadata.asin)
+            return fixture
         }
 
-    // ========== Contributor Transformation Tests ==========
+        // ========== Book Not Found Tests ==========
 
-    @Test
-    fun `transforms contributors to editable format with roles`() =
-        runTest {
-            // Given
-            val author = TestData.contributor(id = "c1", name = "Jane Austen", roles = listOf("Author"))
-            val narrator = TestData.contributor(id = "c2", name = "Rosamund Pike", roles = listOf("Narrator"))
-            val book =
-                TestData.bookDetail(
-                    id = "book-1",
-                    allContributors = listOf(author, narrator),
-                )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+        test("returns not found error when book does not exist") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("nonexistent") } returns null
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("nonexistent")
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
-
-            assertEquals(2, editData.contributors.size)
-
-            val editableAuthor = editData.contributors.find { it.id == "c1" }
-            assertNotNull(editableAuthor)
-            assertEquals("Jane Austen", editableAuthor.name)
-            assertTrue(editableAuthor.roles.contains(ContributorRole.AUTHOR))
-
-            val editableNarrator = editData.contributors.find { it.id == "c2" }
-            assertNotNull(editableNarrator)
-            assertEquals("Rosamund Pike", editableNarrator.name)
-            assertTrue(editableNarrator.roles.contains(ContributorRole.NARRATOR))
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.error.shouldBeInstanceOf<com.calypsan.listenup.api.error.ValidationError>()
+                (failure.message.contains("not found", ignoreCase = true)) shouldBe true
+            }
         }
 
-    @Test
-    fun `handles contributors with multiple roles`() =
-        runTest {
-            // Given
-            val multiRoleContributor =
-                TestData.contributor(
-                    id = "c1",
-                    name = "Neil Gaiman",
-                    roles = listOf("Author", "Narrator"),
-                )
-            val book =
-                TestData.bookDetail(
-                    id = "book-1",
-                    allContributors = listOf(multiRoleContributor),
-                )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+        // ========== Metadata Transformation Tests ==========
 
-            // When
-            val result = useCase("book-1")
+        test("transforms book metadata correctly") {
+            runTest {
+                // Given
+                val book =
+                    TestData.bookDetail(
+                        id = "book-1",
+                        title = "The Great Gatsby",
+                        subtitle = "A Novel",
+                        description = "Jazz Age story",
+                        publishYear = 1925,
+                        publisher = "Scribner",
+                        language = "en",
+                        isbn = "978-0743273565",
+                        asin = "B000FC0PDA",
+                        abridged = false,
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // When
+                val result = useCase("book-1")
 
-            assertEquals(1, editData.contributors.size)
-            val contributor = editData.contributors.first()
-            assertEquals(2, contributor.roles.size)
-            assertTrue(contributor.roles.contains(ContributorRole.AUTHOR))
-            assertTrue(contributor.roles.contains(ContributorRole.NARRATOR))
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                editData.bookId shouldBe "book-1"
+                editData.metadata.title shouldBe "The Great Gatsby"
+                editData.metadata.subtitle shouldBe "A Novel"
+                editData.metadata.description shouldBe "Jazz Age story"
+                editData.metadata.publishYear shouldBe "1925"
+                editData.metadata.publisher shouldBe "Scribner"
+                editData.metadata.language shouldBe "en"
+                editData.metadata.isbn shouldBe "978-0743273565"
+                editData.metadata.asin shouldBe "B000FC0PDA"
+                editData.metadata.abridged shouldBe false
+            }
         }
 
-    // ========== Series Transformation Tests ==========
+        test("handles null optional fields with empty strings") {
+            runTest {
+                // Given
+                val book =
+                    TestData.bookDetail(
+                        id = "book-1",
+                        title = "Minimal Book",
+                        subtitle = null,
+                        description = null,
+                        publishYear = null,
+                        publisher = null,
+                        language = null,
+                        isbn = null,
+                        asin = null,
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
 
-    @Test
-    fun `transforms series to editable format`() =
-        runTest {
-            // Given
-            val book =
-                TestData.bookInSeries(
-                    id = "book-1",
-                    title = "The Fellowship of the Ring",
-                    seriesId = "lotr-series",
-                    seriesName = "The Lord of the Rings",
-                    seriesSequence = "1",
-                )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+                // When
+                val result = useCase("book-1")
 
-            // When
-            val result = useCase("book-1")
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
-
-            assertEquals(1, editData.series.size)
-            val series = editData.series.first()
-            assertEquals("lotr-series", series.id)
-            assertEquals("The Lord of the Rings", series.name)
-            assertEquals("1", series.sequence)
+                editData.metadata.subtitle shouldBe ""
+                editData.metadata.description shouldBe ""
+                editData.metadata.publishYear shouldBe ""
+                editData.metadata.publisher shouldBe ""
+                editData.metadata.language shouldBe null
+                editData.metadata.isbn shouldBe ""
+                editData.metadata.asin shouldBe ""
+            }
         }
 
-    @Test
-    fun `handles book with no series`() =
-        runTest {
-            // Given
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+        // ========== Contributor Transformation Tests ==========
 
-            // When
-            val result = useCase("book-1")
+        test("transforms contributors to editable format with roles") {
+            runTest {
+                // Given
+                val author = TestData.contributor(id = "c1", name = "Jane Austen", roles = listOf("Author"))
+                val narrator = TestData.contributor(id = "c2", name = "Rosamund Pike", roles = listOf("Narrator"))
+                val book =
+                    TestData.bookDetail(
+                        id = "book-1",
+                        allContributors = listOf(author, narrator),
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // When
+                val result = useCase("book-1")
 
-            assertTrue(editData.series.isEmpty())
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                editData.contributors.size shouldBe 2
+
+                val editableAuthor = editData.contributors.find { it.id == "c1" }
+                editableAuthor.shouldNotBeNull()
+                editableAuthor.name shouldBe "Jane Austen"
+                (editableAuthor.roles.contains(ContributorRole.AUTHOR)) shouldBe true
+
+                val editableNarrator = editData.contributors.find { it.id == "c2" }
+                editableNarrator.shouldNotBeNull()
+                editableNarrator.name shouldBe "Rosamund Pike"
+                (editableNarrator.roles.contains(ContributorRole.NARRATOR)) shouldBe true
+            }
         }
 
-    // ========== Genre Loading Tests ==========
+        test("handles contributors with multiple roles") {
+            runTest {
+                // Given
+                val multiRoleContributor =
+                    TestData.contributor(
+                        id = "c1",
+                        name = "Neil Gaiman",
+                        roles = listOf("Author", "Narrator"),
+                    )
+                val book =
+                    TestData.bookDetail(
+                        id = "book-1",
+                        allContributors = listOf(multiRoleContributor),
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
 
-    @Test
-    fun `loads all genres for picker`() =
-        runTest {
-            // Given
-            val allGenres =
-                listOf(
-                    TestData.genre(id = "g1", name = "Fiction", path = "/fiction"),
-                    TestData.genre(id = "g2", name = "Mystery", path = "/mystery"),
-                    TestData.genre(id = "g3", name = "Romance", path = "/romance"),
-                )
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            everySuspend { fixture.genreRepository.getAll() } returns allGenres
-            val useCase = fixture.build()
+                // When
+                val result = useCase("book-1")
 
-            // When
-            val result = useCase("book-1")
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
-
-            assertEquals(3, editData.allGenres.size)
-            assertTrue(editData.allGenres.any { it.id == "g1" && it.name == "Fiction" })
-            assertTrue(editData.allGenres.any { it.id == "g2" && it.name == "Mystery" })
-            assertTrue(editData.allGenres.any { it.id == "g3" && it.name == "Romance" })
+                editData.contributors.size shouldBe 1
+                val contributor = editData.contributors.first()
+                contributor.roles.size shouldBe 2
+                (contributor.roles.contains(ContributorRole.AUTHOR)) shouldBe true
+                (contributor.roles.contains(ContributorRole.NARRATOR)) shouldBe true
+            }
         }
 
-    @Test
-    fun `loads genres assigned to book`() =
-        runTest {
-            // Given
-            val bookGenres =
-                listOf(
-                    TestData.genre(id = "g1", name = "Fiction", path = "/fiction"),
-                )
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            everySuspend { fixture.genreRepository.getGenresForBook("book-1") } returns bookGenres
-            val useCase = fixture.build()
+        // ========== Series Transformation Tests ==========
 
-            // When
-            val result = useCase("book-1")
+        test("transforms series to editable format") {
+            runTest {
+                // Given
+                val book =
+                    TestData.bookInSeries(
+                        id = "book-1",
+                        title = "The Fellowship of the Ring",
+                        seriesId = "lotr-series",
+                        seriesName = "The Lord of the Rings",
+                        seriesSequence = "1",
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // When
+                val result = useCase("book-1")
 
-            assertEquals(1, editData.genres.size)
-            assertEquals("g1", editData.genres.first().id)
-            assertEquals("Fiction", editData.genres.first().name)
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                editData.series.size shouldBe 1
+                val series = editData.series.first()
+                series.id shouldBe "lotr-series"
+                series.name shouldBe "The Lord of the Rings"
+                series.sequence shouldBe "1"
+            }
         }
 
-    @Test
-    fun `returns empty genres when genre loading fails`() =
-        runTest {
-            // Given
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            everySuspend { fixture.genreRepository.getAll() } throws Exception("Network error")
-            everySuspend { fixture.genreRepository.getGenresForBook(any()) } throws Exception("Network error")
-            val useCase = fixture.build()
+        test("handles book with no series") {
+            runTest {
+                // Given
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("book-1")
 
-            // Then - should still succeed, just with empty genres
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            assertTrue(editData.allGenres.isEmpty())
-            assertTrue(editData.genres.isEmpty())
+                editData.series.isEmpty() shouldBe true
+            }
         }
 
-    // ========== Tag Loading Tests ==========
+        // ========== Genre Loading Tests ==========
 
-    @Test
-    fun `loads all tags for picker`() =
-        runTest {
-            // Given
-            val allTags =
-                listOf(
-                    TestData.tag(id = "t1", slug = "favorites"),
-                    TestData.tag(id = "t2", slug = "to-read"),
-                    TestData.tag(id = "t3", slug = "completed"),
-                )
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            everySuspend { fixture.tagRepository.getAll() } returns allTags
-            val useCase = fixture.build()
+        test("loads all genres for picker") {
+            runTest {
+                // Given
+                val allGenres =
+                    listOf(
+                        TestData.genre(id = "g1", name = "Fiction", path = "/fiction"),
+                        TestData.genre(id = "g2", name = "Mystery", path = "/mystery"),
+                        TestData.genre(id = "g3", name = "Romance", path = "/romance"),
+                    )
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { fixture.genreRepository.getAll() } returns allGenres
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("book-1")
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            assertEquals(3, editData.allTags.size)
-            assertTrue(editData.allTags.any { it.id == "t1" && it.slug == "favorites" })
-            assertTrue(editData.allTags.any { it.id == "t2" && it.slug == "to-read" })
-            assertTrue(editData.allTags.any { it.id == "t3" && it.slug == "completed" })
+                editData.allGenres.size shouldBe 3
+                (editData.allGenres.any { it.id == "g1" && it.name == "Fiction" }) shouldBe true
+                (editData.allGenres.any { it.id == "g2" && it.name == "Mystery" }) shouldBe true
+                (editData.allGenres.any { it.id == "g3" && it.name == "Romance" }) shouldBe true
+            }
         }
 
-    @Test
-    fun `loads tags assigned to book`() =
-        runTest {
-            // Given
-            val bookTags =
-                listOf(
-                    TestData.tag(id = "t1", slug = "favorites"),
-                )
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            everySuspend { fixture.tagRepository.getTagsForBook("book-1") } returns bookTags
-            val useCase = fixture.build()
+        test("loads genres assigned to book") {
+            runTest {
+                // Given
+                val bookGenres =
+                    listOf(
+                        TestData.genre(id = "g1", name = "Fiction", path = "/fiction"),
+                    )
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { fixture.genreRepository.getGenresForBook("book-1") } returns bookGenres
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("book-1")
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            assertEquals(1, editData.tags.size)
-            assertEquals("t1", editData.tags.first().id)
-            assertEquals("favorites", editData.tags.first().slug)
+                editData.genres.size shouldBe 1
+                editData.genres.first().id shouldBe "g1"
+                editData.genres.first().name shouldBe "Fiction"
+            }
         }
 
-    @Test
-    fun `returns empty tags when tag loading fails`() =
-        runTest {
-            // Given
-            val book = TestData.bookDetail(id = "book-1")
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            everySuspend { fixture.tagRepository.getAll() } throws Exception("Network error")
-            everySuspend { fixture.tagRepository.getTagsForBook(any()) } throws Exception("Network error")
-            val useCase = fixture.build()
+        test("returns empty genres when genre loading fails") {
+            runTest {
+                // Given
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { fixture.genreRepository.getAll() } throws Exception("Network error")
+                everySuspend { fixture.genreRepository.getGenresForBook(any()) } throws Exception("Network error")
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("book-1")
 
-            // Then - should still succeed, just with empty tags
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // Then - should still succeed, just with empty genres
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            assertTrue(editData.allTags.isEmpty())
-            assertTrue(editData.tags.isEmpty())
+                editData.allGenres.isEmpty() shouldBe true
+                editData.genres.isEmpty() shouldBe true
+            }
         }
 
-    // ========== Cover Path Tests ==========
+        // ========== Tag Loading Tests ==========
 
-    @Test
-    fun `includes cover path from book`() =
-        runTest {
-            // Given
-            val book =
-                TestData.bookDetail(
-                    id = "book-1",
-                    coverPath = "/covers/great-gatsby.jpg",
-                )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+        test("loads all tags for picker") {
+            runTest {
+                // Given
+                val allTags =
+                    listOf(
+                        TestData.tag(id = "t1", slug = "favorites"),
+                        TestData.tag(id = "t2", slug = "to-read"),
+                        TestData.tag(id = "t3", slug = "completed"),
+                    )
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { fixture.tagRepository.getAll() } returns allTags
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("book-1")
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            assertEquals("/covers/great-gatsby.jpg", editData.coverPath)
+                editData.allTags.size shouldBe 3
+                (editData.allTags.any { it.id == "t1" && it.slug == "favorites" }) shouldBe true
+                (editData.allTags.any { it.id == "t2" && it.slug == "to-read" }) shouldBe true
+                (editData.allTags.any { it.id == "t3" && it.slug == "completed" }) shouldBe true
+            }
         }
 
-    @Test
-    fun `handles null cover path`() =
-        runTest {
-            // Given
-            val book =
-                TestData.bookDetail(
-                    id = "book-1",
-                    coverPath = null,
-                )
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
-            val useCase = fixture.build()
+        test("loads tags assigned to book") {
+            runTest {
+                // Given
+                val bookTags =
+                    listOf(
+                        TestData.tag(id = "t1", slug = "favorites"),
+                    )
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { fixture.tagRepository.getTagsForBook("book-1") } returns bookTags
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase("book-1")
+                // When
+                val result = useCase("book-1")
 
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            assertEquals(null, editData.coverPath)
+                editData.tags.size shouldBe 1
+                editData.tags.first().id shouldBe "t1"
+                editData.tags.first().slug shouldBe "favorites"
+            }
         }
 
-    // ========== Full Integration Test ==========
+        test("returns empty tags when tag loading fails") {
+            runTest {
+                // Given
+                val book = TestData.bookDetail(id = "book-1")
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { fixture.tagRepository.getAll() } throws Exception("Network error")
+                everySuspend { fixture.tagRepository.getTagsForBook(any()) } throws Exception("Network error")
+                val useCase = fixture.build()
 
-    @Test
-    fun `loads complete book edit data`() =
-        runTest {
-            // Given - a fully populated book with all data
-            val author = TestData.contributor(id = "c1", name = "Brandon Sanderson", roles = listOf("Author"))
-            val narrator = TestData.contributor(id = "c2", name = "Michael Kramer", roles = listOf("Narrator"))
-            val book =
-                TestData.bookDetail(
-                    id = "stormlight-1",
-                    title = "The Way of Kings",
-                    subtitle = "Book One of The Stormlight Archive",
-                    description = "Epic fantasy at its finest",
-                    publishYear = 2010,
-                    publisher = "Tor Books",
-                    language = "en",
-                    isbn = "978-0765326355",
-                    asin = "B003P2WO5E",
-                    abridged = false,
-                    seriesId = "stormlight",
-                    seriesName = "The Stormlight Archive",
-                    seriesSequence = "1",
-                    allContributors = listOf(author, narrator),
-                    coverPath = "/covers/way-of-kings.jpg",
-                )
-            val allGenres =
-                listOf(
-                    TestData.genre(id = "g1", name = "Fantasy", path = "/fantasy"),
-                    TestData.genre(id = "g2", name = "Epic Fantasy", path = "/fantasy/epic"),
-                )
-            val bookGenres = listOf(allGenres[1])
-            val allTags =
-                listOf(
-                    TestData.tag(id = "t1", slug = "favorites"),
-                    TestData.tag(id = "t2", slug = "to-read"),
-                )
-            val bookTags = listOf(allTags[0])
+                // When
+                val result = useCase("book-1")
 
-            val fixture = createFixture()
-            everySuspend { fixture.bookRepository.getBookDetail("stormlight-1") } returns book
-            everySuspend { fixture.genreRepository.getAll() } returns allGenres
-            everySuspend { fixture.genreRepository.getGenresForBook("stormlight-1") } returns bookGenres
-            everySuspend { fixture.tagRepository.getAll() } returns allTags
-            everySuspend { fixture.tagRepository.getTagsForBook("stormlight-1") } returns bookTags
-            val useCase = fixture.build()
+                // Then - should still succeed, just with empty tags
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
 
-            // When
-            val result = useCase("stormlight-1")
-
-            // Then
-            val success = assertIs<Success<*>>(result)
-            val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
-
-            // Verify all data is present
-            assertEquals("stormlight-1", editData.bookId)
-            assertEquals("The Way of Kings", editData.metadata.title)
-            assertEquals("Book One of The Stormlight Archive", editData.metadata.subtitle)
-            assertEquals(2, editData.contributors.size)
-            assertEquals(1, editData.series.size)
-            assertEquals("The Stormlight Archive", editData.series.first().name)
-            assertEquals(2, editData.allGenres.size)
-            assertEquals(1, editData.genres.size)
-            assertEquals("Epic Fantasy", editData.genres.first().name)
-            assertEquals(2, editData.allTags.size)
-            assertEquals(1, editData.tags.size)
-            assertEquals("favorites", editData.tags.first().slug)
-            assertEquals("/covers/way-of-kings.jpg", editData.coverPath)
+                editData.allTags.isEmpty() shouldBe true
+                editData.tags.isEmpty() shouldBe true
+            }
         }
-}
+
+        // ========== Cover Path Tests ==========
+
+        test("includes cover path from book") {
+            runTest {
+                // Given
+                val book =
+                    TestData.bookDetail(
+                        id = "book-1",
+                        coverPath = "/covers/great-gatsby.jpg",
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase("book-1")
+
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                editData.coverPath shouldBe "/covers/great-gatsby.jpg"
+            }
+        }
+
+        test("handles null cover path") {
+            runTest {
+                // Given
+                val book =
+                    TestData.bookDetail(
+                        id = "book-1",
+                        coverPath = null,
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("book-1") } returns book
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase("book-1")
+
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                editData.coverPath shouldBe null
+            }
+        }
+
+        // ========== Full Integration Test ==========
+
+        test("loads complete book edit data") {
+            runTest {
+                // Given - a fully populated book with all data
+                val author = TestData.contributor(id = "c1", name = "Brandon Sanderson", roles = listOf("Author"))
+                val narrator = TestData.contributor(id = "c2", name = "Michael Kramer", roles = listOf("Narrator"))
+                val book =
+                    TestData.bookDetail(
+                        id = "stormlight-1",
+                        title = "The Way of Kings",
+                        subtitle = "Book One of The Stormlight Archive",
+                        description = "Epic fantasy at its finest",
+                        publishYear = 2010,
+                        publisher = "Tor Books",
+                        language = "en",
+                        isbn = "978-0765326355",
+                        asin = "B003P2WO5E",
+                        abridged = false,
+                        seriesId = "stormlight",
+                        seriesName = "The Stormlight Archive",
+                        seriesSequence = "1",
+                        allContributors = listOf(author, narrator),
+                        coverPath = "/covers/way-of-kings.jpg",
+                    )
+                val allGenres =
+                    listOf(
+                        TestData.genre(id = "g1", name = "Fantasy", path = "/fantasy"),
+                        TestData.genre(id = "g2", name = "Epic Fantasy", path = "/fantasy/epic"),
+                    )
+                val bookGenres = listOf(allGenres[1])
+                val allTags =
+                    listOf(
+                        TestData.tag(id = "t1", slug = "favorites"),
+                        TestData.tag(id = "t2", slug = "to-read"),
+                    )
+                val bookTags = listOf(allTags[0])
+
+                val fixture = createFixture()
+                everySuspend { fixture.bookRepository.getBookDetail("stormlight-1") } returns book
+                everySuspend { fixture.genreRepository.getAll() } returns allGenres
+                everySuspend { fixture.genreRepository.getGenresForBook("stormlight-1") } returns bookGenres
+                everySuspend { fixture.tagRepository.getAll() } returns allTags
+                everySuspend { fixture.tagRepository.getTagsForBook("stormlight-1") } returns bookTags
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase("stormlight-1")
+
+                // Then
+                val success = result.shouldBeInstanceOf<Success<*>>()
+                val editData = success.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                // Verify all data is present
+                editData.bookId shouldBe "stormlight-1"
+                editData.metadata.title shouldBe "The Way of Kings"
+                editData.metadata.subtitle shouldBe "Book One of The Stormlight Archive"
+                editData.contributors.size shouldBe 2
+                editData.series.size shouldBe 1
+                editData.series.first().name shouldBe "The Stormlight Archive"
+                editData.allGenres.size shouldBe 2
+                editData.genres.size shouldBe 1
+                editData.genres.first().name shouldBe "Epic Fantasy"
+                editData.allTags.size shouldBe 2
+                editData.tags.size shouldBe 1
+                editData.tags.first().slug shouldBe "favorites"
+                editData.coverPath shouldBe "/covers/way-of-kings.jpg"
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCaseTest.kt
@@ -29,10 +29,10 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import com.calypsan.listenup.client.core.failureOf
 
 /**
@@ -49,701 +49,703 @@ import com.calypsan.listenup.client.core.failureOf
  * - Error propagation and fail-fast behavior
  * - Multiple changes in single call
  */
-class UpdateBookUseCaseTest {
-    // ========== Test Fixtures ==========
+class UpdateBookUseCaseTest :
+    FunSpec({
 
-    private class TestFixture {
-        val bookEditRepository: BookEditRepository = mock()
-        val genreRepository: GenreRepository = mock()
-        val tagRepository: TagRepository = mock()
-        val imageRepository: ImageRepository = mock()
-        val imageStagingRepository: ImageStagingRepository = mock()
+        // ========== Test Fixtures ==========
 
-        fun build(): UpdateBookUseCase =
-            UpdateBookUseCase(
-                bookEditRepository = bookEditRepository,
-                genreRepository = genreRepository,
-                tagRepository = tagRepository,
-                imageRepository = imageRepository,
-                imageStagingRepository = imageStagingRepository,
+        class TestFixture {
+            val bookEditRepository: BookEditRepository = mock()
+            val genreRepository: GenreRepository = mock()
+            val tagRepository: TagRepository = mock()
+            val imageRepository: ImageRepository = mock()
+            val imageStagingRepository: ImageStagingRepository = mock()
+
+            fun build(): UpdateBookUseCase =
+                UpdateBookUseCase(
+                    bookEditRepository = bookEditRepository,
+                    genreRepository = genreRepository,
+                    tagRepository = tagRepository,
+                    imageRepository = imageRepository,
+                    imageStagingRepository = imageStagingRepository,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Default stubs for successful operations
+            everySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns Success(Unit)
+            everySuspend { fixture.bookEditRepository.setBookContributors(any(), any()) } returns Success(Unit)
+            everySuspend { fixture.bookEditRepository.setBookSeries(any(), any()) } returns Success(Unit)
+            everySuspend { fixture.genreRepository.setGenresForBook(any(), any()) } returns Success(Unit)
+            everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns Success(TestData.tag())
+            everySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) } returns Success(Unit)
+            everySuspend { fixture.imageStagingRepository.commitBookCoverStaging(any()) } returns Success(Unit)
+            everySuspend { fixture.imageRepository.uploadBookCover(any(), any(), any()) } returns Success("https://example.com/cover.jpg")
+
+            return fixture
+        }
+
+        // ========== Test Data Factories ==========
+
+        fun createMetadata(
+            title: String = "Test Book",
+            sortTitle: String = "",
+            subtitle: String = "",
+            description: String = "",
+            publishYear: String = "",
+            publisher: String = "",
+            language: String? = null,
+            isbn: String = "",
+            asin: String = "",
+            abridged: Boolean = false,
+            addedAt: Long? = null,
+        ): BookMetadata =
+            BookMetadata(
+                title = title,
+                sortTitle = sortTitle,
+                subtitle = subtitle,
+                description = description,
+                publishYear = publishYear,
+                publisher = publisher,
+                language = language,
+                isbn = isbn,
+                asin = asin,
+                abridged = abridged,
+                addedAt = addedAt,
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
+        fun createOriginalState(
+            bookId: String = "book-1",
+            metadata: BookMetadata = createMetadata(),
+            contributors: List<EditableContributor> = emptyList(),
+            series: List<EditableSeries> = emptyList(),
+            genres: List<EditableGenre> = emptyList(),
+            tags: List<EditableTag> = emptyList(),
+            allGenres: List<EditableGenre> = emptyList(),
+            allTags: List<EditableTag> = emptyList(),
+            coverPath: String? = null,
+        ): BookEditData =
+            BookEditData(
+                bookId = bookId,
+                metadata = metadata,
+                contributors = contributors,
+                series = series,
+                genres = genres,
+                tags = tags,
+                allGenres = allGenres,
+                allTags = allTags,
+                coverPath = coverPath,
+            )
 
-        // Default stubs for successful operations
-        everySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns Success(Unit)
-        everySuspend { fixture.bookEditRepository.setBookContributors(any(), any()) } returns Success(Unit)
-        everySuspend { fixture.bookEditRepository.setBookSeries(any(), any()) } returns Success(Unit)
-        everySuspend { fixture.genreRepository.setGenresForBook(any(), any()) } returns Success(Unit)
-        everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns Success(TestData.tag())
-        everySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) } returns Success(Unit)
-        everySuspend { fixture.imageStagingRepository.commitBookCoverStaging(any()) } returns Success(Unit)
-        everySuspend { fixture.imageRepository.uploadBookCover(any(), any(), any()) } returns Success("https://example.com/cover.jpg")
+        fun createUpdateRequest(
+            bookId: String = "book-1",
+            metadata: BookMetadata = createMetadata(),
+            contributors: List<EditableContributor> = emptyList(),
+            series: List<EditableSeries> = emptyList(),
+            genres: List<EditableGenre> = emptyList(),
+            tags: List<EditableTag> = emptyList(),
+            pendingCover: PendingCover? = null,
+        ): BookUpdateRequest =
+            BookUpdateRequest(
+                bookId = bookId,
+                metadata = metadata,
+                contributors = contributors,
+                series = series,
+                genres = genres,
+                tags = tags,
+                pendingCover = pendingCover,
+            )
 
-        return fixture
-    }
+        fun createEditableContributor(
+            id: String = "c1",
+            name: String = "Author Name",
+            roles: Set<ContributorRole> = setOf(ContributorRole.AUTHOR),
+        ): EditableContributor =
+            EditableContributor(
+                id = id,
+                name = name,
+                roles = roles,
+            )
 
-    // ========== Test Data Factories ==========
+        fun createEditableSeries(
+            id: String = "s1",
+            name: String = "Series Name",
+            sequence: String? = "1",
+        ): EditableSeries =
+            EditableSeries(
+                id = id,
+                name = name,
+                sequence = sequence,
+            )
 
-    private fun createMetadata(
-        title: String = "Test Book",
-        sortTitle: String = "",
-        subtitle: String = "",
-        description: String = "",
-        publishYear: String = "",
-        publisher: String = "",
-        language: String? = null,
-        isbn: String = "",
-        asin: String = "",
-        abridged: Boolean = false,
-        addedAt: Long? = null,
-    ): BookMetadata =
-        BookMetadata(
-            title = title,
-            sortTitle = sortTitle,
-            subtitle = subtitle,
-            description = description,
-            publishYear = publishYear,
-            publisher = publisher,
-            language = language,
-            isbn = isbn,
-            asin = asin,
-            abridged = abridged,
-            addedAt = addedAt,
-        )
+        fun createEditableGenre(
+            id: String = "g1",
+            name: String = "Fiction",
+            path: String = "/fiction",
+        ): EditableGenre =
+            EditableGenre(
+                id = id,
+                name = name,
+                path = path,
+            )
 
-    private fun createOriginalState(
-        bookId: String = "book-1",
-        metadata: BookMetadata = createMetadata(),
-        contributors: List<EditableContributor> = emptyList(),
-        series: List<EditableSeries> = emptyList(),
-        genres: List<EditableGenre> = emptyList(),
-        tags: List<EditableTag> = emptyList(),
-        allGenres: List<EditableGenre> = emptyList(),
-        allTags: List<EditableTag> = emptyList(),
-        coverPath: String? = null,
-    ): BookEditData =
-        BookEditData(
-            bookId = bookId,
-            metadata = metadata,
-            contributors = contributors,
-            series = series,
-            genres = genres,
-            tags = tags,
-            allGenres = allGenres,
-            allTags = allTags,
-            coverPath = coverPath,
-        )
+        fun createEditableTag(
+            id: String = "t1",
+            slug: String = "favorites",
+        ): EditableTag =
+            EditableTag(
+                id = id,
+                slug = slug,
+            )
 
-    private fun createUpdateRequest(
-        bookId: String = "book-1",
-        metadata: BookMetadata = createMetadata(),
-        contributors: List<EditableContributor> = emptyList(),
-        series: List<EditableSeries> = emptyList(),
-        genres: List<EditableGenre> = emptyList(),
-        tags: List<EditableTag> = emptyList(),
-        pendingCover: PendingCover? = null,
-    ): BookUpdateRequest =
-        BookUpdateRequest(
-            bookId = bookId,
-            metadata = metadata,
-            contributors = contributors,
-            series = series,
-            genres = genres,
-            tags = tags,
-            pendingCover = pendingCover,
-        )
+        // ========== No Changes Tests ==========
 
-    private fun createEditableContributor(
-        id: String = "c1",
-        name: String = "Author Name",
-        roles: Set<ContributorRole> = setOf(ContributorRole.AUTHOR),
-    ): EditableContributor =
-        EditableContributor(
-            id = id,
-            name = name,
-            roles = roles,
-        )
+        test("returns success without calling repos when no changes") {
+            runTest {
+                // Given - identical current and original state
+                val metadata = createMetadata(title = "Same Title")
+                val original = createOriginalState(metadata = metadata)
+                val current = createUpdateRequest(metadata = metadata)
 
-    private fun createEditableSeries(
-        id: String = "s1",
-        name: String = "Series Name",
-        sequence: String? = "1",
-    ): EditableSeries =
-        EditableSeries(
-            id = id,
-            name = name,
-            sequence = sequence,
-        )
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-    private fun createEditableGenre(
-        id: String = "g1",
-        name: String = "Fiction",
-        path: String = "/fiction",
-    ): EditableGenre =
-        EditableGenre(
-            id = id,
-            name = name,
-            path = path,
-        )
+                // When
+                val result = useCase(current, original)
 
-    private fun createEditableTag(
-        id: String = "t1",
-        slug: String = "favorites",
-    ): EditableTag =
-        EditableTag(
-            id = id,
-            slug = slug,
-        )
+                // Then
+                checkIs<Success<Unit>>(result)
 
-    // ========== No Changes Tests ==========
-
-    @Test
-    fun `returns success without calling repos when no changes`() =
-        runTest {
-            // Given - identical current and original state
-            val metadata = createMetadata(title = "Same Title")
-            val original = createOriginalState(metadata = metadata)
-            val current = createUpdateRequest(metadata = metadata)
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-
-            // Verify no repository calls were made
-            verifySuspend(VerifyMode.not) { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
-            verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookContributors(any(), any()) }
-            verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookSeries(any(), any()) }
-            verifySuspend(VerifyMode.not) { fixture.genreRepository.setGenresForBook(any(), any()) }
-        }
-
-    // ========== Metadata Change Tests ==========
-
-    @Test
-    fun `updates metadata when title changes`() =
-        runTest {
-            // Given
-            val originalMetadata = createMetadata(title = "Original Title")
-            val currentMetadata = createMetadata(title = "New Title")
-            val original = createOriginalState(metadata = originalMetadata)
-            val current = createUpdateRequest(metadata = currentMetadata)
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.bookEditRepository.updateBook(bookId = "book-1", title = "New Title", any(), any(), any(), any(), any(), any(), any(), any(), any()) }
-        }
-
-    @Test
-    fun `updates metadata when any field changes`() =
-        runTest {
-            // Given
-            val originalMetadata = createMetadata()
-            val currentMetadata =
-                createMetadata(
-                    subtitle = "New Subtitle",
-                    description = "New Description",
-                    publishYear = "2024",
-                    publisher = "New Publisher",
-                    language = "en",
-                    isbn = "1234567890",
-                    asin = "ASIN123",
-                    abridged = true,
-                )
-            val original = createOriginalState(metadata = originalMetadata)
-            val current = createUpdateRequest(metadata = currentMetadata)
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend {
-                fixture.bookEditRepository.updateBook(
-                    bookId = "book-1",
-                    title = any(),
-                    subtitle = "New Subtitle",
-                    description = "New Description",
-                    publishYear = "2024",
-                    publisher = "New Publisher",
-                    language = "en",
-                    isbn = "1234567890",
-                    asin = "ASIN123",
-                    abridged = true,
-                )
+                // Verify no repository calls were made
+                verifySuspend(VerifyMode.not) { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+                verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookContributors(any(), any()) }
+                verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookSeries(any(), any()) }
+                verifySuspend(VerifyMode.not) { fixture.genreRepository.setGenresForBook(any(), any()) }
             }
         }
 
-    // ========== Contributor Change Tests ==========
+        // ========== Metadata Change Tests ==========
 
-    @Test
-    fun `updates contributors when list changes`() =
-        runTest {
-            // Given
-            val originalContributors =
-                listOf(
-                    createEditableContributor(id = "c1", name = "Author 1"),
-                )
-            val currentContributors =
-                listOf(
-                    createEditableContributor(id = "c1", name = "Author 1"),
-                    createEditableContributor(id = "c2", name = "Author 2"),
-                )
-            val original = createOriginalState(contributors = originalContributors)
-            val current = createUpdateRequest(contributors = currentContributors)
+        test("updates metadata when title changes") {
+            runTest {
+                // Given
+                val originalMetadata = createMetadata(title = "Original Title")
+                val currentMetadata = createMetadata(title = "New Title")
+                val original = createOriginalState(metadata = originalMetadata)
+                val current = createUpdateRequest(metadata = currentMetadata)
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase(current, original)
+                // When
+                val result = useCase(current, original)
 
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.bookEditRepository.setBookContributors("book-1", any()) }
-        }
-
-    @Test
-    fun `does not update contributors when list unchanged`() =
-        runTest {
-            // Given
-            val contributors =
-                listOf(
-                    createEditableContributor(id = "c1", name = "Author 1"),
-                )
-            val original = createOriginalState(contributors = contributors)
-            val current = createUpdateRequest(contributors = contributors)
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            useCase(current, original)
-
-            // Then
-            verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookContributors(any(), any()) }
-        }
-
-    // ========== Series Change Tests ==========
-
-    @Test
-    fun `updates series when list changes`() =
-        runTest {
-            // Given
-            val originalSeries = emptyList<EditableSeries>()
-            val currentSeries =
-                listOf(
-                    createEditableSeries(id = "s1", name = "New Series", sequence = "1"),
-                )
-            val original = createOriginalState(series = originalSeries)
-            val current = createUpdateRequest(series = currentSeries)
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.bookEditRepository.setBookSeries("book-1", any()) }
-        }
-
-    @Test
-    fun `converts series sequence to float`() =
-        runTest {
-            // Given
-            val currentSeries =
-                listOf(
-                    createEditableSeries(id = "s1", name = "Series", sequence = "2.5"),
-                )
-            val original = createOriginalState()
-            val current = createUpdateRequest(series = currentSeries)
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            useCase(current, original)
-
-            // Then
-            verifySuspend {
-                fixture.bookEditRepository.setBookSeries(
-                    "book-1",
-                    listOf(BookSeriesInput(name = "Series", sequence = 2.5f)),
-                )
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.bookEditRepository.updateBook(bookId = "book-1", title = "New Title", any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             }
         }
 
-    // ========== Genre Change Tests ==========
+        test("updates metadata when any field changes") {
+            runTest {
+                // Given
+                val originalMetadata = createMetadata()
+                val currentMetadata =
+                    createMetadata(
+                        subtitle = "New Subtitle",
+                        description = "New Description",
+                        publishYear = "2024",
+                        publisher = "New Publisher",
+                        language = "en",
+                        isbn = "1234567890",
+                        asin = "ASIN123",
+                        abridged = true,
+                    )
+                val original = createOriginalState(metadata = originalMetadata)
+                val current = createUpdateRequest(metadata = currentMetadata)
 
-    @Test
-    fun `updates genres when list changes`() =
-        runTest {
-            // Given
-            val originalGenres = listOf(createEditableGenre(id = "g1", name = "Fiction"))
-            val currentGenres =
-                listOf(
-                    createEditableGenre(id = "g1", name = "Fiction"),
-                    createEditableGenre(id = "g2", name = "Mystery"),
-                )
-            val original = createOriginalState(genres = originalGenres)
-            val current = createUpdateRequest(genres = currentGenres)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+                // When
+                val result = useCase(current, original)
 
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.genreRepository.setGenresForBook("book-1", listOf("g1", "g2")) }
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend {
+                    fixture.bookEditRepository.updateBook(
+                        bookId = "book-1",
+                        title = any(),
+                        subtitle = "New Subtitle",
+                        description = "New Description",
+                        publishYear = "2024",
+                        publisher = "New Publisher",
+                        language = "en",
+                        isbn = "1234567890",
+                        asin = "ASIN123",
+                        abridged = true,
+                    )
+                }
+            }
         }
 
-    @Test
-    fun `does not update genres when list unchanged`() =
-        runTest {
-            // Given
-            val genres = listOf(createEditableGenre(id = "g1", name = "Fiction"))
-            val original = createOriginalState(genres = genres)
-            val current = createUpdateRequest(genres = genres)
+        // ========== Contributor Change Tests ==========
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("updates contributors when list changes") {
+            runTest {
+                // Given
+                val originalContributors =
+                    listOf(
+                        createEditableContributor(id = "c1", name = "Author 1"),
+                    )
+                val currentContributors =
+                    listOf(
+                        createEditableContributor(id = "c1", name = "Author 1"),
+                        createEditableContributor(id = "c2", name = "Author 2"),
+                    )
+                val original = createOriginalState(contributors = originalContributors)
+                val current = createUpdateRequest(contributors = currentContributors)
 
-            // When
-            useCase(current, original)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // Then
-            verifySuspend(VerifyMode.not) { fixture.genreRepository.setGenresForBook(any(), any()) }
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.bookEditRepository.setBookContributors("book-1", any()) }
+            }
         }
 
-    // ========== Tag Change Tests ==========
+        test("does not update contributors when list unchanged") {
+            runTest {
+                // Given
+                val contributors =
+                    listOf(
+                        createEditableContributor(id = "c1", name = "Author 1"),
+                    )
+                val original = createOriginalState(contributors = contributors)
+                val current = createUpdateRequest(contributors = contributors)
 
-    @Test
-    fun `adds new tags`() =
-        runTest {
-            // Given
-            val originalTags = listOf(createEditableTag(id = "t1", slug = "favorites"))
-            val currentTags =
-                listOf(
-                    createEditableTag(id = "t1", slug = "favorites"),
-                    createEditableTag(id = "t2", slug = "to-read"),
-                )
-            val original = createOriginalState(tags = originalTags)
-            val current = createUpdateRequest(tags = currentTags)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+                // When
+                useCase(current, original)
 
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.tagRepository.addTagToBook("book-1", "to-read") }
+                // Then
+                verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookContributors(any(), any()) }
+            }
         }
 
-    @Test
-    fun `removes deleted tags`() =
-        runTest {
-            // Given
-            val originalTags =
-                listOf(
-                    createEditableTag(id = "t1", slug = "favorites"),
-                    createEditableTag(id = "t2", slug = "to-read"),
-                )
-            val currentTags = listOf(createEditableTag(id = "t1", slug = "favorites"))
-            val original = createOriginalState(tags = originalTags)
-            val current = createUpdateRequest(tags = currentTags)
+        // ========== Series Change Tests ==========
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("updates series when list changes") {
+            runTest {
+                // Given
+                val originalSeries = emptyList<EditableSeries>()
+                val currentSeries =
+                    listOf(
+                        createEditableSeries(id = "s1", name = "New Series", sequence = "1"),
+                    )
+                val original = createOriginalState(series = originalSeries)
+                val current = createUpdateRequest(series = currentSeries)
 
-            // When
-            val result = useCase(current, original)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "to-read", "t2") }
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.bookEditRepository.setBookSeries("book-1", any()) }
+            }
         }
 
-    @Test
-    fun `adds and removes tags in single operation`() =
-        runTest {
-            // Given
-            val originalTags =
-                listOf(
-                    createEditableTag(id = "t1", slug = "favorites"),
-                    createEditableTag(id = "t2", slug = "to-read"),
-                )
-            val currentTags =
-                listOf(
-                    createEditableTag(id = "t1", slug = "favorites"),
-                    createEditableTag(id = "t3", slug = "completed"),
-                )
-            val original = createOriginalState(tags = originalTags)
-            val current = createUpdateRequest(tags = currentTags)
+        test("converts series sequence to float") {
+            runTest {
+                // Given
+                val currentSeries =
+                    listOf(
+                        createEditableSeries(id = "s1", name = "Series", sequence = "2.5"),
+                    )
+                val original = createOriginalState()
+                val current = createUpdateRequest(series = currentSeries)
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase(current, original)
+                // When
+                useCase(current, original)
 
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "to-read", "t2") }
-            verifySuspend { fixture.tagRepository.addTagToBook("book-1", "completed") }
+                // Then
+                verifySuspend {
+                    fixture.bookEditRepository.setBookSeries(
+                        "book-1",
+                        listOf(BookSeriesInput(name = "Series", sequence = 2.5f)),
+                    )
+                }
+            }
         }
 
-    @Test
-    fun `does not update tags when unchanged`() =
-        runTest {
-            // Given
-            val tags = listOf(createEditableTag(id = "t1", slug = "favorites"))
-            val original = createOriginalState(tags = tags)
-            val current = createUpdateRequest(tags = tags)
+        // ========== Genre Change Tests ==========
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("updates genres when list changes") {
+            runTest {
+                // Given
+                val originalGenres = listOf(createEditableGenre(id = "g1", name = "Fiction"))
+                val currentGenres =
+                    listOf(
+                        createEditableGenre(id = "g1", name = "Fiction"),
+                        createEditableGenre(id = "g2", name = "Mystery"),
+                    )
+                val original = createOriginalState(genres = originalGenres)
+                val current = createUpdateRequest(genres = currentGenres)
 
-            // When
-            useCase(current, original)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // Then
-            verifySuspend(VerifyMode.not) { fixture.tagRepository.addTagToBook(any(), any()) }
-            verifySuspend(VerifyMode.not) { fixture.tagRepository.removeTagFromBook(any(), any(), any()) }
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.genreRepository.setGenresForBook("book-1", listOf("g1", "g2")) }
+            }
         }
 
-    // ========== Cover Upload Tests ==========
+        test("does not update genres when list unchanged") {
+            runTest {
+                // Given
+                val genres = listOf(createEditableGenre(id = "g1", name = "Fiction"))
+                val original = createOriginalState(genres = genres)
+                val current = createUpdateRequest(genres = genres)
 
-    @Test
-    fun `commits and uploads cover when pending`() =
-        runTest {
-            // Given
-            val pendingCover =
-                PendingCover(
-                    data = byteArrayOf(1, 2, 3),
-                    filename = "cover.jpg",
-                )
-            val original = createOriginalState()
-            val current = createUpdateRequest(pendingCover = pendingCover)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+                // When
+                useCase(current, original)
 
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.imageStagingRepository.commitBookCoverStaging(BookId("book-1")) }
-            verifySuspend { fixture.imageRepository.uploadBookCover("book-1", any(), "cover.jpg") }
+                // Then
+                verifySuspend(VerifyMode.not) { fixture.genreRepository.setGenresForBook(any(), any()) }
+            }
         }
 
-    @Test
-    fun `does not upload cover when no pending cover`() =
-        runTest {
-            // Given
-            val original = createOriginalState()
-            val current = createUpdateRequest(pendingCover = null)
+        // ========== Tag Change Tests ==========
 
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("adds new tags") {
+            runTest {
+                // Given
+                val originalTags = listOf(createEditableTag(id = "t1", slug = "favorites"))
+                val currentTags =
+                    listOf(
+                        createEditableTag(id = "t1", slug = "favorites"),
+                        createEditableTag(id = "t2", slug = "to-read"),
+                    )
+                val original = createOriginalState(tags = originalTags)
+                val current = createUpdateRequest(tags = currentTags)
 
-            // When
-            useCase(current, original)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // Then
-            verifySuspend(VerifyMode.not) { fixture.imageStagingRepository.commitBookCoverStaging(any()) }
-            verifySuspend(VerifyMode.not) { fixture.imageRepository.uploadBookCover(any(), any(), any()) }
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.tagRepository.addTagToBook("book-1", "to-read") }
+            }
         }
 
-    @Test
-    fun `continues save even if cover upload fails`() =
-        runTest {
-            // Given - cover upload will fail
-            val pendingCover =
-                PendingCover(
-                    data = byteArrayOf(1, 2, 3),
-                    filename = "cover.jpg",
-                )
-            val original = createOriginalState()
-            val current = createUpdateRequest(pendingCover = pendingCover)
+        test("removes deleted tags") {
+            runTest {
+                // Given
+                val originalTags =
+                    listOf(
+                        createEditableTag(id = "t1", slug = "favorites"),
+                        createEditableTag(id = "t2", slug = "to-read"),
+                    )
+                val currentTags = listOf(createEditableTag(id = "t1", slug = "favorites"))
+                val original = createOriginalState(tags = originalTags)
+                val current = createUpdateRequest(tags = currentTags)
 
-            val fixture = createFixture()
-            everySuspend { fixture.imageRepository.uploadBookCover(any(), any(), any()) } returns failureOf("Upload failed")
-            val useCase = fixture.build()
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase(current, original)
+                // When
+                val result = useCase(current, original)
 
-            // Then - should still succeed (cover upload is best-effort)
-            checkIs<Success<Unit>>(result)
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "to-read", "t2") }
+            }
         }
 
-    // ========== Error Handling Tests ==========
+        test("adds and removes tags in single operation") {
+            runTest {
+                // Given
+                val originalTags =
+                    listOf(
+                        createEditableTag(id = "t1", slug = "favorites"),
+                        createEditableTag(id = "t2", slug = "to-read"),
+                    )
+                val currentTags =
+                    listOf(
+                        createEditableTag(id = "t1", slug = "favorites"),
+                        createEditableTag(id = "t3", slug = "completed"),
+                    )
+                val original = createOriginalState(tags = originalTags)
+                val current = createUpdateRequest(tags = currentTags)
 
-    @Test
-    fun `returns failure when metadata update fails`() =
-        runTest {
-            // Given
-            val originalMetadata = createMetadata(title = "Original")
-            val currentMetadata = createMetadata(title = "New")
-            val original = createOriginalState(metadata = originalMetadata)
-            val current = createUpdateRequest(metadata = currentMetadata)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val fixture = createFixture()
-            everySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns failureOf("Update failed")
-            val useCase = fixture.build()
+                // When
+                val result = useCase(current, original)
 
-            // When
-            val result = useCase(current, original)
-
-            // Then
-            val failure = assertIs<Failure>(result)
-            assertTrue(failure.message.contains("Update failed"))
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "to-read", "t2") }
+                verifySuspend { fixture.tagRepository.addTagToBook("book-1", "completed") }
+            }
         }
 
-    @Test
-    fun `stops execution on first error`() =
-        runTest {
-            // Given - metadata will fail, contributors also changed
-            val originalMetadata = createMetadata(title = "Original")
-            val currentMetadata = createMetadata(title = "New")
-            val currentContributors = listOf(createEditableContributor())
+        test("does not update tags when unchanged") {
+            runTest {
+                // Given
+                val tags = listOf(createEditableTag(id = "t1", slug = "favorites"))
+                val original = createOriginalState(tags = tags)
+                val current = createUpdateRequest(tags = tags)
 
-            val original = createOriginalState(metadata = originalMetadata)
-            val current =
-                createUpdateRequest(
-                    metadata = currentMetadata,
-                    contributors = currentContributors,
-                )
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val fixture = createFixture()
-            everySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns failureOf("Metadata failed")
-            val useCase = fixture.build()
+                // When
+                useCase(current, original)
 
-            // When
-            useCase(current, original)
-
-            // Then - contributors should not be updated because metadata failed first
-            verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookContributors(any(), any()) }
+                // Then
+                verifySuspend(VerifyMode.not) { fixture.tagRepository.addTagToBook(any(), any()) }
+                verifySuspend(VerifyMode.not) { fixture.tagRepository.removeTagFromBook(any(), any(), any()) }
+            }
         }
 
-    @Test
-    fun `returns failure when contributor update fails`() =
-        runTest {
-            // Given
-            val currentContributors = listOf(createEditableContributor())
-            val original = createOriginalState()
-            val current = createUpdateRequest(contributors = currentContributors)
+        // ========== Cover Upload Tests ==========
 
-            val fixture = createFixture()
-            everySuspend { fixture.bookEditRepository.setBookContributors(any(), any()) } returns failureOf("Contributor update failed")
-            val useCase = fixture.build()
+        test("commits and uploads cover when pending") {
+            runTest {
+                // Given
+                val pendingCover =
+                    PendingCover(
+                        data = byteArrayOf(1, 2, 3),
+                        filename = "cover.jpg",
+                    )
+                val original = createOriginalState()
+                val current = createUpdateRequest(pendingCover = pendingCover)
 
-            // When
-            val result = useCase(current, original)
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // Then
-            val failure = assertIs<Failure>(result)
-            assertTrue(failure.message.contains("Contributor update failed"))
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.imageStagingRepository.commitBookCoverStaging(BookId("book-1")) }
+                verifySuspend { fixture.imageRepository.uploadBookCover("book-1", any(), "cover.jpg") }
+            }
         }
 
-    @Test
-    fun `returns failure when series update fails`() =
-        runTest {
-            // Given
-            val currentSeries = listOf(createEditableSeries())
-            val original = createOriginalState()
-            val current = createUpdateRequest(series = currentSeries)
+        test("does not upload cover when no pending cover") {
+            runTest {
+                // Given
+                val original = createOriginalState()
+                val current = createUpdateRequest(pendingCover = null)
 
-            val fixture = createFixture()
-            everySuspend { fixture.bookEditRepository.setBookSeries(any(), any()) } returns failureOf("Series update failed")
-            val useCase = fixture.build()
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase(current, original)
+                // When
+                useCase(current, original)
 
-            // Then
-            val failure = assertIs<Failure>(result)
-            assertTrue(failure.message.contains("Series update failed"))
+                // Then
+                verifySuspend(VerifyMode.not) { fixture.imageStagingRepository.commitBookCoverStaging(any()) }
+                verifySuspend(VerifyMode.not) { fixture.imageRepository.uploadBookCover(any(), any(), any()) }
+            }
         }
 
-    // ========== Multiple Changes Test ==========
+        test("continues save even if cover upload fails") {
+            runTest {
+                // Given - cover upload will fail
+                val pendingCover =
+                    PendingCover(
+                        data = byteArrayOf(1, 2, 3),
+                        filename = "cover.jpg",
+                    )
+                val original = createOriginalState()
+                val current = createUpdateRequest(pendingCover = pendingCover)
 
-    @Test
-    fun `handles all changes in single call`() =
-        runTest {
-            // Given - everything changed
-            val originalMetadata = createMetadata(title = "Original Title")
-            val currentMetadata = createMetadata(title = "New Title")
+                val fixture = createFixture()
+                everySuspend { fixture.imageRepository.uploadBookCover(any(), any(), any()) } returns failureOf("Upload failed")
+                val useCase = fixture.build()
 
-            val originalContributors = listOf(createEditableContributor(id = "c1", name = "Old Author"))
-            val currentContributors = listOf(createEditableContributor(id = "c2", name = "New Author"))
+                // When
+                val result = useCase(current, original)
 
-            val originalSeries = emptyList<EditableSeries>()
-            val currentSeries = listOf(createEditableSeries(id = "s1", name = "New Series"))
-
-            val originalGenres = listOf(createEditableGenre(id = "g1", name = "Fiction"))
-            val currentGenres = listOf(createEditableGenre(id = "g2", name = "Mystery"))
-
-            val originalTags = listOf(createEditableTag(id = "t1", slug = "old-tag"))
-            val currentTags = listOf(createEditableTag(id = "t2", slug = "new-tag"))
-
-            val pendingCover = PendingCover(data = byteArrayOf(1), filename = "cover.jpg")
-
-            val original =
-                createOriginalState(
-                    metadata = originalMetadata,
-                    contributors = originalContributors,
-                    series = originalSeries,
-                    genres = originalGenres,
-                    tags = originalTags,
-                )
-            val current =
-                createUpdateRequest(
-                    metadata = currentMetadata,
-                    contributors = currentContributors,
-                    series = currentSeries,
-                    genres = currentGenres,
-                    tags = currentTags,
-                    pendingCover = pendingCover,
-                )
-
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(current, original)
-
-            // Then - all operations should be called
-            checkIs<Success<Unit>>(result)
-            verifySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
-            verifySuspend { fixture.bookEditRepository.setBookContributors(any(), any()) }
-            verifySuspend { fixture.bookEditRepository.setBookSeries(any(), any()) }
-            verifySuspend { fixture.genreRepository.setGenresForBook(any(), any()) }
-            verifySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) }
-            verifySuspend { fixture.tagRepository.addTagToBook(any(), any()) }
-            verifySuspend { fixture.imageStagingRepository.commitBookCoverStaging(any()) }
-            verifySuspend { fixture.imageRepository.uploadBookCover(any(), any(), any()) }
+                // Then - should still succeed (cover upload is best-effort)
+                checkIs<Success<Unit>>(result)
+            }
         }
-}
+
+        // ========== Error Handling Tests ==========
+
+        test("returns failure when metadata update fails") {
+            runTest {
+                // Given
+                val originalMetadata = createMetadata(title = "Original")
+                val currentMetadata = createMetadata(title = "New")
+                val original = createOriginalState(metadata = originalMetadata)
+                val current = createUpdateRequest(metadata = currentMetadata)
+
+                val fixture = createFixture()
+                everySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns failureOf("Update failed")
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                (failure.message.contains("Update failed")) shouldBe true
+            }
+        }
+
+        test("stops execution on first error") {
+            runTest {
+                // Given - metadata will fail, contributors also changed
+                val originalMetadata = createMetadata(title = "Original")
+                val currentMetadata = createMetadata(title = "New")
+                val currentContributors = listOf(createEditableContributor())
+
+                val original = createOriginalState(metadata = originalMetadata)
+                val current =
+                    createUpdateRequest(
+                        metadata = currentMetadata,
+                        contributors = currentContributors,
+                    )
+
+                val fixture = createFixture()
+                everySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns failureOf("Metadata failed")
+                val useCase = fixture.build()
+
+                // When
+                useCase(current, original)
+
+                // Then - contributors should not be updated because metadata failed first
+                verifySuspend(VerifyMode.not) { fixture.bookEditRepository.setBookContributors(any(), any()) }
+            }
+        }
+
+        test("returns failure when contributor update fails") {
+            runTest {
+                // Given
+                val currentContributors = listOf(createEditableContributor())
+                val original = createOriginalState()
+                val current = createUpdateRequest(contributors = currentContributors)
+
+                val fixture = createFixture()
+                everySuspend { fixture.bookEditRepository.setBookContributors(any(), any()) } returns failureOf("Contributor update failed")
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                (failure.message.contains("Contributor update failed")) shouldBe true
+            }
+        }
+
+        test("returns failure when series update fails") {
+            runTest {
+                // Given
+                val currentSeries = listOf(createEditableSeries())
+                val original = createOriginalState()
+                val current = createUpdateRequest(series = currentSeries)
+
+                val fixture = createFixture()
+                everySuspend { fixture.bookEditRepository.setBookSeries(any(), any()) } returns failureOf("Series update failed")
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                (failure.message.contains("Series update failed")) shouldBe true
+            }
+        }
+
+        // ========== Multiple Changes Test ==========
+
+        test("handles all changes in single call") {
+            runTest {
+                // Given - everything changed
+                val originalMetadata = createMetadata(title = "Original Title")
+                val currentMetadata = createMetadata(title = "New Title")
+
+                val originalContributors = listOf(createEditableContributor(id = "c1", name = "Old Author"))
+                val currentContributors = listOf(createEditableContributor(id = "c2", name = "New Author"))
+
+                val originalSeries = emptyList<EditableSeries>()
+                val currentSeries = listOf(createEditableSeries(id = "s1", name = "New Series"))
+
+                val originalGenres = listOf(createEditableGenre(id = "g1", name = "Fiction"))
+                val currentGenres = listOf(createEditableGenre(id = "g2", name = "Mystery"))
+
+                val originalTags = listOf(createEditableTag(id = "t1", slug = "old-tag"))
+                val currentTags = listOf(createEditableTag(id = "t2", slug = "new-tag"))
+
+                val pendingCover = PendingCover(data = byteArrayOf(1), filename = "cover.jpg")
+
+                val original =
+                    createOriginalState(
+                        metadata = originalMetadata,
+                        contributors = originalContributors,
+                        series = originalSeries,
+                        genres = originalGenres,
+                        tags = originalTags,
+                    )
+                val current =
+                    createUpdateRequest(
+                        metadata = currentMetadata,
+                        contributors = currentContributors,
+                        series = currentSeries,
+                        genres = currentGenres,
+                        tags = currentTags,
+                        pendingCover = pendingCover,
+                    )
+
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(current, original)
+
+                // Then - all operations should be called
+                checkIs<Success<Unit>>(result)
+                verifySuspend { fixture.bookEditRepository.updateBook(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+                verifySuspend { fixture.bookEditRepository.setBookContributors(any(), any()) }
+                verifySuspend { fixture.bookEditRepository.setBookSeries(any(), any()) }
+                verifySuspend { fixture.genreRepository.setGenresForBook(any(), any()) }
+                verifySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) }
+                verifySuspend { fixture.tagRepository.addTagToBook(any(), any()) }
+                verifySuspend { fixture.imageStagingRepository.commitBookCoverStaging(any()) }
+                verifySuspend { fixture.imageRepository.uploadBookCover(any(), any(), any()) }
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/contributor/ApplyContributorMetadataUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/contributor/ApplyContributorMetadataUseCaseTest.kt
@@ -14,371 +14,373 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
-class ApplyContributorMetadataUseCaseTest {
-    // ========== Test Fixture ==========
+class ApplyContributorMetadataUseCaseTest :
+    FunSpec({
 
-    private class TestFixture {
-        val metadataRepository: MetadataRepository = mock()
-        val imageRepository: ImageRepository = mock()
-        val contributorRepository: ContributorRepository = mock()
+        // ========== Test Fixture ==========
 
-        fun build(): ApplyContributorMetadataUseCase =
-            ApplyContributorMetadataUseCase(
-                metadataRepository = metadataRepository,
-                imageRepository = imageRepository,
-                contributorRepository = contributorRepository,
+        class TestFixture {
+            val metadataRepository: MetadataRepository = mock()
+            val imageRepository: ImageRepository = mock()
+            val contributorRepository: ContributorRepository = mock()
+
+            fun build(): ApplyContributorMetadataUseCase =
+                ApplyContributorMetadataUseCase(
+                    metadataRepository = metadataRepository,
+                    imageRepository = imageRepository,
+                    contributorRepository = contributorRepository,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Default stubs
+            everySuspend { fixture.contributorRepository.getById(any()) } returns null
+            everySuspend { fixture.contributorRepository.upsertContributor(any()) } returns Unit
+
+            return fixture
+        }
+
+        // ========== Test Data Factories ==========
+
+        fun createRequest(
+            contributorId: String = "contributor-123",
+            asin: String = "B001ABC123",
+            imageUrl: String? = "https://audible.com/image.jpg",
+            name: Boolean = true,
+            biography: Boolean = true,
+            image: Boolean = true,
+        ): ApplyContributorMetadataRequest =
+            ApplyContributorMetadataRequest(
+                contributorId = contributorId,
+                asin = asin,
+                imageUrl = imageUrl,
+                selections =
+                    MetadataFieldSelections(
+                        name = name,
+                        biography = biography,
+                        image = image,
+                    ),
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
+        fun createContributorWithMetadata(
+            id: String = "contributor-123",
+            name: String = "Updated Author",
+            biography: String? = "Updated biography",
+            imageUrl: String? = "https://server.com/contributor-image.jpg",
+            imageBlurHash: String? = null,
+        ): ContributorWithMetadata =
+            ContributorWithMetadata(
+                id = id,
+                name = name,
+                biography = biography,
+                imageUrl = imageUrl,
+                imageBlurHash = imageBlurHash,
+            )
 
-        // Default stubs
-        everySuspend { fixture.contributorRepository.getById(any()) } returns null
-        everySuspend { fixture.contributorRepository.upsertContributor(any()) } returns Unit
+        // ========== Validation Tests ==========
 
-        return fixture
-    }
+        test("returns failure when no fields selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+                val request = createRequest(name = false, biography = false, image = false)
 
-    // ========== Test Data Factories ==========
+                // When
+                val result = useCase(request)
 
-    private fun createRequest(
-        contributorId: String = "contributor-123",
-        asin: String = "B001ABC123",
-        imageUrl: String? = "https://audible.com/image.jpg",
-        name: Boolean = true,
-        biography: Boolean = true,
-        image: Boolean = true,
-    ): ApplyContributorMetadataRequest =
-        ApplyContributorMetadataRequest(
-            contributorId = contributorId,
-            asin = asin,
-            imageUrl = imageUrl,
-            selections =
-                MetadataFieldSelections(
-                    name = name,
-                    biography = biography,
-                    image = image,
-                ),
-        )
-
-    private fun createContributorWithMetadata(
-        id: String = "contributor-123",
-        name: String = "Updated Author",
-        biography: String? = "Updated biography",
-        imageUrl: String? = "https://server.com/contributor-image.jpg",
-        imageBlurHash: String? = null,
-    ): ContributorWithMetadata =
-        ContributorWithMetadata(
-            id = id,
-            name = name,
-            biography = biography,
-            imageUrl = imageUrl,
-            imageBlurHash = imageBlurHash,
-        )
-
-    // ========== Validation Tests ==========
-
-    @Test
-    fun `returns failure when no fields selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-            val request = createRequest(name = false, biography = false, image = false)
-
-            // When
-            val result = useCase(request)
-
-            // Then
-            assertIs<Failure>(result)
-            assertEquals("Please select at least one field to apply", result.message)
-        }
-
-    // ========== Success Tests ==========
-
-    @Test
-    fun `applies metadata successfully`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(createRequest())
-
-            // Then
-            assertIs<Success<Contributor>>(result)
-            assertEquals("contributor-123", result.data.id.value)
-            assertEquals("Updated Author", result.data.name)
-        }
-
-    @Test
-    fun `passes correct parameters to repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
-
-            val request =
-                createRequest(
-                    contributorId = "my-contributor",
-                    asin = "MY-ASIN",
-                    imageUrl = "https://example.com/img.jpg",
-                    name = true,
-                    biography = false,
-                    image = true,
-                )
-
-            // When
-            useCase(request)
-
-            // Then
-            verifySuspend {
-                fixture.metadataRepository.applyContributorMetadata(
-                    contributorId = "my-contributor",
-                    asin = "MY-ASIN",
-                    imageUrl = "https://example.com/img.jpg",
-                    applyName = true,
-                    applyBiography = false,
-                    applyImage = true,
-                )
+                // Then
+                result.shouldBeInstanceOf<Failure>()
+                result.message shouldBe "Please select at least one field to apply"
             }
         }
 
-    @Test
-    fun `upserts entity to repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
+        // ========== Success Tests ==========
 
-            // When
-            useCase(createRequest())
+        test("applies metadata successfully") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
 
-            // Then
-            verifySuspend {
-                fixture.contributorRepository.upsertContributor(any())
+                // When
+                val result = useCase(createRequest())
+
+                // Then
+                val success = result.shouldBeInstanceOf<Success<Contributor>>()
+                success.data.id.value shouldBe "contributor-123"
+                success.data.name shouldBe "Updated Author"
             }
         }
 
-    // ========== Image Download Tests ==========
+        test("passes correct parameters to repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
 
-    @Test
-    fun `downloads and saves image when imageUrl present`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = "https://server.com/image.jpg")
-            val imageData = byteArrayOf(1, 2, 3, 4)
+                val request =
+                    createRequest(
+                        contributorId = "my-contributor",
+                        asin = "MY-ASIN",
+                        imageUrl = "https://example.com/img.jpg",
+                        name = true,
+                        biography = false,
+                        image = true,
+                    )
 
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            everySuspend {
-                fixture.imageRepository.downloadContributorImage("contributor-123")
-            } returns Success(imageData)
-            everySuspend {
-                fixture.imageRepository.saveContributorImage(any(), any())
-            } returns Success(Unit)
-            everySuspend {
-                fixture.imageRepository.getContributorImagePath("contributor-123")
-            } returns "/images/contributor-123.jpg"
+                // When
+                useCase(request)
 
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(createRequest())
-
-            // Then
-            assertIs<Success<Contributor>>(result)
-            assertEquals("/images/contributor-123.jpg", result.data.imagePath)
-        }
-
-    @Test
-    fun `skips image download when imageUrl is null`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
-
-            // When
-            useCase(createRequest())
-
-            // Then - should not attempt to download
-            verifySuspend(VerifyMode.not) {
-                fixture.imageRepository.downloadContributorImage(any())
+                // Then
+                verifySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(
+                        contributorId = "my-contributor",
+                        asin = "MY-ASIN",
+                        imageUrl = "https://example.com/img.jpg",
+                        applyName = true,
+                        applyBiography = false,
+                        applyImage = true,
+                    )
+                }
             }
         }
 
-    @Test
-    fun `succeeds when image download fails`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = "https://server.com/image.jpg")
+        test("upserts entity to repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
 
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            everySuspend {
-                fixture.imageRepository.downloadContributorImage(any())
-            } returns Failure(Exception("Download failed"))
+                // When
+                useCase(createRequest())
 
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(createRequest())
-
-            // Then - should succeed without image
-            assertIs<Success<Contributor>>(result)
+                // Then
+                verifySuspend {
+                    fixture.contributorRepository.upsertContributor(any())
+                }
+            }
         }
 
-    @Test
-    fun `succeeds when image save fails`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = "https://server.com/image.jpg")
-            val imageData = byteArrayOf(1, 2, 3, 4)
+        // ========== Image Download Tests ==========
 
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            everySuspend {
-                fixture.imageRepository.downloadContributorImage(any())
-            } returns Success(imageData)
-            everySuspend {
-                fixture.imageRepository.saveContributorImage(any(), any())
-            } returns Failure(Exception("Save failed"))
+        test("downloads and saves image when imageUrl present") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = "https://server.com/image.jpg")
+                val imageData = byteArrayOf(1, 2, 3, 4)
 
-            val useCase = fixture.build()
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                everySuspend {
+                    fixture.imageRepository.downloadContributorImage("contributor-123")
+                } returns Success(imageData)
+                everySuspend {
+                    fixture.imageRepository.saveContributorImage(any(), any())
+                } returns Success(Unit)
+                everySuspend {
+                    fixture.imageRepository.getContributorImagePath("contributor-123")
+                } returns "/images/contributor-123.jpg"
 
-            // When
-            val result = useCase(createRequest())
+                val useCase = fixture.build()
 
-            // Then - should succeed without saved image
-            assertIs<Success<Contributor>>(result)
+                // When
+                val result = useCase(createRequest())
+
+                // Then
+                val success = result.shouldBeInstanceOf<Success<Contributor>>()
+                success.data.imagePath shouldBe "/images/contributor-123.jpg"
+            }
         }
 
-    // ========== API Error Tests ==========
+        test("skips image download when imageUrl is null") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
 
-    @Test
-    fun `returns failure when repository returns error`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Error("Server rejected request")
-            val useCase = fixture.build()
+                // When
+                useCase(createRequest())
 
-            // When
-            val result = useCase(createRequest())
-
-            // Then
-            assertIs<Failure>(result)
-            assertEquals("Server rejected request", result.message)
+                // Then - should not attempt to download
+                verifySuspend(VerifyMode.not) {
+                    fixture.imageRepository.downloadContributorImage(any())
+                }
+            }
         }
 
-    @Test
-    fun `returns failure when repository returns disambiguation`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.NeedsDisambiguation(emptyList())
-            val useCase = fixture.build()
+        test("succeeds when image download fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = "https://server.com/image.jpg")
 
-            // When
-            val result = useCase(createRequest())
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                everySuspend {
+                    fixture.imageRepository.downloadContributorImage(any())
+                } returns Failure(Exception("Download failed"))
 
-            // Then
-            assertIs<Failure>(result)
-            assertEquals("Unexpected disambiguation request", result.message)
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(createRequest())
+
+                // Then - should succeed without image
+                result.shouldBeInstanceOf<Success<Contributor>>()
+            }
         }
 
-    // ========== Field Selection Tests ==========
+        test("succeeds when image save fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = "https://server.com/image.jpg")
+                val imageData = byteArrayOf(1, 2, 3, 4)
 
-    @Test
-    fun `accepts request with only name selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                everySuspend {
+                    fixture.imageRepository.downloadContributorImage(any())
+                } returns Success(imageData)
+                everySuspend {
+                    fixture.imageRepository.saveContributorImage(any(), any())
+                } returns Failure(Exception("Save failed"))
 
-            val request = createRequest(name = true, biography = false, image = false)
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase(request)
+                // When
+                val result = useCase(createRequest())
 
-            // Then
-            assertIs<Success<Contributor>>(result)
+                // Then - should succeed without saved image
+                result.shouldBeInstanceOf<Success<Contributor>>()
+            }
         }
 
-    @Test
-    fun `accepts request with only biography selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
+        // ========== API Error Tests ==========
 
-            val request = createRequest(name = false, biography = true, image = false)
+        test("returns failure when repository returns error") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Error("Server rejected request")
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase(request)
+                // When
+                val result = useCase(createRequest())
 
-            // Then
-            assertIs<Success<Contributor>>(result)
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.message shouldBe "Server rejected request"
+            }
         }
 
-    @Test
-    fun `accepts request with only image selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributorData = createContributorWithMetadata(imageUrl = null)
-            everySuspend {
-                fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
-            } returns ContributorMetadataResult.Success(contributor = contributorData)
-            val useCase = fixture.build()
+        test("returns failure when repository returns disambiguation") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.NeedsDisambiguation(emptyList())
+                val useCase = fixture.build()
 
-            val request = createRequest(name = false, biography = false, image = true)
+                // When
+                val result = useCase(createRequest())
 
-            // When
-            val result = useCase(request)
-
-            // Then
-            assertIs<Success<Contributor>>(result)
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.message shouldBe "Unexpected disambiguation request"
+            }
         }
-}
+
+        // ========== Field Selection Tests ==========
+
+        test("accepts request with only name selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
+
+                val request = createRequest(name = true, biography = false, image = false)
+
+                // When
+                val result = useCase(request)
+
+                // Then
+                result.shouldBeInstanceOf<Success<Contributor>>()
+            }
+        }
+
+        test("accepts request with only biography selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
+
+                val request = createRequest(name = false, biography = true, image = false)
+
+                // When
+                val result = useCase(request)
+
+                // Then
+                result.shouldBeInstanceOf<Success<Contributor>>()
+            }
+        }
+
+        test("accepts request with only image selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributorData = createContributorWithMetadata(imageUrl = null)
+                everySuspend {
+                    fixture.metadataRepository.applyContributorMetadata(any(), any(), any(), any(), any(), any())
+                } returns ContributorMetadataResult.Success(contributor = contributorData)
+                val useCase = fixture.build()
+
+                val request = createRequest(name = false, biography = false, image = true)
+
+                // When
+                val result = useCase(request)
+
+                // Then
+                result.shouldBeInstanceOf<Success<Contributor>>()
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/contributor/DeleteContributorUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/contributor/DeleteContributorUseCaseTest.kt
@@ -9,10 +9,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import com.calypsan.listenup.client.core.failureOf
 
 /**
@@ -22,93 +22,95 @@ import com.calypsan.listenup.client.core.failureOf
  * - Successful deletion
  * - Repository error propagation
  */
-class DeleteContributorUseCaseTest {
-    // ========== Test Fixtures ==========
+class DeleteContributorUseCaseTest :
+    FunSpec({
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-        // Default: successful deletion
-        everySuspend { fixture.contributorRepository.deleteContributor(any()) } returns Success(Unit)
-        return fixture
-    }
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val contributorRepository: ContributorRepository = mock()
+        class TestFixture {
+            val contributorRepository: ContributorRepository = mock()
 
-        fun build(): DeleteContributorUseCase =
-            DeleteContributorUseCase(
-                contributorRepository = contributorRepository,
-            )
-    }
-
-    // ========== Success Tests ==========
-
-    @Test
-    fun `delete contributor returns success`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(contributorId = "contributor-123")
-
-            // Then
-            checkIs<Success<Unit>>(result)
-        }
-
-    @Test
-    fun `delete contributor calls repository with correct ID`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            useCase(contributorId = "contributor-456")
-
-            // Then
-            verifySuspend { fixture.contributorRepository.deleteContributor("contributor-456") }
-        }
-
-    // ========== Error Handling Tests ==========
-
-    @Test
-    fun `delete contributor returns failure when repository fails`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.contributorRepository.deleteContributor(any()) } returns
-                failureOf("Contributor not found")
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(contributorId = "contributor-123")
-
-            // Then
-            val failure = assertIs<Failure>(result)
-            assertEquals("Contributor not found", failure.message)
-        }
-
-    @Test
-    fun `delete contributor propagates repository exception`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation.
-            everySuspend { fixture.contributorRepository.deleteContributor(any()) } returns
-                Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Network error"),
+            fun build(): DeleteContributorUseCase =
+                DeleteContributorUseCase(
+                    contributorRepository = contributorRepository,
                 )
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(contributorId = "contributor-123")
-
-            // Then
-            val failure = assertIs<Failure>(result)
-            assertEquals("Network error", failure.message)
         }
-}
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+            // Default: successful deletion
+            everySuspend { fixture.contributorRepository.deleteContributor(any()) } returns Success(Unit)
+            return fixture
+        }
+
+        // ========== Success Tests ==========
+
+        test("delete contributor returns success") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(contributorId = "contributor-123")
+
+                // Then
+                checkIs<Success<Unit>>(result)
+            }
+        }
+
+        test("delete contributor calls repository with correct ID") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                // When
+                useCase(contributorId = "contributor-456")
+
+                // Then
+                verifySuspend { fixture.contributorRepository.deleteContributor("contributor-456") }
+            }
+        }
+
+        // ========== Error Handling Tests ==========
+
+        test("delete contributor returns failure when repository fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.contributorRepository.deleteContributor(any()) } returns
+                    failureOf("Contributor not found")
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(contributorId = "contributor-123")
+
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.message shouldBe "Contributor not found"
+            }
+        }
+
+        test("delete contributor propagates repository exception") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation.
+                everySuspend { fixture.contributorRepository.deleteContributor(any()) } returns
+                    Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Network error"),
+                    )
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(contributorId = "contributor-123")
+
+                // Then
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.message shouldBe "Network error"
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/contributor/UpdateContributorUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/contributor/UpdateContributorUseCaseTest.kt
@@ -11,425 +11,427 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertIs
 
-class UpdateContributorUseCaseTest {
-    // ========== Test Fixture ==========
+class UpdateContributorUseCaseTest :
+    FunSpec({
 
-    private class TestFixture {
-        val contributorEditRepository: ContributorEditRepository = mock()
+        // ========== Test Fixture ==========
 
-        fun build(): UpdateContributorUseCase =
-            UpdateContributorUseCase(
-                contributorEditRepository = contributorEditRepository,
+        class TestFixture {
+            val contributorEditRepository: ContributorEditRepository = mock()
+
+            fun build(): UpdateContributorUseCase =
+                UpdateContributorUseCase(
+                    contributorEditRepository = contributorEditRepository,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Default stubs for successful operations
+            everySuspend {
+                fixture.contributorEditRepository.updateContributor(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns Success(Unit)
+            everySuspend {
+                fixture.contributorEditRepository.mergeContributor(any(), any())
+            } returns Success(Unit)
+
+            return fixture
+        }
+
+        // ========== Test Data Factories ==========
+
+        fun createRequest(
+            contributorId: String = "contributor-123",
+            name: String = "Test Author",
+            biography: String? = "Test biography",
+            website: String? = "https://example.com",
+            birthDate: String? = "1970-01-01",
+            deathDate: String? = null,
+            aliases: List<String> = emptyList(),
+            newAliases: Set<String> = emptySet(),
+            contributorsToMerge: Map<String, ContributorSearchResult> = emptyMap(),
+        ): ContributorUpdateRequest =
+            ContributorUpdateRequest(
+                contributorId = contributorId,
+                name = name,
+                biography = biography,
+                website = website,
+                birthDate = birthDate,
+                deathDate = deathDate,
+                aliases = aliases,
+                newAliases = newAliases,
+                contributorsToMerge = contributorsToMerge,
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs for successful operations
-        everySuspend {
-            fixture.contributorEditRepository.updateContributor(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
+        fun createSearchResult(
+            id: String = "contributor-456",
+            name: String = "Other Author",
+            bookCount: Int = 5,
+        ): ContributorSearchResult =
+            ContributorSearchResult(
+                id = id,
+                name = name,
+                bookCount = bookCount,
             )
-        } returns Success(Unit)
-        everySuspend {
-            fixture.contributorEditRepository.mergeContributor(any(), any())
-        } returns Success(Unit)
 
-        return fixture
-    }
+        // ========== Success Tests ==========
 
-    // ========== Test Data Factories ==========
+        test("updates contributor successfully") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-    private fun createRequest(
-        contributorId: String = "contributor-123",
-        name: String = "Test Author",
-        biography: String? = "Test biography",
-        website: String? = "https://example.com",
-        birthDate: String? = "1970-01-01",
-        deathDate: String? = null,
-        aliases: List<String> = emptyList(),
-        newAliases: Set<String> = emptySet(),
-        contributorsToMerge: Map<String, ContributorSearchResult> = emptyMap(),
-    ): ContributorUpdateRequest =
-        ContributorUpdateRequest(
-            contributorId = contributorId,
-            name = name,
-            biography = biography,
-            website = website,
-            birthDate = birthDate,
-            deathDate = deathDate,
-            aliases = aliases,
-            newAliases = newAliases,
-            contributorsToMerge = contributorsToMerge,
-        )
+                // When
+                val result = useCase(createRequest())
 
-    private fun createSearchResult(
-        id: String = "contributor-456",
-        name: String = "Other Author",
-        bookCount: Int = 5,
-    ): ContributorSearchResult =
-        ContributorSearchResult(
-            id = id,
-            name = name,
-            bookCount = bookCount,
-        )
-
-    // ========== Success Tests ==========
-
-    @Test
-    fun `updates contributor successfully`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(createRequest())
-
-            // Then
-            assertIs<Success<Unit>>(result)
-            verifySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    "contributor-123",
-                    "Test Author",
-                    "Test biography",
-                    "https://example.com",
-                    "1970-01-01",
-                    null,
-                    emptyList(),
-                )
+                // Then
+                result.shouldBeInstanceOf<Success<Unit>>()
+                verifySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        "contributor-123",
+                        "Test Author",
+                        "Test biography",
+                        "https://example.com",
+                        "1970-01-01",
+                        null,
+                        emptyList(),
+                    )
+                }
             }
         }
 
-    @Test
-    fun `converts blank biography to null`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("converts blank biography to null") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // When
-            useCase(createRequest(biography = "  "))
+                // When
+                useCase(createRequest(biography = "  "))
 
-            // Then
-            verifySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    any(),
-                    any(),
-                    null, // biography should be null
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                )
+                // Then
+                verifySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        any(),
+                        any(),
+                        null, // biography should be null
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                    )
+                }
             }
         }
 
-    @Test
-    fun `converts blank website to null`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("converts blank website to null") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            // When
-            useCase(createRequest(website = ""))
+                // When
+                useCase(createRequest(website = ""))
 
-            // Then
-            verifySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    any(),
-                    any(),
-                    any(),
-                    null, // website should be null
-                    any(),
-                    any(),
-                    any(),
-                )
+                // Then
+                verifySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        any(),
+                        any(),
+                        any(),
+                        null, // website should be null
+                        any(),
+                        any(),
+                        any(),
+                    )
+                }
             }
         }
 
-    // ========== Alias Merge Tests ==========
+        // ========== Alias Merge Tests ==========
 
-    @Test
-    fun `merges contributor when alias is selected from search`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-            val searchResult = createSearchResult(id = "source-id", name = "Pen Name")
+        test("merges contributor when alias is selected from search") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+                val searchResult = createSearchResult(id = "source-id", name = "Pen Name")
 
-            val request =
-                createRequest(
-                    contributorId = "target-id",
-                    aliases = listOf("Pen Name"),
-                    newAliases = setOf("Pen Name"),
-                    contributorsToMerge = mapOf("pen name" to searchResult),
-                )
+                val request =
+                    createRequest(
+                        contributorId = "target-id",
+                        aliases = listOf("Pen Name"),
+                        newAliases = setOf("Pen Name"),
+                        contributorsToMerge = mapOf("pen name" to searchResult),
+                    )
 
-            // When
-            val result = useCase(request)
+                // When
+                val result = useCase(request)
 
-            // Then
-            assertIs<Success<Unit>>(result)
-            verifySuspend {
-                fixture.contributorEditRepository.mergeContributor(
-                    targetId = "target-id",
-                    sourceId = "source-id",
-                )
+                // Then
+                result.shouldBeInstanceOf<Success<Unit>>()
+                verifySuspend {
+                    fixture.contributorEditRepository.mergeContributor(
+                        targetId = "target-id",
+                        sourceId = "source-id",
+                    )
+                }
             }
         }
 
-    @Test
-    fun `does not merge when alias name matches current contributor`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-            val searchResult = createSearchResult(id = "contributor-123", name = "Same Author")
+        test("does not merge when alias name matches current contributor") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+                val searchResult = createSearchResult(id = "contributor-123", name = "Same Author")
 
-            val request =
-                createRequest(
-                    contributorId = "contributor-123",
-                    aliases = listOf("Same Author"),
-                    newAliases = setOf("Same Author"),
-                    contributorsToMerge = mapOf("same author" to searchResult),
-                )
+                val request =
+                    createRequest(
+                        contributorId = "contributor-123",
+                        aliases = listOf("Same Author"),
+                        newAliases = setOf("Same Author"),
+                        contributorsToMerge = mapOf("same author" to searchResult),
+                    )
 
-            // When
-            useCase(request)
+                // When
+                useCase(request)
 
-            // Then - should not merge with self
-            verifySuspend(VerifyMode.not) {
-                fixture.contributorEditRepository.mergeContributor(any(), any())
+                // Then - should not merge with self
+                verifySuspend(VerifyMode.not) {
+                    fixture.contributorEditRepository.mergeContributor(any(), any())
+                }
             }
         }
 
-    @Test
-    fun `does not merge when alias not in contributorsToMerge map`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("does not merge when alias not in contributorsToMerge map") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val request =
-                createRequest(
-                    aliases = listOf("Manual Alias"),
-                    newAliases = setOf("Manual Alias"),
-                    contributorsToMerge = emptyMap(), // No tracked contributor
-                )
+                val request =
+                    createRequest(
+                        aliases = listOf("Manual Alias"),
+                        newAliases = setOf("Manual Alias"),
+                        contributorsToMerge = emptyMap(), // No tracked contributor
+                    )
 
-            // When
-            useCase(request)
+                // When
+                useCase(request)
 
-            // Then - should not attempt merge
-            verifySuspend(VerifyMode.not) {
-                fixture.contributorEditRepository.mergeContributor(any(), any())
+                // Then - should not attempt merge
+                verifySuspend(VerifyMode.not) {
+                    fixture.contributorEditRepository.mergeContributor(any(), any())
+                }
             }
         }
 
-    @Test
-    fun `continues update even when merge fails`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend {
-                fixture.contributorEditRepository.mergeContributor(any(), any())
-            } returns Failure(Exception("Merge failed"))
-            val useCase = fixture.build()
+        test("continues update even when merge fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend {
+                    fixture.contributorEditRepository.mergeContributor(any(), any())
+                } returns Failure(Exception("Merge failed"))
+                val useCase = fixture.build()
 
-            val searchResult = createSearchResult(id = "source-id", name = "Pen Name")
-            val request =
-                createRequest(
-                    contributorId = "target-id",
-                    aliases = listOf("Pen Name"),
-                    newAliases = setOf("Pen Name"),
-                    contributorsToMerge = mapOf("pen name" to searchResult),
-                )
+                val searchResult = createSearchResult(id = "source-id", name = "Pen Name")
+                val request =
+                    createRequest(
+                        contributorId = "target-id",
+                        aliases = listOf("Pen Name"),
+                        newAliases = setOf("Pen Name"),
+                        contributorsToMerge = mapOf("pen name" to searchResult),
+                    )
 
-            // When
-            val result = useCase(request)
+                // When
+                val result = useCase(request)
 
-            // Then - should still succeed (merge is non-critical)
-            assertIs<Success<Unit>>(result)
-            verifySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                )
+                // Then - should still succeed (merge is non-critical)
+                result.shouldBeInstanceOf<Success<Unit>>()
+                verifySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                    )
+                }
             }
         }
 
-    @Test
-    fun `merges multiple contributors when multiple aliases selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("merges multiple contributors when multiple aliases selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
 
-            val request =
-                createRequest(
-                    contributorId = "target-id",
-                    aliases = listOf("Alias One", "Alias Two"),
-                    newAliases = setOf("Alias One", "Alias Two"),
-                    contributorsToMerge =
-                        mapOf(
-                            "alias one" to createSearchResult(id = "source-1", name = "Alias One"),
-                            "alias two" to createSearchResult(id = "source-2", name = "Alias Two"),
-                        ),
-                )
+                val request =
+                    createRequest(
+                        contributorId = "target-id",
+                        aliases = listOf("Alias One", "Alias Two"),
+                        newAliases = setOf("Alias One", "Alias Two"),
+                        contributorsToMerge =
+                            mapOf(
+                                "alias one" to createSearchResult(id = "source-1", name = "Alias One"),
+                                "alias two" to createSearchResult(id = "source-2", name = "Alias Two"),
+                            ),
+                    )
 
-            // When
-            useCase(request)
+                // When
+                useCase(request)
 
-            // Then
-            verifySuspend { fixture.contributorEditRepository.mergeContributor("target-id", "source-1") }
-            verifySuspend { fixture.contributorEditRepository.mergeContributor("target-id", "source-2") }
-        }
-
-    @Test
-    fun `only merges new aliases not existing ones`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            val request =
-                createRequest(
-                    contributorId = "target-id",
-                    aliases = listOf("Existing Alias", "New Alias"),
-                    newAliases = setOf("New Alias"), // Only "New Alias" is new
-                    contributorsToMerge =
-                        mapOf(
-                            "existing alias" to createSearchResult(id = "source-1", name = "Existing Alias"),
-                            "new alias" to createSearchResult(id = "source-2", name = "New Alias"),
-                        ),
-                )
-
-            // When
-            useCase(request)
-
-            // Then - only merge the new alias
-            verifySuspend(VerifyMode.not) { fixture.contributorEditRepository.mergeContributor("target-id", "source-1") }
-            verifySuspend { fixture.contributorEditRepository.mergeContributor("target-id", "source-2") }
-        }
-
-    // ========== Error Handling Tests ==========
-
-    @Test
-    fun `returns failure when update fails`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                )
-            } returns Failure(Exception("Update failed"))
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(createRequest())
-
-            // Then
-            assertIs<Failure>(result)
-        }
-
-    @Test
-    fun `returns failure when update throws exception`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                )
-            } throws RuntimeException("Network error")
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase(createRequest())
-
-            // Then
-            assertIs<Failure>(result)
-        }
-
-    // ========== Empty/Null Field Tests ==========
-
-    @Test
-    fun `handles null optional fields`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            val request =
-                createRequest(
-                    biography = null,
-                    website = null,
-                    birthDate = null,
-                    deathDate = null,
-                )
-
-            // When
-            val result = useCase(request)
-
-            // Then
-            assertIs<Success<Unit>>(result)
-        }
-
-    @Test
-    fun `handles empty aliases list`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
-
-            val request = createRequest(aliases = emptyList())
-
-            // When
-            val result = useCase(request)
-
-            // Then
-            assertIs<Success<Unit>>(result)
-            verifySuspend {
-                fixture.contributorEditRepository.updateContributor(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    emptyList(),
-                )
+                // Then
+                verifySuspend { fixture.contributorEditRepository.mergeContributor("target-id", "source-1") }
+                verifySuspend { fixture.contributorEditRepository.mergeContributor("target-id", "source-2") }
             }
         }
-}
+
+        test("only merges new aliases not existing ones") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                val request =
+                    createRequest(
+                        contributorId = "target-id",
+                        aliases = listOf("Existing Alias", "New Alias"),
+                        newAliases = setOf("New Alias"), // Only "New Alias" is new
+                        contributorsToMerge =
+                            mapOf(
+                                "existing alias" to createSearchResult(id = "source-1", name = "Existing Alias"),
+                                "new alias" to createSearchResult(id = "source-2", name = "New Alias"),
+                            ),
+                    )
+
+                // When
+                useCase(request)
+
+                // Then - only merge the new alias
+                verifySuspend(VerifyMode.not) { fixture.contributorEditRepository.mergeContributor("target-id", "source-1") }
+                verifySuspend { fixture.contributorEditRepository.mergeContributor("target-id", "source-2") }
+            }
+        }
+
+        // ========== Error Handling Tests ==========
+
+        test("returns failure when update fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns Failure(Exception("Update failed"))
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(createRequest())
+
+                // Then
+                result.shouldBeInstanceOf<Failure>()
+            }
+        }
+
+        test("returns failure when update throws exception") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } throws RuntimeException("Network error")
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(createRequest())
+
+                // Then
+                result.shouldBeInstanceOf<Failure>()
+            }
+        }
+
+        // ========== Empty/Null Field Tests ==========
+
+        test("handles null optional fields") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                val request =
+                    createRequest(
+                        biography = null,
+                        website = null,
+                        birthDate = null,
+                        deathDate = null,
+                    )
+
+                // When
+                val result = useCase(request)
+
+                // Then
+                result.shouldBeInstanceOf<Success<Unit>>()
+            }
+        }
+
+        test("handles empty aliases list") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                val request = createRequest(aliases = emptyList())
+
+                // When
+                val result = useCase(request)
+
+                // Then
+                result.shouldBeInstanceOf<Success<Unit>>()
+                verifySuspend {
+                    fixture.contributorEditRepository.updateContributor(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        emptyList(),
+                    )
+                }
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/library/RefreshLibraryUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/library/RefreshLibraryUseCaseTest.kt
@@ -11,12 +11,12 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * Tests for RefreshLibraryUseCase.
@@ -28,158 +28,160 @@ import kotlin.test.assertIs
  * - Reset for new library flow
  * - SyncState exposure
  */
-class RefreshLibraryUseCaseTest {
-    // ========== Test Fixtures ==========
+class RefreshLibraryUseCaseTest :
+    FunSpec({
 
-    private class TestFixture {
-        val syncRepository: SyncRepository = mock()
-        val syncStateFlow = MutableStateFlow<SyncState>(SyncState.Idle)
+        // ========== Test Fixtures ==========
 
-        init {
-            every { syncRepository.syncState } returns syncStateFlow
+        class TestFixture {
+            val syncRepository: SyncRepository = mock()
+            val syncStateFlow = MutableStateFlow<SyncState>(SyncState.Idle)
+
+            init {
+                every { syncRepository.syncState } returns syncStateFlow
+            }
+
+            fun build(): RefreshLibraryUseCase =
+                RefreshLibraryUseCase(
+                    syncRepository = syncRepository,
+                )
         }
 
-        fun build(): RefreshLibraryUseCase =
-            RefreshLibraryUseCase(
-                syncRepository = syncRepository,
-            )
-    }
+        fun createFixture(): TestFixture = TestFixture()
 
-    private fun createFixture(): TestFixture = TestFixture()
+        // ========== Successful Sync Tests ==========
 
-    // ========== Successful Sync Tests ==========
+        test("successful sync returns success result") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.syncRepository.sync() } returns Success(Unit)
+                val useCase = fixture.build()
 
-    @Test
-    fun `successful sync returns success result`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.syncRepository.sync() } returns Success(Unit)
-            val useCase = fixture.build()
+                // When
+                val result = useCase()
 
-            // When
-            val result = useCase()
-
-            // Then
-            val success = assertIs<Success<RefreshLibraryResult>>(result)
-            assertEquals("Library refreshed successfully", success.data.message)
-        }
-
-    @Test
-    fun `sync updates state flow`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.syncRepository.sync() } returns Success(Unit)
-            val useCase = fixture.build()
-
-            // When
-            fixture.syncStateFlow.value = SyncState.Syncing
-            val result = useCase()
-            fixture.syncStateFlow.value = SyncState.Success(timestamp = Timestamp.now())
-
-            // Then
-            val success = assertIs<Success<RefreshLibraryResult>>(result)
-            // State flow accessible via useCase.syncState
-            assertEquals(fixture.syncStateFlow.value, useCase.syncState.value)
-        }
-
-    // ========== Error Handling Tests ==========
-
-    @Test
-    fun `sync failure propagates repository AppError unmodified`() =
-        runTest {
-            // The use case is a pure pass-through on failure — translation to
-            // user-facing copy happens in the presentation layer, not here.
-            val fixture = createFixture()
-            val repoFailure = Failure(Exception("Connection refused"))
-            everySuspend { fixture.syncRepository.sync() } returns repoFailure
-            val useCase = fixture.build()
-
-            val result = useCase()
-
-            val failure = assertIs<Failure>(result)
-            assertEquals(repoFailure.error, failure.error)
-        }
-
-    // ========== Reset for New Library Tests ==========
-
-    @Test
-    fun `resetForNewLibrary calls sync repository with library id`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.syncRepository.resetForNewLibrary(any()) } returns Success(Unit)
-            val useCase = fixture.build()
-
-            // When
-            useCase.resetForNewLibrary("new-library-id")
-
-            // Then
-            verifySuspend {
-                fixture.syncRepository.resetForNewLibrary("new-library-id")
+                // Then
+                val success = result.shouldBeInstanceOf<Success<RefreshLibraryResult>>()
+                success.data.message shouldBe "Library refreshed successfully"
             }
         }
 
-    @Test
-    fun `resetForNewLibrary success returns success result`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.syncRepository.resetForNewLibrary(any()) } returns Success(Unit)
-            val useCase = fixture.build()
+        test("sync updates state flow") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.syncRepository.sync() } returns Success(Unit)
+                val useCase = fixture.build()
 
-            // When
-            val result = useCase.resetForNewLibrary("new-library-id")
+                // When
+                fixture.syncStateFlow.value = SyncState.Syncing
+                val result = useCase()
+                fixture.syncStateFlow.value = SyncState.Success(timestamp = Timestamp.now())
 
-            // Then
-            val success = assertIs<Success<RefreshLibraryResult>>(result)
-            assertEquals("Library synced with new server", success.data.message)
+                // Then
+                result.shouldBeInstanceOf<Success<RefreshLibraryResult>>()
+                // State flow accessible via useCase.syncState
+                useCase.syncState.value shouldBe fixture.syncStateFlow.value
+            }
         }
 
-    @Test
-    fun `resetForNewLibrary failure propagates repository AppError unmodified`() =
-        runTest {
-            val fixture = createFixture()
-            val repoFailure = Failure(Exception("Reset failed"))
-            everySuspend { fixture.syncRepository.resetForNewLibrary(any()) } returns repoFailure
-            val useCase = fixture.build()
+        // ========== Error Handling Tests ==========
 
-            val result = useCase.resetForNewLibrary("new-library-id")
+        test("sync failure propagates repository AppError unmodified") {
+            runTest {
+                // The use case is a pure pass-through on failure — translation to
+                // user-facing copy happens in the presentation layer, not here.
+                val fixture = createFixture()
+                val repoFailure = Failure(Exception("Connection refused"))
+                everySuspend { fixture.syncRepository.sync() } returns repoFailure
+                val useCase = fixture.build()
 
-            val failure = assertIs<Failure>(result)
-            assertEquals(repoFailure.error, failure.error)
+                val result = useCase()
+
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.error shouldBe repoFailure.error
+            }
         }
 
-    // ========== SyncState Access Tests ==========
+        // ========== Reset for New Library Tests ==========
 
-    @Test
-    fun `syncState exposes sync repository state flow`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val useCase = fixture.build()
+        test("resetForNewLibrary calls sync repository with library id") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.syncRepository.resetForNewLibrary(any()) } returns Success(Unit)
+                val useCase = fixture.build()
 
-            // When
-            fixture.syncStateFlow.value = SyncState.Syncing
+                // When
+                useCase.resetForNewLibrary("new-library-id")
 
-            // Then
-            assertEquals(SyncState.Syncing, useCase.syncState.value)
+                // Then
+                verifySuspend {
+                    fixture.syncRepository.resetForNewLibrary("new-library-id")
+                }
+            }
         }
 
-    @Test
-    fun `syncState reflects success status after sync`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val timestamp = Timestamp.now()
-            val useCase = fixture.build()
+        test("resetForNewLibrary success returns success result") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.syncRepository.resetForNewLibrary(any()) } returns Success(Unit)
+                val useCase = fixture.build()
 
-            // When
-            fixture.syncStateFlow.value = SyncState.Success(timestamp = timestamp)
+                // When
+                val result = useCase.resetForNewLibrary("new-library-id")
 
-            // Then
-            val state = assertIs<SyncState.Success>(useCase.syncState.value)
-            assertEquals(timestamp, state.timestamp)
+                // Then
+                val success = result.shouldBeInstanceOf<Success<RefreshLibraryResult>>()
+                success.data.message shouldBe "Library synced with new server"
+            }
         }
-}
+
+        test("resetForNewLibrary failure propagates repository AppError unmodified") {
+            runTest {
+                val fixture = createFixture()
+                val repoFailure = Failure(Exception("Reset failed"))
+                everySuspend { fixture.syncRepository.resetForNewLibrary(any()) } returns repoFailure
+                val useCase = fixture.build()
+
+                val result = useCase.resetForNewLibrary("new-library-id")
+
+                val failure = result.shouldBeInstanceOf<Failure>()
+                failure.error shouldBe repoFailure.error
+            }
+        }
+
+        // ========== SyncState Access Tests ==========
+
+        test("syncState exposes sync repository state flow") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                // When
+                fixture.syncStateFlow.value = SyncState.Syncing
+
+                // Then
+                useCase.syncState.value shouldBe SyncState.Syncing
+            }
+        }
+
+        test("syncState reflects success status after sync") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val timestamp = Timestamp.now()
+                val useCase = fixture.build()
+
+                // When
+                fixture.syncStateFlow.value = SyncState.Success(timestamp = timestamp)
+
+                // Then
+                val state = useCase.syncState.value.shouldBeInstanceOf<SyncState.Success>()
+                state.timestamp shouldBe timestamp
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
@@ -4,12 +4,13 @@ import app.cash.turbine.turbineScope
 import com.calypsan.listenup.client.TestData
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.error.ErrorBus
 import com.calypsan.listenup.client.domain.model.Genre
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.domain.model.Tag
 import com.calypsan.listenup.client.domain.repository.BookRepository
-import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.TagRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
@@ -20,6 +21,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -30,16 +35,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
-import com.calypsan.listenup.client.core.error.ErrorBus
 
 /**
  * Tests for BookDetailViewModel.
@@ -55,782 +50,814 @@ import com.calypsan.listenup.client.core.error.ErrorBus
  * Uses Mokkery for mocking domain repositories.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class BookDetailViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class BookDetailViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixtures ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val bookRepository: BookRepository = mock()
-        val tagRepository: TagRepository = mock()
-        val playbackPositionRepository: PlaybackPositionRepository = mock()
-        val userRepository: UserRepository = mock()
-        val shelfRepository: ShelfRepository = mock()
-        val addBooksToShelfUseCase: AddBooksToShelfUseCase = mock()
-        val createShelfUseCase: CreateShelfUseCase = mock()
+        // ========== Test Fixtures ==========
 
-        fun build(): BookDetailViewModel =
-            BookDetailViewModel(
-                bookRepository = bookRepository,
-                tagRepository = tagRepository,
-                playbackPositionRepository = playbackPositionRepository,
-                userRepository = userRepository,
-                shelfRepository = shelfRepository,
-                addBooksToShelfUseCase = addBooksToShelfUseCase,
-                createShelfUseCase = createShelfUseCase,
-                errorBus = ErrorBus(),
+        fun createFixture(): Triple<BookRepository, PlaybackPositionRepository, (TagRepository) -> BookDetailViewModel> {
+            val bookRepository: BookRepository = mock()
+            val tagRepository: TagRepository = mock()
+            val playbackPositionRepository: PlaybackPositionRepository = mock()
+            val userRepository: UserRepository = mock()
+            val shelfRepository: ShelfRepository = mock()
+            val addBooksToShelfUseCase: AddBooksToShelfUseCase = mock()
+            val createShelfUseCase: CreateShelfUseCase = mock()
+
+            // Default stubs for domain repositories
+            everySuspend { playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
+            every { userRepository.observeCurrentUser() } returns flowOf(null)
+            every { shelfRepository.observeMyShelves(any()) } returns flowOf(emptyList())
+            every { tagRepository.observeAll() } returns flowOf(emptyList())
+            every { userRepository.observeIsAdmin() } returns flowOf(false)
+
+            return Triple(bookRepository, playbackPositionRepository) { customTagRepo: TagRepository ->
+                BookDetailViewModel(
+                    bookRepository = bookRepository,
+                    tagRepository = customTagRepo,
+                    playbackPositionRepository = playbackPositionRepository,
+                    userRepository = userRepository,
+                    shelfRepository = shelfRepository,
+                    addBooksToShelfUseCase = addBooksToShelfUseCase,
+                    createShelfUseCase = createShelfUseCase,
+                    errorBus = ErrorBus(),
+                )
+            }
+        }
+
+        // Convenience fixture class to avoid Triple unpacking
+        class TestFixture {
+            val bookRepository: BookRepository = mock()
+            val tagRepository: TagRepository = mock()
+            val playbackPositionRepository: PlaybackPositionRepository = mock()
+            val userRepository: UserRepository = mock()
+            val shelfRepository: ShelfRepository = mock()
+            val addBooksToShelfUseCase: AddBooksToShelfUseCase = mock()
+            val createShelfUseCase: CreateShelfUseCase = mock()
+
+            fun setup() {
+                everySuspend { playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
+                every { userRepository.observeCurrentUser() } returns flowOf(null)
+                every { shelfRepository.observeMyShelves(any()) } returns flowOf(emptyList())
+                every { tagRepository.observeAll() } returns flowOf(emptyList())
+                every { userRepository.observeIsAdmin() } returns flowOf(false)
+            }
+
+            fun build(): BookDetailViewModel =
+                BookDetailViewModel(
+                    bookRepository = bookRepository,
+                    tagRepository = tagRepository,
+                    playbackPositionRepository = playbackPositionRepository,
+                    userRepository = userRepository,
+                    shelfRepository = shelfRepository,
+                    addBooksToShelfUseCase = addBooksToShelfUseCase,
+                    createShelfUseCase = createShelfUseCase,
+                    errorBus = ErrorBus(),
+                )
+        }
+
+        fun createTestFixture(): TestFixture {
+            val fixture = TestFixture()
+            fixture.setup()
+            return fixture
+        }
+
+        // ========== Test Data Factories ==========
+
+        fun createPlaybackPosition(
+            bookId: String = "book-1",
+            positionMs: Long = 1_800_000L, // 30 min in
+            playbackSpeed: Float = 1.0f,
+        ): PlaybackPosition =
+            PlaybackPosition(
+                bookId = bookId,
+                positionMs = positionMs,
+                playbackSpeed = playbackSpeed,
+                hasCustomSpeed = false,
+                updatedAtMs = 1704067200000L, // Fixed test timestamp
+                syncedAtMs = null,
+                lastPlayedAtMs = 1704067200000L, // Fixed test timestamp
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs for domain repositories
-        everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
-        every { fixture.userRepository.observeCurrentUser() } returns flowOf(null)
-        every { fixture.shelfRepository.observeMyShelves(any()) } returns flowOf(emptyList())
-        every { fixture.tagRepository.observeAll() } returns flowOf(emptyList())
-        every { fixture.userRepository.observeIsAdmin() } returns flowOf(false)
-
-        return fixture
-    }
-
-    // ========== Test Data Factories ==========
-
-    private fun createPlaybackPosition(
-        bookId: String = "book-1",
-        positionMs: Long = 1_800_000L, // 30 min in
-        playbackSpeed: Float = 1.0f,
-    ): PlaybackPosition =
-        PlaybackPosition(
-            bookId = bookId,
-            positionMs = positionMs,
-            playbackSpeed = playbackSpeed,
-            hasCustomSpeed = false,
-            updatedAtMs = 1704067200000L, // Fixed test timestamp
-            syncedAtMs = null,
-            lastPlayedAtMs = 1704067200000L, // Fixed test timestamp
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State Tests ==========
-
-    @Test
-    fun `initial state is Loading`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                val initial = states.awaitItem()
-
-                // Then
-                assertIs<BookDetailUiState.Loading>(initial)
-                states.cancel()
-            }
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    // ========== Load Book Tests ==========
-
-    @Test
-    fun `loadBook success populates book data`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(title = "My Book", description = "A description")
-            val chapters = listOf(TestData.chapter(id = "ch1"), TestData.chapter(id = "ch2"))
-            every { fixture.bookRepository.observeBookDetail("book-1") } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters("book-1") } returns chapters
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals(book, ready.book)
-                assertEquals("A description", ready.description)
-                assertEquals(2, ready.chapters.size)
-                states.cancel()
-            }
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `loadBook not found sets Error state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookDetail("nonexistent") } returns flowOf(null)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("nonexistent")
-                advanceUntilIdle()
-
-                // Then
-                val error = assertIs<BookDetailUiState.Error>(states.expectMostRecentItem())
-                assertEquals("Book not found", error.message)
-                states.cancel()
-            }
-        }
-
-    // ========== Subtitle Filtering Tests ==========
-
-    @Test
-    fun `loadBook filters redundant subtitle with series name and book number`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book =
-                TestData.bookDetail(
-                    subtitle = "The Stormlight Archive, Book 1",
-                    seriesId = "series-1",
-                    seriesName = "The Stormlight Archive",
-                    seriesSequence = "1",
-                )
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - subtitle should be filtered out (redundant)
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertNull(ready.subtitle)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook keeps meaningful subtitle`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book =
-                TestData.bookDetail(
-                    subtitle = "A Novel of Discovery",
-                    seriesName = "The Stormlight Archive",
-                    seriesSequence = "1",
-                )
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - subtitle should be kept (not redundant)
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals("A Novel of Discovery", ready.subtitle)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook keeps subtitle when no series`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book =
-                TestData.bookDetail(
-                    subtitle = "Part 1",
-                    seriesName = null,
-                )
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - subtitle should be kept (no series to be redundant with)
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals("Part 1", ready.subtitle)
-                states.cancel()
-            }
-        }
-
-    // ========== Genre Loading Tests ==========
-
-    @Test
-    fun `loadBook loads genres from BookDetail`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val bookGenres =
-                listOf(
-                    Genre(id = "g1", name = "Fiction", slug = "fiction", path = "/fiction"),
-                    Genre(id = "g2", name = "Fantasy", slug = "fantasy", path = "/fiction/fantasy"),
-                    Genre(id = "g3", name = "Adventure", slug = "adventure", path = "/fiction/adventure"),
-                )
-            val book = TestData.bookDetail(genres = bookGenres)
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                val genresList = ready.genresList
-                assertEquals(3, genresList.size)
-                assertEquals("Fiction", genresList[0])
-                assertEquals("Fantasy", genresList[1])
-                assertEquals("Adventure", genresList[2])
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook handles empty genres from BookDetail`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail()
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            // BookDetail genres default to empty
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertTrue(ready.genresList.isEmpty())
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook handles genre loading failure gracefully`() =
-        runTest {
-            // Given - genres come bundled in BookDetail; an empty list represents
-            // both "no genres" and "loader failed but recovered" — the VM has no
-            // separate failure path since the repository is the SSoT.
-            val fixture = createFixture()
-            val book = TestData.bookDetail()
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - book loads successfully despite genre failure
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals(book, ready.book)
-                assertTrue(ready.genresList.isEmpty())
-                states.cancel()
-            }
-        }
-
-    // ========== Progress Calculation Tests ==========
-
-    @Test
-    fun `loadBook calculates progress from playback position`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(duration = 3_600_000L) // 1 hour
-            val position = createPlaybackPosition(positionMs = 1_800_000L) // 30 min in
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - 30 min / 60 min = 0.5
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals(0.5f, ready.progress)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook hides progress when no position saved`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(duration = 3_600_000L)
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertNull(ready.progress)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook shows progress when nearly complete but not marked finished`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(duration = 3_600_000L) // 1 hour
-            val position = createPlaybackPosition(positionMs = 3_564_000L) // 99% complete
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - progress is shown based on position, hidden only when isFinished=true
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                val progress = ready.progress
-                assertNotNull(progress)
-                assertEquals(0.99f, progress, 0.01f)
-                states.cancel()
-            }
-        }
-
-    // ========== Time Remaining Tests ==========
-
-    @Test
-    fun `loadBook formats time remaining with hours and minutes`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(duration = 10_800_000L) // 3 hours
-            val position = createPlaybackPosition(positionMs = 2_700_000L) // 45 min in
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - 2h 15m remaining
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals("2h 15m left", ready.timeRemainingFormatted)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook formats time remaining with minutes only`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(duration = 3_600_000L) // 1 hour
-            val position = createPlaybackPosition(positionMs = 2_700_000L) // 45 min in
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - 15m remaining
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals("15m left", ready.timeRemainingFormatted)
-                states.cancel()
-            }
-        }
-
-    // ========== Tag Management Tests ==========
-
-    @Test
-    fun `showTagPicker sets showTagPicker to true when Ready`() =
-        runTest {
-            // Given - must load a book so state is Ready (updateReady no-ops on Loading)
-            val fixture = createFixture()
-            val book = TestData.bookDetail(id = "book-1")
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-                assertFalse(assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem()).showTagPicker)
-
-                // When
-                viewModel.showTagPicker()
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertTrue(ready.showTagPicker)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `hideTagPicker sets showTagPicker to false`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(id = "book-1")
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-                viewModel.showTagPicker()
-                advanceUntilIdle()
-                assertTrue(assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem()).showTagPicker)
-
-                // When
-                viewModel.hideTagPicker()
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertFalse(ready.showTagPicker)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook loads tags for book`() =
-        runTest {
-            // Given - tags come bundled with BookDetail; allTags is the picker-wide flow
-            val fixture = createFixture()
-            val bookTags =
-                listOf(
-                    Tag(id = "tag-1", slug = "favorites", bookCount = 5),
-                )
-            val allTags =
-                listOf(
-                    Tag(id = "tag-1", slug = "favorites", bookCount = 5),
-                    Tag(id = "tag-2", slug = "to-read", bookCount = 3),
-                )
-            val book = TestData.bookDetail(tags = bookTags)
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            every { fixture.tagRepository.observeAll() } returns flowOf(allTags)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals(1, ready.tags.size)
-                assertEquals("Favorites", ready.tags[0].displayName())
-                assertEquals(2, ready.allTags.size)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `addTag calls repository and refreshes tags`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(id = "book-1")
-            val tag = TestData.tag(id = "tag-1", slug = "favorites")
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns AppResult.Success(tag)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-                assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-
-                // When - addTag takes a slug
-                viewModel.addTag("favorites")
-                advanceUntilIdle()
-
-                // Then
-                verifySuspend { fixture.tagRepository.addTagToBook("book-1", "favorites") }
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `removeTag calls repository and refreshes tags`() =
-        runTest {
-            // Given - need tags in state for removeTag to find the tag by slug
-            val fixture = createFixture()
-            val bookTags =
-                listOf(Tag(id = "tag-1", slug = "favorites", bookCount = 5))
-            val book = TestData.bookDetail(id = "book-1", tags = bookTags)
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) } returns AppResult.Success(Unit)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-                assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-
-                // When - removeTag takes a slug and finds tag ID from state
-                viewModel.removeTag("favorites")
-                advanceUntilIdle()
-
-                // Then
-                verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "favorites", "tag-1") }
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `addNewTag adds tag to book`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = TestData.bookDetail(id = "book-1")
-            val newTag = TestData.tag(id = "new-tag", slug = "new-tag")
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns AppResult.Success(newTag)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-                assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                viewModel.showTagPicker()
-                advanceUntilIdle()
-
-                // When - addNewTag sends raw input, server normalizes to slug
-                viewModel.addNewTag("New Tag")
-                advanceUntilIdle()
-
-                // Then
-                verifySuspend { fixture.tagRepository.addTagToBook("book-1", "New Tag") }
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertFalse(ready.showTagPicker) // Picker should close
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `tag operations do nothing when no book loaded`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                val initial = states.awaitItem() // initial Loading
-
-                // When - try to add tag without loading book
-                viewModel.addTag("tag-1")
-                advanceUntilIdle()
-
-                // Then - state stays Loading, no API calls made
-                assertIs<BookDetailUiState.Loading>(initial)
-                states.cancel()
-            }
-        }
-
-    @Test
-    fun `loadBook handles tag loading failure gracefully`() =
-        runTest {
-            // Given - tags come bundled with BookDetail; an empty list is the
-            // benign default when nothing has been loaded yet.
-            val fixture = createFixture()
-            val book = TestData.bookDetail()
-            every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-
-                // Then - book loads successfully, tags are empty but no error
-                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals(book, ready.book)
-                states.cancel()
-            }
-        }
-
-    // ========== Race Condition Tests ==========
-
-    @Test
-    fun `rapid loadBook calls for different bookIds emit one coherent sequence with no cross-book contamination`() =
-        runTest {
-            val fixture = createFixture()
-            val bookX = TestData.bookDetail(id = "book-X", title = "Book X")
-            val bookY = TestData.bookDetail(id = "book-Y", title = "Book Y")
-            // Make book-X's observer never complete — emits once then suspends in
-            // awaitCancellation. flatMapLatest cancels it when book-Y is requested,
-            // and book-Y's flowOf emits and completes immediately. The final state
-            // must be Ready for book-Y.
-            every { fixture.bookRepository.observeBookDetail("book-X") } returns
-                flow {
-                    emit(bookX)
-                    awaitCancellation()
+        // ========== Initial State Tests ==========
+
+        test("initial state is Loading") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    val initial = states.awaitItem()
+
+                    // Then
+                    initial.shouldBeInstanceOf<BookDetailUiState.Loading>()
+                    states.cancel()
                 }
-            every { fixture.bookRepository.observeBookDetail("book-Y") } returns flowOf(bookY)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-X")
-                viewModel.loadBook("book-Y")
-                advanceUntilIdle()
-
-                val final = states.expectMostRecentItem()
-                // flatMapLatest cancels the in-flight book-X observer when book-Y
-                // is requested. Final state must be Ready for book-Y, not
-                // contaminated by book-X.
-                assertTrue(final is BookDetailUiState.Ready)
-                assertEquals("book-Y", final.book.id.value)
-                states.cancel()
             }
         }
 
-    @Test
-    fun `book switch cancels prior observeBookDetail subscription`() =
-        runTest {
-            val fixture = createFixture()
-            val book1 = TestData.bookDetail(id = "book-1", title = "Book 1")
-            val book2 = TestData.bookDetail(id = "book-2", title = "Book 2")
-            every { fixture.bookRepository.observeBookDetail("book-1") } returns
-                flow {
-                    emit(book1)
-                    awaitCancellation()
+        // ========== Load Book Tests ==========
+
+        test("loadBook success populates book data") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(title = "My Book", description = "A description")
+                val chapters = listOf(TestData.chapter(id = "ch1"), TestData.chapter(id = "ch2"))
+                every { fixture.bookRepository.observeBookDetail("book-1") } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters("book-1") } returns chapters
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.book shouldBe book
+                    ready.description shouldBe "A description"
+                    ready.chapters.size shouldBe 2
+                    states.cancel()
                 }
-            every { fixture.bookRepository.observeBookDetail("book-2") } returns flowOf(book2)
-            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
-            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                viewModel.loadBook("book-1")
-                advanceUntilIdle()
-                val ready1 = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals("book-1", ready1.book.id.value)
-
-                // Switching to book-2 must cancel book-1's observer (which is parked
-                // in awaitCancellation). flatMapLatest does this automatically.
-                viewModel.loadBook("book-2")
-                advanceUntilIdle()
-                val ready2 = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
-                assertEquals("book-2", ready2.book.id.value)
-
-                states.cancel()
             }
         }
-}
+
+        test("loadBook not found sets Error state") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                every { fixture.bookRepository.observeBookDetail("nonexistent") } returns flowOf(null)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("nonexistent")
+                    advanceUntilIdle()
+
+                    // Then
+                    val error = states.expectMostRecentItem() as BookDetailUiState.Error
+                    error.message shouldBe "Book not found"
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Subtitle Filtering Tests ==========
+
+        test("loadBook filters redundant subtitle with series name and book number") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book =
+                    TestData.bookDetail(
+                        subtitle = "The Stormlight Archive, Book 1",
+                        seriesId = "series-1",
+                        seriesName = "The Stormlight Archive",
+                        seriesSequence = "1",
+                    )
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - subtitle should be filtered out (redundant)
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.subtitle shouldBe null
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook keeps meaningful subtitle") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book =
+                    TestData.bookDetail(
+                        subtitle = "A Novel of Discovery",
+                        seriesName = "The Stormlight Archive",
+                        seriesSequence = "1",
+                    )
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - subtitle should be kept (not redundant)
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.subtitle shouldBe "A Novel of Discovery"
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook keeps subtitle when no series") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book =
+                    TestData.bookDetail(
+                        subtitle = "Part 1",
+                        seriesName = null,
+                    )
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - subtitle should be kept (no series to be redundant with)
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.subtitle shouldBe "Part 1"
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Genre Loading Tests ==========
+
+        test("loadBook loads genres from BookDetail") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val bookGenres =
+                    listOf(
+                        Genre(id = "g1", name = "Fiction", slug = "fiction", path = "/fiction"),
+                        Genre(id = "g2", name = "Fantasy", slug = "fantasy", path = "/fiction/fantasy"),
+                        Genre(id = "g3", name = "Adventure", slug = "adventure", path = "/fiction/adventure"),
+                    )
+                val book = TestData.bookDetail(genres = bookGenres)
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    val genresList = ready.genresList
+                    genresList.size shouldBe 3
+                    genresList[0] shouldBe "Fiction"
+                    genresList[1] shouldBe "Fantasy"
+                    genresList[2] shouldBe "Adventure"
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook handles empty genres from BookDetail") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail()
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                // BookDetail genres default to empty
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    (ready.genresList.isEmpty()) shouldBe true
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook handles genre loading failure gracefully") {
+            runTest {
+                // Given - genres come bundled in BookDetail; an empty list represents
+                // both "no genres" and "loader failed but recovered" — the VM has no
+                // separate failure path since the repository is the SSoT.
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail()
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - book loads successfully despite genre failure
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.book shouldBe book
+                    (ready.genresList.isEmpty()) shouldBe true
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Progress Calculation Tests ==========
+
+        test("loadBook calculates progress from playback position") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(duration = 3_600_000L) // 1 hour
+                val position = createPlaybackPosition(positionMs = 1_800_000L) // 30 min in
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - 30 min / 60 min = 0.5
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.progress shouldBe 0.5f
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook hides progress when no position saved") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(duration = 3_600_000L)
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.progress shouldBe null
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook shows progress when nearly complete but not marked finished") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(duration = 3_600_000L) // 1 hour
+                val position = createPlaybackPosition(positionMs = 3_564_000L) // 99% complete
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - progress is shown based on position, hidden only when isFinished=true
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    val progress = ready.progress
+                    progress.shouldNotBeNull()
+                    (progress in 0.98f..1.0f) shouldBe true
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Time Remaining Tests ==========
+
+        test("loadBook formats time remaining with hours and minutes") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(duration = 10_800_000L) // 3 hours
+                val position = createPlaybackPosition(positionMs = 2_700_000L) // 45 min in
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - 2h 15m remaining
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.timeRemainingFormatted shouldBe "2h 15m left"
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook formats time remaining with minutes only") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(duration = 3_600_000L) // 1 hour
+                val position = createPlaybackPosition(positionMs = 2_700_000L) // 45 min in
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(position)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - 15m remaining
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.timeRemainingFormatted shouldBe "15m left"
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Tag Management Tests ==========
+
+        test("showTagPicker sets showTagPicker to true when Ready") {
+            runTest {
+                // Given - must load a book so state is Ready (updateReady no-ops on Loading)
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(id = "book-1")
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+                    (states.expectMostRecentItem() as BookDetailUiState.Ready).showTagPicker shouldBe false
+
+                    // When
+                    viewModel.showTagPicker()
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.showTagPicker shouldBe true
+                    states.cancel()
+                }
+            }
+        }
+
+        test("hideTagPicker sets showTagPicker to false") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(id = "book-1")
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+                    viewModel.showTagPicker()
+                    advanceUntilIdle()
+                    (states.expectMostRecentItem() as BookDetailUiState.Ready).showTagPicker shouldBe true
+
+                    // When
+                    viewModel.hideTagPicker()
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.showTagPicker shouldBe false
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook loads tags for book") {
+            runTest {
+                // Given - tags come bundled with BookDetail; allTags is the picker-wide flow
+                val fixture = createTestFixture()
+                val bookTags =
+                    listOf(
+                        Tag(id = "tag-1", slug = "favorites", bookCount = 5),
+                    )
+                val allTags =
+                    listOf(
+                        Tag(id = "tag-1", slug = "favorites", bookCount = 5),
+                        Tag(id = "tag-2", slug = "to-read", bookCount = 3),
+                    )
+                val book = TestData.bookDetail(tags = bookTags)
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                every { fixture.tagRepository.observeAll() } returns flowOf(allTags)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.tags.size shouldBe 1
+                    ready.tags[0].displayName() shouldBe "Favorites"
+                    ready.allTags.size shouldBe 2
+                    states.cancel()
+                }
+            }
+        }
+
+        test("addTag calls repository and refreshes tags") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(id = "book-1")
+                val tag = TestData.tag(id = "tag-1", slug = "favorites")
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns AppResult.Success(tag)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+                    states.expectMostRecentItem().shouldBeInstanceOf<BookDetailUiState.Ready>()
+
+                    // When - addTag takes a slug
+                    viewModel.addTag("favorites")
+                    advanceUntilIdle()
+
+                    // Then
+                    verifySuspend { fixture.tagRepository.addTagToBook("book-1", "favorites") }
+                    states.cancel()
+                }
+            }
+        }
+
+        test("removeTag calls repository and refreshes tags") {
+            runTest {
+                // Given - need tags in state for removeTag to find the tag by slug
+                val fixture = createTestFixture()
+                val bookTags =
+                    listOf(Tag(id = "tag-1", slug = "favorites", bookCount = 5))
+                val book = TestData.bookDetail(id = "book-1", tags = bookTags)
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) } returns AppResult.Success(Unit)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+                    states.expectMostRecentItem().shouldBeInstanceOf<BookDetailUiState.Ready>()
+
+                    // When - removeTag takes a slug and finds tag ID from state
+                    viewModel.removeTag("favorites")
+                    advanceUntilIdle()
+
+                    // Then
+                    verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "favorites", "tag-1") }
+                    states.cancel()
+                }
+            }
+        }
+
+        test("addNewTag adds tag to book") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail(id = "book-1")
+                val newTag = TestData.tag(id = "new-tag", slug = "new-tag")
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns AppResult.Success(newTag)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+                    states.expectMostRecentItem().shouldBeInstanceOf<BookDetailUiState.Ready>()
+                    viewModel.showTagPicker()
+                    advanceUntilIdle()
+
+                    // When - addNewTag sends raw input, server normalizes to slug
+                    viewModel.addNewTag("New Tag")
+                    advanceUntilIdle()
+
+                    // Then
+                    verifySuspend { fixture.tagRepository.addTagToBook("book-1", "New Tag") }
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.showTagPicker shouldBe false // Picker should close
+                    states.cancel()
+                }
+            }
+        }
+
+        test("tag operations do nothing when no book loaded") {
+            runTest {
+                // Given
+                val fixture = createTestFixture()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    val initial = states.awaitItem() // initial Loading
+
+                    // When - try to add tag without loading book
+                    viewModel.addTag("tag-1")
+                    advanceUntilIdle()
+
+                    // Then - state stays Loading, no API calls made
+                    initial.shouldBeInstanceOf<BookDetailUiState.Loading>()
+                    states.cancel()
+                }
+            }
+        }
+
+        test("loadBook handles tag loading failure gracefully") {
+            runTest {
+                // Given - tags come bundled with BookDetail; an empty list is the
+                // benign default when nothing has been loaded yet.
+                val fixture = createTestFixture()
+                val book = TestData.bookDetail()
+                every { fixture.bookRepository.observeBookDetail(any()) } returns flowOf(book)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+
+                    // Then - book loads successfully, tags are empty but no error
+                    val ready = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready.book shouldBe book
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Race Condition Tests ==========
+
+        test("rapid loadBook calls for different bookIds emit one coherent sequence with no cross-book contamination") {
+            runTest {
+                val fixture = createTestFixture()
+                val bookX = TestData.bookDetail(id = "book-X", title = "Book X")
+                val bookY = TestData.bookDetail(id = "book-Y", title = "Book Y")
+                // Make book-X's observer never complete — emits once then suspends in
+                // awaitCancellation. flatMapLatest cancels it when book-Y is requested,
+                // and book-Y's flowOf emits and completes immediately. The final state
+                // must be Ready for book-Y.
+                every { fixture.bookRepository.observeBookDetail("book-X") } returns
+                    flow {
+                        emit(bookX)
+                        awaitCancellation()
+                    }
+                every { fixture.bookRepository.observeBookDetail("book-Y") } returns flowOf(bookY)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-X")
+                    viewModel.loadBook("book-Y")
+                    advanceUntilIdle()
+
+                    val final = states.expectMostRecentItem()
+                    // flatMapLatest cancels the in-flight book-X observer when book-Y
+                    // is requested. Final state must be Ready for book-Y, not
+                    // contaminated by book-X.
+                    (final is BookDetailUiState.Ready) shouldBe true
+                    (final as BookDetailUiState.Ready).book.id.value shouldBe "book-Y"
+                    states.cancel()
+                }
+            }
+        }
+
+        test("book switch cancels prior observeBookDetail subscription") {
+            runTest {
+                val fixture = createTestFixture()
+                val book1 = TestData.bookDetail(id = "book-1", title = "Book 1")
+                val book2 = TestData.bookDetail(id = "book-2", title = "Book 2")
+                every { fixture.bookRepository.observeBookDetail("book-1") } returns
+                    flow {
+                        emit(book1)
+                        awaitCancellation()
+                    }
+                every { fixture.bookRepository.observeBookDetail("book-2") } returns flowOf(book2)
+                everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+                everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    viewModel.loadBook("book-1")
+                    advanceUntilIdle()
+                    val ready1 = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready1.book.id.value shouldBe "book-1"
+
+                    // Switching to book-2 must cancel book-1's observer (which is parked
+                    // in awaitCancellation). flatMapLatest does this automatically.
+                    viewModel.loadBook("book-2")
+                    advanceUntilIdle()
+                    val ready2 = states.expectMostRecentItem() as BookDetailUiState.Ready
+                    ready2.book.id.value shouldBe "book-2"
+
+                    states.cancel()
+                }
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModelTest.kt
@@ -18,6 +18,10 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,13 +33,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for BookReadersViewModel.
@@ -54,43 +51,16 @@ import kotlin.test.assertTrue
  * Uses Mokkery for mocking `SessionRepository`, `EventStreamRepository`, and `UserRepository`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class BookReadersViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class BookReadersViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixtures ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val sessionRepository: SessionRepository = mock()
-        val eventStreamRepository: EventStreamRepository = mock()
-        val userRepository: UserRepository = mock()
-        val readersFlow = MutableStateFlow(emptyResult())
-        val bookEvents = MutableSharedFlow<BookEvent>()
+        // ========== Test Data Factories ==========
 
-        fun build(): BookReadersViewModel =
-            BookReadersViewModel(
-                sessionRepository = sessionRepository,
-                eventStreamRepository = eventStreamRepository,
-                userRepository = userRepository,
-            )
-    }
+        val BOOK_ID = "book-1"
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        every { fixture.sessionRepository.observeBookReaders(any()) } returns fixture.readersFlow
-        everySuspend { fixture.sessionRepository.refreshBookReaders(any()) } returns Unit
-        every { fixture.eventStreamRepository.bookEvents } returns fixture.bookEvents
-        everySuspend { fixture.userRepository.getCurrentUser() } returns createUser()
-
-        return fixture
-    }
-
-    // ========== Test Data Factories ==========
-
-    companion object {
-        private const val BOOK_ID = "book-1"
-
-        private fun createUser(
+        fun createUser(
             id: String = "user-1",
             displayName: String = "Reader",
         ): User =
@@ -106,7 +76,7 @@ class BookReadersViewModelTest {
                 updatedAtMs = 0L,
             )
 
-        private fun createSession(
+        fun createSession(
             id: String = "session-1",
             startedAt: String = "2026-04-10T12:00:00Z",
             finishedAt: String? = null,
@@ -120,7 +90,7 @@ class BookReadersViewModelTest {
                 listenTimeMs = 0L,
             )
 
-        private fun createReader(
+        fun createReader(
             userId: String = "user-2",
             displayName: String = "Other Reader",
             isCurrentlyReading: Boolean = true,
@@ -139,312 +109,344 @@ class BookReadersViewModelTest {
                 isCurrentUser = false,
             )
 
-        private fun emptyResult(): BookReadersResult =
+        fun emptyResult(): BookReadersResult =
             BookReadersResult(
                 yourSessions = emptyList(),
                 otherReaders = emptyList(),
                 totalReaders = 0,
                 totalCompletions = 0,
             )
-    }
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
+        // ========== Test Fixtures ==========
 
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State ==========
-
-    @Test
-    fun `initial state is Loading before observeReaders is called`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-
-            // When - viewModel created, observeReaders NOT called
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                val initial = states.awaitItem()
-
-                // Then - state is Loading
-                assertIs<BookReadersUiState.Loading>(initial)
-                states.cancel()
-            }
-        }
-
-    // ========== Reactive Observation ==========
-
-    @Test
-    fun `observeReaders emits Ready with mapped fields when repository flow emits`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val session = createSession(id = "session-1")
-            val other = createReader(userId = "user-2", displayName = "Other Reader")
-            fixture.readersFlow.value =
+        class TestFixture {
+            val sessionRepository: SessionRepository = mock()
+            val eventStreamRepository: EventStreamRepository = mock()
+            val userRepository: UserRepository = mock()
+            val readersFlow = MutableStateFlow(
                 BookReadersResult(
-                    yourSessions = listOf(session),
-                    otherReaders = listOf(other),
-                    totalReaders = 2,
-                    totalCompletions = 1,
+                    yourSessions = emptyList(),
+                    otherReaders = emptyList(),
+                    totalReaders = 0,
+                    totalCompletions = 0,
                 )
-            val viewModel = fixture.build()
+            )
+            val bookEvents = MutableSharedFlow<BookEvent>()
 
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.observeReaders(BOOK_ID)
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookReadersUiState.Ready>(states.expectMostRecentItem())
-                assertEquals(listOf(session), ready.yourSessions)
-                assertEquals(listOf(other), ready.otherReaders)
-                assertEquals(2, ready.totalReaders)
-                assertEquals(1, ready.totalCompletions)
-                // Current user info built from sessions + profile
-                val currentUserInfo = ready.currentUserReaderInfo
-                assertNotNull(currentUserInfo)
-                assertEquals("user-1", currentUserInfo.userId)
-                assertTrue(ready.hasYourHistory)
-                assertTrue(ready.hasOtherReaders)
-                states.cancel()
-            }
+            fun build(): BookReadersViewModel =
+                BookReadersViewModel(
+                    sessionRepository = sessionRepository,
+                    eventStreamRepository = eventStreamRepository,
+                    userRepository = userRepository,
+                )
         }
 
-    @Test
-    fun `Ready has isEmpty true when yourSessions and otherReaders are empty`() =
-        runTest {
-            // Given - default fixture emits an empty result
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.observeReaders(BOOK_ID)
-                advanceUntilIdle()
-
-                // Then
-                val ready = assertIs<BookReadersUiState.Ready>(states.expectMostRecentItem())
-                assertTrue(ready.isEmpty)
-                assertEquals(emptyList(), ready.allReaders)
-                states.cancel()
-            }
-        }
-
-    // ========== Error Handling ==========
-
-    @Test
-    fun `Error state emitted with thrown message when repository flow throws`() =
-        runTest {
-            // Given - repository flow that throws
+        fun createFixture(createUser: () -> User): TestFixture {
             val fixture = TestFixture()
-            every { fixture.sessionRepository.observeBookReaders(any()) } returns
-                flow {
-                    throw RuntimeException("boom")
-                }
+
+            every { fixture.sessionRepository.observeBookReaders(any()) } returns fixture.readersFlow
             everySuspend { fixture.sessionRepository.refreshBookReaders(any()) } returns Unit
             every { fixture.eventStreamRepository.bookEvents } returns fixture.bookEvents
             everySuspend { fixture.userRepository.getCurrentUser() } returns createUser()
 
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.observeReaders(BOOK_ID)
-                advanceUntilIdle()
-
-                // Then
-                val err = assertIs<BookReadersUiState.Error>(states.expectMostRecentItem())
-                assertEquals("boom", err.message)
-                states.cancel()
-            }
+            return fixture
         }
 
-    // ========== Observation Gating ==========
-
-    @Test
-    fun `observeReaders is a no-op when already active for the same bookId`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When - call twice with the same book id
-                viewModel.observeReaders(BOOK_ID)
-                advanceUntilIdle()
-                viewModel.observeReaders(BOOK_ID)
-                advanceUntilIdle()
-
-                // Then - repository observed only once (MutableStateFlow idempotency)
-                verify(VerifyMode.exactly(1)) { fixture.sessionRepository.observeBookReaders(BOOK_ID) }
-                states.expectMostRecentItem() // drain emitted Ready before cancel
-                states.cancel()
-            }
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    // ========== Refresh ==========
-
-    @Test
-    fun `refresh calls refreshBookReaders on sessionRepository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            turbineScope {
-                val states = viewModel.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                // When
-                viewModel.refresh(BOOK_ID)
-                advanceUntilIdle()
-
-                // Then
-                verifySuspend { fixture.sessionRepository.refreshBookReaders(BOOK_ID) }
-                states.cancel()
-            }
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    // ========== Race Condition Tests ==========
+        // ========== Initial State ==========
 
-    @Test
-    fun `rapid book-switch emits one coherent sequence without cross-contamination`() =
-        runTest {
-            val fixture = createFixture()
-            val resultX =
-                BookReadersResult(
-                    yourSessions = emptyList(),
-                    otherReaders = listOf(createReader(userId = "x-reader")),
-                    totalReaders = 1,
-                    totalCompletions = 0,
-                )
-            val resultY =
-                BookReadersResult(
-                    yourSessions = emptyList(),
-                    otherReaders = listOf(createReader(userId = "y-reader"), createReader(userId = "y-reader-2")),
-                    totalReaders = 2,
-                    totalCompletions = 0,
-                )
-            val flowX = MutableStateFlow(resultX)
-            val flowY = MutableStateFlow(resultY)
-            every { fixture.sessionRepository.observeBookReaders("book-X") } returns flowX
-            every { fixture.sessionRepository.observeBookReaders("book-Y") } returns flowY
+        test("initial state is Loading before observeReaders is called") {
+            runTest {
+                // Given
+                val fixture = createFixture { createUser() }
 
-            val vm = fixture.build()
+                // When - viewModel created, observeReaders NOT called
+                val viewModel = fixture.build()
 
-            turbineScope {
-                val states = vm.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    val initial = states.awaitItem()
 
-                vm.observeReaders("book-X")
-                advanceUntilIdle()
-                val xState = states.expectMostRecentItem()
-                assertTrue(xState is BookReadersUiState.Ready)
-                assertEquals(1, xState.totalReaders)
-
-                vm.observeReaders("book-Y")
-                advanceUntilIdle()
-                val yState = states.expectMostRecentItem()
-                assertTrue(yState is BookReadersUiState.Ready)
-                // Y-specific assertion: 2 readers, not 1 from X
-                assertEquals(2, yState.totalReaders)
-
-                states.cancel()
-            }
-        }
-
-    // ========== SSE Tests ==========
-
-    @Test
-    fun `SSE event for current book triggers debounced refresh`() =
-        runTest {
-            val fixture = createFixture()
-            val vm = fixture.build()
-
-            turbineScope {
-                val states = vm.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
-
-                vm.observeReaders("book-X")
-                advanceUntilIdle()
-                states.expectMostRecentItem() // consume Ready
-
-                // Emit an SSE event for book-X
-                fixture.bookEvents.emit(
-                    BookEvent.ReadingSessionUpdated(
-                        sessionId = "session-1",
-                        bookId = "book-X",
-                        isCompleted = false,
-                        listenTimeMs = 0L,
-                        finishedAt = null,
-                    ),
-                )
-
-                // Advance past the 2-second debounce
-                advanceTimeBy(2_500)
-                advanceUntilIdle()
-
-                verifySuspend(mode = VerifyMode.atLeast(1)) {
-                    fixture.sessionRepository.refreshBookReaders("book-X")
+                    // Then - state is Loading
+                    initial.shouldBeInstanceOf<BookReadersUiState.Loading>()
+                    states.cancel()
                 }
-
-                states.cancel()
             }
         }
 
-    @Test
-    fun `SSE event for non-current book does not trigger refresh`() =
-        runTest {
-            val fixture = createFixture()
-            val vm = fixture.build()
+        // ========== Reactive Observation ==========
 
-            turbineScope {
-                val states = vm.state.testIn(backgroundScope)
-                states.awaitItem() // initial Loading
+        test("observeReaders emits Ready with mapped fields when repository flow emits") {
+            runTest {
+                // Given
+                val fixture = createFixture { createUser() }
+                val session = createSession(id = "session-1")
+                val other = createReader(userId = "user-2", displayName = "Other Reader")
+                fixture.readersFlow.value =
+                    BookReadersResult(
+                        yourSessions = listOf(session),
+                        otherReaders = listOf(other),
+                        totalReaders = 2,
+                        totalCompletions = 1,
+                    )
+                val viewModel = fixture.build()
 
-                vm.observeReaders("book-X")
-                advanceUntilIdle()
-                states.expectMostRecentItem() // consume Ready
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
 
-                // Emit an SSE event for a DIFFERENT book (book-Y) while VM is observing book-X
-                fixture.bookEvents.emit(
-                    BookEvent.ReadingSessionUpdated(
-                        sessionId = "session-2",
-                        bookId = "book-Y",
-                        isCompleted = false,
-                        listenTimeMs = 0L,
-                        finishedAt = null,
-                    ),
-                )
+                    // When
+                    viewModel.observeReaders(BOOK_ID)
+                    advanceUntilIdle()
 
-                advanceTimeBy(3_000)
-                advanceUntilIdle()
-
-                verifySuspend(mode = VerifyMode.not) {
-                    fixture.sessionRepository.refreshBookReaders("book-Y")
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookReadersUiState.Ready
+                    ready.yourSessions shouldBe listOf(session)
+                    ready.otherReaders shouldBe listOf(other)
+                    ready.totalReaders shouldBe 2
+                    ready.totalCompletions shouldBe 1
+                    // Current user info built from sessions + profile
+                    val currentUserInfo = ready.currentUserReaderInfo
+                    currentUserInfo.shouldNotBeNull()
+                    currentUserInfo.userId shouldBe "user-1"
+                    (ready.hasYourHistory) shouldBe true
+                    (ready.hasOtherReaders) shouldBe true
+                    states.cancel()
                 }
-
-                states.cancel()
             }
         }
-}
+
+        test("Ready has isEmpty true when yourSessions and otherReaders are empty") {
+            runTest {
+                // Given - default fixture emits an empty result
+                val fixture = createFixture { createUser() }
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.observeReaders(BOOK_ID)
+                    advanceUntilIdle()
+
+                    // Then
+                    val ready = states.expectMostRecentItem() as BookReadersUiState.Ready
+                    (ready.isEmpty) shouldBe true
+                    ready.allReaders shouldBe emptyList()
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Error Handling ==========
+
+        test("Error state emitted with thrown message when repository flow throws") {
+            runTest {
+                // Given - repository flow that throws
+                val fixture = TestFixture()
+                every { fixture.sessionRepository.observeBookReaders(any()) } returns
+                    flow {
+                        throw RuntimeException("boom")
+                    }
+                everySuspend { fixture.sessionRepository.refreshBookReaders(any()) } returns Unit
+                every { fixture.eventStreamRepository.bookEvents } returns fixture.bookEvents
+                everySuspend { fixture.userRepository.getCurrentUser() } returns createUser()
+
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.observeReaders(BOOK_ID)
+                    advanceUntilIdle()
+
+                    // Then
+                    val err = states.expectMostRecentItem() as BookReadersUiState.Error
+                    err.message shouldBe "boom"
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Observation Gating ==========
+
+        test("observeReaders is a no-op when already active for the same bookId") {
+            runTest {
+                // Given
+                val fixture = createFixture { createUser() }
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When - call twice with the same book id
+                    viewModel.observeReaders(BOOK_ID)
+                    advanceUntilIdle()
+                    viewModel.observeReaders(BOOK_ID)
+                    advanceUntilIdle()
+
+                    // Then - repository observed only once (MutableStateFlow idempotency)
+                    verify(VerifyMode.exactly(1)) { fixture.sessionRepository.observeBookReaders(BOOK_ID) }
+                    states.expectMostRecentItem() // drain emitted Ready before cancel
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Refresh ==========
+
+        test("refresh calls refreshBookReaders on sessionRepository") {
+            runTest {
+                // Given
+                val fixture = createFixture { createUser() }
+                val viewModel = fixture.build()
+
+                turbineScope {
+                    val states = viewModel.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    // When
+                    viewModel.refresh(BOOK_ID)
+                    advanceUntilIdle()
+
+                    // Then
+                    verifySuspend { fixture.sessionRepository.refreshBookReaders(BOOK_ID) }
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== Race Condition Tests ==========
+
+        test("rapid book-switch emits one coherent sequence without cross-contamination") {
+            runTest {
+                val fixture = createFixture { createUser() }
+                val resultX =
+                    BookReadersResult(
+                        yourSessions = emptyList(),
+                        otherReaders = listOf(createReader(userId = "x-reader")),
+                        totalReaders = 1,
+                        totalCompletions = 0,
+                    )
+                val resultY =
+                    BookReadersResult(
+                        yourSessions = emptyList(),
+                        otherReaders = listOf(createReader(userId = "y-reader"), createReader(userId = "y-reader-2")),
+                        totalReaders = 2,
+                        totalCompletions = 0,
+                    )
+                val flowX = MutableStateFlow(resultX)
+                val flowY = MutableStateFlow(resultY)
+                every { fixture.sessionRepository.observeBookReaders("book-X") } returns flowX
+                every { fixture.sessionRepository.observeBookReaders("book-Y") } returns flowY
+
+                val vm = fixture.build()
+
+                turbineScope {
+                    val states = vm.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    vm.observeReaders("book-X")
+                    advanceUntilIdle()
+                    val xState = states.expectMostRecentItem()
+                    (xState is BookReadersUiState.Ready) shouldBe true
+                    (xState as BookReadersUiState.Ready).totalReaders shouldBe 1
+
+                    vm.observeReaders("book-Y")
+                    advanceUntilIdle()
+                    val yState = states.expectMostRecentItem()
+                    (yState is BookReadersUiState.Ready) shouldBe true
+                    // Y-specific assertion: 2 readers, not 1 from X
+                    (yState as BookReadersUiState.Ready).totalReaders shouldBe 2
+
+                    states.cancel()
+                }
+            }
+        }
+
+        // ========== SSE Tests ==========
+
+        test("SSE event for current book triggers debounced refresh") {
+            runTest {
+                val fixture = createFixture { createUser() }
+                val vm = fixture.build()
+
+                turbineScope {
+                    val states = vm.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    vm.observeReaders("book-X")
+                    advanceUntilIdle()
+                    states.expectMostRecentItem() // consume Ready
+
+                    // Emit an SSE event for book-X
+                    fixture.bookEvents.emit(
+                        BookEvent.ReadingSessionUpdated(
+                            sessionId = "session-1",
+                            bookId = "book-X",
+                            isCompleted = false,
+                            listenTimeMs = 0L,
+                            finishedAt = null,
+                        ),
+                    )
+
+                    // Advance past the 2-second debounce
+                    advanceTimeBy(2_500)
+                    advanceUntilIdle()
+
+                    verifySuspend(mode = VerifyMode.atLeast(1)) {
+                        fixture.sessionRepository.refreshBookReaders("book-X")
+                    }
+
+                    states.cancel()
+                }
+            }
+        }
+
+        test("SSE event for non-current book does not trigger refresh") {
+            runTest {
+                val fixture = createFixture { createUser() }
+                val vm = fixture.build()
+
+                turbineScope {
+                    val states = vm.state.testIn(backgroundScope)
+                    states.awaitItem() // initial Loading
+
+                    vm.observeReaders("book-X")
+                    advanceUntilIdle()
+                    states.expectMostRecentItem() // consume Ready
+
+                    // Emit an SSE event for a DIFFERENT book (book-Y) while VM is observing book-X
+                    fixture.bookEvents.emit(
+                        BookEvent.ReadingSessionUpdated(
+                            sessionId = "session-2",
+                            bookId = "book-Y",
+                            isCompleted = false,
+                            listenTimeMs = 0L,
+                            finishedAt = null,
+                        ),
+                    )
+
+                    advanceTimeBy(3_000)
+                    advanceUntilIdle()
+
+                    verifySuspend(mode = VerifyMode.not) {
+                        fixture.sessionRepository.refreshBookReaders("book-Y")
+                    }
+
+                    states.cancel()
+                }
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModelTest.kt
@@ -58,7 +58,7 @@ class BookReadersViewModelTest :
 
         // ========== Test Data Factories ==========
 
-        val BOOK_ID = "book-1"
+        val testBookId = "book-1"
 
         fun createUser(
             id: String = "user-1",
@@ -123,14 +123,15 @@ class BookReadersViewModelTest :
             val sessionRepository: SessionRepository = mock()
             val eventStreamRepository: EventStreamRepository = mock()
             val userRepository: UserRepository = mock()
-            val readersFlow = MutableStateFlow(
-                BookReadersResult(
-                    yourSessions = emptyList(),
-                    otherReaders = emptyList(),
-                    totalReaders = 0,
-                    totalCompletions = 0,
+            val readersFlow =
+                MutableStateFlow(
+                    BookReadersResult(
+                        yourSessions = emptyList(),
+                        otherReaders = emptyList(),
+                        totalReaders = 0,
+                        totalCompletions = 0,
+                    ),
                 )
-            )
             val bookEvents = MutableSharedFlow<BookEvent>()
 
             fun build(): BookReadersViewModel =
@@ -203,7 +204,7 @@ class BookReadersViewModelTest :
                     states.awaitItem() // initial Loading
 
                     // When
-                    viewModel.observeReaders(BOOK_ID)
+                    viewModel.observeReaders(testBookId)
                     advanceUntilIdle()
 
                     // Then
@@ -234,7 +235,7 @@ class BookReadersViewModelTest :
                     states.awaitItem() // initial Loading
 
                     // When
-                    viewModel.observeReaders(BOOK_ID)
+                    viewModel.observeReaders(testBookId)
                     advanceUntilIdle()
 
                     // Then
@@ -267,7 +268,7 @@ class BookReadersViewModelTest :
                     states.awaitItem() // initial Loading
 
                     // When
-                    viewModel.observeReaders(BOOK_ID)
+                    viewModel.observeReaders(testBookId)
                     advanceUntilIdle()
 
                     // Then
@@ -291,13 +292,13 @@ class BookReadersViewModelTest :
                     states.awaitItem() // initial Loading
 
                     // When - call twice with the same book id
-                    viewModel.observeReaders(BOOK_ID)
+                    viewModel.observeReaders(testBookId)
                     advanceUntilIdle()
-                    viewModel.observeReaders(BOOK_ID)
+                    viewModel.observeReaders(testBookId)
                     advanceUntilIdle()
 
                     // Then - repository observed only once (MutableStateFlow idempotency)
-                    verify(VerifyMode.exactly(1)) { fixture.sessionRepository.observeBookReaders(BOOK_ID) }
+                    verify(VerifyMode.exactly(1)) { fixture.sessionRepository.observeBookReaders(testBookId) }
                     states.expectMostRecentItem() // drain emitted Ready before cancel
                     states.cancel()
                 }
@@ -317,11 +318,11 @@ class BookReadersViewModelTest :
                     states.awaitItem() // initial Loading
 
                     // When
-                    viewModel.refresh(BOOK_ID)
+                    viewModel.refresh(testBookId)
                     advanceUntilIdle()
 
                     // Then
-                    verifySuspend { fixture.sessionRepository.refreshBookReaders(BOOK_ID) }
+                    verifySuspend { fixture.sessionRepository.refreshBookReaders(testBookId) }
                     states.cancel()
                 }
             }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/BookEditViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/BookEditViewModelTest.kt
@@ -409,7 +409,9 @@ class BookEditViewModelTest :
 
                 // Then
                 viewModel.state.value.series.size shouldBe 1
-                viewModel.state.value.series.first().name shouldBe "The Stormlight Archive"
+                viewModel.state.value.series
+                    .first()
+                    .name shouldBe "The Stormlight Archive"
                 (viewModel.state.value.hasChanges) shouldBe true
             }
         }
@@ -429,8 +431,12 @@ class BookEditViewModelTest :
 
                 // Then
                 viewModel.state.value.series.size shouldBe 1
-                viewModel.state.value.series.first().name shouldBe "New Fantasy Series"
-                viewModel.state.value.series.first().id shouldBe null // New series has no ID
+                viewModel.state.value.series
+                    .first()
+                    .name shouldBe "New Fantasy Series"
+                viewModel.state.value.series
+                    .first()
+                    .id shouldBe null // New series has no ID
             }
         }
 
@@ -452,7 +458,9 @@ class BookEditViewModelTest :
                 viewModel.onEvent(BookEditUiEvent.SeriesSequenceChanged(loadedSeries, "1"))
 
                 // Then
-                viewModel.state.value.series.first().sequence shouldBe "1"
+                viewModel.state.value.series
+                    .first()
+                    .sequence shouldBe "1"
                 (viewModel.state.value.hasChanges) shouldBe true
             }
         }
@@ -475,7 +483,9 @@ class BookEditViewModelTest :
 
                 // Then
                 viewModel.state.value.genres.size shouldBe 1
-                viewModel.state.value.genres.first().name shouldBe "Fantasy"
+                viewModel.state.value.genres
+                    .first()
+                    .name shouldBe "Fantasy"
                 (viewModel.state.value.hasChanges) shouldBe true
             }
         }
@@ -522,7 +532,9 @@ class BookEditViewModelTest :
 
                 // Then
                 viewModel.state.value.tags.size shouldBe 1
-                viewModel.state.value.tags.first().displayName() shouldBe "Favorites"
+                viewModel.state.value.tags
+                    .first()
+                    .displayName() shouldBe "Favorites"
                 (viewModel.state.value.hasChanges) shouldBe true
             }
         }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/BookEditViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/BookEditViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.calypsan.listenup.client.presentation.bookedit
 
+import app.cash.turbine.test
 import com.calypsan.listenup.client.TestData
 import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.failureOf
 import com.calypsan.listenup.client.domain.model.BookEditData
 import com.calypsan.listenup.client.domain.model.BookMetadata
 import com.calypsan.listenup.client.domain.model.ContributorSearchResponse
@@ -13,12 +15,14 @@ import com.calypsan.listenup.client.domain.repository.ImageStagingRepository
 import com.calypsan.listenup.client.domain.repository.SeriesRepository
 import com.calypsan.listenup.client.domain.usecase.book.LoadBookForEditUseCase
 import com.calypsan.listenup.client.domain.usecase.book.UpdateBookUseCase
-import app.cash.turbine.test
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -26,14 +30,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
-import com.calypsan.listenup.client.core.failureOf
 
 /**
  * Tests for BookEditViewModel.
@@ -50,642 +46,613 @@ import com.calypsan.listenup.client.core.failureOf
  * Uses Mokkery for mocking use cases and repository contracts.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class BookEditViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class BookEditViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixtures ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val loadBookForEditUseCase: LoadBookForEditUseCase = mock()
-        val updateBookUseCase: UpdateBookUseCase = mock()
-        val contributorRepository: ContributorRepository = mock()
-        val seriesRepository: SeriesRepository = mock()
-        val imageStagingRepository: ImageStagingRepository = mock()
+        // ========== Test Fixtures ==========
 
-        fun build(): BookEditViewModel =
-            BookEditViewModel(
-                loadBookForEditUseCase = loadBookForEditUseCase,
-                updateBookUseCase = updateBookUseCase,
-                contributorRepository = contributorRepository,
-                seriesRepository = seriesRepository,
-                imageStagingRepository = imageStagingRepository,
-            )
-    }
+        class TestFixture {
+            val loadBookForEditUseCase: LoadBookForEditUseCase = mock()
+            val updateBookUseCase: UpdateBookUseCase = mock()
+            val contributorRepository: ContributorRepository = mock()
+            val seriesRepository: SeriesRepository = mock()
+            val imageStagingRepository: ImageStagingRepository = mock()
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs for delegate operations
-        everySuspend { fixture.contributorRepository.searchContributors(any(), any()) } returns
-            ContributorSearchResponse(emptyList(), false, 0L)
-        everySuspend { fixture.seriesRepository.searchSeries(any(), any()) } returns
-            SeriesSearchResponse(emptyList(), false, 0L)
-
-        return fixture
-    }
-
-    private fun createBookEditData(
-        bookId: String = "book-1",
-        title: String = "Test Book",
-        subtitle: String = "",
-        description: String = "",
-        publishYear: String = "",
-        publisher: String = "",
-        language: String? = null,
-        isbn: String = "",
-        asin: String = "",
-        abridged: Boolean = false,
-        addedAt: Long? = null,
-        contributors: List<EditableContributor> = emptyList(),
-        series: List<EditableSeries> = emptyList(),
-        genres: List<EditableGenre> = emptyList(),
-        tags: List<EditableTag> = emptyList(),
-        allGenres: List<EditableGenre> = emptyList(),
-        allTags: List<EditableTag> = emptyList(),
-        coverPath: String? = null,
-    ): BookEditData =
-        BookEditData(
-            bookId = bookId,
-            metadata =
-                BookMetadata(
-                    title = title,
-                    sortTitle = "",
-                    subtitle = subtitle,
-                    description = description,
-                    publishYear = publishYear,
-                    publisher = publisher,
-                    language = language,
-                    isbn = isbn,
-                    asin = asin,
-                    abridged = abridged,
-                    addedAt = addedAt,
-                ),
-            contributors = contributors,
-            series = series,
-            genres = genres,
-            tags = tags,
-            allGenres = allGenres,
-            allTags = allTags,
-            coverPath = coverPath,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State Tests ==========
-
-    @Test
-    fun `initial state has isLoading true`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            // Then
-            assertTrue(viewModel.state.value.isLoading)
-            assertEquals("", viewModel.state.value.title)
-            assertFalse(viewModel.state.value.hasChanges)
-        }
-
-    // ========== Load Book Tests ==========
-
-    @Test
-    fun `loadBook success populates state with book data`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val author = EditableContributor(id = "author-1", name = "Brandon Sanderson", roles = setOf(ContributorRole.AUTHOR))
-            val narrator = EditableContributor(id = "narrator-1", name = "Michael Kramer", roles = setOf(ContributorRole.NARRATOR))
-            val editData =
-                createBookEditData(
-                    bookId = "book-1",
-                    title = "The Way of Kings",
-                    subtitle = "Book One of the Stormlight Archive",
-                    description = "An epic fantasy adventure",
-                    publishYear = "2010",
-                    publisher = "Tor Books",
-                    language = "en",
-                    contributors = listOf(author, narrator),
+            fun build(): BookEditViewModel =
+                BookEditViewModel(
+                    loadBookForEditUseCase = loadBookForEditUseCase,
+                    updateBookUseCase = updateBookUseCase,
+                    contributorRepository = contributorRepository,
+                    seriesRepository = seriesRepository,
+                    imageStagingRepository = imageStagingRepository,
                 )
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.isLoading)
-            assertEquals("The Way of Kings", state.title)
-            assertEquals("Book One of the Stormlight Archive", state.subtitle)
-            assertEquals("An epic fantasy adventure", state.description)
-            assertEquals("2010", state.publishYear)
-            assertEquals("Tor Books", state.publisher)
-            assertEquals("en", state.language)
-            assertFalse(state.hasChanges)
-            assertNull(state.error)
         }
 
-    @Test
-    fun `loadBook not found sets error state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.loadBookForEditUseCase("nonexistent") } returns failureOf("Book not found")
-            val viewModel = fixture.build()
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
 
-            // When
-            viewModel.loadBook("nonexistent")
-            advanceUntilIdle()
+            // Default stubs for delegate operations
+            everySuspend { fixture.contributorRepository.searchContributors(any(), any()) } returns
+                ContributorSearchResponse(emptyList(), false, 0L)
+            everySuspend { fixture.seriesRepository.searchSeries(any(), any()) } returns
+                SeriesSearchResponse(emptyList(), false, 0L)
 
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.isLoading)
-            assertEquals("Book not found", state.error)
+            return fixture
         }
 
-    @Test
-    fun `loadBook converts contributors to editable format with roles`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor =
-                EditableContributor(
-                    id = "person-1",
-                    name = "Patrick Rothfuss",
-                    roles = setOf(ContributorRole.AUTHOR, ContributorRole.NARRATOR),
-                )
-            val editData =
-                createBookEditData(
-                    bookId = "book-1",
-                    title = "The Name of the Wind",
-                    contributors = listOf(contributor),
-                )
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertEquals(1, state.contributors.size)
-            val editable = state.contributors.first()
-            assertEquals("Patrick Rothfuss", editable.name)
-            assertTrue(ContributorRole.AUTHOR in editable.roles)
-            assertTrue(ContributorRole.NARRATOR in editable.roles)
-        }
-
-    // ========== Metadata Change Tracking Tests ==========
-
-    @Test
-    fun `changing title sets hasChanges to true`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", title = "Original Title")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            assertFalse(viewModel.state.value.hasChanges)
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.TitleChanged("New Title"))
-
-            // Then
-            assertTrue(viewModel.state.value.hasChanges)
-            assertEquals("New Title", viewModel.state.value.title)
-        }
-
-    @Test
-    fun `reverting title to original clears hasChanges`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", title = "Original Title")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When - change then revert
-            viewModel.onEvent(BookEditUiEvent.TitleChanged("New Title"))
-            assertTrue(viewModel.state.value.hasChanges)
-            viewModel.onEvent(BookEditUiEvent.TitleChanged("Original Title"))
-
-            // Then
-            assertFalse(viewModel.state.value.hasChanges)
-        }
-
-    @Test
-    fun `publish year only accepts numeric input`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When - try to input invalid characters
-            viewModel.onEvent(BookEditUiEvent.PublishYearChanged("20ab24cd"))
-
-            // Then - only digits kept, max 4 chars
-            assertEquals("2024", viewModel.state.value.publishYear)
-        }
-
-    // ========== Contributor Management Tests ==========
-
-    @Test
-    fun `adding role section makes role visible`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.AddRoleSection(ContributorRole.EDITOR))
-
-            // Then
-            assertTrue(ContributorRole.EDITOR in viewModel.state.value.visibleRoles)
-        }
-
-    @Test
-    fun `entering contributor name adds new contributor with role`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", contributors = emptyList())
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.RoleContributorEntered(ContributorRole.AUTHOR, "New Author"))
-            advanceUntilIdle()
-
-            // Then
-            val authors = viewModel.state.value.authors
-            assertEquals(1, authors.size)
-            assertEquals("New Author", authors.first().name)
-            assertNull(authors.first().id) // New contributor has no ID
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    @Test
-    fun `selecting contributor from search adds with existing ID`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", contributors = emptyList())
-            val searchResult = ContributorSearchResult(id = "existing-1", name = "Existing Author", bookCount = 10)
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.RoleContributorSelected(ContributorRole.AUTHOR, searchResult))
-            advanceUntilIdle()
-
-            // Then
-            val authors = viewModel.state.value.authors
-            assertEquals(1, authors.size)
-            assertEquals("existing-1", authors.first().id)
-            assertEquals("Existing Author", authors.first().name)
-        }
-
-    @Test
-    fun `removing contributor from role updates state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val author = EditableContributor(id = "author-1", name = "Author Name", roles = setOf(ContributorRole.AUTHOR))
-            val editData = createBookEditData(bookId = "book-1", contributors = listOf(author))
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            assertEquals(1, viewModel.state.value.authors.size)
-
-            // When
-            val editable =
-                viewModel.state.value.contributors
-                    .first()
-            viewModel.onEvent(BookEditUiEvent.RemoveContributor(editable, ContributorRole.AUTHOR))
-
-            // Then
-            assertEquals(0, viewModel.state.value.authors.size)
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    // ========== Series Management Tests ==========
-
-    @Test
-    fun `selecting series from search adds to book`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            val searchResult = SeriesSearchResult(id = "series-1", name = "The Stormlight Archive", bookCount = 4)
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.SeriesSelected(searchResult))
-
-            // Then
-            assertEquals(1, viewModel.state.value.series.size)
-            assertEquals(
-                "The Stormlight Archive",
-                viewModel.state.value.series
-                    .first()
-                    .name,
+        fun createBookEditData(
+            bookId: String = "book-1",
+            title: String = "Test Book",
+            subtitle: String = "",
+            description: String = "",
+            publishYear: String = "",
+            publisher: String = "",
+            language: String? = null,
+            isbn: String = "",
+            asin: String = "",
+            abridged: Boolean = false,
+            addedAt: Long? = null,
+            contributors: List<EditableContributor> = emptyList(),
+            series: List<EditableSeries> = emptyList(),
+            genres: List<EditableGenre> = emptyList(),
+            tags: List<EditableTag> = emptyList(),
+            allGenres: List<EditableGenre> = emptyList(),
+            allTags: List<EditableTag> = emptyList(),
+            coverPath: String? = null,
+        ): BookEditData =
+            BookEditData(
+                bookId = bookId,
+                metadata =
+                    BookMetadata(
+                        title = title,
+                        sortTitle = "",
+                        subtitle = subtitle,
+                        description = description,
+                        publishYear = publishYear,
+                        publisher = publisher,
+                        language = language,
+                        isbn = isbn,
+                        asin = asin,
+                        abridged = abridged,
+                        addedAt = addedAt,
+                    ),
+                contributors = contributors,
+                series = series,
+                genres = genres,
+                tags = tags,
+                allGenres = allGenres,
+                allTags = allTags,
+                coverPath = coverPath,
             )
-            assertTrue(viewModel.state.value.hasChanges)
+
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `entering series name creates new series`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.SeriesEntered("New Fantasy Series"))
-
-            // Then
-            assertEquals(1, viewModel.state.value.series.size)
-            assertEquals(
-                "New Fantasy Series",
-                viewModel.state.value.series
-                    .first()
-                    .name,
-            )
-            assertNull(
-                viewModel.state.value.series
-                    .first()
-                    .id,
-            ) // New series has no ID
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `updating series sequence modifies existing series`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val series = EditableSeries(id = "series-1", name = "Mistborn", sequence = null)
-            val editData = createBookEditData(bookId = "book-1", series = listOf(series))
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+        // ========== Initial State Tests ==========
 
-            // When
-            val loadedSeries =
-                viewModel.state.value.series
-                    .first()
-            viewModel.onEvent(BookEditUiEvent.SeriesSequenceChanged(loadedSeries, "1"))
+        test("initial state has isLoading true") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
 
-            // Then
-            assertEquals(
-                "1",
-                viewModel.state.value.series
-                    .first()
-                    .sequence,
-            )
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    // ========== Genre Management Tests ==========
-
-    @Test
-    fun `selecting genre adds to book`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            val genre = EditableGenre(id = "genre-1", name = "Fantasy", path = "/fiction/fantasy")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.GenreSelected(genre))
-
-            // Then
-            assertEquals(1, viewModel.state.value.genres.size)
-            assertEquals(
-                "Fantasy",
-                viewModel.state.value.genres
-                    .first()
-                    .name,
-            )
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    @Test
-    fun `removing genre updates state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val genre = EditableGenre(id = "genre-1", name = "Fantasy", path = "/fiction/fantasy")
-            val editData = createBookEditData(bookId = "book-1", genres = listOf(genre))
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            assertEquals(1, viewModel.state.value.genres.size)
-
-            // When
-            val editableGenre =
-                viewModel.state.value.genres
-                    .first()
-            viewModel.onEvent(BookEditUiEvent.RemoveGenre(editableGenre))
-
-            // Then
-            assertEquals(0, viewModel.state.value.genres.size)
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    // ========== Tag Management Tests ==========
-
-    @Test
-    fun `selecting tag adds to book`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            val tag = EditableTag(id = "tag-1", slug = "favorites")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.TagSelected(tag))
-
-            // Then
-            assertEquals(1, viewModel.state.value.tags.size)
-            assertEquals(
-                "Favorites",
-                viewModel.state.value.tags
-                    .first()
-                    .displayName(),
-            )
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    @Test
-    fun `removing tag updates state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val tag = EditableTag(id = "tag-1", slug = "favorites")
-            val editData = createBookEditData(bookId = "book-1", tags = listOf(tag))
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            assertEquals(1, viewModel.state.value.tags.size)
-
-            // When
-            val editableTag =
-                viewModel.state.value.tags
-                    .first()
-            viewModel.onEvent(BookEditUiEvent.RemoveTag(editableTag))
-
-            // Then
-            assertEquals(0, viewModel.state.value.tags.size)
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    // ========== Save Tests ==========
-
-    @Test
-    fun `save with no changes navigates back without calling use case`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", title = "Unchanged")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            assertFalse(viewModel.state.value.hasChanges)
-
-            // When / Then
-            viewModel.navActions.test {
-                viewModel.onEvent(BookEditUiEvent.Save)
-                advanceUntilIdle()
-                assertEquals(BookEditNavAction.NavigateBack, awaitItem())
+                // Then
+                (viewModel.state.value.isLoading) shouldBe true
+                viewModel.state.value.title shouldBe ""
+                (viewModel.state.value.hasChanges) shouldBe false
             }
         }
 
-    @Test
-    fun `save with changes calls use case and navigates back`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", title = "Original")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            everySuspend { fixture.updateBookUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+        // ========== Load Book Tests ==========
 
-            // When / Then
-            viewModel.navActions.test {
+        test("loadBook success populates state with book data") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val author = EditableContributor(id = "author-1", name = "Brandon Sanderson", roles = setOf(ContributorRole.AUTHOR))
+                val narrator = EditableContributor(id = "narrator-1", name = "Michael Kramer", roles = setOf(ContributorRole.NARRATOR))
+                val editData =
+                    createBookEditData(
+                        bookId = "book-1",
+                        title = "The Way of Kings",
+                        subtitle = "Book One of the Stormlight Archive",
+                        description = "An epic fantasy adventure",
+                        publishYear = "2010",
+                        publisher = "Tor Books",
+                        language = "en",
+                        contributors = listOf(author, narrator),
+                    )
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.state.value
+                (state.isLoading) shouldBe false
+                state.title shouldBe "The Way of Kings"
+                state.subtitle shouldBe "Book One of the Stormlight Archive"
+                state.description shouldBe "An epic fantasy adventure"
+                state.publishYear shouldBe "2010"
+                state.publisher shouldBe "Tor Books"
+                state.language shouldBe "en"
+                (state.hasChanges) shouldBe false
+                state.error shouldBe null
+            }
+        }
+
+        test("loadBook not found sets error state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.loadBookForEditUseCase("nonexistent") } returns failureOf("Book not found")
+                val viewModel = fixture.build()
+
+                // When
+                viewModel.loadBook("nonexistent")
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.state.value
+                (state.isLoading) shouldBe false
+                state.error shouldBe "Book not found"
+            }
+        }
+
+        test("loadBook converts contributors to editable format with roles") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor =
+                    EditableContributor(
+                        id = "person-1",
+                        name = "Patrick Rothfuss",
+                        roles = setOf(ContributorRole.AUTHOR, ContributorRole.NARRATOR),
+                    )
+                val editData =
+                    createBookEditData(
+                        bookId = "book-1",
+                        title = "The Name of the Wind",
+                        contributors = listOf(contributor),
+                    )
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.state.value
+                state.contributors.size shouldBe 1
+                val editable = state.contributors.first()
+                editable.name shouldBe "Patrick Rothfuss"
+                (ContributorRole.AUTHOR in editable.roles) shouldBe true
+                (ContributorRole.NARRATOR in editable.roles) shouldBe true
+            }
+        }
+
+        // ========== Metadata Change Tracking Tests ==========
+
+        test("changing title sets hasChanges to true") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", title = "Original Title")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                (viewModel.state.value.hasChanges) shouldBe false
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.TitleChanged("New Title"))
+
+                // Then
+                (viewModel.state.value.hasChanges) shouldBe true
+                viewModel.state.value.title shouldBe "New Title"
+            }
+        }
+
+        test("reverting title to original clears hasChanges") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", title = "Original Title")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When - change then revert
+                viewModel.onEvent(BookEditUiEvent.TitleChanged("New Title"))
+                (viewModel.state.value.hasChanges) shouldBe true
+                viewModel.onEvent(BookEditUiEvent.TitleChanged("Original Title"))
+
+                // Then
+                (viewModel.state.value.hasChanges) shouldBe false
+            }
+        }
+
+        test("publish year only accepts numeric input") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When - try to input invalid characters
+                viewModel.onEvent(BookEditUiEvent.PublishYearChanged("20ab24cd"))
+
+                // Then - only digits kept, max 4 chars
+                viewModel.state.value.publishYear shouldBe "2024"
+            }
+        }
+
+        // ========== Contributor Management Tests ==========
+
+        test("adding role section makes role visible") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.AddRoleSection(ContributorRole.EDITOR))
+
+                // Then
+                (ContributorRole.EDITOR in viewModel.state.value.visibleRoles) shouldBe true
+            }
+        }
+
+        test("entering contributor name adds new contributor with role") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", contributors = emptyList())
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.RoleContributorEntered(ContributorRole.AUTHOR, "New Author"))
+                advanceUntilIdle()
+
+                // Then
+                val authors = viewModel.state.value.authors
+                authors.size shouldBe 1
+                authors.first().name shouldBe "New Author"
+                authors.first().id shouldBe null // New contributor has no ID
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        test("selecting contributor from search adds with existing ID") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", contributors = emptyList())
+                val searchResult = ContributorSearchResult(id = "existing-1", name = "Existing Author", bookCount = 10)
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.RoleContributorSelected(ContributorRole.AUTHOR, searchResult))
+                advanceUntilIdle()
+
+                // Then
+                val authors = viewModel.state.value.authors
+                authors.size shouldBe 1
+                authors.first().id shouldBe "existing-1"
+                authors.first().name shouldBe "Existing Author"
+            }
+        }
+
+        test("removing contributor from role updates state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val author = EditableContributor(id = "author-1", name = "Author Name", roles = setOf(ContributorRole.AUTHOR))
+                val editData = createBookEditData(bookId = "book-1", contributors = listOf(author))
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                viewModel.state.value.authors.size shouldBe 1
+
+                // When
+                val editable =
+                    viewModel.state.value.contributors
+                        .first()
+                viewModel.onEvent(BookEditUiEvent.RemoveContributor(editable, ContributorRole.AUTHOR))
+
+                // Then
+                viewModel.state.value.authors.size shouldBe 0
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        // ========== Series Management Tests ==========
+
+        test("selecting series from search adds to book") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                val searchResult = SeriesSearchResult(id = "series-1", name = "The Stormlight Archive", bookCount = 4)
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.SeriesSelected(searchResult))
+
+                // Then
+                viewModel.state.value.series.size shouldBe 1
+                viewModel.state.value.series.first().name shouldBe "The Stormlight Archive"
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        test("entering series name creates new series") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.SeriesEntered("New Fantasy Series"))
+
+                // Then
+                viewModel.state.value.series.size shouldBe 1
+                viewModel.state.value.series.first().name shouldBe "New Fantasy Series"
+                viewModel.state.value.series.first().id shouldBe null // New series has no ID
+            }
+        }
+
+        test("updating series sequence modifies existing series") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val series = EditableSeries(id = "series-1", name = "Mistborn", sequence = null)
+                val editData = createBookEditData(bookId = "book-1", series = listOf(series))
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                val loadedSeries =
+                    viewModel.state.value.series
+                        .first()
+                viewModel.onEvent(BookEditUiEvent.SeriesSequenceChanged(loadedSeries, "1"))
+
+                // Then
+                viewModel.state.value.series.first().sequence shouldBe "1"
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        // ========== Genre Management Tests ==========
+
+        test("selecting genre adds to book") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                val genre = EditableGenre(id = "genre-1", name = "Fantasy", path = "/fiction/fantasy")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.GenreSelected(genre))
+
+                // Then
+                viewModel.state.value.genres.size shouldBe 1
+                viewModel.state.value.genres.first().name shouldBe "Fantasy"
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        test("removing genre updates state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val genre = EditableGenre(id = "genre-1", name = "Fantasy", path = "/fiction/fantasy")
+                val editData = createBookEditData(bookId = "book-1", genres = listOf(genre))
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                viewModel.state.value.genres.size shouldBe 1
+
+                // When
+                val editableGenre =
+                    viewModel.state.value.genres
+                        .first()
+                viewModel.onEvent(BookEditUiEvent.RemoveGenre(editableGenre))
+
+                // Then
+                viewModel.state.value.genres.size shouldBe 0
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        // ========== Tag Management Tests ==========
+
+        test("selecting tag adds to book") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                val tag = EditableTag(id = "tag-1", slug = "favorites")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(BookEditUiEvent.TagSelected(tag))
+
+                // Then
+                viewModel.state.value.tags.size shouldBe 1
+                viewModel.state.value.tags.first().displayName() shouldBe "Favorites"
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        test("removing tag updates state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val tag = EditableTag(id = "tag-1", slug = "favorites")
+                val editData = createBookEditData(bookId = "book-1", tags = listOf(tag))
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                viewModel.state.value.tags.size shouldBe 1
+
+                // When
+                val editableTag =
+                    viewModel.state.value.tags
+                        .first()
+                viewModel.onEvent(BookEditUiEvent.RemoveTag(editableTag))
+
+                // Then
+                viewModel.state.value.tags.size shouldBe 0
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        // ========== Save Tests ==========
+
+        test("save with no changes navigates back without calling use case") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", title = "Unchanged")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                (viewModel.state.value.hasChanges) shouldBe false
+
+                // When / Then
+                viewModel.navActions.test {
+                    viewModel.onEvent(BookEditUiEvent.Save)
+                    advanceUntilIdle()
+                    awaitItem() shouldBe BookEditNavAction.NavigateBack
+                }
+            }
+        }
+
+        test("save with changes calls use case and navigates back") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", title = "Original")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                everySuspend { fixture.updateBookUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When / Then
+                viewModel.navActions.test {
+                    viewModel.onEvent(BookEditUiEvent.TitleChanged("Updated"))
+                    viewModel.onEvent(BookEditUiEvent.Save)
+                    advanceUntilIdle()
+                    verifySuspend { fixture.updateBookUseCase(any(), any()) }
+                    awaitItem() shouldBe BookEditNavAction.NavigateBack
+                }
+            }
+        }
+
+        test("save failure shows error") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1", title = "Original")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                everySuspend { fixture.updateBookUseCase(any(), any()) } returns failureOf("Save failed")
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // When
                 viewModel.onEvent(BookEditUiEvent.TitleChanged("Updated"))
                 viewModel.onEvent(BookEditUiEvent.Save)
                 advanceUntilIdle()
-                verifySuspend { fixture.updateBookUseCase(any(), any()) }
-                assertEquals(BookEditNavAction.NavigateBack, awaitItem())
+
+                // Then
+                viewModel.state.value.error shouldBe "Save failed"
+                // No nav action emitted on failure — Channel stays silent.
+                viewModel.navActions.test {
+                    expectNoEvents()
+                }
             }
         }
 
-    @Test
-    fun `save failure shows error`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1", title = "Original")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            everySuspend { fixture.updateBookUseCase(any(), any()) } returns failureOf("Save failed")
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+        test("cancel navigates back") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val editData = createBookEditData(bookId = "book-1")
+                everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
+                val viewModel = fixture.build()
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
 
-            // When
-            viewModel.onEvent(BookEditUiEvent.TitleChanged("Updated"))
-            viewModel.onEvent(BookEditUiEvent.Save)
-            advanceUntilIdle()
-
-            // Then
-            assertEquals("Save failed", viewModel.state.value.error)
-            // No nav action emitted on failure — Channel stays silent.
-            viewModel.navActions.test {
-                expectNoEvents()
+                // When / Then
+                viewModel.navActions.test {
+                    viewModel.onEvent(BookEditUiEvent.Cancel)
+                    awaitItem() shouldBe BookEditNavAction.NavigateBack
+                }
             }
         }
 
-    @Test
-    fun `cancel navigates back`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val editData = createBookEditData(bookId = "book-1")
-            everySuspend { fixture.loadBookForEditUseCase("book-1") } returns Success(editData)
-            val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+        test("dismiss error clears error state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.loadBookForEditUseCase("nonexistent") } returns failureOf("Book not found")
+                val viewModel = fixture.build()
+                viewModel.loadBook("nonexistent")
+                advanceUntilIdle()
+                viewModel.state.value.error shouldBe "Book not found"
 
-            // When / Then
-            viewModel.navActions.test {
-                viewModel.onEvent(BookEditUiEvent.Cancel)
-                assertEquals(BookEditNavAction.NavigateBack, awaitItem())
+                // When
+                viewModel.onEvent(BookEditUiEvent.DismissError)
+
+                // Then
+                viewModel.state.value.error shouldBe null
             }
         }
-
-    @Test
-    fun `dismiss error clears error state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.loadBookForEditUseCase("nonexistent") } returns failureOf("Book not found")
-            val viewModel = fixture.build()
-            viewModel.loadBook("nonexistent")
-            advanceUntilIdle()
-            assertEquals("Book not found", viewModel.state.value.error)
-
-            // When
-            viewModel.onEvent(BookEditUiEvent.DismissError)
-
-            // Then
-            assertNull(viewModel.state.value.error)
-        }
-}
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/CoverUploadDelegateTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookedit/delegates/CoverUploadDelegateTest.kt
@@ -9,76 +9,78 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
+import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CoverUploadDelegateTest {
-    private fun buildDelegate(
-        state: MutableStateFlow<BookEditUiState>,
-        imageStagingRepository: ImageStagingRepository,
-    ): CoverUploadDelegate {
-        val scope: CoroutineScope = TestScope(StandardTestDispatcher())
-        return CoverUploadDelegate(
-            state = state,
-            imageStagingRepository = imageStagingRepository,
-            scope = scope,
-            onChangesMade = {},
-        )
-    }
+class CoverUploadDelegateTest :
+    FunSpec({
 
-    @Test
-    fun `cleanupStagingOnClear does nothing when bookId is blank`() =
-        runTest {
-            val state = MutableStateFlow(defaultUiState(bookId = "", stagingCoverPath = "/tmp/staging"))
-            val repo: ImageStagingRepository = mock()
-            val delegate = buildDelegate(state, repo)
+        fun buildDelegate(
+            state: MutableStateFlow<BookEditUiState>,
+            imageStagingRepository: ImageStagingRepository,
+        ): CoverUploadDelegate {
+            val scope: CoroutineScope = TestScope(StandardTestDispatcher())
+            return CoverUploadDelegate(
+                state = state,
+                imageStagingRepository = imageStagingRepository,
+                scope = scope,
+                onChangesMade = {},
+            )
+        }
 
-            delegate.cleanupStagingOnClear()
+        fun defaultUiState(
+            bookId: String,
+            stagingCoverPath: String?,
+        ): BookEditUiState =
+            BookEditUiState(
+                bookId = bookId,
+                stagingCoverPath = stagingCoverPath,
+            )
 
-            verify(mode = VerifyMode.not) {
-                repo.requestBookCoverStagingCleanup(any())
+        test("cleanupStagingOnClear does nothing when bookId is blank") {
+            runTest {
+                val state = MutableStateFlow(defaultUiState(bookId = "", stagingCoverPath = "/tmp/staging"))
+                val repo: ImageStagingRepository = mock()
+                val delegate = buildDelegate(state, repo)
+
+                delegate.cleanupStagingOnClear()
+
+                verify(mode = VerifyMode.not) {
+                    repo.requestBookCoverStagingCleanup(any())
+                }
             }
         }
 
-    @Test
-    fun `cleanupStagingOnClear does nothing when no staging cover path`() =
-        runTest {
-            val state = MutableStateFlow(defaultUiState(bookId = "book-1", stagingCoverPath = null))
-            val repo: ImageStagingRepository = mock()
-            val delegate = buildDelegate(state, repo)
+        test("cleanupStagingOnClear does nothing when no staging cover path") {
+            runTest {
+                val state = MutableStateFlow(defaultUiState(bookId = "book-1", stagingCoverPath = null))
+                val repo: ImageStagingRepository = mock()
+                val delegate = buildDelegate(state, repo)
 
-            delegate.cleanupStagingOnClear()
+                delegate.cleanupStagingOnClear()
 
-            verify(mode = VerifyMode.not) {
-                repo.requestBookCoverStagingCleanup(any())
+                verify(mode = VerifyMode.not) {
+                    repo.requestBookCoverStagingCleanup(any())
+                }
             }
         }
 
-    @Test
-    fun `cleanupStagingOnClear requests cleanup when bookId and staging path are present`() =
-        runTest {
-            val state = MutableStateFlow(defaultUiState(bookId = "book-1", stagingCoverPath = "/tmp/staging-book-1.jpg"))
-            val repo: ImageStagingRepository = mock()
-            every { repo.requestBookCoverStagingCleanup(any()) } returns Unit
-            val delegate = buildDelegate(state, repo)
+        test("cleanupStagingOnClear requests cleanup when bookId and staging path are present") {
+            runTest {
+                val state = MutableStateFlow(defaultUiState(bookId = "book-1", stagingCoverPath = "/tmp/staging-book-1.jpg"))
+                val repo: ImageStagingRepository = mock()
+                every { repo.requestBookCoverStagingCleanup(any()) } returns Unit
+                val delegate = buildDelegate(state, repo)
 
-            delegate.cleanupStagingOnClear()
+                delegate.cleanupStagingOnClear()
 
-            verify { repo.requestBookCoverStagingCleanup(BookId("book-1")) }
+                verify { repo.requestBookCoverStagingCleanup(BookId("book-1")) }
+            }
         }
-
-    private fun defaultUiState(
-        bookId: String,
-        stagingCoverPath: String?,
-    ): BookEditUiState =
-        BookEditUiState(
-            bookId = bookId,
-            stagingCoverPath = stagingCoverPath,
-        )
-}
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModelTest.kt
@@ -16,495 +16,487 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlin.time.Clock
 
 /**
  * Tests for ContributorBooksViewModel.
  *
  * The VM uses `.stateIn(WhileSubscribed)`, so tests must keep a background
- * collector alive via [keepStateHot] before asserting on `state.value`.
+ * collector alive via keepStateHot before asserting on `state.value`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ContributorBooksViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ContributorBooksViewModelTest :
+    FunSpec({
 
-    private class TestFixture {
-        val contributorRepository: ContributorRepository = mock()
-        val playbackPositionRepository: PlaybackPositionRepository = mock()
+        val testDispatcher = StandardTestDispatcher()
 
-        val contributorFlow = MutableStateFlow<Contributor?>(null)
-        val booksFlow = MutableStateFlow<List<BookWithContributorRole>>(emptyList())
+        // ========== Test Fixtures ==========
 
-        fun build(): ContributorBooksViewModel =
-            ContributorBooksViewModel(
-                contributorRepository = contributorRepository,
-                playbackPositionRepository = playbackPositionRepository,
+        class TestFixture {
+            val contributorRepository: ContributorRepository = mock()
+            val playbackPositionRepository: PlaybackPositionRepository = mock()
+
+            val contributorFlow = MutableStateFlow<Contributor?>(null)
+            val booksFlow = MutableStateFlow<List<BookWithContributorRole>>(emptyList())
+
+            fun build(): ContributorBooksViewModel =
+                ContributorBooksViewModel(
+                    contributorRepository = contributorRepository,
+                    playbackPositionRepository = playbackPositionRepository,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            every { fixture.contributorRepository.observeById(any()) } returns fixture.contributorFlow
+            every { fixture.contributorRepository.observeBooksForContributorRole(any(), any()) } returns fixture.booksFlow
+            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
+
+            return fixture
+        }
+
+        fun createContributor(
+            id: String = "contributor-1",
+            name: String = "Stephen King",
+        ): Contributor =
+            Contributor(
+                id =
+                    com.calypsan.listenup.client.core
+                        .ContributorId(id),
+                name = name,
+                description = null,
+                imagePath = null,
+                imageBlurHash = null,
+                website = null,
+                birthDate = null,
+                deathDate = null,
+                aliases = emptyList(),
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
+        fun createBook(
+            id: String = "book-1",
+            title: String = "Test Book",
+            duration: Long = 3_600_000L,
+            coverPath: String? = null,
+            series: List<BookSeries> = emptyList(),
+        ): BookListItem =
+            BookListItem(
+                id = BookId(id),
+                title = title,
+                coverPath = coverPath,
+                duration = duration,
+                authors = emptyList(),
+                narrators = emptyList(),
+                addedAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
+                series = series,
+            )
 
-        every { fixture.contributorRepository.observeById(any()) } returns fixture.contributorFlow
-        every { fixture.contributorRepository.observeBooksForContributorRole(any(), any()) } returns fixture.booksFlow
-        everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
+        fun createBookWithContributorRole(
+            book: BookListItem,
+            creditedAs: String? = null,
+        ): BookWithContributorRole =
+            BookWithContributorRole(
+                book = book,
+                creditedAs = creditedAs,
+            )
 
-        return fixture
-    }
+        fun createPlaybackPosition(
+            bookId: String,
+            positionMs: Long,
+        ): PlaybackPosition =
+            PlaybackPosition(
+                bookId = bookId,
+                positionMs = positionMs,
+                playbackSpeed = 1.0f,
+                hasCustomSpeed = false,
+                updatedAtMs = Clock.System.now().toEpochMilliseconds(),
+                syncedAtMs = null,
+                lastPlayedAtMs = null,
+            )
 
-    /** Keep the VM's WhileSubscribed state flow hot for the duration of the test. */
-    private fun TestScope.keepStateHot(viewModel: ContributorBooksViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
-
-    private fun createContributor(
-        id: String = "contributor-1",
-        name: String = "Stephen King",
-    ): Contributor =
-        Contributor(
-            id =
-                com.calypsan.listenup.client.core
-                    .ContributorId(id),
-            name = name,
-            description = null,
-            imagePath = null,
-            imageBlurHash = null,
-            website = null,
-            birthDate = null,
-            deathDate = null,
-            aliases = emptyList(),
-        )
-
-    private fun createBook(
-        id: String = "book-1",
-        title: String = "Test Book",
-        duration: Long = 3_600_000L,
-        coverPath: String? = null,
-        series: List<BookSeries> = emptyList(),
-    ): BookListItem =
-        BookListItem(
-            id = BookId(id),
-            title = title,
-            coverPath = coverPath,
-            duration = duration,
-            authors = emptyList(),
-            narrators = emptyList(),
-            addedAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-            series = series,
-        )
-
-    private fun createBookWithContributorRole(
-        book: BookListItem,
-        creditedAs: String? = null,
-    ): BookWithContributorRole =
-        BookWithContributorRole(
-            book = book,
-            creditedAs = creditedAs,
-        )
-
-    private fun createPlaybackPosition(
-        bookId: String,
-        positionMs: Long,
-    ): PlaybackPosition =
-        PlaybackPosition(
-            bookId = bookId,
-            positionMs = positionMs,
-            playbackSpeed = 1.0f,
-            hasCustomSpeed = false,
-            updatedAtMs = Clock.System.now().toEpochMilliseconds(),
-            syncedAtMs = null,
-            lastPlayedAtMs = null,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State ==========
-
-    @Test
-    fun `initial state is Idle pre-loadBooks`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            assertEquals(ContributorBooksUiState.Idle, viewModel.state.value)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    // ========== Load Books ==========
-
-    @Test
-    fun `loadBooks populates contributor name`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor(name = "Stephen King")
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals("Stephen King", state.contributorName)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `loadBooks sets role display name`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        // ========== Initial State ==========
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            advanceUntilIdle()
+        test("initial state is Idle pre-loadBooks") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals("Written By", state.roleDisplayName)
+                viewModel.state.value shouldBe ContributorBooksUiState.Idle
+            }
         }
 
-    @Test
-    fun `loadBooks groups books by series`() =
-        runTest {
-            val fixture = createFixture()
-            val book1 =
-                createBook(
-                    id = "book-1",
-                    title = "The Dark Tower",
-                    series = listOf(BookSeries(seriesId = "dark-tower-series", seriesName = "Dark Tower", sequence = "1")),
-                )
-            val book2 =
-                createBook(
-                    id = "book-2",
-                    title = "The Drawing of the Three",
-                    series = listOf(BookSeries(seriesId = "dark-tower-series", seriesName = "Dark Tower", sequence = "2")),
-                )
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        // ========== Load Books ==========
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value =
-                listOf(
-                    createBookWithContributorRole(book1),
-                    createBookWithContributorRole(book2),
-                )
-            advanceUntilIdle()
+        test("loadBooks populates contributor name") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals(1, state.seriesGroups.size)
-            assertEquals("Dark Tower", state.seriesGroups[0].seriesName)
-            assertEquals(2, state.seriesGroups[0].books.size)
-            assertTrue(state.standaloneBooks.isEmpty())
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor(name = "Stephen King")
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.contributorName shouldBe "Stephen King"
+            }
         }
 
-    @Test
-    fun `loadBooks separates standalone books from series books`() =
-        runTest {
-            val fixture = createFixture()
-            val seriesBook =
-                createBook(
-                    id = "book-1",
-                    title = "Series Book",
-                    series = listOf(BookSeries(seriesId = "a-series", seriesName = "A Series", sequence = null)),
-                )
-            val standaloneBook = createBook(id = "book-2", title = "Standalone Book")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks sets role display name") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value =
-                listOf(
-                    createBookWithContributorRole(seriesBook),
-                    createBookWithContributorRole(standaloneBook),
-                )
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals(1, state.seriesGroups.size)
-            assertEquals(1, state.standaloneBooks.size)
-            assertEquals("Standalone Book", state.standaloneBooks[0].title)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.roleDisplayName shouldBe "Written By"
+            }
         }
 
-    @Test
-    fun `loadBooks sorts series books by sequence`() =
-        runTest {
-            val fixture = createFixture()
-            val book1 =
-                createBook(
-                    id = "book-1",
-                    title = "Book One",
-                    series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = "2")),
-                )
-            val book2 =
-                createBook(
-                    id = "book-2",
-                    title = "Book Two",
-                    series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = "1")),
-                )
-            val book3 =
-                createBook(
-                    id = "book-3",
-                    title = "Book Three",
-                    series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = "1.5")),
-                )
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks groups books by series") {
+            runTest {
+                val fixture = createFixture()
+                val book1 =
+                    createBook(
+                        id = "book-1",
+                        title = "The Dark Tower",
+                        series = listOf(BookSeries(seriesId = "dark-tower-series", seriesName = "Dark Tower", sequence = "1")),
+                    )
+                val book2 =
+                    createBook(
+                        id = "book-2",
+                        title = "The Drawing of the Three",
+                        series = listOf(BookSeries(seriesId = "dark-tower-series", seriesName = "Dark Tower", sequence = "2")),
+                    )
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value =
-                listOf(
-                    createBookWithContributorRole(book1),
-                    createBookWithContributorRole(book2),
-                    createBookWithContributorRole(book3),
-                )
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value =
+                    listOf(
+                        createBookWithContributorRole(book1),
+                        createBookWithContributorRole(book2),
+                    )
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            val seriesBooks = state.seriesGroups[0].books
-            assertEquals("Book Two", seriesBooks[0].title)
-            assertEquals("Book Three", seriesBooks[1].title)
-            assertEquals("Book One", seriesBooks[2].title)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.seriesGroups.size shouldBe 1
+                state.seriesGroups[0].seriesName shouldBe "Dark Tower"
+                state.seriesGroups[0].books.size shouldBe 2
+                (state.standaloneBooks.isEmpty()) shouldBe true
+            }
         }
 
-    @Test
-    fun `loadBooks sorts standalone books alphabetically`() =
-        runTest {
-            val fixture = createFixture()
-            val book1 = createBook(id = "book-1", title = "Zebra")
-            val book2 = createBook(id = "book-2", title = "Alpha")
-            val book3 = createBook(id = "book-3", title = "Beta")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks separates standalone books from series books") {
+            runTest {
+                val fixture = createFixture()
+                val seriesBook =
+                    createBook(
+                        id = "book-1",
+                        title = "Series Book",
+                        series = listOf(BookSeries(seriesId = "a-series", seriesName = "A Series", sequence = null)),
+                    )
+                val standaloneBook = createBook(id = "book-2", title = "Standalone Book")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value =
-                listOf(
-                    createBookWithContributorRole(book1),
-                    createBookWithContributorRole(book2),
-                    createBookWithContributorRole(book3),
-                )
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value =
+                    listOf(
+                        createBookWithContributorRole(seriesBook),
+                        createBookWithContributorRole(standaloneBook),
+                    )
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals("Alpha", state.standaloneBooks[0].title)
-            assertEquals("Beta", state.standaloneBooks[1].title)
-            assertEquals("Zebra", state.standaloneBooks[2].title)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.seriesGroups.size shouldBe 1
+                state.standaloneBooks.size shouldBe 1
+                state.standaloneBooks[0].title shouldBe "Standalone Book"
+            }
         }
 
-    @Test
-    fun `loadBooks sorts series groups alphabetically by series name`() =
-        runTest {
-            val fixture = createFixture()
-            val book1 =
-                createBook(
-                    id = "book-1",
-                    title = "Book",
-                    series = listOf(BookSeries(seriesId = "zebra-series", seriesName = "Zebra Series", sequence = null)),
-                )
-            val book2 =
-                createBook(
-                    id = "book-2",
-                    title = "Book",
-                    series = listOf(BookSeries(seriesId = "alpha-series", seriesName = "Alpha Series", sequence = null)),
-                )
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks sorts series books by sequence") {
+            runTest {
+                val fixture = createFixture()
+                val book1 =
+                    createBook(
+                        id = "book-1",
+                        title = "Book One",
+                        series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = "2")),
+                    )
+                val book2 =
+                    createBook(
+                        id = "book-2",
+                        title = "Book Two",
+                        series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = "1")),
+                    )
+                val book3 =
+                    createBook(
+                        id = "book-3",
+                        title = "Book Three",
+                        series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = "1.5")),
+                    )
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value =
-                listOf(
-                    createBookWithContributorRole(book1),
-                    createBookWithContributorRole(book2),
-                )
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value =
+                    listOf(
+                        createBookWithContributorRole(book1),
+                        createBookWithContributorRole(book2),
+                        createBookWithContributorRole(book3),
+                    )
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals(2, state.seriesGroups.size)
-            assertEquals("Alpha Series", state.seriesGroups[0].seriesName)
-            assertEquals("Zebra Series", state.seriesGroups[1].seriesName)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                val seriesBooks = state.seriesGroups[0].books
+                seriesBooks[0].title shouldBe "Book Two"
+                seriesBooks[1].title shouldBe "Book Three"
+                seriesBooks[2].title shouldBe "Book One"
+            }
         }
 
-    // ========== Book Progress ==========
+        test("loadBooks sorts standalone books alphabetically") {
+            runTest {
+                val fixture = createFixture()
+                val book1 = createBook(id = "book-1", title = "Zebra")
+                val book2 = createBook(id = "book-2", title = "Alpha")
+                val book3 = createBook(id = "book-3", title = "Beta")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-    @Test
-    fun `loadBooks calculates book progress`() =
-        runTest {
-            val fixture = createFixture()
-            val book = createBook(id = "book-1", duration = 10_000L)
-            everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
-                AppResult.Success(createPlaybackPosition("book-1", 5_000L))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value =
+                    listOf(
+                        createBookWithContributorRole(book1),
+                        createBookWithContributorRole(book2),
+                        createBookWithContributorRole(book3),
+                    )
+                advanceUntilIdle()
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals(0.5f, state.bookProgress[BookId("book-1")])
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.standaloneBooks[0].title shouldBe "Alpha"
+                state.standaloneBooks[1].title shouldBe "Beta"
+                state.standaloneBooks[2].title shouldBe "Zebra"
+            }
         }
 
-    @Test
-    fun `loadBooks excludes completed books from progress`() =
-        runTest {
-            val fixture = createFixture()
-            val book = createBook(id = "book-1", duration = 10_000L)
-            everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
-                AppResult.Success(createPlaybackPosition("book-1", 9_999L))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks sorts series groups alphabetically by series name") {
+            runTest {
+                val fixture = createFixture()
+                val book1 =
+                    createBook(
+                        id = "book-1",
+                        title = "Book",
+                        series = listOf(BookSeries(seriesId = "zebra-series", seriesName = "Zebra Series", sequence = null)),
+                    )
+                val book2 =
+                    createBook(
+                        id = "book-2",
+                        title = "Book",
+                        series = listOf(BookSeries(seriesId = "alpha-series", seriesName = "Alpha Series", sequence = null)),
+                    )
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value =
+                    listOf(
+                        createBookWithContributorRole(book1),
+                        createBookWithContributorRole(book2),
+                    )
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertFalse(state.bookProgress.containsKey(BookId("book-1")))
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.seriesGroups.size shouldBe 2
+                state.seriesGroups[0].seriesName shouldBe "Alpha Series"
+                state.seriesGroups[1].seriesName shouldBe "Zebra Series"
+            }
         }
 
-    // ========== Derived Properties ==========
+        // ========== Book Progress ==========
 
-    @Test
-    fun `totalBooks returns sum of series and standalone books`() =
-        runTest {
-            val fixture = createFixture()
-            val seriesBook1 =
-                createBook(
-                    id = "book-1",
-                    title = "Series 1",
-                    series = listOf(BookSeries(seriesId = "s-series", seriesName = "S", sequence = null)),
-                )
-            val seriesBook2 =
-                createBook(
-                    id = "book-2",
-                    title = "Series 2",
-                    series = listOf(BookSeries(seriesId = "s-series", seriesName = "S", sequence = null)),
-                )
-            val standalone = createBook(id = "book-3", title = "Standalone")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks calculates book progress") {
+            runTest {
+                val fixture = createFixture()
+                val book = createBook(id = "book-1", duration = 10_000L)
+                everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
+                    AppResult.Success(createPlaybackPosition("book-1", 5_000L))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value =
-                listOf(
-                    createBookWithContributorRole(seriesBook1),
-                    createBookWithContributorRole(seriesBook2),
-                    createBookWithContributorRole(standalone),
-                )
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals(3, state.totalBooks)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.bookProgress[BookId("book-1")] shouldBe 0.5f
+            }
         }
 
-    @Test
-    fun `hasStandaloneBooks is true when standalone books exist`() =
-        runTest {
-            val fixture = createFixture()
-            val book = createBook(id = "book-1")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadBooks excludes completed books from progress") {
+            runTest {
+                val fixture = createFixture()
+                val book = createBook(id = "book-1", duration = 10_000L)
+                everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
+                    AppResult.Success(createPlaybackPosition("book-1", 9_999L))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
-            advanceUntilIdle()
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
+                advanceUntilIdle()
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertTrue(state.hasStandaloneBooks)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                (state.bookProgress.containsKey(BookId("book-1"))) shouldBe false
+            }
         }
 
-    @Test
-    fun `hasStandaloneBooks is false when no standalone books`() =
-        runTest {
-            val fixture = createFixture()
-            val book =
-                createBook(
-                    id = "book-1",
-                    series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = null)),
-                )
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        // ========== Derived Properties ==========
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
-            advanceUntilIdle()
+        test("totalBooks returns sum of series and standalone books") {
+            runTest {
+                val fixture = createFixture()
+                val seriesBook1 =
+                    createBook(
+                        id = "book-1",
+                        title = "Series 1",
+                        series = listOf(BookSeries(seriesId = "s-series", seriesName = "S", sequence = null)),
+                    )
+                val seriesBook2 =
+                    createBook(
+                        id = "book-2",
+                        title = "Series 2",
+                        series = listOf(BookSeries(seriesId = "s-series", seriesName = "S", sequence = null)),
+                    )
+                val standalone = createBook(id = "book-3", title = "Standalone")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertFalse(state.hasStandaloneBooks)
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value =
+                    listOf(
+                        createBookWithContributorRole(seriesBook1),
+                        createBookWithContributorRole(seriesBook2),
+                        createBookWithContributorRole(standalone),
+                    )
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.totalBooks shouldBe 3
+            }
         }
 
-    // ========== Cover Path ==========
+        test("hasStandaloneBooks is true when standalone books exist") {
+            runTest {
+                val fixture = createFixture()
+                val book = createBook(id = "book-1")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-    @Test
-    fun `loadBooks passes through coverPath from domain model`() =
-        runTest {
-            val fixture = createFixture()
-            val book = createBook(id = "book-1", coverPath = "/path/to/cover.jpg")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
+                advanceUntilIdle()
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertEquals("/path/to/cover.jpg", state.standaloneBooks[0].coverPath)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                (state.hasStandaloneBooks) shouldBe true
+            }
         }
 
-    // ========== Empty State ==========
+        test("hasStandaloneBooks is false when no standalone books") {
+            runTest {
+                val fixture = createFixture()
+                val book =
+                    createBook(
+                        id = "book-1",
+                        series = listOf(BookSeries(seriesId = "test-series", seriesName = "Series", sequence = null)),
+                    )
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-    @Test
-    fun `loadBooks handles empty book list`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
+                advanceUntilIdle()
 
-            viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
-            fixture.contributorFlow.value = createContributor()
-            fixture.booksFlow.value = emptyList()
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorBooksUiState.Ready>(viewModel.state.value)
-            assertTrue(state.seriesGroups.isEmpty())
-            assertTrue(state.standaloneBooks.isEmpty())
-            assertEquals(0, state.totalBooks)
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                (state.hasStandaloneBooks) shouldBe false
+            }
         }
-}
+
+        // ========== Cover Path ==========
+
+        test("loadBooks passes through coverPath from domain model") {
+            runTest {
+                val fixture = createFixture()
+                val book = createBook(id = "book-1", coverPath = "/path/to/cover.jpg")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value = listOf(createBookWithContributorRole(book))
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                state.standaloneBooks[0].coverPath shouldBe "/path/to/cover.jpg"
+            }
+        }
+
+        // ========== Empty State ==========
+
+        test("loadBooks handles empty book list") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadBooks("contributor-1", ContributorRole.AUTHOR.apiValue)
+                fixture.contributorFlow.value = createContributor()
+                fixture.booksFlow.value = emptyList()
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorBooksUiState.Ready
+                (state.seriesGroups.isEmpty()) shouldBe true
+                (state.standaloneBooks.isEmpty()) shouldBe true
+                state.totalBooks shouldBe 0
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
@@ -17,449 +17,432 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlin.time.Clock
 
 /**
  * Tests for ContributorDetailViewModel.
  *
  * The VM uses `.stateIn(WhileSubscribed)`, so tests must keep a background
- * collector alive via [keepStateHot] before asserting on `state.value`.
+ * collector alive via keepStateHot before asserting on `state.value`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ContributorDetailViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ContributorDetailViewModelTest :
+    FunSpec({
 
-    private class TestFixture {
-        val contributorRepository: ContributorRepository = mock()
-        val playbackPositionRepository: PlaybackPositionRepository = mock()
-        val deleteContributorUseCase: DeleteContributorUseCase = mock()
+        val testDispatcher = StandardTestDispatcher()
 
-        val contributorFlow = MutableStateFlow<Contributor?>(null)
-        val rolesFlow = MutableStateFlow<List<RoleWithBookCount>>(emptyList())
+        // ========== Test Fixtures ==========
 
-        fun build(): ContributorDetailViewModel =
-            ContributorDetailViewModel(
-                contributorRepository = contributorRepository,
-                playbackPositionRepository = playbackPositionRepository,
-                deleteContributorUseCase = deleteContributorUseCase,
-            )
-    }
+        class TestFixture {
+            val contributorRepository: ContributorRepository = mock()
+            val playbackPositionRepository: PlaybackPositionRepository = mock()
+            val deleteContributorUseCase: DeleteContributorUseCase = mock()
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
+            val contributorFlow = MutableStateFlow<Contributor?>(null)
+            val rolesFlow = MutableStateFlow<List<RoleWithBookCount>>(emptyList())
 
-        every { fixture.contributorRepository.observeById(any()) } returns fixture.contributorFlow
-        every { fixture.contributorRepository.observeRolesWithCountForContributor(any()) } returns fixture.rolesFlow
-        every { fixture.contributorRepository.observeBooksForContributorRole(any(), any()) } returns flowOf(emptyList())
-        everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
-
-        return fixture
-    }
-
-    /** Keep the VM's WhileSubscribed state flow hot for the duration of the test. */
-    private fun TestScope.keepStateHot(viewModel: ContributorDetailViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
-
-    private fun createContributor(
-        id: String = "contributor-1",
-        name: String = "Test Author",
-        description: String? = "A prolific author",
-    ): Contributor =
-        Contributor(
-            id =
-                com.calypsan.listenup.client.core
-                    .ContributorId(id),
-            name = name,
-            description = description,
-            imagePath = null,
-            imageBlurHash = null,
-            website = null,
-            birthDate = null,
-            deathDate = null,
-            aliases = emptyList(),
-        )
-
-    private fun createBook(
-        id: String = "book-1",
-        title: String = "Test Book",
-        duration: Long = 3_600_000L,
-        coverPath: String? = null,
-    ): BookListItem =
-        BookListItem(
-            id = BookId(id),
-            title = title,
-            coverPath = coverPath,
-            duration = duration,
-            authors = emptyList(),
-            narrators = emptyList(),
-            addedAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-        )
-
-    private fun createBookWithContributorRole(
-        book: BookListItem,
-        creditedAs: String? = null,
-    ): BookWithContributorRole =
-        BookWithContributorRole(
-            book = book,
-            creditedAs = creditedAs,
-        )
-
-    private fun createPlaybackPosition(
-        bookId: String,
-        positionMs: Long,
-    ): PlaybackPosition =
-        PlaybackPosition(
-            bookId = bookId,
-            positionMs = positionMs,
-            playbackSpeed = 1.0f,
-            hasCustomSpeed = false,
-            updatedAtMs = Clock.System.now().toEpochMilliseconds(),
-            syncedAtMs = null,
-            lastPlayedAtMs = null,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State ==========
-
-    @Test
-    fun `initial state is Idle pre-loadContributor`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            assertEquals(ContributorDetailUiState.Idle, viewModel.state.value)
+            fun build(): ContributorDetailViewModel =
+                ContributorDetailViewModel(
+                    contributorRepository = contributorRepository,
+                    playbackPositionRepository = playbackPositionRepository,
+                    deleteContributorUseCase = deleteContributorUseCase,
+                )
         }
 
-    // ========== Load Contributor ==========
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
 
-    @Test
-    fun `loadContributor success populates contributor data`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor(name = "Stephen King", description = "Master of horror")
-            val roles = listOf(RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 5))
+            every { fixture.contributorRepository.observeById(any()) } returns fixture.contributorFlow
+            every { fixture.contributorRepository.observeRolesWithCountForContributor(any()) } returns fixture.rolesFlow
+            every { fixture.contributorRepository.observeBooksForContributorRole(any(), any()) } returns flowOf(emptyList())
+            everySuspend { fixture.playbackPositionRepository.get(any<BookId>()) } returns AppResult.Success(null)
 
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = roles
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Stephen King", state.contributor.name)
-            assertEquals("Master of horror", state.contributor.description)
+            return fixture
         }
 
-    @Test
-    fun `loadContributor loads books for each role`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val authorRole = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 2)
-            val book = createBook(id = "book-1", title = "The Shining")
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book)))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(authorRole)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(1, state.roleSections.size)
-            assertEquals(ContributorRole.AUTHOR.apiValue, state.roleSections[0].role)
-            assertEquals(1, state.roleSections[0].previewBooks.size)
-            assertEquals("The Shining", state.roleSections[0].previewBooks[0].title)
-        }
-
-    @Test
-    fun `loadContributor creates multiple role sections`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val authorRole = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 3)
-            val narratorRole = RoleWithBookCount(role = ContributorRole.NARRATOR.apiValue, bookCount = 2)
-
-            val book1 = createBook(id = "book-1", title = "Author Book")
-            val book2 = createBook(id = "book-2", title = "Narrator Book")
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book1)))
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.NARRATOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book2)))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(authorRole, narratorRole)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(2, state.roleSections.size)
-            assertEquals(ContributorRole.AUTHOR.apiValue, state.roleSections[0].role)
-            assertEquals(ContributorRole.NARRATOR.apiValue, state.roleSections[1].role)
-        }
-
-    // ========== Role Display Name ==========
-
-    @Test
-    fun `roleToDisplayName converts author to Written By`() {
-        assertEquals("Written By", ContributorDetailViewModel.roleToDisplayName(ContributorRole.AUTHOR.apiValue))
-    }
-
-    @Test
-    fun `roleToDisplayName converts narrator to Narrated By`() {
-        assertEquals("Narrated By", ContributorDetailViewModel.roleToDisplayName(ContributorRole.NARRATOR.apiValue))
-    }
-
-    @Test
-    fun `roleToDisplayName converts translator to Translated By`() {
-        assertEquals("Translated By", ContributorDetailViewModel.roleToDisplayName(ContributorRole.TRANSLATOR.apiValue))
-    }
-
-    @Test
-    fun `roleToDisplayName converts editor to Edited By`() {
-        assertEquals("Edited By", ContributorDetailViewModel.roleToDisplayName(ContributorRole.EDITOR.apiValue))
-    }
-
-    @Test
-    fun `roleToDisplayName capitalizes unknown roles`() {
-        assertEquals("Producer", ContributorDetailViewModel.roleToDisplayName("producer"))
-    }
-
-    @Test
-    fun `roleToDisplayName handles uppercase input`() {
-        assertEquals("Written By", ContributorDetailViewModel.roleToDisplayName("AUTHOR"))
-    }
-
-    // ========== Book Progress ==========
-
-    @Test
-    fun `loadContributor calculates book progress`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book)))
-            everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
-                AppResult.Success(createPlaybackPosition("book-1", 5_000L))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(role)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(0.5f, state.bookProgress[BookId("book-1")])
-        }
-
-    @Test
-    fun `loadContributor excludes completed books from progress`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book)))
-            everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
-                AppResult.Success(createPlaybackPosition("book-1", 9_999L))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(role)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(state.bookProgress.containsKey(BookId("book-1")))
-        }
-
-    @Test
-    fun `loadContributor excludes zero progress from map`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book)))
-            everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns AppResult.Success(createPlaybackPosition("book-1", 0L))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(role)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(state.bookProgress.containsKey(BookId("book-1")))
-        }
-
-    // ========== View All Threshold ==========
-
-    @Test
-    fun `RoleSection showViewAll is true when bookCount exceeds threshold`() {
-        val section =
-            RoleSection(
-                role = ContributorRole.AUTHOR.apiValue,
-                displayName = "Written By",
-                bookCount = ContributorDetailViewModel.VIEW_ALL_THRESHOLD + 1,
-                previewBooks = emptyList(),
+        fun createContributor(
+            id: String = "contributor-1",
+            name: String = "Test Author",
+            description: String? = "A prolific author",
+        ): Contributor =
+            Contributor(
+                id =
+                    com.calypsan.listenup.client.core
+                        .ContributorId(id),
+                name = name,
+                description = description,
+                imagePath = null,
+                imageBlurHash = null,
+                website = null,
+                birthDate = null,
+                deathDate = null,
+                aliases = emptyList(),
             )
 
-        assertTrue(section.showViewAll)
-    }
-
-    @Test
-    fun `RoleSection showViewAll is false when bookCount at threshold`() {
-        val section =
-            RoleSection(
-                role = ContributorRole.AUTHOR.apiValue,
-                displayName = "Written By",
-                bookCount = ContributorDetailViewModel.VIEW_ALL_THRESHOLD,
-                previewBooks = emptyList(),
+        fun createBook(
+            id: String = "book-1",
+            title: String = "Test Book",
+            duration: Long = 3_600_000L,
+            coverPath: String? = null,
+        ): BookListItem =
+            BookListItem(
+                id = BookId(id),
+                title = title,
+                coverPath = coverPath,
+                duration = duration,
+                authors = emptyList(),
+                narrators = emptyList(),
+                addedAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
             )
 
-        assertFalse(section.showViewAll)
-    }
-
-    @Test
-    fun `RoleSection showViewAll is false when bookCount below threshold`() {
-        val section =
-            RoleSection(
-                role = ContributorRole.AUTHOR.apiValue,
-                displayName = "Written By",
-                bookCount = 3,
-                previewBooks = emptyList(),
+        fun createBookWithContributorRole(
+            book: BookListItem,
+            creditedAs: String? = null,
+        ): BookWithContributorRole =
+            BookWithContributorRole(
+                book = book,
+                creditedAs = creditedAs,
             )
 
-        assertFalse(section.showViewAll)
-    }
+        fun createPlaybackPosition(
+            bookId: String,
+            positionMs: Long,
+        ): PlaybackPosition =
+            PlaybackPosition(
+                bookId = bookId,
+                positionMs = positionMs,
+                playbackSpeed = 1.0f,
+                hasCustomSpeed = false,
+                updatedAtMs = Clock.System.now().toEpochMilliseconds(),
+                syncedAtMs = null,
+                lastPlayedAtMs = null,
+            )
 
-    // ========== Cover Path ==========
-
-    @Test
-    fun `loadContributor passes through coverPath from domain model`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
-            val book = createBook(id = "book-1", coverPath = "/path/to/cover.jpg")
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book)))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(role)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("/path/to/cover.jpg", state.roleSections[0].previewBooks[0].coverPath)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `loadContributor handles null coverPath`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
-            val book = createBook(id = "book-1", coverPath = null)
-
-            every {
-                fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
-            } returns flowOf(listOf(createBookWithContributorRole(book)))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor
-            fixture.rolesFlow.value = listOf(role)
-            advanceUntilIdle()
-
-            val state = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertNull(state.roleSections[0].previewBooks[0].coverPath)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    // ========== Reactive Updates ==========
+        // ========== Initial State ==========
 
-    @Test
-    fun `loadContributor updates when contributor flow emits new value`() =
-        runTest {
-            val fixture = createFixture()
-            val contributor1 = createContributor(name = "Original Name")
-            val contributor2 = createContributor(name = "Updated Name")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("initial state is Idle pre-loadContributor") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+                advanceUntilIdle()
 
-            viewModel.loadContributor("contributor-1")
-            fixture.contributorFlow.value = contributor1
-            fixture.rolesFlow.value = emptyList()
-            advanceUntilIdle()
-            val first = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Original Name", first.contributor.name)
-
-            fixture.contributorFlow.value = contributor2
-            advanceUntilIdle()
-
-            val second = assertIs<ContributorDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Updated Name", second.contributor.name)
+                viewModel.state.value shouldBe ContributorDetailUiState.Idle
+            }
         }
-}
+
+        // ========== Load Contributor ==========
+
+        test("loadContributor success populates contributor data") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor(name = "Stephen King", description = "Master of horror")
+                val roles = listOf(RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 5))
+
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = roles
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                state.contributor.name shouldBe "Stephen King"
+                state.contributor.description shouldBe "Master of horror"
+            }
+        }
+
+        test("loadContributor loads books for each role") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val authorRole = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 2)
+                val book = createBook(id = "book-1", title = "The Shining")
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book)))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(authorRole)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                state.roleSections.size shouldBe 1
+                state.roleSections[0].role shouldBe ContributorRole.AUTHOR.apiValue
+                state.roleSections[0].previewBooks.size shouldBe 1
+                state.roleSections[0].previewBooks[0].title shouldBe "The Shining"
+            }
+        }
+
+        test("loadContributor creates multiple role sections") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val authorRole = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 3)
+                val narratorRole = RoleWithBookCount(role = ContributorRole.NARRATOR.apiValue, bookCount = 2)
+
+                val book1 = createBook(id = "book-1", title = "Author Book")
+                val book2 = createBook(id = "book-2", title = "Narrator Book")
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book1)))
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.NARRATOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book2)))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(authorRole, narratorRole)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                state.roleSections.size shouldBe 2
+                state.roleSections[0].role shouldBe ContributorRole.AUTHOR.apiValue
+                state.roleSections[1].role shouldBe ContributorRole.NARRATOR.apiValue
+            }
+        }
+
+        // ========== Role Display Name ==========
+
+        test("roleToDisplayName converts author to Written By") {
+            ContributorDetailViewModel.roleToDisplayName(ContributorRole.AUTHOR.apiValue) shouldBe "Written By"
+        }
+
+        test("roleToDisplayName converts narrator to Narrated By") {
+            ContributorDetailViewModel.roleToDisplayName(ContributorRole.NARRATOR.apiValue) shouldBe "Narrated By"
+        }
+
+        test("roleToDisplayName converts translator to Translated By") {
+            ContributorDetailViewModel.roleToDisplayName(ContributorRole.TRANSLATOR.apiValue) shouldBe "Translated By"
+        }
+
+        test("roleToDisplayName converts editor to Edited By") {
+            ContributorDetailViewModel.roleToDisplayName(ContributorRole.EDITOR.apiValue) shouldBe "Edited By"
+        }
+
+        test("roleToDisplayName capitalizes unknown roles") {
+            ContributorDetailViewModel.roleToDisplayName("producer") shouldBe "Producer"
+        }
+
+        test("roleToDisplayName handles uppercase input") {
+            ContributorDetailViewModel.roleToDisplayName("AUTHOR") shouldBe "Written By"
+        }
+
+        // ========== Book Progress ==========
+
+        test("loadContributor calculates book progress") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book)))
+                everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
+                    AppResult.Success(createPlaybackPosition("book-1", 5_000L))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(role)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                state.bookProgress[BookId("book-1")] shouldBe 0.5f
+            }
+        }
+
+        test("loadContributor excludes completed books from progress") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book)))
+                everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns
+                    AppResult.Success(createPlaybackPosition("book-1", 9_999L))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(role)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                (state.bookProgress.containsKey(BookId("book-1"))) shouldBe false
+            }
+        }
+
+        test("loadContributor excludes zero progress from map") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book)))
+                everySuspend { fixture.playbackPositionRepository.get(BookId("book-1")) } returns AppResult.Success(createPlaybackPosition("book-1", 0L))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(role)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                (state.bookProgress.containsKey(BookId("book-1"))) shouldBe false
+            }
+        }
+
+        // ========== View All Threshold ==========
+
+        test("RoleSection showViewAll is true when bookCount exceeds threshold") {
+            val section =
+                RoleSection(
+                    role = ContributorRole.AUTHOR.apiValue,
+                    displayName = "Written By",
+                    bookCount = ContributorDetailViewModel.VIEW_ALL_THRESHOLD + 1,
+                    previewBooks = emptyList(),
+                )
+
+            (section.showViewAll) shouldBe true
+        }
+
+        test("RoleSection showViewAll is false when bookCount at threshold") {
+            val section =
+                RoleSection(
+                    role = ContributorRole.AUTHOR.apiValue,
+                    displayName = "Written By",
+                    bookCount = ContributorDetailViewModel.VIEW_ALL_THRESHOLD,
+                    previewBooks = emptyList(),
+                )
+
+            (section.showViewAll) shouldBe false
+        }
+
+        test("RoleSection showViewAll is false when bookCount below threshold") {
+            val section =
+                RoleSection(
+                    role = ContributorRole.AUTHOR.apiValue,
+                    displayName = "Written By",
+                    bookCount = 3,
+                    previewBooks = emptyList(),
+                )
+
+            (section.showViewAll) shouldBe false
+        }
+
+        // ========== Cover Path ==========
+
+        test("loadContributor passes through coverPath from domain model") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
+                val book = createBook(id = "book-1", coverPath = "/path/to/cover.jpg")
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book)))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(role)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                state.roleSections[0].previewBooks[0].coverPath shouldBe "/path/to/cover.jpg"
+            }
+        }
+
+        test("loadContributor handles null coverPath") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 1)
+                val book = createBook(id = "book-1", coverPath = null)
+
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("contributor-1", ContributorRole.AUTHOR.apiValue)
+                } returns flowOf(listOf(createBookWithContributorRole(book)))
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(role)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value as ContributorDetailUiState.Ready
+                state.roleSections[0].previewBooks[0].coverPath.shouldBeNull()
+            }
+        }
+
+        // ========== Reactive Updates ==========
+
+        test("loadContributor updates when contributor flow emits new value") {
+            runTest {
+                val fixture = createFixture()
+                val contributor1 = createContributor(name = "Original Name")
+                val contributor2 = createContributor(name = "Updated Name")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("contributor-1")
+                fixture.contributorFlow.value = contributor1
+                fixture.rolesFlow.value = emptyList()
+                advanceUntilIdle()
+                val first = viewModel.state.value as ContributorDetailUiState.Ready
+                first.contributor.name shouldBe "Original Name"
+
+                fixture.contributorFlow.value = contributor2
+                advanceUntilIdle()
+
+                val second = viewModel.state.value as ContributorDetailUiState.Ready
+                second.contributor.name shouldBe "Updated Name"
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
@@ -417,7 +417,10 @@ class ContributorDetailViewModelTest :
                 advanceUntilIdle()
 
                 val state = viewModel.state.value as ContributorDetailUiState.Ready
-                state.roleSections[0].previewBooks[0].coverPath.shouldBeNull()
+                state.roleSections[0]
+                    .previewBooks[0]
+                    .coverPath
+                    .shouldBeNull()
             }
         }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModelTest.kt
@@ -16,6 +16,8 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -23,12 +25,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * Tests for ContributorEditViewModel.
@@ -40,309 +36,303 @@ import kotlin.test.assertTrue
  * - Handling merge errors gracefully
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ContributorEditViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ContributorEditViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixture ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val contributorRepository: ContributorRepository = mock()
-        val contributorEditRepository: ContributorEditRepository = mock()
-        val updateContributorUseCase: UpdateContributorUseCase = mock()
-        val imageRepository: ImageRepository = mock()
+        // ========== Test Fixture ==========
 
-        fun build(): ContributorEditViewModel =
-            ContributorEditViewModel(
-                contributorRepository = contributorRepository,
-                contributorEditRepository = contributorEditRepository,
-                updateContributorUseCase = updateContributorUseCase,
-                imageRepository = imageRepository,
+        class TestFixture {
+            val contributorRepository: ContributorRepository = mock()
+            val contributorEditRepository: ContributorEditRepository = mock()
+            val updateContributorUseCase: UpdateContributorUseCase = mock()
+            val imageRepository: ImageRepository = mock()
+
+            fun build(): ContributorEditViewModel =
+                ContributorEditViewModel(
+                    contributorRepository = contributorRepository,
+                    contributorEditRepository = contributorEditRepository,
+                    updateContributorUseCase = updateContributorUseCase,
+                    imageRepository = imageRepository,
+                )
+        }
+
+        fun createFixture(): TestFixture = TestFixture()
+
+        // ========== Test Data Factories ==========
+
+        fun createContributor(
+            id: String = "contributor-1",
+            name: String = "Stephen King",
+            aliases: List<String> = emptyList(),
+        ): Contributor =
+            Contributor(
+                id =
+                    com.calypsan.listenup.client.core
+                        .ContributorId(id),
+                name = name,
+                description = null,
+                imagePath = null,
+                imageBlurHash = null,
+                website = null,
+                birthDate = null,
+                deathDate = null,
+                aliases = aliases,
             )
-    }
 
-    private fun createFixture(): TestFixture = TestFixture()
-
-    // ========== Test Data Factories ==========
-
-    private fun createContributor(
-        id: String = "contributor-1",
-        name: String = "Stephen King",
-        aliases: List<String> = emptyList(),
-    ): Contributor =
-        Contributor(
-            id =
-                com.calypsan.listenup.client.core
-                    .ContributorId(id),
-            name = name,
-            description = null,
-            imagePath = null,
-            imageBlurHash = null,
-            website = null,
-            birthDate = null,
-            deathDate = null,
-            aliases = aliases,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Load Contributor Tests ==========
-
-    @Test
-    fun `loadContributor populates state with contributor data`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor =
-                createContributor(
-                    name = "Stephen King",
-                    aliases = listOf("Richard Bachman", "John Swithen"),
-                )
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
-
-            val viewModel = fixture.build()
-
-            // When
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.isLoading)
-            assertEquals("Stephen King", state.name)
-            assertEquals(2, state.aliases.size)
-            assertTrue(state.aliases.contains("Richard Bachman"))
-            assertTrue(state.aliases.contains("John Swithen"))
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `loadContributor handles contributor not found`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.contributorRepository.getById("nonexistent") } returns null
-
-            val viewModel = fixture.build()
-
-            // When
-            viewModel.loadContributor("nonexistent")
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.isLoading)
-            assertEquals("Contributor not found", state.error)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    // ========== Alias Selection Tests ==========
+        // ========== Load Contributor Tests ==========
 
-    @Test
-    fun `selecting alias from search adds to aliases list and marks for merge`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
+        test("loadContributor populates state with contributor data") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor =
+                    createContributor(
+                        name = "Stephen King",
+                        aliases = listOf("Richard Bachman", "John Swithen"),
+                    )
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
 
-            val searchResult =
-                ContributorSearchResult(
-                    id = "contributor-2",
-                    name = "Richard Bachman",
-                    bookCount = 5,
-                )
-            everySuspend { fixture.contributorRepository.searchContributors(any(), any()) } returns
-                ContributorSearchResponse(
-                    contributors = listOf(searchResult),
-                    isOfflineResult = false,
-                    tookMs = 10L,
-                )
+                val viewModel = fixture.build()
 
-            val viewModel = fixture.build()
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
+                // When
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
 
-            // When - select alias from autocomplete
-            viewModel.onEvent(ContributorEditUiEvent.AliasSelected(searchResult))
-
-            // Then
-            val state = viewModel.state.value
-            assertTrue(state.aliases.contains("Richard Bachman"))
-            assertTrue(state.hasChanges)
-        }
-
-    // ========== Save with Merge Tests ==========
-
-    @Test
-    fun `save calls use case for new aliases from autocomplete`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
-            everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns Success(Unit)
-
-            val viewModel = fixture.build()
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
-
-            // Add alias via autocomplete (which tracks for merge)
-            val searchResult =
-                ContributorSearchResult(
-                    id = "contributor-2",
-                    name = "Richard Bachman",
-                    bookCount = 5,
-                )
-            viewModel.onEvent(ContributorEditUiEvent.AliasSelected(searchResult))
-
-            // When
-            viewModel.onEvent(ContributorEditUiEvent.Save)
-            advanceUntilIdle()
-
-            // Then - verify use case was called
-            verifySuspend(VerifyMode.exactly(1)) {
-                fixture.updateContributorUseCase.invoke(any())
+                // Then
+                val state = viewModel.state.value
+                (state.isLoading) shouldBe false
+                state.name shouldBe "Stephen King"
+                state.aliases.size shouldBe 2
+                (state.aliases.contains("Richard Bachman")) shouldBe true
+                (state.aliases.contains("John Swithen")) shouldBe true
             }
         }
 
-    @Test
-    fun `save handles use case failure gracefully`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
+        test("loadContributor handles contributor not found") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.contributorRepository.getById("nonexistent") } returns null
 
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
-            // Use case fails
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation to the ViewModel.
-            everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns
-                Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Network error"),
-                )
+                val viewModel = fixture.build()
 
-            val viewModel = fixture.build()
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
+                // When
+                viewModel.loadContributor("nonexistent")
+                advanceUntilIdle()
 
-            // Add alias via autocomplete
-            val searchResult =
-                ContributorSearchResult(
-                    id = "contributor-2",
-                    name = "Richard Bachman",
-                    bookCount = 5,
-                )
-            viewModel.onEvent(ContributorEditUiEvent.AliasSelected(searchResult))
-
-            // When
-            viewModel.onEvent(ContributorEditUiEvent.Save)
-            advanceUntilIdle()
-
-            // Then - error should be shown (ViewModel prepends "Failed to save: ")
-            assertEquals("Failed to save: Network error", viewModel.state.value.error)
-        }
-
-    @Test
-    fun `manual alias entry calls use case`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
-            everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns Success(Unit)
-
-            val viewModel = fixture.build()
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
-
-            // Add alias via manual text entry (not autocomplete)
-            viewModel.onEvent(ContributorEditUiEvent.AliasEntered("New Pen Name"))
-
-            // When
-            viewModel.onEvent(ContributorEditUiEvent.Save)
-            advanceUntilIdle()
-
-            // Then - use case should be called
-            verifySuspend(VerifyMode.exactly(1)) {
-                fixture.updateContributorUseCase.invoke(any())
+                // Then
+                val state = viewModel.state.value
+                (state.isLoading) shouldBe false
+                state.error shouldBe "Contributor not found"
             }
         }
 
-    @Test
-    fun `removing alias calls repository unmerge`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor(aliases = listOf("Richard Bachman"))
+        // ========== Alias Selection Tests ==========
 
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
-            everySuspend { fixture.contributorEditRepository.unmergeContributor(any(), any()) } returns
-                Success(Unit)
+        test("selecting alias from search adds to aliases list and marks for merge") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
 
-            val viewModel = fixture.build()
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
+                val searchResult =
+                    ContributorSearchResult(
+                        id = "contributor-2",
+                        name = "Richard Bachman",
+                        bookCount = 5,
+                    )
+                everySuspend { fixture.contributorRepository.searchContributors(any(), any()) } returns
+                    ContributorSearchResponse(
+                        contributors = listOf(searchResult),
+                        isOfflineResult = false,
+                        tookMs = 10L,
+                    )
 
-            // Verify alias is present
-            assertTrue(
-                viewModel.state.value.aliases
-                    .contains("Richard Bachman"),
-            )
-            assertFalse(viewModel.state.value.hasChanges)
+                val viewModel = fixture.build()
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
 
-            // When - removing an original alias calls the repository unmerge
-            viewModel.onEvent(ContributorEditUiEvent.RemoveAlias("Richard Bachman"))
-            advanceUntilIdle()
+                // When - select alias from autocomplete
+                viewModel.onEvent(ContributorEditUiEvent.AliasSelected(searchResult))
 
-            // Then
-            assertFalse(
-                viewModel.state.value.aliases
-                    .contains("Richard Bachman"),
-            )
-            // Verify unmerge was called
-            verifySuspend(VerifyMode.exactly(1)) {
-                fixture.contributorEditRepository.unmergeContributor("contributor-1", "Richard Bachman")
+                // Then
+                val state = viewModel.state.value
+                (state.aliases.contains("Richard Bachman")) shouldBe true
+                (state.hasChanges) shouldBe true
             }
         }
 
-    @Test
-    fun `save calls use case with correct parameters`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
+        // ========== Save with Merge Tests ==========
 
-            everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
-            everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns Success(Unit)
+        test("save calls use case for new aliases from autocomplete") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
 
-            val viewModel = fixture.build()
-            viewModel.loadContributor("contributor-1")
-            advanceUntilIdle()
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
+                everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns Success(Unit)
 
-            // Change name
-            viewModel.onEvent(ContributorEditUiEvent.NameChanged("Stephen Edwin King"))
+                val viewModel = fixture.build()
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
 
-            // When / Then
-            viewModel.navActions.test {
+                // Add alias via autocomplete (which tracks for merge)
+                val searchResult =
+                    ContributorSearchResult(
+                        id = "contributor-2",
+                        name = "Richard Bachman",
+                        bookCount = 5,
+                    )
+                viewModel.onEvent(ContributorEditUiEvent.AliasSelected(searchResult))
+
+                // When
                 viewModel.onEvent(ContributorEditUiEvent.Save)
                 advanceUntilIdle()
 
-                // Verify use case was called
+                // Then - verify use case was called
                 verifySuspend(VerifyMode.exactly(1)) {
                     fixture.updateContributorUseCase.invoke(any())
                 }
-
-                // Verify navigation
-                assertEquals(ContributorEditNavAction.SaveSuccess, awaitItem())
             }
         }
-}
+
+        test("save handles use case failure gracefully") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
+                // Use case fails
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation to the ViewModel.
+                everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns
+                    Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Network error"),
+                    )
+
+                val viewModel = fixture.build()
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
+
+                // Add alias via autocomplete
+                val searchResult =
+                    ContributorSearchResult(
+                        id = "contributor-2",
+                        name = "Richard Bachman",
+                        bookCount = 5,
+                    )
+                viewModel.onEvent(ContributorEditUiEvent.AliasSelected(searchResult))
+
+                // When
+                viewModel.onEvent(ContributorEditUiEvent.Save)
+                advanceUntilIdle()
+
+                // Then - error should be shown (ViewModel prepends "Failed to save: ")
+                viewModel.state.value.error shouldBe "Failed to save: Network error"
+            }
+        }
+
+        test("manual alias entry calls use case") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
+                everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns Success(Unit)
+
+                val viewModel = fixture.build()
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
+
+                // Add alias via manual text entry (not autocomplete)
+                viewModel.onEvent(ContributorEditUiEvent.AliasEntered("New Pen Name"))
+
+                // When
+                viewModel.onEvent(ContributorEditUiEvent.Save)
+                advanceUntilIdle()
+
+                // Then - use case should be called
+                verifySuspend(VerifyMode.exactly(1)) {
+                    fixture.updateContributorUseCase.invoke(any())
+                }
+            }
+        }
+
+        test("removing alias calls repository unmerge") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor(aliases = listOf("Richard Bachman"))
+
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
+                everySuspend { fixture.contributorEditRepository.unmergeContributor(any(), any()) } returns
+                    Success(Unit)
+
+                val viewModel = fixture.build()
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
+
+                // Verify alias is present
+                (viewModel.state.value.aliases.contains("Richard Bachman")) shouldBe true
+                (viewModel.state.value.hasChanges) shouldBe false
+
+                // When - removing an original alias calls the repository unmerge
+                viewModel.onEvent(ContributorEditUiEvent.RemoveAlias("Richard Bachman"))
+                advanceUntilIdle()
+
+                // Then
+                (viewModel.state.value.aliases.contains("Richard Bachman")) shouldBe false
+                // Verify unmerge was called
+                verifySuspend(VerifyMode.exactly(1)) {
+                    fixture.contributorEditRepository.unmergeContributor("contributor-1", "Richard Bachman")
+                }
+            }
+        }
+
+        test("save calls use case with correct parameters") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+
+                everySuspend { fixture.contributorRepository.getById("contributor-1") } returns contributor
+                everySuspend { fixture.updateContributorUseCase.invoke(any()) } returns Success(Unit)
+
+                val viewModel = fixture.build()
+                viewModel.loadContributor("contributor-1")
+                advanceUntilIdle()
+
+                // Change name
+                viewModel.onEvent(ContributorEditUiEvent.NameChanged("Stephen Edwin King"))
+
+                // When / Then
+                viewModel.navActions.test {
+                    viewModel.onEvent(ContributorEditUiEvent.Save)
+                    advanceUntilIdle()
+
+                    // Verify use case was called
+                    verifySuspend(VerifyMode.exactly(1)) {
+                        fixture.updateContributorUseCase.invoke(any())
+                    }
+
+                    // Verify navigation
+                    awaitItem() shouldBe ContributorEditNavAction.SaveSuccess
+                }
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModelTest.kt
@@ -288,7 +288,10 @@ class ContributorEditViewModelTest :
                 advanceUntilIdle()
 
                 // Verify alias is present
-                (viewModel.state.value.aliases.contains("Richard Bachman")) shouldBe true
+                (
+                    viewModel.state.value.aliases
+                        .contains("Richard Bachman")
+                ) shouldBe true
                 (viewModel.state.value.hasChanges) shouldBe false
 
                 // When - removing an original alias calls the repository unmerge
@@ -296,7 +299,10 @@ class ContributorEditViewModelTest :
                 advanceUntilIdle()
 
                 // Then
-                (viewModel.state.value.aliases.contains("Richard Bachman")) shouldBe false
+                (
+                    viewModel.state.value.aliases
+                        .contains("Richard Bachman")
+                ) shouldBe false
                 // Verify unmerge was called
                 verifySuspend(VerifyMode.exactly(1)) {
                     fixture.contributorEditRepository.unmergeContributor("contributor-1", "Richard Bachman")

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributormetadata/ContributorMetadataViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributormetadata/ContributorMetadataViewModelTest.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.presentation.contributormetadata
 
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.error.ErrorBus
 import com.calypsan.listenup.client.domain.model.Contributor
 import com.calypsan.listenup.client.domain.model.ContributorMetadataCandidate
 import com.calypsan.listenup.client.domain.repository.ContributorMetadataProfile
@@ -16,6 +17,8 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -24,14 +27,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
-import com.calypsan.listenup.client.core.error.ErrorBus
 
 /**
  * Tests for ContributorMetadataViewModel.
@@ -44,483 +39,483 @@ import com.calypsan.listenup.client.core.error.ErrorBus
  * - Error handling
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ContributorMetadataViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ContributorMetadataViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixture ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val contributorRepository: ContributorRepository = mock()
-        val metadataRepository: MetadataRepository = mock()
-        val applyContributorMetadataUseCase: ApplyContributorMetadataUseCase = mock()
+        // ========== Test Fixture ==========
 
-        fun build(): ContributorMetadataViewModel =
-            ContributorMetadataViewModel(
-                contributorRepository = contributorRepository,
-                metadataRepository = metadataRepository,
-                applyContributorMetadataUseCase = applyContributorMetadataUseCase,
-                errorBus = ErrorBus(),
+        class TestFixture {
+            val contributorRepository: ContributorRepository = mock()
+            val metadataRepository: MetadataRepository = mock()
+            val applyContributorMetadataUseCase: ApplyContributorMetadataUseCase = mock()
+
+            fun build(): ContributorMetadataViewModel =
+                ContributorMetadataViewModel(
+                    contributorRepository = contributorRepository,
+                    metadataRepository = metadataRepository,
+                    applyContributorMetadataUseCase = applyContributorMetadataUseCase,
+                    errorBus = ErrorBus(),
+                )
+        }
+
+        fun createFixture(): TestFixture = TestFixture()
+
+        // ========== Test Data Factories ==========
+
+        fun createContributor(
+            id: String = "contributor-1",
+            name: String = "Stephen King",
+        ): Contributor =
+            Contributor(
+                id =
+                    com.calypsan.listenup.client.core
+                        .ContributorId(id),
+                name = name,
+                description = null,
+                imagePath = null,
             )
-    }
 
-    private fun createFixture(): TestFixture = TestFixture()
+        fun createSearchResult(
+            asin: String = "B001ASIN01",
+            name: String = "Stephen King",
+            imageUrl: String? = "https://example.com/image.jpg",
+        ): ContributorMetadataCandidate =
+            ContributorMetadataCandidate(
+                asin = asin,
+                name = name,
+                imageUrl = imageUrl,
+                description = "142 titles",
+            )
 
-    // ========== Test Data Factories ==========
+        fun createProfile(
+            asin: String = "B001ASIN01",
+            name: String = "Stephen King",
+            biography: String? = "Stephen King is a prolific author...",
+            imageUrl: String? = "https://example.com/image.jpg",
+        ): ContributorMetadataProfile =
+            ContributorMetadataProfile(
+                asin = asin,
+                name = name,
+                biography = biography,
+                imageUrl = imageUrl,
+            )
 
-    private fun createContributor(
-        id: String = "contributor-1",
-        name: String = "Stephen King",
-    ): Contributor =
-        Contributor(
-            id =
-                com.calypsan.listenup.client.core
-                    .ContributorId(id),
-            name = name,
-            description = null,
-            imagePath = null,
-        )
-
-    private fun createSearchResult(
-        asin: String = "B001ASIN01",
-        name: String = "Stephen King",
-        imageUrl: String? = "https://example.com/image.jpg",
-    ): ContributorMetadataCandidate =
-        ContributorMetadataCandidate(
-            asin = asin,
-            name = name,
-            imageUrl = imageUrl,
-            description = "142 titles",
-        )
-
-    private fun createProfile(
-        asin: String = "B001ASIN01",
-        name: String = "Stephen King",
-        biography: String? = "Stephen King is a prolific author...",
-        imageUrl: String? = "https://example.com/image.jpg",
-    ): ContributorMetadataProfile =
-        ContributorMetadataProfile(
-            asin = asin,
-            name = name,
-            biography = biography,
-            imageUrl = imageUrl,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initialization Tests ==========
-
-    @Test
-    fun `init synchronously resets state to prevent stale state bugs`() =
-        runTest {
-            // Given - ViewModel with stale state from previous contributor
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            // Simulate stale state (e.g., applySuccess from previous contributor)
-            // We can't set this directly, but we can verify the fix works by checking
-            // that init() synchronously sets contributorId before any async work
-
-            val contributor = createContributor(id = "contributor-2", name = "Neil Gaiman")
-            every { fixture.contributorRepository.observeById("contributor-2") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns emptyList()
-
-            // When
-            viewModel.init("contributor-2")
-
-            // Then - synchronous state reset happens immediately (before advanceUntilIdle)
-            val stateBeforeAsync = viewModel.state.value
-            assertEquals("contributor-2", stateBeforeAsync.contributorId)
-            assertFalse(stateBeforeAsync.applySuccess) // Reset from default
-            assertNull(stateBeforeAsync.currentContributor) // Not loaded yet
-            assertEquals("", stateBeforeAsync.searchQuery) // Reset
-            assertTrue(stateBeforeAsync.searchResults.isEmpty()) // Reset
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `init loads contributor and pre-fills search query`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor(name = "Stephen King")
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "us") } returns
-                listOf(createSearchResult())
-
-            val viewModel = fixture.build()
-
-            // When
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertEquals("contributor-1", state.contributorId)
-            assertEquals(contributor, state.currentContributor)
-            assertEquals("Stephen King", state.searchQuery)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `init auto-searches with contributor name`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor(name = "Stephen King")
-            val searchResults = listOf(createSearchResult())
+        // ========== Initialization Tests ==========
 
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "us") } returns searchResults
+        test("init synchronously resets state to prevent stale state bugs") {
+            runTest {
+                // Given - ViewModel with stale state from previous contributor
+                val fixture = createFixture()
+                val viewModel = fixture.build()
 
-            val viewModel = fixture.build()
+                // Simulate stale state (e.g., applySuccess from previous contributor)
+                // We can't set this directly, but we can verify the fix works by checking
+                // that init() synchronously sets contributorId before any async work
 
-            // When
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
+                val contributor = createContributor(id = "contributor-2", name = "Neil Gaiman")
+                every { fixture.contributorRepository.observeById("contributor-2") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns emptyList()
 
-            // Then
-            val state = viewModel.state.value
-            assertEquals(searchResults, state.searchResults)
-            verifySuspend(VerifyMode.exactly(1)) {
-                fixture.metadataRepository.searchContributors("Stephen King", "us")
+                // When
+                viewModel.init("contributor-2")
+
+                // Then - synchronous state reset happens immediately (before advanceUntilIdle)
+                val stateBeforeAsync = viewModel.state.value
+                stateBeforeAsync.contributorId shouldBe "contributor-2"
+                (stateBeforeAsync.applySuccess) shouldBe false // Reset from default
+                stateBeforeAsync.currentContributor shouldBe null // Not loaded yet
+                stateBeforeAsync.searchQuery shouldBe "" // Reset
+                (stateBeforeAsync.searchResults.isEmpty()) shouldBe true // Reset
             }
         }
 
-    @Test
-    fun `init does not auto-search when contributor name is blank`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor(name = "")
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+        test("init loads contributor and pre-fills search query") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor(name = "Stephen King")
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "us") } returns
+                    listOf(createSearchResult())
 
-            val viewModel = fixture.build()
+                val viewModel = fixture.build()
 
-            // When
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
+                // When
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
 
-            // Then - search should not be called
-            verifySuspend(VerifyMode.exactly(0)) {
-                fixture.metadataRepository.searchContributors(any(), any())
+                // Then
+                val state = viewModel.state.value
+                state.contributorId shouldBe "contributor-1"
+                state.currentContributor shouldBe contributor
+                state.searchQuery shouldBe "Stephen King"
             }
         }
 
-    // ========== Search Tests ==========
+        test("init auto-searches with contributor name") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor(name = "Stephen King")
+                val searchResults = listOf(createSearchResult())
 
-    @Test
-    fun `search updates state with results`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val searchResults =
-                listOf(
-                    createSearchResult(asin = "B001", name = "Stephen King"),
-                    createSearchResult(asin = "B002", name = "Stephen King Jr"),
-                )
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "us") } returns searchResults
 
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns searchResults
+                val viewModel = fixture.build()
 
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
+                // When
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
 
-            // When - manual search with different query
-            viewModel.updateQuery("Stephen")
-            viewModel.search()
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertEquals(2, state.searchResults.size)
-            assertFalse(state.isSearching)
-            assertNull(state.searchError)
-        }
-
-    @Test
-    fun `search handles error gracefully`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } throws
-                RuntimeException("Network error")
-
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.isSearching)
-            assertEquals("Network error", state.searchError)
-        }
-
-    @Test
-    fun `search with blank query does nothing`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor(name = "")
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-
-            viewModel.updateQuery("   ") // Blank query
-
-            // When
-            viewModel.search()
-            advanceUntilIdle()
-
-            // Then - search should not be called (only the auto-search check, which is skipped for blank name)
-            verifySuspend(VerifyMode.exactly(0)) {
-                fixture.metadataRepository.searchContributors(any(), any())
+                // Then
+                val state = viewModel.state.value
+                state.searchResults shouldBe searchResults
+                verifySuspend(VerifyMode.exactly(1)) {
+                    fixture.metadataRepository.searchContributors("Stephen King", "us")
+                }
             }
         }
 
-    // ========== Candidate Selection Tests ==========
+        test("init does not auto-search when contributor name is blank") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor(name = "")
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
 
-    @Test
-    fun `selectCandidate loads profile`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val searchResult = createSearchResult()
-            val profile = createProfile()
+                val viewModel = fixture.build()
 
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
-            everySuspend { fixture.metadataRepository.getContributorProfile("B001ASIN01") } returns profile
+                // When
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
 
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.selectCandidate(searchResult)
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertEquals(searchResult, state.selectedCandidate)
-            assertEquals(profile, state.previewProfile)
-            assertFalse(state.isLoadingPreview)
-            assertNull(state.previewError)
-        }
-
-    @Test
-    fun `selectCandidate initializes field selections based on profile`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val searchResult = createSearchResult()
-            // Profile with name and biography but no image
-            val profile = createProfile(imageUrl = null)
-
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
-            everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
-
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-
-            // When
-            viewModel.selectCandidate(searchResult)
-            advanceUntilIdle()
-
-            // Then - image selection should be false since no image available
-            val selections = viewModel.state.value.selections
-            assertTrue(selections.name)
-            assertTrue(selections.biography)
-            assertFalse(selections.image)
-        }
-
-    // ========== Apply Tests ==========
-
-    @Test
-    fun `apply successfully updates contributor via use case`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val searchResult = createSearchResult()
-            val profile = createProfile()
-            val updatedContributor = createContributor(name = "Updated Name")
-
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
-            everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
-            everySuspend { fixture.applyContributorMetadataUseCase.invoke(any()) } returns Success(updatedContributor)
-
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-            viewModel.selectCandidate(searchResult)
-            advanceUntilIdle()
-
-            // When
-            viewModel.apply()
-            advanceUntilIdle()
-
-            // Then
-            val state = viewModel.state.value
-            assertTrue(state.applySuccess)
-            assertFalse(state.isApplying)
-            assertNull(state.applyError)
-            assertEquals(updatedContributor, state.currentContributor)
-
-            // Verify use case was called
-            verifySuspend(VerifyMode.exactly(1)) {
-                fixture.applyContributorMetadataUseCase.invoke(any())
+                // Then - search should not be called
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.metadataRepository.searchContributors(any(), any())
+                }
             }
         }
 
-    @Test
-    fun `apply handles use case failure`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val searchResult = createSearchResult()
-            val profile = createProfile()
+        // ========== Search Tests ==========
 
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
-            everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation to the ViewModel.
-            everySuspend { fixture.applyContributorMetadataUseCase.invoke(any()) } returns
-                Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Server error"),
-                )
+        test("search updates state with results") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val searchResults =
+                    listOf(
+                        createSearchResult(asin = "B001", name = "Stephen King"),
+                        createSearchResult(asin = "B002", name = "Stephen King Jr"),
+                    )
 
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-            viewModel.selectCandidate(searchResult)
-            advanceUntilIdle()
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns searchResults
 
-            // When
-            viewModel.apply()
-            advanceUntilIdle()
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
 
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.applySuccess)
-            assertFalse(state.isApplying)
-            assertEquals("Server error", state.applyError)
-        }
+                // When - manual search with different query
+                viewModel.updateQuery("Stephen")
+                viewModel.search()
+                advanceUntilIdle()
 
-    @Test
-    fun `apply does nothing when no fields selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val searchResult = createSearchResult()
-            // Profile with nothing available
-            val profile =
-                ContributorMetadataProfile(
-                    asin = "B001ASIN01",
-                    name = "",
-                    biography = null,
-                    imageUrl = null,
-                )
-
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
-            everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
-
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
-            viewModel.selectCandidate(searchResult)
-            advanceUntilIdle()
-
-            // When
-            viewModel.apply()
-            advanceUntilIdle()
-
-            // Then - use case should not be called since no fields selected
-            verifySuspend(VerifyMode.exactly(0)) {
-                fixture.applyContributorMetadataUseCase.invoke(any())
+                // Then
+                val state = viewModel.state.value
+                state.searchResults.size shouldBe 2
+                (state.isSearching) shouldBe false
+                state.searchError shouldBe null
             }
         }
 
-    // ========== Field Toggle Tests ==========
+        test("search handles error gracefully") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
 
-    @Test
-    fun `toggleField updates selections`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns emptyList()
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } throws
+                    RuntimeException("Network error")
 
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
 
-            // Initial state - all true by default
-            assertTrue(viewModel.state.value.selections.name)
-
-            // When
-            viewModel.toggleField(ContributorMetadataField.NAME)
-
-            // Then
-            assertFalse(viewModel.state.value.selections.name)
-
-            // Toggle back
-            viewModel.toggleField(ContributorMetadataField.NAME)
-            assertTrue(viewModel.state.value.selections.name)
+                // Then
+                val state = viewModel.state.value
+                (state.isSearching) shouldBe false
+                state.searchError shouldBe "Network error"
+            }
         }
 
-    // ========== Region Change Tests ==========
+        test("search with blank query does nothing") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor(name = "")
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
 
-    @Test
-    fun `changeRegion updates state and re-searches`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor = createContributor()
-            val usResults = listOf(createSearchResult(name = "Stephen King US"))
-            val ukResults = listOf(createSearchResult(name = "Stephen King UK"))
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
 
-            every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
-            everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "us") } returns usResults
-            everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "uk") } returns ukResults
+                viewModel.updateQuery("   ") // Blank query
 
-            val viewModel = fixture.build()
-            viewModel.init("contributor-1")
-            advanceUntilIdle()
+                // When
+                viewModel.search()
+                advanceUntilIdle()
 
-            // Verify initial region and results
-            assertEquals(com.calypsan.listenup.client.presentation.metadata.AudibleRegion.US, viewModel.state.value.selectedRegion)
-            assertEquals(usResults, viewModel.state.value.searchResults)
-
-            // When
-            viewModel.changeRegion(com.calypsan.listenup.client.presentation.metadata.AudibleRegion.UK)
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(com.calypsan.listenup.client.presentation.metadata.AudibleRegion.UK, viewModel.state.value.selectedRegion)
-            assertEquals(ukResults, viewModel.state.value.searchResults)
+                // Then - search should not be called (only the auto-search check, which is skipped for blank name)
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.metadataRepository.searchContributors(any(), any())
+                }
+            }
         }
-}
+
+        // ========== Candidate Selection Tests ==========
+
+        test("selectCandidate loads profile") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val searchResult = createSearchResult()
+                val profile = createProfile()
+
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
+                everySuspend { fixture.metadataRepository.getContributorProfile("B001ASIN01") } returns profile
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.selectCandidate(searchResult)
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.state.value
+                state.selectedCandidate shouldBe searchResult
+                state.previewProfile shouldBe profile
+                (state.isLoadingPreview) shouldBe false
+                state.previewError shouldBe null
+            }
+        }
+
+        test("selectCandidate initializes field selections based on profile") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val searchResult = createSearchResult()
+                // Profile with name and biography but no image
+                val profile = createProfile(imageUrl = null)
+
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
+                everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+
+                // When
+                viewModel.selectCandidate(searchResult)
+                advanceUntilIdle()
+
+                // Then - image selection should be false since no image available
+                val selections = viewModel.state.value.selections
+                (selections.name) shouldBe true
+                (selections.biography) shouldBe true
+                (selections.image) shouldBe false
+            }
+        }
+
+        // ========== Apply Tests ==========
+
+        test("apply successfully updates contributor via use case") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val searchResult = createSearchResult()
+                val profile = createProfile()
+                val updatedContributor = createContributor(name = "Updated Name")
+
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
+                everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
+                everySuspend { fixture.applyContributorMetadataUseCase.invoke(any()) } returns Success(updatedContributor)
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+                viewModel.selectCandidate(searchResult)
+                advanceUntilIdle()
+
+                // When
+                viewModel.apply()
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.state.value
+                (state.applySuccess) shouldBe true
+                (state.isApplying) shouldBe false
+                state.applyError shouldBe null
+                state.currentContributor shouldBe updatedContributor
+
+                // Verify use case was called
+                verifySuspend(VerifyMode.exactly(1)) {
+                    fixture.applyContributorMetadataUseCase.invoke(any())
+                }
+            }
+        }
+
+        test("apply handles use case failure") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val searchResult = createSearchResult()
+                val profile = createProfile()
+
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
+                everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation to the ViewModel.
+                everySuspend { fixture.applyContributorMetadataUseCase.invoke(any()) } returns
+                    Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Server error"),
+                    )
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+                viewModel.selectCandidate(searchResult)
+                advanceUntilIdle()
+
+                // When
+                viewModel.apply()
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.state.value
+                (state.applySuccess) shouldBe false
+                (state.isApplying) shouldBe false
+                state.applyError shouldBe "Server error"
+            }
+        }
+
+        test("apply does nothing when no fields selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val searchResult = createSearchResult()
+                // Profile with nothing available
+                val profile =
+                    ContributorMetadataProfile(
+                        asin = "B001ASIN01",
+                        name = "",
+                        biography = null,
+                        imageUrl = null,
+                    )
+
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns listOf(searchResult)
+                everySuspend { fixture.metadataRepository.getContributorProfile(any()) } returns profile
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+                viewModel.selectCandidate(searchResult)
+                advanceUntilIdle()
+
+                // When
+                viewModel.apply()
+                advanceUntilIdle()
+
+                // Then - use case should not be called since no fields selected
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.applyContributorMetadataUseCase.invoke(any())
+                }
+            }
+        }
+
+        // ========== Field Toggle Tests ==========
+
+        test("toggleField updates selections") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors(any(), any()) } returns emptyList()
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+
+                // Initial state - all true by default
+                (viewModel.state.value.selections.name) shouldBe true
+
+                // When
+                viewModel.toggleField(ContributorMetadataField.NAME)
+
+                // Then
+                (viewModel.state.value.selections.name) shouldBe false
+
+                // Toggle back
+                viewModel.toggleField(ContributorMetadataField.NAME)
+                (viewModel.state.value.selections.name) shouldBe true
+            }
+        }
+
+        // ========== Region Change Tests ==========
+
+        test("changeRegion updates state and re-searches") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor = createContributor()
+                val usResults = listOf(createSearchResult(name = "Stephen King US"))
+                val ukResults = listOf(createSearchResult(name = "Stephen King UK"))
+
+                every { fixture.contributorRepository.observeById("contributor-1") } returns flowOf(contributor)
+                everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "us") } returns usResults
+                everySuspend { fixture.metadataRepository.searchContributors("Stephen King", "uk") } returns ukResults
+
+                val viewModel = fixture.build()
+                viewModel.init("contributor-1")
+                advanceUntilIdle()
+
+                // Verify initial region and results
+                viewModel.state.value.selectedRegion shouldBe com.calypsan.listenup.client.presentation.metadata.AudibleRegion.US
+                viewModel.state.value.searchResults shouldBe usResults
+
+                // When
+                viewModel.changeRegion(com.calypsan.listenup.client.presentation.metadata.AudibleRegion.UK)
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value.selectedRegion shouldBe com.calypsan.listenup.client.presentation.metadata.AudibleRegion.UK
+                viewModel.state.value.searchResults shouldBe ukResults
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryActionsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryActionsViewModelTest.kt
@@ -20,6 +20,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,12 +31,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
 
 /**
  * Tests for LibraryActionsViewModel.
@@ -51,435 +48,435 @@ import kotlin.test.assertIs
  * Uses Mokkery for mocking dependencies.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class LibraryActionsViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class LibraryActionsViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixtures ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val selectionManager = LibrarySelectionManager()
-        val userRepository: UserRepository = mock()
-        val collectionRepository: CollectionRepository = mock()
-        val shelfRepository: ShelfRepository = mock()
-        val addBooksToCollectionUseCase: AddBooksToCollectionUseCase = mock()
-        val refreshCollectionsUseCase: RefreshCollectionsUseCase = mock()
-        val addBooksToShelfUseCase: AddBooksToShelfUseCase = mock()
-        val createShelfUseCase: CreateShelfUseCase = mock()
+        // ========== Test Fixtures ==========
 
-        val userFlow = MutableStateFlow<User?>(null)
-        val collectionsFlow = MutableStateFlow<List<Collection>>(emptyList())
-        val shelvesFlow = MutableStateFlow<List<Shelf>>(emptyList())
+        class TestFixture {
+            val selectionManager = LibrarySelectionManager()
+            val userRepository: UserRepository = mock()
+            val collectionRepository: CollectionRepository = mock()
+            val shelfRepository: ShelfRepository = mock()
+            val addBooksToCollectionUseCase: AddBooksToCollectionUseCase = mock()
+            val refreshCollectionsUseCase: RefreshCollectionsUseCase = mock()
+            val addBooksToShelfUseCase: AddBooksToShelfUseCase = mock()
+            val createShelfUseCase: CreateShelfUseCase = mock()
 
-        fun build(): LibraryActionsViewModel =
-            LibraryActionsViewModel(
-                selectionManager = selectionManager,
-                userRepository = userRepository,
-                collectionRepository = collectionRepository,
-                shelfRepository = shelfRepository,
-                addBooksToCollectionUseCase = addBooksToCollectionUseCase,
-                refreshCollectionsUseCase = refreshCollectionsUseCase,
-                addBooksToShelfUseCase = addBooksToShelfUseCase,
-                createShelfUseCase = createShelfUseCase,
+            val userFlow = MutableStateFlow<User?>(null)
+            val collectionsFlow = MutableStateFlow<List<Collection>>(emptyList())
+            val shelvesFlow = MutableStateFlow<List<Shelf>>(emptyList())
+
+            fun build(): LibraryActionsViewModel =
+                LibraryActionsViewModel(
+                    selectionManager = selectionManager,
+                    userRepository = userRepository,
+                    collectionRepository = collectionRepository,
+                    shelfRepository = shelfRepository,
+                    addBooksToCollectionUseCase = addBooksToCollectionUseCase,
+                    refreshCollectionsUseCase = refreshCollectionsUseCase,
+                    addBooksToShelfUseCase = addBooksToShelfUseCase,
+                    createShelfUseCase = createShelfUseCase,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Default stubs for reactive observation
+            every { fixture.userRepository.observeCurrentUser() } returns fixture.userFlow
+            every { fixture.collectionRepository.observeAll() } returns fixture.collectionsFlow
+            every { fixture.shelfRepository.observeMyShelves(any()) } returns fixture.shelvesFlow
+
+            return fixture
+        }
+
+        // ========== Test Data Factories ==========
+
+        fun createUser(
+            id: String = "user-1",
+            email: String = "test@example.com",
+            displayName: String = "Test User",
+            isAdmin: Boolean = false,
+        ): User =
+            User(
+                id =
+                    UserId(id),
+                email = email,
+                displayName = displayName,
+                isAdmin = isAdmin,
+                createdAtMs = 1704067200000L,
+                updatedAtMs = 1704067200000L,
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
+        fun createCollection(
+            id: String = "collection-1",
+            name: String = "Test Collection",
+            bookCount: Int = 0,
+        ): Collection =
+            Collection(
+                id = id,
+                name = name,
+                bookCount = bookCount,
+                createdAtMs = 1704067200000L,
+                updatedAtMs = 1704067200000L,
+            )
 
-        // Default stubs for reactive observation
-        every { fixture.userRepository.observeCurrentUser() } returns fixture.userFlow
-        every { fixture.collectionRepository.observeAll() } returns fixture.collectionsFlow
-        every { fixture.shelfRepository.observeMyShelves(any()) } returns fixture.shelvesFlow
+        fun createShelf(
+            id: String = "shelf-1",
+            name: String = "My Shelf",
+            ownerId: String = "user-1",
+        ): Shelf =
+            Shelf(
+                id = id,
+                name = name,
+                description = "",
+                ownerId = ownerId,
+                ownerDisplayName = "Test User",
+                ownerAvatarColor = "#6B7280",
+                bookCount = 0,
+                totalDurationSeconds = 0,
+                createdAtMs = 1704067200000L,
+                updatedAtMs = 1704067200000L,
+            )
 
-        return fixture
-    }
-
-    // ========== Test Data Factories ==========
-
-    private fun createUser(
-        id: String = "user-1",
-        email: String = "test@example.com",
-        displayName: String = "Test User",
-        isAdmin: Boolean = false,
-    ): User =
-        User(
-            id =
-                UserId(id),
-            email = email,
-            displayName = displayName,
-            isAdmin = isAdmin,
-            createdAtMs = 1704067200000L,
-            updatedAtMs = 1704067200000L,
-        )
-
-    private fun createCollection(
-        id: String = "collection-1",
-        name: String = "Test Collection",
-        bookCount: Int = 0,
-    ): Collection =
-        Collection(
-            id = id,
-            name = name,
-            bookCount = bookCount,
-            createdAtMs = 1704067200000L,
-            updatedAtMs = 1704067200000L,
-        )
-
-    private fun createShelf(
-        id: String = "shelf-1",
-        name: String = "My Shelf",
-        ownerId: String = "user-1",
-    ): Shelf =
-        Shelf(
-            id = id,
-            name = name,
-            description = "",
-            ownerId = ownerId,
-            ownerDisplayName = "Test User",
-            ownerAvatarColor = "#6B7280",
-            bookCount = 0,
-            totalDurationSeconds = 0,
-            createdAtMs = 1704067200000L,
-            updatedAtMs = 1704067200000L,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Selection Mode Tests ==========
-
-    @Test
-    fun `selectionMode is None initially`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(SelectionMode.None, viewModel.selectionMode.value)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `selectionMode reflects selection manager state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-
-            // Then
-            val mode = assertIs<SelectionMode.Active>(viewModel.selectionMode.value)
-            assertEquals(setOf("book-1"), mode.selectedIds)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `selectionMode updates when manager changes`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-            assertEquals(SelectionMode.None, viewModel.selectionMode.value)
+        // ========== Selection Mode Tests ==========
 
-            // When
-            fixture.selectionManager.enterSelectionMode("book-1")
-            advanceUntilIdle()
+        test("selectionMode is None initially") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then
-            checkIs<SelectionMode.Active>(viewModel.selectionMode.value)
+                // Then
+                viewModel.selectionMode.value shouldBe SelectionMode.None
+            }
         }
 
-    // ========== addSelectedToCollection Tests ==========
+        test("selectionMode reflects selection manager state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-    @Test
-    fun `addSelectedToCollection does nothing when no books selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-
-            // When
-            viewModel.addSelectedToCollection("collection-1")
-            advanceUntilIdle()
-
-            // Then - use case should not be called, loading should be false
-            assertFalse(viewModel.isAddingToCollection.value)
+                // Then
+                val mode = viewModel.selectionMode.value.shouldBeInstanceOf<SelectionMode.Active>()
+                mode.selectedIds shouldBe setOf("book-1")
+            }
         }
 
-    @Test
-    fun `addSelectedToCollection calls use case with selected book IDs`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            fixture.selectionManager.toggleSelection("book-2")
-            everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("selectionMode updates when manager changes") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+                viewModel.selectionMode.value shouldBe SelectionMode.None
 
-            // When
-            viewModel.addSelectedToCollection("collection-1")
-            advanceUntilIdle()
+                // When
+                fixture.selectionManager.enterSelectionMode("book-1")
+                advanceUntilIdle()
 
-            // Then
-            verifySuspend { fixture.addBooksToCollectionUseCase("collection-1", any()) }
+                // Then
+                checkIs<SelectionMode.Active>(viewModel.selectionMode.value)
+            }
         }
 
-    @Test
-    fun `addSelectedToCollection clears selection on success`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-            checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+        // ========== addSelectedToCollection Tests ==========
 
-            // When
-            viewModel.addSelectedToCollection("collection-1")
-            advanceUntilIdle()
+        test("addSelectedToCollection does nothing when no books selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then
-            assertEquals(SelectionMode.None, fixture.selectionManager.selectionMode.value)
+                // When
+                viewModel.addSelectedToCollection("collection-1")
+                advanceUntilIdle()
+
+                // Then - use case should not be called, loading should be false
+                (viewModel.isAddingToCollection.value) shouldBe false
+            }
         }
 
-    @Test
-    fun `addSelectedToCollection does not clear selection on failure`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns
-                Failure(RuntimeException("Network error"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("addSelectedToCollection calls use case with selected book IDs") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                fixture.selectionManager.toggleSelection("book-2")
+                everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.addSelectedToCollection("collection-1")
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToCollection("collection-1")
+                advanceUntilIdle()
 
-            // Then - selection should still be active
-            checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+                // Then
+                verifySuspend { fixture.addBooksToCollectionUseCase("collection-1", any()) }
+            }
         }
 
-    @Test
-    fun `addSelectedToCollection sets and clears loading state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("addSelectedToCollection clears selection on success") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+                checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
 
-            // When
-            viewModel.addSelectedToCollection("collection-1")
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToCollection("collection-1")
+                advanceUntilIdle()
 
-            // Then - loading should be false after completion
-            assertFalse(viewModel.isAddingToCollection.value)
+                // Then
+                fixture.selectionManager.selectionMode.value shouldBe SelectionMode.None
+            }
         }
 
-    // ========== addSelectedToShelf Tests ==========
+        test("addSelectedToCollection does not clear selection on failure") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns
+                    Failure(RuntimeException("Network error"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-    @Test
-    fun `addSelectedToShelf does nothing when no books selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToCollection("collection-1")
+                advanceUntilIdle()
 
-            // When
-            viewModel.addSelectedToShelf("shelf-1")
-            advanceUntilIdle()
-
-            // Then - use case should not be called
-            assertFalse(viewModel.isAddingToShelf.value)
+                // Then - selection should still be active
+                checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+            }
         }
 
-    @Test
-    fun `addSelectedToShelf calls use case with selected book IDs`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("addSelectedToCollection sets and clears loading state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.addSelectedToShelf("shelf-1")
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToCollection("collection-1")
+                advanceUntilIdle()
 
-            // Then
-            verifySuspend { fixture.addBooksToShelfUseCase("shelf-1", any()) }
+                // Then - loading should be false after completion
+                (viewModel.isAddingToCollection.value) shouldBe false
+            }
         }
 
-    @Test
-    fun `addSelectedToShelf clears selection on success`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== addSelectedToShelf Tests ==========
 
-            // When
-            viewModel.addSelectedToShelf("shelf-1")
-            advanceUntilIdle()
+        test("addSelectedToShelf does nothing when no books selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then
-            assertEquals(SelectionMode.None, fixture.selectionManager.selectionMode.value)
+                // When
+                viewModel.addSelectedToShelf("shelf-1")
+                advanceUntilIdle()
+
+                // Then - use case should not be called
+                (viewModel.isAddingToShelf.value) shouldBe false
+            }
         }
 
-    @Test
-    fun `addSelectedToShelf does not clear selection on failure`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns
-                Failure(RuntimeException("Server error"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("addSelectedToShelf calls use case with selected book IDs") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.addSelectedToShelf("shelf-1")
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToShelf("shelf-1")
+                advanceUntilIdle()
 
-            // Then - selection should still be active
-            checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+                // Then
+                verifySuspend { fixture.addBooksToShelfUseCase("shelf-1", any()) }
+            }
         }
 
-    // ========== createShelfAndAddBooks Tests ==========
+        test("addSelectedToShelf clears selection on success") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-    @Test
-    fun `createShelfAndAddBooks does nothing when no books selected`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToShelf("shelf-1")
+                advanceUntilIdle()
 
-            // When
-            viewModel.createShelfAndAddBooks("New Shelf")
-            advanceUntilIdle()
-
-            // Then - use case should not be called
-            assertFalse(viewModel.isAddingToShelf.value)
+                // Then
+                fixture.selectionManager.selectionMode.value shouldBe SelectionMode.None
+            }
         }
 
-    @Test
-    fun `createShelfAndAddBooks creates shelf then adds books`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            val newShelf = createShelf(id = "new-shelf", name = "My New Shelf")
-            everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("addSelectedToShelf does not clear selection on failure") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns
+                    Failure(RuntimeException("Server error"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.createShelfAndAddBooks("My New Shelf")
-            advanceUntilIdle()
+                // When
+                viewModel.addSelectedToShelf("shelf-1")
+                advanceUntilIdle()
 
-            // Then
-            verifySuspend { fixture.createShelfUseCase("My New Shelf", null) }
-            verifySuspend { fixture.addBooksToShelfUseCase("new-shelf", any()) }
+                // Then - selection should still be active
+                checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+            }
         }
 
-    @Test
-    fun `createShelfAndAddBooks clears selection on success`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            val newShelf = createShelf()
-            everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== createShelfAndAddBooks Tests ==========
 
-            // When
-            viewModel.createShelfAndAddBooks("New Shelf")
-            advanceUntilIdle()
+        test("createShelfAndAddBooks does nothing when no books selected") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then
-            assertEquals(SelectionMode.None, fixture.selectionManager.selectionMode.value)
+                // When
+                viewModel.createShelfAndAddBooks("New Shelf")
+                advanceUntilIdle()
+
+                // Then - use case should not be called
+                (viewModel.isAddingToShelf.value) shouldBe false
+            }
         }
 
-    @Test
-    fun `createShelfAndAddBooks does not clear selection on shelf creation failure`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            everySuspend { fixture.createShelfUseCase(any(), any()) } returns
-                Failure(RuntimeException("Failed to create shelf"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("createShelfAndAddBooks creates shelf then adds books") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                val newShelf = createShelf(id = "new-shelf", name = "My New Shelf")
+                everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.createShelfAndAddBooks("New Shelf")
-            advanceUntilIdle()
+                // When
+                viewModel.createShelfAndAddBooks("My New Shelf")
+                advanceUntilIdle()
 
-            // Then - selection should still be active
-            checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+                // Then
+                verifySuspend { fixture.createShelfUseCase("My New Shelf", null) }
+                verifySuspend { fixture.addBooksToShelfUseCase("new-shelf", any()) }
+            }
         }
 
-    @Test
-    fun `createShelfAndAddBooks does not clear selection on addBooks failure`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            val newShelf = createShelf()
-            everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns
-                Failure(RuntimeException("Failed to add books"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("createShelfAndAddBooks clears selection on success") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                val newShelf = createShelf()
+                everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.createShelfAndAddBooks("New Shelf")
-            advanceUntilIdle()
+                // When
+                viewModel.createShelfAndAddBooks("New Shelf")
+                advanceUntilIdle()
 
-            // Then - selection should still be active
-            checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+                // Then
+                fixture.selectionManager.selectionMode.value shouldBe SelectionMode.None
+            }
         }
 
-    @Test
-    fun `createShelfAndAddBooks sets and clears loading state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.selectionManager.enterSelectionMode("book-1")
-            val newShelf = createShelf()
-            everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
-            everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("createShelfAndAddBooks does not clear selection on shelf creation failure") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                everySuspend { fixture.createShelfUseCase(any(), any()) } returns
+                    Failure(RuntimeException("Failed to create shelf"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.createShelfAndAddBooks("New Shelf")
-            advanceUntilIdle()
+                // When
+                viewModel.createShelfAndAddBooks("New Shelf")
+                advanceUntilIdle()
 
-            // Then - loading should be false after completion
-            assertFalse(viewModel.isAddingToShelf.value)
+                // Then - selection should still be active
+                checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+            }
         }
-}
+
+        test("createShelfAndAddBooks does not clear selection on addBooks failure") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                val newShelf = createShelf()
+                everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns
+                    Failure(RuntimeException("Failed to add books"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                // When
+                viewModel.createShelfAndAddBooks("New Shelf")
+                advanceUntilIdle()
+
+                // Then - selection should still be active
+                checkIs<SelectionMode.Active>(fixture.selectionManager.selectionMode.value)
+            }
+        }
+
+        test("createShelfAndAddBooks sets and clears loading state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.selectionManager.enterSelectionMode("book-1")
+                val newShelf = createShelf()
+                everySuspend { fixture.createShelfUseCase(any(), any()) } returns Success(newShelf)
+                everySuspend { fixture.addBooksToShelfUseCase(any(), any()) } returns Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                // When
+                viewModel.createShelfAndAddBooks("New Shelf")
+                advanceUntilIdle()
+
+                // Then - loading should be false after completion
+                (viewModel.isAddingToShelf.value) shouldBe false
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -28,6 +28,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,16 +38,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * Tests for LibraryViewModel.
@@ -59,921 +56,936 @@ import kotlin.test.assertIs
  * - Per-upstream .catch gracefully degrades to empty defaults on transient failures
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class LibraryViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class LibraryViewModelTest :
+    FunSpec({
 
-    // ========== Test Data Factories ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private fun createTestBook(
-        id: String = "book-1",
-        title: String = "Test Book",
-        authors: List<BookContributor> = listOf(BookContributor("author-1", "Test Author")),
-        duration: Long = 3_600_000L, // 1 hour
-        publishYear: Int? = 2023,
-        seriesName: String? = null,
-        seriesId: String? = null,
-        seriesSequence: String? = null,
-        addedAt: Timestamp = Timestamp(1000L),
-    ): BookListItem {
-        val seriesList =
-            if (seriesId != null && seriesName != null) {
-                listOf(BookSeries(seriesId = seriesId, seriesName = seriesName, sequence = seriesSequence))
-            } else {
-                emptyList()
-            }
-        return BookListItem(
-            id = BookId(id),
-            title = title,
-            authors = authors,
-            narrators = emptyList(),
-            duration = duration,
-            coverPath = null,
-            addedAt = addedAt,
-            updatedAt = addedAt,
-            publishYear = publishYear,
-            series = seriesList,
-        )
-    }
+        // ========== Test Data Factories ==========
 
-    private fun createTestSeries(
-        id: String = "series-1",
-        name: String = "Test Series",
-        createdAt: Timestamp = Timestamp(1000L),
-    ): Series =
-        Series(
-            id =
-                com.calypsan.listenup.client.core
-                    .SeriesId(id),
-            name = name,
-            description = null,
-            createdAt = createdAt,
-        )
-
-    private fun createTestContributor(
-        id: String = "contrib-1",
-        name: String = "Test Contributor",
-        bookCount: Int = 5,
-    ): ContributorWithBookCount =
-        ContributorWithBookCount(
-            contributor =
-                Contributor(
-                    id =
-                        com.calypsan.listenup.client.core
-                            .ContributorId(id),
-                    name = name,
-                    description = null,
-                    imagePath = null,
-                ),
-            bookCount = bookCount,
-        )
-
-    private fun createDummyBook(id: String): BookListItem {
-        val now =
-            Timestamp(
-                kotlin.time.Clock.System
-                    .now()
-                    .toEpochMilliseconds(),
+        fun createTestBook(
+            id: String = "book-1",
+            title: String = "Test Book",
+            authors: List<BookContributor> = listOf(BookContributor("author-1", "Test Author")),
+            duration: Long = 3_600_000L, // 1 hour
+            publishYear: Int? = 2023,
+            seriesName: String? = null,
+            seriesId: String? = null,
+            seriesSequence: String? = null,
+            addedAt: Timestamp = Timestamp(1000L),
+        ): BookListItem {
+            val seriesList =
+                if (seriesId != null && seriesName != null) {
+                    listOf(BookSeries(seriesId = seriesId, seriesName = seriesName, sequence = seriesSequence))
+                } else {
+                    emptyList()
+                }
+            return BookListItem(
+                id = BookId(id),
+                title = title,
+                authors = authors,
+                narrators = emptyList(),
+                duration = duration,
+                coverPath = null,
+                addedAt = addedAt,
+                updatedAt = addedAt,
+                publishYear = publishYear,
+                series = seriesList,
             )
-        return BookListItem(
-            id = BookId(id),
-            title = "Book $id",
-            coverPath = null,
-            duration = 3600000L,
-            authors = emptyList(),
-            narrators = emptyList(),
-            addedAt = now,
-            updatedAt = now,
-        )
-    }
-
-    // ========== Test Fixture Builder ==========
-
-    private class TestFixture {
-        val bookRepository: BookRepository = mock()
-        val seriesRepository: SeriesRepository = mock()
-        val contributorRepository: ContributorRepository = mock()
-        val syncRepository: SyncRepository = mock()
-        val authSession: AuthSession = mock()
-        val libraryPreferences: LibraryPreferences = mock()
-        val syncStatusRepository: SyncStatusRepository = mock()
-        val playbackPositionRepository: PlaybackPositionRepository = mock()
-        val selectionManager: LibrarySelectionManager = LibrarySelectionManager()
-
-        val syncStateFlow = MutableStateFlow<SyncState>(SyncState.Idle)
-
-        fun build(): LibraryViewModel =
-            LibraryViewModel(
-                bookRepository = bookRepository,
-                seriesRepository = seriesRepository,
-                contributorRepository = contributorRepository,
-                playbackPositionRepository = playbackPositionRepository,
-                syncRepository = syncRepository,
-                authSession = authSession,
-                libraryPreferences = libraryPreferences,
-                syncStatusRepository = syncStatusRepository,
-                selectionManager = selectionManager,
-            )
-    }
-
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs for all dependencies
-        every { fixture.bookRepository.observeBookListItems() } returns flowOf(emptyList<BookListItem>())
-        every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(emptyList())
-        every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.AUTHOR.apiValue) } returns
-            flowOf(emptyList())
-        every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.NARRATOR.apiValue) } returns
-            flowOf(emptyList())
-        every { fixture.syncRepository.syncState } returns fixture.syncStateFlow
-        every { fixture.syncRepository.isServerScanning } returns MutableStateFlow(false)
-        every { fixture.syncRepository.scanProgress } returns MutableStateFlow(null)
-        every { fixture.playbackPositionRepository.observeAll() } returns flowOf(emptyMap())
-
-        // Default library preferences stubs (no persisted state)
-        everySuspend { fixture.libraryPreferences.getBooksSortState() } returns null
-        everySuspend { fixture.libraryPreferences.getSeriesSortState() } returns null
-        everySuspend { fixture.libraryPreferences.getAuthorsSortState() } returns null
-        everySuspend { fixture.libraryPreferences.getNarratorsSortState() } returns null
-        everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns true
-        everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns true
-
-        return fixture
-    }
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    /**
-     * Keeps the ViewModel's `stateIn(WhileSubscribed)` pipeline hot so that
-     * the `combine` upstreams emit. Without a subscriber, `stateIn` sits on its
-     * `initialValue` (Loading).
-     */
-    private fun TestScope.keepStateHot(viewModel: LibraryViewModel) {
-        backgroundScope.launch { viewModel.uiState.collect { } }
-    }
-
-    // ========== Initial State Tests ==========
-
-    @Test
-    fun `initial state is Loading before pipeline subscribes`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-
-            // When - no keepStateHot, so stateIn sits on its initialValue
-            val viewModel = fixture.build()
-
-            // Then
-            assertIs<LibraryUiState.Loading>(viewModel.uiState.value)
         }
 
-    @Test
-    fun `pipeline transitions to Loaded after subscription`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-        }
-
-    // ========== Sort State Initialization Tests ==========
-
-    @Test
-    fun `initial books sort state is title ascending`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.TITLE, loaded.booksSortState.category)
-            assertEquals(SortDirection.ASCENDING, loaded.booksSortState.direction)
-        }
-
-    @Test
-    fun `initial series sort state is name ascending`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.NAME, loaded.seriesSortState.category)
-            assertEquals(SortDirection.ASCENDING, loaded.seriesSortState.direction)
-        }
-
-    @Test
-    fun `initial authors sort state is name ascending`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.NAME, loaded.authorsSortState.category)
-            assertEquals(SortDirection.ASCENDING, loaded.authorsSortState.direction)
-        }
-
-    @Test
-    fun `loads persisted books sort state on init`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.getBooksSortState() } returns "duration:descending"
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.DURATION, loaded.booksSortState.category)
-            assertEquals(SortDirection.DESCENDING, loaded.booksSortState.direction)
-        }
-
-    @Test
-    fun `loads persisted series sort state on init`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.getSeriesSortState() } returns "book_count:descending"
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.BOOK_COUNT, loaded.seriesSortState.category)
-            assertEquals(SortDirection.DESCENDING, loaded.seriesSortState.direction)
-        }
-
-    @Test
-    fun `ignores invalid persisted sort state`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.getBooksSortState() } returns "invalid:garbage"
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then - falls back to default
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.TITLE, loaded.booksSortState.category)
-            assertEquals(SortDirection.ASCENDING, loaded.booksSortState.direction)
-        }
-
-    // ========== Event Handling: Sort State Changes ==========
-
-    @Test
-    fun `BooksCategoryChanged updates books sort category`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.AUTHOR))
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.AUTHOR, loaded.booksSortState.category)
-        }
-
-    @Test
-    fun `BooksCategoryChanged uses category default direction`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When - DURATION defaults to DESCENDING
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.DURATION))
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortDirection.DESCENDING, loaded.booksSortState.direction)
-        }
-
-    @Test
-    fun `BooksDirectionToggled toggles sort direction`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            assertEquals(
-                SortDirection.ASCENDING,
-                assertIs<LibraryUiState.Loaded>(viewModel.uiState.value).booksSortState.direction,
+        fun createTestSeries(
+            id: String = "series-1",
+            name: String = "Test Series",
+            createdAt: Timestamp = Timestamp(1000L),
+        ): Series =
+            Series(
+                id =
+                    com.calypsan.listenup.client.core
+                        .SeriesId(id),
+                name = name,
+                description = null,
+                createdAt = createdAt,
             )
 
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksDirectionToggled)
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortDirection.DESCENDING, loaded.booksSortState.direction)
-        }
-
-    @Test
-    fun `sort state change persists to settings`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.YEAR))
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend { fixture.libraryPreferences.setBooksSortState("year:descending") }
-        }
-
-    @Test
-    fun `SeriesCategoryChanged updates series sort category`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setSeriesSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(LibraryUiEvent.SeriesCategoryChanged(SortCategory.BOOK_COUNT))
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.BOOK_COUNT, loaded.seriesSortState.category)
-        }
-
-    @Test
-    fun `AuthorsCategoryChanged updates authors sort category`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setAuthorsSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(LibraryUiEvent.AuthorsCategoryChanged(SortCategory.BOOK_COUNT))
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(SortCategory.BOOK_COUNT, loaded.authorsSortState.category)
-        }
-
-    // ========== Toggle Ignore Title Articles ==========
-
-    @Test
-    fun `ToggleIgnoreTitleArticles toggles preference`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            assertEquals(
-                true,
-                assertIs<LibraryUiState.Loaded>(viewModel.uiState.value).ignoreTitleArticles,
+        fun createTestContributor(
+            id: String = "contrib-1",
+            name: String = "Test Contributor",
+            bookCount: Int = 5,
+        ): ContributorWithBookCount =
+            ContributorWithBookCount(
+                contributor =
+                    Contributor(
+                        id =
+                            com.calypsan.listenup.client.core
+                                .ContributorId(id),
+                        name = name,
+                        description = null,
+                        imagePath = null,
+                    ),
+                bookCount = bookCount,
             )
 
-            // When
-            viewModel.onEvent(LibraryUiEvent.ToggleIgnoreTitleArticles)
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(false, loaded.ignoreTitleArticles)
-            verifySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(false) }
-        }
-
-    // ========== Books Sorting Tests ==========
-
-    @Test
-    fun `books sorted by title ascending`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "Zebra"),
-                    createTestBook(id = "2", title = "Apple"),
-                    createTestBook(id = "3", title = "Mango"),
+        fun createDummyBook(id: String): BookListItem {
+            val now =
+                Timestamp(
+                    kotlin.time.Clock.System
+                        .now()
+                        .toEpochMilliseconds(),
                 )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Apple", "Mango", "Zebra"), loaded.books.map { it.title })
+            return BookListItem(
+                id = BookId(id),
+                title = "Book $id",
+                coverPath = null,
+                duration = 3600000L,
+                authors = emptyList(),
+                narrators = emptyList(),
+                addedAt = now,
+                updatedAt = now,
+            )
         }
 
-    @Test
-    fun `books sorted by title descending`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "Apple"),
-                    createTestBook(id = "2", title = "Zebra"),
-                    createTestBook(id = "3", title = "Mango"),
+        // ========== Test Fixture Builder ==========
+
+        class TestFixture {
+            val bookRepository: BookRepository = mock()
+            val seriesRepository: SeriesRepository = mock()
+            val contributorRepository: ContributorRepository = mock()
+            val syncRepository: SyncRepository = mock()
+            val authSession: AuthSession = mock()
+            val libraryPreferences: LibraryPreferences = mock()
+            val syncStatusRepository: SyncStatusRepository = mock()
+            val playbackPositionRepository: PlaybackPositionRepository = mock()
+            val selectionManager: LibrarySelectionManager = LibrarySelectionManager()
+
+            val syncStateFlow = MutableStateFlow<SyncState>(SyncState.Idle)
+
+            fun build(): LibraryViewModel =
+                LibraryViewModel(
+                    bookRepository = bookRepository,
+                    seriesRepository = seriesRepository,
+                    contributorRepository = contributorRepository,
+                    playbackPositionRepository = playbackPositionRepository,
+                    syncRepository = syncRepository,
+                    authSession = authSession,
+                    libraryPreferences = libraryPreferences,
+                    syncStatusRepository = syncStatusRepository,
+                    selectionManager = selectionManager,
                 )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksDirectionToggled)
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Zebra", "Mango", "Apple"), loaded.books.map { it.title })
         }
 
-    @Test
-    fun `books sorted by title ignores leading articles when enabled`() =
-        runTest {
-            // Given - "The" should be ignored, so "The Zebra" sorts as "Zebra"
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "The Zebra"),
-                    createTestBook(id = "2", title = "Apple"),
-                    createTestBook(id = "3", title = "A Mango"),
-                )
-            val fixture = createFixture()
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Default stubs for all dependencies
+            every { fixture.bookRepository.observeBookListItems() } returns flowOf(emptyList<BookListItem>())
+            every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(emptyList())
+            every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.AUTHOR.apiValue) } returns
+                flowOf(emptyList())
+            every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.NARRATOR.apiValue) } returns
+                flowOf(emptyList())
+            every { fixture.syncRepository.syncState } returns fixture.syncStateFlow
+            every { fixture.syncRepository.isServerScanning } returns MutableStateFlow(false)
+            every { fixture.syncRepository.scanProgress } returns MutableStateFlow(null)
+            every { fixture.playbackPositionRepository.observeAll() } returns flowOf(emptyMap())
+
+            // Default library preferences stubs (no persisted state)
+            everySuspend { fixture.libraryPreferences.getBooksSortState() } returns null
+            everySuspend { fixture.libraryPreferences.getSeriesSortState() } returns null
+            everySuspend { fixture.libraryPreferences.getAuthorsSortState() } returns null
+            everySuspend { fixture.libraryPreferences.getNarratorsSortState() } returns null
             everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns true
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+            everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns true
 
-            // Then - Should sort as: Apple, A Mango (as "Mango"), The Zebra (as "Zebra")
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Apple", "A Mango", "The Zebra"), loaded.books.map { it.title })
+            return fixture
         }
 
-    @Test
-    fun `books sorted by author groups by author then title`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(
-                        id = "1",
-                        title = "Zebra Book",
-                        authors = listOf(BookContributor("a1", "Alice")),
-                    ),
-                    createTestBook(
-                        id = "2",
-                        title = "Apple Book",
-                        authors = listOf(BookContributor("b1", "Bob")),
-                    ),
-                    createTestBook(
-                        id = "3",
-                        title = "Cherry Book",
-                        authors = listOf(BookContributor("a1", "Alice")),
-                    ),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.AUTHOR))
-            advanceUntilIdle()
-
-            // Then - Alice's books first (then by title), then Bob's
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(
-                listOf("Cherry Book", "Zebra Book", "Apple Book"),
-                loaded.books.map { it.title },
-            )
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `books sorted by duration ascending`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "Long", duration = 10_000_000L),
-                    createTestBook(id = "2", title = "Short", duration = 1_000_000L),
-                    createTestBook(id = "3", title = "Medium", duration = 5_000_000L),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When - Change to duration, then toggle to ascending
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.DURATION))
-            advanceUntilIdle()
-            viewModel.onEvent(LibraryUiEvent.BooksDirectionToggled) // DURATION defaults DESC, toggle to ASC
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Short", "Medium", "Long"), loaded.books.map { it.title })
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `books sorted by year descending handles null publish years`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "Old", publishYear = 2020),
-                    createTestBook(id = "2", title = "No Year", publishYear = null),
-                    createTestBook(id = "3", title = "New", publishYear = 2024),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+        // ========== Initial State Tests ==========
 
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.YEAR))
-            advanceUntilIdle()
+        test("initial state is Loading before pipeline subscribes") {
+            runTest {
+                // Given
+                val fixture = createFixture()
 
-            // Then - Year DESC: newest first, null years go to end (treated as 0)
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("New", "Old", "No Year"), loaded.books.map { it.title })
+                // When - no keepStateHot, so stateIn sits on its initialValue
+                val viewModel = fixture.build()
+
+                // Then
+                viewModel.uiState.value.shouldBeInstanceOf<LibraryUiState.Loading>()
+            }
         }
 
-    @Test
-    fun `books sorted by added date descending`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "First", addedAt = Timestamp(1000L)),
-                    createTestBook(id = "2", title = "Last", addedAt = Timestamp(3000L)),
-                    createTestBook(id = "3", title = "Middle", addedAt = Timestamp(2000L)),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+        test("pipeline transitions to Loaded after subscription") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-            // When
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.ADDED))
-            advanceUntilIdle()
-
-            // Then - Added DESC: most recent first
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Last", "Middle", "First"), loaded.books.map { it.title })
+                // Then
+                viewModel.uiState.value.shouldBeInstanceOf<LibraryUiState.Loaded>()
+            }
         }
 
-    @Test
-    fun `books sorted by series groups by series then sequence then title`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "Book A", seriesId = "alpha", seriesName = "Alpha Series", seriesSequence = "2"),
-                    createTestBook(id = "2", title = "Book B", seriesId = "alpha", seriesName = "Alpha Series", seriesSequence = "1"),
-                    createTestBook(id = "3", title = "Standalone", seriesName = null, seriesSequence = null),
-                    createTestBook(id = "4", title = "Book C", seriesId = "beta", seriesName = "Beta Series", seriesSequence = "1"),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+        // ========== Sort State Initialization Tests ==========
 
-            // When - SERIES defaults to ASCENDING
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.SERIES))
-            advanceUntilIdle()
+        test("initial books sort state is title ascending") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-            // Then - Series ASC: Alpha (seq 1, 2), Beta (seq 1), then null series at end
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Book B", "Book A", "Book C", "Standalone"), loaded.books.map { it.title })
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksSortState.category shouldBe SortCategory.TITLE
+                loaded.booksSortState.direction shouldBe SortDirection.ASCENDING
+            }
         }
 
-    @Test
-    fun `books sorted by series handles decimal sequences`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "1", title = "Book 2", seriesName = "Series", seriesSequence = "2"),
-                    createTestBook(id = "2", title = "Book 1.5", seriesName = "Series", seriesSequence = "1.5"),
-                    createTestBook(id = "3", title = "Book 1", seriesName = "Series", seriesSequence = "1"),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+        test("initial series sort state is name ascending") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-            // When - SERIES defaults to ASCENDING
-            viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.SERIES))
-            advanceUntilIdle()
-
-            // Then - Should handle 1 < 1.5 < 2
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Book 1", "Book 1.5", "Book 2"), loaded.books.map { it.title })
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.seriesSortState.category shouldBe SortCategory.NAME
+                loaded.seriesSortState.direction shouldBe SortDirection.ASCENDING
+            }
         }
 
-    // ========== Series Sorting Tests ==========
+        test("initial authors sort state is name ascending") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-    @Test
-    fun `series sorted by name ascending`() =
-        runTest {
-            // Given - each series needs 2+ books to avoid filtering by hideSingleBookSeries
-            val seriesList =
-                listOf(
-                    SeriesWithBooks(
-                        series = createTestSeries(id = "1", name = "Zebra Series"),
-                        books = listOf(createDummyBook("z1"), createDummyBook("z2")),
-                        bookSequences = emptyMap(),
-                    ),
-                    SeriesWithBooks(
-                        series = createTestSeries(id = "2", name = "Apple Series"),
-                        books = listOf(createDummyBook("a1"), createDummyBook("a2")),
-                        bookSequences = emptyMap(),
-                    ),
-                )
-            val fixture = createFixture()
-            every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(seriesList)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Apple Series", "Zebra Series"), loaded.series.map { it.series.name })
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.authorsSortState.category shouldBe SortCategory.NAME
+                loaded.authorsSortState.direction shouldBe SortDirection.ASCENDING
+            }
         }
 
-    @Test
-    fun `series sorted by book count descending`() =
-        runTest {
-            // Given - each series needs 2+ books to avoid filtering by hideSingleBookSeries
-            val seriesList =
-                listOf(
-                    SeriesWithBooks(
-                        series = createTestSeries(id = "1", name = "Small"),
-                        books = listOf(createDummyBook("s1"), createDummyBook("s2")),
-                        bookSequences = emptyMap(),
-                    ),
-                    SeriesWithBooks(
-                        series = createTestSeries(id = "2", name = "Big"),
-                        books =
-                            listOf(
-                                createDummyBook("b1"),
-                                createDummyBook("b2"),
-                                createDummyBook("b3"),
+        test("loads persisted books sort state on init") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.getBooksSortState() } returns "duration:descending"
+
+                // When
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksSortState.category shouldBe SortCategory.DURATION
+                loaded.booksSortState.direction shouldBe SortDirection.DESCENDING
+            }
+        }
+
+        test("loads persisted series sort state on init") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.getSeriesSortState() } returns "book_count:descending"
+
+                // When
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.seriesSortState.category shouldBe SortCategory.BOOK_COUNT
+                loaded.seriesSortState.direction shouldBe SortDirection.DESCENDING
+            }
+        }
+
+        test("ignores invalid persisted sort state") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.getBooksSortState() } returns "invalid:garbage"
+
+                // When
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then - falls back to default
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksSortState.category shouldBe SortCategory.TITLE
+                loaded.booksSortState.direction shouldBe SortDirection.ASCENDING
+            }
+        }
+
+        // ========== Event Handling: Sort State Changes ==========
+
+        test("BooksCategoryChanged updates books sort category") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.AUTHOR))
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksSortState.category shouldBe SortCategory.AUTHOR
+            }
+        }
+
+        test("BooksCategoryChanged uses category default direction") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When - DURATION defaults to DESCENDING
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.DURATION))
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksSortState.direction shouldBe SortDirection.DESCENDING
+            }
+        }
+
+        test("BooksDirectionToggled toggles sort direction") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+                (viewModel.uiState.value as LibraryUiState.Loaded).booksSortState.direction shouldBe SortDirection.ASCENDING
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksDirectionToggled)
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksSortState.direction shouldBe SortDirection.DESCENDING
+            }
+        }
+
+        test("sort state change persists to settings") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.YEAR))
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.libraryPreferences.setBooksSortState("year:descending") }
+            }
+        }
+
+        test("SeriesCategoryChanged updates series sort category") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setSeriesSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.SeriesCategoryChanged(SortCategory.BOOK_COUNT))
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.seriesSortState.category shouldBe SortCategory.BOOK_COUNT
+            }
+        }
+
+        test("AuthorsCategoryChanged updates authors sort category") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setAuthorsSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.AuthorsCategoryChanged(SortCategory.BOOK_COUNT))
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.authorsSortState.category shouldBe SortCategory.BOOK_COUNT
+            }
+        }
+
+        // ========== Toggle Ignore Title Articles ==========
+
+        test("ToggleIgnoreTitleArticles toggles preference") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+                (viewModel.uiState.value as LibraryUiState.Loaded).ignoreTitleArticles shouldBe true
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.ToggleIgnoreTitleArticles)
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.ignoreTitleArticles shouldBe false
+                verifySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(false) }
+            }
+        }
+
+        // ========== Books Sorting Tests ==========
+
+        test("books sorted by title ascending") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Zebra"),
+                        createTestBook(id = "2", title = "Apple"),
+                        createTestBook(id = "3", title = "Mango"),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Apple", "Mango", "Zebra")
+            }
+        }
+
+        test("books sorted by title descending") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Apple"),
+                        createTestBook(id = "2", title = "Zebra"),
+                        createTestBook(id = "3", title = "Mango"),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksDirectionToggled)
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Zebra", "Mango", "Apple")
+            }
+        }
+
+        test("books sorted by title ignores leading articles when enabled") {
+            runTest {
+                // Given - "The" should be ignored, so "The Zebra" sorts as "Zebra"
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "The Zebra"),
+                        createTestBook(id = "2", title = "Apple"),
+                        createTestBook(id = "3", title = "A Mango"),
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns true
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then - Should sort as: Apple, A Mango (as "Mango"), The Zebra (as "Zebra")
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Apple", "A Mango", "The Zebra")
+            }
+        }
+
+        test("books sorted by author groups by author then title") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(
+                            id = "1",
+                            title = "Zebra Book",
+                            authors = listOf(BookContributor("a1", "Alice")),
+                        ),
+                        createTestBook(
+                            id = "2",
+                            title = "Apple Book",
+                            authors = listOf(BookContributor("b1", "Bob")),
+                        ),
+                        createTestBook(
+                            id = "3",
+                            title = "Cherry Book",
+                            authors = listOf(BookContributor("a1", "Alice")),
+                        ),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.AUTHOR))
+                advanceUntilIdle()
+
+                // Then - Alice's books first (then by title), then Bob's
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Cherry Book", "Zebra Book", "Apple Book")
+            }
+        }
+
+        test("books sorted by duration ascending") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Long", duration = 10_000_000L),
+                        createTestBook(id = "2", title = "Short", duration = 1_000_000L),
+                        createTestBook(id = "3", title = "Medium", duration = 5_000_000L),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When - Change to duration, then toggle to ascending
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.DURATION))
+                advanceUntilIdle()
+                viewModel.onEvent(LibraryUiEvent.BooksDirectionToggled) // DURATION defaults DESC, toggle to ASC
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Short", "Medium", "Long")
+            }
+        }
+
+        test("books sorted by year descending handles null publish years") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Old", publishYear = 2020),
+                        createTestBook(id = "2", title = "No Year", publishYear = null),
+                        createTestBook(id = "3", title = "New", publishYear = 2024),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.YEAR))
+                advanceUntilIdle()
+
+                // Then - Year DESC: newest first, null years go to end (treated as 0)
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("New", "Old", "No Year")
+            }
+        }
+
+        test("books sorted by added date descending") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "First", addedAt = Timestamp(1000L)),
+                        createTestBook(id = "2", title = "Last", addedAt = Timestamp(3000L)),
+                        createTestBook(id = "3", title = "Middle", addedAt = Timestamp(2000L)),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.ADDED))
+                advanceUntilIdle()
+
+                // Then - Added DESC: most recent first
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Last", "Middle", "First")
+            }
+        }
+
+        test("books sorted by series groups by series then sequence then title") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Book A", seriesId = "alpha", seriesName = "Alpha Series", seriesSequence = "2"),
+                        createTestBook(id = "2", title = "Book B", seriesId = "alpha", seriesName = "Alpha Series", seriesSequence = "1"),
+                        createTestBook(id = "3", title = "Standalone", seriesName = null, seriesSequence = null),
+                        createTestBook(id = "4", title = "Book C", seriesId = "beta", seriesName = "Beta Series", seriesSequence = "1"),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When - SERIES defaults to ASCENDING
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.SERIES))
+                advanceUntilIdle()
+
+                // Then - Series ASC: Alpha (seq 1, 2), Beta (seq 1), then null series at end
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Book B", "Book A", "Book C", "Standalone")
+            }
+        }
+
+        test("books sorted by series handles decimal sequences") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Book 2", seriesName = "Series", seriesSequence = "2"),
+                        createTestBook(id = "2", title = "Book 1.5", seriesName = "Series", seriesSequence = "1.5"),
+                        createTestBook(id = "3", title = "Book 1", seriesName = "Series", seriesSequence = "1"),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                everySuspend { fixture.libraryPreferences.setBooksSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When - SERIES defaults to ASCENDING
+                viewModel.onEvent(LibraryUiEvent.BooksCategoryChanged(SortCategory.SERIES))
+                advanceUntilIdle()
+
+                // Then - Should handle 1 < 1.5 < 2
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Book 1", "Book 1.5", "Book 2")
+            }
+        }
+
+        // ========== Series Sorting Tests ==========
+
+        test("series sorted by name ascending") {
+            runTest {
+                // Given - each series needs 2+ books to avoid filtering by hideSingleBookSeries
+                val seriesList =
+                    listOf(
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "1", name = "Zebra Series"),
+                            books = listOf(createDummyBook("z1"), createDummyBook("z2")),
+                            bookSequences = emptyMap(),
+                        ),
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "2", name = "Apple Series"),
+                            books = listOf(createDummyBook("a1"), createDummyBook("a2")),
+                            bookSequences = emptyMap(),
+                        ),
+                    )
+                val fixture = createFixture()
+                every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(seriesList)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.series.map { it.series.name } shouldBe listOf("Apple Series", "Zebra Series")
+            }
+        }
+
+        test("series sorted by book count descending") {
+            runTest {
+                // Given - each series needs 2+ books to avoid filtering by hideSingleBookSeries
+                val seriesList =
+                    listOf(
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "1", name = "Small"),
+                            books = listOf(createDummyBook("s1"), createDummyBook("s2")),
+                            bookSequences = emptyMap(),
+                        ),
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "2", name = "Big"),
+                            books =
+                                listOf(
+                                    createDummyBook("b1"),
+                                    createDummyBook("b2"),
+                                    createDummyBook("b3"),
+                                ),
+                            bookSequences = emptyMap(),
+                        ),
+                    )
+                val fixture = createFixture()
+                every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(seriesList)
+                everySuspend { fixture.libraryPreferences.setSeriesSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.SeriesCategoryChanged(SortCategory.BOOK_COUNT))
+                advanceUntilIdle()
+
+                // Then - Book count DESC: most books first
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.series.map { it.series.name } shouldBe listOf("Big", "Small")
+            }
+        }
+
+        // ========== Contributors Sorting Tests ==========
+
+        test("authors sorted by name ascending") {
+            runTest {
+                // Given
+                val authors =
+                    listOf(
+                        createTestContributor(id = "1", name = "Zelda"),
+                        createTestContributor(id = "2", name = "Adam"),
+                    )
+                val fixture = createFixture()
+                every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.AUTHOR.apiValue) } returns
+                    flowOf(authors)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.authors.map { it.contributor.name } shouldBe listOf("Adam", "Zelda")
+            }
+        }
+
+        test("authors sorted by book count descending") {
+            runTest {
+                // Given
+                val authors =
+                    listOf(
+                        createTestContributor(id = "1", name = "Few Books", bookCount = 2),
+                        createTestContributor(id = "2", name = "Many Books", bookCount = 10),
+                    )
+                val fixture = createFixture()
+                every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.AUTHOR.apiValue) } returns
+                    flowOf(authors)
+                everySuspend { fixture.libraryPreferences.setAuthorsSortState(any()) } returns Unit
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onEvent(LibraryUiEvent.AuthorsCategoryChanged(SortCategory.BOOK_COUNT))
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.authors.map { it.contributor.name } shouldBe listOf("Many Books", "Few Books")
+            }
+        }
+
+        // ========== Auto-Sync Tests ==========
+
+        test("onScreenVisible triggers sync when authenticated and never synced") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.authSession.getAccessToken() } returns AccessToken("token")
+                everySuspend { fixture.syncStatusRepository.getLastSyncTime() } returns null // Never synced
+                everySuspend { fixture.bookRepository.refreshBooks() } returns Success(Unit)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onScreenVisible()
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.bookRepository.refreshBooks() }
+            }
+        }
+
+        test("onScreenVisible does not sync when not authenticated") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.authSession.getAccessToken() } returns null // Not authenticated
+                everySuspend { fixture.syncStatusRepository.getLastSyncTime() } returns null
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // When
+                viewModel.onScreenVisible()
+                advanceUntilIdle()
+
+                // Then - refreshBooks should not be called (verified indirectly via absence of exception)
+            }
+        }
+
+        // ========== Book Progress Tests ==========
+
+        test("bookProgress calculates progress from positions and durations") {
+            runTest {
+                // Given
+                val books =
+                    listOf(
+                        createTestBook(id = "book-1", duration = 10_000L),
+                        createTestBook(id = "book-2", duration = 20_000L),
+                    )
+                val positions =
+                    mapOf(
+                        BookId("book-1") to
+                            PlaybackPosition(
+                                bookId = "book-1",
+                                positionMs = 5_000L, // 50% progress
+                                playbackSpeed = 1.0f,
+                                hasCustomSpeed = false,
+                                updatedAtMs = 0L,
+                                syncedAtMs = null,
+                                lastPlayedAtMs = null,
                             ),
-                        bookSequences = emptyMap(),
-                    ),
-                )
-            val fixture = createFixture()
-            every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(seriesList)
-            everySuspend { fixture.libraryPreferences.setSeriesSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+                        BookId("book-2") to
+                            PlaybackPosition(
+                                bookId = "book-2",
+                                positionMs = 10_000L, // 50% progress
+                                playbackSpeed = 1.0f,
+                                hasCustomSpeed = false,
+                                updatedAtMs = 0L,
+                                syncedAtMs = null,
+                                lastPlayedAtMs = null,
+                            ),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                every { fixture.playbackPositionRepository.observeAll() } returns flowOf(positions)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-            // When
-            viewModel.onEvent(LibraryUiEvent.SeriesCategoryChanged(SortCategory.BOOK_COUNT))
-            advanceUntilIdle()
-
-            // Then - Book count DESC: most books first
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Big", "Small"), loaded.series.map { it.series.name })
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.bookProgress[BookId("book-1")] shouldBe 0.5f
+                loaded.bookProgress[BookId("book-2")] shouldBe 0.5f
+            }
         }
 
-    // ========== Contributors Sorting Tests ==========
+        test("bookProgress includes completed books for completion badge") {
+            runTest {
+                // Given - book at 99%+ is considered complete
+                // (UI uses this to show completion badge instead of progress overlay)
+                val books =
+                    listOf(
+                        createTestBook(id = "book-1", duration = 10_000L),
+                    )
+                val positions =
+                    mapOf(
+                        BookId("book-1") to
+                            PlaybackPosition(
+                                bookId = "book-1",
+                                positionMs = 9_950L, // 99.5% - should be included for completion badge
+                                playbackSpeed = 1.0f,
+                                hasCustomSpeed = false,
+                                updatedAtMs = 0L,
+                                syncedAtMs = null,
+                                lastPlayedAtMs = null,
+                            ),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                every { fixture.playbackPositionRepository.observeAll() } returns flowOf(positions)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-    @Test
-    fun `authors sorted by name ascending`() =
-        runTest {
-            // Given
-            val authors =
-                listOf(
-                    createTestContributor(id = "1", name = "Zelda"),
-                    createTestContributor(id = "2", name = "Adam"),
-                )
-            val fixture = createFixture()
-            every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.AUTHOR.apiValue) } returns
-                flowOf(authors)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Adam", "Zelda"), loaded.authors.map { it.contributor.name })
+                // Then - completed book is included with its progress (for completion badge)
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.bookProgress[BookId("book-1")] shouldBe 0.995f
+            }
         }
 
-    @Test
-    fun `authors sorted by book count descending`() =
-        runTest {
-            // Given
-            val authors =
-                listOf(
-                    createTestContributor(id = "1", name = "Few Books", bookCount = 2),
-                    createTestContributor(id = "2", name = "Many Books", bookCount = 10),
-                )
-            val fixture = createFixture()
-            every { fixture.contributorRepository.observeContributorsByRole(ContributorRole.AUTHOR.apiValue) } returns
-                flowOf(authors)
-            everySuspend { fixture.libraryPreferences.setAuthorsSortState(any()) } returns Unit
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+        // ========== Per-Upstream Catch Tests ==========
 
-            // When
-            viewModel.onEvent(LibraryUiEvent.AuthorsCategoryChanged(SortCategory.BOOK_COUNT))
-            advanceUntilIdle()
+        test("transient observeBooks failure keeps state as Loaded with empty books") {
+            runTest {
+                // Given - book repository flow throws on first collect; per-upstream .catch emits empty list
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flow { throw RuntimeException("transient") }
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(listOf("Many Books", "Few Books"), loaded.authors.map { it.contributor.name })
+                // Then - state degrades gracefully to Loaded with empty books rather than Error
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.size shouldBe 0
+            }
         }
 
-    // ========== Auto-Sync Tests ==========
+        test("transient observeAll(positions) failure keeps state as Loaded with empty progress") {
+            runTest {
+                // Given - playback position flow throws on first collect; per-upstream .catch emits empty map
+                val fixture = createFixture()
+                every { fixture.playbackPositionRepository.observeAll() } returns flow { throw RuntimeException("transient") }
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
 
-    @Test
-    fun `onScreenVisible triggers sync when authenticated and never synced`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.authSession.getAccessToken() } returns AccessToken("token")
-            everySuspend { fixture.syncStatusRepository.getLastSyncTime() } returns null // Never synced
-            everySuspend { fixture.bookRepository.refreshBooks() } returns Success(Unit)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onScreenVisible()
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend { fixture.bookRepository.refreshBooks() }
+                // Then - state degrades gracefully to Loaded with empty progress maps rather than Error
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.bookProgress.size shouldBe 0
+                loaded.bookIsFinished.size shouldBe 0
+            }
         }
-
-    @Test
-    fun `onScreenVisible does not sync when not authenticated`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.authSession.getAccessToken() } returns null // Not authenticated
-            everySuspend { fixture.syncStatusRepository.getLastSyncTime() } returns null
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.onScreenVisible()
-            advanceUntilIdle()
-
-            // Then - refreshBooks should not be called (verified indirectly via absence of exception)
-        }
-
-    // ========== Book Progress Tests ==========
-
-    @Test
-    fun `bookProgress calculates progress from positions and durations`() =
-        runTest {
-            // Given
-            val books =
-                listOf(
-                    createTestBook(id = "book-1", duration = 10_000L),
-                    createTestBook(id = "book-2", duration = 20_000L),
-                )
-            val positions =
-                mapOf(
-                    BookId("book-1") to
-                        PlaybackPosition(
-                            bookId = "book-1",
-                            positionMs = 5_000L, // 50% progress
-                            playbackSpeed = 1.0f,
-                            hasCustomSpeed = false,
-                            updatedAtMs = 0L,
-                            syncedAtMs = null,
-                            lastPlayedAtMs = null,
-                        ),
-                    BookId("book-2") to
-                        PlaybackPosition(
-                            bookId = "book-2",
-                            positionMs = 10_000L, // 50% progress
-                            playbackSpeed = 1.0f,
-                            hasCustomSpeed = false,
-                            updatedAtMs = 0L,
-                            syncedAtMs = null,
-                            lastPlayedAtMs = null,
-                        ),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            every { fixture.playbackPositionRepository.observeAll() } returns flowOf(positions)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(0.5f, loaded.bookProgress[BookId("book-1")])
-            assertEquals(0.5f, loaded.bookProgress[BookId("book-2")])
-        }
-
-    @Test
-    fun `bookProgress includes completed books for completion badge`() =
-        runTest {
-            // Given - book at 99%+ is considered complete
-            // (UI uses this to show completion badge instead of progress overlay)
-            val books =
-                listOf(
-                    createTestBook(id = "book-1", duration = 10_000L),
-                )
-            val positions =
-                mapOf(
-                    BookId("book-1") to
-                        PlaybackPosition(
-                            bookId = "book-1",
-                            positionMs = 9_950L, // 99.5% - should be included for completion badge
-                            playbackSpeed = 1.0f,
-                            hasCustomSpeed = false,
-                            updatedAtMs = 0L,
-                            syncedAtMs = null,
-                            lastPlayedAtMs = null,
-                        ),
-                )
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
-            every { fixture.playbackPositionRepository.observeAll() } returns flowOf(positions)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then - completed book is included with its progress (for completion badge)
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(0.995f, loaded.bookProgress[BookId("book-1")])
-        }
-
-    // ========== Per-Upstream Catch Tests ==========
-
-    @Test
-    fun `transient observeBooks failure keeps state as Loaded with empty books`() =
-        runTest {
-            // Given - book repository flow throws on first collect; per-upstream .catch emits empty list
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeBookListItems() } returns flow { throw RuntimeException("transient") }
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then - state degrades gracefully to Loaded with empty books rather than Error
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(0, loaded.books.size)
-        }
-
-    @Test
-    fun `transient observeAll(positions) failure keeps state as Loaded with empty progress`() =
-        runTest {
-            // Given - playback position flow throws on first collect; per-upstream .catch emits empty map
-            val fixture = createFixture()
-            every { fixture.playbackPositionRepository.observeAll() } returns flow { throw RuntimeException("transient") }
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then - state degrades gracefully to Loaded with empty progress maps rather than Error
-            val loaded = assertIs<LibraryUiState.Loaded>(viewModel.uiState.value)
-            assertEquals(0, loaded.bookProgress.size)
-            assertEquals(0, loaded.bookIsFinished.size)
-        }
-}
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/seriesdetail/SeriesDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/seriesdetail/SeriesDetailViewModelTest.kt
@@ -13,265 +13,256 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SeriesDetailViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class SeriesDetailViewModelTest :
+    FunSpec({
 
-    private class TestFixture {
-        val seriesRepository: SeriesRepository = mock()
-        val imageRepository: ImageRepository = mock()
-        val seriesFlow = MutableStateFlow<SeriesWithBooks?>(null)
+        val testDispatcher = StandardTestDispatcher()
 
-        fun build(): SeriesDetailViewModel =
-            SeriesDetailViewModel(
-                seriesRepository = seriesRepository,
-                imageRepository = imageRepository,
+        class TestFixture {
+            val seriesRepository: SeriesRepository = mock()
+            val imageRepository: ImageRepository = mock()
+            val seriesFlow = MutableStateFlow<SeriesWithBooks?>(null)
+
+            fun build(): SeriesDetailViewModel =
+                SeriesDetailViewModel(
+                    seriesRepository = seriesRepository,
+                    imageRepository = imageRepository,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+            every { fixture.seriesRepository.observeSeriesWithBooks(any()) } returns fixture.seriesFlow
+            every { fixture.imageRepository.seriesCoverExists(any()) } returns false
+            return fixture
+        }
+
+        fun createSeries(
+            id: String = "series-1",
+            name: String = "Test Series",
+            description: String? = "A great series",
+        ): Series =
+            Series(
+                id =
+                    com.calypsan.listenup.client.core
+                        .SeriesId(id),
+                name = name,
+                description = description,
+                createdAt = Timestamp(1704067200000L),
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-        every { fixture.seriesRepository.observeSeriesWithBooks(any()) } returns fixture.seriesFlow
-        every { fixture.imageRepository.seriesCoverExists(any()) } returns false
-        return fixture
-    }
+        fun createBook(
+            id: String = "book-1",
+            title: String = "Test Book",
+            seriesSequence: String? = "1",
+            seriesId: String = "series-1",
+            seriesName: String = "Test Series",
+        ): BookListItem =
+            BookListItem(
+                id = BookId(id),
+                title = title,
+                subtitle = null,
+                authors = listOf(BookContributor(id = "author-1", name = "Author", roles = listOf("Author"))),
+                narrators = emptyList(),
+                duration = 3_600_000L,
+                coverPath = null,
+                addedAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
+                series = listOf(BookSeries(seriesId = seriesId, seriesName = seriesName, sequence = seriesSequence)),
+            )
 
-    private fun TestScope.keepStateHot(viewModel: SeriesDetailViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
+        fun createSeriesWithBooks(
+            series: Series,
+            books: List<BookListItem>,
+            bookSequences: Map<String, String?> = emptyMap(),
+        ): SeriesWithBooks =
+            SeriesWithBooks(
+                series = series,
+                books = books,
+                bookSequences = bookSequences,
+            )
 
-    private fun createSeries(
-        id: String = "series-1",
-        name: String = "Test Series",
-        description: String? = "A great series",
-    ): Series =
-        Series(
-            id =
-                com.calypsan.listenup.client.core
-                    .SeriesId(id),
-            name = name,
-            description = description,
-            createdAt = Timestamp(1704067200000L),
-        )
-
-    private fun createBook(
-        id: String = "book-1",
-        title: String = "Test Book",
-        seriesSequence: String? = "1",
-        seriesId: String = "series-1",
-        seriesName: String = "Test Series",
-    ): BookListItem =
-        BookListItem(
-            id = BookId(id),
-            title = title,
-            subtitle = null,
-            authors = listOf(BookContributor(id = "author-1", name = "Author", roles = listOf("Author"))),
-            narrators = emptyList(),
-            duration = 3_600_000L,
-            coverPath = null,
-            addedAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-            series = listOf(BookSeries(seriesId = seriesId, seriesName = seriesName, sequence = seriesSequence)),
-        )
-
-    private fun createSeriesWithBooks(
-        series: Series,
-        books: List<BookListItem>,
-        bookSequences: Map<String, String?> = emptyMap(),
-    ): SeriesWithBooks =
-        SeriesWithBooks(
-            series = series,
-            books = books,
-            bookSequences = bookSequences,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State ==========
-
-    @Test
-    fun `initial state is Idle pre-loadSeries`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            assertEquals(SeriesDetailUiState.Idle, viewModel.state.value)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    // ========== Load Series ==========
-
-    @Test
-    fun `loadSeries success populates series data`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries(name = "Epic Fantasy Series", description = "An epic adventure")
-            val book = createBook(id = "book-1", title = "Book One")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.loadSeries("series-1")
-            fixture.seriesFlow.value =
-                createSeriesWithBooks(
-                    series = series,
-                    books = listOf(book),
-                    bookSequences = mapOf("book-1" to "1"),
-                )
-            advanceUntilIdle()
-
-            val state = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Epic Fantasy Series", state.seriesName)
-            assertEquals("An epic adventure", state.seriesDescription)
-            assertEquals(1, state.books.size)
-            assertEquals("Book One", state.books[0].title)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `loadSeries not found sets error state`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        // ========== Initial State ==========
 
-            viewModel.loadSeries("nonexistent")
-            fixture.seriesFlow.value = null
-            advanceUntilIdle()
+        test("initial state is Idle pre-loadSeries") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+                advanceUntilIdle()
 
-            val state = assertIs<SeriesDetailUiState.Error>(viewModel.state.value)
-            assertEquals("Series not found", state.message)
+                viewModel.state.value shouldBe SeriesDetailUiState.Idle
+            }
         }
 
-    @Test
-    fun `loadSeries sorts books by sequence number`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries()
-            val book1 = createBook(id = "book-1", title = "Book One", seriesSequence = "1")
-            val book2 = createBook(id = "book-2", title = "Book Two", seriesSequence = "2")
-            val book3 = createBook(id = "book-3", title = "Book Three", seriesSequence = "1.5")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        // ========== Load Series ==========
 
-            viewModel.loadSeries("series-1")
-            fixture.seriesFlow.value =
-                createSeriesWithBooks(
-                    series = series,
-                    books = listOf(book2, book3, book1),
-                    bookSequences = mapOf("book-1" to "1", "book-2" to "2", "book-3" to "1.5"),
-                )
-            advanceUntilIdle()
+        test("loadSeries success populates series data") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries(name = "Epic Fantasy Series", description = "An epic adventure")
+                val book = createBook(id = "book-1", title = "Book One")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            val state = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(3, state.books.size)
-            assertEquals("Book One", state.books[0].title)
-            assertEquals("Book Three", state.books[1].title)
-            assertEquals("Book Two", state.books[2].title)
+                viewModel.loadSeries("series-1")
+                fixture.seriesFlow.value =
+                    createSeriesWithBooks(
+                        series = series,
+                        books = listOf(book),
+                        bookSequences = mapOf("book-1" to "1"),
+                    )
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                state.seriesName shouldBe "Epic Fantasy Series"
+                state.seriesDescription shouldBe "An epic adventure"
+                state.books.size shouldBe 1
+                state.books[0].title shouldBe "Book One"
+            }
         }
 
-    @Test
-    fun `loadSeries handles books with null sequence`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries()
-            val book1 = createBook(id = "book-1", title = "Numbered Book", seriesSequence = "1")
-            val book2 = createBook(id = "book-2", title = "Unnumbered Book", seriesSequence = null)
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadSeries not found sets error state") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadSeries("series-1")
-            fixture.seriesFlow.value =
-                createSeriesWithBooks(
-                    series = series,
-                    books = listOf(book2, book1),
-                    bookSequences = mapOf("book-1" to "1", "book-2" to null),
-                )
-            advanceUntilIdle()
+                viewModel.loadSeries("nonexistent")
+                fixture.seriesFlow.value = null
+                advanceUntilIdle()
 
-            val state = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(2, state.books.size)
-            assertEquals("Numbered Book", state.books[0].title)
-            assertEquals("Unnumbered Book", state.books[1].title)
+                val state = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Error>()
+                state.message shouldBe "Series not found"
+            }
         }
 
-    @Test
-    fun `loadSeries handles null series description`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries(description = null)
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadSeries sorts books by sequence number") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries()
+                val book1 = createBook(id = "book-1", title = "Book One", seriesSequence = "1")
+                val book2 = createBook(id = "book-2", title = "Book Two", seriesSequence = "2")
+                val book3 = createBook(id = "book-3", title = "Book Three", seriesSequence = "1.5")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadSeries("series-1")
-            fixture.seriesFlow.value = createSeriesWithBooks(series = series, books = emptyList())
-            advanceUntilIdle()
+                viewModel.loadSeries("series-1")
+                fixture.seriesFlow.value =
+                    createSeriesWithBooks(
+                        series = series,
+                        books = listOf(book2, book3, book1),
+                        bookSequences = mapOf("book-1" to "1", "book-2" to "2", "book-3" to "1.5"),
+                    )
+                advanceUntilIdle()
 
-            val state = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertNull(state.seriesDescription)
+                val state = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                state.books.size shouldBe 3
+                state.books[0].title shouldBe "Book One"
+                state.books[1].title shouldBe "Book Three"
+                state.books[2].title shouldBe "Book Two"
+            }
         }
 
-    @Test
-    fun `loadSeries handles empty books list`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries(name = "Empty Series")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadSeries handles books with null sequence") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries()
+                val book1 = createBook(id = "book-1", title = "Numbered Book", seriesSequence = "1")
+                val book2 = createBook(id = "book-2", title = "Unnumbered Book", seriesSequence = null)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadSeries("series-1")
-            fixture.seriesFlow.value = createSeriesWithBooks(series = series, books = emptyList())
-            advanceUntilIdle()
+                viewModel.loadSeries("series-1")
+                fixture.seriesFlow.value =
+                    createSeriesWithBooks(
+                        series = series,
+                        books = listOf(book2, book1),
+                        bookSequences = mapOf("book-1" to "1", "book-2" to null),
+                    )
+                advanceUntilIdle()
 
-            val state = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Empty Series", state.seriesName)
-            assertTrue(state.books.isEmpty())
+                val state = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                state.books.size shouldBe 2
+                state.books[0].title shouldBe "Numbered Book"
+                state.books[1].title shouldBe "Unnumbered Book"
+            }
         }
 
-    @Test
-    fun `loadSeries updates when flow emits new value`() =
-        runTest {
-            val fixture = createFixture()
-            val series1 = createSeries(name = "Original Name")
-            val series2 = createSeries(name = "Updated Name")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("loadSeries handles null series description") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries(description = null)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
 
-            viewModel.loadSeries("series-1")
-            fixture.seriesFlow.value = createSeriesWithBooks(series = series1, books = emptyList())
-            advanceUntilIdle()
-            val first = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Original Name", first.seriesName)
+                viewModel.loadSeries("series-1")
+                fixture.seriesFlow.value = createSeriesWithBooks(series = series, books = emptyList())
+                advanceUntilIdle()
 
-            fixture.seriesFlow.value = createSeriesWithBooks(series = series2, books = emptyList())
-            advanceUntilIdle()
-
-            val second = assertIs<SeriesDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Updated Name", second.seriesName)
+                val state = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                state.seriesDescription shouldBe null
+            }
         }
-}
+
+        test("loadSeries handles empty books list") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries(name = "Empty Series")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadSeries("series-1")
+                fixture.seriesFlow.value = createSeriesWithBooks(series = series, books = emptyList())
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                state.seriesName shouldBe "Empty Series"
+                (state.books.isEmpty()) shouldBe true
+            }
+        }
+
+        test("loadSeries updates when flow emits new value") {
+            runTest {
+                val fixture = createFixture()
+                val series1 = createSeries(name = "Original Name")
+                val series2 = createSeries(name = "Updated Name")
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadSeries("series-1")
+                fixture.seriesFlow.value = createSeriesWithBooks(series = series1, books = emptyList())
+                advanceUntilIdle()
+                val first = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                first.seriesName shouldBe "Original Name"
+
+                fixture.seriesFlow.value = createSeriesWithBooks(series = series2, books = emptyList())
+                advanceUntilIdle()
+
+                val second = viewModel.state.value.shouldBeInstanceOf<SeriesDetailUiState.Ready>()
+                second.seriesName shouldBe "Updated Name"
+            }
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/seriesedit/SeriesEditViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/seriesedit/SeriesEditViewModelTest.kt
@@ -16,6 +16,8 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -23,301 +25,294 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SeriesEditViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class SeriesEditViewModelTest :
+    FunSpec({
 
-    // ========== Test Fixture ==========
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val seriesRepository: SeriesRepository = mock()
-        val updateSeriesUseCase: UpdateSeriesUseCase = mock()
-        val imageRepository: ImageRepository = mock()
-        val imageStagingRepository: ImageStagingRepository = mock()
+        // ========== Test Fixture ==========
 
-        fun build(): SeriesEditViewModel =
-            SeriesEditViewModel(
-                seriesRepository = seriesRepository,
-                updateSeriesUseCase = updateSeriesUseCase,
-                imageRepository = imageRepository,
-                imageStagingRepository = imageStagingRepository,
-            )
-    }
+        class TestFixture {
+            val seriesRepository: SeriesRepository = mock()
+            val updateSeriesUseCase: UpdateSeriesUseCase = mock()
+            val imageRepository: ImageRepository = mock()
+            val imageStagingRepository: ImageStagingRepository = mock()
 
-    private fun createFixture(): TestFixture = TestFixture()
-
-    // ========== Test Data Factories ==========
-
-    private fun createSeries(
-        id: String = "series-1",
-        name: String = "Test Series",
-        description: String? = "A test series",
-    ) = Series(
-        id =
-            com.calypsan.listenup.client.core
-                .SeriesId(id),
-        name = name,
-        description = description,
-    )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Loading Tests ==========
-
-    @Test
-    fun `initial state is loading`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-
-            assertTrue(viewModel.state.value.isLoading)
-        }
-
-    @Test
-    fun `loadSeries populates state with series data`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns series
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-
-            assertFalse(viewModel.state.value.isLoading)
-            assertEquals("Test Series", viewModel.state.value.name)
-            assertEquals("A test series", viewModel.state.value.description)
-            assertEquals(1, viewModel.state.value.bookCount)
-        }
-
-    @Test
-    fun `loadSeries shows error for missing series`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("missing") } returns null
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("missing")
-            advanceUntilIdle()
-
-            assertFalse(viewModel.state.value.isLoading)
-            assertEquals("Series not found", viewModel.state.value.error)
-        }
-
-    // ========== Change Tracking Tests ==========
-
-    @Test
-    fun `NameChanged updates state and tracks changes`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-            assertFalse(viewModel.state.value.hasChanges)
-
-            viewModel.onEvent(SeriesEditUiEvent.NameChanged("New Name"))
-
-            assertEquals("New Name", viewModel.state.value.name)
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    @Test
-    fun `DescriptionChanged updates state and tracks changes`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-
-            viewModel.onEvent(SeriesEditUiEvent.DescriptionChanged("New description"))
-
-            assertEquals("New description", viewModel.state.value.description)
-            assertTrue(viewModel.state.value.hasChanges)
-        }
-
-    // ========== Save Tests ==========
-
-    @Test
-    fun `SaveClicked with no changes navigates back immediately`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-
-            viewModel.navActions.test {
-                viewModel.onEvent(SeriesEditUiEvent.SaveClicked)
-                advanceUntilIdle()
-                assertEquals(SeriesEditNavAction.NavigateBack, awaitItem())
-            }
-        }
-
-    @Test
-    fun `SaveClicked with changes calls use case`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-            everySuspend { fixture.updateSeriesUseCase.invoke(any()) } returns Success(Unit)
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-            viewModel.onEvent(SeriesEditUiEvent.NameChanged("Updated Name"))
-
-            viewModel.navActions.test {
-                viewModel.onEvent(SeriesEditUiEvent.SaveClicked)
-                advanceUntilIdle()
-                verifySuspend { fixture.updateSeriesUseCase.invoke(any()) }
-                assertEquals(SeriesEditNavAction.NavigateBack, awaitItem())
-            }
-        }
-
-    @Test
-    fun `SaveClicked shows error when use case fails`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation to the ViewModel.
-            everySuspend { fixture.updateSeriesUseCase.invoke(any()) } returns
-                Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Save failed"),
+            fun build(): SeriesEditViewModel =
+                SeriesEditViewModel(
+                    seriesRepository = seriesRepository,
+                    updateSeriesUseCase = updateSeriesUseCase,
+                    imageRepository = imageRepository,
+                    imageStagingRepository = imageStagingRepository,
                 )
+        }
 
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-            viewModel.onEvent(SeriesEditUiEvent.NameChanged("Updated Name"))
+        fun createFixture(): TestFixture = TestFixture()
 
-            viewModel.onEvent(SeriesEditUiEvent.SaveClicked)
-            advanceUntilIdle()
+        // ========== Test Data Factories ==========
 
-            assertEquals("Failed to save: Save failed", viewModel.state.value.error)
-            viewModel.navActions.test {
-                expectNoEvents()
+        fun createSeries(
+            id: String = "series-1",
+            name: String = "Test Series",
+            description: String? = "A test series",
+        ) = Series(
+            id =
+                com.calypsan.listenup.client.core
+                    .SeriesId(id),
+            name = name,
+            description = description,
+        )
+
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
+        }
+
+        afterTest {
+            Dispatchers.resetMain()
+        }
+
+        // ========== Loading Tests ==========
+
+        test("initial state is loading") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+
+                (viewModel.state.value.isLoading) shouldBe true
             }
         }
 
-    // ========== Cancel Tests ==========
+        test("loadSeries populates state with series data") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns series
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
 
-    @Test
-    fun `CancelClicked navigates back`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-            everySuspend { fixture.imageStagingRepository.deleteSeriesCoverStaging(any()) } returns Success(Unit)
-
-            val viewModel = fixture.build()
-            viewModel.loadSeries("series-1")
-            advanceUntilIdle()
-
-            viewModel.navActions.test {
-                viewModel.onEvent(SeriesEditUiEvent.CancelClicked)
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
                 advanceUntilIdle()
-                assertEquals(SeriesEditNavAction.NavigateBack, awaitItem())
+
+                (viewModel.state.value.isLoading) shouldBe false
+                viewModel.state.value.name shouldBe "Test Series"
+                viewModel.state.value.description shouldBe "A test series"
+                viewModel.state.value.bookCount shouldBe 1
             }
         }
 
-    // ========== Error Handling Tests ==========
+        test("loadSeries shows error for missing series") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("missing") } returns null
 
-    @Test
-    fun `ErrorDismissed clears error`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.seriesRepository.getById("missing") } returns null
+                val viewModel = fixture.build()
+                viewModel.loadSeries("missing")
+                advanceUntilIdle()
 
-            val viewModel = fixture.build()
-            viewModel.loadSeries("missing")
-            advanceUntilIdle()
-            assertTrue(viewModel.state.value.error != null)
-
-            viewModel.onEvent(SeriesEditUiEvent.ErrorDismissed)
-
-            assertNull(viewModel.state.value.error)
-        }
-
-    // ========== Staging cleanup on clear ==========
-
-    @Test
-    fun `onCleared requests staging cleanup when staging cover is present`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries(id = "series-1")
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns series
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns emptyList()
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-            everySuspend { fixture.imageStagingRepository.saveSeriesCoverStaging("series-1", any()) } returns Success(Unit)
-            every { fixture.imageStagingRepository.getSeriesCoverStagingPath("series-1") } returns "/tmp/staging-series-1.jpg"
-            every { fixture.imageStagingRepository.requestSeriesCoverStagingCleanup(any()) } returns Unit
-
-            val vm = fixture.build()
-            vm.loadSeries("series-1")
-            advanceUntilIdle()
-            vm.onEvent(SeriesEditUiEvent.CoverSelected(byteArrayOf(1, 2, 3), "cover.jpg"))
-            advanceUntilIdle()
-
-            vm.invokeOnCleared()
-
-            verify { fixture.imageStagingRepository.requestSeriesCoverStagingCleanup("series-1") }
-        }
-
-    @Test
-    fun `onCleared does not request cleanup when no staging cover exists`() =
-        runTest {
-            val fixture = createFixture()
-            val series = createSeries(id = "series-1")
-            everySuspend { fixture.seriesRepository.getById("series-1") } returns series
-            everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns emptyList()
-            everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
-
-            val vm = fixture.build()
-            vm.loadSeries("series-1")
-            advanceUntilIdle()
-
-            vm.invokeOnCleared()
-
-            verify(mode = VerifyMode.not) {
-                fixture.imageStagingRepository.requestSeriesCoverStagingCleanup(any())
+                (viewModel.state.value.isLoading) shouldBe false
+                viewModel.state.value.error shouldBe "Series not found"
             }
         }
-}
+
+        // ========== Change Tracking Tests ==========
+
+        test("NameChanged updates state and tracks changes") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
+                advanceUntilIdle()
+                (viewModel.state.value.hasChanges) shouldBe false
+
+                viewModel.onEvent(SeriesEditUiEvent.NameChanged("New Name"))
+
+                viewModel.state.value.name shouldBe "New Name"
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        test("DescriptionChanged updates state and tracks changes") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
+                advanceUntilIdle()
+
+                viewModel.onEvent(SeriesEditUiEvent.DescriptionChanged("New description"))
+
+                viewModel.state.value.description shouldBe "New description"
+                (viewModel.state.value.hasChanges) shouldBe true
+            }
+        }
+
+        // ========== Save Tests ==========
+
+        test("SaveClicked with no changes navigates back immediately") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
+                advanceUntilIdle()
+
+                viewModel.navActions.test {
+                    viewModel.onEvent(SeriesEditUiEvent.SaveClicked)
+                    advanceUntilIdle()
+                    awaitItem() shouldBe SeriesEditNavAction.NavigateBack
+                }
+            }
+        }
+
+        test("SaveClicked with changes calls use case") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+                everySuspend { fixture.updateSeriesUseCase.invoke(any()) } returns Success(Unit)
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
+                advanceUntilIdle()
+                viewModel.onEvent(SeriesEditUiEvent.NameChanged("Updated Name"))
+
+                viewModel.navActions.test {
+                    viewModel.onEvent(SeriesEditUiEvent.SaveClicked)
+                    advanceUntilIdle()
+                    verifySuspend { fixture.updateSeriesUseCase.invoke(any()) }
+                    awaitItem() shouldBe SeriesEditNavAction.NavigateBack
+                }
+            }
+        }
+
+        test("SaveClicked shows error when use case fails") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation to the ViewModel.
+                everySuspend { fixture.updateSeriesUseCase.invoke(any()) } returns
+                    Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Save failed"),
+                    )
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
+                advanceUntilIdle()
+                viewModel.onEvent(SeriesEditUiEvent.NameChanged("Updated Name"))
+
+                viewModel.onEvent(SeriesEditUiEvent.SaveClicked)
+                advanceUntilIdle()
+
+                viewModel.state.value.error shouldBe "Failed to save: Save failed"
+                viewModel.navActions.test {
+                    expectNoEvents()
+                }
+            }
+        }
+
+        // ========== Cancel Tests ==========
+
+        test("CancelClicked navigates back") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns createSeries()
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns listOf("book-1")
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+                everySuspend { fixture.imageStagingRepository.deleteSeriesCoverStaging(any()) } returns Success(Unit)
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("series-1")
+                advanceUntilIdle()
+
+                viewModel.navActions.test {
+                    viewModel.onEvent(SeriesEditUiEvent.CancelClicked)
+                    advanceUntilIdle()
+                    awaitItem() shouldBe SeriesEditNavAction.NavigateBack
+                }
+            }
+        }
+
+        // ========== Error Handling Tests ==========
+
+        test("ErrorDismissed clears error") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.seriesRepository.getById("missing") } returns null
+
+                val viewModel = fixture.build()
+                viewModel.loadSeries("missing")
+                advanceUntilIdle()
+                (viewModel.state.value.error != null) shouldBe true
+
+                viewModel.onEvent(SeriesEditUiEvent.ErrorDismissed)
+
+                viewModel.state.value.error shouldBe null
+            }
+        }
+
+        // ========== Staging cleanup on clear ==========
+
+        test("onCleared requests staging cleanup when staging cover is present") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries(id = "series-1")
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns series
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns emptyList()
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+                everySuspend { fixture.imageStagingRepository.saveSeriesCoverStaging("series-1", any()) } returns Success(Unit)
+                every { fixture.imageStagingRepository.getSeriesCoverStagingPath("series-1") } returns "/tmp/staging-series-1.jpg"
+                every { fixture.imageStagingRepository.requestSeriesCoverStagingCleanup(any()) } returns Unit
+
+                val vm = fixture.build()
+                vm.loadSeries("series-1")
+                advanceUntilIdle()
+                vm.onEvent(SeriesEditUiEvent.CoverSelected(byteArrayOf(1, 2, 3), "cover.jpg"))
+                advanceUntilIdle()
+
+                vm.invokeOnCleared()
+
+                verify { fixture.imageStagingRepository.requestSeriesCoverStagingCleanup("series-1") }
+            }
+        }
+
+        test("onCleared does not request cleanup when no staging cover exists") {
+            runTest {
+                val fixture = createFixture()
+                val series = createSeries(id = "series-1")
+                everySuspend { fixture.seriesRepository.getById("series-1") } returns series
+                everySuspend { fixture.seriesRepository.getBookIdsForSeries("series-1") } returns emptyList()
+                everySuspend { fixture.imageRepository.seriesCoverExists("series-1") } returns false
+
+                val vm = fixture.build()
+                vm.loadSeries("series-1")
+                advanceUntilIdle()
+
+                vm.invokeOnCleared()
+
+                verify(mode = VerifyMode.not) {
+                    fixture.imageStagingRepository.requestSeriesCoverStagingCleanup(any())
+                }
+            }
+        }
+    })
 
 private fun androidx.lifecycle.ViewModel.invokeOnCleared() {
     this.javaClass.superclass

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDaoTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDaoTest.kt
@@ -16,85 +16,100 @@ import kotlinx.coroutines.test.runTest
  */
 class AudioFileDaoTest :
     FunSpec({
-        lateinit var db: ListenUpDatabase
-        lateinit var bookDao: BookDao
-        lateinit var audioFileDao: AudioFileDao
-
-        beforeTest {
-            db = createInMemoryTestDatabase()
-            bookDao = db.bookDao()
-            audioFileDao = db.audioFileDao()
-        }
-
-        afterTest {
-            db.close()
-        }
 
         test("upsertAll and getForBook returns rows ordered by index ASC") {
-            runTest {
-                audioFileSeedBook(bookDao)
-                audioFileDao.upsertAll(
-                    listOf(
-                        audioFile(index = 2),
-                        audioFile(index = 0),
-                        audioFile(index = 1),
-                    ),
-                )
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val audioFileDao = db.audioFileDao()
+                    audioFileSeedBook(bookDao)
+                    audioFileDao.upsertAll(
+                        listOf(
+                            audioFile(index = 2),
+                            audioFile(index = 0),
+                            audioFile(index = 1),
+                        ),
+                    )
 
-                val result = audioFileDao.getForBook("b1")
+                    val result = audioFileDao.getForBook("b1")
 
-                result.map { it.index } shouldBe listOf(0, 1, 2)
+                    result.map { it.index } shouldBe listOf(0, 1, 2)
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("deleteForBook removes only that book's rows") {
-            runTest {
-                audioFileSeedBook(bookDao, id = "b1")
-                audioFileSeedBook(bookDao, id = "b2")
-                audioFileDao.upsertAll(
-                    listOf(
-                        audioFile(bookId = "b1", index = 0),
-                        audioFile(bookId = "b2", index = 0),
-                    ),
-                )
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val audioFileDao = db.audioFileDao()
+                    audioFileSeedBook(bookDao, id = "b1")
+                    audioFileSeedBook(bookDao, id = "b2")
+                    audioFileDao.upsertAll(
+                        listOf(
+                            audioFile(bookId = "b1", index = 0),
+                            audioFile(bookId = "b2", index = 0),
+                        ),
+                    )
 
-                audioFileDao.deleteForBook("b1")
+                    audioFileDao.deleteForBook("b1")
 
-                audioFileDao.getForBook("b1").isEmpty() shouldBe true
-                audioFileDao.getForBook("b2").map { it.index } shouldBe listOf(0)
+                    audioFileDao.getForBook("b1").isEmpty() shouldBe true
+                    audioFileDao.getForBook("b2").map { it.index } shouldBe listOf(0)
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("cascade delete removes rows when book is deleted") {
-            runTest {
-                audioFileSeedBook(bookDao, id = "b1")
-                audioFileDao.upsertAll(
-                    listOf(
-                        audioFile(bookId = "b1", index = 0),
-                        audioFile(bookId = "b1", index = 1),
-                    ),
-                )
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val audioFileDao = db.audioFileDao()
+                    audioFileSeedBook(bookDao, id = "b1")
+                    audioFileDao.upsertAll(
+                        listOf(
+                            audioFile(bookId = "b1", index = 0),
+                            audioFile(bookId = "b1", index = 1),
+                        ),
+                    )
 
-                bookDao.deleteById(BookId("b1"))
+                    bookDao.deleteById(BookId("b1"))
 
-                audioFileDao.getForBook("b1").isEmpty() shouldBe true
+                    audioFileDao.getForBook("b1").isEmpty() shouldBe true
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("upsert with same composite PK replaces existing row") {
-            runTest {
-                audioFileSeedBook(bookDao)
-                audioFileDao.upsertAll(
-                    listOf(audioFile(index = 0, id = "old-id", filename = "old.m4b")),
-                )
-                audioFileDao.upsertAll(
-                    listOf(audioFile(index = 0, id = "new-id", filename = "new.m4b")),
-                )
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val audioFileDao = db.audioFileDao()
+                    audioFileSeedBook(bookDao)
+                    audioFileDao.upsertAll(
+                        listOf(audioFile(index = 0, id = "old-id", filename = "old.m4b")),
+                    )
+                    audioFileDao.upsertAll(
+                        listOf(audioFile(index = 0, id = "new-id", filename = "new.m4b")),
+                    )
 
-                val result = audioFileDao.getForBook("b1")
-                result.size shouldBe 1
-                result.first().id shouldBe "new-id"
-                result.first().filename shouldBe "new.m4b"
+                    val result = audioFileDao.getForBook("b1")
+                    result.size shouldBe 1
+                    result.first().id shouldBe "new-id"
+                    result.first().filename shouldBe "new.m4b"
+                }
+            } finally {
+                db.close()
             }
         }
     })

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDaoTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDaoTest.kt
@@ -3,11 +3,9 @@ package com.calypsan.listenup.client.data.local.db
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Verifies [AudioFileDao] against a real in-memory [ListenUpDatabase].
@@ -16,125 +14,134 @@ import kotlin.test.assertTrue
  * ordering by index ASC, Flow re-emission on upsert, scoped deletes, and
  * FK CASCADE on book deletion.
  */
-class AudioFileDaoTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val bookDao = db.bookDao()
-    private val audioFileDao = db.audioFileDao()
+class AudioFileDaoTest :
+    FunSpec({
+        lateinit var db: ListenUpDatabase
+        lateinit var bookDao: BookDao
+        lateinit var audioFileDao: AudioFileDao
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    private suspend fun seedBook(id: String = "b1") {
-        bookDao.upsert(
-            BookEntity(
-                id = BookId(id),
-                title = "Test $id",
-                sortTitle = "Test $id",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 0L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
-
-    private fun audioFile(
-        bookId: String = "b1",
-        index: Int,
-        id: String = "af-$bookId-$index",
-        filename: String = "chapter${index + 1}.m4b",
-        duration: Long = 1_800_000L,
-    ): AudioFileEntity =
-        AudioFileEntity(
-            bookId = BookId(bookId),
-            index = index,
-            id = id,
-            filename = filename,
-            format = "m4b",
-            codec = "aac",
-            duration = duration,
-            size = 45_000_000L,
-        )
-
-    @Test
-    fun `upsertAll and getForBook returns rows ordered by index ASC`() =
-        runTest {
-            seedBook()
-            audioFileDao.upsertAll(
-                listOf(
-                    audioFile(index = 2),
-                    audioFile(index = 0),
-                    audioFile(index = 1),
-                ),
-            )
-
-            val result = audioFileDao.getForBook("b1")
-
-            assertEquals(listOf(0, 1, 2), result.map { it.index })
+        beforeTest {
+            db = createInMemoryTestDatabase()
+            bookDao = db.bookDao()
+            audioFileDao = db.audioFileDao()
         }
 
-    @Test
-    fun `deleteForBook removes only that book's rows`() =
-        runTest {
-            seedBook(id = "b1")
-            seedBook(id = "b2")
-            audioFileDao.upsertAll(
-                listOf(
-                    audioFile(bookId = "b1", index = 0),
-                    audioFile(bookId = "b2", index = 0),
-                ),
-            )
-
-            audioFileDao.deleteForBook("b1")
-
-            assertTrue(audioFileDao.getForBook("b1").isEmpty())
-            assertEquals(listOf(0), audioFileDao.getForBook("b2").map { it.index })
+        afterTest {
+            db.close()
         }
 
-    @Test
-    fun `cascade delete removes rows when book is deleted`() =
-        runTest {
-            seedBook(id = "b1")
-            audioFileDao.upsertAll(
-                listOf(
-                    audioFile(bookId = "b1", index = 0),
-                    audioFile(bookId = "b1", index = 1),
-                ),
-            )
+        test("upsertAll and getForBook returns rows ordered by index ASC") {
+            runTest {
+                audioFileSeedBook(bookDao)
+                audioFileDao.upsertAll(
+                    listOf(
+                        audioFile(index = 2),
+                        audioFile(index = 0),
+                        audioFile(index = 1),
+                    ),
+                )
 
-            bookDao.deleteById(BookId("b1"))
+                val result = audioFileDao.getForBook("b1")
 
-            assertTrue(audioFileDao.getForBook("b1").isEmpty())
+                result.map { it.index } shouldBe listOf(0, 1, 2)
+            }
         }
 
-    @Test
-    fun `upsert with same composite PK replaces existing row`() =
-        runTest {
-            seedBook()
-            audioFileDao.upsertAll(
-                listOf(audioFile(index = 0, id = "old-id", filename = "old.m4b")),
-            )
-            audioFileDao.upsertAll(
-                listOf(audioFile(index = 0, id = "new-id", filename = "new.m4b")),
-            )
+        test("deleteForBook removes only that book's rows") {
+            runTest {
+                audioFileSeedBook(bookDao, id = "b1")
+                audioFileSeedBook(bookDao, id = "b2")
+                audioFileDao.upsertAll(
+                    listOf(
+                        audioFile(bookId = "b1", index = 0),
+                        audioFile(bookId = "b2", index = 0),
+                    ),
+                )
 
-            val result = audioFileDao.getForBook("b1")
-            assertEquals(1, result.size)
-            assertEquals("new-id", result.first().id)
-            assertEquals("new.m4b", result.first().filename)
+                audioFileDao.deleteForBook("b1")
+
+                audioFileDao.getForBook("b1").isEmpty() shouldBe true
+                audioFileDao.getForBook("b2").map { it.index } shouldBe listOf(0)
+            }
         }
+
+        test("cascade delete removes rows when book is deleted") {
+            runTest {
+                audioFileSeedBook(bookDao, id = "b1")
+                audioFileDao.upsertAll(
+                    listOf(
+                        audioFile(bookId = "b1", index = 0),
+                        audioFile(bookId = "b1", index = 1),
+                    ),
+                )
+
+                bookDao.deleteById(BookId("b1"))
+
+                audioFileDao.getForBook("b1").isEmpty() shouldBe true
+            }
+        }
+
+        test("upsert with same composite PK replaces existing row") {
+            runTest {
+                audioFileSeedBook(bookDao)
+                audioFileDao.upsertAll(
+                    listOf(audioFile(index = 0, id = "old-id", filename = "old.m4b")),
+                )
+                audioFileDao.upsertAll(
+                    listOf(audioFile(index = 0, id = "new-id", filename = "new.m4b")),
+                )
+
+                val result = audioFileDao.getForBook("b1")
+                result.size shouldBe 1
+                result.first().id shouldBe "new-id"
+                result.first().filename shouldBe "new.m4b"
+            }
+        }
+    })
+
+private suspend fun audioFileSeedBook(
+    bookDao: BookDao,
+    id: String = "b1",
+) {
+    bookDao.upsert(
+        BookEntity(
+            id = BookId(id),
+            title = "Test $id",
+            sortTitle = "Test $id",
+            subtitle = null,
+            coverHash = null,
+            coverBlurHash = null,
+            dominantColor = null,
+            darkMutedColor = null,
+            vibrantColor = null,
+            totalDuration = 0L,
+            description = null,
+            publishYear = null,
+            publisher = null,
+            language = null,
+            isbn = null,
+            asin = null,
+            abridged = false,
+            createdAt = Timestamp(1L),
+            updatedAt = Timestamp(1L),
+        ),
+    )
 }
+
+private fun audioFile(
+    bookId: String = "b1",
+    index: Int,
+    id: String = "af-$bookId-$index",
+    filename: String = "chapter${index + 1}.m4b",
+    duration: Long = 1_800_000L,
+): AudioFileEntity =
+    AudioFileEntity(
+        bookId = BookId(bookId),
+        index = index,
+        id = id,
+        filename = filename,
+        format = "m4b",
+        codec = "aac",
+        duration = duration,
+        size = 45_000_000L,
+    )

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
@@ -26,47 +26,48 @@ import kotlinx.coroutines.test.runTest
  */
 class BookDaoRandomUnstartedTest :
     FunSpec({
-        lateinit var db: ListenUpDatabase
-        lateinit var bookDao: BookDao
-        lateinit var seriesDao: SeriesDao
-        lateinit var bookSeriesDao: BookSeriesDao
-
-        beforeTest {
-            db = createInMemoryTestDatabase()
-            bookDao = db.bookDao()
-            seriesDao = db.seriesDao()
-            bookSeriesDao = db.bookSeriesDao()
-        }
-
-        afterTest {
-            db.close()
-        }
 
         // ── observeRandomUnstartedBooks ──────────────────────────────────────────────
 
         test("observeRandomUnstartedBooks returns mid-series books (neutral, no sequence filter)") {
-            runTest {
-                randomUnstartedSeedThreeBooks(bookDao, seriesDao, bookSeriesDao)
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val seriesDao = db.seriesDao()
+                    val bookSeriesDao = db.bookSeriesDao()
+                    randomUnstartedSeedThreeBooks(bookDao, seriesDao, bookSeriesDao)
 
-                bookDao.observeRandomUnstartedBooks(limit = 10).test {
-                    val emitted = awaitItem().map { it.id.value }.toSet()
-                    ("mid-series" in emitted) shouldBe true
-                    cancelAndIgnoreRemainingEvents()
+                    bookDao.observeRandomUnstartedBooks(limit = 10).test {
+                        val emitted = awaitItem().map { it.id.value }.toSet()
+                        ("mid-series" in emitted) shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
                 }
+            } finally {
+                db.close()
             }
         }
 
         // ── observeRandomUnstartedBooksWithAuthor ────────────────────────────────────
 
         test("observeRandomUnstartedBooksWithAuthor returns mid-series books (neutral, no sequence filter)") {
-            runTest {
-                randomUnstartedSeedThreeBooks(bookDao, seriesDao, bookSeriesDao)
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val seriesDao = db.seriesDao()
+                    val bookSeriesDao = db.bookSeriesDao()
+                    randomUnstartedSeedThreeBooks(bookDao, seriesDao, bookSeriesDao)
 
-                bookDao.observeRandomUnstartedBooksWithAuthor(limit = 10).test {
-                    val emitted = awaitItem().map { it.id.value }.toSet()
-                    ("mid-series" in emitted) shouldBe true
-                    cancelAndIgnoreRemainingEvents()
+                    bookDao.observeRandomUnstartedBooksWithAuthor(limit = 10).test {
+                        val emitted = awaitItem().map { it.id.value }.toSet()
+                        ("mid-series" in emitted) shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
                 }
+            } finally {
+                db.close()
             }
         }
     })

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
@@ -5,10 +5,9 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.SeriesId
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertTrue
 
 /**
  * Regression coverage for the Discover "Random Unstarted" silent-filter bug (W6 Phase F, Drift #1).
@@ -25,116 +24,126 @@ import kotlin.test.assertTrue
  * These tests seed a mid-series book (sequence "3") alongside a standalone and a
  * first-in-series book, then assert that neutral methods include the mid-series book.
  */
-class BookDaoRandomUnstartedTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val bookDao = db.bookDao()
-    private val seriesDao = db.seriesDao()
-    private val bookSeriesDao = db.bookSeriesDao()
+class BookDaoRandomUnstartedTest :
+    FunSpec({
+        lateinit var db: ListenUpDatabase
+        lateinit var bookDao: BookDao
+        lateinit var seriesDao: SeriesDao
+        lateinit var bookSeriesDao: BookSeriesDao
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
+        beforeTest {
+            db = createInMemoryTestDatabase()
+            bookDao = db.bookDao()
+            seriesDao = db.seriesDao()
+            bookSeriesDao = db.bookSeriesDao()
+        }
 
-    private suspend fun seedBook(id: String) {
-        bookDao.upsert(
-            BookEntity(
-                id = BookId(id),
-                title = "Book $id",
-                sortTitle = "Book $id",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 0L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
+        afterTest {
+            db.close()
+        }
 
-    private suspend fun seedSeries(
-        id: String,
-        name: String,
-    ) {
-        seriesDao.upsert(
-            SeriesEntity(
-                id = SeriesId(id),
-                name = name,
-                description = null,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
+        // ── observeRandomUnstartedBooks ──────────────────────────────────────────────
 
-    private suspend fun linkBookToSeries(
-        bookId: String,
-        seriesId: String,
-        sequence: String?,
-    ) {
-        bookSeriesDao.insertAll(
-            listOf(
-                BookSeriesCrossRef(
-                    bookId = BookId(bookId),
-                    seriesId = SeriesId(seriesId),
-                    sequence = sequence,
-                ),
-            ),
-        )
-    }
+        test("observeRandomUnstartedBooks returns mid-series books (neutral, no sequence filter)") {
+            runTest {
+                randomUnstartedSeedThreeBooks(bookDao, seriesDao, bookSeriesDao)
 
-    /** Seeds: standalone, first-in-series (sequence "1"), mid-series (sequence "3"). */
-    private suspend fun seedThreeBooks() {
-        seedBook(id = "standalone")
-        seedBook(id = "first-in-series")
-        seedBook(id = "mid-series")
-
-        seedSeries(id = "s1", name = "Test Series")
-        linkBookToSeries(bookId = "first-in-series", seriesId = "s1", sequence = "1")
-        linkBookToSeries(bookId = "mid-series", seriesId = "s1", sequence = "3")
-    }
-
-    // ── observeRandomUnstartedBooks ──────────────────────────────────────────────
-
-    @Test
-    fun `observeRandomUnstartedBooks returns mid-series books (neutral, no sequence filter)`() =
-        runTest {
-            seedThreeBooks()
-
-            bookDao.observeRandomUnstartedBooks(limit = 10).test {
-                val emitted = awaitItem().map { it.id.value }.toSet()
-                assertTrue(
-                    "mid-series" in emitted,
-                    "neutral query must include mid-series book; DAO name must not lie",
-                )
-                cancelAndIgnoreRemainingEvents()
+                bookDao.observeRandomUnstartedBooks(limit = 10).test {
+                    val emitted = awaitItem().map { it.id.value }.toSet()
+                    ("mid-series" in emitted) shouldBe true
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
 
-    // ── observeRandomUnstartedBooksWithAuthor ────────────────────────────────────
+        // ── observeRandomUnstartedBooksWithAuthor ────────────────────────────────────
 
-    @Test
-    fun `observeRandomUnstartedBooksWithAuthor returns mid-series books (neutral, no sequence filter)`() =
-        runTest {
-            seedThreeBooks()
+        test("observeRandomUnstartedBooksWithAuthor returns mid-series books (neutral, no sequence filter)") {
+            runTest {
+                randomUnstartedSeedThreeBooks(bookDao, seriesDao, bookSeriesDao)
 
-            bookDao.observeRandomUnstartedBooksWithAuthor(limit = 10).test {
-                val emitted = awaitItem().map { it.id.value }.toSet()
-                assertTrue(
-                    "mid-series" in emitted,
-                    "neutral query must include mid-series book; DAO name must not lie",
-                )
-                cancelAndIgnoreRemainingEvents()
+                bookDao.observeRandomUnstartedBooksWithAuthor(limit = 10).test {
+                    val emitted = awaitItem().map { it.id.value }.toSet()
+                    ("mid-series" in emitted) shouldBe true
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
+    })
+
+private suspend fun randomUnstartedSeedBook(
+    bookDao: BookDao,
+    id: String,
+) {
+    bookDao.upsert(
+        BookEntity(
+            id = BookId(id),
+            title = "Book $id",
+            sortTitle = "Book $id",
+            subtitle = null,
+            coverHash = null,
+            coverBlurHash = null,
+            dominantColor = null,
+            darkMutedColor = null,
+            vibrantColor = null,
+            totalDuration = 0L,
+            description = null,
+            publishYear = null,
+            publisher = null,
+            language = null,
+            isbn = null,
+            asin = null,
+            abridged = false,
+            createdAt = Timestamp(1L),
+            updatedAt = Timestamp(1L),
+        ),
+    )
+}
+
+private suspend fun randomUnstartedSeedSeries(
+    seriesDao: SeriesDao,
+    id: String,
+    name: String,
+) {
+    seriesDao.upsert(
+        SeriesEntity(
+            id = SeriesId(id),
+            name = name,
+            description = null,
+            createdAt = Timestamp(1L),
+            updatedAt = Timestamp(1L),
+        ),
+    )
+}
+
+private suspend fun randomUnstartedLinkBookToSeries(
+    bookSeriesDao: BookSeriesDao,
+    bookId: String,
+    seriesId: String,
+    sequence: String?,
+) {
+    bookSeriesDao.insertAll(
+        listOf(
+            BookSeriesCrossRef(
+                bookId = BookId(bookId),
+                seriesId = SeriesId(seriesId),
+                sequence = sequence,
+            ),
+        ),
+    )
+}
+
+/** Seeds: standalone, first-in-series (sequence "1"), mid-series (sequence "3"). */
+private suspend fun randomUnstartedSeedThreeBooks(
+    bookDao: BookDao,
+    seriesDao: SeriesDao,
+    bookSeriesDao: BookSeriesDao,
+) {
+    randomUnstartedSeedBook(bookDao, id = "standalone")
+    randomUnstartedSeedBook(bookDao, id = "first-in-series")
+    randomUnstartedSeedBook(bookDao, id = "mid-series")
+
+    randomUnstartedSeedSeries(seriesDao, id = "s1", name = "Test Series")
+    randomUnstartedLinkBookToSeries(bookSeriesDao, bookId = "first-in-series", seriesId = "s1", sequence = "1")
+    randomUnstartedLinkBookToSeries(bookSeriesDao, bookId = "mid-series", seriesId = "s1", sequence = "3")
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRecentlyAddedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRecentlyAddedTest.kt
@@ -26,39 +26,33 @@ import kotlinx.coroutines.test.runTest
  */
 class BookDaoRecentlyAddedTest :
     FunSpec({
-        lateinit var db: ListenUpDatabase
-        lateinit var bookDao: BookDao
-        lateinit var seriesDao: SeriesDao
-        lateinit var bookSeriesDao: BookSeriesDao
-
-        beforeTest {
-            db = createInMemoryTestDatabase()
-            bookDao = db.bookDao()
-            seriesDao = db.seriesDao()
-            bookSeriesDao = db.bookSeriesDao()
-        }
-
-        afterTest {
-            db.close()
-        }
 
         test("observeRecentlyAddedWithAuthor returns all recently added books regardless of series sequence") {
-            runTest {
-                // Three books across the full sequence spectrum. createdAt timestamps are
-                // distinct so the ORDER BY is deterministic — newest first.
-                recentlyAddedSeedBook(bookDao, id = "standalone", createdAt = 3_000L)
-                recentlyAddedSeedBook(bookDao, id = "first-in-series", createdAt = 2_000L)
-                recentlyAddedSeedBook(bookDao, id = "mid-series", createdAt = 1_000L)
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val bookDao = db.bookDao()
+                    val seriesDao = db.seriesDao()
+                    val bookSeriesDao = db.bookSeriesDao()
 
-                recentlyAddedSeedSeries(seriesDao, id = "s1", name = "Test Series")
-                recentlyAddedLinkBookToSeries(bookSeriesDao, bookId = "first-in-series", seriesId = "s1", sequence = "1")
-                recentlyAddedLinkBookToSeries(bookSeriesDao, bookId = "mid-series", seriesId = "s1", sequence = "3")
+                    // Three books across the full sequence spectrum. createdAt timestamps are
+                    // distinct so the ORDER BY is deterministic — newest first.
+                    recentlyAddedSeedBook(bookDao, id = "standalone", createdAt = 3_000L)
+                    recentlyAddedSeedBook(bookDao, id = "first-in-series", createdAt = 2_000L)
+                    recentlyAddedSeedBook(bookDao, id = "mid-series", createdAt = 1_000L)
 
-                bookDao.observeRecentlyAddedWithAuthor(limit = 10).test {
-                    val emitted = awaitItem().map { it.id.value }
-                    emitted shouldBe listOf("standalone", "first-in-series", "mid-series")
-                    cancelAndIgnoreRemainingEvents()
+                    recentlyAddedSeedSeries(seriesDao, id = "s1", name = "Test Series")
+                    recentlyAddedLinkBookToSeries(bookSeriesDao, bookId = "first-in-series", seriesId = "s1", sequence = "1")
+                    recentlyAddedLinkBookToSeries(bookSeriesDao, bookId = "mid-series", seriesId = "s1", sequence = "3")
+
+                    bookDao.observeRecentlyAddedWithAuthor(limit = 10).test {
+                        val emitted = awaitItem().map { it.id.value }
+                        emitted shouldBe listOf("standalone", "first-in-series", "mid-series")
+                        cancelAndIgnoreRemainingEvents()
+                    }
                 }
+            } finally {
+                db.close()
             }
         }
     })

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRecentlyAddedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRecentlyAddedTest.kt
@@ -5,10 +5,9 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.SeriesId
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Regression coverage for the Discover "Recently Added" half-list bug (W6 Phase A, Bug 5).
@@ -25,98 +24,104 @@ import kotlin.test.assertEquals
  * These tests seed a standalone book, a first-in-series book and a mid-series book,
  * then assert that the neutral method returns all three.
  */
-class BookDaoRecentlyAddedTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val bookDao = db.bookDao()
-    private val seriesDao = db.seriesDao()
-    private val bookSeriesDao = db.bookSeriesDao()
+class BookDaoRecentlyAddedTest :
+    FunSpec({
+        lateinit var db: ListenUpDatabase
+        lateinit var bookDao: BookDao
+        lateinit var seriesDao: SeriesDao
+        lateinit var bookSeriesDao: BookSeriesDao
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
+        beforeTest {
+            db = createInMemoryTestDatabase()
+            bookDao = db.bookDao()
+            seriesDao = db.seriesDao()
+            bookSeriesDao = db.bookSeriesDao()
+        }
 
-    private suspend fun seedBook(
-        id: String,
-        createdAt: Long,
-    ) {
-        bookDao.upsert(
-            BookEntity(
-                id = BookId(id),
-                title = "Book $id",
-                sortTitle = "Book $id",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 0L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(createdAt),
-                updatedAt = Timestamp(createdAt),
-            ),
-        )
-    }
+        afterTest {
+            db.close()
+        }
 
-    private suspend fun seedSeries(
-        id: String,
-        name: String,
-    ) {
-        seriesDao.upsert(
-            SeriesEntity(
-                id = SeriesId(id),
-                name = name,
-                description = null,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
+        test("observeRecentlyAddedWithAuthor returns all recently added books regardless of series sequence") {
+            runTest {
+                // Three books across the full sequence spectrum. createdAt timestamps are
+                // distinct so the ORDER BY is deterministic — newest first.
+                recentlyAddedSeedBook(bookDao, id = "standalone", createdAt = 3_000L)
+                recentlyAddedSeedBook(bookDao, id = "first-in-series", createdAt = 2_000L)
+                recentlyAddedSeedBook(bookDao, id = "mid-series", createdAt = 1_000L)
 
-    private suspend fun linkBookToSeries(
-        bookId: String,
-        seriesId: String,
-        sequence: String?,
-    ) {
-        bookSeriesDao.insertAll(
-            listOf(
-                BookSeriesCrossRef(
-                    bookId = BookId(bookId),
-                    seriesId = SeriesId(seriesId),
-                    sequence = sequence,
-                ),
-            ),
-        )
-    }
+                recentlyAddedSeedSeries(seriesDao, id = "s1", name = "Test Series")
+                recentlyAddedLinkBookToSeries(bookSeriesDao, bookId = "first-in-series", seriesId = "s1", sequence = "1")
+                recentlyAddedLinkBookToSeries(bookSeriesDao, bookId = "mid-series", seriesId = "s1", sequence = "3")
 
-    @Test
-    fun `observeRecentlyAddedWithAuthor returns all recently added books regardless of series sequence`() =
-        runTest {
-            // Three books across the full sequence spectrum. createdAt timestamps are
-            // distinct so the ORDER BY is deterministic — newest first.
-            seedBook(id = "standalone", createdAt = 3_000L)
-            seedBook(id = "first-in-series", createdAt = 2_000L)
-            seedBook(id = "mid-series", createdAt = 1_000L)
-
-            seedSeries(id = "s1", name = "Test Series")
-            linkBookToSeries(bookId = "first-in-series", seriesId = "s1", sequence = "1")
-            linkBookToSeries(bookId = "mid-series", seriesId = "s1", sequence = "3")
-
-            bookDao.observeRecentlyAddedWithAuthor(limit = 10).test {
-                val emitted = awaitItem().map { it.id.value }
-                assertEquals(
-                    listOf("standalone", "first-in-series", "mid-series"),
-                    emitted,
-                    "neutral query must include mid-series books; DAO name must not lie",
-                )
-                cancelAndIgnoreRemainingEvents()
+                bookDao.observeRecentlyAddedWithAuthor(limit = 10).test {
+                    val emitted = awaitItem().map { it.id.value }
+                    emitted shouldBe listOf("standalone", "first-in-series", "mid-series")
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
+    })
+
+private suspend fun recentlyAddedSeedBook(
+    bookDao: BookDao,
+    id: String,
+    createdAt: Long,
+) {
+    bookDao.upsert(
+        BookEntity(
+            id = BookId(id),
+            title = "Book $id",
+            sortTitle = "Book $id",
+            subtitle = null,
+            coverHash = null,
+            coverBlurHash = null,
+            dominantColor = null,
+            darkMutedColor = null,
+            vibrantColor = null,
+            totalDuration = 0L,
+            description = null,
+            publishYear = null,
+            publisher = null,
+            language = null,
+            isbn = null,
+            asin = null,
+            abridged = false,
+            createdAt = Timestamp(createdAt),
+            updatedAt = Timestamp(createdAt),
+        ),
+    )
+}
+
+private suspend fun recentlyAddedSeedSeries(
+    seriesDao: SeriesDao,
+    id: String,
+    name: String,
+) {
+    seriesDao.upsert(
+        SeriesEntity(
+            id = SeriesId(id),
+            name = name,
+            description = null,
+            createdAt = Timestamp(1L),
+            updatedAt = Timestamp(1L),
+        ),
+    )
+}
+
+private suspend fun recentlyAddedLinkBookToSeries(
+    bookSeriesDao: BookSeriesDao,
+    bookId: String,
+    seriesId: String,
+    sequence: String?,
+) {
+    bookSeriesDao.insertAll(
+        listOf(
+            BookSeriesCrossRef(
+                bookId = BookId(bookId),
+                seriesId = SeriesId(seriesId),
+                sequence = sequence,
+            ),
+        ),
+    )
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookWithContributorsMapperTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookWithContributorsMapperTest.kt
@@ -152,10 +152,11 @@ class BookWithContributorsMapperTest :
             // Authors
             result.authors shouldBe listOf(BookContributor(id = "contrib-author", name = "Brandon Sanderson"))
             // Narrators
-            result.narrators shouldBe listOf(
-                BookContributor(id = "contrib-narrator", name = "Michael Kramer"),
-                BookContributor(id = "contrib-narrator2", name = "Kate Reading"),
-            )
+            result.narrators shouldBe
+                listOf(
+                    BookContributor(id = "contrib-narrator", name = "Michael Kramer"),
+                    BookContributor(id = "contrib-narrator2", name = "Kate Reading"),
+                )
             // Series populated from junction.
             result.series.size shouldBe 1
             result.series.first().seriesName shouldBe "The Stormlight Archive"

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookWithContributorsMapperTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookWithContributorsMapperTest.kt
@@ -12,8 +12,8 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Golden-output tests for the canonical mappers in [BookEntityMapper].
@@ -22,255 +22,75 @@ import kotlin.test.assertEquals
  * immediately. Covers [BookWithContributors.toListItem] and
  * [BookWithContributors.toDetail].
  */
-class BookWithContributorsMapperTest {
-    private val bookId = BookId("book-1")
-    private val createdAt = Timestamp(1_700_000_000_000L)
-    private val updatedAt = Timestamp(1_700_000_001_000L)
+class BookWithContributorsMapperTest :
+    FunSpec({
+        val bookId = BookId("book-1")
+        val createdAt = Timestamp(1_700_000_000_000L)
+        val updatedAt = Timestamp(1_700_000_001_000L)
 
-    private fun makeBook() =
-        BookEntity(
-            id = bookId,
-            title = "The Way of Kings",
-            sortTitle = "Way of Kings, The",
-            subtitle = "The Stormlight Archive",
-            coverHash = null,
-            coverBlurHash = "L5H2EC=PM+yV",
-            dominantColor = 0xFF2244CC.toInt(),
-            darkMutedColor = 0xFF112233.toInt(),
-            vibrantColor = 0xFF3366FF.toInt(),
-            totalDuration = 72_000_000L,
-            description = "A fantasy epic.",
-            publishYear = 2010,
-            publisher = "Tor Books",
-            language = "en",
-            isbn = "978-0-7653-2637-9",
-            asin = "B003P2WO5E",
-            abridged = false,
-            createdAt = createdAt,
-            updatedAt = updatedAt,
-        )
-
-    private val authorId = ContributorId("contrib-author")
-    private val narratorId = ContributorId("contrib-narrator")
-    private val narrator2Id = ContributorId("contrib-narrator2")
-    private val seriesId = SeriesId("series-1")
-
-    private fun makeContributors() =
-        listOf(
-            ContributorEntity(
-                id = authorId,
-                name = "Brandon Sanderson",
-                sortName = "Sanderson, Brandon",
-                asin = null,
-                description = null,
-                imagePath = null,
+        fun makeBook() =
+            BookEntity(
+                id = bookId,
+                title = "The Way of Kings",
+                sortTitle = "Way of Kings, The",
+                subtitle = "The Stormlight Archive",
+                coverHash = null,
+                coverBlurHash = "L5H2EC=PM+yV",
+                dominantColor = 0xFF2244CC.toInt(),
+                darkMutedColor = 0xFF112233.toInt(),
+                vibrantColor = 0xFF3366FF.toInt(),
+                totalDuration = 72_000_000L,
+                description = "A fantasy epic.",
+                publishYear = 2010,
+                publisher = "Tor Books",
+                language = "en",
+                isbn = "978-0-7653-2637-9",
+                asin = "B003P2WO5E",
+                abridged = false,
                 createdAt = createdAt,
                 updatedAt = updatedAt,
-            ),
-            ContributorEntity(
-                id = narratorId,
-                name = "Michael Kramer",
-                sortName = null,
-                asin = null,
-                description = null,
-                imagePath = null,
-                createdAt = createdAt,
-                updatedAt = updatedAt,
-            ),
-            ContributorEntity(
-                id = narrator2Id,
-                name = "Kate Reading",
-                sortName = null,
-                asin = null,
-                description = null,
-                imagePath = null,
-                createdAt = createdAt,
-                updatedAt = updatedAt,
-            ),
-        )
-
-    private fun makeContributorRoles() =
-        listOf(
-            BookContributorCrossRef(
-                bookId = bookId,
-                contributorId = authorId,
-                role = "author",
-                creditedAs = null,
-            ),
-            BookContributorCrossRef(
-                bookId = bookId,
-                contributorId = narratorId,
-                role = "narrator",
-                creditedAs = null,
-            ),
-            BookContributorCrossRef(
-                bookId = bookId,
-                contributorId = narrator2Id,
-                role = "narrator",
-                creditedAs = null,
-            ),
-        )
-
-    private fun makeSeries() =
-        listOf(
-            SeriesEntity(
-                id = seriesId,
-                name = "The Stormlight Archive",
-                description = null,
-                createdAt = createdAt,
-                updatedAt = updatedAt,
-            ),
-        )
-
-    private fun makeSeriesSequences() =
-        listOf(
-            BookSeriesCrossRef(
-                bookId = bookId,
-                seriesId = seriesId,
-                sequence = "1",
-            ),
-        )
-
-    @Test
-    fun `toListItem returns BookListItem with authors and narrators populated, no detail-only fields`() {
-        val imageStorage = mock<ImageStorage>()
-        every { imageStorage.exists(any()) } returns false
-
-        val bookWithContributors =
-            BookWithContributors(
-                book = makeBook(),
-                contributors = makeContributors(),
-                contributorRoles = makeContributorRoles(),
-                series = makeSeries(),
-                seriesSequences = makeSeriesSequences(),
             )
 
-        val result = bookWithContributors.toListItem(imageStorage)
+        val authorId = ContributorId("contrib-author")
+        val narratorId = ContributorId("contrib-narrator")
+        val narrator2Id = ContributorId("contrib-narrator2")
+        val seriesId = SeriesId("series-1")
 
-        assertEquals(bookId, result.id)
-        assertEquals("The Way of Kings", result.title)
-        // Authors
-        assertEquals(
-            listOf(BookContributor(id = "contrib-author", name = "Brandon Sanderson")),
-            result.authors,
-        )
-        // Narrators
-        assertEquals(
+        fun makeContributors() =
             listOf(
-                BookContributor(id = "contrib-narrator", name = "Michael Kramer"),
-                BookContributor(id = "contrib-narrator2", name = "Kate Reading"),
-            ),
-            result.narrators,
-        )
-        // Series populated from junction.
-        assertEquals(1, result.series.size)
-        assertEquals("The Stormlight Archive", result.series.first().seriesName)
-    }
-
-    @Test
-    fun `toDetail computes allContributors via dedup-and-role-aggregation, genres+tags forwarded as-is`() {
-        val imageStorage = mock<ImageStorage>()
-        every { imageStorage.exists(any()) } returns false
-
-        val genres = listOf(Genre(id = "genre-1", name = "Fantasy", slug = "fantasy", path = "/fantasy"))
-        val tags = listOf(Tag(id = "tag-1", slug = "epic"))
-
-        val bookWithContributors =
-            BookWithContributors(
-                book = makeBook(),
-                contributors = makeContributors(),
-                contributorRoles = makeContributorRoles(),
-                series = makeSeries(),
-                seriesSequences = makeSeriesSequences(),
-            )
-
-        val result = bookWithContributors.toDetail(imageStorage, genres, tags)
-
-        // allContributors: every distinct contributor with all roles grouped.
-        // The fixture has authorId (role: author), narratorId (role: narrator), narrator2Id (role: narrator) — 3 distinct contributors.
-        assertEquals(3, result.allContributors.size)
-        val sandersonRoles = result.allContributors.first { it.id == "contrib-author" }.roles
-        assertEquals(listOf("author"), sandersonRoles)
-        val kramerRoles = result.allContributors.first { it.id == "contrib-narrator" }.roles
-        assertEquals(listOf("narrator"), kramerRoles)
-        val readingRoles = result.allContributors.first { it.id == "contrib-narrator2" }.roles
-        assertEquals(listOf("narrator"), readingRoles)
-
-        // Genres + tags forwarded verbatim.
-        assertEquals(genres, result.genres)
-        assertEquals(tags, result.tags)
-    }
-
-    @Test
-    fun `toDetail allContributors handles same person in multiple roles by grouping`() {
-        val imageStorage = mock<ImageStorage>()
-        every { imageStorage.exists(any()) } returns false
-
-        // Sanderson is BOTH author and narrator on this book.
-        val authorAndNarratorRoles =
-            listOf(
-                BookContributorCrossRef(bookId, authorId, role = "author", creditedAs = null),
-                BookContributorCrossRef(bookId, authorId, role = "narrator", creditedAs = null),
-            )
-        val singleContributor = makeContributors().first { it.id == authorId }
-
-        val bookWithContributors =
-            BookWithContributors(
-                book = makeBook(),
-                contributors = listOf(singleContributor),
-                contributorRoles = authorAndNarratorRoles,
-                series = emptyList(),
-                seriesSequences = emptyList(),
-            )
-
-        val result = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList())
-
-        assertEquals(1, result.allContributors.size, "Same contributor across roles must dedupe to a single entry")
-        assertEquals(listOf("author", "narrator"), result.allContributors.first().roles)
-    }
-
-    @Test
-    fun `toDetail allContributors prefers creditedAs over canonical contributor name when creditedAs is non-null`() {
-        val imageStorage = mock<ImageStorage>()
-        every { imageStorage.exists(any()) } returns false
-
-        // Same Sanderson contributor, but the cross-ref carries a different attribution
-        // (e.g., the book was originally credited to the author's pen-name before merging).
-        val rolesWithCreditedAs =
-            listOf(
-                BookContributorCrossRef(
-                    bookId = bookId,
-                    contributorId = authorId,
-                    role = "author",
-                    creditedAs = "B. Sanderson (originally credited)",
+                ContributorEntity(
+                    id = authorId,
+                    name = "Brandon Sanderson",
+                    sortName = "Sanderson, Brandon",
+                    asin = null,
+                    description = null,
+                    imagePath = null,
+                    createdAt = createdAt,
+                    updatedAt = updatedAt,
+                ),
+                ContributorEntity(
+                    id = narratorId,
+                    name = "Michael Kramer",
+                    sortName = null,
+                    asin = null,
+                    description = null,
+                    imagePath = null,
+                    createdAt = createdAt,
+                    updatedAt = updatedAt,
+                ),
+                ContributorEntity(
+                    id = narrator2Id,
+                    name = "Kate Reading",
+                    sortName = null,
+                    asin = null,
+                    description = null,
+                    imagePath = null,
+                    createdAt = createdAt,
+                    updatedAt = updatedAt,
                 ),
             )
 
-        val bookWithContributors =
-            BookWithContributors(
-                book = makeBook(),
-                contributors = listOf(makeContributors().first { it.id == authorId }),
-                contributorRoles = rolesWithCreditedAs,
-                series = emptyList(),
-                seriesSequences = emptyList(),
-            )
-
-        val result = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList())
-
-        assertEquals(1, result.allContributors.size)
-        assertEquals(
-            "B. Sanderson (originally credited)",
-            result.allContributors.first().name,
-            "creditedAs must win over canonical contributor name when non-null",
-        )
-    }
-
-    @Test
-    fun `toDetail allContributors falls back to canonical contributor name when creditedAs is null`() {
-        val imageStorage = mock<ImageStorage>()
-        every { imageStorage.exists(any()) } returns false
-
-        val rolesWithoutCreditedAs =
+        fun makeContributorRoles() =
             listOf(
                 BookContributorCrossRef(
                     bookId = bookId,
@@ -278,43 +98,204 @@ class BookWithContributorsMapperTest {
                     role = "author",
                     creditedAs = null,
                 ),
+                BookContributorCrossRef(
+                    bookId = bookId,
+                    contributorId = narratorId,
+                    role = "narrator",
+                    creditedAs = null,
+                ),
+                BookContributorCrossRef(
+                    bookId = bookId,
+                    contributorId = narrator2Id,
+                    role = "narrator",
+                    creditedAs = null,
+                ),
             )
 
-        val bookWithContributors =
-            BookWithContributors(
-                book = makeBook(),
-                contributors = listOf(makeContributors().first { it.id == authorId }),
-                contributorRoles = rolesWithoutCreditedAs,
-                series = emptyList(),
-                seriesSequences = emptyList(),
+        fun makeSeries() =
+            listOf(
+                SeriesEntity(
+                    id = seriesId,
+                    name = "The Stormlight Archive",
+                    description = null,
+                    createdAt = createdAt,
+                    updatedAt = updatedAt,
+                ),
             )
 
-        val result = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList())
-
-        assertEquals(
-            "Brandon Sanderson",
-            result.allContributors.first().name,
-            "Fallback to canonical contributor name when creditedAs is null",
-        )
-    }
-
-    @Test
-    fun `toDetail then toListItem equals toListItem for same input`() {
-        val imageStorage = mock<ImageStorage>()
-        every { imageStorage.exists(any()) } returns false
-
-        val bookWithContributors =
-            BookWithContributors(
-                book = makeBook(),
-                contributors = makeContributors(),
-                contributorRoles = makeContributorRoles(),
-                series = makeSeries(),
-                seriesSequences = makeSeriesSequences(),
+        fun makeSeriesSequences() =
+            listOf(
+                BookSeriesCrossRef(
+                    bookId = bookId,
+                    seriesId = seriesId,
+                    sequence = "1",
+                ),
             )
 
-        val viaDetail = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList()).toListItem()
-        val direct = bookWithContributors.toListItem(imageStorage)
+        test("toListItem returns BookListItem with authors and narrators populated, no detail-only fields") {
+            val imageStorage = mock<ImageStorage>()
+            every { imageStorage.exists(any()) } returns false
 
-        assertEquals(direct, viaDetail, "BookDetail.toListItem() must match canonical toListItem mapper")
-    }
-}
+            val bookWithContributors =
+                BookWithContributors(
+                    book = makeBook(),
+                    contributors = makeContributors(),
+                    contributorRoles = makeContributorRoles(),
+                    series = makeSeries(),
+                    seriesSequences = makeSeriesSequences(),
+                )
+
+            val result = bookWithContributors.toListItem(imageStorage)
+
+            result.id shouldBe bookId
+            result.title shouldBe "The Way of Kings"
+            // Authors
+            result.authors shouldBe listOf(BookContributor(id = "contrib-author", name = "Brandon Sanderson"))
+            // Narrators
+            result.narrators shouldBe listOf(
+                BookContributor(id = "contrib-narrator", name = "Michael Kramer"),
+                BookContributor(id = "contrib-narrator2", name = "Kate Reading"),
+            )
+            // Series populated from junction.
+            result.series.size shouldBe 1
+            result.series.first().seriesName shouldBe "The Stormlight Archive"
+        }
+
+        test("toDetail computes allContributors via dedup-and-role-aggregation, genres+tags forwarded as-is") {
+            val imageStorage = mock<ImageStorage>()
+            every { imageStorage.exists(any()) } returns false
+
+            val genres = listOf(Genre(id = "genre-1", name = "Fantasy", slug = "fantasy", path = "/fantasy"))
+            val tags = listOf(Tag(id = "tag-1", slug = "epic"))
+
+            val bookWithContributors =
+                BookWithContributors(
+                    book = makeBook(),
+                    contributors = makeContributors(),
+                    contributorRoles = makeContributorRoles(),
+                    series = makeSeries(),
+                    seriesSequences = makeSeriesSequences(),
+                )
+
+            val result = bookWithContributors.toDetail(imageStorage, genres, tags)
+
+            // allContributors: every distinct contributor with all roles grouped.
+            // The fixture has authorId (role: author), narratorId (role: narrator), narrator2Id (role: narrator) — 3 distinct contributors.
+            result.allContributors.size shouldBe 3
+            val sandersonRoles = result.allContributors.first { it.id == "contrib-author" }.roles
+            sandersonRoles shouldBe listOf("author")
+            val kramerRoles = result.allContributors.first { it.id == "contrib-narrator" }.roles
+            kramerRoles shouldBe listOf("narrator")
+            val readingRoles = result.allContributors.first { it.id == "contrib-narrator2" }.roles
+            readingRoles shouldBe listOf("narrator")
+
+            // Genres + tags forwarded verbatim.
+            result.genres shouldBe genres
+            result.tags shouldBe tags
+        }
+
+        test("toDetail allContributors handles same person in multiple roles by grouping") {
+            val imageStorage = mock<ImageStorage>()
+            every { imageStorage.exists(any()) } returns false
+
+            // Sanderson is BOTH author and narrator on this book.
+            val authorAndNarratorRoles =
+                listOf(
+                    BookContributorCrossRef(bookId, authorId, role = "author", creditedAs = null),
+                    BookContributorCrossRef(bookId, authorId, role = "narrator", creditedAs = null),
+                )
+            val singleContributor = makeContributors().first { it.id == authorId }
+
+            val bookWithContributors =
+                BookWithContributors(
+                    book = makeBook(),
+                    contributors = listOf(singleContributor),
+                    contributorRoles = authorAndNarratorRoles,
+                    series = emptyList(),
+                    seriesSequences = emptyList(),
+                )
+
+            val result = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList())
+
+            result.allContributors.size shouldBe 1
+            result.allContributors.first().roles shouldBe listOf("author", "narrator")
+        }
+
+        test("toDetail allContributors prefers creditedAs over canonical contributor name when creditedAs is non-null") {
+            val imageStorage = mock<ImageStorage>()
+            every { imageStorage.exists(any()) } returns false
+
+            // Same Sanderson contributor, but the cross-ref carries a different attribution
+            // (e.g., the book was originally credited to the author's pen-name before merging).
+            val rolesWithCreditedAs =
+                listOf(
+                    BookContributorCrossRef(
+                        bookId = bookId,
+                        contributorId = authorId,
+                        role = "author",
+                        creditedAs = "B. Sanderson (originally credited)",
+                    ),
+                )
+
+            val bookWithContributors =
+                BookWithContributors(
+                    book = makeBook(),
+                    contributors = listOf(makeContributors().first { it.id == authorId }),
+                    contributorRoles = rolesWithCreditedAs,
+                    series = emptyList(),
+                    seriesSequences = emptyList(),
+                )
+
+            val result = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList())
+
+            result.allContributors.size shouldBe 1
+            result.allContributors.first().name shouldBe "B. Sanderson (originally credited)"
+        }
+
+        test("toDetail allContributors falls back to canonical contributor name when creditedAs is null") {
+            val imageStorage = mock<ImageStorage>()
+            every { imageStorage.exists(any()) } returns false
+
+            val rolesWithoutCreditedAs =
+                listOf(
+                    BookContributorCrossRef(
+                        bookId = bookId,
+                        contributorId = authorId,
+                        role = "author",
+                        creditedAs = null,
+                    ),
+                )
+
+            val bookWithContributors =
+                BookWithContributors(
+                    book = makeBook(),
+                    contributors = listOf(makeContributors().first { it.id == authorId }),
+                    contributorRoles = rolesWithoutCreditedAs,
+                    series = emptyList(),
+                    seriesSequences = emptyList(),
+                )
+
+            val result = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList())
+
+            result.allContributors.first().name shouldBe "Brandon Sanderson"
+        }
+
+        test("toDetail then toListItem equals toListItem for same input") {
+            val imageStorage = mock<ImageStorage>()
+            every { imageStorage.exists(any()) } returns false
+
+            val bookWithContributors =
+                BookWithContributors(
+                    book = makeBook(),
+                    contributors = makeContributors(),
+                    contributorRoles = makeContributorRoles(),
+                    series = makeSeries(),
+                    seriesSequences = makeSeriesSequences(),
+                )
+
+            val viaDetail = bookWithContributors.toDetail(imageStorage, emptyList(), emptyList()).toListItem()
+            val direct = bookWithContributors.toListItem(imageStorage)
+
+            direct shouldBe viaDetail
+        }
+    })

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/ContributorAliasDaoTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/ContributorAliasDaoTest.kt
@@ -4,11 +4,10 @@ import app.cash.turbine.test
 import com.calypsan.listenup.client.core.ContributorId
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Verifies [ContributorAliasDao] against a real in-memory [ListenUpDatabase].
@@ -17,169 +16,176 @@ import kotlin.test.assertTrue
  * foreign-key cascade on contributor delete, and `OnConflictStrategy.IGNORE`
  * for exact-case duplicates.
  */
-class ContributorAliasDaoTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val contributorDao = db.contributorDao()
-    private val aliasDao = db.contributorAliasDao()
+class ContributorAliasDaoTest :
+    FunSpec({
+        lateinit var db: ListenUpDatabase
+        lateinit var contributorDao: ContributorDao
+        lateinit var aliasDao: ContributorAliasDao
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    private suspend fun seedContributor(
-        id: String = "c-1",
-        name: String = "Stephen King",
-    ) {
-        contributorDao.upsert(
-            ContributorEntity(
-                id = ContributorId(id),
-                name = name,
-                description = null,
-                imagePath = null,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
-
-    @Test
-    fun `insertAll and getForContributor returns aliases sorted alphabetically case-insensitively`() =
-        runTest {
-            seedContributor()
-
-            aliasDao.insertAll(
-                listOf(
-                    ContributorAliasCrossRef(ContributorId("c-1"), "richard bachman"),
-                    ContributorAliasCrossRef(ContributorId("c-1"), "John Swithen"),
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Beryl Evans"),
-                ),
-            )
-
-            val result = aliasDao.getForContributor("c-1")
-
-            assertEquals(listOf("Beryl Evans", "John Swithen", "richard bachman"), result)
+        beforeTest {
+            db = createInMemoryTestDatabase()
+            contributorDao = db.contributorDao()
+            aliasDao = db.contributorAliasDao()
         }
 
-    @Test
-    fun `getForContributor returns empty list when no aliases`() =
-        runTest {
-            seedContributor()
-            assertTrue(aliasDao.getForContributor("c-1").isEmpty())
+        afterTest {
+            db.close()
         }
 
-    @Test
-    fun `deleteForContributor removes only that contributor's aliases`() =
-        runTest {
-            seedContributor(id = "c-1", name = "King")
-            seedContributor(id = "c-2", name = "Gaiman")
-
-            aliasDao.insertAll(
-                listOf(
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                    ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
-                ),
-            )
-
-            aliasDao.deleteForContributor("c-1")
-
-            assertTrue(aliasDao.getForContributor("c-1").isEmpty())
-            assertEquals(listOf("Pinkerton"), aliasDao.getForContributor("c-2"))
-        }
-
-    @Test
-    fun `cascade delete removes only the deleted contributor's aliases`() =
-        runTest {
-            seedContributor(id = "c-1", name = "King")
-            seedContributor(id = "c-2", name = "Gaiman")
-
-            aliasDao.insertAll(
-                listOf(
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
-                    ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
-                ),
-            )
-
-            contributorDao.deleteById("c-1")
-
-            assertTrue(aliasDao.getForContributor("c-1").isEmpty())
-            assertEquals(listOf("Pinkerton"), aliasDao.getForContributor("c-2"))
-        }
-
-    @Test
-    fun `observeForContributor emits initial list and re-emits on change`() =
-        runTest {
-            seedContributor()
-            aliasDao.insertAll(
-                listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")),
-            )
-
-            aliasDao.observeForContributor("c-1").test {
-                assertEquals(listOf("Bachman"), awaitItem())
+        test("insertAll and getForContributor returns aliases sorted alphabetically case-insensitively") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao)
 
                 aliasDao.insertAll(
-                    listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Swithen")),
+                    listOf(
+                        ContributorAliasCrossRef(ContributorId("c-1"), "richard bachman"),
+                        ContributorAliasCrossRef(ContributorId("c-1"), "John Swithen"),
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Beryl Evans"),
+                    ),
                 )
-                assertEquals(listOf("Bachman", "Swithen"), awaitItem())
 
-                aliasDao.deleteForContributor("c-1")
-                assertEquals(emptyList(), awaitItem())
+                val result = aliasDao.getForContributor("c-1")
 
-                cancelAndIgnoreRemainingEvents()
+                result shouldBe listOf("Beryl Evans", "John Swithen", "richard bachman")
             }
         }
 
-    @Test
-    fun `insertAll with duplicate exact-case alias is ignored`() =
-        runTest {
-            seedContributor()
-
-            aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
-            aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
-
-            assertEquals(listOf("Bachman"), aliasDao.getForContributor("c-1"))
+        test("getForContributor returns empty list when no aliases") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao)
+                aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+            }
         }
 
-    @Test
-    fun `insertAll preserves case-different aliases as distinct rows`() =
-        runTest {
-            seedContributor()
+        test("deleteForContributor removes only that contributor's aliases") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao, id = "c-1", name = "King")
+                contributorAliasSeedContributor(contributorDao, id = "c-2", name = "Gaiman")
 
-            aliasDao.insertAll(
-                listOf(
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                    ContributorAliasCrossRef(ContributorId("c-1"), "BACHMAN"),
-                ),
-            )
+                aliasDao.insertAll(
+                    listOf(
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                        ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
+                    ),
+                )
 
-            val result = aliasDao.getForContributor("c-1")
-            assertEquals(2, result.size)
-            assertTrue("Bachman" in result)
-            assertTrue("BACHMAN" in result)
+                aliasDao.deleteForContributor("c-1")
+
+                aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+                aliasDao.getForContributor("c-2") shouldBe listOf("Pinkerton")
+            }
         }
 
-    @Test
-    fun `observeByIdWithAliases returns contributor with aliases from junction`() =
-        runTest {
-            seedContributor()
-            aliasDao.insertAll(
-                listOf(
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
-                    ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                ),
-            )
+        test("cascade delete removes only the deleted contributor's aliases") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao, id = "c-1", name = "King")
+                contributorAliasSeedContributor(contributorDao, id = "c-2", name = "Gaiman")
 
-            val result = contributorDao.getByIdWithAliases("c-1")
+                aliasDao.insertAll(
+                    listOf(
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
+                        ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
+                    ),
+                )
 
-            kotlin.test.assertNotNull(result)
-            assertEquals("c-1", result.contributor.id.value)
-            assertEquals(listOf("Bachman", "Swithen"), result.aliases)
+                contributorDao.deleteById("c-1")
+
+                aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+                aliasDao.getForContributor("c-2") shouldBe listOf("Pinkerton")
+            }
         }
 
-    @Test
-    fun `getByIdWithAliases returns null for missing contributor`() =
-        runTest {
-            assertEquals(null, contributorDao.getByIdWithAliases("no-such-id"))
+        test("observeForContributor emits initial list and re-emits on change") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao)
+                aliasDao.insertAll(
+                    listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")),
+                )
+
+                aliasDao.observeForContributor("c-1").test {
+                    awaitItem() shouldBe listOf("Bachman")
+
+                    aliasDao.insertAll(
+                        listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Swithen")),
+                    )
+                    awaitItem() shouldBe listOf("Bachman", "Swithen")
+
+                    aliasDao.deleteForContributor("c-1")
+                    awaitItem() shouldBe emptyList()
+
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
         }
+
+        test("insertAll with duplicate exact-case alias is ignored") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao)
+
+                aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
+                aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
+
+                aliasDao.getForContributor("c-1") shouldBe listOf("Bachman")
+            }
+        }
+
+        test("insertAll preserves case-different aliases as distinct rows") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao)
+
+                aliasDao.insertAll(
+                    listOf(
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                        ContributorAliasCrossRef(ContributorId("c-1"), "BACHMAN"),
+                    ),
+                )
+
+                val result = aliasDao.getForContributor("c-1")
+                result.size shouldBe 2
+                ("Bachman" in result) shouldBe true
+                ("BACHMAN" in result) shouldBe true
+            }
+        }
+
+        test("observeByIdWithAliases returns contributor with aliases from junction") {
+            runTest {
+                contributorAliasSeedContributor(contributorDao)
+                aliasDao.insertAll(
+                    listOf(
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
+                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                    ),
+                )
+
+                val result = contributorDao.getByIdWithAliases("c-1")
+
+                result.shouldNotBeNull()
+                result.contributor.id.value shouldBe "c-1"
+                result.aliases shouldBe listOf("Bachman", "Swithen")
+            }
+        }
+
+        test("getByIdWithAliases returns null for missing contributor") {
+            runTest {
+                contributorDao.getByIdWithAliases("no-such-id") shouldBe null
+            }
+        }
+    })
+
+private suspend fun contributorAliasSeedContributor(
+    contributorDao: ContributorDao,
+    id: String = "c-1",
+    name: String = "Stephen King",
+) {
+    contributorDao.upsert(
+        ContributorEntity(
+            id = ContributorId(id),
+            name = name,
+            description = null,
+            imagePath = null,
+            createdAt = Timestamp(1L),
+            updatedAt = Timestamp(1L),
+        ),
+    )
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/ContributorAliasDaoTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/ContributorAliasDaoTest.kt
@@ -18,157 +18,206 @@ import kotlinx.coroutines.test.runTest
  */
 class ContributorAliasDaoTest :
     FunSpec({
-        lateinit var db: ListenUpDatabase
-        lateinit var contributorDao: ContributorDao
-        lateinit var aliasDao: ContributorAliasDao
-
-        beforeTest {
-            db = createInMemoryTestDatabase()
-            contributorDao = db.contributorDao()
-            aliasDao = db.contributorAliasDao()
-        }
-
-        afterTest {
-            db.close()
-        }
 
         test("insertAll and getForContributor returns aliases sorted alphabetically case-insensitively") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao)
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao)
 
-                aliasDao.insertAll(
-                    listOf(
-                        ContributorAliasCrossRef(ContributorId("c-1"), "richard bachman"),
-                        ContributorAliasCrossRef(ContributorId("c-1"), "John Swithen"),
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Beryl Evans"),
-                    ),
-                )
+                    aliasDao.insertAll(
+                        listOf(
+                            ContributorAliasCrossRef(ContributorId("c-1"), "richard bachman"),
+                            ContributorAliasCrossRef(ContributorId("c-1"), "John Swithen"),
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Beryl Evans"),
+                        ),
+                    )
 
-                val result = aliasDao.getForContributor("c-1")
+                    val result = aliasDao.getForContributor("c-1")
 
-                result shouldBe listOf("Beryl Evans", "John Swithen", "richard bachman")
+                    result shouldBe listOf("Beryl Evans", "John Swithen", "richard bachman")
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("getForContributor returns empty list when no aliases") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao)
-                aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao)
+                    aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("deleteForContributor removes only that contributor's aliases") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao, id = "c-1", name = "King")
-                contributorAliasSeedContributor(contributorDao, id = "c-2", name = "Gaiman")
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao, id = "c-1", name = "King")
+                    contributorAliasSeedContributor(contributorDao, id = "c-2", name = "Gaiman")
 
-                aliasDao.insertAll(
-                    listOf(
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                        ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
-                    ),
-                )
+                    aliasDao.insertAll(
+                        listOf(
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                            ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
+                        ),
+                    )
 
-                aliasDao.deleteForContributor("c-1")
+                    aliasDao.deleteForContributor("c-1")
 
-                aliasDao.getForContributor("c-1").isEmpty() shouldBe true
-                aliasDao.getForContributor("c-2") shouldBe listOf("Pinkerton")
+                    aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+                    aliasDao.getForContributor("c-2") shouldBe listOf("Pinkerton")
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("cascade delete removes only the deleted contributor's aliases") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao, id = "c-1", name = "King")
-                contributorAliasSeedContributor(contributorDao, id = "c-2", name = "Gaiman")
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao, id = "c-1", name = "King")
+                    contributorAliasSeedContributor(contributorDao, id = "c-2", name = "Gaiman")
 
-                aliasDao.insertAll(
-                    listOf(
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
-                        ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
-                    ),
-                )
+                    aliasDao.insertAll(
+                        listOf(
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
+                            ContributorAliasCrossRef(ContributorId("c-2"), "Pinkerton"),
+                        ),
+                    )
 
-                contributorDao.deleteById("c-1")
+                    contributorDao.deleteById("c-1")
 
-                aliasDao.getForContributor("c-1").isEmpty() shouldBe true
-                aliasDao.getForContributor("c-2") shouldBe listOf("Pinkerton")
+                    aliasDao.getForContributor("c-1").isEmpty() shouldBe true
+                    aliasDao.getForContributor("c-2") shouldBe listOf("Pinkerton")
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("observeForContributor emits initial list and re-emits on change") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao)
-                aliasDao.insertAll(
-                    listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")),
-                )
-
-                aliasDao.observeForContributor("c-1").test {
-                    awaitItem() shouldBe listOf("Bachman")
-
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao)
                     aliasDao.insertAll(
-                        listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Swithen")),
+                        listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")),
                     )
-                    awaitItem() shouldBe listOf("Bachman", "Swithen")
 
-                    aliasDao.deleteForContributor("c-1")
-                    awaitItem() shouldBe emptyList()
+                    aliasDao.observeForContributor("c-1").test {
+                        awaitItem() shouldBe listOf("Bachman")
 
-                    cancelAndIgnoreRemainingEvents()
+                        aliasDao.insertAll(
+                            listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Swithen")),
+                        )
+                        awaitItem() shouldBe listOf("Bachman", "Swithen")
+
+                        aliasDao.deleteForContributor("c-1")
+                        awaitItem() shouldBe emptyList()
+
+                        cancelAndIgnoreRemainingEvents()
+                    }
                 }
+            } finally {
+                db.close()
             }
         }
 
         test("insertAll with duplicate exact-case alias is ignored") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao)
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao)
 
-                aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
-                aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
+                    aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
+                    aliasDao.insertAll(listOf(ContributorAliasCrossRef(ContributorId("c-1"), "Bachman")))
 
-                aliasDao.getForContributor("c-1") shouldBe listOf("Bachman")
+                    aliasDao.getForContributor("c-1") shouldBe listOf("Bachman")
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("insertAll preserves case-different aliases as distinct rows") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao)
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao)
 
-                aliasDao.insertAll(
-                    listOf(
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                        ContributorAliasCrossRef(ContributorId("c-1"), "BACHMAN"),
-                    ),
-                )
+                    aliasDao.insertAll(
+                        listOf(
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                            ContributorAliasCrossRef(ContributorId("c-1"), "BACHMAN"),
+                        ),
+                    )
 
-                val result = aliasDao.getForContributor("c-1")
-                result.size shouldBe 2
-                ("Bachman" in result) shouldBe true
-                ("BACHMAN" in result) shouldBe true
+                    val result = aliasDao.getForContributor("c-1")
+                    result.size shouldBe 2
+                    ("Bachman" in result) shouldBe true
+                    ("BACHMAN" in result) shouldBe true
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("observeByIdWithAliases returns contributor with aliases from junction") {
-            runTest {
-                contributorAliasSeedContributor(contributorDao)
-                aliasDao.insertAll(
-                    listOf(
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
-                        ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
-                    ),
-                )
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    val aliasDao = db.contributorAliasDao()
+                    contributorAliasSeedContributor(contributorDao)
+                    aliasDao.insertAll(
+                        listOf(
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Swithen"),
+                            ContributorAliasCrossRef(ContributorId("c-1"), "Bachman"),
+                        ),
+                    )
 
-                val result = contributorDao.getByIdWithAliases("c-1")
+                    val result = contributorDao.getByIdWithAliases("c-1")
 
-                result.shouldNotBeNull()
-                result.contributor.id.value shouldBe "c-1"
-                result.aliases shouldBe listOf("Bachman", "Swithen")
+                    result.shouldNotBeNull()
+                    result.contributor.id.value shouldBe "c-1"
+                    result.aliases shouldBe listOf("Bachman", "Swithen")
+                }
+            } finally {
+                db.close()
             }
         }
 
         test("getByIdWithAliases returns null for missing contributor") {
-            runTest {
-                contributorDao.getByIdWithAliases("no-such-id") shouldBe null
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val contributorDao = db.contributorDao()
+                    contributorDao.getByIdWithAliases("no-such-id") shouldBe null
+                }
+            } finally {
+                db.close()
             }
         }
     })

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/JvmCoverColorExtractorTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/JvmCoverColorExtractorTest.kt
@@ -1,15 +1,13 @@
 package com.calypsan.listenup.client.data.local.images
 
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Integration tests for JvmCoverColorExtractor.
@@ -17,260 +15,259 @@ import kotlin.test.assertTrue
  * Tests color extraction using programmatically generated test images
  * to verify the k-means clustering and color selection logic.
  */
-class JvmCoverColorExtractorTest {
-    private val extractor = JvmCoverColorExtractor()
+class JvmCoverColorExtractorTest :
+    FunSpec({
+        val extractor = JvmCoverColorExtractor()
 
-    @Test
-    fun `extracts dominant color from solid red image`() =
-        runTest {
-            // Given - a solid red image
-            val imageBytes = createSolidColorImage(Color.RED)
+        fun createSolidColorImage(
+            color: Color,
+            width: Int = 100,
+            height: Int = 100,
+            format: String = "PNG",
+        ): ByteArray {
+            val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+            val graphics = image.createGraphics()
+            graphics.color = color
+            graphics.fillRect(0, 0, width, height)
+            graphics.dispose()
 
-            // When
-            val colors = extractor.extractColors(imageBytes)
-
-            // Then
-            assertNotNull(colors)
-            val dominant = Color(colors.dominant)
-            // Should be close to red (allowing some variance from algorithm)
-            assertTrue(dominant.red > 200, "Red channel should be high: ${dominant.red}")
-            assertTrue(dominant.green < 50, "Green channel should be low: ${dominant.green}")
-            assertTrue(dominant.blue < 50, "Blue channel should be low: ${dominant.blue}")
-        }
-
-    @Test
-    fun `extracts dominant color from solid blue image`() =
-        runTest {
-            // Given - a solid blue image
-            val imageBytes = createSolidColorImage(Color.BLUE)
-
-            // When
-            val colors = extractor.extractColors(imageBytes)
-
-            // Then
-            assertNotNull(colors)
-            val dominant = Color(colors.dominant)
-            assertTrue(dominant.blue > 200, "Blue channel should be high: ${dominant.blue}")
-            assertTrue(dominant.red < 50, "Red channel should be low: ${dominant.red}")
-            assertTrue(dominant.green < 50, "Green channel should be low: ${dominant.green}")
-        }
-
-    @Test
-    fun `extracts colors from two-tone image`() =
-        runTest {
-            // Given - image split vertically: left half red, right half blue
-            val imageBytes = createTwoToneImage(Color.RED, Color.BLUE)
-
-            // When
-            val colors = extractor.extractColors(imageBytes)
-
-            // Then
-            assertNotNull(colors)
-            // Dominant should be either red or blue (whichever cluster is larger)
-            val dominant = Color(colors.dominant)
-            val isRedish = dominant.red > 150 && dominant.blue < 100
-            val isBlueish = dominant.blue > 150 && dominant.red < 100
-            assertTrue(isRedish || isBlueish, "Dominant should be red or blue: $dominant")
-        }
-
-    @Test
-    fun `returns null for empty byte array`() =
-        runTest {
-            // When
-            val colors = extractor.extractColors(ByteArray(0))
-
-            // Then
-            assertNull(colors)
-        }
-
-    @Test
-    fun `returns null for invalid image data`() =
-        runTest {
-            // Given - random garbage bytes
-            val garbageBytes = "not an image at all".toByteArray()
-
-            // When
-            val colors = extractor.extractColors(garbageBytes)
-
-            // Then
-            assertNull(colors)
-        }
-
-    @Test
-    fun `handles very small image`() =
-        runTest {
-            // Given - 1x1 pixel image
-            val imageBytes = createSolidColorImage(Color.GREEN, width = 1, height = 1)
-
-            // When
-            val colors = extractor.extractColors(imageBytes)
-
-            // Then - might be null (too few pixels) or extract the color
-            // Either behavior is acceptable for edge case
-            if (colors != null) {
-                val dominant = Color(colors.dominant)
-                assertTrue(dominant.green > 100, "Should detect green-ish color")
+            return ByteArrayOutputStream().use { baos ->
+                ImageIO.write(image, format, baos)
+                baos.toByteArray()
             }
         }
 
-    @Test
-    fun `handles large image efficiently`() =
-        runTest {
-            // Given - large image (1000x1000 = 1M pixels)
-            val imageBytes = createSolidColorImage(Color.ORANGE, width = 1000, height = 1000)
-
-            // When - should complete in reasonable time due to sampling
-            val startTime = System.currentTimeMillis()
-            val colors = extractor.extractColors(imageBytes)
-            val elapsed = System.currentTimeMillis() - startTime
-
-            // Then
-            assertNotNull(colors)
-            assertTrue(elapsed < 5000, "Should complete in under 5 seconds: ${elapsed}ms")
-        }
-
-    @Test
-    fun `vibrant color has high saturation`() =
-        runTest {
-            // Given - image dominated by saturated color (75% red, 25% gray)
-            // Asymmetric split ensures k-means reliably produces a saturated cluster
-            val image = java.awt.image.BufferedImage(200, 200, java.awt.image.BufferedImage.TYPE_INT_RGB)
+        fun createTwoToneImage(
+            leftColor: Color,
+            rightColor: Color,
+            width: Int = 100,
+            height: Int = 100,
+        ): ByteArray {
+            val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
             val graphics = image.createGraphics()
-            graphics.color = Color(255, 0, 0)
-            graphics.fillRect(0, 0, 150, 200)
-            graphics.color = Color(128, 128, 128)
-            graphics.fillRect(150, 0, 50, 200)
+
+            // Left half
+            graphics.color = leftColor
+            graphics.fillRect(0, 0, width / 2, height)
+
+            // Right half
+            graphics.color = rightColor
+            graphics.fillRect(width / 2, 0, width / 2, height)
+
             graphics.dispose()
-            val imageBytes =
-                java.io.ByteArrayOutputStream().use { baos ->
-                    javax.imageio.ImageIO.write(image, "PNG", baos)
-                    baos.toByteArray()
+
+            return ByteArrayOutputStream().use { baos ->
+                ImageIO.write(image, "PNG", baos)
+                baos.toByteArray()
+            }
+        }
+
+        test("extracts dominant color from solid red image") {
+            runTest {
+                // Given - a solid red image
+                val imageBytes = createSolidColorImage(Color.RED)
+
+                // When
+                val colors = extractor.extractColors(imageBytes)
+
+                // Then
+                colors.shouldNotBeNull()
+                val dominant = Color(colors.dominant)
+                // Should be close to red (allowing some variance from algorithm)
+                (dominant.red > 200) shouldBe true
+                (dominant.green < 50) shouldBe true
+                (dominant.blue < 50) shouldBe true
+            }
+        }
+
+        test("extracts dominant color from solid blue image") {
+            runTest {
+                // Given - a solid blue image
+                val imageBytes = createSolidColorImage(Color.BLUE)
+
+                // When
+                val colors = extractor.extractColors(imageBytes)
+
+                // Then
+                colors.shouldNotBeNull()
+                val dominant = Color(colors.dominant)
+                (dominant.blue > 200) shouldBe true
+                (dominant.red < 50) shouldBe true
+                (dominant.green < 50) shouldBe true
+            }
+        }
+
+        test("extracts colors from two-tone image") {
+            runTest {
+                // Given - image split vertically: left half red, right half blue
+                val imageBytes = createTwoToneImage(Color.RED, Color.BLUE)
+
+                // When
+                val colors = extractor.extractColors(imageBytes)
+
+                // Then
+                colors.shouldNotBeNull()
+                // Dominant should be either red or blue (whichever cluster is larger)
+                val dominant = Color(colors.dominant)
+                val isRedish = dominant.red > 150 && dominant.blue < 100
+                val isBlueish = dominant.blue > 150 && dominant.red < 100
+                (isRedish || isBlueish) shouldBe true
+            }
+        }
+
+        test("returns null for empty byte array") {
+            runTest {
+                // When
+                val colors = extractor.extractColors(ByteArray(0))
+
+                // Then
+                colors shouldBe null
+            }
+        }
+
+        test("returns null for invalid image data") {
+            runTest {
+                // Given - random garbage bytes
+                val garbageBytes = "not an image at all".toByteArray()
+
+                // When
+                val colors = extractor.extractColors(garbageBytes)
+
+                // Then
+                colors shouldBe null
+            }
+        }
+
+        test("handles very small image") {
+            runTest {
+                // Given - 1x1 pixel image
+                val imageBytes = createSolidColorImage(Color.GREEN, width = 1, height = 1)
+
+                // When
+                val colors = extractor.extractColors(imageBytes)
+
+                // Then - might be null (too few pixels) or extract the color
+                // Either behavior is acceptable for edge case
+                if (colors != null) {
+                    val dominant = Color(colors.dominant)
+                    (dominant.green > 100) shouldBe true
                 }
-
-            // When
-            val colors = extractor.extractColors(imageBytes)
-
-            // Then - vibrant should pick the saturated red cluster
-            assertNotNull(colors)
-            val vibrant = Color(colors.vibrant)
-            val hsb = Color.RGBtoHSB(vibrant.red, vibrant.green, vibrant.blue, null)
-            val saturation = hsb[1]
-            assertTrue(saturation > 0.1f, "Vibrant color should have decent saturation: $saturation (rgb: $vibrant)")
+            }
         }
 
-    @Test
-    fun `dark muted color has low brightness`() =
-        runTest {
-            // Given - image with dark and light colors
-            val imageBytes =
-                createTwoToneImage(
-                    Color(50, 30, 30), // Dark brownish
-                    Color(255, 255, 200), // Light cream
-                )
+        test("handles large image efficiently") {
+            runTest {
+                // Given - large image (1000x1000 = 1M pixels)
+                val imageBytes = createSolidColorImage(Color.ORANGE, width = 1000, height = 1000)
 
-            // When
-            val colors = extractor.extractColors(imageBytes)
+                // When - should complete in reasonable time due to sampling
+                val startTime = System.currentTimeMillis()
+                val colors = extractor.extractColors(imageBytes)
+                val elapsed = System.currentTimeMillis() - startTime
 
-            // Then
-            assertNotNull(colors)
-            val darkMuted = Color(colors.darkMuted)
-            val hsb = Color.RGBtoHSB(darkMuted.red, darkMuted.green, darkMuted.blue, null)
-            val brightness = hsb[2]
-            assertTrue(brightness < 0.7f, "Dark muted should have lower brightness: $brightness")
+                // Then
+                colors.shouldNotBeNull()
+                (elapsed < 5000) shouldBe true
+            }
         }
 
-    @Test
-    fun `colors are valid ARGB integers`() =
-        runTest {
-            // Given
-            val imageBytes = createSolidColorImage(Color.CYAN)
+        test("vibrant color has high saturation") {
+            runTest {
+                // Given - image dominated by saturated color (75% red, 25% gray)
+                // Asymmetric split ensures k-means reliably produces a saturated cluster
+                val image = java.awt.image.BufferedImage(200, 200, java.awt.image.BufferedImage.TYPE_INT_RGB)
+                val graphics = image.createGraphics()
+                graphics.color = Color(255, 0, 0)
+                graphics.fillRect(0, 0, 150, 200)
+                graphics.color = Color(128, 128, 128)
+                graphics.fillRect(150, 0, 50, 200)
+                graphics.dispose()
+                val imageBytes =
+                    java.io.ByteArrayOutputStream().use { baos ->
+                        javax.imageio.ImageIO.write(image, "PNG", baos)
+                        baos.toByteArray()
+                    }
 
-            // When
-            val colors = extractor.extractColors(imageBytes)
+                // When
+                val colors = extractor.extractColors(imageBytes)
 
-            // Then
-            assertNotNull(colors)
-
-            // All colors should have full alpha (0xFF in high byte)
-            assertEquals(0xFF, (colors.dominant shr 24) and 0xFF, "Dominant should have full alpha")
-            assertEquals(0xFF, (colors.darkMuted shr 24) and 0xFF, "DarkMuted should have full alpha")
-            assertEquals(0xFF, (colors.vibrant shr 24) and 0xFF, "Vibrant should have full alpha")
-
-            // RGB values should be in valid range (implicit by Int, but verify construction)
-            val dominant = Color(colors.dominant)
-            assertTrue(dominant.red in 0..255)
-            assertTrue(dominant.green in 0..255)
-            assertTrue(dominant.blue in 0..255)
+                // Then - vibrant should pick the saturated red cluster
+                colors.shouldNotBeNull()
+                val vibrant = Color(colors.vibrant)
+                val hsb = Color.RGBtoHSB(vibrant.red, vibrant.green, vibrant.blue, null)
+                val saturation = hsb[1]
+                (saturation > 0.1f) shouldBe true
+            }
         }
 
-    @Test
-    fun `handles PNG format`() =
-        runTest {
-            // Given - PNG image
-            val imageBytes = createSolidColorImage(Color.MAGENTA, format = "PNG")
+        test("dark muted color has low brightness") {
+            runTest {
+                // Given - image with dark and light colors
+                val imageBytes =
+                    createTwoToneImage(
+                        Color(50, 30, 30), // Dark brownish
+                        Color(255, 255, 200), // Light cream
+                    )
 
-            // When
-            val colors = extractor.extractColors(imageBytes)
+                // When
+                val colors = extractor.extractColors(imageBytes)
 
-            // Then
-            assertNotNull(colors)
+                // Then
+                colors.shouldNotBeNull()
+                val darkMuted = Color(colors.darkMuted)
+                val hsb = Color.RGBtoHSB(darkMuted.red, darkMuted.green, darkMuted.blue, null)
+                val brightness = hsb[2]
+                (brightness < 0.7f) shouldBe true
+            }
         }
 
-    @Test
-    fun `handles JPEG format`() =
-        runTest {
-            // Given - JPEG image
-            val imageBytes = createSolidColorImage(Color.YELLOW, format = "JPEG")
+        test("colors are valid ARGB integers") {
+            runTest {
+                // Given
+                val imageBytes = createSolidColorImage(Color.CYAN)
 
-            // When
-            val colors = extractor.extractColors(imageBytes)
+                // When
+                val colors = extractor.extractColors(imageBytes)
 
-            // Then
-            assertNotNull(colors)
+                // Then
+                colors.shouldNotBeNull()
+
+                // All colors should have full alpha (0xFF in high byte)
+                ((colors.dominant shr 24) and 0xFF) shouldBe 0xFF
+                ((colors.darkMuted shr 24) and 0xFF) shouldBe 0xFF
+                ((colors.vibrant shr 24) and 0xFF) shouldBe 0xFF
+
+                // RGB values should be in valid range (implicit by Int, but verify construction)
+                val dominant = Color(colors.dominant)
+                (dominant.red in 0..255) shouldBe true
+                (dominant.green in 0..255) shouldBe true
+                (dominant.blue in 0..255) shouldBe true
+            }
         }
 
-    // --- Helper functions ---
+        test("handles PNG format") {
+            runTest {
+                // Given - PNG image
+                val imageBytes = createSolidColorImage(Color.MAGENTA, format = "PNG")
 
-    private fun createSolidColorImage(
-        color: Color,
-        width: Int = 100,
-        height: Int = 100,
-        format: String = "PNG",
-    ): ByteArray {
-        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
-        val graphics = image.createGraphics()
-        graphics.color = color
-        graphics.fillRect(0, 0, width, height)
-        graphics.dispose()
+                // When
+                val colors = extractor.extractColors(imageBytes)
 
-        return ByteArrayOutputStream().use { baos ->
-            ImageIO.write(image, format, baos)
-            baos.toByteArray()
+                // Then
+                colors.shouldNotBeNull()
+            }
         }
-    }
 
-    private fun createTwoToneImage(
-        leftColor: Color,
-        rightColor: Color,
-        width: Int = 100,
-        height: Int = 100,
-    ): ByteArray {
-        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
-        val graphics = image.createGraphics()
+        test("handles JPEG format") {
+            runTest {
+                // Given - JPEG image
+                val imageBytes = createSolidColorImage(Color.YELLOW, format = "JPEG")
 
-        // Left half
-        graphics.color = leftColor
-        graphics.fillRect(0, 0, width / 2, height)
+                // When
+                val colors = extractor.extractColors(imageBytes)
 
-        // Right half
-        graphics.color = rightColor
-        graphics.fillRect(width / 2, 0, width / 2, height)
-
-        graphics.dispose()
-
-        return ByteArrayOutputStream().use { baos ->
-            ImageIO.write(image, "PNG", baos)
-            baos.toByteArray()
+                // Then
+                colors.shouldNotBeNull()
+            }
         }
-    }
-}
+    })


### PR DESCRIPTION
## Books-domain Kotest migration

Migrates all 32 Books-domain test files in `:shared` from the legacy `kotlin-test` framework to Kotest `FunSpec` — the canonical test framework per `CLAUDE.md`.

- **32 files, 421 tests** — domain models, use cases, repositories, ViewModels, DAO/mapper tests
- Test-count parity verified file-by-file: **421 original `@Test` == 421 migrated `test()`** — no test dropped or weakened
- Mokkery and Turbine usage unchanged; only the assertion framework and test-block structure changed
- `lateinit` DAO fixtures replaced with a detekt-clean per-test `val` idiom
- Gates green: `:shared:jvmTest`, `detekt`, `spotlessCheck`

`kotlin-test` stays in the version catalog — the ~139 non-Books test files across `:shared` / `:composeApp` / `build-logic` migrate opportunistically as their domains are touched (per `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
