### PR TITLE
🐛 fix(server): pin mDNS egress interface on multi-homed hosts

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/mdns/MulticastMdnsResponder.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/mdns/MulticastMdnsResponder.kt
@@ -52,13 +52,7 @@ class MulticastMdnsResponder(
                             .toList()
                             .filterIsInstance<Inet4Address>()
                             .firstOrNull() ?: continue
-                    val socket =
-                        MulticastSocket(PORT).apply {
-                            reuseAddress = true
-                            runCatching { setOption(java.net.StandardSocketOptions.SO_REUSEPORT, true) }
-                            joinGroup(InetSocketAddress(group, PORT), nif)
-                        }
-                    sockets += Bound(socket, nif, ipv4.address)
+                    sockets += Bound(bindMulticastSocket(nif), nif, ipv4.address)
                 }
                 if (sockets.isEmpty()) {
                     log.warn {
@@ -79,6 +73,21 @@ class MulticastMdnsResponder(
             }
         }
     }
+
+    /**
+     * Bind one multicast socket to [nif] and join 224.0.0.251:5353 on it. The crucial step is pinning
+     * the *egress* interface ([MulticastSocket.setNetworkInterface]): `joinGroup` only governs which
+     * interface we *receive* group traffic on, so without this every `send()` would leave via the OS
+     * default route — fatal on a multi-homed host (docker/VPN/multiple NICs), where announcements
+     * would never reach LAN clients on the intended interface.
+     */
+    internal fun bindMulticastSocket(nif: NetworkInterface): MulticastSocket =
+        MulticastSocket(PORT).apply {
+            reuseAddress = true
+            runCatching { setOption(java.net.StandardSocketOptions.SO_REUSEPORT, true) }
+            networkInterface = nif
+            joinGroup(InetSocketAddress(group, PORT), nif)
+        }
 
     private suspend fun announce(bound: Bound) {
         val packet = DnsCodec.encodeResponse(service, bound.ipv4, ttlSeconds = TTL_SECONDS)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/mdns/MulticastMdnsResponderTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/mdns/MulticastMdnsResponderTest.kt
@@ -18,6 +18,26 @@ private const val MDNS_PORT = 5353
 
 class MulticastMdnsResponderTest :
     FunSpec({
+        test("bindMulticastSocket pins the egress interface so sends leave via the joined NIC") {
+            // Deterministic guard (works on any host, incl. single-NIC CI): without setNetworkInterface,
+            // a multi-homed host sends every announcement out the OS default route instead of `nif`,
+            // and no LAN client on the other interfaces ever discovers us.
+            val nif =
+                firstMulticastIpv4Interface()
+                    ?: return@test // no multicast-capable interface here — nothing to assert
+            val service =
+                MdnsServiceInfo(instanceName = "kotest-host", port = 8080, txt = linkedMapOf("id" to "x"))
+            val responder = MulticastMdnsResponder(service, CoroutineScope(Dispatchers.IO + SupervisorJob()))
+
+            val socket = responder.bindMulticastSocket(nif)
+            try {
+                socket.networkInterface.name shouldBe nif.name
+            } finally {
+                runCatching { socket.leaveGroup(InetSocketAddress(InetAddress.getByName(MDNS_GROUP), MDNS_PORT), nif) }
+                socket.close()
+            }
+        }
+
         test("start announces an mDNS packet containing our TXT id and service type") {
             val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
             val service =


### PR DESCRIPTION
## Symptom

mDNS discovery fails for servers running on multi-homed hosts (the common case: a box with docker0, a VPN like Tailscale, and/or multiple NICs). Confirmed broken in-app, and reproduced by `MulticastMdnsResponderTest` failing locally while passing on CI.

## Root cause

`MulticastMdnsResponder` binds one socket per multicast-capable IPv4 interface and calls `joinGroup(nif)` — but `joinGroup` only governs which interface a socket *receives* group traffic on. It never set the socket's **outgoing** interface (`IP_MULTICAST_IF`). So every `send()` left via whatever interface the OS routing table picks for `224.0.0.251` — the default route — regardless of which interface the socket joined on.

On a single-NIC host (CI runners) send and receive land on the same interface, so it works — which is exactly why this was invisible in CI. On a multi-homed host the announcement egresses the wrong interface (or the wildcard `0.0.0.0`), and LAN clients on the intended interface never receive it.

## Fix

Pin the egress interface per socket via `MulticastSocket.setNetworkInterface(nif)` before joining the group. One line; it's the standard requirement every correct mDNS responder (avahi, jmDNS) satisfies.

## Tests

- **New deterministic guard** — `bindMulticastSocket pins the egress interface…` asserts `socket.networkInterface == nif`. Verified it **fails without the fix** (`expected:<docker0> but was:<0.0.0.0>`) and passes with it. Runs on any host including single-NIC CI, so it actually guards the regression CI previously couldn't catch.
- **Existing integration test** now passes on a multi-homed host where it previously failed (real multicast round-trip, 0.24s).
- Full `:server:test` green except a pre-existing, unrelated coroutine-timeout load-flake (`LibraryFolderSyncAccessTest`) that passes in isolation.