### PR TITLE
🐛 fix(client): admin users page — migrate admin user management to AdminUserService RPC

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminApi.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminApi.kt
@@ -1,8 +1,13 @@
 
 package com.calypsan.listenup.client.data.remote
 
+import com.calypsan.listenup.api.dto.auth.AdminUserPatch
+import com.calypsan.listenup.api.dto.auth.PendingRegistrationDecision
+import com.calypsan.listenup.api.dto.auth.PendingRegistrationOutcome
+import com.calypsan.listenup.api.dto.auth.User
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
+import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.remote.model.ApiResponse
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -21,24 +26,22 @@ import kotlinx.serialization.Serializable
  */
 @Suppress("TooManyFunctions")
 interface AdminApiContract {
-    // User management
-    suspend fun getUsers(): AppResult<List<AdminUser>>
+    // User management — bare contract types matching the Kotlin server's REST responses
+    suspend fun getUsers(): AppResult<List<User>>
 
-    suspend fun getUser(userId: String): AppResult<AdminUser>
+    suspend fun getUser(userId: String): AppResult<User>
 
     suspend fun updateUser(
         userId: String,
-        request: UpdateUserRequest,
-    ): AppResult<AdminUser>
+        patch: AdminUserPatch,
+    ): AppResult<User>
 
     suspend fun deleteUser(userId: String): AppResult<Unit>
 
     // Pending user management
-    suspend fun getPendingUsers(): AppResult<List<AdminUser>>
+    suspend fun getPendingUsers(): AppResult<List<User>>
 
-    suspend fun approveUser(userId: String): AppResult<AdminUser>
-
-    suspend fun denyUser(userId: String): AppResult<Unit>
+    suspend fun decidePendingRegistration(decision: PendingRegistrationDecision): AppResult<PendingRegistrationOutcome>
 
     // Invite management
     suspend fun getInvites(): AppResult<List<AdminInvite>>
