### PR TITLE
✨ feat(contract): InstanceService RPC + enriched ServerInfo for server verification

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/InstanceService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/InstanceService.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.api
+
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.result.AppResult
+import kotlinx.rpc.annotations.Rpc
+
+/**
+ * Public instance contract — anonymous callers welcome. Mounted at
+ * `/api/rpc/public` (RPC) and under `GET /api/v1/instance` (REST).
+ *
+ * The client calls [getServerInfo] before authentication to verify a URL points
+ * at a ListenUp server and to route onboarding (setup-vs-login, and whether to
+ * offer self-registration). Like the rest of the contract, the single method
+ * returns [AppResult] so failures cross the wire as typed values, not thrown
+ * exceptions.
+ */
+@Rpc
+interface InstanceService {
+    /** Returns this server's identity, version, setup state, and registration mode. */
+    suspend fun getServerInfo(): AppResult<ServerInfo>
+}

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/ServerInfo.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/ServerInfo.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.api.dto
 
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -7,12 +8,26 @@ import kotlinx.serialization.Serializable
  * Identifies the server instance to clients on first connect.
  *
  * This is the canonical example of a wire DTO: defined once in commonMain,
- * serialized identically by client and server, never duplicated.
+ * serialized identically by client and server, never duplicated. Fetched before
+ * authentication to verify a URL points at a ListenUp server and to route the
+ * onboarding flow — [setupRequired] decides setup-vs-login, [registrationPolicy]
+ * decides whether to offer self-registration (and on what terms).
  */
 @Serializable
 data class ServerInfo(
+    /** Human-readable server name, e.g. "ListenUp". */
     @SerialName("name")
     val name: String,
+    /** Server build version, e.g. "0.0.1". */
+    @SerialName("version")
     val version: String,
+    /** API contract version this server speaks, e.g. "v1". */
+    @SerialName("apiVersion")
     val apiVersion: String,
+    /** True when no users exist yet — the client routes to first-run root setup. */
+    @SerialName("setupRequired")
+    val setupRequired: Boolean,
+    /** Live self-registration policy; gates the "Create Account" affordance (shown when not [RegistrationPolicy.CLOSED]). */
+    @SerialName("registrationPolicy")
+    val registrationPolicy: RegistrationPolicy,
 )

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server
 
 import com.calypsan.listenup.api.BookService
+import com.calypsan.listenup.api.InstanceService
 import com.calypsan.listenup.api.CollectionService
 import com.calypsan.listenup.api.ContributorService
 import com.calypsan.listenup.api.GenreService
