### PR TITLE
🔧 chore(server): gate mDNS off in tests via mdns.enabled flag

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -536,18 +536,25 @@ private fun Application.startBackgroundTasks(
 
     // mDNS advertisement — best-effort, non-fatal. Resolve the persistent instance id, then start the
     // advertiser; register its stop on shutdown. A failure here must never break startup — manual
-    // server-URL entry is the Never-Stranded fallback.
-    scope.launch {
-        runCatching {
-            val instanceId = inject<InstanceIdentity>().value.instanceId()
-            val advertiser = koinGet<MdnsAdvertiser> { parametersOf(instanceId) }
-            advertiser.start()
-            monitor.subscribe(ApplicationStopped) {
-                scope.launch { advertiser.stop() }
+    // server-URL entry is the Never-Stranded fallback. Gated by `mdns.enabled` (default true) so the
+    // test harness can opt out — no test should bind multicast sockets or run a receive loop.
+    if (environment.config
+            .propertyOrNull("mdns.enabled")
+            ?.getString()
+            ?.toBooleanStrictOrNull() != false
+    ) {
+        scope.launch {
+            runCatching {
+                val instanceId = inject<InstanceIdentity>().value.instanceId()
+                val advertiser = koinGet<MdnsAdvertiser> { parametersOf(instanceId) }
+                advertiser.start()
+                monitor.subscribe(ApplicationStopped) {
+                    scope.launch { advertiser.stop() }
+                }
+            }.onFailure { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                logger.warn(e) { "mDNS advertisement failed to start — server keeps running" }
             }
-        }.onFailure { e ->
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            logger.warn(e) { "mDNS advertisement failed to start — server keeps running" }
         }
     }
 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
@@ -78,6 +78,7 @@ internal class AuthEndToEndFixture private constructor(
                             "jwt.issuer" to "listenup",
                             "jwt.audience" to "listenup-client",
                             "registration.policy" to "OPEN",
+                            "mdns.enabled" to "false",
                         )
                 }
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/LiveCorpusBooksPersistenceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/LiveCorpusBooksPersistenceTest.kt
@@ -91,6 +91,7 @@ class LiveCorpusBooksPersistenceTest :
                                 "jwt.issuer" to "listenup",
                                 "jwt.audience" to "listenup-client",
                                 "registration.policy" to "OPEN",
+                                "mdns.enabled" to "false",
                                 "scanner.libraryPath" to corpusPath,
                             )
                     }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndFixture.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndFixture.kt
@@ -64,6 +64,7 @@ internal class ScannerEndToEndFixture private constructor(
                             "jwt.issuer" to "listenup",
                             "jwt.audience" to "listenup-client",
                             "registration.policy" to "OPEN",
+                            "mdns.enabled" to "false",
                             "scanner.libraryPath" to libraryRoot.toString(),
                         )
                 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/TestApplicationConfig.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/TestApplicationConfig.kt
@@ -44,6 +44,9 @@ fun ApplicationTestBuilder.useIsolatedTestConfig(
                 "jwt.issuer" to "listenup",
                 "jwt.audience" to "listenup-client",
                 "registration.policy" to registrationPolicy,
+                // No test should bind multicast sockets or run an mDNS receive loop — pure overhead
+                // and a source of cross-test load that flakes the firehose timeout budget.
+                "mdns.enabled" to "false",
             ).apply {
                 if (libraryPath != null) put("scanner.libraryPath", libraryPath)
                 if (seedProfile != null) put("seed.profile", seedProfile)


### PR DESCRIPTION
## What

Adds an `mdns.enabled` config flag (default **true** — production unchanged) and sets it `false` across the test harness, so `module()` no longer starts the mDNS advertiser during tests.

## Why

No test should bind multicast sockets on every network interface and run a receive loop — that's real network I/O and log noise (`mDNS advertisement started/failed`) in every full-server `testApplication` boot, of which there are hundreds. This is test hygiene.

**Honest scope note:** this is *not* a flake fix. I gated mDNS while investigating the `:server:test` load-flakes and measured the result — mDNS boots dropped to 0, but the flakes persisted (a different test trips each run; they're environmental timing jitter against a hard 1-minute coroutine budget in SSE-heavy tests, and specs already run sequentially so there's no parallelism to reduce). Shipping this purely as the hygiene win it is.

## Coverage

Verified empirically: a full `:server:test` run logs `mDNS advertisement started` **0 times**. The flag is set in `useIsolatedTestConfig` and the three fixtures that build their own `MapApplicationConfig` (`AuthEndToEndFixture`, `ScannerEndToEndFixture`, `LiveCorpusBooksPersistenceTest`); `SyncTestApplication` never calls `module()` so it was already mDNS-free.

Default-on logic: `mdns.enabled` absent or any value other than `"false"` → advertiser starts (production behavior preserved).