@@ -108,56 +111,63 @@ private fun userPath(userId: String) = "$ADMIN_USERS_PATH/$userId"
 /**
  * API client for admin operations.
  *
- * Requires authentication via ApiClientFactory.
+ * Requires authentication via [ApiClientFactory].
  * All endpoints require the user to be an admin (IsRoot or Role=admin).
+ *
+ * User-management methods use [suspendRunCatching] directly because the Kotlin server
+ * returns **bare** contract types — not the `ApiResponse` envelope that the Go server
+ * used. The [apiCall]/[apiCallUnit] helpers are envelope-shaped and cannot be used here;
+ * this is the same pattern as [CollectionInboxApi].
  */
 class AdminApi(
     private val clientFactory: ApiClientFactory,
 ) : AdminApiContract {
-    // User Management
+    // User Management — bare contract types (Kotlin server returns no ApiResponse envelope)
 
-    override suspend fun getUsers(): AppResult<List<AdminUser>> =
-        apiCall(errorMessage = "Admin users response missing data") {
-            clientFactory.getClient().get(ADMIN_USERS_PATH).body<ApiResponse<UsersResponse>>()
-        }.map { it.users }
+    override suspend fun getUsers(): AppResult<List<User>> =
+        suspendRunCatching {
+            clientFactory.getClient().get(ADMIN_USERS_PATH).body<List<User>>()
+        }
 
-    override suspend fun getUser(userId: String): AppResult<AdminUser> =
-        apiCall(errorMessage = "Admin user detail response missing data") {
-            clientFactory.getClient().get(userPath(userId)).body<ApiResponse<AdminUser>>()
+    override suspend fun getUser(userId: String): AppResult<User> =
+        suspendRunCatching {
+            clientFactory.getClient().get(userPath(userId)).body<User>()
         }
 
     override suspend fun updateUser(
         userId: String,
-        request: UpdateUserRequest,
-    ): AppResult<AdminUser> =
-        apiCall(errorMessage = "Admin update-user response missing data") {
+        patch: AdminUserPatch,
+    ): AppResult<User> =
+        suspendRunCatching {
             clientFactory
                 .getClient()
                 .patch(userPath(userId)) {
-                    setBody(request)
-                }.body<ApiResponse<AdminUser>>()
+                    setBody(patch)
+                }.body<User>()
         }
 
     override suspend fun deleteUser(userId: String): AppResult<Unit> =
-        apiCallUnit {
-            clientFactory.getClient().delete(userPath(userId)).body<ApiResponse<Unit>>()
-        }
+        suspendRunCatching {
+            // 204 No Content — read the status to consume the response; no body to decode.
+            clientFactory.getClient().delete(userPath(userId)).status
+        }.map { }
 
     // Pending User Management
 
-    override suspend fun getPendingUsers(): AppResult<List<AdminUser>> =
-        apiCall(errorMessage = "Pending users response missing data") {
-            clientFactory.getClient().get("$ADMIN_USERS_PATH/pending").body<ApiResponse<UsersResponse>>()
-        }.map { it.users }
-
-    override suspend fun approveUser(userId: String): AppResult<AdminUser> =
-        apiCall(errorMessage = "Approve user response missing data") {
-            clientFactory.getClient().post("$ADMIN_USERS_PATH/$userId/approve").body<ApiResponse<AdminUser>>()
+    override suspend fun getPendingUsers(): AppResult<List<User>> =
+        suspendRunCatching {
+            clientFactory.getClient().get("$ADMIN_USERS_PATH/pending").body<List<User>>()
         }
 
-    override suspend fun denyUser(userId: String): AppResult<Unit> =
-        apiCallUnit {
-            clientFactory.getClient().post("$ADMIN_USERS_PATH/$userId/deny").body<ApiResponse<Unit>>()
+    override suspend fun decidePendingRegistration(
+        decision: PendingRegistrationDecision,
+    ): AppResult<PendingRegistrationOutcome> =
+        suspendRunCatching {
+            clientFactory
+                .getClient()
+                .post("$ADMIN_USERS_PATH/pending-decision") {
+                    setBody(decision)
+                }.body<PendingRegistrationOutcome>()
         }
 
     // Invite Management
@@ -329,56 +339,11 @@ class AdminApi(
 // Response wrappers
 
 @Serializable
-private data class UsersResponse(
-    @SerialName("users") val users: List<AdminUser>,
-)
-
-@Serializable
 private data class InvitesResponse(
     @SerialName("invites") val invites: List<AdminInvite>,
 )
 
 // Models
-
-/**
- * Admin view of a user.
- * Contains more information than the regular user model.
- */
-@Serializable
-data class AdminUser(
-    @SerialName("id") val id: String,
-    @SerialName("email") val email: String,
-    @SerialName("display_name") val displayName: String? = null,
-    @SerialName("first_name") val firstName: String? = null,
-    @SerialName("last_name") val lastName: String? = null,
-    @SerialName("is_root") val isRoot: Boolean,
-    @SerialName("role") val role: String,
-    @SerialName("status") val status: String = "active",
-    @SerialName("permissions") val permissions: UserPermissionsResponse = UserPermissionsResponse(),
-    @SerialName("invited_by") val invitedBy: String? = null,
-    @SerialName("created_at") val createdAt: String,
-    @SerialName("updated_at") val updatedAt: String? = null,
-    @SerialName("last_login_at") val lastLoginAt: String? = null,
-) {
-    /**
-     * Check if this user can be modified/deleted by the current admin.
-     * Root users cannot be modified except by themselves.
-     */
-    val isProtected: Boolean get() = isRoot
-
-    /**
-     * Whether this user is pending admin approval.
-     */
-    val isPending: Boolean get() = status == "pending"
-}
-
-/**
- * User permission flags returned by the server.
- */
-@Serializable
-data class UserPermissionsResponse(
-    @SerialName("can_share") val canShare: Boolean = true,
-)
 
 /**
  * Admin view of an invite.
@@ -426,26 +391,6 @@ data class CreateInviteRequest(
     @SerialName("email") val email: String,
     @SerialName("role") val role: String = "member",
     @SerialName("expires_in_days") val expiresInDays: Int = 7,
-)
-
-/**
- * Request to update a user.
- */
-@Serializable
-data class UpdateUserRequest(
-    @SerialName("role") val role: String? = null,
-    @SerialName("first_name") val firstName: String? = null,
-    @SerialName("last_name") val lastName: String? = null,
-    @SerialName("permissions") val permissions: UpdatePermissionsRequest? = null,
-)
-
-/**
- * Request to update user permissions.
- * Only include fields that should be changed.
- */
-@Serializable
-data class UpdatePermissionsRequest(
-    @SerialName("can_share") val canShare: Boolean? = null,
 )
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminUserRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminUserRpcFactory.kt
@@ -1,0 +1,71 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.api.AdminUserService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.serialization.json.json
+import kotlinx.rpc.withService
+
+/**
+ * Supplies the [AdminUserService] kotlinx.rpc proxy backing the admin user-management
+ * surface (roster, approval queue, role/permission edits, soft-delete). An interface so
+ * repositories depend on a seam that fakes in tests; [KtorAdminUserRpcFactory] is the
+ * production implementation over the bearer-gated `/api/rpc/authed` WebSocket.
+ *
+ * Mirrors [LibraryAdminRpcFactory] — the established RPC-factory shape.
+ */
+interface AdminUserRpcFactory {
+    /** Returns the cached [AdminUserService] proxy, connecting on first use. */
+    suspend fun get(): AdminUserService
+
+    /** Drop the cached proxy and the RPC-flavored HttpClient. */
+    suspend fun invalidate()
+}
+
+open class KtorAdminUserRpcFactory(
+    private val apiClientFactory: ApiClientFactory,
+    private val serverConfig: ServerConfig,
+) : AdminUserRpcFactory,
+    RemoteCache {
+    private val mutex = Mutex()
+    private var cachedRpcClient: HttpClient? = null
+    private var cachedService: AdminUserService? = null
+
+    override suspend fun get(): AdminUserService =
+        mutex.withLock {
+            cachedService ?: connect().also { cachedService = it }
+        }
+
+    override suspend fun invalidate() {
+        mutex.withLock {
+            cachedService = null
+            cachedRpcClient = null
+        }
+    }
+
+    internal open suspend fun connect(): AdminUserService {
+        val baseUrl = rpcBaseUrl()
+        return rpcClient().rpc("$baseUrl/api/rpc/authed").withService<AdminUserService>()
+    }
+
+    private suspend fun rpcClient(): HttpClient =
+        cachedRpcClient ?: apiClientFactory
+            .getClient()
+            .config {
+                installKrpc {
+                    serialization { json(contractJson) }
+                }
+            }.also { cachedRpcClient = it }
+
+    private suspend fun rpcBaseUrl(): String {
+        val httpUrl =
+            serverConfig.getActiveUrl()?.value
+                ?: error("Server URL not configured — cannot open RPC connection")
+        return toWebSocketScheme(httpUrl)
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminUserRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminUserRpcFactory.kt
@@ -27,6 +27,17 @@ interface AdminUserRpcFactory {
     suspend fun invalidate()
 }
 
+/**
+ * Production [AdminUserRpcFactory] over the bearer-gated `/api/rpc/authed` WebSocket.
+ *
+ * Caches the [AdminUserService] proxy and the RPC-flavored [HttpClient] per mount.
+ * [invalidate] drops both caches; the next [get] call reconnects fresh — used by
+ * [RpcCacheInvalidator] on logout or server-URL change.
+ *
+ * Declared `open` so tests can subclass and override [connect] with a fake WebSocket.
+ *
+ * Mirrors [KtorLibraryAdminRpcFactory] — the established RPC-factory shape.
+ */
 open class KtorAdminUserRpcFactory(
     private val apiClientFactory: ApiClientFactory,
     private val serverConfig: ServerConfig,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -1,11 +1,16 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.api.dto.auth.AdminUserPatch
+import com.calypsan.listenup.api.dto.auth.PendingRegistrationDecision
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.flatMap
 import com.calypsan.listenup.api.result.map
 import com.calypsan.listenup.client.data.remote.AdminApiContract
+import com.calypsan.listenup.client.data.remote.AdminUserRpcFactory
 import com.calypsan.listenup.client.data.remote.BrowseFilesystemResponse
 import com.calypsan.listenup.client.data.remote.AdminInvite
-import com.calypsan.listenup.client.data.remote.AdminUser
 import com.calypsan.listenup.client.data.remote.CollectionRef
 import com.calypsan.listenup.client.data.remote.CreateInviteRequest
 import com.calypsan.listenup.client.data.remote.InboxBookResponse
@@ -14,8 +19,6 @@ import com.calypsan.listenup.client.data.remote.ServerSettingsRequest
 import com.calypsan.listenup.client.data.remote.UpdateInstanceRequest
 import com.calypsan.listenup.client.data.remote.ServerSettingsResponse
 import com.calypsan.listenup.client.data.remote.UpdateLibraryRequest
-import com.calypsan.listenup.client.data.remote.UpdatePermissionsRequest
-import com.calypsan.listenup.client.data.remote.UpdateUserRequest
 import com.calypsan.listenup.client.domain.model.AccessMode
 import com.calypsan.listenup.client.domain.model.AdminUserInfo
 import com.calypsan.listenup.client.domain.model.InboxBook
@@ -24,39 +27,47 @@ import com.calypsan.listenup.client.domain.model.InviteInfo
 import com.calypsan.listenup.client.domain.model.Library
 import com.calypsan.listenup.client.domain.model.ServerSettings
 import com.calypsan.listenup.client.domain.model.StagedCollection
-import com.calypsan.listenup.client.domain.model.UserPermissions
 import com.calypsan.listenup.client.domain.repository.AdminRepository
 
 /**
- * Implementation of AdminRepository using AdminApiContract.
+ * Implementation of AdminRepository using AdminApiContract for non-user operations
+ * and [AdminUserRpcFactory] for user management (routed through the Kotlin RPC server).
  *
- * Wraps admin API calls and converts data layer types to domain models.
  * All methods return [AppResult] — no exceptions are thrown.
  *
- * @property adminApi API client for admin operations
+ * @property adminApi API client for invite/settings/inbox/library operations
+ * @property adminUserRpc RPC factory for user-management operations
  */
 class AdminRepositoryImpl(
     private val adminApi: AdminApiContract,
+    private val adminUserRpc: AdminUserRpcFactory,
 ) : AdminRepository {
     // ═══════════════════════════════════════════════════════════════════════
     // USER MANAGEMENT
     // ═══════════════════════════════════════════════════════════════════════
 
     override suspend fun getUsers(): AppResult<List<AdminUserInfo>> =
-        adminApi.getUsers().map { users -> users.map { it.toDomain() } }
+        adminUserRpc.get().listUsers().map { users -> users.map { it.toAdminUserInfo() } }
 
     override suspend fun getPendingUsers(): AppResult<List<AdminUserInfo>> =
-        adminApi.getPendingUsers().map { users -> users.map { it.toDomain() } }
+        adminUserRpc.get().listPendingUsers().map { users -> users.map { it.toAdminUserInfo() } }
 
     override suspend fun approveUser(userId: String): AppResult<AdminUserInfo> =
-        adminApi.approveUser(userId).map { it.toDomain() }
+        adminUserRpc.get()
+            .decidePendingRegistration(PendingRegistrationDecision(UserId(userId), approved = true))
+            .flatMap { adminUserRpc.get().getUser(UserId(userId)) }
+            .map { it.toAdminUserInfo() }
 
-    override suspend fun denyUser(userId: String): AppResult<Unit> = adminApi.denyUser(userId)
+    override suspend fun denyUser(userId: String): AppResult<Unit> =
+        adminUserRpc.get()
+            .decidePendingRegistration(PendingRegistrationDecision(UserId(userId), approved = false))
+            .map { }
 
-    override suspend fun deleteUser(userId: String): AppResult<Unit> = adminApi.deleteUser(userId)
+    override suspend fun deleteUser(userId: String): AppResult<Unit> =
+        adminUserRpc.get().deleteUser(UserId(userId))
 
     override suspend fun getUser(userId: String): AppResult<AdminUserInfo> =
-        adminApi.getUser(userId).map { it.toDomain() }
+        adminUserRpc.get().getUser(UserId(userId)).map { it.toAdminUserInfo() }
 
     override suspend fun updateUser(
         userId: String,
@@ -65,24 +76,15 @@ class AdminRepositoryImpl(
         role: String?,
         canShare: Boolean?,
     ): AppResult<AdminUserInfo> {
-        val permissionsUpdate =
-            if (canShare != null) {
-                UpdatePermissionsRequest(
-                    canShare = canShare,
-                )
-            } else {
-                null
-            }
-
-        val request =
-            UpdateUserRequest(
-                firstName = firstName,
-                lastName = lastName,
-                role = role,
-                permissions = permissionsUpdate,
-            )
-
-        return adminApi.updateUser(userId, request).map { it.toDomain() }
+        // firstName/lastName have no contract field — they must NOT be sent to the server.
+        // displayName is deferred to a future domain-realignment follow-up.
+        val patch = AdminUserPatch(
+            role = role?.let { UserRole.valueOf(it) },
+            permissions = canShare?.let {
+                com.calypsan.listenup.api.dto.auth.UserPermissions(canShare = it)
+            },
+        )
+        return adminUserRpc.get().updateUser(UserId(userId), patch).map { it.toAdminUserInfo() }
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -201,26 +203,6 @@ class AdminRepositoryImpl(
 // ═══════════════════════════════════════════════════════════════════════════
 // CONVERSION FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════
-
-/**
- * Convert AdminUser API model to AdminUserInfo domain model.
- */
-private fun AdminUser.toDomain(): AdminUserInfo =
-    AdminUserInfo(
-        id = id,
-        email = email,
-        displayName = displayName,
-        firstName = firstName,
-        lastName = lastName,
-        isRoot = isRoot,
-        role = role,
-        status = status,
-        permissions =
-            UserPermissions(
-                canShare = permissions.canShare,
-            ),
-        createdAt = createdAt,
-    )
 
 /**
  * Convert AdminInvite API model to InviteInfo domain model.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -3,7 +3,9 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.dto.auth.AdminUserPatch
 import com.calypsan.listenup.api.dto.auth.PendingRegistrationDecision
 import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserPermissions
 import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.flatMap
 import com.calypsan.listenup.api.result.map
@@ -28,12 +30,19 @@ import com.calypsan.listenup.client.domain.model.Library
 import com.calypsan.listenup.client.domain.model.ServerSettings
 import com.calypsan.listenup.client.domain.model.StagedCollection
 import com.calypsan.listenup.client.domain.repository.AdminRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Implementation of AdminRepository using AdminApiContract for non-user operations
  * and [AdminUserRpcFactory] for user management (routed through the Kotlin RPC server).
  *
- * All methods return [AppResult] — no exceptions are thrown.
+ * All methods return [AppResult] — no exceptions are thrown. The [catching] helper wraps
+ * every RPC call so that transport-level exceptions (e.g. [io.ktor.client.plugins.websocket.WebSocketException]
+ * on a 401 WS handshake) are converted to [AppResult.Failure] rather than propagating as
+ * unhandled exceptions. This mirrors [AuthRepositoryImpl.catching] and upholds the contract.
  *
  * @property adminApi API client for invite/settings/inbox/library operations
  * @property adminUserRpc RPC factory for user-management operations
@@ -47,27 +56,39 @@ class AdminRepositoryImpl(
     // ═══════════════════════════════════════════════════════════════════════
 
     override suspend fun getUsers(): AppResult<List<AdminUserInfo>> =
-        adminUserRpc.get().listUsers().map { users -> users.map { it.toAdminUserInfo() } }
+        catching("getUsers") {
+            adminUserRpc.get().listUsers().map { users -> users.map { it.toAdminUserInfo() } }
+        }
 
     override suspend fun getPendingUsers(): AppResult<List<AdminUserInfo>> =
-        adminUserRpc.get().listPendingUsers().map { users -> users.map { it.toAdminUserInfo() } }
+        catching("getPendingUsers") {
+            adminUserRpc.get().listPendingUsers().map { users -> users.map { it.toAdminUserInfo() } }
+        }
 
     override suspend fun approveUser(userId: String): AppResult<AdminUserInfo> =
-        adminUserRpc.get()
-            .decidePendingRegistration(PendingRegistrationDecision(UserId(userId), approved = true))
-            .flatMap { adminUserRpc.get().getUser(UserId(userId)) }
-            .map { it.toAdminUserInfo() }
+        catching("approveUser") {
+            adminUserRpc
+                .get()
+                .decidePendingRegistration(PendingRegistrationDecision(UserId(userId), approved = true))
+                .flatMap { adminUserRpc.get().getUser(UserId(userId)) }
+                .map { it.toAdminUserInfo() }
+        }
 
     override suspend fun denyUser(userId: String): AppResult<Unit> =
-        adminUserRpc.get()
-            .decidePendingRegistration(PendingRegistrationDecision(UserId(userId), approved = false))
-            .map { }
+        catching("denyUser") {
+            adminUserRpc
+                .get()
+                .decidePendingRegistration(PendingRegistrationDecision(UserId(userId), approved = false))
+                .map { }
+        }
 
     override suspend fun deleteUser(userId: String): AppResult<Unit> =
-        adminUserRpc.get().deleteUser(UserId(userId))
+        catching("deleteUser") { adminUserRpc.get().deleteUser(UserId(userId)) }
 
     override suspend fun getUser(userId: String): AppResult<AdminUserInfo> =
-        adminUserRpc.get().getUser(UserId(userId)).map { it.toAdminUserInfo() }
+        catching("getUser") {
+            adminUserRpc.get().getUser(UserId(userId)).map { it.toAdminUserInfo() }
+        }
 
     override suspend fun updateUser(
         userId: String,
@@ -78,14 +99,39 @@ class AdminRepositoryImpl(
     ): AppResult<AdminUserInfo> {
         // firstName/lastName have no contract field — they must NOT be sent to the server.
         // displayName is deferred to a future domain-realignment follow-up.
-        val patch = AdminUserPatch(
-            role = role?.let { UserRole.valueOf(it) },
-            permissions = canShare?.let {
-                com.calypsan.listenup.api.dto.auth.UserPermissions(canShare = it)
-            },
-        )
-        return adminUserRpc.get().updateUser(UserId(userId), patch).map { it.toAdminUserInfo() }
+        val patch =
+            AdminUserPatch(
+                role = role?.let { UserRole.valueOf(it) },
+                permissions = canShare?.let { UserPermissions(canShare = it) },
+            )
+        return catching("updateUser") {
+            adminUserRpc.get().updateUser(UserId(userId), patch).map { it.toAdminUserInfo() }
+        }
     }
+
+    /**
+     * Catches transport-level exceptions from RPC calls and converts them to
+     * [AppResult.Failure], preserving the [AppResult] contract. [CancellationException]
+     * is always re-thrown per kotlinx.coroutines convention.
+     *
+     * This is required because [AdminUserRpcFactory.get] opens a WebSocket connection
+     * on first use; if authentication fails (HTTP 401 during the WS upgrade), the RPC
+     * library throws [io.ktor.client.plugins.websocket.WebSocketException] rather than
+     * returning an error response. Without this boundary the exception escapes into the
+     * caller's coroutine as an unhandled exception.
+     */
+    private suspend inline fun <T> catching(
+        op: String,
+        block: () -> AppResult<T>,
+    ): AppResult<T> =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "admin user RPC $op failed at the transport boundary" }
+            AppResult.Failure(InternalError())
+        }
 
     // ═══════════════════════════════════════════════════════════════════════
     // INVITE MANAGEMENT

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -96,18 +96,27 @@ class AdminRepositoryImpl(
         lastName: String?,
         role: String?,
         canShare: Boolean?,
-    ): AppResult<AdminUserInfo> {
-        // firstName/lastName have no contract field — they must NOT be sent to the server.
-        // displayName is deferred to a future domain-realignment follow-up.
-        val patch =
-            AdminUserPatch(
-                role = role?.let { UserRole.valueOf(it) },
-                permissions = canShare?.let { UserPermissions(canShare = it) },
-            )
-        return catching("updateUser") {
+    ): AppResult<AdminUserInfo> =
+        catching("updateUser") {
+            // firstName/lastName have no contract field — they must NOT be sent (displayName is
+            // deferred to a future domain-realignment follow-up). The server applies
+            // AdminUserPatch.permissions wholesale (canEdit + canShare) and the admin UI only
+            // toggles canShare, so read the user first to preserve its current canEdit.
+            val permissions =
+                canShare?.let { share ->
+                    when (val current = adminUserRpc.get().getUser(UserId(userId))) {
+                        is AppResult.Success -> {
+                            UserPermissions(canEdit = current.data.permissions.canEdit, canShare = share)
+                        }
+
+                        is AppResult.Failure -> {
+                            return@catching current
+                        }
+                    }
+                }
+            val patch = AdminUserPatch(role = role?.let { UserRole.valueOf(it) }, permissions = permissions)
             adminUserRpc.get().updateUser(UserId(userId), patch).map { it.toAdminUserInfo() }
         }
-    }
 
     /**
      * Catches transport-level exceptions from RPC calls and converts them to

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapper.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.dto.auth.User
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.client.domain.model.AdminUserInfo
+import com.calypsan.listenup.client.domain.model.UserPermissions
+
+/**
+ * Maps the contract [User] returned by [com.calypsan.listenup.api.AdminUserService] to the
+ * admin-screen domain model [AdminUserInfo]. The contract has no first/last name (only
+ * [User.displayName]); [AdminUserInfo.displayableName] already falls back to displayName.
+ */
+internal fun User.toAdminUserInfo(): AdminUserInfo = AdminUserInfo(
+    id = id.value,
+    email = email,
+    displayName = displayName,
+    firstName = null,
+    lastName = null,
+    isRoot = role == UserRole.ROOT,
+    role = role.name,
+    status = status.name,
+    permissions = UserPermissions(canShare = permissions.canShare),
+    createdAt = createdAt.toString(),
+)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapper.kt
@@ -10,15 +10,16 @@ import com.calypsan.listenup.client.domain.model.UserPermissions
  * admin-screen domain model [AdminUserInfo]. The contract has no first/last name (only
  * [User.displayName]); [AdminUserInfo.displayableName] already falls back to displayName.
  */
-internal fun User.toAdminUserInfo(): AdminUserInfo = AdminUserInfo(
-    id = id.value,
-    email = email,
-    displayName = displayName,
-    firstName = null,
-    lastName = null,
-    isRoot = role == UserRole.ROOT,
-    role = role.name,
-    status = status.name,
-    permissions = UserPermissions(canShare = permissions.canShare),
-    createdAt = createdAt.toString(),
-)
+internal fun User.toAdminUserInfo(): AdminUserInfo =
+    AdminUserInfo(
+        id = id.value,
+        email = email,
+        displayName = displayName,
+        firstName = null,
+        lastName = null,
+        isRoot = role == UserRole.ROOT,
+        role = role.name,
+        status = status.name,
+        permissions = UserPermissions(canShare = permissions.canShare),
+        createdAt = createdAt.toString(),
+    )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -12,7 +12,9 @@ import com.calypsan.listenup.client.data.remote.ABSImportApi
 import com.calypsan.listenup.client.data.remote.ABSImportApiContract
 import com.calypsan.listenup.client.data.remote.AdminApi
 import com.calypsan.listenup.client.data.remote.AdminApiContract
+import com.calypsan.listenup.client.data.remote.AdminUserRpcFactory
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
+import com.calypsan.listenup.client.data.remote.KtorAdminUserRpcFactory
 import com.calypsan.listenup.client.data.remote.CollectionInboxApi
 import com.calypsan.listenup.client.data.remote.CollectionInboxApiContract
 import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
@@ -658,12 +660,12 @@ val syncModule =
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 
         // AdminUserRpcFactory — kotlinx.rpc proxy for AdminUserService (user roster, approval queue, edits).
-        single<com.calypsan.listenup.client.data.remote.AdminUserRpcFactory> {
-            com.calypsan.listenup.client.data.remote.KtorAdminUserRpcFactory(
+        single<AdminUserRpcFactory> {
+            KtorAdminUserRpcFactory(
                 apiClientFactory = get(),
                 serverConfig = get(),
             )
-        }
+        } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 
         // TagRpcFactory — kotlinx.rpc proxy for TagService (observations from Room; mutations via RPC).
         single<TagRpcFactory> {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -657,6 +657,14 @@ val syncModule =
             )
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 
+        // AdminUserRpcFactory — kotlinx.rpc proxy for AdminUserService (user roster, approval queue, edits).
+        single<com.calypsan.listenup.client.data.remote.AdminUserRpcFactory> {
+            com.calypsan.listenup.client.data.remote.KtorAdminUserRpcFactory(
+                apiClientFactory = get(),
+                serverConfig = get(),
+            )
+        }
+
         // TagRpcFactory — kotlinx.rpc proxy for TagService (observations from Room; mutations via RPC).
         single<TagRpcFactory> {
             KtorTagRpcFactory(
@@ -1048,7 +1056,7 @@ val syncModule =
 
         // AdminRepository for admin operations (SOLID: interface in domain, impl in data)
         single<AdminRepository> {
-            AdminRepositoryImpl(adminApi = get())
+            AdminRepositoryImpl(adminApi = get(), adminUserRpc = get())
         }
 
         // ProfileRepository for public user profiles (SOLID: interface in domain, impl in data)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -43,31 +43,36 @@ private class FakeAdminUserService : AdminUserService {
         users[user.id.value] = user
     }
 
-    override suspend fun listUsers(): AppResult<List<User>> =
-        AppResult.Success(users.values.toList())
+    override suspend fun listUsers(): AppResult<List<User>> = AppResult.Success(users.values.toList())
 
-    override suspend fun listPendingUsers(): AppResult<List<User>> =
-        AppResult.Success(users.values.filter { it.status == UserStatus.PENDING_APPROVAL })
+    override suspend fun listPendingUsers(): AppResult<List<User>> = AppResult.Success(users.values.filter { it.status == UserStatus.PENDING_APPROVAL })
 
     override suspend fun getUser(id: UserId): AppResult<User> {
-        val user = users[id.value] ?: return AppResult.Failure(
-            com.calypsan.listenup.api.error.InternalError(debugInfo = "not found: ${id.value}"),
-        )
+        val user =
+            users[id.value] ?: return AppResult.Failure(
+                com.calypsan.listenup.api.error
+                    .InternalError(debugInfo = "not found: ${id.value}"),
+            )
         return AppResult.Success(user)
     }
 
-    override suspend fun searchUsers(query: String): AppResult<List<User>> =
-        AppResult.Success(users.values.filter { it.email.contains(query) || it.displayName.contains(query) })
+    override suspend fun searchUsers(query: String): AppResult<List<User>> = AppResult.Success(users.values.filter { it.email.contains(query) || it.displayName.contains(query) })
 
-    override suspend fun updateUser(id: UserId, patch: AdminUserPatch): AppResult<User> {
+    override suspend fun updateUser(
+        id: UserId,
+        patch: AdminUserPatch,
+    ): AppResult<User> {
         lastPatch = patch
-        val existing = users[id.value] ?: return AppResult.Failure(
-            com.calypsan.listenup.api.error.InternalError(debugInfo = "not found: ${id.value}"),
-        )
-        val updated = existing.copy(
-            role = patch.role ?: existing.role,
-            permissions = patch.permissions ?: existing.permissions,
-        )
+        val existing =
+            users[id.value] ?: return AppResult.Failure(
+                com.calypsan.listenup.api.error
+                    .InternalError(debugInfo = "not found: ${id.value}"),
+            )
+        val updated =
+            existing.copy(
+                role = patch.role ?: existing.role,
+                permissions = patch.permissions ?: existing.permissions,
+            )
         users[id.value] = updated
         return AppResult.Success(updated)
     }
@@ -82,10 +87,12 @@ private class FakeAdminUserService : AdminUserService {
         request: PendingRegistrationDecision,
     ): AppResult<PendingRegistrationOutcome> {
         lastDecision = request
-        val user = users[request.userId.value]
-            ?: return AppResult.Failure(
-                com.calypsan.listenup.api.error.InternalError(debugInfo = "not found: ${request.userId.value}"),
-            )
+        val user =
+            users[request.userId.value]
+                ?: return AppResult.Failure(
+                    com.calypsan.listenup.api.error
+                        .InternalError(debugInfo = "not found: ${request.userId.value}"),
+                )
         val newStatus = if (request.approved) UserStatus.ACTIVE else UserStatus.DENIED
         users[request.userId.value] = user.copy(status = newStatus)
         return AppResult.Success(
@@ -93,17 +100,16 @@ private class FakeAdminUserService : AdminUserService {
         )
     }
 
-    override suspend fun getRegistrationPolicy(): AppResult<RegistrationPolicy> =
-        AppResult.Success(RegistrationPolicy.OPEN)
+    override suspend fun getRegistrationPolicy(): AppResult<RegistrationPolicy> = AppResult.Success(RegistrationPolicy.OPEN)
 
-    override suspend fun setRegistrationPolicy(policy: RegistrationPolicy): AppResult<Unit> =
-        AppResult.Success(Unit)
+    override suspend fun setRegistrationPolicy(policy: RegistrationPolicy): AppResult<Unit> = AppResult.Success(Unit)
 }
 
 private class FakeAdminUserRpcFactory(
     private val service: FakeAdminUserService,
 ) : AdminUserRpcFactory {
     override suspend fun get(): AdminUserService = service
+
     override suspend fun invalidate() = Unit
 }
 
@@ -206,13 +212,14 @@ class AdminRepositoryImplUserTest :
             )
             val repo = buildRepo(service)
 
-            val result = repo.updateUser(
-                userId = "u4",
-                firstName = "Alice",
-                lastName = "Smith",
-                role = "ADMIN",
-                canShare = false,
-            )
+            val result =
+                repo.updateUser(
+                    userId = "u4",
+                    firstName = "Alice",
+                    lastName = "Smith",
+                    role = "ADMIN",
+                    canShare = false,
+                )
 
             (result is AppResult.Success) shouldBe true
             val patch = service.lastPatch

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -203,11 +203,12 @@ class AdminRepositoryImplUserTest :
             service.deletedIds shouldBe listOf("u3")
         }
 
-        test("updateUser builds patch with role and permissions but null displayName") {
+        test("updateUser sets role + canShare, preserves canEdit, never sends displayName") {
             val service = FakeAdminUserService()
+            // Seed canEdit = false to prove it is preserved, not reset to the default true.
             service.seedUser(
                 testUser("u4", role = UserRole.MEMBER).copy(
-                    permissions = UserPermissions(canEdit = true, canShare = true),
+                    permissions = UserPermissions(canEdit = false, canShare = true),
                 ),
             )
             val repo = buildRepo(service)
@@ -227,9 +228,27 @@ class AdminRepositoryImplUserTest :
             patch?.displayName shouldBe null
             patch?.role shouldBe UserRole.ADMIN
             patch?.permissions?.canShare shouldBe false
+            // canEdit preserved via read-before-write (server applies permissions wholesale)
+            patch?.permissions?.canEdit shouldBe false
 
             val info = (result as AppResult.Success).data
             info.role shouldBe "ADMIN"
             info.permissions.canShare shouldBe false
+        }
+
+        test("a transport exception from the RPC factory becomes AppResult.Failure, not a throw") {
+            val throwingFactory =
+                object : AdminUserRpcFactory {
+                    override suspend fun get(): AdminUserService = throw IllegalStateException("simulated WS 401")
+
+                    override suspend fun invalidate() = Unit
+                }
+            val repo =
+                AdminRepositoryImpl(
+                    adminApi = mock<com.calypsan.listenup.client.data.remote.AdminApiContract>(),
+                    adminUserRpc = throwingFactory,
+                )
+
+            (repo.getUsers() is AppResult.Failure) shouldBe true
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -1,0 +1,228 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.AdminUserService
+import com.calypsan.listenup.api.dto.auth.AdminUserPatch
+import com.calypsan.listenup.api.dto.auth.PendingRegistrationDecision
+import com.calypsan.listenup.api.dto.auth.PendingRegistrationOutcome
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
+import com.calypsan.listenup.api.dto.auth.User
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserPermissions
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.auth.UserStatus
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.AdminUserRpcFactory
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+// ─── Fakes ────────────────────────────────────────────────────────────────────
+
+private fun testUser(
+    id: String = "u1",
+    role: UserRole = UserRole.MEMBER,
+    status: UserStatus = UserStatus.ACTIVE,
+) = User(
+    id = UserId(id),
+    email = "$id@example.com",
+    displayName = "User $id",
+    role = role,
+    status = status,
+    createdAt = 1_000_000L,
+    permissions = UserPermissions(canEdit = true, canShare = true),
+)
+
+private class FakeAdminUserService : AdminUserService {
+    private val users = mutableMapOf<String, User>()
+
+    var lastDecision: PendingRegistrationDecision? = null
+    var lastPatch: AdminUserPatch? = null
+    val deletedIds = mutableListOf<String>()
+
+    fun seedUser(user: User) {
+        users[user.id.value] = user
+    }
+
+    override suspend fun listUsers(): AppResult<List<User>> =
+        AppResult.Success(users.values.toList())
+
+    override suspend fun listPendingUsers(): AppResult<List<User>> =
+        AppResult.Success(users.values.filter { it.status == UserStatus.PENDING_APPROVAL })
+
+    override suspend fun getUser(id: UserId): AppResult<User> {
+        val user = users[id.value] ?: return AppResult.Failure(
+            com.calypsan.listenup.api.error.InternalError(debugInfo = "not found: ${id.value}"),
+        )
+        return AppResult.Success(user)
+    }
+
+    override suspend fun searchUsers(query: String): AppResult<List<User>> =
+        AppResult.Success(users.values.filter { it.email.contains(query) || it.displayName.contains(query) })
+
+    override suspend fun updateUser(id: UserId, patch: AdminUserPatch): AppResult<User> {
+        lastPatch = patch
+        val existing = users[id.value] ?: return AppResult.Failure(
+            com.calypsan.listenup.api.error.InternalError(debugInfo = "not found: ${id.value}"),
+        )
+        val updated = existing.copy(
+            role = patch.role ?: existing.role,
+            permissions = patch.permissions ?: existing.permissions,
+        )
+        users[id.value] = updated
+        return AppResult.Success(updated)
+    }
+
+    override suspend fun deleteUser(id: UserId): AppResult<Unit> {
+        deletedIds += id.value
+        users.remove(id.value)
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun decidePendingRegistration(
+        request: PendingRegistrationDecision,
+    ): AppResult<PendingRegistrationOutcome> {
+        lastDecision = request
+        val user = users[request.userId.value]
+            ?: return AppResult.Failure(
+                com.calypsan.listenup.api.error.InternalError(debugInfo = "not found: ${request.userId.value}"),
+            )
+        val newStatus = if (request.approved) UserStatus.ACTIVE else UserStatus.DENIED
+        users[request.userId.value] = user.copy(status = newStatus)
+        return AppResult.Success(
+            if (request.approved) PendingRegistrationOutcome.Approved else PendingRegistrationOutcome.Denied,
+        )
+    }
+
+    override suspend fun getRegistrationPolicy(): AppResult<RegistrationPolicy> =
+        AppResult.Success(RegistrationPolicy.OPEN)
+
+    override suspend fun setRegistrationPolicy(policy: RegistrationPolicy): AppResult<Unit> =
+        AppResult.Success(Unit)
+}
+
+private class FakeAdminUserRpcFactory(
+    private val service: FakeAdminUserService,
+) : AdminUserRpcFactory {
+    override suspend fun get(): AdminUserService = service
+    override suspend fun invalidate() = Unit
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+class AdminRepositoryImplUserTest :
+    FunSpec({
+
+        fun buildRepo(service: FakeAdminUserService): AdminRepositoryImpl {
+            val unusedApi = mock<com.calypsan.listenup.client.data.remote.AdminApiContract>()
+            return AdminRepositoryImpl(
+                adminApi = unusedApi,
+                adminUserRpc = FakeAdminUserRpcFactory(service),
+            )
+        }
+
+        test("getUsers maps contract Users to AdminUserInfo, ROOT user has isRoot=true") {
+            val service = FakeAdminUserService()
+            service.seedUser(testUser("u1", role = UserRole.ROOT))
+            service.seedUser(testUser("u2", role = UserRole.MEMBER))
+            val repo = buildRepo(service)
+
+            val result = repo.getUsers()
+
+            (result is AppResult.Success) shouldBe true
+            val infos = (result as AppResult.Success).data
+            infos.size shouldBe 2
+            val root = infos.first { it.id == "u1" }
+            root.isRoot shouldBe true
+            root.role shouldBe "ROOT"
+            val member = infos.first { it.id == "u2" }
+            member.isRoot shouldBe false
+            member.role shouldBe "MEMBER"
+        }
+
+        test("getPendingUsers returns only PENDING_APPROVAL users") {
+            val service = FakeAdminUserService()
+            service.seedUser(testUser("active1", status = UserStatus.ACTIVE))
+            service.seedUser(testUser("pending1", status = UserStatus.PENDING_APPROVAL))
+            service.seedUser(testUser("pending2", status = UserStatus.PENDING_APPROVAL))
+            val repo = buildRepo(service)
+
+            val result = repo.getPendingUsers()
+
+            (result is AppResult.Success) shouldBe true
+            val infos = (result as AppResult.Success).data
+            infos.size shouldBe 2
+            infos.all { it.status == "PENDING_APPROVAL" } shouldBe true
+        }
+
+        test("approveUser records approved=true decision and returns user with ACTIVE status") {
+            val service = FakeAdminUserService()
+            service.seedUser(testUser("u1", status = UserStatus.PENDING_APPROVAL))
+            val repo = buildRepo(service)
+
+            val result = repo.approveUser("u1")
+
+            // Assert the decision that was recorded
+            val decision = service.lastDecision
+            decision?.userId shouldBe UserId("u1")
+            decision?.approved shouldBe true
+
+            // Assert the returned domain model has ACTIVE status
+            (result is AppResult.Success) shouldBe true
+            val info = (result as AppResult.Success).data
+            info.id shouldBe "u1"
+            info.status shouldBe "ACTIVE"
+        }
+
+        test("denyUser records approved=false decision") {
+            val service = FakeAdminUserService()
+            service.seedUser(testUser("u2", status = UserStatus.PENDING_APPROVAL))
+            val repo = buildRepo(service)
+
+            val result = repo.denyUser("u2")
+
+            val decision = service.lastDecision
+            decision?.userId shouldBe UserId("u2")
+            decision?.approved shouldBe false
+            (result is AppResult.Success) shouldBe true
+        }
+
+        test("deleteUser forwards deleteUser(UserId(id)) to the service") {
+            val service = FakeAdminUserService()
+            service.seedUser(testUser("u3"))
+            val repo = buildRepo(service)
+
+            val result = repo.deleteUser("u3")
+
+            (result is AppResult.Success) shouldBe true
+            service.deletedIds shouldBe listOf("u3")
+        }
+
+        test("updateUser builds patch with role and permissions but null displayName") {
+            val service = FakeAdminUserService()
+            service.seedUser(
+                testUser("u4", role = UserRole.MEMBER).copy(
+                    permissions = UserPermissions(canEdit = true, canShare = true),
+                ),
+            )
+            val repo = buildRepo(service)
+
+            val result = repo.updateUser(
+                userId = "u4",
+                firstName = "Alice",
+                lastName = "Smith",
+                role = "ADMIN",
+                canShare = false,
+            )
+
+            (result is AppResult.Success) shouldBe true
+            val patch = service.lastPatch
+            // displayName must NOT be sent — no contract field for first/last name
+            patch?.displayName shouldBe null
+            patch?.role shouldBe UserRole.ADMIN
+            patch?.permissions?.canShare shouldBe false
+
+            val info = (result as AppResult.Success).data
+            info.role shouldBe "ADMIN"
+            info.permissions.canShare shouldBe false
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapperTest.kt
@@ -8,30 +8,38 @@ import com.calypsan.listenup.api.dto.auth.UserStatus
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class AdminUserMapperTest : FunSpec({
-    fun user(role: UserRole = UserRole.MEMBER, displayName: String = "Ada") = User(
-        id = UserId("u1"), email = "ada@x", displayName = displayName, role = role,
-        status = UserStatus.ACTIVE, createdAt = 1_700_000_000_000L,
-        permissions = UserPermissions(canEdit = true, canShare = false),
-    )
+class AdminUserMapperTest :
+    FunSpec({
+        fun user(
+            role: UserRole = UserRole.MEMBER,
+            displayName: String = "Ada",
+        ) = User(
+            id = UserId("u1"),
+            email = "ada@x",
+            displayName = displayName,
+            role = role,
+            status = UserStatus.ACTIVE,
+            createdAt = 1_700_000_000_000L,
+            permissions = UserPermissions(canEdit = true, canShare = false),
+        )
 
-    test("maps contract User to AdminUserInfo with isRoot true for ROOT") {
-        val info = user(role = UserRole.ROOT).toAdminUserInfo()
-        info.id shouldBe "u1"
-        info.email shouldBe "ada@x"
-        info.displayName shouldBe "Ada"
-        info.isRoot shouldBe true
-        info.role shouldBe "ROOT"
-        info.status shouldBe "ACTIVE"
-        info.createdAt shouldBe "1700000000000"
-        info.permissions.canShare shouldBe false
-        info.firstName shouldBe null
-        info.lastName shouldBe null
-    }
+        test("maps contract User to AdminUserInfo with isRoot true for ROOT") {
+            val info = user(role = UserRole.ROOT).toAdminUserInfo()
+            info.id shouldBe "u1"
+            info.email shouldBe "ada@x"
+            info.displayName shouldBe "Ada"
+            info.isRoot shouldBe true
+            info.role shouldBe "ROOT"
+            info.status shouldBe "ACTIVE"
+            info.createdAt shouldBe "1700000000000"
+            info.permissions.canShare shouldBe false
+            info.firstName shouldBe null
+            info.lastName shouldBe null
+        }
 
-    test("isRoot is false for non-ROOT and displayableName falls back to displayName") {
-        val info = user(role = UserRole.MEMBER, displayName = "Ada").toAdminUserInfo()
-        info.isRoot shouldBe false
-        info.displayableName shouldBe "Ada"
-    }
-})
+        test("isRoot is false for non-ROOT and displayableName falls back to displayName") {
+            val info = user(role = UserRole.MEMBER, displayName = "Ada").toAdminUserInfo()
+            info.isRoot shouldBe false
+            info.displayableName shouldBe "Ada"
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminUserMapperTest.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.dto.auth.User
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserPermissions
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.auth.UserStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class AdminUserMapperTest : FunSpec({
+    fun user(role: UserRole = UserRole.MEMBER, displayName: String = "Ada") = User(
+        id = UserId("u1"), email = "ada@x", displayName = displayName, role = role,
+        status = UserStatus.ACTIVE, createdAt = 1_700_000_000_000L,
+        permissions = UserPermissions(canEdit = true, canShare = false),
+    )
+
+    test("maps contract User to AdminUserInfo with isRoot true for ROOT") {
+        val info = user(role = UserRole.ROOT).toAdminUserInfo()
+        info.id shouldBe "u1"
+        info.email shouldBe "ada@x"
+        info.displayName shouldBe "Ada"
+        info.isRoot shouldBe true
+        info.role shouldBe "ROOT"
+        info.status shouldBe "ACTIVE"
+        info.createdAt shouldBe "1700000000000"
+        info.permissions.canShare shouldBe false
+        info.firstName shouldBe null
+        info.lastName shouldBe null
+    }
+
+    test("isRoot is false for non-ROOT and displayableName falls back to displayName") {
+        val info = user(role = UserRole.MEMBER, displayName = "Ada").toAdminUserInfo()
+        info.isRoot shouldBe false
+        info.displayableName shouldBe "Ada"
+    }
+})

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/e2e/ClientKoinGraphE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/e2e/ClientKoinGraphE2ETest.kt
@@ -83,18 +83,18 @@ class ClientKoinGraphE2ETest :
             }
         }
 
-        test("RpcCacheInvalidator receives all 17 RemoteCache instances via getAll") {
+        test("RpcCacheInvalidator receives all 18 RemoteCache instances via getAll") {
             val fixture = autoClose(DiWiredClientFixture.start())
             val koin = fixture.koin.koin
 
             val invalidator = koin.get<RpcCacheInvalidator>()
             val defaultInvalidator = invalidator.shouldBeInstanceOf<DefaultRpcCacheInvalidator>()
 
-            // getAll<RemoteCache>() must return exactly 17: ApiClientFactory + 16 KtorXRpcFactory
+            // getAll<RemoteCache>() must return exactly 18: ApiClientFactory + 17 KtorXRpcFactory
             // implementations. If any single is missing a `bind RemoteCache::class` declaration,
             // the count will be wrong and the assertion fails before production code ever misses
             // an invalidation.
-            defaultInvalidator.caches shouldHaveSize 17
+            defaultInvalidator.caches shouldHaveSize 18
             defaultInvalidator.caches.any { it is ApiClientFactory } shouldBe true
         }
 


### PR DESCRIPTION
## Problem

The Admin page failed with "Failed to load users: Something went wrong on the server." Root cause (proven live against the running server): the client's admin data layer spoke the **old Go server's JSON contract** (snake_case `AdminUser` wrapped in an `ApiResponse` envelope), while the new Kotlin server returns **bare contract types**. Decoding a bare `[User]` array into the envelope threw, surfacing as a generic error. The whole admin REST user surface was drifted (e.g. the client even posted to non-existent `/approve` + `/deny`; the server uses `/pending-decision`).

## Fix

Route first-party admin **user-management** through the contract-native `AdminUserService` RPC (already exposed by the server on `/api/rpc/authed`), and fix the parallel REST `AdminApi` to the bare contract — both surfaces end correct. The domain interface (`AdminRepository`) and ViewModels are unchanged, so no UI churn.

- **`User.toAdminUserInfo()` mapper** — contract `User` → domain `AdminUserInfo`.
- **`AdminUserRpcFactory`** — mirrors the 17 existing `*RpcFactory`s; bound to `RemoteCache` so logout/server-switch invalidates it.
- **`AdminRepositoryImpl` user methods → RPC**, wrapped in a `catching{}` transport boundary (mirrors `AuthRepositoryImpl.catching`) — RPC `get()` throws `WebSocketException` on a 401 WS handshake, and the data layer must never throw.
- **REST `AdminApi` user methods** reworked to the bare contract `User`/`AdminUserPatch` + correct paths (kept as a parallel surface — now identical in shape to `CollectionInboxApi`). Go-era `AdminUser`/`UsersResponse`/`UpdateUserRequest`/etc. removed.
- **`updateUser` preserves `canEdit`** via read-before-write (the server applies `AdminUserPatch.permissions` wholesale and the admin UI only toggles `canShare`).

## Notable bug caught during review

A singleton-loop E2E test instantiates `AdminViewModel`, whose `init{}` fires a background `getUsers()`. Under REST, `apiCall` converted the unauthenticated 401 to `AppResult.Failure`; under RPC, `adminUserRpc.get()` *threw* a `WebSocketException` that escaped the daemon coroutine and got misattributed to a sibling test. The `catching{}` boundary fixes this — RPC-backed repos must convert transport throws to `AppResult`.

## Tests

- `AdminUserMapperTest`, `AdminRepositoryImplUserTest` (in-memory fakes for the service seam) — incl. approve→decide→refetch, the `updateUser` patch (role + canShare; `canEdit` preserved; `displayName` never sent), and the `catching` transport-exception boundary.
- `ClientKoinGraphE2ETest` — boots a **real** in-process server and authenticates through the DI-wired graph (RemoteCache count 17→18).
- Full Linux gate green: `:contract:jvmTest :sharedLogic:jvmTest :sharedUI:compileAndroidHostTest spotlessCheck detekt :androidApp:assembleDebug`. iOS gates run on CI.
- On-device verification was skipped (the dev server DB was empty — separate issue); coverage rests on the real-server E2E auth test above.

## Deferred follow-ups (documented, out of scope)

- `firstName`/`lastName` in `updateUser` are no-ops — the contract has only `displayName`; a domain-realignment follow-up.
- `approveUser` makes two RPC calls (`decidePendingRegistration` then `getUser`) because the server returns `PendingRegistrationOutcome`, not the user; a transient failure between them returns `Failure` though approval committed. Low impact (list refreshes on nav).