@@ -205,6 +206,7 @@ fun Application.module() {
     val sessions by inject<SessionService>()
     val authService by inject<AuthServiceImpl>()
     val adminUserService by inject<AdminUserServiceImpl>()
+    val instanceService by inject<InstanceService>()
 
     installJwtAuth(jwt, sessions)
 
@@ -232,11 +234,12 @@ fun Application.module() {
 
     routing {
         healthRoutes()
-        instanceRoutes()
+        instanceRoutes(instanceService)
         sseRoutes()
         authRoutes(authService)
         rpcRoutes(
             authService,
+            instanceService,
             scannerService,
             bookService,
             contributorService,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/InstanceServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/InstanceServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.InstanceService
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.db.UserEntity
+import com.calypsan.listenup.server.settings.ServerSettingsRepository
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+
+/**
+ * Serves the pre-auth [ServerInfo] the client fetches on first connect.
+ *
+ * [ServerInfo.setupRequired] is derived, not stored: a fresh instance with no
+ * users needs root setup. [ServerInfo.registrationPolicy] is read live from
+ * [ServerSettingsRepository] so an admin's `setRegistrationPolicy` is reflected
+ * on the next verification without a restart. The remaining fields are static
+ * server identity.
+ */
+class InstanceServiceImpl(
+    private val db: Database,
+    private val settings: ServerSettingsRepository,
+) : InstanceService {
+    override suspend fun getServerInfo(): AppResult<ServerInfo> {
+        val setupRequired = suspendTransaction(db) { UserEntity.all().limit(1).empty() }
+        return AppResult.Success(
+            ServerInfo(
+                name = SERVER_NAME,
+                version = SERVER_VERSION,
+                apiVersion = API_VERSION,
+                setupRequired = setupRequired,
+                registrationPolicy = settings.registrationPolicy(),
+            ),
+        )
+    }
+
+    private companion object {
+        const val SERVER_NAME = "ListenUp"
+        const val SERVER_VERSION = "0.0.1"
+        const val API_VERSION = "v1"
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -9,6 +9,8 @@ import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.PasswordHasher
 import com.calypsan.listenup.server.auth.RefreshTokenGenerator
 import com.calypsan.listenup.server.auth.RefreshTokenHasher
+import com.calypsan.listenup.api.InstanceService
+import com.calypsan.listenup.server.api.InstanceServiceImpl
 import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.db.DatabaseConfig
 import com.calypsan.listenup.server.db.DatabaseFactory
@@ -84,6 +86,13 @@ fun authModule(config: ApplicationConfig): Module =
                 sessions = get(),
                 settings = get(),
                 clock = get(),
+            )
+        }
+
+        single<InstanceService> {
+            InstanceServiceImpl(
+                db = get(),
+                settings = get(),
             )
         }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/InstanceRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/InstanceRoutes.kt
@@ -1,7 +1,14 @@
 package com.calypsan.listenup.server.routes
 
-import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.InstanceService
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.plugins.toHttpStatus
+import com.calypsan.listenup.server.plugins.withCorrelationId
 import io.ktor.resources.Resource
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.callid.callId
 import io.ktor.server.resources.get
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -9,14 +16,23 @@ import io.ktor.server.routing.Route
 @Resource("/api/v1/instance")
 class InstanceResource
 
-fun Route.instanceRoutes() {
+/**
+ * Third-party REST mirror of [InstanceService.getServerInfo]. First-party Kotlin
+ * clients use the kotlinx.rpc proxy on `/api/rpc/public`; this anonymous GET
+ * exists for the OpenAPI surface and non-Kotlin integrations. Same DTO, same
+ * source — the route just unwraps the [AppResult] into an HTTP response.
+ */
+fun Route.instanceRoutes(instanceService: InstanceService) {
     get<InstanceResource> {
-        call.respond(
-            ServerInfo(
-                name = "ListenUp",
-                version = "0.0.1",
-                apiVersion = "v1",
-            ),
-        )
+        when (val result = instanceService.getServerInfo()) {
+            is AppResult.Success -> call.respond(result.data)
+            is AppResult.Failure -> call.respondBareAppError(result.error)
+        }
     }
+}
+
+private suspend fun ApplicationCall.respondBareAppError(error: AppError) {
+    val status = error.toHttpStatus()
+    val correlated = error.withCorrelationId(callId)
+    respond(status, correlated)
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.BookService
 import com.calypsan.listenup.api.CollectionService
 import com.calypsan.listenup.api.ContributorService
 import com.calypsan.listenup.api.GenreService
+import com.calypsan.listenup.api.InstanceService
 import com.calypsan.listenup.api.LibraryAdminService
 import com.calypsan.listenup.api.MetadataLookupService
 import com.calypsan.listenup.api.PlaybackProgressService
@@ -69,6 +70,7 @@ private const val AUTH_WALL_REGRESSION_MSG =
 @Suppress("CognitiveComplexMethod", "CyclomaticComplexMethod", "LongParameterList")
 fun Route.rpcRoutes(
     authService: AuthServiceImpl,
+    instanceService: InstanceService,
     scannerService: ScannerService? = null,
     bookService: BookService? = null,
     contributorService: ContributorService? = null,
@@ -86,6 +88,7 @@ fun Route.rpcRoutes(
     rpc("/api/rpc/public") {
         rpcConfig { serialization { json(contractJson) } }
         registerService<PingService> { guard(PingServiceImpl()) }
+        registerService<InstanceService> { guard(instanceService) }
         registerService<AuthServicePublic> { guard(authService as AuthServicePublic) }
         if (scannerService != null) {
             registerService<ScannerService> { guard(scannerService) }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/e2e/StubInstanceRepository.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/e2e/StubInstanceRepository.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.e2e
 
+import com.calypsan.listenup.api.dto.ServerInfo
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.core.AppResult
 import com.calypsan.listenup.client.domain.model.Instance
@@ -15,6 +16,9 @@ import com.calypsan.listenup.client.domain.repository.VerifiedServer
  */
 internal class StubInstanceRepository : InstanceRepository {
     override suspend fun findReachableUrl(urls: List<String>): String? = urls.firstOrNull()
+
+    override suspend fun getServerInfo(forceRefresh: Boolean): AppResult<ServerInfo> =
+        AppResult.Failure(InternalError(debugInfo = "server info not used in F12"))
 
     override suspend fun getInstance(forceRefresh: Boolean): AppResult<Instance> =
         AppResult.Failure(InternalError(debugInfo = "instance lookup not used in F12"))

--- a/server/src/test/kotlin/com/calypsan/listenup/server/routes/InstanceServiceRpcTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/routes/InstanceServiceRpcTest.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.InstanceService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.client.rpcConfig
+import kotlinx.rpc.krpc.serialization.json.json
+import kotlinx.rpc.withService
+
+/**
+ * End-to-end reachability test for [InstanceService] over the public kotlinx.rpc
+ * surface — the pre-auth call the client makes on first connect to verify a server.
+ *
+ * Boots the full `Application.module()` via [testApplication], connects an
+ * unauthenticated [InstanceService] proxy to `/api/rpc/public`, and asserts
+ * [InstanceService.getServerInfo] returns the seeded server identity. On a fresh
+ * isolated DB no users exist, so [ServerInfo.setupRequired] must be `true`.
+ */
+class InstanceServiceRpcTest :
+    FunSpec({
+
+        test("getServerInfo over the public RPC surface reports setupRequired on a fresh instance") {
+            testApplication {
+                useIsolatedTestConfig()
+                application { module() }
+
+                val rpcClient =
+                    createClient {
+                        install(WebSockets)
+                        installKrpc()
+                    }
+
+                val service =
+                    rpcClient
+                        .rpc("ws://localhost/api/rpc/public") {
+                            rpcConfig { serialization { json(contractJson) } }
+                        }.withService<InstanceService>()
+
+                val success =
+                    service
+                        .getServerInfo()
+                        .shouldBeInstanceOf<AppResult.Success<ServerInfo>>()
+
+                success.data.name shouldBe "ListenUp"
+                success.data.apiVersion shouldBe "v1"
+                success.data.setupRequired shouldBe true
+                success.data.registrationPolicy shouldBe RegistrationPolicy.OPEN
+            }
+        }
+    })

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/InstanceRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/InstanceRpcFactory.kt
@@ -1,0 +1,68 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.api.InstanceService
+import com.calypsan.listenup.api.contractJson
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.WebSockets
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.client.rpcConfig
+import kotlinx.rpc.krpc.serialization.json.json
+import kotlinx.rpc.withService
+
+/**
+ * Supplies an [InstanceService] kotlinx.rpc proxy for pre-authentication server
+ * verification.
+ *
+ * Unlike the post-login factories ([AuthRpcFactory], [BookRpcFactory], …) this
+ * one does **not** reuse [ApiClientFactory] or read [ServerConfig]: verification
+ * runs before any server URL is saved, and `ApiClientFactory.getClient()` errors
+ * when no active URL is configured. So the proxy is built per call against an
+ * explicit URL the caller is trying to verify — a transient connection, not a
+ * cached one.
+ *
+ * An interface so the repository depends on a seam that fakes in tests;
+ * [KtorInstanceRpcFactory] is the production implementation over WebSocket RPC.
+ */
+interface InstanceRpcFactory {
+    /**
+     * Connect to [wsBaseUrl] (a `ws://`/`wss://` origin) and fetch its
+     * [com.calypsan.listenup.api.dto.ServerInfo] over the public RPC surface.
+     *
+     * @param wsBaseUrl WebSocket-scheme origin, e.g. `wss://library.example.com`.
+     * @return the service's typed [com.calypsan.listenup.api.result.AppResult];
+     *   transport failures surface as a thrown exception the caller catches.
+     */
+    suspend fun getServerInfo(
+        wsBaseUrl: String,
+    ): com.calypsan.listenup.api.result.AppResult<com.calypsan.listenup.api.dto.ServerInfo>
+}
+
+/**
+ * Production [InstanceRpcFactory]: opens a fresh kRPC WebSocket to the explicit
+ * URL's `/api/rpc/public` mount, fetches once, and lets the client be GC'd. No
+ * caching — verification is a one-shot probe against a URL that may not pan out.
+ *
+ * Wire serialization is the contract-layer [contractJson] — one wire format,
+ * the same the server registers with.
+ */
+class KtorInstanceRpcFactory : InstanceRpcFactory {
+    override suspend fun getServerInfo(
+        wsBaseUrl: String,
+    ): com.calypsan.listenup.api.result.AppResult<com.calypsan.listenup.api.dto.ServerInfo> {
+        val client =
+            HttpClient {
+                installKrpc()
+                install(WebSockets)
+            }
+        return try {
+            client
+                .rpc("${wsBaseUrl.trimEnd('/')}/api/rpc/public") {
+                    rpcConfig { serialization { json(contractJson) } }
+                }.withService<InstanceService>()
+                .getServerInfo()
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStore.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStore.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.api.dto.auth.AccessToken
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import com.calypsan.listenup.api.dto.auth.RefreshToken
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
@@ -129,23 +130,24 @@ class AuthSessionStore(
         val startMark = TimeSource.Monotonic.markNow()
         _authState.value = DomainAuthState.CheckingServer
 
-        return when (val result = instanceRepository.getInstance(forceRefresh = true)) {
+        return when (val result = instanceRepository.getServerInfo(forceRefresh = true)) {
             is Success -> {
-                logger.info { "checkServerStatus: getInstance succeeded (${startMark.elapsedNow()})" }
-                secureStorage.save(KEY_OPEN_REGISTRATION, result.data.openRegistration.toString())
+                logger.info { "checkServerStatus: getServerInfo succeeded (${startMark.elapsedNow()})" }
+                val openRegistration = result.data.registrationPolicy != RegistrationPolicy.CLOSED
+                secureStorage.save(KEY_OPEN_REGISTRATION, openRegistration.toString())
 
                 val newState =
                     if (result.data.setupRequired) {
                         DomainAuthState.NeedsSetup
                     } else {
-                        DomainAuthState.NeedsLogin(openRegistration = result.data.openRegistration)
+                        DomainAuthState.NeedsLogin(openRegistration = openRegistration)
                     }
                 _authState.value = newState
                 newState
             }
 
             is Failure -> {
-                logger.info { "checkServerStatus: getInstance failed (${startMark.elapsedNow()}): ${result.message}" }
+                logger.info { "checkServerStatus: getServerInfo failed (${startMark.elapsedNow()}): ${result.message}" }
                 val cachedOpenRegistration = getCachedOpenRegistration()
                 _authState.value = DomainAuthState.NeedsLogin(openRegistration = cachedOpenRegistration)
                 DomainAuthState.NeedsLogin(openRegistration = cachedOpenRegistration)
@@ -160,11 +162,12 @@ class AuthSessionStore(
         val currentState = _authState.value
         if (currentState !is DomainAuthState.NeedsLogin) return
 
-        when (val result = instanceRepository.getInstance(forceRefresh = true)) {
+        when (val result = instanceRepository.getServerInfo(forceRefresh = true)) {
             is Success -> {
-                secureStorage.save(KEY_OPEN_REGISTRATION, result.data.openRegistration.toString())
+                val openRegistration = result.data.registrationPolicy != RegistrationPolicy.CLOSED
+                secureStorage.save(KEY_OPEN_REGISTRATION, openRegistration.toString())
                 if (_authState.value is DomainAuthState.NeedsLogin) {
-                    _authState.value = DomainAuthState.NeedsLogin(openRegistration = result.data.openRegistration)
+                    _authState.value = DomainAuthState.NeedsLogin(openRegistration = openRegistration)
                 }
             }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.api.dto.ServerInfo
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.core.AppResult
 import com.calypsan.listenup.core.Failure
@@ -8,55 +9,203 @@ import com.calypsan.listenup.core.Success
 import com.calypsan.listenup.core.appJson
 import com.calypsan.listenup.core.flatMap
 import com.calypsan.listenup.core.suspendRunCatching
-import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
+import com.calypsan.listenup.client.data.remote.InstanceRpcFactory
 import com.calypsan.listenup.client.data.remote.dataOrFailure
+import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
 import com.calypsan.listenup.client.data.remote.model.ApiResponse
+import com.calypsan.listenup.client.data.remote.toWebSocketScheme
 import com.calypsan.listenup.client.domain.model.Instance
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.VerifiedServer
+import com.calypsan.listenup.api.result.AppResult as RpcResult
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.timeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.json
+import kotlin.coroutines.cancellation.CancellationException
 
 private val logger = KotlinLogging.logger {}
 
 private const val REQUEST_TIMEOUT_MS = 30_000L
-private const val QUICK_CHECK_TIMEOUT_MS = 3_000L
 private const val CONNECT_TIMEOUT_MS = 10_000L
 private const val SOCKET_TIMEOUT_MS = 30_000L
 
 /**
- * Implementation of InstanceRepository that fetches data from the ListenUp API.
+ * [InstanceRepository] split across two transports:
+ *  - **Verification + the screen-one [getServerInfo] probe** go over the
+ *    [InstanceService] kotlinx.rpc proxy ([InstanceRpcFactory]). Verification is
+ *    pre-authentication — there is no saved URL yet — so the factory connects to
+ *    an **explicit** candidate URL rather than reading `ServerConfig`.
+ *  - **[getInstance]** stays on the legacy REST `ApiResponse<Instance>` path,
+ *    retained for admin/settings consumers that read the richer [Instance]
+ *    (notably `remoteUrl`) until a dedicated admin GET surface exists.
  *
- * Uses dynamic server URL resolution to support runtime URL changes (e.g., user
- * selecting a different server via MDNS discovery).
- *
- * This repository acts as a single source of truth for instance data.
- * Future enhancements could include:
- * - In-memory caching with cache invalidation
- * - Offline support with local persistence
- * - Automatic refresh on stale data
+ * [getServerUrl] supplies the already-saved URL for the post-connect probes.
  */
 class InstanceRepositoryImpl(
     private val getServerUrl: suspend () -> ServerUrl?,
+    private val instanceRpcFactory: InstanceRpcFactory,
 ) : InstanceRepository {
-    /**
-     * Cached instance data.
-     * TODO: Add proper cache invalidation strategy when requirements are clearer.
-     */
-    private var cachedInstance: Instance? = null
+    private var cachedServerInfo: ServerInfo? = null
+
+    override suspend fun getServerInfo(forceRefresh: Boolean): AppResult<ServerInfo> {
+        if (!forceRefresh) {
+            cachedServerInfo?.let { return Success(it) }
+        }
+
+        val serverUrl = getServerUrl()
+        if (serverUrl == null) {
+            logger.warn { "Cannot fetch server info: server URL not configured" }
+            return AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "Server URL not configured"))
+        }
+
+        return when (val result = callServerInfo(toWebSocketScheme(serverUrl.value))) {
+            is Success -> {
+                cachedServerInfo = result.data
+                result
+            }
+
+            is Failure -> {
+                result
+            }
+        }
+    }
+
+    override suspend fun verifyServer(baseUrl: String): AppResult<VerifiedServer> {
+        val urlsToTry = normalizeUrl(baseUrl)
+        var lastFailure: AppResult.Failure? = null
+        for ((index, currentUrl) in urlsToTry.withIndex()) {
+            logger.debug { "Verifying server at $currentUrl" }
+            when (val result = callServerInfo(toWebSocketScheme(currentUrl))) {
+                is Success -> {
+                    logger.info { "Server verified at $currentUrl" }
+                    return Success(VerifiedServer(result.data, currentUrl))
+                }
+
+                is Failure -> {
+                    val message =
+                        result.error.debugInfo
+                            .orEmpty()
+                            .lowercase() + result.error.message.lowercase()
+                    val isSslError =
+                        message.contains("ssl") || message.contains("tls") || message.contains("handshake")
+                    lastFailure = result
+                    if (isSslError && index < urlsToTry.size - 1) {
+                        logger.debug { "SSL error at $currentUrl, trying next candidate" }
+                        continue
+                    }
+                    break
+                }
+            }
+        }
+        return lastFailure
+            ?: AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "Server verification failed"))
+    }
 
     /**
-     * Creates an HTTP client for the given server URL.
-     * Each API call creates a fresh client to ensure we use the current URL.
+     * Try multiple URLs to find one whose public RPC mount answers.
+     *
+     * Used when connecting to discovered servers where the primary URL (LAN IP
+     * from mDNS) may be unreachable; falls back to alternates which may include
+     * Tailscale/VPN addresses.
+     *
+     * @param urls List of URLs to try, in priority order.
+     * @return The first reachable URL, or null if none work.
      */
-    private fun createClient(serverUrl: ServerUrl): HttpClient =
+    override suspend fun findReachableUrl(urls: List<String>): String? {
+        for (url in urls) {
+            logger.debug { "Quick-checking reachability: $url" }
+            when (callServerInfo(toWebSocketScheme(url))) {
+                is Success -> {
+                    logger.info { "Server reachable at $url" }
+                    return url
+                }
+
+                is Failure -> {
+                    continue
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * One-shot RPC probe of [wsBaseUrl]'s public mount, bridged to the client
+     * [AppResult]. The proxy already returns a typed [RpcResult] carrying an
+     * `AppError`, so a failure passes through without re-mapping; a thrown
+     * transport exception is mapped by [Failure]. `CancellationException` is
+     * re-raised per coroutines convention.
+     */
+    private suspend fun callServerInfo(wsBaseUrl: String): AppResult<ServerInfo> =
+        try {
+            when (val result = instanceRpcFactory.getServerInfo(wsBaseUrl)) {
+                is RpcResult.Success -> Success(result.data)
+                is RpcResult.Failure -> AppResult.Failure(result.error)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Failure(e)
+        }
+
+    /**
+     * Normalize URL by adding protocol if missing.
+     * Returns candidate URLs to try (IP addresses → HTTP first, else HTTPS first).
+     */
+    private fun normalizeUrl(url: String): List<String> =
+        if (url.startsWith("https://") || url.startsWith("http://")) {
+            listOf(url)
+        } else {
+            val isIpAddress = url.substringBefore(':').all { it.isDigit() || it == '.' }
+            if (isIpAddress) {
+                listOf("http://$url", "https://$url")
+            } else {
+                listOf("https://$url", "http://$url")
+            }
+        }
+
+    // ── Legacy REST path (admin/settings only) ──────────────────────────────
+    // Retained verbatim until the admin surface exposes the richer Instance
+    // fields (e.g. remoteUrl) over a dedicated GET. New code uses getServerInfo().
+
+    private var cachedInstance: Instance? = null
+
+    override suspend fun getInstance(forceRefresh: Boolean): AppResult<Instance> {
+        if (!forceRefresh && cachedInstance != null) {
+            return Success(cachedInstance!!)
+        }
+
+        val serverUrl = getServerUrl()
+        if (serverUrl == null) {
+            logger.warn { "Cannot fetch instance: server URL not configured" }
+            return AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "Server URL not configured"))
+        }
+
+        logger.debug { "Fetching instance from ${serverUrl.value}/api/v1/instance" }
+
+        val result =
+            suspendRunCatching {
+                val client = createRestClient(serverUrl)
+                try {
+                    val response: ApiResponse<Instance> = client.get("/api/v1/instance").body()
+                    response.dataOrFailure("Failed to fetch instance")
+                } finally {
+                    client.close()
+                }
+            }.flatMap { it }
+
+        if (result is AppResult.Success) {
+            cachedInstance = result.data
+        }
+
+        return result
+    }
+
+    private fun createRestClient(serverUrl: ServerUrl): HttpClient =
         HttpClient {
             installListenUpErrorHandling()
 
@@ -72,179 +221,6 @@ class InstanceRepositoryImpl(
 
             defaultRequest {
                 url(serverUrl.value)
-            }
-        }
-
-    override suspend fun getInstance(forceRefresh: Boolean): AppResult<Instance> {
-        // Return cached data if available and refresh not forced
-        if (!forceRefresh && cachedInstance != null) {
-            return Success(cachedInstance!!)
-        }
-
-        val serverUrl = getServerUrl()
-        if (serverUrl == null) {
-            logger.warn { "Cannot fetch instance: server URL not configured" }
-            return AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "Server URL not configured"))
-        }
-
-        logger.debug { "Fetching instance from ${serverUrl.value}/api/v1/instance" }
-
-        val result =
-            suspendRunCatching {
-                val client = createClient(serverUrl)
-                try {
-                    val response: ApiResponse<Instance> = client.get("/api/v1/instance").body()
-
-                    logger.debug { "Received instance response: success=${response.success}" }
-
-                    response.dataOrFailure("Failed to fetch instance")
-                } finally {
-                    client.close()
-                }
-            }.flatMap { it }
-
-        // Cache successful results
-        if (result is AppResult.Success) {
-            cachedInstance = result.data
-        }
-
-        return result
-    }
-
-    private suspend fun attemptServerVerification(currentUrl: String): AppResult<VerifiedServer> {
-        val client = createUnauthenticatedClient()
-        return try {
-            val instanceUrl = currentUrl.trimEnd('/') + "/api/v1/instance"
-            logger.debug { "Verifying server at $instanceUrl" }
-            val response: ApiResponse<Instance> = client.get(instanceUrl).body()
-            when (val result = response.toResult()) {
-                is Success -> {
-                    logger.info { "Server verified at $currentUrl" }
-                    Success(VerifiedServer(result.data, currentUrl))
-                }
-
-                is Failure -> {
-                    result
-                }
-            }
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Failure(e)
-        } finally {
-            client.close()
-        }
-    }
-
-    override suspend fun verifyServer(baseUrl: String): AppResult<VerifiedServer> {
-        val urlsToTry = normalizeUrl(baseUrl)
-        var lastFailure: AppResult.Failure? = null
-        for ((index, currentUrl) in urlsToTry.withIndex()) {
-            when (val result = attemptServerVerification(currentUrl)) {
-                is Success -> {
-                    return result
-                }
-
-                is Failure -> {
-                    val errorMessage = result.message.lowercase()
-                    val isSslError =
-                        errorMessage.contains("ssl") ||
-                            errorMessage.contains("tls") ||
-                            errorMessage.contains("handshake")
-                    if (isSslError && index < urlsToTry.size - 1) {
-                        logger.debug { "SSL error at $currentUrl, trying HTTP fallback" }
-                        lastFailure = result
-                        continue
-                    }
-                    lastFailure = result
-                    break
-                }
-            }
-        }
-        return lastFailure
-            ?: AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "Server verification failed"))
-    }
-
-    /**
-     * Normalize URL by adding protocol if missing.
-     * Returns list of URLs to try (HTTPS first, then HTTP fallback).
-     */
-    private fun normalizeUrl(url: String): List<String> =
-        if (url.startsWith("https://") || url.startsWith("http://")) {
-            listOf(url)
-        } else {
-            // IP addresses (e.g. 192.168.1.1:8080) are almost certainly HTTP.
-            // Try HTTP first to avoid TLS handshake timeout on plain HTTP servers.
-            val isIpAddress = url.substringBefore(':').all { it.isDigit() || it == '.' }
-            if (isIpAddress) {
-                listOf("http://$url", "https://$url")
-            } else {
-                listOf("https://$url", "http://$url")
-            }
-        }
-
-    /**
-     * Try multiple URLs to find one that's reachable, with a quick timeout.
-     *
-     * Used when connecting to discovered servers where the primary URL
-     * (LAN IP from mDNS) may be unreachable. Falls back to alternate URLs
-     * which may include Tailscale/VPN addresses resolved via DNS.
-     *
-     * @param urls List of URLs to try, in priority order
-     * @return The first reachable URL, or null if none work
-     */
-    override suspend fun findReachableUrl(urls: List<String>): String? {
-        val quickClient =
-            HttpClient {
-                installListenUpErrorHandling()
-
-                install(ContentNegotiation) {
-                    json(appJson)
-                }
-                install(HttpTimeout) {
-                    requestTimeoutMillis = QUICK_CHECK_TIMEOUT_MS
-                    connectTimeoutMillis = QUICK_CHECK_TIMEOUT_MS
-                    socketTimeoutMillis = QUICK_CHECK_TIMEOUT_MS
-                }
-            }
-
-        return try {
-            for (url in urls) {
-                try {
-                    val instanceUrl = url.trimEnd('/') + "/api/v1/instance"
-                    logger.debug { "Quick-checking reachability: $instanceUrl" }
-                    quickClient.get(instanceUrl)
-                    logger.info { "Server reachable at $url" }
-                    return url
-                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logger.debug { "Not reachable at $url: ${e.message}" }
-                    continue
-                }
-            }
-            null
-        } finally {
-            quickClient.close()
-        }
-    }
-
-    /**
-     * Creates an unauthenticated HTTP client for server verification.
-     * Used before authentication when validating server URLs.
-     */
-    private fun createUnauthenticatedClient(): HttpClient =
-        HttpClient {
-            installListenUpErrorHandling()
-
-            install(ContentNegotiation) {
-                json(appJson)
-            }
-
-            install(HttpTimeout) {
-                requestTimeoutMillis = REQUEST_TIMEOUT_MS
-                connectTimeoutMillis = CONNECT_TIMEOUT_MS
-                socketTimeoutMillis = SOCKET_TIMEOUT_MS
             }
         }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -20,8 +20,10 @@ import com.calypsan.listenup.client.data.remote.CollectionInboxApiContract
 import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
 import com.calypsan.listenup.client.data.remote.KtorCollectionRpcFactory
 import com.calypsan.listenup.client.data.remote.BookRpcFactory
+import com.calypsan.listenup.client.data.remote.InstanceRpcFactory
 import com.calypsan.listenup.client.data.remote.ContributorRpcFactory
 import com.calypsan.listenup.client.data.remote.KtorBookRpcFactory
+import com.calypsan.listenup.client.data.remote.KtorInstanceRpcFactory
 import com.calypsan.listenup.client.data.remote.KtorContributorRpcFactory
 import com.calypsan.listenup.client.data.remote.KtorSeriesRpcFactory
 import com.calypsan.listenup.client.data.remote.SeriesRpcFactory
@@ -305,12 +307,14 @@ val repositoryModule =
         // InstanceRepository reads server URL directly from SecureStorage to avoid circular
         // dependency (SettingsRepository -> InstanceRepository -> SettingsRepository).
         // The URL is stored before checkServerStatus() is called.
+        single<InstanceRpcFactory> { KtorInstanceRpcFactory() }
         single<InstanceRepository> {
             val secureStorage: com.calypsan.listenup.core.SecureStorage = get()
             InstanceRepositoryImpl(
                 getServerUrl = {
                     secureStorage.read("server_url")?.let { ServerUrl(it) }
                 },
+                instanceRpcFactory = get(),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
@@ -1,24 +1,28 @@
 package com.calypsan.listenup.client.domain.repository
 
+import com.calypsan.listenup.api.dto.ServerInfo
 import com.calypsan.listenup.core.AppResult
 import com.calypsan.listenup.client.domain.model.Instance
 
 /**
- * Result of server verification containing the instance and verified URL.
+ * Result of server verification: the server's [ServerInfo] and the URL that
+ * successfully connected.
  *
- * @property instance The server instance information
- * @property verifiedUrl The URL that successfully connected (may include protocol that worked)
+ * @property serverInfo The verified server's identity, setup state, and registration policy.
+ * @property verifiedUrl The URL that connected (the protocol variant that worked).
  */
 data class VerifiedServer(
-    val instance: Instance,
+    val serverInfo: ServerInfo,
     val verifiedUrl: String,
 )
 
 /**
- * Repository for managing server instance data.
+ * Repository for server-instance data.
  *
- * This interface defines the contract for accessing instance information.
- * Implementations handle data fetching, caching, and error handling.
+ * Verification and the pre-auth [getServerInfo] probe go over kotlinx.rpc
+ * ([ServerInfo]); the legacy [getInstance] REST path remains for admin/settings
+ * consumers that still read the richer [Instance] (e.g. `remoteUrl`) until those
+ * screens migrate.
  */
 interface InstanceRepository {
     // Try multiple URLs to find one that's reachable.
@@ -26,22 +30,31 @@ interface InstanceRepository {
     suspend fun findReachableUrl(urls: List<String>): String?
 
     /**
-     * Retrieves the current server instance information.
+     * Fetches the current server's [ServerInfo] over RPC (the screen-one probe).
      *
-     * @param forceRefresh If true, bypasses any cached data and fetches fresh data from the server
-     * @return Result containing the Instance on success, or an error on failure
+     * @param forceRefresh If true, bypasses any cached value and re-fetches.
+     * @return [ServerInfo] on success, or a typed failure (e.g. no URL configured / unreachable).
+     */
+    suspend fun getServerInfo(forceRefresh: Boolean = false): AppResult<ServerInfo>
+
+    /**
+     * Legacy REST fetch of the richer [Instance] aggregate.
+     *
+     * Retained only for admin/settings consumers that read fields absent from
+     * [ServerInfo] (notably `remoteUrl`). Migrates away once a dedicated admin
+     * GET surface exists. New code should prefer [getServerInfo].
      */
     suspend fun getInstance(forceRefresh: Boolean = false): AppResult<Instance>
 
     /**
      * Verifies a server URL is a valid ListenUp instance before authentication.
      *
-     * Used during initial server connection setup. Creates an unauthenticated
-     * HTTP client to fetch /api/v1/instance and verify the server is ListenUp.
-     * Tries HTTPS first, then falls back to HTTP if SSL fails.
+     * Connects an unauthenticated kotlinx.rpc proxy to the candidate server's
+     * public mount and fetches [ServerInfo]. Tries HTTPS/WSS first, falls back to
+     * HTTP/WS, mirroring the protocol the user's URL implies.
      *
-     * @param baseUrl The server URL to verify (with or without protocol)
-     * @return Result containing VerifiedServer with instance and working URL on success
+     * @param baseUrl The server URL to verify (with or without protocol).
+     * @return [VerifiedServer] with the [ServerInfo] and the working URL on success.
      */
     suspend fun verifyServer(baseUrl: String): AppResult<VerifiedServer>
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/InstanceContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/InstanceContractTest.kt
@@ -1,0 +1,50 @@
+package com.calypsan.listenup.api
+
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+
+/**
+ * Round-trips [ServerInfo] through [contractJson].
+ *
+ * [ServerInfo] is the payload the client fetches on first connect to verify a
+ * server and route the onboarding flow. The verify path reads exactly two of its
+ * fields — [ServerInfo.setupRequired] (NeedsSetup vs NeedsLogin) and
+ * [ServerInfo.registrationPolicy] (whether to offer "Create Account") — so this
+ * test pins that both survive the wire intact. Field-name drift on either side
+ * would otherwise surface only as a failed server-verification on screen one.
+ */
+class InstanceContractTest :
+    FunSpec({
+
+        test("ServerInfo round-trips with all fields populated") {
+            val original =
+                ServerInfo(
+                    name = "ListenUp",
+                    version = "0.0.1",
+                    apiVersion = "v1",
+                    setupRequired = true,
+                    registrationPolicy = RegistrationPolicy.OPEN,
+                )
+            roundTrip(original) shouldBe original
+        }
+
+        test("ServerInfo preserves setupRequired and registrationPolicy across the wire") {
+            val decoded =
+                roundTrip(
+                    ServerInfo(
+                        name = "ListenUp",
+                        version = "0.0.1",
+                        apiVersion = "v1",
+                        setupRequired = false,
+                        registrationPolicy = RegistrationPolicy.APPROVAL_QUEUE,
+                    ),
+                )
+            decoded.setupRequired shouldBe false
+            decoded.registrationPolicy shouldBe RegistrationPolicy.APPROVAL_QUEUE
+        }
+    })
+
+private inline fun <reified T : Any> roundTrip(value: T): T = contractJson.decodeFromString<T>(contractJson.encodeToString(value))

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
@@ -6,9 +6,9 @@ import com.calypsan.listenup.core.Failure
 import com.calypsan.listenup.core.SecureStorage
 import com.calypsan.listenup.core.ServerUrl
 import com.calypsan.listenup.core.Success
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import com.calypsan.listenup.client.domain.model.AuthState
-import com.calypsan.listenup.client.domain.model.Instance
-import com.calypsan.listenup.client.domain.model.InstanceId
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import dev.mokkery.answering.returns
@@ -20,18 +20,17 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import com.calypsan.listenup.core.Timestamp
 
-private fun createTestInstance(setupRequired: Boolean): Instance =
-    Instance(
-        id = InstanceId("test-instance"),
+private fun createTestServerInfo(
+    setupRequired: Boolean,
+    registrationPolicy: RegistrationPolicy = RegistrationPolicy.OPEN,
+): ServerInfo =
+    ServerInfo(
         name = "Test Instance",
         version = "1.0.0",
-        localUrl = "http://localhost:8080",
-        remoteUrl = null,
+        apiVersion = "v1",
         setupRequired = setupRequired,
-        createdAt = Timestamp(0L),
-        updatedAt = Timestamp(0L),
+        registrationPolicy = registrationPolicy,
     )
 
 private fun createMockStorage(): SecureStorage = mock<SecureStorage>()
@@ -229,8 +228,8 @@ class AuthSessionStoreTest :
                 val storage = createMockStorage()
                 val instanceRepository = createMockInstanceRepository()
                 everySuspend { storage.save(any(), any()) } returns Unit
-                everySuspend { instanceRepository.getInstance(forceRefresh = true) } returns
-                    Success(createTestInstance(setupRequired = true))
+                everySuspend { instanceRepository.getServerInfo(forceRefresh = true) } returns
+                    Success(createTestServerInfo(setupRequired = true))
                 val store = createStore(storage = storage, instanceRepository = instanceRepository)
 
                 store.checkServerStatus()
@@ -244,7 +243,7 @@ class AuthSessionStoreTest :
                 val storage = createMockStorage()
                 val instanceRepository = createMockInstanceRepository()
                 everySuspend { storage.read("open_registration") } returns null
-                everySuspend { instanceRepository.getInstance(forceRefresh = true) } returns
+                everySuspend { instanceRepository.getServerInfo(forceRefresh = true) } returns
                     Failure(Exception("Network error"))
                 val store = createStore(storage = storage, instanceRepository = instanceRepository)
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImplTest.kt
@@ -1,109 +1,108 @@
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.client.checkIs
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
+import com.calypsan.listenup.api.error.InternalError
+import com.calypsan.listenup.client.data.remote.InstanceRpcFactory
 import com.calypsan.listenup.core.Failure
 import com.calypsan.listenup.core.ServerUrl
+import com.calypsan.listenup.core.Success
+import com.calypsan.listenup.api.result.AppResult as RpcResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 /**
- * Tests for InstanceRepositoryImpl.
- *
- * Note: Since InstanceRepositoryImpl now makes direct HTTP calls, these tests
- * focus on verifying the behavior when no server URL is configured.
- * Integration tests with a mock HTTP server would be needed for full coverage.
+ * Drives [InstanceRepositoryImpl]'s RPC-backed verification path through a fake
+ * [InstanceRpcFactory] — no network. Pins the two screen-one behaviours:
+ *  - [InstanceRepositoryImpl.verifyServer] returns the [ServerInfo] + the URL
+ *    that connected.
+ *  - [InstanceRepositoryImpl.getServerInfo] bridges the contract result to the
+ *    client `core.AppResult`, and fails (without calling the factory) when no
+ *    server URL is configured.
  */
-class InstanceRepositoryImplTest {
-    // ========== Error Handling Tests ==========
+class InstanceRepositoryImplTest :
+    FunSpec({
 
-    @Test
-    fun `getInstance returns failure when server URL is not configured`() =
-        runTest {
-            // Given - no server URL configured
+        val serverInfo =
+            ServerInfo(
+                name = "ListenUp",
+                version = "0.0.1",
+                apiVersion = "v1",
+                setupRequired = true,
+                registrationPolicy = RegistrationPolicy.OPEN,
+            )
+
+        /** Fake factory: records the ws URL it was asked for, returns a canned result. */
+        class FakeInstanceRpcFactory(
+            private val result: RpcResult<ServerInfo>,
+        ) : InstanceRpcFactory {
+            var lastWsUrl: String? = null
+
+            override suspend fun getServerInfo(wsBaseUrl: String): RpcResult<ServerInfo> {
+                lastWsUrl = wsBaseUrl
+                return result
+            }
+        }
+
+        test("verifyServer returns the ServerInfo and the verified URL on success") {
+            val factory = FakeInstanceRpcFactory(RpcResult.Success(serverInfo))
             val repository =
                 InstanceRepositoryImpl(
                     getServerUrl = { null },
+                    instanceRpcFactory = factory,
                 )
 
-            // When
-            val result = repository.getInstance()
+            val result = repository.verifyServer("https://library.example.com")
 
-            // Then
-            // Body-level message convention: the IllegalStateException is mapped to
-            // InternalError, so the "Server URL not configured" text now lives in
-            // debugInfo. Keep the Failure assertion only.
-            assertIs<Failure>(result)
+            val verified = result.shouldBeInstanceOf<Success<*>>()
+            val data = verified.data as com.calypsan.listenup.client.domain.repository.VerifiedServer
+            data.serverInfo shouldBe serverInfo
+            data.verifiedUrl shouldBe "https://library.example.com"
+            // The factory is connected over the ws-scheme equivalent.
+            factory.lastWsUrl shouldBe "wss://library.example.com"
         }
 
-    @Test
-    fun `getInstance with forceRefresh returns failure when server URL is not configured`() =
-        runTest {
-            // Given - no server URL configured
+        test("getServerInfo returns failure without touching the factory when no URL is configured") {
+            val factory = FakeInstanceRpcFactory(RpcResult.Success(serverInfo))
             val repository =
                 InstanceRepositoryImpl(
                     getServerUrl = { null },
+                    instanceRpcFactory = factory,
                 )
 
-            // When
-            val result = repository.getInstance(forceRefresh = true)
+            val result = repository.getServerInfo()
 
-            // Then
-            // Body-level message convention: the IllegalStateException is mapped to
-            // InternalError, so the "Server URL not configured" text now lives in
-            // debugInfo. Keep the Failure assertion only.
-            assertIs<Failure>(result)
+            result.shouldBeInstanceOf<Failure>()
+            factory.lastWsUrl shouldBe null
         }
 
-    @Test
-    fun `getInstance calls getServerUrl to get dynamic URL`() =
-        runTest {
-            // Given
-            var urlFetchCount = 0
+        test("getServerInfo bridges a configured-URL success to core.Success") {
+            val factory = FakeInstanceRpcFactory(RpcResult.Success(serverInfo))
             val repository =
                 InstanceRepositoryImpl(
-                    getServerUrl = {
-                        urlFetchCount++
-                        // Return null to fail immediately without making HTTP call
-                        null
-                    },
+                    getServerUrl = { ServerUrl("http://192.168.1.10:8080") },
+                    instanceRpcFactory = factory,
                 )
 
-            // When
-            repository.getInstance()
-            repository.getInstance(forceRefresh = true)
+            val result = repository.getServerInfo()
 
-            // Then - getServerUrl should be called for each non-cached request
-            // First call: no cache, so getServerUrl is called
-            // Second call with forceRefresh: cache bypassed, so getServerUrl is called
-            assertTrue(urlFetchCount >= 2, "Expected getServerUrl to be called at least twice, but was $urlFetchCount")
+            val success = result.shouldBeInstanceOf<Success<ServerInfo>>()
+            success.data shouldBe serverInfo
+            factory.lastWsUrl shouldBe "ws://192.168.1.10:8080"
         }
 
-    @Test
-    fun `getInstance uses cached data when forceRefresh is false and cache exists`() =
-        runTest {
-            // Given - this test verifies caching behavior indirectly
-            // If caching works, getServerUrl won't be called on subsequent requests
-            var urlFetchCount = 0
+        test("getServerInfo bridges a contract Failure to core.Failure") {
+            val factory = FakeInstanceRpcFactory(RpcResult.Failure(InternalError()))
             val repository =
                 InstanceRepositoryImpl(
-                    getServerUrl = {
-                        urlFetchCount++
-                        // Return null - we're just testing if getServerUrl is called
-                        null
-                    },
+                    getServerUrl = { ServerUrl("http://192.168.1.10:8080") },
+                    instanceRpcFactory = factory,
                 )
 
-            // When - first call (no cache)
-            repository.getInstance()
-            val countAfterFirst = urlFetchCount
+            val result = repository.getServerInfo()
 
-            // When - second call without forceRefresh (would use cache if it existed)
-            // Since first call failed (no URL), there's no cache, so it calls again
-            repository.getInstance(forceRefresh = false)
-
-            // Then - because first call failed (no cache stored), second call also fetches
-            assertTrue(urlFetchCount > countAfterFirst, "Expected getServerUrl to be called again since cache is empty")
+            result.shouldBeInstanceOf<Failure>()
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/SettingsAuthCycleTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/SettingsAuthCycleTest.kt
@@ -98,6 +98,13 @@ private class InMemorySecureStorage : SecureStorage {
 private class NoOpInstanceRepository : InstanceRepository {
     override suspend fun findReachableUrl(urls: List<String>): String? = null
 
+    override suspend fun getServerInfo(forceRefresh: Boolean): AppResult<com.calypsan.listenup.api.dto.ServerInfo> =
+        AppResult.Failure(
+            com.calypsan.listenup.api.error.TransportError.NetworkUnavailable(
+                debugInfo = "NoOpInstanceRepository",
+            ),
+        )
+
     override suspend fun getInstance(forceRefresh: Boolean): AppResult<Instance> =
         AppResult.Failure(
             com.calypsan.listenup.api.error.TransportError.NetworkUnavailable(


### PR DESCRIPTION
Adds @Rpc InstanceService.getServerInfo and extends ServerInfo with
setupRequired + registrationMode so first-connect verification moves off the
legacy REST envelope onto kotlinx.rpc. Server impl derives setupRequired from
the user table and registrationMode from policy; registered on /api/rpc/public,
with the REST /api/v1/instance route emitting the same enriched payload.