### PR TITLE
✨ feat(server): demo server with seeded synthetic library

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -35,7 +35,20 @@ The generated library and demo database live under `server/build/` and are wiped
 
 ### Manual activation
 
-`runDemo` is a convenience wrapper. You can activate the demo seed profile on any server run by setting environment variables directly:
+`runDemo` is a convenience wrapper. You can activate the demo seed profile on any server run by
+setting `LISTENUP_SEED_PROFILE=demo` directly. When you do, the server looks for the synthetic
+library at `build/seed-library` and falls back gracefully (logging a warning) if it is not there.
+
+To get the synthetic library in place first:
+
+```bash
+./gradlew :server:generateSeedLibrary
+LISTENUP_SEED_PROFILE=demo \
+LISTENUP_DB_URL=jdbc:sqlite:/path/to/demo.db \
+./gradlew :server:run
+```
+
+Or point at your own library by setting `LISTENUP_LIBRARY_PATH` explicitly:
 
 ```bash
 LISTENUP_SEED_PROFILE=demo \

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,45 @@
+# ListenUp Server
+
+## Demo server
+
+Run a fully seeded demo server in one command:
+
+```bash
+./gradlew :server:runDemo
+```
+
+This generates a synthetic audiobook library under `server/build/seed-library/`, then starts the server at `http://localhost:8080` with the demo library and a pre-created demo account.
+
+### Prerequisites
+
+`ffmpeg` must be on your `PATH`. The library generator uses it to produce the synthetic audio files.
+
+### Credentials
+
+| Field    | Value                |
+|----------|----------------------|
+| Email    | `demo@listenup.app`  |
+| Password | `demo-password`      |
+
+### Android emulator
+
+Point the app's manual server URL entry at `http://10.0.2.2:8080` — the emulator's loopback alias for the host machine.
+
+### Cleanup
+
+The generated library and demo database live under `server/build/` and are wiped by:
+
+```bash
+./gradlew clean
+```
+
+### Manual activation
+
+`runDemo` is a convenience wrapper. You can activate the demo seed profile on any server run by setting environment variables directly:
+
+```bash
+LISTENUP_SEED_PROFILE=demo \
+LISTENUP_LIBRARY_PATH=/path/to/your/library \
+LISTENUP_DB_URL=jdbc:sqlite:/path/to/demo.db \
+./gradlew :server:run
+```

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -110,3 +110,14 @@ kotlin {
 tasks.test {
     useJUnitPlatform()
 }
+
+val seedLibraryDir = layout.buildDirectory.dir("seed-library")
+
+tasks.register<JavaExec>("generateSeedLibrary") {
+    group = "demo"
+    description = "Generates the synthetic audiobook library for the demo server (requires ffmpeg)."
+    mainClass.set("com.calypsan.listenup.server.seed.SeedLibraryGenerator")
+    classpath = sourceSets["main"].runtimeClasspath
+    args(seedLibraryDir.get().asFile.absolutePath)
+    outputs.dir(seedLibraryDir)
+}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -121,3 +121,14 @@ tasks.register<JavaExec>("generateSeedLibrary") {
     args(seedLibraryDir.get().asFile.absolutePath)
     outputs.dir(seedLibraryDir)
 }
+
+tasks.register<JavaExec>("runDemo") {
+    group = "demo"
+    description = "Runs the server as a seeded demo server (generates the synthetic library first)."
+    dependsOn("generateSeedLibrary")
+    mainClass.set("com.calypsan.listenup.server.ApplicationKt")
+    classpath = sourceSets["main"].runtimeClasspath
+    environment("LISTENUP_SEED_PROFILE", "demo")
+    environment("LISTENUP_LIBRARY_PATH", seedLibraryDir.get().asFile.absolutePath)
+    environment("LISTENUP_DB_URL", "jdbc:sqlite:${layout.buildDirectory.get().asFile.absolutePath}/demo.db")
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -63,9 +63,9 @@ fun Application.module() {
     install(SSE)
     install(Krpc)
 
-    val resolvedLibraryPath = resolveLibraryPath()
-    val applicationScope = CoroutineScope(coroutineContext + SupervisorJob())
     val seedProfile = resolveSeedProfile()
+    val applicationScope = CoroutineScope(coroutineContext + SupervisorJob())
+    val resolvedLibraryPath = resolveLibraryPath() ?: resolveDemoLibraryFallback(seedProfile)
 
     install(Koin) {
         val modules = mutableListOf(authModule(environment.config))
@@ -168,6 +168,26 @@ private fun Application.resolveSeedProfile(): String? {
         return null
     }
     return raw
+}
+
+/**
+ * When the demo seed profile is active and no explicit `scanner.libraryPath` is set, fall back to
+ * the generated synthetic library at `build/seed-library` (produced by `:server:generateSeedLibrary`).
+ * Returns null — with a guiding log line — if that directory does not exist yet.
+ */
+private fun Application.resolveDemoLibraryFallback(seedProfile: String?): Path? {
+    if (seedProfile != SEED_PROFILE_DEMO) return null
+    val candidate = Path.of("build", "seed-library")
+    if (!Files.isDirectory(candidate)) {
+        logger.warn {
+            "seed.profile=demo but no synthetic library at '$candidate' — run " +
+                "':server:generateSeedLibrary' (or use ':server:runDemo'). The demo user is still " +
+                "seeded; the library will be empty until then."
+        }
+        return null
+    }
+    logger.info { "seed.profile=demo — scanning the generated synthetic library at '$candidate'" }
+    return candidate
 }
 
 /**

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -11,8 +11,10 @@ import com.calypsan.listenup.server.cover.CoverResponder
 import com.calypsan.listenup.server.di.authModule
 import com.calypsan.listenup.server.di.booksModule
 import com.calypsan.listenup.server.di.scannerModule
+import com.calypsan.listenup.server.di.seedModule
 import com.calypsan.listenup.server.di.syncModule
 import com.calypsan.listenup.server.embeddedmeta.embeddedmetaModule
+import com.calypsan.listenup.server.seed.SeedRunner
 import com.calypsan.listenup.server.plugins.JWT_PROVIDER
 import com.calypsan.listenup.server.plugins.installAppErrorStatusPages
 import com.calypsan.listenup.server.plugins.installCallIdAndLogging
@@ -51,6 +53,8 @@ import java.nio.file.Path
 
 private val logger = KotlinLogging.logger {}
 
+private const val SEED_PROFILE_DEMO = "demo"
+
 fun main(args: Array<String>) = EngineMain.main(args)
 
 fun Application.module() {
@@ -61,6 +65,7 @@ fun Application.module() {
 
     val resolvedLibraryPath = resolveLibraryPath()
     val applicationScope = CoroutineScope(coroutineContext + SupervisorJob())
+    val seedProfile = resolveSeedProfile()
 
     install(Koin) {
         val modules = mutableListOf(authModule(environment.config))
@@ -70,7 +75,19 @@ fun Application.module() {
         }
         modules += embeddedmetaModule
         modules += syncModule()
+        if (seedProfile == SEED_PROFILE_DEMO) modules += seedModule()
         modules(modules)
+    }
+
+    if (seedProfile == SEED_PROFILE_DEMO) {
+        val seedRunner by inject<SeedRunner>()
+        applicationScope.launch {
+            runCatching { seedRunner.run() }
+                .onFailure { e ->
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    logger.error(e) { "demo seeding failed — server keeps running" }
+                }
+        }
     }
 
     installCallIdAndLogging()
@@ -131,6 +148,26 @@ private fun Application.resolveLibraryPath(): Path? {
         return null
     }
     return path
+}
+
+/**
+ * Reads `seed.profile` from configuration. Returns the trimmed value, or null when
+ * unset/blank. Only `"demo"` is recognized today; an unrecognized non-blank value is
+ * returned as null and logged as ignored.
+ */
+private fun Application.resolveSeedProfile(): String? {
+    val raw =
+        environment.config
+            .propertyOrNull("seed.profile")
+            ?.getString()
+            ?.trim()
+            .orEmpty()
+    if (raw.isBlank()) return null
+    if (raw != SEED_PROFILE_DEMO) {
+        logger.warn { "seed.profile '$raw' is not a recognized profile — ignoring" }
+        return null
+    }
+    return raw
 }
 
 /**

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/SeedModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/SeedModule.kt
@@ -1,0 +1,17 @@
+package com.calypsan.listenup.server.di
+
+import com.calypsan.listenup.server.seed.SeedRunner
+import com.calypsan.listenup.server.seed.UserDomainSeeder
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Koin module for the demo seed profile. Installed by `Application.module()` only
+ * when `seed.profile = demo`. The `SeedRunner`'s seeder list is hand-assembled —
+ * every future domain phase adds its `DomainSeeder` to this list.
+ */
+fun seedModule(): Module =
+    module {
+        single { UserDomainSeeder(db = get(), authService = get()) }
+        single { SeedRunner(seeders = listOf(get<UserDomainSeeder>())) }
+    }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/DomainSeeder.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/DomainSeeder.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.server.seed
+
+/**
+ * Seeds one non-scanner domain with curated, structurally-correct demo data.
+ *
+ * Each migrated domain that holds non-scanner state contributes one implementation,
+ * registered in [com.calypsan.listenup.server.di.seedModule]. Books are *not* seeded
+ * this way — book content comes from scanning the synthetic library.
+ *
+ * Implementations MUST write through the domain's own service/repository write-path,
+ * never raw SQL, so the seeded rows are indistinguishable from real ones.
+ */
+interface DomainSeeder {
+    /** Domain name — used only for ordering diagnostics and log lines. */
+    val domainName: String
+
+    /** Run order; lower runs first. A seeder with a cross-domain FK dependency declares a higher value. */
+    val order: Int
+
+    /** True when this domain already holds data. When true, [seed] is skipped — the idempotency gate. */
+    suspend fun isAlreadySeeded(): Boolean
+
+    /** Writes the curated demo rows. Only called when [isAlreadySeeded] returned false. */
+    suspend fun seed()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryDescriptor.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryDescriptor.kt
@@ -56,11 +56,22 @@ data class SeedBook(
  * rerun `:server:generateSeedLibrary` to regenerate the files.
  */
 object SeedLibraryDescriptor {
-    val BOOKS: List<SeedBook> = buildList {
-        addRepresentativeBooks()
-        addEdgeCaseBooks()
-    }
+    val BOOKS: List<SeedBook> =
+        buildList {
+            addRepresentativeBooks()
+            addEdgeCaseBooks()
+        }
 }
+
+private const val AUTHOR_WREN_HALLOWAY = "Wren Halloway"
+private const val NARRATOR_MARLOWE_FINCH = "Marlowe Finch"
+private const val SERIES_EMBER_CODEX = "The Ember Codex"
+
+/** Common track file names reused across many seed books. */
+private const val TRACK_SINGLE_M4B = "book.m4b"
+private const val TRACK_01_MP3 = "01.mp3"
+private const val TRACK_02_MP3 = "02.mp3"
+private const val TRACK_03_MP3 = "03.mp3"
 
 /**
  * Core library entries: a series, single-file and multi-file standalones, and multi-disc.
@@ -71,14 +82,14 @@ private fun MutableList<SeedBook>.addRepresentativeBooks() {
     // Book 1 — single-file, embedded chapters, METADATA_JSON sidecar
     add(
         SeedBook(
-            folderPath = "Wren Halloway/The Ember Codex/The Ember Codex",
-            title = "The Ember Codex",
-            authors = listOf("Wren Halloway"),
-            narrators = listOf("Marlowe Finch"),
-            series = SeedSeries(name = "The Ember Codex", sequence = "1"),
+            folderPath = "$AUTHOR_WREN_HALLOWAY/$SERIES_EMBER_CODEX/$SERIES_EMBER_CODEX",
+            title = SERIES_EMBER_CODEX,
+            authors = listOf(AUTHOR_WREN_HALLOWAY),
+            narrators = listOf(NARRATOR_MARLOWE_FINCH),
+            series = SeedSeries(name = SERIES_EMBER_CODEX, sequence = "1"),
             tracks =
                 listOf(
-                    SeedTrack(fileName = "book.m4b", durationSeconds = 18, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_SINGLE_M4B, durationSeconds = 18, trackNumber = 1),
                 ),
             chapters =
                 listOf(
@@ -95,16 +106,16 @@ private fun MutableList<SeedBook>.addRepresentativeBooks() {
     // Book 2 — multi-file, no embedded chapters, NFO sidecar
     add(
         SeedBook(
-            folderPath = "Wren Halloway/The Ember Codex/The Ember Codex - Shattered Sigil",
-            title = "The Ember Codex: Shattered Sigil",
-            authors = listOf("Wren Halloway"),
-            narrators = listOf("Marlowe Finch"),
-            series = SeedSeries(name = "The Ember Codex", sequence = "2"),
+            folderPath = "$AUTHOR_WREN_HALLOWAY/$SERIES_EMBER_CODEX/$SERIES_EMBER_CODEX - Shattered Sigil",
+            title = "$SERIES_EMBER_CODEX: Shattered Sigil",
+            authors = listOf(AUTHOR_WREN_HALLOWAY),
+            narrators = listOf(NARRATOR_MARLOWE_FINCH),
+            series = SeedSeries(name = SERIES_EMBER_CODEX, sequence = "2"),
             tracks =
                 listOf(
-                    SeedTrack(fileName = "01.mp3", durationSeconds = 5, trackNumber = 1),
-                    SeedTrack(fileName = "02.mp3", durationSeconds = 6, trackNumber = 2),
-                    SeedTrack(fileName = "03.mp3", durationSeconds = 5, trackNumber = 3),
+                    SeedTrack(fileName = TRACK_01_MP3, durationSeconds = 5, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_02_MP3, durationSeconds = 6, trackNumber = 2),
+                    SeedTrack(fileName = TRACK_03_MP3, durationSeconds = 5, trackNumber = 3),
                 ),
             chapters = emptyList(),
             sidecar = SeedSidecar.NFO,
@@ -116,16 +127,16 @@ private fun MutableList<SeedBook>.addRepresentativeBooks() {
     // Book 3 — multi-file, no embedded chapters, OPF sidecar
     add(
         SeedBook(
-            folderPath = "Wren Halloway/The Ember Codex/The Ember Codex - The Final Pyre",
-            title = "The Ember Codex: The Final Pyre",
-            authors = listOf("Wren Halloway"),
-            narrators = listOf("Marlowe Finch"),
-            series = SeedSeries(name = "The Ember Codex", sequence = "3"),
+            folderPath = "$AUTHOR_WREN_HALLOWAY/$SERIES_EMBER_CODEX/$SERIES_EMBER_CODEX - The Final Pyre",
+            title = "$SERIES_EMBER_CODEX: The Final Pyre",
+            authors = listOf(AUTHOR_WREN_HALLOWAY),
+            narrators = listOf(NARRATOR_MARLOWE_FINCH),
+            series = SeedSeries(name = SERIES_EMBER_CODEX, sequence = "3"),
             tracks =
                 listOf(
-                    SeedTrack(fileName = "01.mp3", durationSeconds = 4, trackNumber = 1),
-                    SeedTrack(fileName = "02.mp3", durationSeconds = 5, trackNumber = 2),
-                    SeedTrack(fileName = "03.mp3", durationSeconds = 6, trackNumber = 3),
+                    SeedTrack(fileName = TRACK_01_MP3, durationSeconds = 4, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_02_MP3, durationSeconds = 5, trackNumber = 2),
+                    SeedTrack(fileName = TRACK_03_MP3, durationSeconds = 6, trackNumber = 3),
                     SeedTrack(fileName = "04.mp3", durationSeconds = 4, trackNumber = 4),
                 ),
             chapters = emptyList(),
@@ -136,6 +147,8 @@ private fun MutableList<SeedBook>.addRepresentativeBooks() {
     )
 
     // ── Standalone: multi-disc, DESC_TXT sidecar ────────────────────────────────────────────
+    // discFolders=true: the generator places exactly one track under each CDn/ folder —
+    // a deliberate synthetic-data simplification, not a faithful real-world multi-disc layout.
     add(
         SeedBook(
             folderPath = "Cassia Vane/The Clockwork Archipelago",
@@ -145,9 +158,9 @@ private fun MutableList<SeedBook>.addRepresentativeBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "01.mp3", durationSeconds = 5, trackNumber = 1),
-                    SeedTrack(fileName = "02.mp3", durationSeconds = 6, trackNumber = 2),
-                    SeedTrack(fileName = "03.mp3", durationSeconds = 5, trackNumber = 3),
+                    SeedTrack(fileName = TRACK_01_MP3, durationSeconds = 5, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_02_MP3, durationSeconds = 6, trackNumber = 2),
+                    SeedTrack(fileName = TRACK_03_MP3, durationSeconds = 5, trackNumber = 3),
                     SeedTrack(fileName = "04.mp3", durationSeconds = 6, trackNumber = 4),
                     SeedTrack(fileName = "05.mp3", durationSeconds = 5, trackNumber = 5),
                 ),
@@ -169,7 +182,7 @@ private fun MutableList<SeedBook>.addRepresentativeBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "book.m4b", durationSeconds = 20, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_SINGLE_M4B, durationSeconds = 20, trackNumber = 1),
                 ),
             chapters =
                 listOf(
@@ -199,9 +212,9 @@ private fun MutableList<SeedBook>.addEdgeCaseBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "01.mp3", durationSeconds = 4, trackNumber = 1),
-                    SeedTrack(fileName = "02.mp3", durationSeconds = 5, trackNumber = 2),
-                    SeedTrack(fileName = "03.mp3", durationSeconds = 4, trackNumber = 3),
+                    SeedTrack(fileName = TRACK_01_MP3, durationSeconds = 4, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_02_MP3, durationSeconds = 5, trackNumber = 2),
+                    SeedTrack(fileName = TRACK_03_MP3, durationSeconds = 4, trackNumber = 3),
                 ),
             chapters = emptyList(),
             sidecar = SeedSidecar.NONE,
@@ -220,7 +233,7 @@ private fun MutableList<SeedBook>.addEdgeCaseBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "book.m4b", durationSeconds = 15, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_SINGLE_M4B, durationSeconds = 15, trackNumber = 1),
                 ),
             chapters =
                 listOf(
@@ -244,9 +257,9 @@ private fun MutableList<SeedBook>.addEdgeCaseBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "01.mp3", durationSeconds = 5, trackNumber = 1),
-                    SeedTrack(fileName = "02.mp3", durationSeconds = 6, trackNumber = 2),
-                    SeedTrack(fileName = "03.mp3", durationSeconds = 5, trackNumber = 3),
+                    SeedTrack(fileName = TRACK_01_MP3, durationSeconds = 5, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_02_MP3, durationSeconds = 6, trackNumber = 2),
+                    SeedTrack(fileName = TRACK_03_MP3, durationSeconds = 5, trackNumber = 3),
                 ),
             chapters = emptyList(),
             sidecar = SeedSidecar.NFO,
@@ -265,7 +278,7 @@ private fun MutableList<SeedBook>.addEdgeCaseBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "book.m4b", durationSeconds = 16, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_SINGLE_M4B, durationSeconds = 16, trackNumber = 1),
                 ),
             chapters =
                 listOf(
@@ -289,7 +302,7 @@ private fun MutableList<SeedBook>.addEdgeCaseBooks() {
             series = null,
             tracks =
                 listOf(
-                    SeedTrack(fileName = "book.m4b", durationSeconds = 14, trackNumber = 1),
+                    SeedTrack(fileName = TRACK_SINGLE_M4B, durationSeconds = 14, trackNumber = 1),
                 ),
             chapters =
                 listOf(

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryDescriptor.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryDescriptor.kt
@@ -1,0 +1,304 @@
+package com.calypsan.listenup.server.seed
+
+/** Which sidecar metadata file a seed book ships, so the generator exercises every parser path. */
+enum class SeedSidecar {
+    NONE,
+    METADATA_JSON,
+    NFO,
+    OPF,
+    READER_TXT,
+    DESC_TXT,
+}
+
+/** One audio track. [durationSeconds] is short (a few seconds) — the files are tiny by design. */
+data class SeedTrack(
+    val fileName: String,
+    val durationSeconds: Int,
+    val trackNumber: Int,
+)
+
+/** A chapter marker, used for single-file books that carry embedded chapters. */
+data class SeedChapter(
+    val title: String,
+    val startSeconds: Int,
+)
+
+/** Series membership. */
+data class SeedSeries(
+    val name: String,
+    val sequence: String,
+)
+
+/**
+ * One synthetic audiobook. [folderPath] is relative to the library root and ends in the
+ * book's title folder; the generator lays the bottom three path components out as
+ * `<author>/<series>/<title>` so the scanner's FolderShape resolves author + series + title.
+ * Multi-disc books put their tracks under `CD1/`, `CD2/` subfolders (see [discFolders]).
+ */
+data class SeedBook(
+    val folderPath: String,
+    val title: String,
+    val authors: List<String>,
+    val narrators: List<String>,
+    val series: SeedSeries?,
+    val tracks: List<SeedTrack>,
+    val chapters: List<SeedChapter>,
+    val sidecar: SeedSidecar,
+    val hasCover: Boolean,
+    val description: String,
+    val discFolders: Boolean = false,
+)
+
+/**
+ * The committed synthetic library: ~10-12 books spanning single- and multi-file audiobooks,
+ * a multi-book series, a spread of contributors, and deliberate edge cases (no cover, sparse
+ * metadata, very long title, multi-narrator). Edit this list to change the demo library;
+ * rerun `:server:generateSeedLibrary` to regenerate the files.
+ */
+object SeedLibraryDescriptor {
+    val BOOKS: List<SeedBook> = buildList {
+        addRepresentativeBooks()
+        addEdgeCaseBooks()
+    }
+}
+
+/**
+ * Core library entries: a series, single-file and multi-file standalones, and multi-disc.
+ * Covers METADATA_JSON, NFO, OPF, and DESC_TXT sidecars.
+ */
+private fun MutableList<SeedBook>.addRepresentativeBooks() {
+    // ── The Ember Codex trilogy (series, 3 books) ────────────────────────────────────────────
+    // Book 1 — single-file, embedded chapters, METADATA_JSON sidecar
+    add(
+        SeedBook(
+            folderPath = "Wren Halloway/The Ember Codex/The Ember Codex",
+            title = "The Ember Codex",
+            authors = listOf("Wren Halloway"),
+            narrators = listOf("Marlowe Finch"),
+            series = SeedSeries(name = "The Ember Codex", sequence = "1"),
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "book.m4b", durationSeconds = 18, trackNumber = 1),
+                ),
+            chapters =
+                listOf(
+                    SeedChapter(title = "The First Flame", startSeconds = 0),
+                    SeedChapter(title = "Ash and Ember", startSeconds = 6),
+                    SeedChapter(title = "The Codex Revealed", startSeconds = 12),
+                ),
+            sidecar = SeedSidecar.METADATA_JSON,
+            hasCover = true,
+            description = "Lyra discovers a tome that should not exist — and a power she cannot name.",
+        ),
+    )
+
+    // Book 2 — multi-file, no embedded chapters, NFO sidecar
+    add(
+        SeedBook(
+            folderPath = "Wren Halloway/The Ember Codex/The Ember Codex - Shattered Sigil",
+            title = "The Ember Codex: Shattered Sigil",
+            authors = listOf("Wren Halloway"),
+            narrators = listOf("Marlowe Finch"),
+            series = SeedSeries(name = "The Ember Codex", sequence = "2"),
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "01.mp3", durationSeconds = 5, trackNumber = 1),
+                    SeedTrack(fileName = "02.mp3", durationSeconds = 6, trackNumber = 2),
+                    SeedTrack(fileName = "03.mp3", durationSeconds = 5, trackNumber = 3),
+                ),
+            chapters = emptyList(),
+            sidecar = SeedSidecar.NFO,
+            hasCover = true,
+            description = "The sigil fractures. The alliance splinters. Lyra stands alone.",
+        ),
+    )
+
+    // Book 3 — multi-file, no embedded chapters, OPF sidecar
+    add(
+        SeedBook(
+            folderPath = "Wren Halloway/The Ember Codex/The Ember Codex - The Final Pyre",
+            title = "The Ember Codex: The Final Pyre",
+            authors = listOf("Wren Halloway"),
+            narrators = listOf("Marlowe Finch"),
+            series = SeedSeries(name = "The Ember Codex", sequence = "3"),
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "01.mp3", durationSeconds = 4, trackNumber = 1),
+                    SeedTrack(fileName = "02.mp3", durationSeconds = 5, trackNumber = 2),
+                    SeedTrack(fileName = "03.mp3", durationSeconds = 6, trackNumber = 3),
+                    SeedTrack(fileName = "04.mp3", durationSeconds = 4, trackNumber = 4),
+                ),
+            chapters = emptyList(),
+            sidecar = SeedSidecar.OPF,
+            hasCover = true,
+            description = "Fire must consume everything before something new can grow.",
+        ),
+    )
+
+    // ── Standalone: multi-disc, DESC_TXT sidecar ────────────────────────────────────────────
+    add(
+        SeedBook(
+            folderPath = "Cassia Vane/The Clockwork Archipelago",
+            title = "The Clockwork Archipelago",
+            authors = listOf("Cassia Vane"),
+            narrators = listOf("Idris Okafor"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "01.mp3", durationSeconds = 5, trackNumber = 1),
+                    SeedTrack(fileName = "02.mp3", durationSeconds = 6, trackNumber = 2),
+                    SeedTrack(fileName = "03.mp3", durationSeconds = 5, trackNumber = 3),
+                    SeedTrack(fileName = "04.mp3", durationSeconds = 6, trackNumber = 4),
+                    SeedTrack(fileName = "05.mp3", durationSeconds = 5, trackNumber = 5),
+                ),
+            chapters = emptyList(),
+            sidecar = SeedSidecar.DESC_TXT,
+            hasCover = true,
+            description = "Islands of brass and steam. A navigator who cannot forget. A chart that rewrites itself.",
+            discFolders = true,
+        ),
+    )
+
+    // ── Standalone: single-file, embedded chapters, READER_TXT sidecar ─────────────────────
+    add(
+        SeedBook(
+            folderPath = "Theo Morrow/The Glass Meridian",
+            title = "The Glass Meridian",
+            authors = listOf("Theo Morrow"),
+            narrators = listOf("Priya Sundaram"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "book.m4b", durationSeconds = 20, trackNumber = 1),
+                ),
+            chapters =
+                listOf(
+                    SeedChapter(title = "Zero Latitude", startSeconds = 0),
+                    SeedChapter(title = "The Glass Line", startSeconds = 7),
+                    SeedChapter(title = "True North", startSeconds = 14),
+                ),
+            sidecar = SeedSidecar.READER_TXT,
+            hasCover = true,
+            description = "A cartographer who maps places that do not yet exist.",
+        ),
+    )
+}
+
+/**
+ * Edge-case entries: no cover, very long title, multi-narrator, and the NONE sidecar
+ * (sparse metadata — deliberately thin so the scanner exercises its fallback paths).
+ */
+private fun MutableList<SeedBook>.addEdgeCaseBooks() {
+    // NONE sidecar + no cover — exercises sparse-metadata scanner path
+    add(
+        SeedBook(
+            folderPath = "Aldric Penn/The Salt Roads",
+            title = "The Salt Roads",
+            authors = listOf("Aldric Penn"),
+            narrators = listOf("Nora Vex"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "01.mp3", durationSeconds = 4, trackNumber = 1),
+                    SeedTrack(fileName = "02.mp3", durationSeconds = 5, trackNumber = 2),
+                    SeedTrack(fileName = "03.mp3", durationSeconds = 4, trackNumber = 3),
+                ),
+            chapters = emptyList(),
+            sidecar = SeedSidecar.NONE,
+            hasCover = false,
+            description = "Trade routes, betrayal, and a merchant who knows too much.",
+        ),
+    )
+
+    // Title > 80 chars — exercises long-title handling in DB and UI
+    add(
+        SeedBook(
+            folderPath = "Isolde Crane/A Treatise on the Peculiar Navigation of Unmapped Tidal Seas",
+            title = "A Treatise on the Peculiar Navigation of Unmapped Tidal Seas and Their Inhabitants",
+            authors = listOf("Isolde Crane"),
+            narrators = listOf("Finn Maccabe"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "book.m4b", durationSeconds = 15, trackNumber = 1),
+                ),
+            chapters =
+                listOf(
+                    SeedChapter(title = "Prologue", startSeconds = 0),
+                    SeedChapter(title = "On Currents Unseen", startSeconds = 6),
+                    SeedChapter(title = "Afterword", startSeconds = 11),
+                ),
+            sidecar = SeedSidecar.METADATA_JSON,
+            hasCover = true,
+            description = "A Victorian scholar's field notes on seas that refuse to be charted.",
+        ),
+    )
+
+    // Multi-narrator — exercises narrator-list parsing and contributor join table
+    add(
+        SeedBook(
+            folderPath = "Sable Orin/The Fractured Court",
+            title = "The Fractured Court",
+            authors = listOf("Sable Orin"),
+            narrators = listOf("Lena Vask", "Dex Orin"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "01.mp3", durationSeconds = 5, trackNumber = 1),
+                    SeedTrack(fileName = "02.mp3", durationSeconds = 6, trackNumber = 2),
+                    SeedTrack(fileName = "03.mp3", durationSeconds = 5, trackNumber = 3),
+                ),
+            chapters = emptyList(),
+            sidecar = SeedSidecar.NFO,
+            hasCover = true,
+            description = "Two narrators voice a courtroom where no verdict is safe.",
+        ),
+    )
+
+    // Co-authored standalone — exercises multi-author contributor join table
+    add(
+        SeedBook(
+            folderPath = "Remy Vaux and Dalia Stern/The Iron Horizon",
+            title = "The Iron Horizon",
+            authors = listOf("Remy Vaux", "Dalia Stern"),
+            narrators = listOf("Kit Harker"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "book.m4b", durationSeconds = 16, trackNumber = 1),
+                ),
+            chapters =
+                listOf(
+                    SeedChapter(title = "Chapter 1", startSeconds = 0),
+                    SeedChapter(title = "Chapter 2", startSeconds = 8),
+                ),
+            sidecar = SeedSidecar.OPF,
+            hasCover = true,
+            description = "Two engineers. One impossible bridge. A city that bets everything on them.",
+        ),
+    )
+
+    // Single-file with DESC_TXT — rounds out the sidecar coverage without repeating a kind
+    // used in the representative set; also ensures we stay at exactly 10 books.
+    add(
+        SeedBook(
+            folderPath = "Petra Lund/The Hollow Winter",
+            title = "The Hollow Winter",
+            authors = listOf("Petra Lund"),
+            narrators = listOf("Soren Mast"),
+            series = null,
+            tracks =
+                listOf(
+                    SeedTrack(fileName = "book.m4b", durationSeconds = 14, trackNumber = 1),
+                ),
+            chapters =
+                listOf(
+                    SeedChapter(title = "First Snow", startSeconds = 0),
+                    SeedChapter(title = "The Long Dark", startSeconds = 7),
+                ),
+            sidecar = SeedSidecar.READER_TXT,
+            hasCover = true,
+            description = "A lighthouse keeper. Eleven months of silence. One letter that changes everything.",
+        ),
+    )
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryGenerator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryGenerator.kt
@@ -4,7 +4,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.add
-import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.put
@@ -15,6 +14,11 @@ import kotlin.io.path.writeText
 import kotlin.math.abs
 
 private val logger = KotlinLogging.logger {}
