### PR TITLE
🐛 fix(onboarding): scan-event ordering + firehose suppression + LibraryReadiness consolidation

### DIFF
--- a/contract/src/appleMain/kotlin/com/calypsan/listenup/core/AppleSecureStorage.kt
+++ b/contract/src/appleMain/kotlin/com/calypsan/listenup/core/AppleSecureStorage.kt
@@ -10,8 +10,6 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import platform.CoreFoundation.CFDictionaryCreateMutable
 import platform.CoreFoundation.CFDictionaryRef
@@ -50,7 +48,7 @@ import platform.Security.kSecValueData
  * Features:
  * - Hardware-backed encryption via Secure Enclave (when available)
  * - Items accessible after first device unlock (kSecAttrAccessibleAfterFirstUnlock)
- * - Thread-safe operations via Dispatchers.IO
+ * - Thread-safe operations via IODispatcher
  * - Proper memory management with memScoped
  */
 private val logger = KotlinLogging.logger {}
@@ -62,7 +60,7 @@ class AppleSecureStorage : SecureStorage {
     override suspend fun save(
         key: String,
         value: String,
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(IODispatcher) {
         logger.debug { "Keychain save started: $key" }
         val startMark = TimeSource.Monotonic.markNow()
 
@@ -107,7 +105,7 @@ class AppleSecureStorage : SecureStorage {
     }
 
     override suspend fun read(key: String): String? =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             val query =
                 CFDictionaryCreateMutable(
                     null,
@@ -147,7 +145,7 @@ class AppleSecureStorage : SecureStorage {
         }
 
     override suspend fun delete(key: String) =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             val query =
                 CFDictionaryCreateMutable(
                     null,
@@ -166,7 +164,7 @@ class AppleSecureStorage : SecureStorage {
         }
 
     override suspend fun clear() =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             val query =
                 CFDictionaryCreateMutable(
                     null,

--- a/contract/src/appleMain/kotlin/com/calypsan/listenup/core/Dispatchers.apple.kt
+++ b/contract/src/appleMain/kotlin/com/calypsan/listenup/core/Dispatchers.apple.kt
@@ -2,6 +2,11 @@ package com.calypsan.listenup.core
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
-// iOS doesn't have Dispatchers.IO (it's internal), so we use Default
-actual val IODispatcher: CoroutineDispatcher = Dispatchers.Default
+// Kotlin/Native gained a real Dispatchers.IO (an elastic pool sized for blocking
+// I/O) in kotlinx-coroutines 1.7 — reached via the `kotlinx.coroutines.IO`
+// extension import. Use it so IODispatcher means the same thing on every
+// platform; the old Dispatchers.Default fallback put blocking I/O on the
+// CPU-bound pool, where it could starve compute coroutines.
+actual val IODispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImpl.kt
@@ -13,7 +13,6 @@ import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.LibraryError
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.api.result.map
 import com.calypsan.listenup.api.sync.LibraryFolderSyncPayload
 import com.calypsan.listenup.api.sync.LibrarySyncPayload
 import com.calypsan.listenup.core.FolderId
@@ -328,7 +327,10 @@ internal class LibraryAdminServiceImpl(
     override suspend fun scanLibrary(libraryId: LibraryId): AppResult<Unit> {
         // Admin-only: triggering a scan is a privileged server operation.
         requireAdmin()?.let { return AppResult.Failure(it) }
-        return scanOrchestrator.scanLibrary(libraryId).map {}
+        // Fire-and-forget: kick the scan off and return "accepted" immediately. The scan
+        // runs on the server's lifecycle scope and streams progress over SSE, so the
+        // caller (admin RPC / onboarding wizard) never blocks on the full walk.
+        return scanOrchestrator.scanLibraryAsync(libraryId)
     }
 
     override suspend fun scanFolder(folderId: FolderId): AppResult<Unit> {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.SearchService
 import com.calypsan.listenup.api.SeriesService
 import com.calypsan.listenup.api.TagService
 import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.server.api.BookAccessPolicy
 import com.calypsan.listenup.server.api.BookServiceImpl
 import com.calypsan.listenup.server.api.CollectionAccessPolicy
@@ -245,6 +246,7 @@ private fun Module.coverAndPersisterBindings(
             libraryRegistry = get(),
             db = get(),
             scanResultBus = get<MutableSharedFlow<ScanResult>>(named("scanResultBus")),
+            eventBus = get<MutableSharedFlow<ScanEvent>>(),
             scope = get(),
             metrics = get(),
             coverImageStore = get<CoverImageStore>(),

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
@@ -55,7 +55,7 @@ internal class ScanCoordinator(
     val libraryId: LibraryId,
     private val runFullScan: suspend () -> ScanResult,
     private val runIncremental: suspend (Path) -> Unit,
-    scope: CoroutineScope,
+    private val scope: CoroutineScope,
 ) {
     private val mutex = Mutex()
     private val pendingPaths: MutableSet<Path> = ConcurrentHashMap.newKeySet()
@@ -88,6 +88,31 @@ internal class ScanCoordinator(
         } finally {
             mutex.unlock()
         }
+    }
+
+    /**
+     * Fire-and-forget full scan: acquire the single-flight lock synchronously (so the
+     * caller learns [ScanError.AlreadyRunning] immediately), then run the scan on [scope]
+     * and return [AppResult.Success] right away — "202 Accepted" semantics. The scan
+     * outlives the triggering request; progress streams over SSE. Used by the admin/wizard
+     * `scanLibrary` trigger, which must not block on the whole walk.
+     */
+    fun scanFullAsync(): AppResult<Unit> {
+        if (!mutex.tryLock()) {
+            return AppResult.Failure(ScanError.AlreadyRunning())
+        }
+        scope.launch {
+            try {
+                runFullScan()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                logger.error(e) { "background full scan failed for library ${libraryId.value}" }
+            } finally {
+                mutex.unlock()
+            }
+        }
+        return AppResult.Success(Unit)
     }
 
     fun reanalyze(bookRoot: Path) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
@@ -149,6 +149,24 @@ internal class ScanOrchestrator(
     }
 
     /**
+     * Fire-and-forget variant of [scanLibrary]: kicks the full scan off on the library's
+     * coordinator scope and returns immediately ("202 Accepted"). Returns
+     * [LibraryError.NotFound] when the library isn't registered and
+     * [ScanError.AlreadyRunning] when a scan is already in flight — both surfaced
+     * synchronously. The scan itself runs in the background and streams progress over SSE.
+     *
+     * This is what the admin/wizard `LibraryAdminService.scanLibrary` trigger uses, so the
+     * RPC/HTTP call doesn't block for the entire walk. [scanLibrary] (blocking, returns the
+     * [ScanResult]) is retained for the scanner vertical's synchronous summary endpoint.
+     */
+    suspend fun scanLibraryAsync(libraryId: LibraryId): AppResult<Unit> {
+        val bundle =
+            mutex.withLock { bundlesByLibrary[libraryId] }
+                ?: return AppResult.Failure(LibraryError.NotFound())
+        return bundle.coordinator.scanFullAsync()
+    }
+
+    /**
      * Triggers an incremental re-analysis of the subtree under [folderId].
      *
      * Returns [LibraryError.FolderNotFound] when [folderId] is not registered.

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -143,10 +143,11 @@ internal class Scanner(
                 scope = ScanScope.Full,
             )
         lastResult = result
+        // Hand the result to BookPersister; it emits ScanEvent.Completed once the books are
+        // persisted (see BookPersister.persist). The Scanner must NOT emit Completed here — that
+        // would signal "done" before any book is queryable.
         scanResultBus.emit(result)
-        val summary = result.toSummary()
-        eventBus.emit(ScanEvent.Completed(correlationId, library.id, summary))
-        logger.info { "scan complete [library=${library.id.value}]: ${formatScanCompleteLog(summary)}" }
+        logger.info { "scan walk complete [library=${library.id.value}]: ${formatScanCompleteLog(result.toSummary())}" }
         return result
     }
 
@@ -242,8 +243,8 @@ internal class Scanner(
                 filesSkipped = 0,
                 scope = subtreeScope,
             )
+        // BookPersister emits ScanEvent.Completed after persisting this incremental result.
         scanResultBus.emit(lastResult!!)
-        eventBus.emit(ScanEvent.Completed(correlationId, library.id, lastResult!!.toSummary()))
     }
 
     private fun partitionBooksUnder(

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImpl.kt
@@ -48,5 +48,10 @@ internal class ScannerServiceImpl(
     override fun observeProgress(libraryId: LibraryId?): Flow<RpcEvent<ScanEvent>> =
         eventBus
             .let { bus -> if (libraryId != null) bus.filter { it.libraryId == libraryId } else bus }
+            // Progress monitoring needs only the lightweight lifecycle/progress events. Each
+            // [ScanEvent.Change] carries a full [AnalyzedBook] (metadata + artwork) — a 1000-book
+            // scan would stream multi-MB frames and OOM a subscriber that just wants progress.
+            // Per-book changes reach clients via the sync substrate (firehose + catch-up), not here.
+            .filter { it !is ScanEvent.Change }
             .map { RpcEvent.Data(it) }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
 import com.calypsan.listenup.api.dto.scanner.CoverSource
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanScope
+import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.CoverSource as SyncCoverSource
 import com.calypsan.listenup.core.BookId
@@ -11,12 +12,16 @@ import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.server.cover.CoverImageStore
 import com.calypsan.listenup.server.db.LibraryFolderTable
+import com.calypsan.listenup.server.scanner.toSummary
+import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.io.path.readBytes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.nio.file.Path as JPath
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -69,6 +74,7 @@ class BookPersister(
     private val libraryRegistry: LibraryRegistry,
     private val db: Database,
     private val scanResultBus: SharedFlow<ScanResult>,
+    private val eventBus: MutableSharedFlow<ScanEvent>,
     private val scope: CoroutineScope,
     private val metrics: BookPersisterMetrics,
     private val coverImageStore: CoverImageStore? = null,
@@ -87,6 +93,35 @@ class BookPersister(
         // Falls back to a sentinel folderId so a misconfigured folder doesn't
         // block persistence; the TODO below tracks proper error surfacing.
         val folderId = resolveFolderId(result.rootPath)
+
+        // A FULL scan is bulk population (onboarding, re-scan): suppress the per-book firehose
+        // PUBLISH so the lossy live tail (ChangeBus replay=256, DROP_OLDEST) never carries the
+        // burst — an arbitrarily large library would otherwise overflow it and trip a client
+        // CursorStale → catch-up spin. Revisions still bump, so the client does one clean REST
+        // catch-up after the Completed below. Incremental scans ARE live deltas; they publish.
+        if (result.scope is ScanScope.Full) {
+            withContext(FirehoseSuppressed) { persistAll(result, libraryId, folderId) }
+        } else {
+            persistAll(result, libraryId, folderId)
+        }
+
+        // Completed is emitted HERE — after every book is committed and (for a full scan) the
+        // tombstone sweep has run — not by the Scanner before this persist runs. `Completed` must
+        // mean "the library is persisted and queryable", so the client reconciles a settled server
+        // exactly once instead of racing a still-writing one (the premature-Completed bug).
+        eventBus.emit(ScanEvent.Completed(result.correlationId, libraryId, result.toSummary()))
+    }
+
+    /**
+     * Persists every book in [result] and, for a [ScanScope.Full] result, runs the tombstone
+     * sweep. The caller decides whether this runs under [FirehoseSuppressed]; this method is
+     * suppression-agnostic.
+     */
+    private suspend fun persistAll(
+        result: ScanResult,
+        libraryId: LibraryId,
+        folderId: FolderId,
+    ) {
         val seenIds = mutableSetOf<BookId>()
         // Use the scan result's rootPath for filesystem cover reads — aligned
         // with Analyzer's own path resolution (Analyzer.kt: rootPath.resolve(relPath)).

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/FirehoseSuppressed.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/FirehoseSuppressed.kt
@@ -1,0 +1,28 @@
+package com.calypsan.listenup.server.sync
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Coroutine-context marker that suppresses the per-write [ChangeBus] *publish*
+ * while a bulk write runs, **without** suppressing the revision bump.
+ *
+ * Present in the context → [SyncableRepository.upsert] / [SyncableRepository.softDelete]
+ * still bump the global revision counter and commit the row (so REST catch-up via
+ * `pullSince` sees every row), but they skip `bus.publish(...)`. The lossy live-tail
+ * ([ChangeBus]'s `replay = 256`, `DROP_OLDEST`) therefore never carries the burst —
+ * the onboarding full-scan of an arbitrarily large library can no longer overflow the
+ * buffer and trip a client `CursorStale` → catch-up spin.
+ *
+ * Scope: [com.calypsan.listenup.server.services.BookPersister] wraps a FULL-scan
+ * persist in `withContext(FirehoseSuppressed) { ... }`. Incremental scans and every
+ * non-scan write run without the marker, so they publish normally — they ARE live
+ * deltas. The client reconciles the suppressed bulk write once, via REST catch-up,
+ * after the `ScanEvent.Completed` that the persister emits at the end.
+ *
+ * Defaults to *publishing*: absence of the marker is the universal case, so all
+ * existing write paths are unchanged.
+ */
+object FirehoseSuppressed : AbstractCoroutineContextElement(Key) {
+    object Key : CoroutineContext.Key<FirehoseSuppressed>
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -215,13 +215,7 @@ private suspend fun ServerSSESession.streamFirehose(
     // transport — likely because `launch(heartbeatJob + ...)` reparents
     // outside the session's structured-concurrency tree. A manual launch
     // on the session's own scope is observable end-to-end.
-    val heartbeatJob =
-        launch {
-            while (isActive) {
-                delay(heartbeatIntervalMillis)
-                send(ServerSentEvent(comments = "keepalive"))
-            }
-        }
+    val heartbeatJob = launch { runKeepalive(heartbeatIntervalMillis) }
 
     // Per-user control frames (e.g. AccessChanged) ride a separate, non-replayed bus
     // channel — they carry no revision and must not enter Last-Event-Id resume. Deliver
@@ -264,8 +258,52 @@ private suspend fun ServerSSESession.streamFirehose(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        val cid = UUID.randomUUID().toString()
-        log.error(e) { "Uncaught SSE flow exception [cid=$cid]" }
+        if (isClientDisconnect(e)) {
+            // Normal: the client closed the SSE connection (navigated away, backgrounded,
+            // or restarted) mid-stream. The write channel is gone, so there's nothing to
+            // report and nothing we could send. End the stream quietly — never a 500.
+            log.debug { "SSE firehose client disconnected; ending stream" }
+        } else {
+            sendStreamError(e)
+        }
+    } finally {
+        heartbeatJob.cancel()
+        controlJob.cancel()
+    }
+}
+
+/**
+ * Comment-line keepalive loop for one SSE connection: emits `:keepalive` every
+ * [intervalMillis] ms until cancelled. A failed write means the client is gone — end
+ * quietly (the main collect's teardown handles the rest); only unexpected errors are
+ * logged. Extracted from `streamFirehose` so its try/catch nesting doesn't inflate that
+ * function's cognitive complexity.
+ */
+private suspend fun ServerSSESession.runKeepalive(intervalMillis: Long) {
+    try {
+        while (coroutineContext.isActive) {
+            delay(intervalMillis)
+            send(ServerSentEvent(comments = "keepalive"))
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        if (!isClientDisconnect(e)) {
+            log.warn(e) { "SSE heartbeat stopped on unexpected error" }
+        }
+    }
+}
+
+/**
+ * Best-effort [SyncControl.StreamError] frame for a genuine (non-disconnect) firehose
+ * failure. Logs with a correlation id, then attempts the send — if the connection is
+ * already gone the write also fails, so it's wrapped in [runCatching] to ensure a dead
+ * client never escalates into an unhandled 500.
+ */
+private suspend fun ServerSSESession.sendStreamError(e: Exception) {
+    val cid = UUID.randomUUID().toString()
+    log.error(e) { "Uncaught SSE flow exception [cid=$cid]" }
+    runCatching {
         send(
             data =
                 contractJson.encodeToString(
@@ -281,10 +319,26 @@ private suspend fun ServerSSESession.streamFirehose(
                 ),
             event = SSE_EVENT_CONTROL,
         )
-    } finally {
-        heartbeatJob.cancel()
-        controlJob.cancel()
     }
+}
+
+/**
+ * True when [e] (or anything in its cause chain) is a client-closed-connection write —
+ * the expected outcome when an SSE subscriber navigates away, backgrounds, or restarts.
+ *
+ * These surface as Ktor's `ClosedWriteChannelException` / `ChannelWriteException`, usually
+ * wrapping a `java.io.IOException: Broken pipe`. We match on simple names + the broken-pipe
+ * IOException rather than importing engine-internal types, so the check stays transport-agnostic.
+ */
+private fun isClientDisconnect(e: Throwable): Boolean {
+    var cur: Throwable? = e
+    while (cur != null) {
+        val name = cur::class.simpleName
+        if (name == "ClosedWriteChannelException" || name == "ChannelWriteException") return true
+        if (cur is java.io.IOException && cur.message?.contains("Broken pipe", ignoreCase = true) == true) return true
+        cur = cur.cause
+    }
+    return false
 }
 
 /**

--- a/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/sync/SyncableRepository.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.api.sync.Page
 import com.calypsan.listenup.api.sync.SyncEvent
 import java.security.MessageDigest
 import kotlin.time.Clock
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -173,6 +174,10 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         if (userScoped) {
             requireNotNull(userId) { "user-scoped write on '$domainName' requires a userId" }
         }
+        // Read the suppression marker in the outer suspend context, before the transaction:
+        // the revision still bumps and the row still commits, but a suppressed write skips
+        // the live-tail publish (see [FirehoseSuppressed]).
+        val suppressed = currentCoroutineContext()[FirehoseSuppressed.Key] != null
         return suspendTransaction(db) {
             val rev = nextRevision()
             val now = clock.now().toEpochMilliseconds()
@@ -209,7 +214,9 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                         payload = saved,
                     )
                 }
-            bus.publish(repo = this@SyncableRepository, event = event, userId = userId)
+            if (!suppressed) {
+                bus.publish(repo = this@SyncableRepository, event = event, userId = userId)
+            }
 
             AppResult.Success(saved)
         }
@@ -260,6 +267,7 @@ abstract class SyncableRepository<T : Any, ID : Any>(
         if (userScoped) {
             requireNotNull(userId) { "user-scoped write on '$domainName' requires a userId" }
         }
+        val suppressed = currentCoroutineContext()[FirehoseSuppressed.Key] != null
         return suspendTransaction(db) {
             val rev = nextRevision()
             val now = clock.now().toEpochMilliseconds()
@@ -279,17 +287,19 @@ abstract class SyncableRepository<T : Any, ID : Any>(
                     ),
                 )
             } else {
-                bus.publish(
-                    repo = this@SyncableRepository,
-                    event =
-                        SyncEvent.Deleted(
-                            id = idStr,
-                            revision = rev,
-                            occurredAt = now,
-                            clientOpId = clientOpId,
-                        ),
-                    userId = userId,
-                )
+                if (!suppressed) {
+                    bus.publish(
+                        repo = this@SyncableRepository,
+                        event =
+                            SyncEvent.Deleted(
+                                id = idStr,
+                                revision = rev,
+                                occurredAt = now,
+                                clientOpId = clientOpId,
+                            ),
+                        userId = userId,
+                    )
+                }
                 AppResult.Success(Unit)
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinatorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinatorTest.kt
@@ -52,6 +52,55 @@ class ScanCoordinatorTest :
             }
         }
 
+        test("scanFullAsync returns Success immediately and runs the scan on the scope") {
+            runTest {
+                var scanRan = false
+                val coordinator =
+                    ScanCoordinator(
+                        libraryId = LibraryId("test-lib"),
+                        runFullScan = {
+                            scanRan = true
+                            emptyResult()
+                        },
+                        runIncremental = { /* unused */ },
+                        scope = backgroundScope,
+                    )
+
+                // Returns "accepted" without waiting for the walk.
+                val result = coordinator.scanFullAsync()
+                result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                // The scan runs on the background scope.
+                runCurrent()
+                scanRan shouldBe true
+            }
+        }
+
+        test("scanFullAsync — a second call while the first is in flight gets AlreadyRunning") {
+            runTest {
+                val gate = CompletableDeferred<Unit>()
+                val coordinator =
+                    ScanCoordinator(
+                        libraryId = LibraryId("test-lib"),
+                        runFullScan = {
+                            gate.await()
+                            emptyResult()
+                        },
+                        runIncremental = { /* unused */ },
+                        scope = backgroundScope,
+                    )
+
+                coordinator.scanFullAsync().shouldBeInstanceOf<AppResult.Success<Unit>>()
+                runCurrent() // first scan acquires the lock and suspends on the gate
+
+                val second = coordinator.scanFullAsync()
+                second.shouldBeInstanceOf<AppResult.Failure>()
+                second.error.shouldBeInstanceOf<ScanError.AlreadyRunning>()
+
+                gate.complete(Unit)
+            }
+        }
+
         test("incremental triggered during a full scan runs after the scan finishes") {
             runTest {
                 val incrementalCalls = mutableListOf<Path>()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestratorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestratorTest.kt
@@ -95,6 +95,25 @@ class ScanOrchestratorTest :
             }
         }
 
+        test("scanLibraryAsync returns Success immediately for a registered library") {
+            runTest {
+                val orchestrator = orchestrator(FakeScannerFactory(), FakeWatcherSupervisor(), backgroundScope)
+                orchestrator.onLibraryAdded(testLib("lib-1", "/tmp/books"))
+
+                val result = orchestrator.scanLibraryAsync(LibraryId("lib-1"))
+                result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+            }
+        }
+
+        test("scanLibraryAsync returns LibraryError.NotFound for unknown library") {
+            runTest {
+                val orchestrator = orchestrator(FakeScannerFactory(), FakeWatcherSupervisor(), backgroundScope)
+
+                val result = orchestrator.scanLibraryAsync(LibraryId("ghost"))
+                result.shouldBeInstanceOf<AppResult.Failure>().error.shouldBeInstanceOf<LibraryError.NotFound>()
+            }
+        }
+
         test("scanLibrary returns LibraryError.NotFound for unknown library") {
             runTest {
                 val orchestrator = orchestrator(FakeScannerFactory(), FakeWatcherSupervisor(), backgroundScope)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerInboxIngestTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerInboxIngestTest.kt
@@ -189,6 +189,7 @@ private fun fixture(
             libraryRegistry = LibraryRegistry(db, env = mapOf("LISTENUP_LIBRARY_PATH" to "/tmp/test-library")),
             db = db,
             scanResultBus = MutableSharedFlow(),
+            eventBus = MutableSharedFlow(),
             scope = scope,
             metrics = BookPersisterMetrics(SimpleMeterRegistry()),
         )

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerServiceImplTest.kt
@@ -5,17 +5,23 @@ package com.calypsan.listenup.server.scanner
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
 import com.calypsan.listenup.api.error.ScanError
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.streaming.RpcEvent
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import com.calypsan.listenup.server.testing.testLibrary
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 
@@ -45,6 +51,49 @@ class ScannerServiceImplTest :
                     val failure = result.shouldBeInstanceOf<AppResult.Failure>()
                     failure.error.shouldBeInstanceOf<ScanError.LibraryPathNotConfigured>()
                 }
+            }
+        }
+
+        test("observeProgress drops heavy Change events, keeping only lifecycle/progress") {
+            runTest {
+                // replay so the late subscriber sees all pre-emitted events deterministically.
+                val eventBus = MutableSharedFlow<ScanEvent>(replay = 10)
+                val orchestrator =
+                    ScanOrchestrator(
+                        scannerFactory = { error("scannerFactory unused by observeProgress") },
+                        watcherSupervisor = NoOpWatcherSupervisor,
+                    )
+                val service = ScannerServiceImpl(orchestrator, { TEST_LIBRARY_ID }, eventBus.asSharedFlow())
+
+                eventBus.emit(ScanEvent.Started(correlationId = "c", libraryId = TEST_LIBRARY_ID, rootPath = "/x"))
+                // A Change carries a full AnalyzedBook (artwork bytes) — must NOT reach the progress stream.
+                eventBus.emit(
+                    ScanEvent.Change(
+                        correlationId = "c",
+                        libraryId = TEST_LIBRARY_ID,
+                        event = ChangeEventDto.Removed(rootRelPath = "Author/Title"),
+                    ),
+                )
+                eventBus.emit(
+                    ScanEvent.Progress(
+                        correlationId = "c",
+                        libraryId = TEST_LIBRARY_ID,
+                        phase = ScanPhase.ANALYZING,
+                        filesWalked = 2,
+                        booksAnalyzed = 1,
+                        errors = 0,
+                    ),
+                )
+
+                // Change is filtered, so the first two delivered events are Started then Progress.
+                val received =
+                    service
+                        .observeProgress()
+                        .take(2)
+                        .toList()
+                        .map { (it as RpcEvent.Data).value::class.simpleName }
+
+                received shouldContainExactly listOf("Started", "Progress")
             }
         }
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
@@ -36,9 +36,11 @@ class ScannerTest :
                     result.changes.size shouldBe 2
                     result.changes.all { it is ChangeEventDto.Added } shouldBe true
 
+                    // The Scanner emits the scanning-phase events only. ScanEvent.Completed is emitted
+                    // by BookPersister AFTER persistence (see BookPersisterTest), so it is NOT here.
                     val events = eventBus.replayCache
                     events.first().shouldBeInstanceOf<ScanEvent.Started>()
-                    events.last().shouldBeInstanceOf<ScanEvent.Completed>()
+                    events.none { it is ScanEvent.Completed } shouldBe true
                     events.count { it is ScanEvent.Change } shouldBe 2
                 }
             }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -10,9 +10,11 @@ import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanScope
 import com.calypsan.listenup.api.dto.scanner.TrackEntry
 import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -21,6 +23,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -74,6 +77,57 @@ class BookPersisterTest :
 
                     fake.softDeleteAbsentCalls shouldHaveSize 1
                     fake.softDeleteAbsentCalls.single() shouldBe setOf(BookId("id-a"), BookId("id-b"))
+                }
+            }
+        }
+
+        test("emits ScanEvent.Completed only after every book is persisted") {
+            withInMemoryDatabase {
+                val db = this
+                runTest {
+                    val eventBus = MutableSharedFlow<ScanEvent>(replay = 16)
+                    val fake = FakeBookIngest()
+                    val persister = persister(db, fake, scope = this, eventBus = eventBus)
+
+                    persister.persist(scanResult(listOf(analyzedBook("a"), analyzedBook("b")), ScanScope.Full))
+
+                    // Completed is emitted by the persister — proving it fires AFTER persistence, not
+                    // before it (the premature-Completed race). Its summary reflects the committed books.
+                    val completed = eventBus.replayCache.filterIsInstance<ScanEvent.Completed>().single()
+                    completed.result.totalBooks shouldBe 2
+                    fake.resolved shouldContainExactly listOf("a", "b")
+                }
+            }
+        }
+
+        test("full scan suppresses the firehose while persisting books") {
+            withInMemoryDatabase {
+                val db = this
+                runTest {
+                    val fake = FakeBookIngest()
+                    val persister = persister(db, fake, scope = this)
+
+                    persister.persist(scanResult(listOf(analyzedBook("a"), analyzedBook("b")), ScanScope.Full))
+
+                    // Every book is persisted with FirehoseSuppressed active, so the bulk burst
+                    // never hits the lossy live tail; the sweep runs suppressed too.
+                    fake.suppressionObserved shouldContainExactly listOf(true, true)
+                    fake.softDeleteAbsentSuppressed shouldContainExactly listOf(true)
+                }
+            }
+        }
+
+        test("incremental scan persists with the firehose live (no suppression)") {
+            withInMemoryDatabase {
+                val db = this
+                runTest {
+                    val fake = FakeBookIngest()
+                    val persister = persister(db, fake, scope = this)
+
+                    persister.persist(scanResult(listOf(analyzedBook("a")), ScanScope.Subtree("some/path")))
+
+                    // Incremental scans ARE live deltas — they publish normally.
+                    fake.suppressionObserved shouldContainExactly listOf(false)
                 }
             }
         }
@@ -137,12 +191,19 @@ private class FakeBookIngest(
     /** seenIds sets passed to each [softDeleteAbsent] call. */
     val softDeleteAbsentCalls = mutableListOf<Set<BookId>>()
 
+    /** Whether [FirehoseSuppressed] was in the coroutine context for each [resolveOrInsert], in call order. */
+    val suppressionObserved = mutableListOf<Boolean>()
+
+    /** Whether [FirehoseSuppressed] was in the coroutine context for each [softDeleteAbsent], in call order. */
+    val softDeleteAbsentSuppressed = mutableListOf<Boolean>()
+
     override suspend fun resolveOrInsert(
         libraryId: LibraryId,
         folderId: com.calypsan.listenup.core.FolderId,
         analyzed: AnalyzedBook,
         pendingCover: PendingCover?,
     ): AppResult<IngestOutcome> {
+        suppressionObserved += currentCoroutineContext()[FirehoseSuppressed.Key] != null
         val path = analyzed.candidate.rootRelPath
         if (path in throwForRootRelPath) {
             error("simulated escaped failure for $path")
@@ -158,6 +219,7 @@ private class FakeBookIngest(
         libraryId: LibraryId,
         seenIds: Set<BookId>,
     ) {
+        softDeleteAbsentSuppressed += currentCoroutineContext()[FirehoseSuppressed.Key] != null
         softDeleteAbsentCalls += seenIds
     }
 }
@@ -168,6 +230,7 @@ private fun persister(
     db: Database,
     ingest: BookIngestPort,
     scope: CoroutineScope,
+    eventBus: MutableSharedFlow<ScanEvent> = MutableSharedFlow(),
     metrics: BookPersisterMetrics = BookPersisterMetrics(SimpleMeterRegistry()),
 ): BookPersister =
     BookPersister(
@@ -175,6 +238,7 @@ private fun persister(
         libraryRegistry = LibraryRegistry(db, env = mapOf("LISTENUP_LIBRARY_PATH" to "/lib")),
         db = db,
         scanResultBus = MutableSharedFlow(),
+        eventBus = eventBus,
         scope = scope,
         metrics = metrics,
     )

--- a/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryFirehoseSuppressionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/sync/SyncableRepositoryFirehoseSuppressionTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+
+/**
+ * Pins the [FirehoseSuppressed] gate on the [SyncableRepository] write path —
+ * the keystone of Stage 2 (onboarding firehose suppression).
+ *
+ * Under the marker, `upsert`/`softDelete` MUST still bump the revision and commit
+ * the row (so REST `pullSince` catch-up sees it) but MUST NOT publish to the
+ * [ChangeBus] live tail (so a bulk burst can't overflow `replay = 256` →
+ * `CursorStale`). Without the marker, every write publishes as before.
+ */
+class SyncableRepositoryFirehoseSuppressionTest :
+    FunSpec({
+
+        test("upsert under FirehoseSuppressed bumps revision and commits the row but publishes no event") {
+            withInMemoryDatabase {
+                val db = this
+                val bus = ChangeBus()
+                val repo = FixtureRepository(db, bus, SyncRegistry())
+
+                runTest {
+                    suspendTransaction(db) { SchemaUtils.create(FixtureTestTable) }
+
+                    withContext(FirehoseSuppressed) {
+                        repo.upsert(
+                            FixturePayload(FixtureId("sup"), "suppressed", revision = 0, updatedAt = 0),
+                            clientOpId = "op-sup",
+                        )
+                    }
+                    advanceUntilIdle()
+
+                    // No event reached the live tail.
+                    bus.subscribe().replayCache.shouldBeEmpty()
+
+                    // ...yet REST catch-up sees the committed row (revision was still bumped).
+                    val page = repo.pullSince(userId = null, cursor = 0, limit = 10)
+                    page.items.map { it.id.value } shouldContainExactly listOf("sup")
+                }
+            }
+        }
+
+        test("upsert without the marker publishes to the live tail as before") {
+            withInMemoryDatabase {
+                val db = this
+                val bus = ChangeBus()
+                val repo = FixtureRepository(db, bus, SyncRegistry())
+
+                runTest {
+                    suspendTransaction(db) { SchemaUtils.create(FixtureTestTable) }
+
+                    repo.upsert(
+                        FixturePayload(FixtureId("norm"), "normal", revision = 0, updatedAt = 0),
+                        clientOpId = "op-norm",
+                    )
+                    advanceUntilIdle()
+
+                    bus.subscribe().replayCache.map { it.event.id } shouldContainExactly listOf("norm")
+                }
+            }
+        }
+
+        test("softDelete under FirehoseSuppressed tombstones the row but publishes no event") {
+            withInMemoryDatabase {
+                val db = this
+                val bus = ChangeBus()
+                val repo = FixtureRepository(db, bus, SyncRegistry())
+
+                runTest {
+                    suspendTransaction(db) { SchemaUtils.create(FixtureTestTable) }
+
+                    // Seed a row with the firehose live so we have a clean tail to assert against.
+                    repo.upsert(
+                        FixturePayload(FixtureId("gone"), "doomed", revision = 0, updatedAt = 0),
+                        clientOpId = "op-seed",
+                    )
+                    advanceUntilIdle()
+                    bus.subscribe().replayCache.map { it.event.id } shouldContainExactly listOf("gone")
+
+                    withContext(FirehoseSuppressed) {
+                        repo.softDelete(FixtureId("gone"), clientOpId = "op-del")
+                    }
+                    advanceUntilIdle()
+
+                    // The Deleted event was suppressed — the tail still shows only the seed Created.
+                    bus.subscribe().replayCache.map { it.event.id } shouldContainExactly listOf("gone")
+                    bus.subscribe().replayCache.size shouldBe 1
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -5,6 +5,7 @@ package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.core.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.api.error.DownloadError
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
@@ -21,8 +22,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -214,7 +213,7 @@ class AppleDownloadService(
         audioFile: AudioFileResponse,
         serverUrl: String,
         token: String,
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(IODispatcher) {
         val audioFileId = audioFile.id
         val filename = audioFile.filename
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorage.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorage.kt
@@ -3,10 +3,9 @@ package com.calypsan.listenup.client.data.local.images
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.Failure
 import com.calypsan.listenup.core.AppResult
+import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.core.Success
 import com.calypsan.listenup.client.domain.repository.ImageStorage
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
 import kotlinx.io.buffered
@@ -44,7 +43,7 @@ class CommonImageStorage(
         bookId: BookId,
         imageData: ByteArray,
     ): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getCoverFile(bookId)
                 writeBytes(file, imageData)
@@ -61,7 +60,7 @@ class CommonImageStorage(
     override fun exists(bookId: BookId): Boolean = SystemFileSystem.exists(getCoverFile(bookId))
 
     override suspend fun deleteCover(bookId: BookId): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getCoverFile(bookId)
                 deleteIfExists(file)
@@ -79,7 +78,7 @@ class CommonImageStorage(
         bookId: BookId,
         imageData: ByteArray,
     ): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getCoverStagingFile(bookId)
                 writeBytes(file, imageData)
@@ -94,7 +93,7 @@ class CommonImageStorage(
     override fun getCoverStagingPath(bookId: BookId): String = getCoverStagingFile(bookId).toString()
 
     override suspend fun commitCoverStaging(bookId: BookId): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val stagingFile = getCoverStagingFile(bookId)
                 val targetFile = getCoverFile(bookId)
@@ -119,7 +118,7 @@ class CommonImageStorage(
         }
 
     override suspend fun deleteCoverStaging(bookId: BookId): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 deleteIfExists(getCoverStagingFile(bookId))
                 Success(Unit)
@@ -131,7 +130,7 @@ class CommonImageStorage(
         }
 
     override suspend fun clearAll(): AppResult<Int> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 var deletedCount = 0
 
@@ -158,7 +157,7 @@ class CommonImageStorage(
         contributorId: String,
         imageData: ByteArray,
     ): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getContributorFile(contributorId)
                 writeBytes(file, imageData)
@@ -176,7 +175,7 @@ class CommonImageStorage(
         SystemFileSystem.exists(getContributorFile(contributorId))
 
     override suspend fun deleteContributorImage(contributorId: String): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 deleteIfExists(getContributorFile(contributorId))
                 Success(Unit)
@@ -193,7 +192,7 @@ class CommonImageStorage(
         seriesId: String,
         imageData: ByteArray,
     ): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getSeriesCoverFile(seriesId)
                 writeBytes(file, imageData)
@@ -210,7 +209,7 @@ class CommonImageStorage(
     override fun seriesCoverExists(seriesId: String): Boolean = SystemFileSystem.exists(getSeriesCoverFile(seriesId))
 
     override suspend fun deleteSeriesCover(seriesId: String): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 deleteIfExists(getSeriesCoverFile(seriesId))
                 Success(Unit)
@@ -227,7 +226,7 @@ class CommonImageStorage(
         seriesId: String,
         imageData: ByteArray,
     ): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getSeriesCoverStagingFile(seriesId)
                 writeBytes(file, imageData)
@@ -242,7 +241,7 @@ class CommonImageStorage(
     override fun getSeriesCoverStagingPath(seriesId: String): String = getSeriesCoverStagingFile(seriesId).toString()
 
     override suspend fun commitSeriesCoverStaging(seriesId: String): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val stagingFile = getSeriesCoverStagingFile(seriesId)
                 val targetFile = getSeriesCoverFile(seriesId)
@@ -267,7 +266,7 @@ class CommonImageStorage(
         }
 
     override suspend fun deleteSeriesCoverStaging(seriesId: String): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 deleteIfExists(getSeriesCoverStagingFile(seriesId))
                 Success(Unit)
@@ -284,7 +283,7 @@ class CommonImageStorage(
         userId: String,
         imageData: ByteArray,
     ): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 val file = getUserAvatarFile(userId)
                 writeBytes(file, imageData)
@@ -301,7 +300,7 @@ class CommonImageStorage(
     override fun userAvatarExists(userId: String): Boolean = SystemFileSystem.exists(getUserAvatarFile(userId))
 
     override suspend fun deleteUserAvatar(userId: String): AppResult<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             try {
                 deleteIfExists(getUserAvatarFile(userId))
                 Success(Unit)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ScannerRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ScannerRpcFactory.kt
@@ -1,0 +1,76 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.api.ScannerService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.serialization.json.json
+import kotlinx.rpc.withService
+
+/**
+ * Supplies the [ScannerService] kotlinx.rpc proxy used to observe live scan
+ * progress (`observeProgress(): Flow<RpcEvent<ScanEvent>>`).
+ *
+ * [ScannerService] is mounted on the **public** RPC surface (`/api/rpc/public`),
+ * so this factory does not attach a bearer token — it mirrors the public-mount
+ * pattern of the auth/instance factories. The proxy is cached and reused; the
+ * underlying [HttpClient] comes from [ApiClientFactory] (same one the rest of the
+ * app uses), so [invalidate] drops the cached proxy when that client is recycled.
+ */
+interface ScannerRpcFactory {
+    /** Returns the cached [ScannerService] proxy, connecting on first use. */
+    suspend fun get(): ScannerService
+
+    /** Drop the cached proxy and RPC-flavored client. */
+    suspend fun invalidate()
+}
+
+/**
+ * Production [ScannerRpcFactory]: mounts [ScannerService] over `/api/rpc/public`.
+ * Mirrors [KtorLibraryAdminRpcFactory], substituting the public mount.
+ */
+open class KtorScannerRpcFactory(
+    private val apiClientFactory: ApiClientFactory,
+    private val serverConfig: ServerConfig,
+) : ScannerRpcFactory {
+    private val mutex = Mutex()
+    private var cachedRpcClient: HttpClient? = null
+    private var cachedService: ScannerService? = null
+
+    override suspend fun get(): ScannerService =
+        mutex.withLock {
+            cachedService ?: connect().also { cachedService = it }
+        }
+
+    override suspend fun invalidate() {
+        mutex.withLock {
+            cachedService = null
+            cachedRpcClient = null
+        }
+    }
+
+    internal open suspend fun connect(): ScannerService {
+        val baseUrl = rpcBaseUrl()
+        return rpcClient().rpc("$baseUrl/api/rpc/public").withService<ScannerService>()
+    }
+
+    private suspend fun rpcClient(): HttpClient =
+        cachedRpcClient ?: apiClientFactory
+            .getClient()
+            .config {
+                installKrpc {
+                    serialization { json(contractJson) }
+                }
+            }.also { cachedRpcClient = it }
+
+    private suspend fun rpcBaseUrl(): String {
+        val httpUrl =
+            serverConfig.getActiveUrl()?.value
+                ?: error("Server URL not configured — cannot open RPC connection")
+        return toWebSocketScheme(httpUrl)
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.core.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.core.Success
 import com.calypsan.listenup.core.suspendRunCatching
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
@@ -29,7 +30,6 @@ import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.api.result.getOrNull as wireResultOrNull
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
@@ -156,7 +156,7 @@ class BookRepositoryImpl(
             .map { rows -> rows.map { it.toListItem(imageStorage) } }
             // toListItem's per-book cover stat is blocking I/O — keep it off the collector
             // (Dispatchers.Main for the Library screen), or a large library freezes the UI thread.
-            .flowOn(Dispatchers.IO)
+            .flowOn(IODispatcher)
 
     override suspend fun getBookListItem(id: String): BookListItem? =
         bookDao.getByIdWithContributors(BookId(id))?.toListItem(imageStorage)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
@@ -29,10 +29,13 @@ import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.api.result.getOrNull as wireResultOrNull
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 
@@ -142,9 +145,18 @@ class BookRepositoryImpl(
         }
 
     override fun observeBookListItems(): Flow<List<BookListItem>> =
-        bookDao.observeAllWithContributors().map { rows ->
-            rows.map { it.toListItem(imageStorage) }
-        }
+        bookDao
+            .observeAllWithContributors()
+            // conflate BEFORE the map: during an initial-population burst the book table is
+            // invalidated once per inserted book, and re-mapping the whole library (a BookListItem +
+            // a blocking ImageStorage.exists cover stat per book) on every one is O(n²) allocation
+            // that exhausts the heap → OOM. Conflate collapses a burst into a single re-map of the
+            // latest snapshot; the UI still converges to the correct final list.
+            .conflate()
+            .map { rows -> rows.map { it.toListItem(imageStorage) } }
+            // toListItem's per-book cover stat is blocking I/O — keep it off the collector
+            // (Dispatchers.Main for the Library screen), or a large library freezes the UI thread.
+            .flowOn(Dispatchers.IO)
 
     override suspend fun getBookListItem(id: String): BookListItem? =
         bookDao.getByIdWithContributors(BookId(id))?.toListItem(imageStorage)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImpl.kt
@@ -25,7 +25,6 @@ import com.calypsan.listenup.client.domain.repository.SeriesRepository
 import com.calypsan.listenup.api.result.getOrNull as wireResultOrNull
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
@@ -183,7 +182,7 @@ class SeriesRepositoryImpl(
                     bookSequences = sequences,
                 )
             }
-        }.flowOn(Dispatchers.IO) // per-book toListItem does a blocking cover stat — keep it off the collector (Main).
+        }.flowOn(IODispatcher) // per-book toListItem does a blocking cover stat — keep it off the collector (Main).
 
     // ========== Series Detail Methods ==========
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImpl.kt
@@ -25,8 +25,11 @@ import com.calypsan.listenup.client.domain.repository.SeriesRepository
 import com.calypsan.listenup.api.result.getOrNull as wireResultOrNull
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
@@ -153,7 +156,10 @@ class SeriesRepositoryImpl(
     override fun observeAllWithBooks(): Flow<List<SeriesWithBooks>> =
         combine(
             seriesDao.observeAllWithBooks(),
-            bookDao.observeAllWithContributors(),
+            // conflate the book stream: during initial population it invalidates once per inserted
+            // book, and the combine below re-maps every book via toListItem (blocking cover stat) on
+            // each — O(n²) allocation that OOMs. Collapse the burst to the latest snapshot.
+            bookDao.observeAllWithContributors().conflate(),
         ) { seriesEntities, allBooksWithContributors ->
             val booksById = allBooksWithContributors.associateBy { it.book.id }
             seriesEntities.map { entity ->
@@ -177,7 +183,7 @@ class SeriesRepositoryImpl(
                     bookSequences = sequences,
                 )
             }
-        }
+        }.flowOn(Dispatchers.IO) // per-book toListItem does a blocking cover stat — keep it off the collector (Main).
 
     // ========== Series Detail Methods ==========
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -5,6 +5,9 @@ import com.calypsan.listenup.core.Success
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.core.suspendRunCatching
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.streaming.RpcEvent
+import com.calypsan.listenup.client.data.remote.ScannerRpcFactory
 import com.calypsan.listenup.client.data.sync.ConnectionState
 import com.calypsan.listenup.client.data.sync.SyncEngine
 import com.calypsan.listenup.client.data.sync.SyncEngineState
@@ -18,8 +21,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private val logger = KotlinLogging.logger {}
 
@@ -38,10 +46,27 @@ class SyncRepositoryImpl(
     private val syncEngineState: SyncEngineState,
     private val authSession: AuthSession,
     private val listeningEventRecorder: ListeningEventRecorder,
-    scope: CoroutineScope,
+    private val scannerRpcFactory: ScannerRpcFactory,
+    private val scope: CoroutineScope,
 ) : SyncRepository {
     /** Ensures [ListeningEventRecorder.recoverOrphan] runs at most once per process lifetime. */
     private var orphanRecovered = false
+
+    /**
+     * Guards the at-most-once launch of the scan-progress observer. [startEngineForCurrentUser] can
+     * be called concurrently (sync + connectRealtime + resetForNewLibrary) on the multi-threaded
+     * [scope], so the launch decision must be a single atomic check-and-set, not a plain var read.
+     */
+    private val scanObserverMutex = Mutex()
+    private var scanObserverStarted = false
+
+    /**
+     * Latches once the initial library-population scan completes. After that the shell is "ready"
+     * and later (watcher-driven incremental) scans must never re-block it via [isServerScanning].
+     * Process-lived: a fresh launch starts `false`, but with no scan running nothing re-arms the
+     * overlay, so a relaunched client with books already in Room shows the library immediately.
+     */
+    private var hasCompletedInitialScan = false
     override val syncState: StateFlow<SyncState> =
         syncEngineState
             .observe()
@@ -65,8 +90,11 @@ class SyncRepositoryImpl(
                 initialValue = SyncState.Idle,
             )
 
-    override val isServerScanning: StateFlow<Boolean> = MutableStateFlow(false)
-    override val scanProgress: StateFlow<ScanProgressState?> = MutableStateFlow(null)
+    private val _isServerScanning = MutableStateFlow(false)
+    override val isServerScanning: StateFlow<Boolean> = _isServerScanning.asStateFlow()
+
+    private val _scanProgress = MutableStateFlow<ScanProgressState?>(null)
+    override val scanProgress: StateFlow<ScanProgressState?> = _scanProgress.asStateFlow()
 
     override suspend fun sync(): AppResult<Unit> = startEngineForCurrentUser()
 
@@ -84,6 +112,7 @@ class SyncRepositoryImpl(
         suspendRunCatching {
             val userId = authSession.getUserId() ?: return@suspendRunCatching Unit
             syncEngine.start(userId)
+            startScanProgressObserver()
             if (!orphanRecovered) {
                 orphanRecovered = true
                 try {
@@ -97,4 +126,146 @@ class SyncRepositoryImpl(
                 }
             }
         }
+
+    /**
+     * Launches (once) the live scan-progress observer over [ScannerService.observeProgress].
+     *
+     * The live SSE tail that delivers scanned books is best-effort (the server's change bus
+     * drops events under a large-scan burst), so a freshly-scanned library can finish with the
+     * client still missing rows. This observer drives the [isServerScanning]/[scanProgress] UI
+     * state from the scan event stream and, on [ScanEvent.Completed], forces a catch-up
+     * reconcile ([SyncEngine.handleCursorStale]) so every scanned book lands in Room — no app
+     * restart required. Runs on the long-lived [scope]; failures are logged and the stream is
+     * left to re-establish on the next [startEngineForCurrentUser].
+     */
+    private suspend fun startScanProgressObserver() {
+        val shouldStart =
+            scanObserverMutex.withLock {
+                if (scanObserverStarted) {
+                    false
+                } else {
+                    scanObserverStarted = true
+                    true
+                }
+            }
+        if (!shouldStart) return
+        scope.launch {
+            try {
+                scannerRpcFactory
+                    .get()
+                    .observeProgress()
+                    .catch { e ->
+                        if (e is kotlin.coroutines.cancellation.CancellationException) throw e
+                        logger.warn(e) { "Scan-progress stream failed; scan UI/reconcile paused" }
+                        resetScanObserver()
+                    }.collect { rpcEvent ->
+                        val event = (rpcEvent as? RpcEvent.Data)?.value ?: return@collect
+                        applyScanEvent(
+                            event = event,
+                            isInitialScanComplete = { hasCompletedInitialScan },
+                            setScanning = { _isServerScanning.value = it },
+                            setProgress = { _scanProgress.value = it },
+                            markInitialScanComplete = { hasCompletedInitialScan = true },
+                            // Awaited, not fire-and-forget: the initial populating gate must stay up
+                            // until this reconcile actually lands the books in Room (see applyScanEvent).
+                            // Parking this collector for the duration is safe — [SyncEngine.handleCursorStale]
+                            // is mutex-guarded + coalescing (no concurrent catch-up spin), Completed is
+                            // already consumed, and the cold RPC stream applies backpressure rather than
+                            // dropping any later event.
+                            reconcile = { syncEngine.handleCursorStale() },
+                        )
+                    }
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Scan-progress observer stopped unexpectedly" }
+                resetScanObserver()
+            }
+        }
+    }
+
+    /** Never-stranded reset: a dropped progress stream must not leave the shell blocked. */
+    private suspend fun resetScanObserver() {
+        _isServerScanning.value = false
+        _scanProgress.value = null
+        scanObserverMutex.withLock { scanObserverStarted = false }
+    }
+}
+
+/**
+ * Pure reducer for a single [ScanEvent]: maps it to scan-UI state (via [setScanning] / [setProgress])
+ * and, on [ScanEvent.Completed], invokes [reconcile] — a catch-up that pulls the books the lossy
+ * live tail may have dropped during the scan burst. Extracted as a top-level function so it is
+ * testable without mocking the final [SyncEngine]: tests drive it with recording lambdas.
+ *
+ * **Initial-population semantics.** `isServerScanning` is the app-readiness signal: the navigation
+ * layer shows a full-screen populating screen while it is `true`, because a brand-new library has
+ * nothing to navigate yet. That signal must therefore reflect **only the initial population**. A
+ * later watcher-driven incremental scan emits its own `Started`/`Progress` (a fresh `correlationId`)
+ * — if those re-armed the flag they would slam the populating screen back over an already-usable
+ * library, and a missed terminal event would latch it there forever. So once the first population
+ * settles ([markInitialScanComplete]), subsequent scans never drive it: [isInitialScanComplete]
+ * short-circuits `setScanning(true)`.
+ *
+ * **Completed ≠ ready.** `ScanEvent.Completed` means the *server* persisted the books, not that the
+ * *client's* Room reflects them — the catch-up [reconcile] still has to pull them in. So on the
+ * initial Completed the gate stays up (`scanning` true) across the awaited [reconcile]; only once it
+ * returns (Room now holds the library) does the gate clear and readiness latch. Clearing on Completed
+ * would mount the shell mid-import (empty grid, then a thousand covers decoding under the catch-up —
+ * the onboarding OOM). [reconcile] runs on every Completed (incrementals also pull dropped deltas),
+ * but only the initial one drives the gate.
+ */
+internal suspend fun applyScanEvent(
+    event: ScanEvent,
+    isInitialScanComplete: () -> Boolean,
+    setScanning: (Boolean) -> Unit,
+    setProgress: (ScanProgressState?) -> Unit,
+    markInitialScanComplete: () -> Unit,
+    reconcile: suspend () -> Unit,
+) {
+    when (event) {
+        is ScanEvent.Started -> {
+            if (!isInitialScanComplete()) {
+                setScanning(true)
+                setProgress(null)
+            }
+        }
+
+        is ScanEvent.Progress -> {
+            if (!isInitialScanComplete()) {
+                setScanning(true)
+                setProgress(
+                    ScanProgressState(
+                        phase = event.phase.name,
+                        current = event.booksAnalyzed,
+                        total = event.filesWalked,
+                        added = 0,
+                        updated = 0,
+                        removed = 0,
+                    ),
+                )
+            }
+        }
+
+        is ScanEvent.Completed -> {
+            val drivesGate = !isInitialScanComplete()
+            if (drivesGate) {
+                // Server done persisting; client now imports. Drop the granular walk progress so the
+                // populating screen shows its indeterminate "finishing up" state while we pull books.
+                setProgress(null)
+            }
+            logger.info { "Scan completed — reconciling to pull scanned books" }
+            reconcile()
+            if (drivesGate) {
+                // Room now holds the library — clear the gate and latch so no later incremental can
+                // re-block the shell.
+                setScanning(false)
+                markInitialScanComplete()
+            }
+        }
+
+        is ScanEvent.Change -> {
+            // No-op: the live tail plus the Completed reconcile cover applied changes.
+        }
+    }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserRepositoryImpl.kt
@@ -1,13 +1,13 @@
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.core.Success
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.Timestamp
-import com.calypsan.listenup.api.dto.auth.UserId
+import kotlin.coroutines.cancellation.CancellationException
 import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.local.db.UserEntity
-import com.calypsan.listenup.client.data.remote.CurrentUserResponse
-import com.calypsan.listenup.client.data.remote.SessionApiContract
+import com.calypsan.listenup.client.data.remote.AuthRpcFactory
 import com.calypsan.listenup.client.domain.model.User
+import com.calypsan.listenup.client.domain.model.toDomain
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
@@ -23,11 +23,12 @@ private val logger = KotlinLogging.logger {}
  * domain types to ViewModels.
  *
  * @property userDao Room DAO for user operations
- * @property sessionApi API for fetching user profile from server
+ * @property authRpcFactory Supplies the bearer-gated [AuthServiceAuthed] RPC proxy used to
+ *   refresh the current user's profile from the server (RPC-first; no REST fallback).
  */
 class UserRepositoryImpl(
     private val userDao: UserDao,
-    private val sessionApi: SessionApiContract,
+    private val authRpcFactory: AuthRpcFactory,
 ) : UserRepository {
     override fun observeCurrentUser(): Flow<User?> = userDao.observeCurrentUser().map { it?.toDomain() }
 
@@ -47,19 +48,30 @@ class UserRepositoryImpl(
     }
 
     override suspend fun refreshCurrentUser(): User? {
-        logger.debug { "Refreshing current user from server" }
-        return when (val result = sessionApi.getCurrentUser()) {
-            is Success -> {
-                val user = result.data.toDomain()
-                saveUser(user)
-                logger.info { "User data refreshed: ${user.email}" }
-                user
-            }
+        logger.debug { "Refreshing current user from server (RPC)" }
+        // Opening the RPC connection can fail (e.g. no server URL configured yet). This is a
+        // fallible refresh, not a fatal path: swallow to null so callers fall back to the
+        // locally-persisted user instead of surfacing a hard failure. CancellationException
+        // is always re-raised per structured-concurrency rules.
+        return try {
+            when (val result = authRpcFactory.authedService().currentUser()) {
+                is AppResult.Success -> {
+                    val user = result.data.toDomain()
+                    saveUser(user)
+                    logger.info { "User data refreshed: isAdmin=${user.isAdmin}" }
+                    user
+                }
 
-            else -> {
-                logger.warn { "Failed to refresh current user from server" }
-                null
+                is AppResult.Failure -> {
+                    logger.warn { "Failed to refresh current user via RPC: ${result.error.code}" }
+                    null
+                }
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "refreshCurrentUser failed before a result (RPC connect/transport)" }
+            null
         }
     }
 }
@@ -83,25 +95,6 @@ private fun UserEntity.toDomain(): User =
         tagline = tagline,
         createdAtMs = createdAt.epochMillis,
         updatedAtMs = updatedAt.epochMillis,
-    )
-
-/**
- * Convert CurrentUserResponse API model to User domain model.
- */
-private fun CurrentUserResponse.toDomain(): User =
-    User(
-        id = UserId(id),
-        email = email,
-        displayName = displayName,
-        firstName = firstName,
-        lastName = lastName,
-        isAdmin = isRoot,
-        avatarType = avatarType,
-        avatarValue = avatarValue,
-        avatarColor = avatarColor,
-        tagline = null, // API doesn't return tagline for current user
-        createdAtMs = createdAt,
-        updatedAtMs = updatedAt,
     )
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClient.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.sync.DomainList
 import com.calypsan.listenup.api.sync.Page
 import com.calypsan.listenup.api.sync.Tombstoned
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.core.AppResult
 import com.calypsan.listenup.core.suspendRunCatching
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -13,7 +14,12 @@ import io.ktor.client.request.get
 import kotlinx.serialization.json.JsonElement
 
 private val logger = KotlinLogging.logger {}
-private const val PAGE_LIMIT = 500
+
+// Smaller pages trade a few more HTTP round-trips for a much lower peak heap: each page is decoded
+// to a JsonElement tree AND a List<Payload> before it is applied, so a 500-book page is a large
+// transient spike during onboarding. Stability over raw sync speed (a 1000-book initial population
+// otherwise pushed the client to OOM).
+private const val PAGE_LIMIT = 100
 private const val SERVER_URL_NOT_CONFIGURED = "Server URL not configured"
 
 /**
@@ -39,6 +45,7 @@ class SyncCatchUpClient(
     private val httpClientProvider: suspend () -> HttpClient,
     private val serverUrlProvider: suspend () -> String?,
     private val store: SyncCursorStore,
+    private val transactionRunner: TransactionRunner,
 ) : CatchUp {
     /** Drain catch-up for [handler]. Cursor advances incrementally per page. */
     override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> =
@@ -56,9 +63,25 @@ class SyncCatchUpClient(
                         Page.serializer(handler.payloadSerializer),
                         element,
                     )
-                for (item in page.items) {
-                    val isTomb = (item as? Tombstoned)?.deletedAt != null
-                    handler.onCatchUpItem(item, isTomb)
+                // Apply the whole page in ONE outer transaction. Each handler.onCatchUpItem still
+                // runs its own atomically {} — those nest as savepoints, so per-item failures stay
+                // isolated, but Room's invalidation tracker fires ONCE per page instead of once per
+                // row. On a fresh library that turns ~1000 single-row commits (each re-running the
+                // whole-table observe query → the onboarding GC storm) into a handful of page commits,
+                // and books still stream in page-by-page.
+                val failed =
+                    transactionRunner.atomically {
+                        var failures = 0
+                        for (item in page.items) {
+                            val isTomb = (item as? Tombstoned)?.deletedAt != null
+                            if (handler.onCatchUpItem(item, isTomb) is AppResult.Failure) failures++
+                        }
+                        failures
+                    }
+                if (failed > 0) {
+                    // The cursor still advances (idempotent upserts + a later reconcile re-pulls), but
+                    // surface the loss rather than discarding it silently.
+                    logger.warn { "catchUp(${handler.domainName}): $failed/${page.items.size} items failed to apply" }
                 }
                 page.nextCursor?.let {
                     store.setCursor(handler.domainName, it)
@@ -94,10 +117,12 @@ class SyncCatchUpClient(
                         Page.serializer(handler.payloadSerializer),
                         element,
                     )
-                for (item in page.items) {
-                    val isTomb = (item as? Tombstoned)?.deletedAt != null
-                    handler.onCatchUpItem(item, isTomb)
-                    if (!isTomb) accessibleIds += handler.syncId(item)
+                transactionRunner.atomically {
+                    for (item in page.items) {
+                        val isTomb = (item as? Tombstoned)?.deletedAt != null
+                        handler.onCatchUpItem(item, isTomb)
+                        if (!isTomb) accessibleIds += handler.syncId(item)
+                    }
                 }
                 val next = page.nextCursor
                 if (next != null) since = next

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -78,6 +78,17 @@ class SyncEngine(
     private var currentUser: String? = null
     private var engineJob: Job? = null
 
+    // Serializes + coalesces CursorStale recovery. During initial population the server can emit
+    // CursorStale repeatedly (its replay-bus floor outruns the client's reseeded cursor while the
+    // scan is still writing), and the dispatcher routes each straight into handleCursorStale — on
+    // top of the scan-completion reconcile. Unguarded, every signal started ANOTHER full catchUpAll
+    // concurrently: overlapping page re-decodes (runaway large-object GC) that saturated the
+    // dispatcher and starved the UI. This guard runs at most one recovery at a time and collapses a
+    // burst of triggers into a single follow-up pass.
+    private val cursorStaleMutex = Mutex()
+    private var cursorStaleRunning = false
+    private var cursorStalePending = false
+
     // Flips to true on the last line of [runStart] for the active user. If
     // [runStart] throws before that line, the flag stays false even though
     // engineJob has completed — that's the signal start() uses to retry
@@ -244,8 +255,51 @@ class SyncEngine(
      *     and the loop would spin forever (the H1 bug).
      *  4. Reconnect SSE. Live tail resumes from the new cursor.
      */
-    internal suspend fun handleCursorStale(lastKnown: Long?) {
-        logger.info { "CursorStale received; lastKnown=$lastKnown — disconnect → catchUp → reseed → reconnect" }
+    internal suspend fun handleCursorStale() {
+        // Coalesce: if a recovery is already running, request a single follow-up pass and return
+        // instead of starting a concurrent catchUpAll. The first caller drains the pending flag in a
+        // loop so the last-requested signal is honoured exactly once.
+        val shouldRun =
+            cursorStaleMutex.withLock {
+                if (cursorStaleRunning) {
+                    cursorStalePending = true
+                    false
+                } else {
+                    cursorStaleRunning = true
+                    true
+                }
+            }
+        if (!shouldRun) return
+
+        try {
+            var more = true
+            while (more) {
+                runCursorStaleRecovery()
+                more =
+                    cursorStaleMutex.withLock {
+                        if (cursorStalePending) {
+                            cursorStalePending = false
+                            true
+                        } else {
+                            cursorStaleRunning = false
+                            false
+                        }
+                    }
+            }
+        } finally {
+            // Normal exit already cleared cursorStaleRunning in the loop; this only fires when a
+            // recovery threw or was cancelled, so a future CursorStale can still recover.
+            if (cursorStaleRunning) {
+                cursorStaleMutex.withLock {
+                    cursorStaleRunning = false
+                    cursorStalePending = false
+                }
+            }
+        }
+    }
+
+    private suspend fun runCursorStaleRecovery() {
+        logger.info { "CursorStale recovery — disconnect → catchUp → reseed → reconnect" }
         sseClient.disconnect()
         when (val result = catchUp.catchUpAll(registry)) {
             is AppResult.Success -> {}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -20,7 +20,7 @@ class SyncEventDispatcher(
     private val queue: PendingOperationQueue,
     private val state: SyncEngineState,
     private val cursorAdvance: suspend (domainName: String, revision: Long) -> Unit,
-    private val onCursorStale: suspend (lastKnown: Long?) -> Unit = {},
+    private val onCursorStale: suspend () -> Unit = {},
     private val onAccessChanged: suspend () -> Unit = {},
     private val onUserDeleted: suspend (reason: String?) -> Unit = {},
 ) {
@@ -48,7 +48,7 @@ class SyncEventDispatcher(
                 logger.info {
                     "Cursor stale; signalling engine to orchestrate recovery (lastKnown=${control.lastKnownRevision})"
                 }
-                onCursorStale(control.lastKnownRevision)
+                onCursorStale()
             }
 
             is SyncControl.StreamError -> {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -103,6 +103,7 @@ val clientSyncRenovationModule =
                 httpClientProvider = { apiClientFactory.getClient() },
                 serverUrlProvider = { serverConfig.getServerUrl()?.value },
                 store = get(),
+                transactionRunner = get(),
             )
         }
 
@@ -117,7 +118,7 @@ val clientSyncRenovationModule =
                 // one place. Resolving SyncEngine lazily breaks the Koin
                 // construction cycle (engine depends on dispatcher; dispatcher
                 // only needs engine at runtime, not at construction).
-                onCursorStale = { lastKnown -> get<SyncEngine>().handleCursorStale(lastKnown) },
+                onCursorStale = { get<SyncEngine>().handleCursorStale() },
                 // AccessChanged re-derives the accessible set via catch-up without tearing down
                 // the live tail — same lazy-SyncEngine resolution as onCursorStale to break the
                 // construction cycle.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -630,6 +630,15 @@ val syncModule =
             )
         }
 
+        // ScannerRpcFactory — kotlinx.rpc proxy for ScannerService (public mount):
+        // live scan-progress stream that drives the scan UI + post-scan reconcile.
+        single<com.calypsan.listenup.client.data.remote.ScannerRpcFactory> {
+            com.calypsan.listenup.client.data.remote.KtorScannerRpcFactory(
+                apiClientFactory = get(),
+                serverConfig = get(),
+            )
+        }
+
         // MetadataLookupRpcFactory — kotlinx.rpc proxy for MetadataLookupService.
         single<MetadataLookupRpcFactory> {
             KtorMetadataLookupRpcFactory(
@@ -913,7 +922,7 @@ val syncModule =
 
         // UserRepository for current user profile data (SOLID: interface in domain, impl in data)
         single<UserRepository> {
-            UserRepositoryImpl(userDao = get(), sessionApi = get())
+            UserRepositoryImpl(userDao = get(), authRpcFactory = get())
         }
 
         // UserProfileRepository for other users' profile data (avatars in activity feed, etc.)
@@ -930,6 +939,7 @@ val syncModule =
                 syncEngineState = get(),
                 authSession = get(),
                 listeningEventRecorder = get(),
+                scannerRpcFactory = get(),
                 scope =
                     get(
                         qualifier =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -70,6 +70,15 @@ val authPresentationModule =
             com.calypsan.listenup.client.presentation.setup.LibrarySetupViewModel(
                 libraryAdminRpcFactory = get(),
                 errorBus = get(),
+                // App-lifetime scope: the initial scan triggered after createLibrary must
+                // outlive this wizard (torn down when onboarding finishes and we navigate
+                // to the Shell), so it can't ride viewModelScope.
+                appScope =
+                    get(
+                        qualifier =
+                            org.koin.core.qualifier
+                                .named("appScope"),
+                    ),
             )
         }
     }
@@ -212,9 +221,15 @@ val libraryPresentationModule =
         // Shared selection state - singleton so both ViewModels observe the same state
         single { LibrarySelectionManager() }
 
-        // LibraryViewModel as singleton for preloading - starts loading Room data
-        // immediately when injected at AppShell level, making Library instant
-        single {
+        // factory (NOT single): koinViewModel() then scopes a fresh instance to each
+        // ViewModelStore. A singleton VM is fatal here — when the first owning store is cleared
+        // (e.g. onboarding's backStack.clear()), onCleared() cancels the singleton's viewModelScope,
+        // and the re-served same instance has uiState.stateIn(deadScope) pinned at Loading forever.
+        // Preloading still works: the AppShell's koinViewModel() creates it for the shell's store and
+        // the Library screen reuses that same store-scoped instance. (Matches SearchViewModel below
+        // and sharedUI rule 8; viewModelOf isn't on sharedLogic's classpath, so factory is the
+        // commonMain-equivalent.)
+        factory {
             LibraryViewModel(
                 bookRepository = get(),
                 seriesRepository = get(),
@@ -228,8 +243,8 @@ val libraryPresentationModule =
             )
         }
 
-        // LibraryActionsViewModel as singleton - shares selection state with LibraryViewModel
-        single {
+        // factory — shares selection with LibraryViewModel via the singleton LibrarySelectionManager.
+        factory {
             LibraryActionsViewModel(
                 selectionManager = get(),
                 userRepository = get(),
@@ -464,8 +479,8 @@ val settingsPresentationModule =
         }
         // DevicesViewModel for the Devices (active sessions) screen
         factory { DevicesViewModel(authRepository = get()) }
-        // SyncIndicatorViewModel as singleton for app-wide sync status
-        single { SyncIndicatorViewModel(pendingOperationRepository = get(), syncRepository = get()) }
+        // factory (NOT single) — same cancelled-viewModelScope hazard as the Library VMs above.
+        factory { SyncIndicatorViewModel(pendingOperationRepository = get(), syncRepository = get()) }
         // StorageViewModel for storage management screen
         factory<StorageSpaceProvider> { DownloadFileManagerStorageAdapter(get<DownloadFileManager>()) }
         factory {
@@ -487,7 +502,9 @@ val startupPresentationModule =
             com.calypsan.listenup.client.presentation.startup.AppStartupViewModel(
                 userRepository = get(),
                 libraryAdminRpcFactory = get(),
+                authSession = get(),
                 profileRepository = get(),
+                syncRepository = get(),
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LoginUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LoginUseCase.kt
@@ -48,14 +48,19 @@ open class LoginUseCase(
     }
 
     private suspend fun persistSession(session: AuthSession): AppResult<User> {
+        // Persist the user locally BEFORE flipping auth state. saveAuthTokens moves
+        // AuthState to Authenticated, which immediately spins up the post-login
+        // startup check (AppStartupViewModel); that check reads the current user, so
+        // Room must already hold it or the check races an empty database and reads
+        // null. Save first, then authenticate.
+        val user = session.user.toDomain()
+        userRepository.saveUser(user)
         authSession.saveAuthTokens(
             access = session.accessToken,
             refresh = session.refreshToken,
             sessionId = session.sessionId.value,
             userId = session.user.id.value,
         )
-        val user = session.user.toDomain()
-        userRepository.saveUser(user)
         return AppResult.Success(user)
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/auth/SetupUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/auth/SetupUseCase.kt
@@ -52,14 +52,20 @@ open class SetupUseCase(
     }
 
     private suspend fun persistSession(session: AuthSession): AppResult<User> {
+        // Persist the user locally BEFORE flipping auth state. saveAuthTokens moves
+        // AuthState to Authenticated, which immediately spins up the post-login
+        // startup check (AppStartupViewModel). That check reads the current user to
+        // decide whether an admin still needs to create a library; if Room is empty
+        // because we hadn't saved yet, it reads null and silently lands the admin in
+        // the Shell instead of the Create-Library wizard. Save first, then authenticate.
+        val user = session.user.toDomain()
+        userRepository.saveUser(user)
         authSession.saveAuthTokens(
             access = session.accessToken,
             refresh = session.refreshToken,
             sessionId = session.sessionId.value,
             userId = session.user.id.value,
         )
-        val user = session.user.toDomain()
-        userRepository.saveUser(user)
         return AppResult.Success(user)
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -3,6 +3,7 @@
 package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.core.AppResult
+import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.core.suspendRunCatching
 import com.calypsan.listenup.client.data.remote.PlaybackApiContract
@@ -19,8 +20,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
 import io.ktor.utils.io.readAvailable
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
 import kotlinx.io.buffered
@@ -86,7 +85,7 @@ internal suspend fun downloadAudioFile(
     setProgress: suspend (downloadedBytes: Long, totalBytes: Long) -> Unit = { _, _ -> },
 ): AppResult<Unit> =
     suspendRunCatching {
-        withContext(Dispatchers.IO) {
+        withContext(IODispatcher) {
             // Resolve the download URL (relative — Ktor's defaultRequest provides the base).
             // Phase D: if transcoding is in progress, write WAITING_FOR_SERVER and exit cleanly.
             // SSE transcode.complete handler will re-enqueue via repository.resumeForAudioFile.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/setup/LibrarySetupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/setup/LibrarySetupViewModel.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.LibraryAdminRpcFactory
 import com.calypsan.listenup.core.error.ErrorBus
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,6 +56,7 @@ sealed interface LibrarySetupNavAction {
 class LibrarySetupViewModel(
     private val libraryAdminRpcFactory: LibraryAdminRpcFactory,
     private val errorBus: ErrorBus,
+    private val appScope: CoroutineScope,
 ) : ViewModel() {
     val state: StateFlow<LibrarySetupUiState>
         field = MutableStateFlow(LibrarySetupUiState())
@@ -258,6 +260,7 @@ class LibrarySetupViewModel(
                         )
                     }
                     _navActions.trySend(LibrarySetupNavAction.LibraryCreated(library))
+                    triggerInitialScan(library)
                 }
 
                 is AppResult.Failure -> {
@@ -269,6 +272,35 @@ class LibrarySetupViewModel(
                             error = result.error.message,
                         )
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * Kick off the initial scan of a freshly-created [library].
+     *
+     * The server creates and live-mounts the library on `createLibrary`, but a mounted
+     * watcher only reacts to *future* filesystem changes — existing files are invisible
+     * until an explicit scan walks them. So the wizard must trigger that first scan, or
+     * an onboarded library never yields any books.
+     *
+     * Runs on [appScope], not [viewModelScope]: the server's `scanLibrary` suspends for
+     * the full scan, which easily outlives this wizard (it's torn down the moment
+     * onboarding finishes and the host navigates to the Shell). Tying it to the wizard's
+     * scope would cancel the scan mid-flight. Progress streams to the Shell over SSE;
+     * a failure surfaces on the global error bus.
+     */
+    private fun triggerInitialScan(library: Library) {
+        appScope.launch {
+            when (val result = libraryAdminRpcFactory.get().scanLibrary(library.id)) {
+                is AppResult.Success -> {
+                    logger.info { "Initial scan completed for library ${library.id}" }
+                }
+
+                is AppResult.Failure -> {
+                    errorBus.emit(result.error)
+                    logger.error { "Initial scan failed for library ${library.id}: ${result.error.message}" }
                 }
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -5,12 +5,21 @@ import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.data.remote.LibraryAdminRpcFactory
+import com.calypsan.listenup.client.domain.model.AuthState
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ProfileRepository
+import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
@@ -32,6 +41,14 @@ data class AppStartupState(
     val needsLibrarySetup: Boolean = false,
     val setupCheckFailed: Boolean = false,
     val backgroundedAtMs: Long? = null,
+    /**
+     * True once a setup check has produced a definitive result this authenticated session. Lets the
+     * nav layer keep the readiness overlay up between "authenticated" and the first check result —
+     * otherwise the default `Shell` back-stack entry flashes before the check resolves, because a
+     * not-yet-checked state (`isChecking=false, needsLibrarySetup=false`) is indistinguishable from
+     * a resolved "go to shell" one.
+     */
+    val checkResolved: Boolean = false,
 )
 
 /**
@@ -56,10 +73,44 @@ data class AppStartupState(
 class AppStartupViewModel(
     private val userRepository: UserRepository,
     private val libraryAdminRpcFactory: LibraryAdminRpcFactory,
+    private val authSession: AuthSession,
     private val profileRepository: ProfileRepository,
+    syncRepository: SyncRepository,
 ) : ViewModel() {
     private val _state = MutableStateFlow(AppStartupState())
     val state: StateFlow<AppStartupState> = _state.asStateFlow()
+
+    /**
+     * The single authoritative readiness state the navigation layer consumes via one `when`,
+     * derived from the setup-check [state] and the sync layer's initial-population signal. This is
+     * the consolidation of the previously-scattered overlay/gate booleans into one sealed type.
+     *
+     * Precedence: an unresolved or failed setup check, or a needs-setup answer, always outranks
+     * population — `isServerScanning` is only meaningful once the library exists. Once the library
+     * is populated and the client has imported it (`isServerScanning` false — see `applyScanEvent`),
+     * the state is [LibraryReadiness.Ready].
+     *
+     * `Eagerly`, not `WhileSubscribed`, so [LibraryReadiness] is live for the whole ViewModel
+     * lifetime — the splash gate and lifecycle hooks read state without an active UI subscription.
+     */
+    val readiness: StateFlow<LibraryReadiness> =
+        combine(
+            _state,
+            syncRepository.isServerScanning,
+            syncRepository.scanProgress,
+        ) { s, scanning, progress ->
+            when {
+                !s.checkResolved || s.isChecking -> LibraryReadiness.Checking
+                s.setupCheckFailed -> LibraryReadiness.CheckFailed
+                s.needsLibrarySetup -> LibraryReadiness.NeedsSetup
+                scanning -> LibraryReadiness.Populating(progress)
+                else -> LibraryReadiness.Ready
+            }
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = LibraryReadiness.Checking,
+        )
 
     companion object {
         /** Apps backgrounded longer than this will re-run the library-setup check on resume. */
@@ -67,7 +118,31 @@ class AppStartupViewModel(
     }
 
     init {
-        runLibrarySetupCheck()
+        // The library-setup check must run when the user is AUTHENTICATED — not at
+        // construction. This VM is created eagerly at app launch (MainActivity holds it
+        // for the foreground/background hooks and the splash gate) and is Activity-scoped,
+        // so a one-shot init check would run before login, resolve a null user, cache
+        // "no setup needed", and never re-run once the user actually registers/logs in.
+        // Observing authState re-runs the check on each transition to Authenticated.
+        observeAuthState()
+    }
+
+    private fun observeAuthState() {
+        viewModelScope.launch {
+            authSession.authState
+                .map { it is AuthState.Authenticated }
+                .distinctUntilChanged()
+                .collect { authenticated ->
+                    if (authenticated) {
+                        logger.info { "AppStartupViewModel: authenticated — running library-setup check" }
+                        _state.value = AppStartupState(isChecking = true)
+                        runLibrarySetupCheck()
+                    } else {
+                        logger.debug { "AppStartupViewModel: not authenticated — no library-setup check" }
+                        _state.value = AppStartupState(isChecking = false)
+                    }
+                }
+        }
     }
 
     // region Lifecycle hooks (call from MainActivity)
@@ -98,6 +173,21 @@ class AppStartupViewModel(
 
     // endregion
 
+    /**
+     * Clear the needs-setup state once the user finishes the create-library wizard. Without this the
+     * stale `needsLibrarySetup = true` keeps the nav layer's pre-wizard readiness overlay latched on
+     * top of the shell forever after setup. Call from the setup-complete callback.
+     */
+    fun onLibrarySetupComplete() {
+        _state.value =
+            _state.value.copy(
+                isChecking = false,
+                needsLibrarySetup = false,
+                setupCheckFailed = false,
+                checkResolved = true,
+            )
+    }
+
     /** Re-run the library-setup check after a transient failure (the retry the nav layer offers). */
     fun retryLibrarySetupCheck() {
         _state.value = AppStartupState(isChecking = true)
@@ -108,7 +198,7 @@ class AppStartupViewModel(
         viewModelScope.launch {
             try {
                 val user = userRepository.refreshCurrentUser() ?: userRepository.getCurrentUser()
-                logger.debug { "AppStartupViewModel: user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
+                logger.info { "AppStartupViewModel: resolved user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
 
                 // Refresh own profile in the background — keeps displayName/tagline/avatarType in sync.
                 // Fire-and-forget: never blocks the startup check or surfaces failures to the UI.
@@ -133,6 +223,7 @@ class AppStartupViewModel(
                                     isChecking = false,
                                     needsLibrarySetup = result.data.needsSetup,
                                     setupCheckFailed = false,
+                                    checkResolved = true,
                                 )
                         }
 
@@ -140,22 +231,29 @@ class AppStartupViewModel(
                             // Honest over silent: never drop an admin into an empty Shell when the
                             // check fails. Surface a retryable error instead of forcing the wizard.
                             logger.warn { "AppStartupViewModel: library status check failed: ${result.error.code}" }
-                            _state.value = _state.value.copy(isChecking = false, setupCheckFailed = true)
+                            _state.value =
+                                _state.value.copy(isChecking = false, setupCheckFailed = true, checkResolved = true)
                         }
                     }
                 } else {
+                    logger.info {
+                        "AppStartupViewModel: not an admin (user=${user?.displayName}, isAdmin=${user?.isAdmin}) — " +
+                            "skipping library-setup check"
+                    }
                     _state.value =
                         _state.value.copy(
                             isChecking = false,
                             needsLibrarySetup = false,
                             setupCheckFailed = false,
+                            checkResolved = true,
                         )
                 }
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                 throw e
             } catch (e: Exception) {
                 logger.warn(e) { "AppStartupViewModel: setup check failed unexpectedly" }
-                _state.value = _state.value.copy(isChecking = false, setupCheckFailed = true)
+                _state.value =
+                    _state.value.copy(isChecking = false, setupCheckFailed = true, checkResolved = true)
             }
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadiness.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadiness.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.client.presentation.startup
+
+import com.calypsan.listenup.client.domain.model.ScanProgressState
+
+/**
+ * The single authoritative answer to "what should the app show right now?" during the
+ * authenticated-startup window — before the library shell is safe to mount.
+ *
+ * Replaces the five raw signals the navigation layer used to juggle (`isChecking`,
+ * `needsLibrarySetup`, `setupCheckFailed`, `checkResolved`, `isServerScanning`) with one sealed
+ * state the nav consumes via a single `when`. Produced by
+ * [AppStartupViewModel.readiness] as a pure derivation of the setup-check state and the
+ * sync layer's scan signal.
+ *
+ * The states are mutually exclusive and ordered by precedence: a server-setup question
+ * ([Checking]/[CheckFailed]/[NeedsSetup]) always outranks population progress, which outranks
+ * [Ready].
+ */
+sealed interface LibraryReadiness {
+    /** The library-setup check is in flight (or hasn't resolved yet). Show the splash/loading gate. */
+    data object Checking : LibraryReadiness
+
+    /** An admin must create a library before anything else can happen. Drive the setup wizard. */
+    data object NeedsSetup : LibraryReadiness
+
+    /**
+     * The initial library population is in progress and not yet visible in the client's Room — either
+     * the server is still scanning or the client is still importing the scanned books (see
+     * `applyScanEvent`). Show the dedicated populating screen and do NOT mount the shell. [progress]
+     * is the live scan progress when available, null during the indeterminate "finishing up" import.
+     */
+    data class Populating(
+        val progress: ScanProgressState?,
+    ) : LibraryReadiness
+
+    /** A populated library is queryable in Room. Mount the shell. */
+    data object Ready : LibraryReadiness
+
+    /**
+     * The setup check could not be completed (transient network/server error). Honest over silent:
+     * surface a retryable error instead of dropping the admin into an empty shell.
+     */
+    data object CheckFailed : LibraryReadiness
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -1,0 +1,182 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.client.domain.model.ScanProgressState
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit tests for [applyScanEvent], the reducer that drives the scan-progress UI state and the
+ * post-scan reconcile in [SyncRepositoryImpl].
+ *
+ * The key regression: `ScanEvent.Completed` must invoke `reconcile` (the catch-up that pulls
+ * books the lossy live tail dropped during the scan burst) — without it, a just-scanned library
+ * shows no books until the app is relaunched.
+ */
+class SyncRepositoryScanProgressTest :
+    FunSpec({
+
+        fun progressEvent(
+            booksAnalyzed: Int,
+            filesWalked: Int,
+        ) = ScanEvent.Progress(
+            correlationId = "c1",
+            libraryId = LibraryId("lib-1"),
+            phase = ScanPhase.ANALYZING,
+            filesWalked = filesWalked,
+            booksAnalyzed = booksAnalyzed,
+            errors = 0,
+        )
+
+        fun completedEvent() =
+            ScanEvent.Completed(
+                correlationId = "c1",
+                libraryId = LibraryId("lib-1"),
+                result =
+                    ScanResultSummary(
+                        correlationId = "c1",
+                        totalBooks = 1,
+                        added = 1,
+                        modified = 0,
+                        removed = 0,
+                        moved = 0,
+                        errors = 0,
+                        durationMs = 10,
+                        filesWalked = 1,
+                    ),
+            )
+
+        test("Completed triggers a reconcile and clears scanning state") {
+            runTest {
+                var scanning: Boolean? = null
+                var progress: ScanProgressState? = ScanProgressState("ANALYZING", 5, 10, 0, 0, 0)
+                var reconciled = false
+                var initialComplete = false
+
+                applyScanEvent(
+                    event = completedEvent(),
+                    isInitialScanComplete = { initialComplete },
+                    setScanning = { scanning = it },
+                    setProgress = { progress = it },
+                    markInitialScanComplete = { initialComplete = true },
+                    reconcile = { reconciled = true },
+                )
+
+                reconciled shouldBe true
+                scanning shouldBe false
+                progress shouldBe null
+                initialComplete shouldBe true
+            }
+        }
+
+        // The residual onboarding bug: `ScanEvent.Completed` means the SERVER persisted the books,
+        // not that the CLIENT's Room reflects them — the catch-up reconcile still has to run. Clearing
+        // `scanning` (the populating gate) on Completed mounted the shell while books were still being
+        // imported. The honest fix keeps the gate up until the awaited reconcile finishes, THEN clears
+        // and latches.
+        test("Completed keeps the populating gate up until the reconcile completes, then clears and latches") {
+            runTest {
+                var scanning = true
+                var initialComplete = false
+                val reconcileGate = CompletableDeferred<Unit>()
+                var scanningSeenDuringReconcile: Boolean? = null
+                var initialSeenDuringReconcile: Boolean? = null
+
+                val job =
+                    launch {
+                        applyScanEvent(
+                            event = completedEvent(),
+                            isInitialScanComplete = { initialComplete },
+                            setScanning = { scanning = it },
+                            setProgress = { },
+                            markInitialScanComplete = { initialComplete = true },
+                            reconcile = {
+                                scanningSeenDuringReconcile = scanning
+                                initialSeenDuringReconcile = initialComplete
+                                reconcileGate.await()
+                            },
+                        )
+                    }
+
+                // Let the reducer reach the (suspended) reconcile.
+                runCurrent()
+                scanningSeenDuringReconcile shouldBe true // gate still up while books import
+                initialSeenDuringReconcile shouldBe false // not latched until import finishes
+                scanning shouldBe true
+
+                // Import finishes → gate clears, readiness latches.
+                reconcileGate.complete(Unit)
+                job.join()
+                scanning shouldBe false
+                initialComplete shouldBe true
+            }
+        }
+
+        test("Progress maps to ScanProgressState and marks scanning, without reconciling") {
+            runTest {
+                var scanning: Boolean? = null
+                var progress: ScanProgressState? = null
+                var reconciled = false
+
+                applyScanEvent(
+                    event = progressEvent(booksAnalyzed = 40, filesWalked = 100),
+                    isInitialScanComplete = { false },
+                    setScanning = { scanning = it },
+                    setProgress = { progress = it },
+                    markInitialScanComplete = { },
+                    reconcile = { reconciled = true },
+                )
+
+                scanning shouldBe true
+                progress?.current shouldBe 40
+                progress?.total shouldBe 100
+                reconciled shouldBe false
+            }
+        }
+
+        // The regression behind the latched full-screen overlay: a watcher-driven incremental scan
+        // emits its own Started/Progress AFTER the initial scan completes. Those must NOT re-arm the
+        // app-readiness flag, or they slam the "Scanning…" overlay back over an already-usable library.
+        test("an incremental scan after the initial scan completes does not re-block the shell") {
+            runTest {
+                var scanning = false
+                var initialComplete = false
+                val apply: suspend (ScanEvent) -> Unit = { event ->
+                    applyScanEvent(
+                        event = event,
+                        isInitialScanComplete = { initialComplete },
+                        setScanning = { scanning = it },
+                        setProgress = { },
+                        markInitialScanComplete = { initialComplete = true },
+                        reconcile = { },
+                    )
+                }
+
+                // Initial population scan.
+                apply(
+                    ScanEvent.Started(correlationId = "full", libraryId = LibraryId("lib-1"), rootPath = "/library"),
+                )
+                scanning shouldBe true
+                apply(progressEvent(booksAnalyzed = 10, filesWalked = 20))
+                scanning shouldBe true
+                apply(completedEvent())
+                scanning shouldBe false
+                initialComplete shouldBe true
+
+                // Watcher-driven incremental scan (fresh correlationId) — must stay out of the shell.
+                apply(
+                    ScanEvent.Started(correlationId = "incremental", libraryId = LibraryId("lib-1"), rootPath = "/library"),
+                )
+                scanning shouldBe false
+                apply(progressEvent(booksAnalyzed = 1, filesWalked = 1))
+                scanning shouldBe false
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserRepositoryImplTest.kt
@@ -1,13 +1,20 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.api.AuthServiceAuthed
+import com.calypsan.listenup.api.dto.auth.User as ContractUser
 import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.auth.UserStatus
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.local.db.UserEntity
-import com.calypsan.listenup.client.data.remote.SessionApiContract
+import com.calypsan.listenup.client.data.remote.AuthRpcFactory
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -77,7 +84,7 @@ class UserRepositoryImplTest {
 
     private fun createMockUserDao(): UserDao = mock<UserDao>()
 
-    private fun createMockSessionApi(): SessionApiContract = mock<SessionApiContract>()
+    private fun createMockAuthRpcFactory(): AuthRpcFactory = mock<AuthRpcFactory>()
 
     // ========== observeCurrentUser Tests ==========
 
@@ -88,8 +95,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity()
             every { userDao.observeCurrentUser() } returns flowOf(entity)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.observeCurrentUser().first()
@@ -107,8 +114,8 @@ class UserRepositoryImplTest {
             // Given
             val userDao = createMockUserDao()
             every { userDao.observeCurrentUser() } returns flowOf(null)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.observeCurrentUser().first()
@@ -126,8 +133,8 @@ class UserRepositoryImplTest {
             val updatedUser = createTestUserEntity(displayName = "Updated Name")
             // Flow emits null -> user1 -> user2 -> null
             every { userDao.observeCurrentUser() } returns flowOf(null, initialUser, updatedUser, null)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val emissions = repository.observeCurrentUser().take(4).toList()
@@ -148,8 +155,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(isRoot = true)
             every { userDao.observeCurrentUser() } returns flowOf(entity)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val isAdmin = repository.observeIsAdmin().first()
@@ -165,8 +172,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(isRoot = false)
             every { userDao.observeCurrentUser() } returns flowOf(entity)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val isAdmin = repository.observeIsAdmin().first()
@@ -181,8 +188,8 @@ class UserRepositoryImplTest {
             // Given
             val userDao = createMockUserDao()
             every { userDao.observeCurrentUser() } returns flowOf(null)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val isAdmin = repository.observeIsAdmin().first()
@@ -200,8 +207,8 @@ class UserRepositoryImplTest {
             val adminUser = createTestUserEntity(isRoot = true)
             // Flow: null -> regular -> admin -> regular
             every { userDao.observeCurrentUser() } returns flowOf(null, regularUser, adminUser, regularUser)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val emissions = repository.observeIsAdmin().take(4).toList()
@@ -220,8 +227,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val userFlow = MutableStateFlow<UserEntity?>(null)
             every { userDao.observeCurrentUser() } returns userFlow
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When/Then - initial state
             assertFalse(repository.observeIsAdmin().first())
@@ -248,8 +255,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity()
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -266,11 +273,67 @@ class UserRepositoryImplTest {
             // Given
             val userDao = createMockUserDao()
             everySuspend { userDao.getCurrentUser() } returns null
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
+
+            // Then
+            assertNull(user)
+        }
+
+    // ========== refreshCurrentUser (RPC) Tests ==========
+
+    @Test
+    fun `refreshCurrentUser fetches the user via RPC AuthServiceAuthed and persists it`() =
+        runTest {
+            // Given - the authed RPC proxy returns a ROOT user
+            val userDao = createMockUserDao()
+            everySuspend { userDao.upsert(any()) } returns Unit
+            val authed = mock<AuthServiceAuthed>()
+            everySuspend { authed.currentUser() } returns
+                AppResult.Success(
+                    ContractUser(
+                        id = UserId("root-1"),
+                        email = "root@example.com",
+                        displayName = "Root Admin",
+                        role = UserRole.ROOT,
+                        status = UserStatus.ACTIVE,
+                        createdAt = 1_700_000_000_000L,
+                    ),
+                )
+            val authRpcFactory = createMockAuthRpcFactory()
+            everySuspend { authRpcFactory.authedService() } returns authed
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+
+            // When
+            val user = repository.refreshCurrentUser()
+
+            // Then - ROOT maps to admin and the user is persisted to Room
+            assertNotNull(user)
+            assertEquals("root@example.com", user.email)
+            assertTrue(user.isAdmin)
+            verifySuspend { userDao.upsert(any()) }
+        }
+
+    @Test
+    fun `refreshCurrentUser returns null when the RPC call fails`() =
+        runTest {
+            // Given
+            val userDao = createMockUserDao()
+            val authed = mock<AuthServiceAuthed>()
+            everySuspend { authed.currentUser() } returns
+                AppResult.Failure(
+                    com.calypsan.listenup.api.error.TransportError
+                        .NetworkUnavailable(),
+                )
+            val authRpcFactory = createMockAuthRpcFactory()
+            everySuspend { authRpcFactory.authedService() } returns authed
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+
+            // When
+            val user = repository.refreshCurrentUser()
 
             // Then
             assertNull(user)
@@ -285,8 +348,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(id = "unique-user-id-123")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -302,8 +365,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(email = "user@listenup.app")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -319,8 +382,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(displayName = "Bookworm Betty")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -336,8 +399,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(firstName = "Elizabeth")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -353,8 +416,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(firstName = null)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -370,8 +433,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(lastName = "Bennet")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -387,8 +450,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(lastName = null)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -404,8 +467,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(isRoot = true)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -421,8 +484,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(isRoot = false)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -438,8 +501,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(avatarType = "auto")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -455,8 +518,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(avatarType = "image")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -476,8 +539,8 @@ class UserRepositoryImplTest {
                     avatarValue = "/avatars/user-001.jpg",
                 )
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -493,8 +556,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(avatarValue = null)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -510,8 +573,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(avatarColor = "#EF4444")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -527,8 +590,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(tagline = "Fantasy is my escape")
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -544,8 +607,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val entity = createTestUserEntity(tagline = null)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -562,8 +625,8 @@ class UserRepositoryImplTest {
             val timestamp = 1704067200000L // 2024-01-01 00:00:00 UTC
             val entity = createTestUserEntity(createdAt = timestamp)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -580,8 +643,8 @@ class UserRepositoryImplTest {
             val timestamp = 1704153600000L // 2024-01-02 00:00:00 UTC
             val entity = createTestUserEntity(updatedAt = timestamp)
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -616,8 +679,8 @@ class UserRepositoryImplTest {
                             .Timestamp(1705000000000L),
                 )
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -652,8 +715,8 @@ class UserRepositoryImplTest {
                     avatarColor = "",
                 )
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -676,8 +739,8 @@ class UserRepositoryImplTest {
                     updatedAt = 0L,
                 )
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -700,8 +763,8 @@ class UserRepositoryImplTest {
                     updatedAt = maxTimestamp,
                 )
             everySuspend { userDao.getCurrentUser() } returns entity
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val user = repository.getCurrentUser()
@@ -731,8 +794,8 @@ class UserRepositoryImplTest {
                     avatarValue = "/path/to/avatar.jpg",
                 )
             every { userDao.observeCurrentUser() } returns flowOf(user1Entity, user2Entity)
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When
             val emissions = repository.observeCurrentUser().take(2).toList()
@@ -759,8 +822,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val userFlow = MutableStateFlow<UserEntity?>(null)
             every { userDao.observeCurrentUser() } returns userFlow
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When/Then - initial null
             assertNull(repository.observeCurrentUser().first())
@@ -787,13 +850,13 @@ class UserRepositoryImplTest {
         runTest {
             // Given
             val userDao = createMockUserDao()
-            val sessionApi = createMockSessionApi()
+            val authRpcFactory = createMockAuthRpcFactory()
             every { userDao.observeCurrentUser() } returns flowOf(null)
             everySuspend { userDao.getCurrentUser() } returns null
 
             // When
             val repository: com.calypsan.listenup.client.domain.repository.UserRepository =
-                UserRepositoryImpl(userDao, sessionApi)
+                UserRepositoryImpl(userDao, authRpcFactory)
 
             // Then - all methods are accessible via interface
             assertNull(repository.observeCurrentUser().first())
@@ -808,8 +871,8 @@ class UserRepositoryImplTest {
             val userDao = createMockUserDao()
             val userFlow = MutableStateFlow<UserEntity?>(null)
             every { userDao.observeCurrentUser() } returns userFlow
-            val sessionApi = createMockSessionApi()
-            val repository = UserRepositoryImpl(userDao, sessionApi)
+            val authRpcFactory = createMockAuthRpcFactory()
+            val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
             // When/Then - null user
             assertFalse(repository.observeIsAdmin().first())

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClientTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClientTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.sync
 
+import com.calypsan.listenup.client.test.db.passThroughTransactionRunner
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.sync.DomainList
 import com.calypsan.listenup.api.sync.Page
@@ -113,6 +114,7 @@ class SyncCatchUpClientTest :
                         httpClientProvider = { httpClient },
                         serverUrlProvider = { "http://test" },
                         store = store,
+                        transactionRunner = passThroughTransactionRunner(),
                     )
 
                 val result = catchUp.catchUp(handler)
@@ -149,6 +151,7 @@ class SyncCatchUpClientTest :
                         httpClientProvider = { httpClient },
                         serverUrlProvider = { "http://test" },
                         store = store,
+                        transactionRunner = passThroughTransactionRunner(),
                     )
 
                 catchUp.catchUp(handler).shouldBeInstanceOf<AppResult.Success<Unit>>()
@@ -171,6 +174,7 @@ class SyncCatchUpClientTest :
                         httpClientProvider = { httpClient },
                         serverUrlProvider = { "http://test" },
                         store = SyncCursorStore(InMemorySyncCursorDao()),
+                        transactionRunner = passThroughTransactionRunner(),
                     )
 
                 val result = catchUp.domains()
@@ -235,6 +239,7 @@ class SyncCatchUpClientTest :
                         httpClientProvider = { httpClient },
                         serverUrlProvider = { "http://test" },
                         store = SyncCursorStore(InMemorySyncCursorDao()),
+                        transactionRunner = passThroughTransactionRunner(),
                     )
 
                 catchUp.catchUpAll(registry).shouldBeInstanceOf<AppResult.Success<Unit>>()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LoginUseCaseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/auth/LoginUseCaseTest.kt
@@ -17,12 +17,14 @@ import com.calypsan.listenup.client.domain.model.User
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.UserRepository
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
@@ -200,6 +202,28 @@ class LoginUseCaseTest :
                     )
                 }
                 verifySuspend { fixture.userRepository.saveUser(any()) }
+            }
+        }
+
+        // The post-login startup check (AppStartupViewModel) runs the instant
+        // authState flips to Authenticated. saveAuthTokens is what flips it, so if
+        // it runs before saveUser the check races an empty Room and reads a null
+        // user. Record both calls into one sequence so the test fails if the order
+        // is ever reversed.
+        test("login persists the user locally before flipping auth state to Authenticated") {
+            runTest {
+                val events = mutableListOf<String>()
+                val fixture = LoginFixture()
+                everySuspend { fixture.userRepository.saveUser(any()) } calls { events.add("saveUser") }
+                everySuspend {
+                    fixture.authSession.saveAuthTokens(any(), any(), any(), any())
+                } calls { events.add("saveAuthTokens") }
+                everySuspend { fixture.authRepository.login(any()) } returns AppResult.Success(createAuthSession())
+                val useCase = fixture.build()
+
+                useCase(email = "user@example.com", password = "password123")
+
+                events shouldContainInOrder listOf("saveUser", "saveAuthTokens")
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/auth/SetupUseCaseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/auth/SetupUseCaseTest.kt
@@ -17,12 +17,14 @@ import com.calypsan.listenup.client.domain.model.User
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.UserRepository
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
@@ -232,6 +234,34 @@ class SetupUseCaseTest :
                     )
                 }
                 verifySuspend { fixture.userRepository.saveUser(any()) }
+            }
+        }
+
+        // The post-login startup check (AppStartupViewModel) runs the instant
+        // authState flips to Authenticated. saveAuthTokens is what flips it, so if
+        // it runs before saveUser the check races an empty Room, reads a null user,
+        // and silently drops the freshly-created admin into the Shell instead of the
+        // Create-Library wizard. Record both calls into one sequence so the test
+        // fails if the order is ever reversed.
+        test("setup persists the user locally before flipping auth state to Authenticated") {
+            runTest {
+                val events = mutableListOf<String>()
+                val fixture = SetupFixture()
+                everySuspend { fixture.userRepository.saveUser(any()) } calls { events.add("saveUser") }
+                everySuspend {
+                    fixture.authSession.saveAuthTokens(any(), any(), any(), any())
+                } calls { events.add("saveAuthTokens") }
+                everySuspend { fixture.authRepository.setup(any()) } returns AppResult.Success(createAuthSession())
+                val useCase = fixture.build()
+
+                useCase(
+                    email = "root@example.com",
+                    password = "password123",
+                    firstName = "Root",
+                    lastName = "Admin",
+                )
+
+                events shouldContainInOrder listOf("saveUser", "saveAuthTokens")
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/setup/LibrarySetupViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/setup/LibrarySetupViewModelTest.kt
@@ -19,6 +19,7 @@ import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -57,7 +58,13 @@ class LibrarySetupViewModelTest :
 
         // ── Helpers ──────────────────────────────────────────────────────────────
 
-        fun makeService(): LibraryAdminService = mock<LibraryAdminService>()
+        fun makeService(): LibraryAdminService =
+            mock<LibraryAdminService> {
+                // Default: the post-create initial scan trigger is a no-op success unless a
+                // test overrides it. Keeps createLibrary-success tests from hitting an
+                // unstubbed call when the wizard fires the scan.
+                everySuspend { scanLibrary(any()) } returns AppResult.Success(Unit)
+            }
 
         fun makeFactory(service: LibraryAdminService): LibraryAdminRpcFactory =
             mock<LibraryAdminRpcFactory>().also {
@@ -86,7 +93,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.getSetupStatus() } returns
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.state.value.isCheckingStatus shouldBe false
@@ -102,7 +109,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.browseFilesystem(any()) } returns
                     AppResult.Success(emptyList())
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.state.value.needsSetup shouldBe true
@@ -117,7 +124,7 @@ class LibrarySetupViewModelTest :
                 val error = InternalError()
                 everySuspend { service.getSetupStatus() } returns AppResult.Failure(error)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), errorBus)
+                val vm = LibrarySetupViewModel(makeFactory(service), errorBus, CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.state.value.isCheckingStatus shouldBe false
@@ -140,7 +147,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.browseFilesystem("/data") } returns
                     AppResult.Success(entries)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.loadDirectory("/data")
@@ -160,7 +167,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.browseFilesystem("/") } returns
                     AppResult.Success(emptyList())
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.loadDirectory("/")
@@ -179,7 +186,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.browseFilesystem("/data/audiobooks") } returns
                     AppResult.Success(emptyList())
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.loadDirectory("/data/audiobooks")
@@ -198,7 +205,7 @@ class LibrarySetupViewModelTest :
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
                 everySuspend { service.browseFilesystem(any()) } returns AppResult.Failure(error)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.loadDirectory("/data")
                 advanceUntilIdle()
@@ -216,7 +223,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.getSetupStatus() } returns
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.createLibrary()
@@ -232,7 +239,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.getSetupStatus() } returns
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.togglePath("/data/audiobooks")
                 vm.setLibraryName("   ")
@@ -253,7 +260,7 @@ class LibrarySetupViewModelTest :
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
                 everySuspend { service.createLibrary(any()) } returns AppResult.Success(library)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.togglePath("/data/audiobooks")
                 vm.setLibraryName("My Library")
@@ -281,7 +288,7 @@ class LibrarySetupViewModelTest :
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
                 everySuspend { service.createLibrary(any()) } returns AppResult.Success(library)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.togglePath("/data/audiobooks")
 
@@ -291,6 +298,28 @@ class LibrarySetupViewModelTest :
                 val action = vm.navActions.first()
                 (action is LibrarySetupNavAction.LibraryCreated) shouldBe true
                 (action as LibrarySetupNavAction.LibraryCreated).library shouldBe library
+            }
+        }
+
+        test("createLibrary success triggers an initial scan of the new library") {
+            runTest {
+                val service = makeService()
+                val library = makeLibrary()
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
+                everySuspend { service.createLibrary(any()) } returns AppResult.Success(library)
+
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
+                advanceUntilIdle()
+                vm.togglePath("/data/audiobooks")
+                vm.setLibraryName("My Library")
+
+                vm.createLibrary()
+                advanceUntilIdle()
+
+                // The server live-mounts a watcher on create but never scans existing files;
+                // the wizard must explicitly trigger the initial scan or no books ever appear.
+                verifySuspend(VerifyMode.exactly(1)) { service.scanLibrary(library.id) }
             }
         }
 
@@ -304,7 +333,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.createLibrary(any()) } sequentiallyReturns
                     listOf(AppResult.Success(lib1), AppResult.Success(lib2))
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 // First library creation
@@ -335,7 +364,7 @@ class LibrarySetupViewModelTest :
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
                 everySuspend { service.createLibrary(any()) } returns AppResult.Failure(error)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.togglePath("/data/audiobooks")
 
@@ -356,7 +385,7 @@ class LibrarySetupViewModelTest :
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
                 everySuspend { service.createLibrary(any()) } returns AppResult.Failure(error)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.togglePath("/data/audiobooks")
 
@@ -376,7 +405,7 @@ class LibrarySetupViewModelTest :
                 everySuspend { service.getSetupStatus() } returns
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
 
                 vm.finishOnboarding()
@@ -397,7 +426,7 @@ class LibrarySetupViewModelTest :
                     AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
                 everySuspend { service.createLibrary(any()) } returns AppResult.Success(library)
 
-                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus())
+                val vm = LibrarySetupViewModel(makeFactory(service), ErrorBus(), CoroutineScope(testDispatcher))
                 advanceUntilIdle()
                 vm.togglePath("/data/audiobooks")
                 vm.togglePath("/data/podcasts")

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -2,18 +2,24 @@ package com.calypsan.listenup.client.presentation.startup
 
 import com.calypsan.listenup.api.LibraryAdminService
 import com.calypsan.listenup.api.dto.SetupStatus
+import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.LibraryAdminRpcFactory
+import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.domain.model.User
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ProfileRepository
+import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.core.AppResult as CoreAppResult
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -58,17 +64,36 @@ class AppStartupViewModelTest {
 
     private fun createMockUserRepository(): UserRepository = mock<UserRepository>()
 
+    /** No-op [ProfileRepository] mock — profile refresh is fire-and-forget and not exercised here. */
+    private fun createNoOpProfileRepository(): ProfileRepository {
+        val repo = mock<ProfileRepository>()
+        everySuspend { repo.refreshMyProfile() } returns CoreAppResult.Success(Unit)
+        return repo
+    }
+
+    // readiness derives from the sync layer's scan signal; these tests don't drive a scan, so a
+    // not-scanning stub is all the aggregator needs.
+    private fun createMockSyncRepository(): SyncRepository {
+        val sync = mock<SyncRepository>()
+        every { sync.isServerScanning } returns MutableStateFlow(false)
+        every { sync.scanProgress } returns MutableStateFlow(null)
+        return sync
+    }
+
     private fun createMockLibraryAdminRpcFactory(service: LibraryAdminService = mock()): LibraryAdminRpcFactory {
         val factory = mock<LibraryAdminRpcFactory>()
         everySuspend { factory.get() } returns service
         return factory
     }
 
-    /** No-op [ProfileRepository] mock — profile refresh is fire-and-forget and not exercised here. */
-    private fun createNoOpProfileRepository(): ProfileRepository {
-        val repo = mock<ProfileRepository>()
-        everySuspend { repo.refreshMyProfile() } returns CoreAppResult.Success(Unit)
-        return repo
+    // The setup check now runs off authState transitions to Authenticated, so the VM needs an
+    // AuthSession. Default to already-Authenticated so existing tests exercise the check as before.
+    private fun createMockAuthSession(
+        authState: AuthState = AuthState.Authenticated(UserId("user-001"), SessionId("session-001")),
+    ): AuthSession {
+        val session = mock<AuthSession>()
+        every { session.authState } returns MutableStateFlow(authState)
+        return session
     }
 
     private fun createTestUser(
@@ -112,7 +137,7 @@ class AppStartupViewModelTest {
             everySuspend { userRepository.getCurrentUser() } returns null
 
             // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
 
             // Then - initial state before coroutine completes
             assertTrue(viewModel.state.value.isChecking)
@@ -129,7 +154,7 @@ class AppStartupViewModelTest {
             everySuspend { userRepository.getCurrentUser() } returns regularUser
 
             // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Then
@@ -151,10 +176,48 @@ class AppStartupViewModelTest {
                 AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
 
             // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Then
+            assertFalse(viewModel.state.value.isChecking)
+            assertTrue(viewModel.state.value.needsLibrarySetup)
+        }
+
+    // Regression: the VM is created eagerly at app launch (before login). The setup check
+    // must NOT run at construction against a null/unauthenticated user — it must run when
+    // authState becomes Authenticated, and re-run on that transition. Before the fix, the
+    // init-time check resolved a null user, cached "no setup needed", and never re-ran after
+    // the user registered, stranding the admin on the homepage instead of the wizard.
+    @Test
+    fun `setup check runs on transition to Authenticated, not at construction`() =
+        runTest {
+            // Given - admin + a library that needs setup, but NOT yet authenticated
+            val userRepository = createMockUserRepository()
+            val service = mock<LibraryAdminService>()
+            val factory = createMockLibraryAdminRpcFactory(service)
+            val adminUser = createTestUser(isAdmin = true)
+            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+            everySuspend { userRepository.getCurrentUser() } returns adminUser
+            everySuspend { service.getSetupStatus() } returns
+                AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
+            val authState = MutableStateFlow<AuthState>(AuthState.NeedsLogin(openRegistration = false))
+            val authSession = mock<AuthSession>()
+            every { authSession.authState } returns authState
+
+            // When - constructed before login (as MainActivity does at app launch)
+            val viewModel = AppStartupViewModel(userRepository, factory, authSession, createNoOpProfileRepository(), createMockSyncRepository())
+            advanceUntilIdle()
+
+            // Then - no premature check; not dropped into the wizard
+            assertFalse(viewModel.state.value.isChecking)
+            assertFalse(viewModel.state.value.needsLibrarySetup)
+
+            // When - the user authenticates (creates the account)
+            authState.value = AuthState.Authenticated(UserId("user-001"), SessionId("session-001"))
+            advanceUntilIdle()
+
+            // Then - the check runs against the authenticated admin → routes to the wizard
             assertFalse(viewModel.state.value.isChecking)
             assertTrue(viewModel.state.value.needsLibrarySetup)
         }
@@ -169,7 +232,7 @@ class AppStartupViewModelTest {
             val factory = createMockLibraryAdminRpcFactory()
             everySuspend { userRepository.refreshCurrentUser() } returns null
             everySuspend { userRepository.getCurrentUser() } returns null
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // When
@@ -189,7 +252,7 @@ class AppStartupViewModelTest {
             val factory = createMockLibraryAdminRpcFactory()
             everySuspend { userRepository.refreshCurrentUser() } returns null
             everySuspend { userRepository.getCurrentUser() } returns null
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Verify backgroundedAtMs is null before the call
@@ -212,7 +275,7 @@ class AppStartupViewModelTest {
             val factory = createMockLibraryAdminRpcFactory()
             everySuspend { userRepository.refreshCurrentUser() } returns null
             everySuspend { userRepository.getCurrentUser() } returns null
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Initial check is complete, isChecking should be false
@@ -245,7 +308,7 @@ class AppStartupViewModelTest {
                 AppResult.Failure(TransportError.NetworkUnavailable())
 
             // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Then - check is settled, failure surfaced, NOT forced into the wizard
@@ -268,7 +331,7 @@ class AppStartupViewModelTest {
                 AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
 
             // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Then
@@ -288,7 +351,7 @@ class AppStartupViewModelTest {
             everySuspend { userRepository.getCurrentUser() } returns regularUser
 
             // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Then
@@ -310,7 +373,7 @@ class AppStartupViewModelTest {
             everySuspend { service.getSetupStatus() } returns
                 AppResult.Failure(TransportError.NetworkUnavailable())
 
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
             assertTrue(viewModel.state.value.setupCheckFailed)
 
@@ -341,7 +404,7 @@ class AppStartupViewModelTest {
             everySuspend { service.getSetupStatus() } returns
                 AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
 
-            val viewModel = AppStartupViewModel(userRepository, factory, createNoOpProfileRepository())
+            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
             advanceUntilIdle()
 
             // Verify initial state

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadinessTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadinessTest.kt
@@ -1,0 +1,188 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.client.presentation.startup
+
+import app.cash.turbine.test
+import com.calypsan.listenup.api.LibraryAdminService
+import com.calypsan.listenup.api.dto.SetupStatus
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.LibraryAdminRpcFactory
+import com.calypsan.listenup.client.domain.model.AuthState
+import com.calypsan.listenup.client.domain.model.ScanProgressState
+import com.calypsan.listenup.client.domain.model.User
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.ProfileRepository
+import com.calypsan.listenup.client.domain.repository.SyncRepository
+import com.calypsan.listenup.client.domain.repository.UserRepository
+import com.calypsan.listenup.core.AppResult as CoreAppResult
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+/**
+ * Behavioural spec for [AppStartupViewModel.readiness] — the single authoritative onboarding state
+ * the navigation layer consumes via one `when`. Drives the VM through the three onboarding journeys
+ * and asserts the exact [LibraryReadiness] transition sequence via Turbine.
+ *
+ * The load-bearing case is `fresh admin`: `Ready` must arrive only after the populating signal
+ * clears — proving the gate spans the client's import, not just the server's scan.
+ */
+class LibraryReadinessTest :
+    FunSpec({
+        val dispatcher = StandardTestDispatcher()
+
+        beforeTest { Dispatchers.setMain(dispatcher) }
+        afterTest { Dispatchers.resetMain() }
+
+        fun adminUser() =
+            User(
+                id = UserId("user-001"),
+                email = "admin@example.com",
+                displayName = "Admin",
+                firstName = null,
+                lastName = null,
+                isAdmin = true,
+                avatarType = "auto",
+                avatarValue = null,
+                avatarColor = "#3B82F6",
+                tagline = null,
+                createdAtMs = 0L,
+                updatedAtMs = 0L,
+            )
+
+        fun userRepoReturning(user: User): UserRepository {
+            val repo = mock<UserRepository>()
+            everySuspend { repo.refreshCurrentUser() } returns user
+            everySuspend { repo.getCurrentUser() } returns user
+            return repo
+        }
+
+        fun adminFactory(service: LibraryAdminService): LibraryAdminRpcFactory {
+            val factory = mock<LibraryAdminRpcFactory>()
+            everySuspend { factory.get() } returns service
+            return factory
+        }
+
+        fun authSession(state: MutableStateFlow<AuthState>): AuthSession {
+            val session = mock<AuthSession>()
+            every { session.authState } returns state
+            return session
+        }
+
+        // Profile refresh is fire-and-forget at startup and not exercised here — a no-op stub.
+        fun profileRepo(): ProfileRepository {
+            val repo = mock<ProfileRepository>()
+            everySuspend { repo.refreshMyProfile() } returns CoreAppResult.Success(Unit)
+            return repo
+        }
+
+        fun syncRepo(
+            scanning: MutableStateFlow<Boolean>,
+            progress: MutableStateFlow<ScanProgressState?> = MutableStateFlow(null),
+        ): SyncRepository {
+            val sync = mock<SyncRepository>()
+            every { sync.isServerScanning } returns scanning
+            every { sync.scanProgress } returns progress
+            return sync
+        }
+
+        val authenticated = AuthState.Authenticated(UserId("user-001"), SessionId("session-001"))
+
+        test("fresh admin: Checking -> NeedsSetup -> Populating -> Ready") {
+            runTest(dispatcher) {
+                val service = mock<LibraryAdminService>()
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
+                val scanning = MutableStateFlow(false)
+                // Start unauthenticated so the setup check fires on the transition, as in real launch.
+                val authState = MutableStateFlow<AuthState>(AuthState.NeedsLogin(openRegistration = false))
+
+                val vm =
+                    AppStartupViewModel(
+                        userRepoReturning(adminUser()),
+                        adminFactory(service),
+                        authSession(authState),
+                        profileRepo(),
+                        syncRepo(scanning),
+                    )
+
+                vm.readiness.test {
+                    awaitItem() shouldBe LibraryReadiness.Checking
+
+                    authState.value = authenticated
+                    advanceUntilIdle()
+                    awaitItem() shouldBe LibraryReadiness.NeedsSetup
+
+                    // Wizard done + the initial scan begins: needs-setup clears while scanning is up.
+                    scanning.value = true
+                    vm.onLibrarySetupComplete()
+                    advanceUntilIdle()
+                    awaitItem() shouldBe LibraryReadiness.Populating(null)
+
+                    // Server scan + client import settle → shell is safe to mount.
+                    scanning.value = false
+                    advanceUntilIdle()
+                    awaitItem() shouldBe LibraryReadiness.Ready
+                }
+            }
+        }
+
+        test("relaunch with an existing library and no scan: Checking -> Ready (no spurious Populating)") {
+            runTest(dispatcher) {
+                val service = mock<LibraryAdminService>()
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
+
+                val vm =
+                    AppStartupViewModel(
+                        userRepoReturning(adminUser()),
+                        adminFactory(service),
+                        authSession(MutableStateFlow(authenticated)),
+                        profileRepo(),
+                        syncRepo(MutableStateFlow(false)),
+                    )
+
+                vm.readiness.test {
+                    awaitItem() shouldBe LibraryReadiness.Checking
+                    advanceUntilIdle()
+                    awaitItem() shouldBe LibraryReadiness.Ready
+                }
+            }
+        }
+
+        test("setup-status failure: Checking -> CheckFailed") {
+            runTest(dispatcher) {
+                val service = mock<LibraryAdminService>()
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
+
+                val vm =
+                    AppStartupViewModel(
+                        userRepoReturning(adminUser()),
+                        adminFactory(service),
+                        authSession(MutableStateFlow(authenticated)),
+                        profileRepo(),
+                        syncRepo(MutableStateFlow(false)),
+                    )
+
+                vm.readiness.test {
+                    awaitItem() shouldBe LibraryReadiness.Checking
+                    advanceUntilIdle()
+                    awaitItem() shouldBe LibraryReadiness.CheckFailed
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoJvmOnlyApisInSharedRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoJvmOnlyApisInSharedRule.kt
@@ -5,25 +5,28 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 
 /**
- * Konsist guard: non-JVM `:shared` source sets must never import a `java.*` or
- * `javax.*` package. Those APIs do not exist on Kotlin/Native (iOS), so a stray
- * import silently breaks the Apple targets — which cannot be compiled on the
- * Linux CI runner to catch it. This rule is the portable structural guard.
+ * Konsist guard: `commonMain` and the Apple/Native source sets must never import a
+ * `java.*` or `javax.*` package. `commonMain` is platform-agnostic by contract, and
+ * those APIs do not exist on Kotlin/Native (iOS) — so a stray import either breaks
+ * the Apple targets outright or quietly bars a JVM-only module (e.g. `:sharedUI`)
+ * from ever gaining one. Either way the Linux CI runner cannot compile the Apple
+ * targets to catch it, so this is the portable structural guard.
  *
- * `jvmMain` / `androidMain` / `desktopMain` are intentionally not checked: the
- * JVM is a legitimate target there.
+ * Scope is every module's shared source sets. The JVM-specific sets (`jvmMain` /
+ * `androidMain` / `desktopMain`) are intentionally excluded: the JVM is a
+ * legitimate target there, and that is where `expect`/`actual` actuals bind to
+ * `java.*` (e.g. `design/util/FileLastModified`).
  */
 class NoJvmOnlyApisInSharedRule :
     FunSpec({
-        test("no non-JVM :shared source set imports java.* or javax.*") {
-            val nonJvmSourceSetMarkers =
-                listOf("/commonMain/", "/appleMain/", "/iosMain/", "/nativeMain/")
+        test("no commonMain or Apple/Native source set imports java.* or javax.*") {
+            val sharedSourceSetMarkers =
+                listOf("/commonMain/", "/appleMain/", "/iosMain/", "/nativeMain/", "/macosMain/")
             val offenders =
                 Konsist
                     .scopeFromProduction()
                     .files
-                    .filter { file -> file.path.contains("/shared/src/") }
-                    .filter { file -> nonJvmSourceSetMarkers.any { file.path.contains(it) } }
+                    .filter { file -> sharedSourceSetMarkers.any { file.path.contains(it) } }
                     .flatMap { file ->
                         file.imports
                             .filter { it.name.startsWith("java.") || it.name.startsWith("javax.") }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/SharedCodeUsesIODispatcherRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/SharedCodeUsesIODispatcherRule.kt
@@ -1,0 +1,51 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Konsist guard: shared (multiplatform) source sets must use
+ * [com.calypsan.listenup.core.IODispatcher], never a raw `Dispatchers.IO`.
+ *
+ * `Dispatchers.IO` is a JVM member but only reachable on Kotlin/Native through
+ * the `kotlinx.coroutines.IO` extension import — a bare `Dispatchers.IO` in
+ * common code compiles on the JVM/Android targets and silently breaks the Apple
+ * targets, which the Linux CI runner cannot compile to catch. Routing every
+ * shared call site through the single `IODispatcher` expect/actual removes the
+ * footgun and keeps one canonical IO dispatcher across the codebase (it resolves
+ * to the real elastic IO pool on every platform — see `core.Dispatchers`).
+ *
+ * Scope is every non-JVM-specific source set across all modules: `commonMain`
+ * and the Apple/Native sets. The JVM-only sets (`jvmMain` / `androidMain` /
+ * `desktopMain`) may use `Dispatchers.IO` directly — that is where the
+ * `IODispatcher` actuals legitimately bind to it.
+ */
+class SharedCodeUsesIODispatcherRule :
+    FunSpec({
+        test("shared source sets use IODispatcher, not a raw Dispatchers.IO") {
+            val sharedSourceSetMarkers =
+                listOf("/commonMain/", "/appleMain/", "/iosMain/", "/nativeMain/", "/macosMain/")
+
+            val offenders =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .filter { file -> sharedSourceSetMarkers.any { file.path.contains(it) } }
+                    // The IODispatcher expect/actual itself is the sanctioned home of the
+                    // platform dispatcher choice — it necessarily names Dispatchers.IO.
+                    .filterNot { file -> file.path.endsWith("/core/Dispatchers.apple.kt") }
+                    .filter { file -> file.usesRawIoDispatcher() }
+                    .map { file -> file.path }
+
+            offenders.shouldBeEmpty()
+        }
+    })
+
+/** True if a non-comment line accesses `Dispatchers.IO` directly. */
+private fun com.lemonappdev.konsist.api.declaration.KoFileDeclaration.usesRawIoDispatcher(): Boolean =
+    text.lineSequence().any { rawLine ->
+        val line = rawLine.trim()
+        val isComment = line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")
+        !isComment && line.contains("Dispatchers.IO")
+    }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleLifecycleTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleLifecycleTest.kt
@@ -87,7 +87,7 @@ class CursorStaleLifecycleTest :
                     // a real CursorStale frame.
                     sseClient.reseed(0L)
 
-                    engine.handleCursorStale(lastKnown = 0L)
+                    engine.handleCursorStale()
 
                     // Lifecycle invariants post-handling:
                     //  - SSE is reconnected, not in permanent Disconnected.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleReentrancyTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleReentrancyTest.kt
@@ -1,0 +1,159 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.core.AppResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Pins the fix for the onboarding catch-up ↔ CursorStale spin.
+ *
+ * During initial population the server emits `Completed` before it has finished writing all book
+ * revisions, so the client reconciles a still-moving server: each reconnect lands below the
+ * (DROP_OLDEST) replay-bus floor and the server replies `CursorStale`, which the dispatcher routes
+ * straight back into [SyncEngine.handleCursorStale]. With no guard, every such signal — plus the
+ * fire-and-forget scan-completion reconcile — starts ANOTHER full `catchUpAll`, so many re-decode
+ * passes run concurrently: the runaway large-object GC and the render-starved (never-clearing)
+ * scan overlay.
+ *
+ * Guarded + coalescing, at most one recovery runs at a time and a burst of triggers collapses into
+ * a single follow-up pass.
+ */
+class CursorStaleReentrancyTest :
+    FunSpec({
+
+        test("concurrent CursorStale recoveries never run catchUpAll concurrently and coalesce") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    // A catch-up that parks until released, recording concurrency + total calls.
+                    val gate = CompletableDeferred<Unit>()
+                    val inFlight = AtomicInteger(0)
+                    val maxConcurrent = AtomicInteger(0)
+                    val totalCalls = AtomicInteger(0)
+                    val catchUp =
+                        object : CatchUp {
+                            override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>) = AppResult.Success(Unit)
+
+                            override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
+                                totalCalls.incrementAndGet()
+                                val now = inFlight.incrementAndGet()
+                                maxConcurrent.updateAndGet { prev -> maxOf(prev, now) }
+                                try {
+                                    gate.await()
+                                } finally {
+                                    inFlight.decrementAndGet()
+                                }
+                                return AppResult.Success(Unit)
+                            }
+
+                            override suspend fun <T : Any> catchUpTransient(
+                                handler: SyncDomainHandler<T>,
+                            ) = AppResult.Success(emptySet<String>())
+
+                            override suspend fun domains() = AppResult.Success(emptyList<String>())
+                        }
+
+                    val state = SyncEngineState()
+                    val engine = buildEngineWithCatchUp(db, state, catchUp, scope)
+
+                    // Three CursorStale recoveries race in while catch-up is parked (in flight).
+                    val jobs = (1..3).map { scope.launch { engine.handleCursorStale() } }
+
+                    withTimeout(5.seconds) {
+                        while (totalCalls.get() == 0) delay(5)
+                    }
+                    // Give the other two a real chance to (wrongly) start their own catch-up.
+                    delay(300)
+
+                    // The decisive invariant: catchUpAll is never re-entered concurrently.
+                    maxConcurrent.get() shouldBe 1
+
+                    gate.complete(Unit)
+                    withTimeout(5.seconds) { jobs.forEach { it.join() } }
+
+                    // Coalesced: at most one in-flight recovery + one queued follow-up — not one per trigger.
+                    (totalCalls.get() <= 2) shouldBe true
+                } finally {
+                    scope.cancel()
+                    db.close()
+                }
+            }
+        }
+    })
+
+private fun buildEngineWithCatchUp(
+    db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+    state: SyncEngineState,
+    catchUp: CatchUp,
+    scope: CoroutineScope,
+): SyncEngine {
+    val registry = ClientSyncDomainRegistry()
+    val store = SyncCursorStore(db.syncCursorDao())
+    val queue =
+        PendingOperationQueue(
+            dao = db.pendingOperationV2Dao(),
+            sender = PendingOperationSender { AppResult.Success(Unit) },
+        )
+    val dispatcher =
+        SyncEventDispatcher(
+            registry = registry,
+            queue = queue,
+            state = state,
+            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+        )
+    return SyncEngine(
+        registry = registry,
+        queue = queue,
+        state = state,
+        store = store,
+        catchUp = catchUp,
+        sseClient = NoopSseClient(state),
+        dispatcher = dispatcher,
+        downloadRepository = FakeDownloadRepository(),
+        scope = scope,
+    )
+}
+
+/** Minimal [SseClient] whose connect/disconnect only flip [SyncEngineState] — no real transport. */
+private class NoopSseClient(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        seeded = newLastEventId
+    }
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
@@ -152,10 +152,10 @@ class SyncEventDispatcherTest :
             }
         }
 
-        test("control: SyncControl.CursorStale sets state and triggers callback with lastKnown") {
+        test("control: SyncControl.CursorStale triggers the recovery callback") {
             runTest {
                 val db = createInMemoryTestDatabase()
-                var seenLastKnown: Long? = null
+                var recoveryTriggered = false
                 val dispatcher =
                     SyncEventDispatcher(
                         registry = ClientSyncDomainRegistry(),
@@ -166,10 +166,9 @@ class SyncEventDispatcherTest :
                             ),
                         state = SyncEngineState(),
                         cursorAdvance = { _, _ -> },
-                        onCursorStale = { lastKnown -> seenLastKnown = lastKnown },
+                        onCursorStale = { recoveryTriggered = true },
                     )
-                val lastKnownRevision = 1_000L
-                val control = SyncControl.CursorStale(lastKnownRevision = lastKnownRevision)
+                val control = SyncControl.CursorStale(lastKnownRevision = 1_000L)
                 val frame =
                     ParsedSseFrame(
                         id = null,
@@ -177,7 +176,7 @@ class SyncEventDispatcherTest :
                         data = contractJson.encodeToString(SyncControl.serializer(), control),
                     )
                 dispatcher.handle(frame)
-                seenLastKnown shouldBe lastKnownRevision
+                recoveryTriggered shouldBe true
                 db.close()
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -407,6 +407,7 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
                     // testApplication serves relative URLs in-process — an empty base URL is correct here.
                     serverUrlProvider = { "" },
                     store = store,
+                    transactionRunner = RoomTransactionRunner(clientDb),
                 )
 
             val sseClient =
@@ -428,9 +429,9 @@ fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Uni
                     queue = queue,
                     state = state,
                     cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
-                    onCursorStale = { lastKnown ->
+                    onCursorStale = {
                         checkNotNull(engineRef) { "SyncEngine not yet constructed" }
-                            .handleCursorStale(lastKnown)
+                            .handleCursorStale()
                     },
                 )
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
@@ -275,6 +275,7 @@ private fun buildMemberSyncEngine(
             httpClientProvider = { testClient },
             serverUrlProvider = { "" },
             store = store,
+            transactionRunner = RoomTransactionRunner(clientDb),
         )
     val sseClient =
         SyncSseClient(
@@ -291,8 +292,8 @@ private fun buildMemberSyncEngine(
             queue = queue,
             state = state,
             cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
-            onCursorStale = { lastKnown ->
-                checkNotNull(engineRef) { "SyncEngine not yet constructed" }.handleCursorStale(lastKnown)
+            onCursorStale = {
+                checkNotNull(engineRef) { "SyncEngine not yet constructed" }.handleCursorStale()
             },
             onAccessChanged = {
                 checkNotNull(engineRef) { "SyncEngine not yet constructed" }.handleAccessChanged()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
@@ -223,6 +223,7 @@ fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -> Unit)
                     httpClientProvider = { testClient },
                     serverUrlProvider = { "" },
                     store = store,
+                    transactionRunner = RoomTransactionRunner(clientDb),
                 )
 
             val sseClient =
@@ -240,9 +241,9 @@ fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -> Unit)
                     queue = queue,
                     state = state,
                     cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
-                    onCursorStale = { lastKnown ->
+                    onCursorStale = {
                         checkNotNull(engineRef) { "SyncEngine not yet constructed" }
-                            .handleCursorStale(lastKnown)
+                            .handleCursorStale()
                     },
                 )
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelRealRoomTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelRealRoomTest.kt
@@ -1,0 +1,295 @@
+@file:OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.DelicateCoroutinesApi::class)
+
+package com.calypsan.listenup.client.presentation.library
+
+import com.calypsan.listenup.api.sync.BookSyncPayload
+import com.calypsan.listenup.api.sync.ContributorSyncPayload
+import com.calypsan.listenup.api.sync.SeriesSyncPayload
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.BookEntityMapper
+import com.calypsan.listenup.client.data.local.db.ChapterDao
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.remote.BookRpcFactory
+import com.calypsan.listenup.client.data.remote.ContributorApiContract
+import com.calypsan.listenup.client.data.remote.ContributorRpcFactory
+import com.calypsan.listenup.client.data.remote.SeriesApiContract
+import com.calypsan.listenup.client.data.remote.SeriesRpcFactory
+import com.calypsan.listenup.client.data.repository.BookRepositoryImpl
+import com.calypsan.listenup.client.data.repository.ContributorRepositoryImpl
+import com.calypsan.listenup.client.data.repository.PlaybackPositionRepositoryImpl
+import com.calypsan.listenup.client.data.repository.SeriesRepositoryImpl
+import com.calypsan.listenup.core.AppResult
+import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.data.sync.PendingOperationSender
+import com.calypsan.listenup.client.data.sync.SyncDomainHandler
+import com.calypsan.listenup.client.data.sync.handlers.BookSyncDomainHandler
+import com.calypsan.listenup.client.domain.model.ContributorRole
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.GenreRepository
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.NetworkMonitor
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Exercises the LibraryViewModel's data sources against a **real** in-memory Room database, rather
+ * than the `flowOf(...)` mocks the unit test uses — which emit-once-and-complete and so can mask
+ * real Room behaviour.
+ *
+ * Part 1 asserts each `rawContent` source flow emits its first value on an empty DB (so the
+ * top-level combine can produce a value and `uiState` leaves its `Loading` seed). Part 2 pins the
+ * threading fix: `observeBookListItems` does a blocking per-book cover stat
+ * ([ImageStorage.exists]) and must run it OFF the collector (the UI's `Dispatchers.Main`), or a
+ * large library freezes the thread.
+ */
+class LibraryViewModelRealRoomTest :
+    FunSpec({
+
+        // ───────────────────────── Part 1: each rawContent source emits ─────────────────────────
+
+        test("observeBookListItems emits an initial value on an empty DB") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runBlocking {
+                    val books = withTimeout(5.seconds) { realBookRepository(db).observeBookListItems().first() }
+                    books shouldBe emptyList()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("observeAllWithBooks emits an initial value on an empty DB") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runBlocking {
+                    val series = withTimeout(5.seconds) { realSeriesRepository(db).observeAllWithBooks().first() }
+                    series shouldBe emptyList()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("observeContributorsByRole(author) emits an initial value on an empty DB") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runBlocking {
+                    val authors =
+                        withTimeout(5.seconds) {
+                            realContributorRepository(db)
+                                .observeContributorsByRole(ContributorRole.AUTHOR.apiValue)
+                                .first()
+                        }
+                    authors shouldBe emptyList()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("observeAll(positions) emits an initial value on an empty DB") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runBlocking {
+                    val positions =
+                        withTimeout(5.seconds) { realPlaybackPositionRepository(db).observeAll().first() }
+                    positions shouldBe emptyMap()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ───────────────────── Part 2: heavy per-book cover I/O runs off the collector ─────────────────────
+
+        test("observeBookListItems performs its per-book cover lookup off the collector's thread") {
+            val db = createInMemoryTestDatabase()
+            val collectorDispatcher = newSingleThreadContext("library-collector-thread")
+            try {
+                // ImageStorage.exists is a blocking filesystem stat in production. Capture which
+                // thread each call runs on: it must NOT be the flow's collector (in the app, Main).
+                val coverLookupThreads = mutableListOf<String>()
+                val imageStorage =
+                    mock<ImageStorage> {
+                        every { exists(any()) } calls
+                            {
+                                coverLookupThreads.add(Thread.currentThread().name)
+                                false
+                            }
+                    }
+                val repository = bookRepositoryWith(db, imageStorage)
+                seedBook(db, "b1")
+
+                runBlocking {
+                    val items =
+                        withTimeout(5.seconds) {
+                            withContext(collectorDispatcher) {
+                                repository.observeBookListItems().first { it.isNotEmpty() }
+                            }
+                        }
+                    items.size shouldBe 1
+
+                    // The per-book cover stat must have happened, but never on the collector thread —
+                    // otherwise a large library blocks the UI thread and the Library tab spins forever.
+                    coverLookupThreads.shouldNotBeEmpty()
+                    coverLookupThreads.forEach { it shouldNotContain "library-collector-thread" }
+                }
+            } finally {
+                collectorDispatcher.close()
+                db.close()
+            }
+        }
+    })
+
+/** Seeds a single minimal book into [db] via the real sync handler — the same write path SSE uses. */
+private suspend fun seedBook(
+    db: ListenUpDatabase,
+    id: String,
+) {
+    val handler = BookSyncDomainHandler(db, BookEntityMapper(), RoomTransactionRunner(db), ClientSyncDomainRegistry())
+    handler.onCatchUpItem(
+        BookSyncPayload(
+            id = id,
+            libraryId = LibraryId("test-library"),
+            folderId = FolderId("test-folder"),
+            title = "Book $id",
+            sortTitle = "Book $id",
+            subtitle = null,
+            description = null,
+            publishYear = null,
+            publisher = null,
+            language = null,
+            isbn = null,
+            asin = null,
+            abridged = false,
+            explicit = false,
+            totalDuration = 3_600_000L,
+            cover = null,
+            rootRelPath = "books/$id",
+            inode = null,
+            scannedAt = 1L,
+            contributors = emptyList(),
+            series = emptyList(),
+            audioFiles = emptyList(),
+            chapters = emptyList(),
+            revision = 0L,
+            updatedAt = 0L,
+            createdAt = 0L,
+            deletedAt = null,
+        ),
+        isTombstone = false,
+    )
+}
+
+private fun bookRepositoryWith(
+    db: ListenUpDatabase,
+    imageStorage: ImageStorage,
+): BookRepositoryImpl {
+    val transactionRunner = RoomTransactionRunner(db)
+    val genreRepository = mock<GenreRepository> { every { observeGenresForBook(any()) } returns MutableStateFlow(emptyList()) }
+    val tagRepository =
+        mock<com.calypsan.listenup.client.domain.repository.TagRepository> {
+            every { observeTagsForBook(any()) } returns MutableStateFlow(emptyList())
+        }
+    return BookRepositoryImpl(
+        bookDao = db.bookDao(),
+        chapterDao = mock<ChapterDao>(),
+        audioFileDao = mock<AudioFileDao>(),
+        searchDao = db.searchDao(),
+        transactionRunner = transactionRunner,
+        imageStorage = imageStorage,
+        genreRepository = genreRepository,
+        tagRepository = tagRepository,
+        networkMonitor = mock<NetworkMonitor> { every { isOnline() } returns false },
+        bookRpcFactory = mock<BookRpcFactory>(),
+        bookSyncDomainHandler =
+            BookSyncDomainHandler(db, BookEntityMapper(), transactionRunner, ClientSyncDomainRegistry()),
+    )
+}
+
+// ───────────────────────────────── real repositories over Room ─────────────────────────────────
+//
+// The observe-flows touch only the DAOs + ImageStorage; every other collaborator (RPC, network,
+// API, sync handlers, pending queue) is mocked because the read path never invokes it.
+
+private fun mockImageStorage(): ImageStorage = mock<ImageStorage> { every { exists(any()) } returns false }
+
+private fun realBookRepository(db: ListenUpDatabase): BookRepositoryImpl {
+    val transactionRunner = RoomTransactionRunner(db)
+    val genreRepository = mock<GenreRepository> { every { observeGenresForBook(any()) } returns MutableStateFlow(emptyList()) }
+    val tagRepository =
+        mock<com.calypsan.listenup.client.domain.repository.TagRepository> {
+            every { observeTagsForBook(any()) } returns MutableStateFlow(emptyList())
+        }
+    return BookRepositoryImpl(
+        bookDao = db.bookDao(),
+        chapterDao = mock<ChapterDao>(),
+        audioFileDao = mock<AudioFileDao>(),
+        searchDao = db.searchDao(),
+        transactionRunner = transactionRunner,
+        imageStorage = mockImageStorage(),
+        genreRepository = genreRepository,
+        tagRepository = tagRepository,
+        networkMonitor = mock<NetworkMonitor> { every { isOnline() } returns false },
+        bookRpcFactory = mock<BookRpcFactory>(),
+        bookSyncDomainHandler =
+            BookSyncDomainHandler(db, BookEntityMapper(), transactionRunner, ClientSyncDomainRegistry()),
+    )
+}
+
+private fun realSeriesRepository(db: ListenUpDatabase): SeriesRepositoryImpl =
+    SeriesRepositoryImpl(
+        seriesDao = db.seriesDao(),
+        bookDao = db.bookDao(),
+        searchDao = db.searchDao(),
+        api = mock<SeriesApiContract>(),
+        networkMonitor = mock<NetworkMonitor> { every { isOnline() } returns false },
+        imageStorage = mockImageStorage(),
+        rpcFactory = mock<SeriesRpcFactory>(),
+        seriesSyncHandler = mock<SyncDomainHandler<SeriesSyncPayload>>(),
+    )
+
+private fun realContributorRepository(db: ListenUpDatabase): ContributorRepositoryImpl =
+    ContributorRepositoryImpl(
+        contributorDao = db.contributorDao(),
+        bookDao = db.bookDao(),
+        searchDao = db.searchDao(),
+        api = mock<ContributorApiContract>(),
+        networkMonitor = mock<NetworkMonitor> { every { isOnline() } returns false },
+        imageStorage = mockImageStorage(),
+        rpcFactory = mock<ContributorRpcFactory>(),
+        contributorSyncHandler = mock<SyncDomainHandler<ContributorSyncPayload>>(),
+    )
+
+private fun realPlaybackPositionRepository(db: ListenUpDatabase): PlaybackPositionRepositoryImpl =
+    PlaybackPositionRepositoryImpl(
+        dao = db.playbackPositionDao(),
+        transactionRunner = RoomTransactionRunner(db),
+        pendingQueue =
+            PendingOperationQueue(
+                dao = db.pendingOperationV2Dao(),
+                sender = PendingOperationSender { AppResult.Success(Unit) },
+            ),
+        authSession = mock<AuthSession>(),
+    )

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -356,8 +356,9 @@ class ListenUp :
 
         // Initialize Koin dependency injection
         startKoin {
-            // Use Android logger for Koin diagnostic messages
-            androidLogger(Level.DEBUG)
+            // INFO, not DEBUG: Koin's DEBUG level logs every dependency resolution, which floods
+            // logcat during sync (e.g. per-event SyncCursorStore lookups across a 1000-book scan).
+            androidLogger(Level.INFO)
 
             // Provide Android Context to Koin
             androidContext(this@ListenUp)

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -10,7 +10,10 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.data.repository.DeepLinkManager
 import com.calypsan.listenup.client.data.repository.ShortcutAction
 import com.calypsan.listenup.client.data.repository.ShortcutActionManager
@@ -27,6 +30,8 @@ import com.calypsan.listenup.client.shortcuts.ShortcutActions
 import com.calypsan.listenup.client.foldable.PostureProvider
 import com.calypsan.listenup.client.presentation.startup.AppStartupViewModel
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.compose.koinInject
@@ -72,6 +77,26 @@ class MainActivity : ComponentActivity() {
         // Initialize local preferences (theme, dynamic colors, etc.) from storage
         lifecycleScope.launch {
             localPreferences.initializeLocalPreferences()
+        }
+
+        // Connect realtime sync as soon as auth becomes Authenticated — including
+        // mid-session (a fresh onboarding), not only on the next onResume/restart.
+        // Without this, a just-registered user has no live SSE stream, so books the
+        // server scans right after library creation don't arrive until the app is
+        // relaunched. Re-collected per STARTED so foreground resumes reconnect too;
+        // engine.start() is single-flight, so overlapping with onResume is safe.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                authSession.authState
+                    .map { it is AuthState.Authenticated }
+                    .distinctUntilChanged()
+                    .collect { authenticated ->
+                        if (authenticated) {
+                            logger.debug { "Authenticated — connecting realtime sync" }
+                            syncRepository.connectRealtime()
+                        }
+                    }
+            }
         }
 
         setContent {

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/design/util/FileLastModified.android.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/design/util/FileLastModified.android.kt
@@ -1,0 +1,5 @@
+package com.calypsan.listenup.client.design.util
+
+import java.io.File
+
+internal actual fun fileLastModifiedMillis(path: String): Long? = File(path).takeIf { it.exists() }?.lastModified()

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -50,9 +50,15 @@ import com.calypsan.listenup.client.data.repository.ShortcutActionManager
 import com.calypsan.listenup.client.data.sync.LibraryResetHelperContract
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.LinearProgressIndicator
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
 import com.calypsan.listenup.client.design.components.ListenUpButton
+import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
+import com.calypsan.listenup.client.domain.model.ScanProgressState
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.features.admin.AdminScreen
@@ -90,6 +96,7 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import com.calypsan.listenup.client.presentation.startup.AppStartupViewModel
+import com.calypsan.listenup.client.presentation.startup.LibraryReadiness
 import com.calypsan.listenup.client.design.LocalDeviceContext
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.core.Success
@@ -289,6 +296,68 @@ private fun SetupCheckFailedScreen(onRetry: () -> Unit) {
 }
 
 /**
+ * Full-screen "setting up your library" gate, shown while the initial population scan runs INSTEAD
+ * of the app shell. The shell (and its Library grid + cover loading) only mounts once the library
+ * is ready — so the user never navigates an empty app and the heavy grid doesn't compete with the
+ * sync/catch-up for memory during onboarding.
+ *
+ * Drives live progress off [ScanProgressState]; falls back to an indeterminate state before the
+ * first progress event arrives.
+ */
+private const val POPULATING_PROGRESS_WIDTH_FRACTION = 0.6f
+
+@Composable
+private fun LibraryPopulatingScreen(scanProgress: ScanProgressState?) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(32.dp),
+        ) {
+            ListenUpLoadingIndicator(size = 64.dp)
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text =
+                    if (scanProgress != null) {
+                        scanProgress.phaseDisplayName +
+                            if (scanProgress.total > 0) " ${scanProgress.current}/${scanProgress.total}" else ""
+                    } else {
+                        "Setting up your library…"
+                    },
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            if (scanProgress?.progressFraction != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                LinearProgressIndicator(
+                    progress = { scanProgress.progressFraction!! },
+                    modifier = Modifier.fillMaxWidth(POPULATING_PROGRESS_WIDTH_FRACTION),
+                )
+            }
+
+            val summary = scanProgress?.changesSummary
+            if (summary != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
  * Server setup navigation - shown when no server URL is configured.
  *
  * Flow:
@@ -457,7 +526,9 @@ private fun AuthenticatedNavigation(
     // foreground resume. The ViewModel lives in the Activity's ViewModelStore, so it is only
     // discarded on process death (true cold start).
     val startupViewModel: AppStartupViewModel = koinViewModel()
-    val startupState by startupViewModel.state.collectAsStateWithLifecycle()
+    // One authoritative readiness state drives every onboarding gate below — no more juggling
+    // isChecking/needsLibrarySetup/checkResolved/setupCheckFailed/isServerScanning across three sites.
+    val readiness by startupViewModel.readiness.collectAsStateWithLifecycle()
 
     // Hoist navigation state above the isChecking check so it survives loading periods.
     // rememberNavBackStack persists across configuration changes and process death
@@ -468,9 +539,9 @@ private fun AuthenticatedNavigation(
     // Track shell tab state here so it survives navigation to detail screens
     var currentShellDestination by remember { mutableStateOf<ShellDestination>(ShellDestination.Home) }
 
-    // Navigate to LibrarySetup when the check completes and setup is needed
-    LaunchedEffect(startupState.needsLibrarySetup, startupState.isChecking) {
-        if (!startupState.isChecking && startupState.needsLibrarySetup) {
+    // Navigate to LibrarySetup the moment readiness resolves to "needs setup".
+    LaunchedEffect(readiness) {
+        if (readiness is LibraryReadiness.NeedsSetup && backStack.lastOrNull() != LibrarySetup) {
             backStack.clear()
             backStack.add(LibrarySetup)
         }
@@ -593,6 +664,17 @@ private fun AuthenticatedNavigation(
                 entryProvider =
                     entryProvider {
                         entry<Shell> {
+                            // Readiness gate: while the initial library population is running we show a
+                            // dedicated full-screen progress screen and DO NOT mount the shell — so the
+                            // user never navigates an empty app, and the Library grid + Coil don't decode
+                            // a thousand covers while the sync/catch-up is still churning (which exhausted
+                            // the heap → OOM). Populating spans the server scan AND the client import, so
+                            // when it clears the books are already in Room (see applyScanEvent).
+                            (readiness as? LibraryReadiness.Populating)?.let { populating ->
+                                LibraryPopulatingScreen(scanProgress = populating.progress)
+                                return@entry
+                            }
+
                             // Preload library data by injecting LibraryViewModel early
                             @Suppress("UNUSED_VARIABLE")
                             val libraryViewModel: LibraryViewModel = koinViewModel()
@@ -684,6 +766,9 @@ private fun AuthenticatedNavigation(
                         entry<LibrarySetup> {
                             LibrarySetupScreen(
                                 onSetupComplete = {
+                                    // Clear the stale needs-setup flag so the startup readiness overlay
+                                    // can't re-latch on top of the shell after we navigate away.
+                                    startupViewModel.onLibrarySetupComplete()
                                     // Trigger sync to pull newly scanned books
                                     scope.launch {
                                         logger.info { "Library setup complete, triggering sync" }
@@ -1232,17 +1317,31 @@ private fun AuthenticatedNavigation(
                         .padding(bottom = 16.dp),
             )
 
-            // Overlay loading indicator while startup check is in progress.
-            // Using an overlay instead of early return preserves the backStack state.
-            if (startupState.isChecking) {
-                FullScreenLoadingIndicator()
-            } else if (startupState.setupCheckFailed) {
-                // Honest over silent: when the admin's library-setup check could not be
-                // completed (e.g. transient network failure), surface a retryable error
-                // instead of silently dropping them into an empty Shell.
-                SetupCheckFailedScreen(
-                    onRetry = { startupViewModel.retryLibrarySetupCheck() },
-                )
+            // Single readiness gate for the non-shell startup states. Populating is handled inside the
+            // Shell entry above (so the shell never mounts during import); everything else is covered
+            // here by one `when`. The overlays use an OPAQUE surface because they sit on top of the
+            // default `Shell` back-stack entry, and FullScreenLoadingIndicator is transparent by itself
+            // — without a background the shell flashes through (the "shell flash before the picker").
+            when (readiness) {
+                LibraryReadiness.Checking -> {
+                    FullScreenLoadingIndicator(modifier = Modifier.background(MaterialTheme.colorScheme.surface))
+                }
+
+                LibraryReadiness.NeedsSetup -> {
+                    // Bridge the gap until the LaunchedEffect above swaps the back stack to LibrarySetup;
+                    // once it has, the wizard renders and no overlay is needed.
+                    if (backStack.lastOrNull() != LibrarySetup) {
+                        FullScreenLoadingIndicator(modifier = Modifier.background(MaterialTheme.colorScheme.surface))
+                    }
+                }
+
+                LibraryReadiness.CheckFailed -> {
+                    // Honest over silent: surface a retryable error instead of an empty Shell.
+                    SetupCheckFailedScreen(onRetry = { startupViewModel.retryLibrarySetupCheck() })
+                }
+
+                // Populating renders inside the Shell entry; Ready shows the shell — no overlay for either.
+                is LibraryReadiness.Populating, LibraryReadiness.Ready -> {}
             }
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
@@ -20,12 +20,12 @@ import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
 import coil3.request.ImageRequest
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.client.design.util.decodeBlurHash
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.compose.runtime.produceState
 import com.calypsan.listenup.core.Success
@@ -93,7 +93,7 @@ fun BookCoverImage(
                 .get()
 
         value =
-            withContext(Dispatchers.IO) {
+            withContext(IODispatcher) {
                 val localPath = imageRepository.getBookCoverPath(BookId(bookId))
                 val exists = imageRepository.bookCoverExists(BookId(bookId))
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
@@ -15,8 +15,8 @@ import coil3.request.ImageRequest
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.IODispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 private val logger = KotlinLogging.logger {}
@@ -78,7 +78,7 @@ fun ContributorCoverImage(
                 .get()
 
         value =
-            withContext(Dispatchers.IO) {
+            withContext(IODispatcher) {
                 val localPath = imageRepository.getContributorImagePath(contributorId)
                 val exists = imageRepository.contributorImageExists(contributorId)
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAsyncImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAsyncImage.kt
@@ -19,10 +19,10 @@ import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import com.calypsan.listenup.client.design.util.decodeBlurHash
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.io.File
+import com.calypsan.listenup.client.design.util.fileLastModifiedMillis
+import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.core.Success
+import kotlinx.coroutines.withContext
 
 /**
  * Design system image component with BlurHash placeholder support.
@@ -64,10 +64,9 @@ fun ListenUpAsyncImage(
         key2 = refreshKey,
     ) {
         value =
-            withContext(Dispatchers.IO) {
+            withContext(IODispatcher) {
                 path?.let { filePath ->
-                    val file = File(filePath)
-                    if (file.exists()) "$filePath:${file.lastModified()}" else filePath
+                    fileLastModifiedMillis(filePath)?.let { "$filePath:$it" } ?: filePath
                 }
             }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SeriesCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SeriesCoverImage.kt
@@ -15,8 +15,8 @@ import coil3.request.ImageRequest
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.IODispatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 private val logger = KotlinLogging.logger {}
@@ -78,7 +78,7 @@ fun SeriesCoverImage(
                 .get()
 
         value =
-            withContext(Dispatchers.IO) {
+            withContext(IODispatcher) {
                 val localPath = imageRepository.getSeriesCoverPath(seriesId)
                 val exists = imageRepository.seriesCoverExists(seriesId)
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/util/FileLastModified.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/util/FileLastModified.kt
@@ -1,0 +1,13 @@
+package com.calypsan.listenup.client.design.util
+
+/**
+ * Last-modified time (epoch millis) of the file at [path], or null when the file
+ * does not exist or cannot be stat'd.
+ *
+ * Used to derive a content-versioned image cache key so a file overwritten at a
+ * stable path busts Coil's memory/disk cache. File metadata is a platform API, so
+ * this lives behind `expect`/`actual` — keeping `commonMain` free of `java.io`.
+ *
+ * - Android / Desktop (JVM): `java.io.File.lastModified()`.
+ */
+internal expect fun fileLastModifiedMillis(path: String): Long?

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/AppShell.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/AppShell.kt
@@ -23,19 +23,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.unit.dp
-import com.calypsan.listenup.client.domain.model.ScanProgressState
 import com.calypsan.listenup.client.design.components.ListenUpDestructiveDialog
-import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.domain.model.SyncState
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.SyncRepository
@@ -154,8 +142,6 @@ fun AppShell(
     }
 
     // Collect reactive state - use collectAsState for multiplatform compatibility
-    val isServerScanning by syncRepository.isServerScanning.collectAsStateWithLifecycle()
-    val scanProgress by syncRepository.scanProgress.collectAsStateWithLifecycle()
     val syncState by syncRepository.syncState.collectAsStateWithLifecycle()
     val user by userRepository.observeCurrentUser().collectAsStateWithLifecycle(initialValue = null)
     val searchState by searchViewModel.state.collectAsStateWithLifecycle()
@@ -291,52 +277,41 @@ fun AppShell(
 
     // Common content configuration
     val shellContent: @Composable (PaddingValues) -> Unit = { padding ->
-        if (isServerScanning) {
-            // Block the entire app shell with a scanning overlay
-            ScanningOverlay(
-                scanProgress = scanProgress,
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Content based on current destination
+            when (currentDestination) {
+                ShellDestination.Home -> {
+                    homeContent(
+                        padding,
+                        topBarCollapseFraction,
+                        { onDestinationChange(ShellDestination.Library) },
+                    )
+                }
+
+                ShellDestination.Library -> {
+                    libraryContent(padding, topBarCollapseFraction)
+                }
+
+                ShellDestination.Discover -> {
+                    discoverContent(padding)
+                }
+            }
+
+            // Search results overlay (floats above content when search is active)
+            SearchResultsOverlay(
+                state = searchState,
+                isExpanded = isSearchExpanded,
+                onResultClick = { hit ->
+                    searchViewModel.onResultClicked(hit)
+                },
+                onTypeFilterToggle = { type ->
+                    searchViewModel.toggleTypeFilter(type)
+                },
                 modifier =
                     Modifier
                         .fillMaxSize()
                         .padding(padding),
             )
-        } else {
-            Box(modifier = Modifier.fillMaxSize()) {
-                // Content based on current destination
-                when (currentDestination) {
-                    ShellDestination.Home -> {
-                        homeContent(
-                            padding,
-                            topBarCollapseFraction,
-                            { onDestinationChange(ShellDestination.Library) },
-                        )
-                    }
-
-                    ShellDestination.Library -> {
-                        libraryContent(padding, topBarCollapseFraction)
-                    }
-
-                    ShellDestination.Discover -> {
-                        discoverContent(padding)
-                    }
-                }
-
-                // Search results overlay (floats above content when search is active)
-                SearchResultsOverlay(
-                    state = searchState,
-                    isExpanded = isSearchExpanded,
-                    onResultClick = { hit ->
-                        searchViewModel.onResultClicked(hit)
-                    },
-                    onTypeFilterToggle = { type ->
-                        searchViewModel.toggleTypeFilter(type)
-                    },
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(padding),
-                )
-            }
         }
     }
 
@@ -378,65 +353,6 @@ fun AppShell(
                 snackbarHost = { SnackbarHost(snackbarHostState) },
                 content = shellContent,
             )
-        }
-    }
-}
-
-/**
- * Full-screen scanning overlay.
- *
- * Blocks all app content while the server is scanning the library.
- * Shows the standard ListenUpLoadingIndicator with phase and progress info.
- */
-@Composable
-private fun ScanningOverlay(
-    scanProgress: ScanProgressState?,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier =
-            modifier
-                .background(MaterialTheme.colorScheme.surfaceContainerLow),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            ListenUpLoadingIndicator(size = 64.dp)
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text =
-                    if (scanProgress != null) {
-                        scanProgress.phaseDisplayName +
-                            if (scanProgress.total > 0) " ${scanProgress.current}/${scanProgress.total}" else ""
-                    } else {
-                        "Scanning your library\u2026"
-                    },
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            if (scanProgress?.progressFraction != null) {
-                Spacer(modifier = Modifier.height(16.dp))
-                LinearProgressIndicator(
-                    progress = { scanProgress.progressFraction!! },
-                    modifier = Modifier.fillMaxWidth(0.6f),
-                    trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
-                )
-            }
-
-            val summary = scanProgress?.changesSummary
-            if (summary != null) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = summary,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
         }
     }
 }

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/design/util/FileLastModified.desktop.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/design/util/FileLastModified.desktop.kt
@@ -1,0 +1,5 @@
+package com.calypsan.listenup.client.design.util
+
+import java.io.File
+
+internal actual fun fileLastModifiedMillis(path: String): Long? = File(path).takeIf { it.exists() }?.lastModified()


### PR DESCRIPTION
## Why

Fresh-admin onboarding (empty server → wizard → first scan → library) was fragile and O(library-size): a large library could re-enter a `CursorStale` spin and the app shell could mount mid-import (OOM / books appearing late). Three root causes, fixed at the source rather than mitigated client-side.

## Root causes & fixes

**1. Scan-event ordering (server keystone).** `Scanner.runFullScan` emitted `ScanEvent.Completed` *before* `BookPersister` (separate coroutine) finished persisting → the client reconciled a still-writing server. Now `BookPersister.persist()` emits `Completed` at the end, after the persist loop and `softDeleteAbsent`. `Scanner` no longer emits `Completed`.

**2. Bulk population rode the lossy live firehose (server).** A 1000-book initial burst overflowed the `replay=256 DROP_OLDEST` `ChangeBus` → `CursorStale` spin. New `FirehoseSuppressed` coroutine-context marker: `SyncableRepository.upsert`/`softDelete` skip `bus.publish(...)` when the marker is present (revision bump + row commit stay unconditional, so catch-up still sees the rows). `BookPersister` runs a full-scan persist inside `withContext(FirehoseSuppressed)`; incrementals publish normally.

**3. Readiness inferred across 5 places (client).** Collapsed into one `sealed LibraryReadiness { Checking, NeedsSetup, Populating(progress), Ready, CheckFailed }`. The populating gate now spans the *client* import: on the initial `Completed`, `applyScanEvent` keeps scanning TRUE, awaits reconcile (mutex-coalesced), then clears — so the shell no longer mounts mid-import.

## Tests (TDD, all RED-first)

- Server: `BookPersisterTest` (Completed only after every book persisted; full-scan observes the suppression marker for every insert + the sweep), `SyncableRepositoryFirehoseSuppressionTest` (suppressed writes publish zero yet `pullSince` returns the row), `ScannerTest` updated (asserts `none { Completed }`).
- Client: `LibraryReadinessTest` (3 journeys via Turbine), `SyncRepositoryScanProgressTest` (gate stays up until reconcile completes).

## Verification

Local Linux gate green (`spotlessCheck detekt :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`); on-device verified — books load in, no spin/OOM. iOS gates run on remote CI (not runnable on the Linux dev box).

## Deferred (follow-up)

- Import-phase progress feedback ("Importing N/M books…" vs the indeterminate spinner).
- Re-test raising `SyncCatchUpClient.PAGE_LIMIT` 100→300-500 now the firehose spin is gone (needs on-device OOM re-validation).