### PR TITLE
♻️ refactor: unify datetime on kotlin.time + KMP-safety guard

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -483,7 +483,8 @@ private fun BackupCard(
             }
             Spacer(modifier = Modifier.height(8.dp))
             val localDateTime =
-                Instant.fromEpochMilliseconds(backup.createdAt.epochMillis)
+                Instant
+                    .fromEpochMilliseconds(backup.createdAt.epochMillis)
                     .toLocalDateTime(TimeZone.currentSystemDefault())
             val timeStr = "${localDateTime.hour}:${localDateTime.minute.toString().padStart(2, '0')}"
             Text(

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -65,6 +65,7 @@ import com.calypsan.listenup.client.presentation.admin.ABSImportListUiState
 import com.calypsan.listenup.client.presentation.admin.AdminBackupUiState
 import com.calypsan.listenup.client.presentation.admin.AdminBackupViewModel
 import com.calypsan.listenup.client.util.rememberABSBackupPicker
+import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.koin.compose.viewmodel.koinViewModel
@@ -481,7 +482,9 @@ private fun BackupCard(
                 }
             }
             Spacer(modifier = Modifier.height(8.dp))
-            val localDateTime = backup.createdAt.toLocalDateTime(TimeZone.currentSystemDefault())
+            val localDateTime =
+                Instant.fromEpochMilliseconds(backup.createdAt.epochMillis)
+                    .toLocalDateTime(TimeZone.currentSystemDefault())
             val timeStr = "${localDateTime.hour}:${localDateTime.minute.toString().padStart(2, '0')}"
             Text(
                 text = "Created: ${localDateTime.date} at $timeStr",

--- a/server/src/main/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.auth
 
 import com.calypsan.listenup.api.AuthServiceAuthed
@@ -25,8 +27,9 @@ import com.calypsan.listenup.server.db.UserTable
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
-import java.time.Clock
 import java.util.UUID
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /** Instance-level registration mode. Drives `register()` branching. */
 enum class RegistrationPolicy { OPEN, APPROVAL_QUEUE, CLOSED }
@@ -46,7 +49,7 @@ class AuthServiceImpl(
     internal val sessions: SessionService,
     internal val hasher: PasswordHasher,
     internal val jwt: JwtConfiguration,
-    internal val clock: Clock = Clock.systemUTC(),
+    internal val clock: Clock = Clock.System,
     internal val registrationPolicy: RegistrationPolicy = RegistrationPolicy.OPEN,
     internal val principalProvider: PrincipalProvider = PrincipalProvider.None,
 ) : AuthServicePublic,
@@ -98,7 +101,7 @@ class AuthServiceImpl(
         // Argon2 is CPU-bound and slow on purpose — run it before opening the
         // transaction so we don't hold a DB connection during the hash.
         val passwordHashed = hasher.hash(request.password)
-        val now = clock.millis()
+        val now = clock.now().toEpochMilliseconds()
         val user =
             suspendTransaction(db) {
                 UserEntity.new(newUserId()) {
@@ -137,7 +140,7 @@ class AuthServiceImpl(
         if (!empty) return AppResult.Failure(AuthError.SetupAlreadyComplete())
 
         val passwordHashed = hasher.hash(request.password)
-        val now = clock.millis()
+        val now = clock.now().toEpochMilliseconds()
         val user =
             suspendTransaction(db) {
                 UserEntity.new(newUserId()) {
@@ -167,7 +170,7 @@ class AuthServiceImpl(
             }
         val role = user.role.toContract()
         val accessJwt = jwt.issue(userId = rotated.userId, sessionId = rotated.sessionId, role = role)
-        val accessExp = clock.instant().plus(jwt.accessTokenTtl).toEpochMilli()
+        val accessExp = (clock.now() + jwt.accessTokenTtl).toEpochMilliseconds()
         return AppResult.Success(
             AuthSession(
                 accessToken = AccessToken(accessJwt),
@@ -251,7 +254,7 @@ class AuthServiceImpl(
             return AppResult.Failure(AuthError.PermissionDenied())
         }
 
-        val now = clock.millis()
+        val now = clock.now().toEpochMilliseconds()
         val newStatus = if (request.approved) UserStatusColumn.ACTIVE else UserStatusColumn.DENIED
         suspendTransaction(db) {
             target.status = newStatus
@@ -270,7 +273,7 @@ class AuthServiceImpl(
         val role = userEntity.role.toContract()
         val issued = sessions.createSession(userId, label = label)
         val accessJwt = jwt.issue(userId = userId, sessionId = issued.sessionId, role = role)
-        val expiresAt = clock.instant().plus(jwt.accessTokenTtl).toEpochMilli()
+        val expiresAt = (clock.now() + jwt.accessTokenTtl).toEpochMilliseconds()
         return AuthSession(
             accessToken = AccessToken(accessJwt),
             accessTokenExpiresAt = expiresAt,
@@ -282,7 +285,7 @@ class AuthServiceImpl(
     }
 
     private suspend fun markLastLogin(userId: String) {
-        val now = clock.millis()
+        val now = clock.now().toEpochMilliseconds()
         suspendTransaction(db) {
             UserEntity[userId].lastLoginAt = now
         }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/auth/JwtConfiguration.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/auth/JwtConfiguration.kt
@@ -18,8 +18,7 @@ import kotlin.time.ExperimentalTime
 /** Adapts the injected kotlin.time.Clock to the java.time.Clock that com.auth0:java-jwt requires. */
 private fun Clock.asJavaClock(): java.time.Clock =
     object : java.time.Clock() {
-        override fun instant(): java.time.Instant =
-            java.time.Instant.ofEpochMilli(now().toEpochMilliseconds())
+        override fun instant(): java.time.Instant = java.time.Instant.ofEpochMilli(now().toEpochMilliseconds())
 
         override fun getZone(): java.time.ZoneId = java.time.ZoneOffset.UTC
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/auth/JwtConfiguration.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/auth/JwtConfiguration.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.auth
 
 import com.auth0.jwt.JWT
@@ -7,9 +9,22 @@ import com.auth0.jwt.exceptions.JWTVerificationException
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
-import java.time.Clock
-import java.time.Duration
 import java.util.Date
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+
+/** Adapts the injected kotlin.time.Clock to the java.time.Clock that com.auth0:java-jwt requires. */
+private fun Clock.asJavaClock(): java.time.Clock =
+    object : java.time.Clock() {
+        override fun instant(): java.time.Instant =
+            java.time.Instant.ofEpochMilli(now().toEpochMilliseconds())
+
+        override fun getZone(): java.time.ZoneId = java.time.ZoneOffset.UTC
+
+        override fun withZone(zone: java.time.ZoneId): java.time.Clock = this
+    }
 
 data class AccessTokenClaims(
     val userId: UserId,
@@ -34,7 +49,7 @@ data class JwtConfiguration(
     val issuer: String,
     val audience: String,
     val accessTokenTtl: Duration = DEFAULT_ACCESS_TOKEN_TTL,
-    val clock: Clock = Clock.systemUTC(),
+    val clock: Clock = Clock.System,
 ) {
     init {
         require(secret.toByteArray(Charsets.UTF_8).size >= MIN_SECRET_BYTES) {
@@ -46,9 +61,10 @@ data class JwtConfiguration(
 
     /**
      * The auth0 verifier consults a [Clock] when checking `exp` / `nbf` / `iat`.
-     * Wire our injected [Clock] in so tests with [Clock.fixed] are deterministic
-     * — otherwise verification falls back to the system clock and any token
-     * issued in the test's fixed past is rejected as expired by the wall clock.
+     * Wire our injected [kotlin.time.Clock] in (via [asJavaClock]) so tests with
+     * [com.calypsan.listenup.server.testing.FixedClock] are deterministic — otherwise
+     * verification falls back to the system clock and any token issued in the test's
+     * fixed past is rejected as expired by the wall clock.
      *
      * The clock-aware `build(Clock)` overload only exists on the concrete
      * [JWTVerifier.BaseVerification], not on the `Verification` interface that
@@ -60,15 +76,15 @@ data class JwtConfiguration(
                 .require(algorithm)
                 .withIssuer(issuer)
                 .withAudience(audience) as JWTVerifier.BaseVerification
-        ).build(clock)
+        ).build(clock.asJavaClock())
 
     fun issue(
         userId: UserId,
         sessionId: SessionId,
         role: UserRole,
     ): String {
-        val now = clock.instant()
-        val exp = now.plus(accessTokenTtl)
+        val now = clock.now()
+        val exp = now + accessTokenTtl
         return JWT
             .create()
             .withIssuer(issuer)
@@ -76,9 +92,9 @@ data class JwtConfiguration(
             .withSubject(userId.value)
             .withJWTId(sessionId.value)
             .withClaim(CLAIM_ROLE, role.name)
-            .withIssuedAt(Date.from(now))
-            .withNotBefore(Date.from(now))
-            .withExpiresAt(Date.from(exp))
+            .withIssuedAt(Date(now.toEpochMilliseconds()))
+            .withNotBefore(Date(now.toEpochMilliseconds()))
+            .withExpiresAt(Date(exp.toEpochMilliseconds()))
             .sign(algorithm)
     }
 
@@ -107,6 +123,6 @@ data class JwtConfiguration(
     companion object {
         private const val MIN_SECRET_BYTES = 32
         private const val CLAIM_ROLE = "role"
-        private val DEFAULT_ACCESS_TOKEN_TTL: Duration = Duration.ofMinutes(15)
+        private val DEFAULT_ACCESS_TOKEN_TTL: Duration = 15.minutes
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/auth/SessionService.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.auth
 
 import com.calypsan.listenup.api.dto.auth.RefreshToken
@@ -12,9 +14,11 @@ import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.update
-import java.time.Clock
-import java.time.Duration
 import java.util.UUID
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.ExperimentalTime
 
 /** Result of creating a new session — the raw refresh token is only returned here. */
 data class IssuedSession(
@@ -44,7 +48,7 @@ class SessionService(
     private val tokenHasher: RefreshTokenHasher,
     private val tokenGenerator: RefreshTokenGenerator,
     private val refreshTtl: Duration = DEFAULT_REFRESH_TTL,
-    private val clock: Clock = Clock.systemUTC(),
+    private val clock: Clock = Clock.System,
 ) {
     suspend fun createSession(
         userId: UserId,
@@ -53,8 +57,8 @@ class SessionService(
     ): IssuedSession {
         val raw = tokenGenerator.generate()
         val hash = tokenHasher.hash(raw)
-        val now = clock.millis()
-        val expires = clock.instant().plus(refreshTtl).toEpochMilli()
+        val now = clock.now().toEpochMilliseconds()
+        val expires = (clock.now() + refreshTtl).toEpochMilliseconds()
         val sid = newSessionId()
         val familyId = newFamilyId()
         suspendTransaction(db) {
@@ -80,10 +84,10 @@ class SessionService(
      */
     suspend fun rotate(token: RefreshToken): RotatedSession? {
         val incomingHash = tokenHasher.hash(token.value)
-        val now = clock.millis()
+        val now = clock.now().toEpochMilliseconds()
         val newRaw = tokenGenerator.generate()
         val newHash = tokenHasher.hash(newRaw)
-        val newExpires = clock.instant().plus(refreshTtl).toEpochMilli()
+        val newExpires = (clock.now() + refreshTtl).toEpochMilliseconds()
 
         return suspendTransaction(db) {
             // Pass 1: live-token match → rotate. Indexed via UNIQUE INDEX
@@ -93,7 +97,7 @@ class SessionService(
                     .find {
                         (SessionTable.refreshTokenHash eq incomingHash) and
                             (SessionTable.revokedAt eq null) and
-                            (SessionTable.expiresAt greater clock.millis())
+                            (SessionTable.expiresAt greater clock.now().toEpochMilliseconds())
                     }.firstOrNull()
             if (live != null) {
                 live.previousHash = live.refreshTokenHash
@@ -132,7 +136,7 @@ class SessionService(
                     (SessionTable.userId eq ownerUserId.value) and
                     (SessionTable.revokedAt eq null)
             }) {
-                it[revokedAt] = clock.millis()
+                it[revokedAt] = clock.now().toEpochMilliseconds()
             }
         }
     }
@@ -142,7 +146,7 @@ class SessionService(
             SessionTable.update({
                 (SessionTable.userId eq userId.value) and (SessionTable.revokedAt eq null)
             }) {
-                it[revokedAt] = clock.millis()
+                it[revokedAt] = clock.now().toEpochMilliseconds()
             }
         }
     }
@@ -169,7 +173,7 @@ class SessionService(
     suspend fun isLive(sessionId: SessionId): Boolean =
         suspendTransaction(db) {
             val s = SessionEntity.findById(sessionId.value) ?: return@suspendTransaction false
-            s.revokedAt == null && s.expiresAt > clock.millis()
+            s.revokedAt == null && s.expiresAt > clock.now().toEpochMilliseconds()
         }
 
     suspend fun listActiveFor(userId: UserId): List<SessionEntity> =
@@ -178,7 +182,7 @@ class SessionService(
                 .find {
                     (SessionTable.userId eq userId.value) and
                         (SessionTable.revokedAt eq null) and
-                        (SessionTable.expiresAt greater clock.millis())
+                        (SessionTable.expiresAt greater clock.now().toEpochMilliseconds())
                 }.sortedByDescending { it.lastUsedAt }
                 .toList()
         }
@@ -188,6 +192,6 @@ class SessionService(
     private fun newFamilyId(): String = UUID.randomUUID().toString()
 
     companion object {
-        private val DEFAULT_REFRESH_TTL: Duration = Duration.ofDays(30)
+        private val DEFAULT_REFRESH_TTL: Duration = 30.days
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.di
 
 import com.calypsan.listenup.server.auth.AuthServiceImpl
@@ -13,8 +15,9 @@ import io.ktor.server.config.ApplicationConfig
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.koin.core.module.Module
 import org.koin.dsl.module
-import java.time.Clock
-import java.time.Duration
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.ExperimentalTime
 
 /**
  * Koin server module wiring the auth slice end-to-end. [config] is the Ktor
@@ -26,7 +29,7 @@ import java.time.Duration
  */
 fun authModule(config: ApplicationConfig): Module =
     module {
-        single<Clock> { Clock.systemUTC() }
+        single<Clock> { Clock.System }
 
         single<Database> {
             DatabaseFactory.init(
@@ -45,7 +48,7 @@ fun authModule(config: ApplicationConfig): Module =
                 db = get(),
                 tokenHasher = get(),
                 tokenGenerator = get(),
-                refreshTtl = Duration.ofDays(REFRESH_TOKEN_TTL_DAYS),
+                refreshTtl = REFRESH_TOKEN_TTL_DAYS.days,
                 clock = get(),
             )
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/auth/AuthServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/auth/AuthServiceImplTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.auth
 
 import com.calypsan.listenup.api.dto.auth.LoginRequest
@@ -17,6 +19,7 @@ import com.calypsan.listenup.server.db.DatabaseConfig
 import com.calypsan.listenup.server.db.DatabaseFactory
 import com.calypsan.listenup.server.db.UserEntity
 import com.calypsan.listenup.server.db.UserTable
+import com.calypsan.listenup.server.testing.FixedClock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -26,22 +29,21 @@ import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.nio.file.Files
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneOffset
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 class AuthServiceImplTest :
     FunSpec({
         val pepper = "x".repeat(32).toByteArray()
-        val clock = Clock.fixed(Instant.parse("2026-05-02T12:00:00Z"), ZoneOffset.UTC)
+        val clock = FixedClock(Instant.parse("2026-05-02T12:00:00Z"))
 
         fun newSvc(policy: RegistrationPolicy = RegistrationPolicy.OPEN): AuthServiceImpl {
             val tmp = Files.createTempFile("listenup-test-", ".db").toFile().apply { deleteOnExit() }
             val db = DatabaseFactory.init(DatabaseConfig("jdbc:sqlite:${tmp.absolutePath}"))
             val hasher = PasswordHasher()
             val sessions = SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = clock)
-            val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client", Duration.ofMinutes(15), clock)
+            val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client", 15.minutes, clock)
             return AuthServiceImpl(
                 db = db,
                 sessions = sessions,

--- a/server/src/test/kotlin/com/calypsan/listenup/server/auth/JwtConfigurationTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/auth/JwtConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.auth
 
 import com.auth0.jwt.JWT
@@ -5,24 +7,25 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.server.testing.FixedClock
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneOffset
 import java.util.Date
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 class JwtConfigurationTest :
     FunSpec({
-        val clock = Clock.fixed(Instant.parse("2026-05-02T12:00:00Z"), ZoneOffset.UTC)
+        val clock = FixedClock(Instant.parse("2026-05-02T12:00:00Z"))
         val cfg =
             JwtConfiguration(
                 secret = "x".repeat(32),
                 issuer = "listenup",
                 audience = "listenup-client",
-                accessTokenTtl = Duration.ofMinutes(15),
+                accessTokenTtl = 15.minutes,
                 clock = clock,
             )
 
@@ -46,7 +49,7 @@ class JwtConfigurationTest :
         }
 
         test("verify rejects expired tokens") {
-            val expiringCfg = cfg.copy(accessTokenTtl = Duration.ofSeconds(-1))
+            val expiringCfg = cfg.copy(accessTokenTtl = (-1).seconds)
             val token = expiringCfg.issue(UserId("u-1"), SessionId("s-1"), UserRole.MEMBER)
             shouldThrow<JwtVerificationException> { cfg.verify(token) }
         }
@@ -78,6 +81,7 @@ class JwtConfigurationTest :
         }
 
         test("verify rejects tokens with missing or invalid role claim") {
+            val expMs = (clock.now() + 60.seconds).toEpochMilliseconds()
             val noRoleToken =
                 JWT
                     .create()
@@ -85,7 +89,7 @@ class JwtConfigurationTest :
                     .withAudience("listenup-client")
                     .withSubject("u-1")
                     .withJWTId("s-1")
-                    .withExpiresAt(Date.from(clock.instant().plusSeconds(60)))
+                    .withExpiresAt(Date(expMs))
                     .sign(Algorithm.HMAC256("x".repeat(32)))
             shouldThrow<JwtVerificationException> { cfg.verify(noRoleToken) }
 
@@ -97,7 +101,7 @@ class JwtConfigurationTest :
                     .withSubject("u-1")
                     .withJWTId("s-1")
                     .withClaim("role", "NOT_A_REAL_ROLE")
-                    .withExpiresAt(Date.from(clock.instant().plusSeconds(60)))
+                    .withExpiresAt(Date(expMs))
                     .sign(Algorithm.HMAC256("x".repeat(32)))
             shouldThrow<JwtVerificationException> { cfg.verify(badRoleToken) }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/auth/SessionServiceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/auth/SessionServiceTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.calypsan.listenup.server.auth
 
 import com.calypsan.listenup.api.dto.auth.RefreshToken
@@ -9,6 +11,7 @@ import com.calypsan.listenup.server.db.SessionTable
 import com.calypsan.listenup.server.db.UserEntity
 import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.db.UserStatusColumn
+import com.calypsan.listenup.server.testing.FixedClock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -17,15 +20,14 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.nio.file.Files
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneOffset
+import kotlin.time.ExperimentalTime
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
 
 class SessionServiceTest :
     FunSpec({
         val pepper = "x".repeat(32).toByteArray()
-        val clock = Clock.fixed(Instant.parse("2026-05-02T12:00:00Z"), ZoneOffset.UTC)
+        val clock = FixedClock(Instant.parse("2026-05-02T12:00:00Z"))
 
         fun freshDb(): Database {
             val tmp = Files.createTempFile("listenup-test-", ".db").toFile().apply { deleteOnExit() }
@@ -165,7 +167,7 @@ class SessionServiceTest :
                     db,
                     RefreshTokenHasher(pepper),
                     RefreshTokenGenerator(),
-                    refreshTtl = Duration.ofMillis(-1),
+                    refreshTtl = (-1).milliseconds,
                     clock = clock,
                 )
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/FixedClock.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/FixedClock.kt
@@ -1,0 +1,14 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.calypsan.listenup.server.testing
+
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** A fixed-point [kotlin.time.Clock] for deterministic time in tests. */
+class FixedClock(
+    private val fixed: Instant,
+) : Clock {
+    override fun now(): Instant = fixed
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/core/ValueClasses.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/core/ValueClasses.kt
@@ -2,7 +2,13 @@
 
 package com.calypsan.listenup.client.core
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlin.jvm.JvmInline
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -140,6 +146,7 @@ value class ContributorId(
  *
  * @property epochMillis Unix epoch milliseconds
  */
+@Serializable(with = TimestampIso8601Serializer::class)
 @JvmInline
 value class Timestamp(
     val epochMillis: Long,
@@ -170,4 +177,25 @@ value class Timestamp(
          */
         fun now(): Timestamp = Timestamp(currentEpochMilliseconds())
     }
+}
+
+/**
+ * Serializes [Timestamp] as an ISO-8601 string (e.g. "2024-11-20T14:30:45.123Z"),
+ * identical to the wire form `kotlin.time.Instant` produces. This keeps the wire
+ * contract stable for `@Serializable` types whose timestamp fields move from
+ * `kotlin.time.Instant` to `Timestamp`.
+ */
+object TimestampIso8601Serializer : KSerializer<Timestamp> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("com.calypsan.listenup.client.core.Timestamp", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Timestamp,
+    ) {
+        encoder.encodeString(Instant.fromEpochMilliseconds(value.epochMillis).toString())
+    }
+
+    override fun deserialize(decoder: Decoder): Timestamp =
+        Timestamp(Instant.parse(decoder.decodeString()).toEpochMilliseconds())
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TagApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TagApi.kt
@@ -13,6 +13,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import com.calypsan.listenup.client.core.Timestamp
 import kotlin.time.Instant
 
 /**
@@ -138,7 +139,7 @@ internal data class TagResponse(
             id = id,
             slug = slug,
             bookCount = bookCount,
-            createdAt = createdAt?.let { Instant.parse(it) },
+            createdAt = createdAt?.let { Timestamp(Instant.parse(it).toEpochMilliseconds()) },
         )
 }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImpl.kt
@@ -11,7 +11,6 @@ import com.calypsan.listenup.client.domain.model.Tag
 import com.calypsan.listenup.client.domain.repository.TagRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlin.time.Instant
 
 /**
  * Implementation of TagRepository using Room and TagApi.
@@ -68,7 +67,7 @@ class TagRepositoryImpl(
                     id = tag.id,
                     slug = tag.slug,
                     bookCount = tag.bookCount,
-                    createdAt = tag.createdAt?.let { Timestamp(it.toEpochMilliseconds()) } ?: Timestamp.now(),
+                    createdAt = tag.createdAt ?: Timestamp.now(),
                 )
             dao.upsert(entity)
             dao.insertBookTag(BookTagCrossRef(bookId = BookId(bookId), tagId = tag.id))
@@ -99,5 +98,5 @@ private fun TagEntity.toDomain(): Tag =
         id = id,
         slug = slug,
         bookCount = bookCount,
-        createdAt = Instant.fromEpochMilliseconds(createdAt.epochMillis),
+        createdAt = createdAt,
     )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BackupInfo.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BackupInfo.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.client.domain.model
 
-import kotlin.time.Instant
+import com.calypsan.listenup.client.core.Timestamp
 
 /**
  * Domain model for a backup file.
@@ -9,7 +9,7 @@ data class BackupInfo(
     val id: String,
     val path: String,
     val size: Long,
-    val createdAt: Instant,
+    val createdAt: Timestamp,
     val checksum: String? = null,
 ) {
     /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Instance.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Instance.kt
@@ -1,10 +1,9 @@
 package com.calypsan.listenup.client.domain.model
 
+import com.calypsan.listenup.client.core.Timestamp
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 /**
  * Type-safe wrapper for Instance IDs.
@@ -33,10 +32,8 @@ value class InstanceId(
  * Each server installation is an "instance" with its own configuration,
  * users, and content library.
  *
- * Timestamp fields use kotlin.time.Instant (Kotlin stdlib) which has native
- * kotlinx.serialization support for ISO-8601 format (e.g., "2024-11-20T14:30:45.123Z").
+ * Timestamp fields use the `Timestamp` value class, serialized as ISO-8601 strings on the wire.
  */
-@OptIn(ExperimentalTime::class)
 @Serializable
 data class Instance(
     @SerialName("id")
@@ -54,9 +51,9 @@ data class Instance(
     @SerialName("setup_required")
     val setupRequired: Boolean,
     @SerialName("created_at")
-    val createdAt: Instant,
+    val createdAt: Timestamp,
     @SerialName("updated_at")
-    val updatedAt: Instant,
+    val updatedAt: Timestamp,
 ) {
     /**
      * True if the instance needs initial setup (no root user configured yet).

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Tag.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Tag.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.client.domain.model
 
-import kotlin.time.Instant
+import com.calypsan.listenup.client.core.Timestamp
 
 /**
  * Domain model for a global tag.
@@ -15,7 +15,7 @@ data class Tag(
     val id: String,
     val slug: String,
     val bookCount: Int = 0,
-    val createdAt: Instant? = null,
+    val createdAt: Timestamp? = null,
 ) {
     /**
      * Converts the slug to a human-readable display name.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminBackupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminBackupViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.calypsan.listenup.client.core.Timestamp
 import kotlin.time.Instant
 
 private val logger = KotlinLogging.logger {}
@@ -233,14 +234,14 @@ class AdminBackupViewModel(
             size = size,
             createdAt =
                 try {
-                    Instant.parse(createdAt)
+                    Timestamp(Instant.parse(createdAt).toEpochMilliseconds())
                 } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     // Date parsing is not an API call — keep try/catch for this non-API failure.
-                    // Use DISTANT_PAST as graceful fallback so the backup still appears in list.
-                    logger.warn(e) { "Failed to parse backup date '$createdAt', using DISTANT_PAST" }
-                    Instant.DISTANT_PAST
+                    // Use epoch as graceful fallback so the backup still appears in list.
+                    logger.warn(e) { "Failed to parse backup date '$createdAt', using epoch" }
+                    Timestamp(0L)
                 },
             checksum = checksum,
         )

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/core/TimestampSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/core/TimestampSerializationTest.kt
@@ -29,4 +29,6 @@ class TimestampSerializationTest :
     })
 
 @Serializable
-private data class TimestampHolder(val at: Timestamp)
+private data class TimestampHolder(
+    val at: Timestamp,
+)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/core/TimestampSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/core/TimestampSerializationTest.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.core
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class TimestampSerializationTest :
+    FunSpec({
+        test("Timestamp serializes as an ISO-8601 string") {
+            val json = contractJson.encodeToString(TimestampHolder(Timestamp(0L)))
+            json shouldBe """{"at":"1970-01-01T00:00:00Z"}"""
+        }
+
+        test("Timestamp decodes from an ISO-8601 string") {
+            val decoded = contractJson.decodeFromString<TimestampHolder>("""{"at":"1970-01-01T00:00:00Z"}""")
+            decoded.at shouldBe Timestamp(0L)
+        }
+
+        test("Timestamp round-trips an arbitrary epoch-millis value through JSON") {
+            val ts = Timestamp(1_732_113_045_123L)
+            val decoded =
+                contractJson.decodeFromString<TimestampHolder>(
+                    contractJson.encodeToString(TimestampHolder(ts)),
+                )
+            decoded.at shouldBe ts
+        }
+    })
+
+@Serializable
+private data class TimestampHolder(val at: Timestamp)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
@@ -20,7 +20,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.time.Instant
+import com.calypsan.listenup.client.core.Timestamp
 
 private fun createTestInstance(setupRequired: Boolean): Instance =
     Instance(
@@ -30,8 +30,8 @@ private fun createTestInstance(setupRequired: Boolean): Instance =
         localUrl = "http://localhost:8080",
         remoteUrl = null,
         setupRequired = setupRequired,
-        createdAt = Instant.DISTANT_PAST,
-        updatedAt = Instant.DISTANT_PAST,
+        createdAt = Timestamp(0L),
+        updatedAt = Timestamp(0L),
     )
 
 private fun createMockStorage(): SecureStorage = mock<SecureStorage>()

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/TagRepositoryImplTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Instant
 
 /**
  * Tests for TagRepositoryImpl.
@@ -111,7 +110,7 @@ class TagRepositoryImplTest {
             // Then
             assertNotNull(result[0].createdAt)
             assertEquals(
-                Instant.fromEpochMilliseconds(1609459200000L),
+                Timestamp(1609459200000L),
                 result[0].createdAt,
             )
         }
@@ -196,7 +195,7 @@ class TagRepositoryImplTest {
 
             // Then
             assertEquals(
-                Instant.fromEpochMilliseconds(1704067200000L),
+                Timestamp(1704067200000L),
                 result[0].createdAt,
             )
         }
@@ -260,7 +259,7 @@ class TagRepositoryImplTest {
             assertEquals("tag-42", result.id)
             assertEquals("coming-of-age", result.slug)
             assertEquals(55, result.bookCount)
-            assertEquals(Instant.fromEpochMilliseconds(1609459200000L), result.createdAt)
+            assertEquals(Timestamp(1609459200000L), result.createdAt)
         }
 
     // ========== getBySlug Tests ==========
@@ -322,7 +321,7 @@ class TagRepositoryImplTest {
             assertEquals("tag-99", result.id)
             assertEquals("morally-grey", result.slug)
             assertEquals(77, result.bookCount)
-            assertEquals(Instant.fromEpochMilliseconds(1672531200000L), result.createdAt)
+            assertEquals(Timestamp(1672531200000L), result.createdAt)
         }
 
     // ========== observeTagsForBook Tests ==========
@@ -381,7 +380,7 @@ class TagRepositoryImplTest {
             assertEquals("tag-1", result[0].id)
             assertEquals("heist", result[0].slug)
             assertEquals(20, result[0].bookCount)
-            assertEquals(Instant.fromEpochMilliseconds(1609459200000L), result[0].createdAt)
+            assertEquals(Timestamp(1609459200000L), result[0].createdAt)
         }
 
     @Test
@@ -463,7 +462,7 @@ class TagRepositoryImplTest {
             assertEquals("tag-5", result[0].id)
             assertEquals("mystery", result[0].slug)
             assertEquals(150, result[0].bookCount)
-            assertEquals(Instant.fromEpochMilliseconds(1640995200000L), result[0].createdAt)
+            assertEquals(Timestamp(1640995200000L), result[0].createdAt)
         }
 
     @Test
@@ -582,7 +581,7 @@ class TagRepositoryImplTest {
             assertEquals("tag-conversion-test", result.id)
             assertEquals("test-conversion-slug", result.slug)
             assertEquals(42, result.bookCount)
-            assertEquals(Instant.fromEpochMilliseconds(1234567890123L), result.createdAt)
+            assertEquals(Timestamp(1234567890123L), result.createdAt)
         }
 
     @Test
@@ -614,7 +613,7 @@ class TagRepositoryImplTest {
             val result = repository.getAll()
 
             // Then
-            assertEquals(Instant.fromEpochMilliseconds(0L), result[0].createdAt)
+            assertEquals(Timestamp(0L), result[0].createdAt)
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/InstanceSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/InstanceSerializationTest.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.client.domain.model
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.client.core.Timestamp
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+// InstanceId is declared in Instance.kt — same package, so no import is needed.
+class InstanceSerializationTest :
+    FunSpec({
+        test("Instance timestamps round-trip through JSON") {
+            val instance =
+                Instance(
+                    id = InstanceId("inst-1"),
+                    name = "Home",
+                    version = "1.0.0",
+                    setupRequired = false,
+                    createdAt = Timestamp(1_732_113_045_000L),
+                    updatedAt = Timestamp(1_732_114_800_000L),
+                )
+            val decoded =
+                contractJson.decodeFromString(
+                    Instance.serializer(),
+                    contractJson.encodeToString(Instance.serializer(), instance),
+                )
+            decoded.createdAt shouldBe instance.createdAt
+            decoded.updatedAt shouldBe instance.updatedAt
+        }
+
+        test("Instance decodes ISO-8601 timestamp strings and re-encodes them unchanged") {
+            val wireJson =
+                """{"id":"inst-1","name":"Home","version":"1.0.0","setup_required":false,""" +
+                    """"created_at":"2024-11-20T14:30:45Z","updated_at":"2024-11-20T15:00:00Z"}"""
+            val instance = contractJson.decodeFromString(Instance.serializer(), wireJson)
+            val reencoded = contractJson.encodeToString(Instance.serializer(), instance)
+            (""""created_at":"2024-11-20T14:30:45Z"""" in reencoded) shouldBe true
+            (""""updated_at":"2024-11-20T15:00:00Z"""" in reencoded) shouldBe true
+        }
+    })

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/GetInstanceUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/GetInstanceUseCaseTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.time.Instant
+import com.calypsan.listenup.client.core.Timestamp
 
 /**
  * Tests for GetInstanceUseCase.
@@ -49,8 +49,8 @@ class GetInstanceUseCaseTest {
             localUrl = "http://localhost:8080",
             remoteUrl = null,
             setupRequired = false,
-            createdAt = Instant.fromEpochMilliseconds(1704067200000L),
-            updatedAt = Instant.fromEpochMilliseconds(1704067200000L),
+            createdAt = Timestamp(1704067200000L),
+            updatedAt = Timestamp(1704067200000L),
         )
 
     // ========== Success Tests ==========

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminBackupViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminBackupViewModelTest.kt
@@ -168,7 +168,7 @@ class AdminBackupViewModelTest {
             val viewModel = AdminBackupViewModel(api, errorBus = ErrorBus())
             advanceUntilIdle()
 
-            // Should not crash, invalid date should use DISTANT_PAST
+            // Should not crash, invalid date should use epoch (Timestamp(0L))
             val ready = assertIs<AdminBackupUiState.Ready>(viewModel.state.value)
             assertEquals(2, ready.backups.size)
             assertEquals("valid", ready.backups[0].id)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModelTest.kt
@@ -29,8 +29,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
+import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.core.error.ErrorBus
 
 /**
@@ -47,7 +46,7 @@ import com.calypsan.listenup.client.core.error.ErrorBus
  * - `saveAll` failure surfaces as transient `error` on Ready
  * - `clearError` clears the transient error on Ready
  */
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class AdminSettingsViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
@@ -102,8 +101,8 @@ class AdminSettingsViewModelTest {
             remoteUrl = remoteUrl,
             openRegistration = false,
             setupRequired = false,
-            createdAt = Instant.fromEpochMilliseconds(0),
-            updatedAt = Instant.fromEpochMilliseconds(0),
+            createdAt = Timestamp(0L),
+            updatedAt = Timestamp(0L),
         )
 
     @BeforeTest

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
@@ -39,10 +39,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
+import com.calypsan.listenup.client.core.Timestamp
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class AdminViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
@@ -55,8 +54,8 @@ class AdminViewModelTest {
             remoteUrl = null,
             openRegistration = openRegistration,
             setupRequired = false,
-            createdAt = Instant.DISTANT_PAST,
-            updatedAt = Instant.DISTANT_PAST,
+            createdAt = Timestamp(0L),
+            updatedAt = Timestamp(0L),
         )
 
     private fun createMockInstanceRepository(openRegistration: Boolean = false): InstanceRepository {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoJvmOnlyApisInSharedRule.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoJvmOnlyApisInSharedRule.kt
@@ -1,0 +1,35 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Konsist guard: non-JVM `:shared` source sets must never import a `java.*` or
+ * `javax.*` package. Those APIs do not exist on Kotlin/Native (iOS), so a stray
+ * import silently breaks the Apple targets — which cannot be compiled on the
+ * Linux CI runner to catch it. This rule is the portable structural guard.
+ *
+ * `jvmMain` / `androidMain` / `desktopMain` are intentionally not checked: the
+ * JVM is a legitimate target there.
+ */
+class NoJvmOnlyApisInSharedRule :
+    FunSpec({
+        test("no non-JVM :shared source set imports java.* or javax.*") {
+            val nonJvmSourceSetMarkers =
+                listOf("/commonMain/", "/appleMain/", "/iosMain/", "/nativeMain/")
+            val offenders =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .filter { file -> file.path.contains("/shared/src/") }
+                    .filter { file -> nonJvmSourceSetMarkers.any { file.path.contains(it) } }
+                    .flatMap { file ->
+                        file.imports
+                            .filter { it.name.startsWith("java.") || it.name.startsWith("javax.") }
+                            .map { "${file.path} -> ${it.name}" }
+                    }
+
+            offenders.shouldBeEmpty()
+        }
+    })


### PR DESCRIPTION
## Summary

Unifies time handling on the KMP-safe Kotlin datetime stack and adds a structural guard against JVM-only APIs in `:shared`.

- **Konsist guard** — new `NoJvmOnlyApisInSharedRule` fails the build if any non-JVM `:shared` source set (`commonMain`/`appleMain`/`iosMain`/`nativeMain`) imports `java.*` or `javax.*`. This is the portable structural guard, since the Apple targets can't be compiled on the Linux CI runner.
- **`:server` → `kotlin.time`** — `SessionService`, `AuthServiceImpl`, `JwtConfiguration`, `AuthModule` move off `java.time` onto `kotlin.time.Clock`/`Duration`. The unavoidable `java.time`/`java.util.Date` conversions are localized to `JwtConfiguration`'s `com.auth0:java-jwt` boundary via a single `asJavaClock()` adapter. A `FixedClock` test helper replaces `java.time.Clock.fixed`.
- **`:shared` `Timestamp` unification** — the `Timestamp` value class is now `@Serializable` with a custom ISO-8601 string serializer; the bare `kotlin.time.Instant` fields in `Tag`, `Instance`, and `BackupInfo` are converted to `Timestamp`.

**Wire-compatible:** the ISO-8601 `Timestamp` serializer produces the byte-identical wire form `kotlin.time.Instant` did, so `Instance` (a `@Serializable` wire type) keeps its contract — no server coordination needed. `InstanceSerializationTest` guards this.

Note: `:shared` commonMain was already JVM-clean; this is a consistency + guard-rail change, not an iOS rescue.

## Test plan
- [x] `:shared:jvmTest` green
- [x] `:server:test` green (525 tests)
- [x] `:androidApp:assembleDebug` green
- [x] `detekt` + `spotlessCheck` green
- [x] Whole-branch code review — cleared for merge (no Critical/Important findings)
