### PR TITLE
👷 ci(contract): run :contract:jvmTest in the JVM test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,10 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      # Kotest across the shared client core (every client consumes :sharedLogic) + server.
+      # Kotest across the contract DTOs, the shared client core (every client consumes
+      # :sharedLogic), and the server.
       - name: Run JVM tests
-        run: ./gradlew :sharedLogic:jvmTest :server:test --no-daemon
+        run: ./gradlew :contract:jvmTest :sharedLogic:jvmTest :server:test --no-daemon
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Adds `:contract:jvmTest` to the CI **Test (JVM)** job, so the contract DTO round-trip tests actually run in CI.

## Why

The Test (JVM) job ran only `:sharedLogic:jvmTest :server:test`. Running `:sharedLogic:jvmTest` compiles against `:contract` but does **not** trigger `:contract`'s test task (Gradle test tasks depend on a dependency's *main* compilation, not its tests), and the iOS lane runs `xcodebuild` on the app scheme, which doesn't run contract's Kotlin tests either. So `:contract`'s 5 commonTest suites (17 tests — the `@Serializable` DTO contract tests) ran **nowhere in CI**, despite the contract boundary being the #1 testing priority in CLAUDE.md.

Verified locally: `:contract:jvmTest` → 5 suites, 17 tests, green.

## Note on the host-test warning

The build emits `WARNING: ... commonTest exists, but android host tests are not enabled` for `:contract`. I deliberately did **not** silence it with `withHostTest {}`: that compiles, but the resulting `testAndroidHostTest` task fails test discovery (the Android unit-test runner doesn't find Kotest's JUnit-Platform tests), which would break `./gradlew check`. The warning is harmless — those tests run on the `jvm()` target — so a cosmetic warning is the better trade than a failing task.