+
+private val prettyJson = Json { prettyPrint = true }
+
+private const val FFMPEG_FLAG_METADATA = "-metadata"
+private const val FFMPEG_FILTER_COMPLEX = "lavfi"
 
 /**
  * Generates the synthetic audiobook library described by [SeedLibraryDescriptor] into
@@ -32,20 +36,29 @@ object SeedLibraryGenerator {
         logger.info { "seed library generated: ${SeedLibraryDescriptor.BOOKS.size} books at $outputRoot" }
     }
 
-    private fun generateBook(root: Path, book: SeedBook) {
+    private fun generateBook(
+        root: Path,
+        book: SeedBook,
+    ) {
         val bookDir = root.resolve(book.folderPath)
         bookDir.createDirectories()
         book.tracks.forEachIndexed { index, track ->
             val trackDir =
-                if (book.discFolders) bookDir.resolve("CD${index + 1}").also { it.createDirectories() }
-                else bookDir
+                if (book.discFolders) {
+                    bookDir.resolve("CD${index + 1}").apply { createDirectories() }
+                } else {
+                    bookDir
+                }
             generateAudioFile(trackDir.resolve(track.fileName), track, book)
         }
         writeSidecar(bookDir, book)
         if (book.hasCover) generateCover(bookDir.resolve("cover.jpg"), book.title)
     }
 
-    private fun writeSidecar(bookDir: Path, book: SeedBook) {
+    private fun writeSidecar(
+        bookDir: Path,
+        book: SeedBook,
+    ) {
         when (book.sidecar) {
             SeedSidecar.NONE -> Unit
             SeedSidecar.METADATA_JSON -> bookDir.resolve("metadata.json").writeText(metadataJson(book))
@@ -64,9 +77,10 @@ object SeedLibraryGenerator {
     /** Runs ffmpeg with the given args, capturing stderr. Throws [IllegalStateException] on non-zero exit. */
     private fun runFfmpeg(args: List<String>) {
         val command = listOf("ffmpeg") + args
-        val process = ProcessBuilder(command)
-            .redirectErrorStream(true)
-            .start()
+        val process =
+            ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start()
         val output = process.inputStream.bufferedReader().readText()
         val exitCode = process.waitFor()
         check(exitCode == 0) {
@@ -78,19 +92,28 @@ object SeedLibraryGenerator {
      * Generates one tiny audio file: a low-bitrate sine tone of [track.durationSeconds].
      * For single-file books with chapters, embeds FFMETADATA chapter atoms.
      */
-    private fun generateAudioFile(target: Path, track: SeedTrack, book: SeedBook) {
+    private fun generateAudioFile(
+        target: Path,
+        track: SeedTrack,
+        book: SeedBook,
+    ) {
         val extension = target.fileName.toString().substringAfterLast('.')
-        val codec = when (extension) {
-            "m4b" -> "aac"
-            "mp3" -> "libmp3lame"
-            else -> error("Unsupported audio extension: .$extension")
-        }
+        val codec =
+            when (extension) {
+                "m4b" -> "aac"
+                "mp3" -> "libmp3lame"
+                else -> error("Unsupported audio extension: .$extension")
+            }
         val firstAuthor = book.authors.firstOrNull() ?: ""
-        val metadataArgs = listOf(
-            "-metadata", "title=${book.title}",
-            "-metadata", "artist=$firstAuthor",
-            "-metadata", "track=${track.trackNumber}",
-        )
+        val metadataArgs =
+            listOf(
+                FFMPEG_FLAG_METADATA,
+                "title=${book.title}",
+                FFMPEG_FLAG_METADATA,
+                "artist=$firstAuthor",
+                FFMPEG_FLAG_METADATA,
+                "track=${track.trackNumber}",
+            )
 
         val isSingleFileWithChapters = book.tracks.size == 1 && book.chapters.isNotEmpty()
         if (isSingleFileWithChapters) {
@@ -100,13 +123,20 @@ object SeedLibraryGenerator {
                 runFfmpeg(
                     listOf(
                         "-y",
-                        "-f", "lavfi",
-                        "-i", "sine=frequency=220:duration=${track.durationSeconds}",
-                        "-i", ffmetaFile.toAbsolutePath().toString(),
-                        "-map", "0:a",
-                        "-map_metadata", "1",
-                        "-c:a", codec,
-                        "-b:a", "32k",
+                        "-f",
+                        FFMPEG_FILTER_COMPLEX,
+                        "-i",
+                        "sine=frequency=220:duration=${track.durationSeconds}",
+                        "-i",
+                        ffmetaFile.toAbsolutePath().toString(),
+                        "-map",
+                        "0:a",
+                        "-map_metadata",
+                        "1",
+                        "-c:a",
+                        codec,
+                        "-b:a",
+                        "32k",
                     ) + metadataArgs + listOf(target.toAbsolutePath().toString()),
                 )
             } finally {
@@ -116,26 +146,35 @@ object SeedLibraryGenerator {
             runFfmpeg(
                 listOf(
                     "-y",
-                    "-f", "lavfi",
-                    "-i", "sine=frequency=220:duration=${track.durationSeconds}",
-                    "-c:a", codec,
-                    "-b:a", "32k",
+                    "-f",
+                    FFMPEG_FILTER_COMPLEX,
+                    "-i",
+                    "sine=frequency=220:duration=${track.durationSeconds}",
+                    "-c:a",
+                    codec,
+                    "-b:a",
+                    "32k",
                 ) + metadataArgs + listOf(target.toAbsolutePath().toString()),
             )
         }
     }
 
     /** Builds the FFMETADATA1 text for a single-file book with embedded chapters. */
-    private fun buildFfmetadata(book: SeedBook, track: SeedTrack): String {
+    private fun buildFfmetadata(
+        book: SeedBook,
+        track: SeedTrack,
+    ): String {
         val sb = StringBuilder()
         sb.appendLine(";FFMETADATA1")
         book.chapters.forEachIndexed { index, chapter ->
             val startMs = chapter.startSeconds * 1000L
-            val endMs = if (index + 1 < book.chapters.size) {
-                book.chapters[index + 1].startSeconds * 1000L
-            } else {
-                track.durationSeconds * 1000L
-            }
+            val endMs =
+                if (index + 1 < book.chapters.size) {
+                    book.chapters[index + 1].startSeconds * 1000L
+                } else {
+                    track.durationSeconds * 1000L
+                }
+            require(endMs >= startMs) { "chapter END ($endMs ms) precedes START ($startMs ms) — check the descriptor" }
             sb.appendLine()
             sb.appendLine("[CHAPTER]")
             sb.appendLine("TIMEBASE=1/1000")
@@ -150,7 +189,10 @@ object SeedLibraryGenerator {
      * Generates a 300x300 solid-color JPEG cover image. The color is derived
      * deterministically from the book title's hash code.
      */
-    private fun generateCover(target: Path, title: String) {
+    private fun generateCover(
+        target: Path,
+        title: String,
+    ) {
         // Map title hash to a pleasing HSL color; use absolute value to avoid negative hex.
         val hue = abs(title.hashCode()) % 360
         // Convert HSL(hue, 70%, 50%) → approximate RGB for ffmpeg color string.
@@ -158,27 +200,35 @@ object SeedLibraryGenerator {
         runFfmpeg(
             listOf(
                 "-y",
-                "-f", "lavfi",
-                "-i", "color=c=$color:s=300x300",
-                "-frames:v", "1",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=$color:s=300x300",
+                "-frames:v",
+                "1",
                 target.toAbsolutePath().toString(),
             ),
         )
     }
 
     /** Converts HSL to a 6-digit hex string for ffmpeg's color= parameter. */
-    private fun hslToHex(hDeg: Int, s: Double, l: Double): String {
+    private fun hslToHex(
+        hDeg: Int,
+        s: Double,
+        l: Double,
+    ): String {
         val c = (1.0 - Math.abs(2.0 * l - 1.0)) * s
-        val x = c * (1.0 - Math.abs((hDeg / 60.0) % 2.0 - 1.0))
+        val x = c * (1.0 - Math.abs(hDeg / 60.0 % 2.0 - 1.0))
         val m = l - c / 2.0
-        val (r1, g1, b1) = when (hDeg / 60) {
-            0 -> Triple(c, x, 0.0)
-            1 -> Triple(x, c, 0.0)
-            2 -> Triple(0.0, c, x)
-            3 -> Triple(0.0, x, c)
-            4 -> Triple(x, 0.0, c)
-            else -> Triple(c, 0.0, x)
-        }
+        val (r1, g1, b1) =
+            when (hDeg / 60) {
+                0 -> Triple(c, x, 0.0)
+                1 -> Triple(x, c, 0.0)
+                2 -> Triple(0.0, c, x)
+                3 -> Triple(0.0, x, c)
+                4 -> Triple(x, 0.0, c)
+                else -> Triple(c, 0.0, x)
+            }
         val r = ((r1 + m) * 255).toInt().coerceIn(0, 255)
         val g = ((g1 + m) * 255).toInt().coerceIn(0, 255)
         val b = ((b1 + m) * 255).toInt().coerceIn(0, 255)
@@ -187,22 +237,22 @@ object SeedLibraryGenerator {
 
     /** Builds ABS-format metadata.json content using kotlinx.serialization. */
     private fun metadataJson(book: SeedBook): String {
-        val json = Json { prettyPrint = true }
-        val obj = buildJsonObject {
-            put("title", book.title)
-            put("subtitle", JsonNull)
-            put("authors", buildJsonArray { book.authors.forEach { add(it) } })
-            put("narrators", buildJsonArray { book.narrators.forEach { add(it) } })
-            put(
-                "series",
-                buildJsonArray {
-                    if (book.series != null) add("${book.series.name} #${book.series.sequence}")
-                },
-            )
-            put("description", book.description)
-            put("publishedYear", 2023)
-        }
-        return json.encodeToString(obj)
+        val obj =
+            buildJsonObject {
+                put("title", book.title)
+                put("subtitle", JsonNull)
+                put("authors", buildJsonArray { book.authors.forEach { add(it) } })
+                put("narrators", buildJsonArray { book.narrators.forEach { add(it) } })
+                put(
+                    "series",
+                    buildJsonArray {
+                        if (book.series != null) add("${book.series.name} #${book.series.sequence}")
+                    },
+                )
+                put("description", book.description)
+                put("publishedYear", 2023)
+            }
+        return prettyJson.encodeToString(obj)
     }
 
     /** Builds Kodi-style book.nfo XML content. */
@@ -224,7 +274,9 @@ object SeedLibraryGenerator {
         val sb = StringBuilder()
         sb.appendLine("""<?xml version="1.0" encoding="utf-8"?>""")
         sb.appendLine("""<package xmlns:opf="http://www.idpf.org/2007/opf">""")
-        sb.appendLine("""  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">""")
+        sb.appendLine(
+            """  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">""",
+        )
         sb.appendLine("    <dc:title>${xmlEscape(book.title)}</dc:title>")
         book.authors.forEach {
             sb.appendLine("""    <dc:creator opf:role="aut">${xmlEscape(it)}</dc:creator>""")

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryGenerator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedLibraryGenerator.kt
@@ -1,0 +1,256 @@
+package com.calypsan.listenup.server.seed
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.put
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.math.abs
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Generates the synthetic audiobook library described by [SeedLibraryDescriptor] into
+ * an output directory, using `ffmpeg`. The output is disposable — regenerate any time.
+ *
+ * Invoked by the `:server:generateSeedLibrary` Gradle task. `main` takes one argument:
+ * the absolute output directory path.
+ */
+object SeedLibraryGenerator {
+    fun generate(outputRoot: Path) {
+        require(ffmpegAvailable()) { "ffmpeg not found on PATH — required to generate the seed library" }
+        if (Files.exists(outputRoot)) outputRoot.toFile().deleteRecursively()
+        outputRoot.createDirectories()
+        SeedLibraryDescriptor.BOOKS.forEach { book -> generateBook(outputRoot, book) }
+        logger.info { "seed library generated: ${SeedLibraryDescriptor.BOOKS.size} books at $outputRoot" }
+    }
+
+    private fun generateBook(root: Path, book: SeedBook) {
+        val bookDir = root.resolve(book.folderPath)
+        bookDir.createDirectories()
+        book.tracks.forEachIndexed { index, track ->
+            val trackDir =
+                if (book.discFolders) bookDir.resolve("CD${index + 1}").also { it.createDirectories() }
+                else bookDir
+            generateAudioFile(trackDir.resolve(track.fileName), track, book)
+        }
+        writeSidecar(bookDir, book)
+        if (book.hasCover) generateCover(bookDir.resolve("cover.jpg"), book.title)
+    }
+
+    private fun writeSidecar(bookDir: Path, book: SeedBook) {
+        when (book.sidecar) {
+            SeedSidecar.NONE -> Unit
+            SeedSidecar.METADATA_JSON -> bookDir.resolve("metadata.json").writeText(metadataJson(book))
+            SeedSidecar.NFO -> bookDir.resolve("book.nfo").writeText(nfoXml(book))
+            SeedSidecar.OPF -> bookDir.resolve("metadata.opf").writeText(opfXml(book))
+            SeedSidecar.READER_TXT -> bookDir.resolve("reader.txt").writeText(book.narrators.joinToString("\n"))
+            SeedSidecar.DESC_TXT -> bookDir.resolve("desc.txt").writeText(book.description)
+        }
+    }
+
+    private fun ffmpegAvailable(): Boolean =
+        runCatching {
+            ProcessBuilder("ffmpeg", "-version").redirectErrorStream(true).start().waitFor() == 0
+        }.getOrDefault(false)
+
+    /** Runs ffmpeg with the given args, capturing stderr. Throws [IllegalStateException] on non-zero exit. */
+    private fun runFfmpeg(args: List<String>) {
+        val command = listOf("ffmpeg") + args
+        val process = ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+        check(exitCode == 0) {
+            "ffmpeg exited with code $exitCode. Output:\n$output"
+        }
+    }
+
+    /**
+     * Generates one tiny audio file: a low-bitrate sine tone of [track.durationSeconds].
+     * For single-file books with chapters, embeds FFMETADATA chapter atoms.
+     */
+    private fun generateAudioFile(target: Path, track: SeedTrack, book: SeedBook) {
+        val extension = target.fileName.toString().substringAfterLast('.')
+        val codec = when (extension) {
+            "m4b" -> "aac"
+            "mp3" -> "libmp3lame"
+            else -> error("Unsupported audio extension: .$extension")
+        }
+        val firstAuthor = book.authors.firstOrNull() ?: ""
+        val metadataArgs = listOf(
+            "-metadata", "title=${book.title}",
+            "-metadata", "artist=$firstAuthor",
+            "-metadata", "track=${track.trackNumber}",
+        )
+
+        val isSingleFileWithChapters = book.tracks.size == 1 && book.chapters.isNotEmpty()
+        if (isSingleFileWithChapters) {
+            val ffmetaFile = Files.createTempFile("listenup-ffmeta-", ".txt")
+            try {
+                ffmetaFile.writeText(buildFfmetadata(book, track))
+                runFfmpeg(
+                    listOf(
+                        "-y",
+                        "-f", "lavfi",
+                        "-i", "sine=frequency=220:duration=${track.durationSeconds}",
+                        "-i", ffmetaFile.toAbsolutePath().toString(),
+                        "-map", "0:a",
+                        "-map_metadata", "1",
+                        "-c:a", codec,
+                        "-b:a", "32k",
+                    ) + metadataArgs + listOf(target.toAbsolutePath().toString()),
+                )
+            } finally {
+                Files.deleteIfExists(ffmetaFile)
+            }
+        } else {
+            runFfmpeg(
+                listOf(
+                    "-y",
+                    "-f", "lavfi",
+                    "-i", "sine=frequency=220:duration=${track.durationSeconds}",
+                    "-c:a", codec,
+                    "-b:a", "32k",
+                ) + metadataArgs + listOf(target.toAbsolutePath().toString()),
+            )
+        }
+    }
+
+    /** Builds the FFMETADATA1 text for a single-file book with embedded chapters. */
+    private fun buildFfmetadata(book: SeedBook, track: SeedTrack): String {
+        val sb = StringBuilder()
+        sb.appendLine(";FFMETADATA1")
+        book.chapters.forEachIndexed { index, chapter ->
+            val startMs = chapter.startSeconds * 1000L
+            val endMs = if (index + 1 < book.chapters.size) {
+                book.chapters[index + 1].startSeconds * 1000L
+            } else {
+                track.durationSeconds * 1000L
+            }
+            sb.appendLine()
+            sb.appendLine("[CHAPTER]")
+            sb.appendLine("TIMEBASE=1/1000")
+            sb.appendLine("START=$startMs")
+            sb.appendLine("END=$endMs")
+            sb.appendLine("title=${chapter.title}")
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Generates a 300x300 solid-color JPEG cover image. The color is derived
+     * deterministically from the book title's hash code.
+     */
+    private fun generateCover(target: Path, title: String) {
+        // Map title hash to a pleasing HSL color; use absolute value to avoid negative hex.
+        val hue = abs(title.hashCode()) % 360
+        // Convert HSL(hue, 70%, 50%) → approximate RGB for ffmpeg color string.
+        val color = hslToHex(hue, 0.70, 0.50)
+        runFfmpeg(
+            listOf(
+                "-y",
+                "-f", "lavfi",
+                "-i", "color=c=$color:s=300x300",
+                "-frames:v", "1",
+                target.toAbsolutePath().toString(),
+            ),
+        )
+    }
+
+    /** Converts HSL to a 6-digit hex string for ffmpeg's color= parameter. */
+    private fun hslToHex(hDeg: Int, s: Double, l: Double): String {
+        val c = (1.0 - Math.abs(2.0 * l - 1.0)) * s
+        val x = c * (1.0 - Math.abs((hDeg / 60.0) % 2.0 - 1.0))
+        val m = l - c / 2.0
+        val (r1, g1, b1) = when (hDeg / 60) {
+            0 -> Triple(c, x, 0.0)
+            1 -> Triple(x, c, 0.0)
+            2 -> Triple(0.0, c, x)
+            3 -> Triple(0.0, x, c)
+            4 -> Triple(x, 0.0, c)
+            else -> Triple(c, 0.0, x)
+        }
+        val r = ((r1 + m) * 255).toInt().coerceIn(0, 255)
+        val g = ((g1 + m) * 255).toInt().coerceIn(0, 255)
+        val b = ((b1 + m) * 255).toInt().coerceIn(0, 255)
+        return "0x%02X%02X%02X".format(r, g, b)
+    }
+
+    /** Builds ABS-format metadata.json content using kotlinx.serialization. */
+    private fun metadataJson(book: SeedBook): String {
+        val json = Json { prettyPrint = true }
+        val obj = buildJsonObject {
+            put("title", book.title)
+            put("subtitle", JsonNull)
+            put("authors", buildJsonArray { book.authors.forEach { add(it) } })
+            put("narrators", buildJsonArray { book.narrators.forEach { add(it) } })
+            put(
+                "series",
+                buildJsonArray {
+                    if (book.series != null) add("${book.series.name} #${book.series.sequence}")
+                },
+            )
+            put("description", book.description)
+            put("publishedYear", 2023)
+        }
+        return json.encodeToString(obj)
+    }
+
+    /** Builds Kodi-style book.nfo XML content. */
+    private fun nfoXml(book: SeedBook): String {
+        val sb = StringBuilder()
+        sb.appendLine("""<?xml version="1.0" encoding="utf-8"?>""")
+        sb.appendLine("<book>")
+        sb.appendLine("  <title>${xmlEscape(book.title)}</title>")
+        sb.appendLine("  <plot>${xmlEscape(book.description)}</plot>")
+        sb.appendLine("  <year>2023</year>")
+        book.authors.forEach { sb.appendLine("  <author>${xmlEscape(it)}</author>") }
+        book.narrators.forEach { sb.appendLine("  <actor>${xmlEscape(it)}</actor>") }
+        sb.append("</book>")
+        return sb.toString()
+    }
+
+    /** Builds Dublin Core OPF XML content. */
+    private fun opfXml(book: SeedBook): String {
+        val sb = StringBuilder()
+        sb.appendLine("""<?xml version="1.0" encoding="utf-8"?>""")
+        sb.appendLine("""<package xmlns:opf="http://www.idpf.org/2007/opf">""")
+        sb.appendLine("""  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">""")
+        sb.appendLine("    <dc:title>${xmlEscape(book.title)}</dc:title>")
+        book.authors.forEach {
+            sb.appendLine("""    <dc:creator opf:role="aut">${xmlEscape(it)}</dc:creator>""")
+        }
+        book.narrators.forEach {
+            sb.appendLine("""    <dc:creator opf:role="nrt">${xmlEscape(it)}</dc:creator>""")
+        }
+        sb.appendLine("    <dc:description>${xmlEscape(book.description)}</dc:description>")
+        sb.appendLine("    <dc:date>2023</dc:date>")
+        sb.appendLine("  </metadata>")
+        sb.append("</package>")
+        return sb.toString()
+    }
+
+    /** Escapes the five special XML characters. */
+    private fun xmlEscape(text: String): String =
+        text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;")
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        require(args.size == 1) { "usage: SeedLibraryGenerator <output-dir>" }
+        generate(Path.of(args[0]))
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedRunner.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/SeedRunner.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.server.seed
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Runs the registered [DomainSeeder]s in ascending [DomainSeeder.order]. Each seeder
+ * runs only when its domain is empty, so invoking the runner against an already-populated
+ * database is a no-op — never a clobber. Invoked once at startup under the `demo` seed profile.
+ */
+class SeedRunner(
+    private val seeders: List<DomainSeeder>,
+) {
+    suspend fun run() {
+        seeders.sortedBy { it.order }.forEach { seeder ->
+            if (seeder.isAlreadySeeded()) {
+                logger.info { "seed: '${seeder.domainName}' already populated — skipping" }
+            } else {
+                logger.info { "seed: seeding '${seeder.domainName}'" }
+                seeder.seed()
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/UserDomainSeeder.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/UserDomainSeeder.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.server.seed
+
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.auth.AuthServiceImpl
+import com.calypsan.listenup.server.db.UserEntity
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Seeds a single demo user — a known account so a developer running the demo server
+ * can log straight in. Created through [AuthServiceImpl.setupRoot] (the real auth
+ * write-path), which yields a ROOT, ACTIVE user.
+ *
+ * Demo credentials are intentionally well-known and documented; the demo profile is
+ * never for production use.
+ */
+class UserDomainSeeder(
+    private val db: Database,
+    private val authService: AuthServiceImpl,
+) : DomainSeeder {
+    override val domainName: String = "user"
+    override val order: Int = 0
+
+    override suspend fun isAlreadySeeded(): Boolean =
+        suspendTransaction(db) { !UserEntity.all().limit(1).empty() }
+
+    override suspend fun seed() {
+        val result =
+            authService.setupRoot(
+                RegisterRequest(
+                    email = DEMO_EMAIL,
+                    password = DEMO_PASSWORD,
+                    displayName = DEMO_DISPLAY_NAME,
+                ),
+            )
+        when (result) {
+            is AppResult.Success -> logger.info { "seed: demo user '$DEMO_EMAIL' created" }
+            is AppResult.Failure ->
+                logger.warn { "seed: demo user not created — ${result.error.code}" }
+        }
+    }
+
+    companion object {
+        const val DEMO_EMAIL = "demo@listenup.app"
+        const val DEMO_PASSWORD = "demo-password"
+        const val DEMO_DISPLAY_NAME = "Demo User"
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/seed/UserDomainSeeder.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/seed/UserDomainSeeder.kt
@@ -25,8 +25,7 @@ class UserDomainSeeder(
     override val domainName: String = "user"
     override val order: Int = 0
 
-    override suspend fun isAlreadySeeded(): Boolean =
-        suspendTransaction(db) { !UserEntity.all().limit(1).empty() }
+    override suspend fun isAlreadySeeded(): Boolean = suspendTransaction(db) { !UserEntity.all().limit(1).empty() }
 
     override suspend fun seed() {
         val result =
@@ -38,9 +37,13 @@ class UserDomainSeeder(
                 ),
             )
         when (result) {
-            is AppResult.Success -> logger.info { "seed: demo user '$DEMO_EMAIL' created" }
-            is AppResult.Failure ->
+            is AppResult.Success -> {
+                logger.info { "seed: demo user '$DEMO_EMAIL' created" }
+            }
+
+            is AppResult.Failure -> {
                 logger.warn { "seed: demo user not created — ${result.error.code}" }
+            }
         }
     }
 

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -44,3 +44,8 @@ scanner {
     libraryPath = ""
     libraryPath = ${?LISTENUP_LIBRARY_PATH}
 }
+
+seed {
+    profile = ""
+    profile = ${?LISTENUP_SEED_PROFILE}
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/seed/DemoProfileBootTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/seed/DemoProfileBootTest.kt
@@ -1,0 +1,48 @@
+package com.calypsan.listenup.server.seed
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.LoginRequest
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class DemoProfileBootTest :
+    FunSpec({
+        test("with seed.profile=demo the server boots and the demo user can log in") {
+            testApplication {
+                useIsolatedTestConfig(seedProfile = "demo")
+                application { module() }
+                val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+
+                eventually(5.seconds) {
+                    val response =
+                        client.post("/api/v1/auth/login") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                LoginRequest(
+                                    email = UserDomainSeeder.DEMO_EMAIL,
+                                    password = UserDomainSeeder.DEMO_PASSWORD,
+                                ),
+                            )
+                        }
+                    response.status shouldBe HttpStatusCode.OK
+                    response.body<AppResult<AuthSession>>().shouldBeInstanceOf<AppResult.Success<AuthSession>>()
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/seed/SeedLibraryDescriptorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/seed/SeedLibraryDescriptorTest.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.server.seed
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+
+class SeedLibraryDescriptorTest :
+    FunSpec({
+        val books = SeedLibraryDescriptor.BOOKS
+
+        test("the library has 10-12 books") {
+            (books.size in 10..12) shouldBe true
+        }
+
+        test("every book has a unique folder path and at least one audio track") {
+            books.map { it.folderPath }.toSet().size shouldBe books.size
+            books.forEach { book -> book.tracks.size shouldBeGreaterThanOrEqual 1 }
+        }
+
+        test("the library covers both single-file and multi-file audiobooks") {
+            books.any { it.tracks.size == 1 } shouldBe true
+            books.any { it.tracks.size > 1 } shouldBe true
+        }
+
+        test("the library includes the required edge cases") {
+            books.any { !it.hasCover } shouldBe true
+            books.any { it.title.length > 80 } shouldBe true
+            books.any { it.narrators.size > 1 } shouldBe true
+            books.map { it.sidecar }.toSet() shouldContain SeedSidecar.NONE
+        }
+
+        test("every sidecar kind is exercised at least once") {
+            val used = books.map { it.sidecar }.toSet()
+            SeedSidecar.entries.forEach { kind -> used shouldContain kind }
+        }
+
+        test("at least one book belongs to a multi-book series") {
+            val seriesCounts = books.mapNotNull { it.series?.name }.groupingBy { it }.eachCount()
+            seriesCounts.values.any { it >= 2 } shouldBe true
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/seed/SeedRunnerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/seed/SeedRunnerTest.kt
@@ -1,0 +1,65 @@
+package com.calypsan.listenup.server.seed
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.test.runTest
+
+class SeedRunnerTest :
+    FunSpec({
+        /** A fake seeder that records calls and reports a controllable "already seeded" state. */
+        class FakeSeeder(
+            override val domainName: String,
+            override val order: Int,
+            private var seeded: Boolean,
+            val log: MutableList<String>,
+        ) : DomainSeeder {
+            override suspend fun isAlreadySeeded(): Boolean = seeded
+
+            override suspend fun seed() {
+                log += domainName
+                seeded = true
+            }
+        }
+
+        test("runs every not-yet-seeded seeder, in ascending order") {
+            val log = mutableListOf<String>()
+            val runner =
+                SeedRunner(
+                    listOf(
+                        FakeSeeder("b", order = 20, seeded = false, log = log),
+                        FakeSeeder("a", order = 10, seeded = false, log = log),
+                    ),
+                )
+
+            runTest { runner.run() }
+
+            log shouldContainExactly listOf("a", "b")
+        }
+
+        test("skips a seeder whose domain is already populated") {
+            val log = mutableListOf<String>()
+            val runner =
+                SeedRunner(
+                    listOf(
+                        FakeSeeder("fresh", order = 10, seeded = false, log = log),
+                        FakeSeeder("populated", order = 20, seeded = true, log = log),
+                    ),
+                )
+
+            runTest { runner.run() }
+
+            log shouldContainExactly listOf("fresh")
+        }
+
+        test("running twice is a no-op the second time") {
+            val log = mutableListOf<String>()
+            val runner = SeedRunner(listOf(FakeSeeder("x", order = 10, seeded = false, log = log)))
+
+            runTest {
+                runner.run()
+                runner.run()
+            }
+
+            log shouldContainExactly listOf("x")
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/seed/UserDomainSeederTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/seed/UserDomainSeederTest.kt
@@ -1,0 +1,73 @@
+package com.calypsan.listenup.server.seed
+
+import com.calypsan.listenup.api.dto.auth.LoginRequest
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.auth.AuthServiceImpl
+import com.calypsan.listenup.server.auth.JwtConfiguration
+import com.calypsan.listenup.server.auth.PasswordHasher
+import com.calypsan.listenup.server.auth.RefreshTokenGenerator
+import com.calypsan.listenup.server.auth.RefreshTokenHasher
+import com.calypsan.listenup.server.auth.SessionService
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.jdbc.Database
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class UserDomainSeederTest :
+    FunSpec({
+        test("seeds the demo user, who can then authenticate") {
+            withInMemoryDatabase {
+                val db = this
+                val authService = newAuthService(db)
+                val seeder = UserDomainSeeder(db, authService)
+
+                runTest {
+                    seeder.isAlreadySeeded() shouldBe false
+                    seeder.seed()
+                    seeder.isAlreadySeeded() shouldBe true
+
+                    val login =
+                        authService.login(
+                            LoginRequest(
+                                email = UserDomainSeeder.DEMO_EMAIL,
+                                password = UserDomainSeeder.DEMO_PASSWORD,
+                            ),
+                        )
+                    login.shouldBeInstanceOf<AppResult.Success<*>>()
+                }
+            }
+        }
+
+        test("seed() is safe to call twice — the second call does not throw") {
+            withInMemoryDatabase {
+                val db = this
+                val authService = newAuthService(db)
+                val seeder = UserDomainSeeder(db, authService)
+                runTest {
+                    seeder.seed()
+                    seeder.seed() // setupRoot returns a Failure on the second call; seed() must swallow it
+                    seeder.isAlreadySeeded() shouldBe true
+                }
+            }
+        }
+    })
+
+private fun newAuthService(db: Database): AuthServiceImpl {
+    val pepper = "x".repeat(32).toByteArray()
+    val clock = FixedClock(Instant.parse("2026-05-02T12:00:00Z"))
+    val hasher = PasswordHasher()
+    val sessions = SessionService(db, RefreshTokenHasher(pepper), RefreshTokenGenerator(), clock = clock)
+    val jwt = JwtConfiguration("x".repeat(32), "listenup", "listenup-client", 15.minutes, clock)
+    return AuthServiceImpl(
+        db = db,
+        sessions = sessions,
+        hasher = hasher,
+        jwt = jwt,
+        clock = clock,
+    )
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/TestApplicationConfig.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/TestApplicationConfig.kt
@@ -18,10 +18,14 @@ import java.nio.file.Files
  *   the scanner and books slices. Must point at an existing directory — the
  *   server skips scanner wiring for a missing/blank path. Tests that need the
  *   books domain (or a scanner) pass a fresh temp directory here.
+ * @param seedProfile when set, adds `seed.profile` so `module()` installs
+ *   the seed module and runs the [com.calypsan.listenup.server.seed.SeedRunner]
+ *   at startup. Pass `"demo"` to exercise the demo-seed boot path.
  */
 fun ApplicationTestBuilder.useIsolatedTestConfig(
     registrationPolicy: String = "OPEN",
     libraryPath: String? = null,
+    seedProfile: String? = null,
 ) {
     val tmp = Files.createTempFile("listenup-test-", ".db").toFile().apply { deleteOnExit() }
     environment {
@@ -35,6 +39,7 @@ fun ApplicationTestBuilder.useIsolatedTestConfig(
                 "registration.policy" to registrationPolicy,
             ).apply {
                 if (libraryPath != null) put("scanner.libraryPath", libraryPath)
+                if (seedProfile != null) put("seed.profile", seedProfile)
             }
     }
 }


### PR DESCRIPTION
## Summary

Makes the Kotlin `:server` runnable as a self-seeding **demo server** — `./gradlew :server:runDemo` yields a populated server to test E2E flows against, with zero live data.

- **`DomainSeeder` SPI + idempotent `SeedRunner`** — the per-domain seeding extension point. v1 ships `UserDomainSeeder` (a demo user created through the real auth write-path); every future domain-migration phase adds one seeder.
- **`seed.profile=demo` config flag** — activates the `SeedRunner` at startup and falls back to the generated synthetic library when no `scanner.libraryPath` is set. Purely additive: non-demo boots are byte-identical to before.
- **Synthetic library** — a committed `SeedLibraryDescriptor` (10 books: single- and multi-file, multi-disc, a 3-book series, all five sidecar kinds, deliberate edge cases) + an ffmpeg-based `SeedLibraryGenerator` that emits tiny playable audio with embedded chapters into a gitignored build directory.
- **`:server:runDemo`** — one command: generates the library, boots the seeded server. Emulator points at `http://10.0.2.2:8080`; log in as `demo@listenup.app` / `demo-password`.

The in-process JVM E2E test harness (the brief's second deliverable) is deliberately scoped out as a follow-on phase.

## Test plan
- [x] `:server:test`, `:shared:jvmTest`, `:androidApp:assembleDebug` green
- [x] `detekt` + `spotlessCheck` green
- [x] Generator verified — `ffprobe` confirms embedded chapters in a generated `.m4b`
- [x] Whole-branch code review cleared (the demo library-path fallback fixed)
- [ ] Manual smoke: `./gradlew :server:runDemo`, point an emulator at it, log in, confirm the library lists and a book plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)
