### PR TITLE
🐛 fix(client): admin page invites + open-registration via RPC

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/InviteRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/InviteRpcFactory.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.remote
 
+import com.calypsan.listenup.api.InviteService
 import com.calypsan.listenup.api.InviteServicePublic
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -14,19 +15,21 @@ import kotlinx.rpc.withService
 /**
  * Supplies the [InviteServicePublic] kotlinx.rpc proxy backing the anonymous
  * invite surface — landing-page lookup ([InviteServicePublic.lookupInvite]) and
- * claim ([InviteServicePublic.claimInvite]).
+ * claim ([InviteServicePublic.claimInvite]) — and the authed [InviteService]
+ * proxy for admin invite management.
  *
  * An interface so the repository depends on a seam that can be faked in tests —
  * [KtorInviteRpcFactory] is the production implementation over WebSocket RPC.
- * Mirrors [TagRpcFactory] — the established RPC-factory-seam precedent. Public
- * only: the client never talks to the authed invite-management service (admin
- * invite mgmt is deferred), so there is no authed proxy here.
+ * Mirrors [TagRpcFactory] — the established RPC-factory-seam precedent.
  */
 interface InviteRpcFactory {
     /** Returns the cached [InviteServicePublic] proxy, connecting on first use. */
     suspend fun publicService(): InviteServicePublic
 
-    /** Drop the cached proxy and the RPC-flavored HttpClient. */
+    /** Returns the cached authed [InviteService] proxy, connecting on first use. */
+    suspend fun adminService(): InviteService
+
+    /** Drop the cached proxies and the RPC-flavored HttpClient. */
     suspend fun invalidate()
 }
 
@@ -51,15 +54,22 @@ open class KtorInviteRpcFactory(
     private val mutex = Mutex()
     private var cachedRpcClient: HttpClient? = null
     private var cachedPublic: InviteServicePublic? = null
+    private var cachedAdmin: InviteService? = null
 
     override suspend fun publicService(): InviteServicePublic =
         mutex.withLock {
             cachedPublic ?: connectPublic().also { cachedPublic = it }
         }
 
+    override suspend fun adminService(): InviteService =
+        mutex.withLock {
+            cachedAdmin ?: connectAdmin().also { cachedAdmin = it }
+        }
+
     override suspend fun invalidate() {
         mutex.withLock {
             cachedPublic = null
+            cachedAdmin = null
             cachedRpcClient = null
         }
     }
@@ -67,6 +77,11 @@ open class KtorInviteRpcFactory(
     internal open suspend fun connectPublic(): InviteServicePublic {
         val baseUrl = rpcBaseUrl()
         return rpcClient().rpc("$baseUrl/api/rpc/public").withService<InviteServicePublic>()
+    }
+
+    internal open suspend fun connectAdmin(): InviteService {
+        val baseUrl = rpcBaseUrl()
+        return rpcClient().rpc("$baseUrl/api/rpc/authed").withService<InviteService>()
     }
 
     private suspend fun rpcClient(): HttpClient =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -9,13 +9,13 @@ import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.flatMap
 import com.calypsan.listenup.api.result.map
+import com.calypsan.listenup.api.dto.invite.InviteId
 import com.calypsan.listenup.client.data.remote.AdminApiContract
 import com.calypsan.listenup.client.data.remote.AdminUserRpcFactory
 import com.calypsan.listenup.client.data.remote.BrowseFilesystemResponse
-import com.calypsan.listenup.client.data.remote.AdminInvite
 import com.calypsan.listenup.client.data.remote.CollectionRef
-import com.calypsan.listenup.client.data.remote.CreateInviteRequest
 import com.calypsan.listenup.client.data.remote.InboxBookResponse
+import com.calypsan.listenup.client.data.remote.InviteRpcFactory
 import com.calypsan.listenup.client.data.remote.LibraryResponse
 import com.calypsan.listenup.client.data.remote.ServerSettingsRequest
 import com.calypsan.listenup.client.data.remote.UpdateInstanceRequest
@@ -30,26 +30,32 @@ import com.calypsan.listenup.client.domain.model.Library
 import com.calypsan.listenup.client.domain.model.ServerSettings
 import com.calypsan.listenup.client.domain.model.StagedCollection
 import com.calypsan.listenup.client.domain.repository.AdminRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 
 private val logger = KotlinLogging.logger {}
 
 /**
- * Implementation of AdminRepository using AdminApiContract for non-user operations
- * and [AdminUserRpcFactory] for user management (routed through the Kotlin RPC server).
+ * Implementation of AdminRepository using AdminApiContract for non-user operations,
+ * [AdminUserRpcFactory] for user management, and [InviteRpcFactory] for invite management
+ * (both routed through the Kotlin RPC server).
  *
  * All methods return [AppResult] — no exceptions are thrown. The [catching] helper wraps
  * every RPC call so that transport-level exceptions (e.g. [io.ktor.client.plugins.websocket.WebSocketException]
  * on a 401 WS handshake) are converted to [AppResult.Failure] rather than propagating as
  * unhandled exceptions. This mirrors [AuthRepositoryImpl.catching] and upholds the contract.
  *
- * @property adminApi API client for invite/settings/inbox/library operations
+ * @property adminApi API client for settings/inbox/library operations
  * @property adminUserRpc RPC factory for user-management operations
+ * @property inviteRpc RPC factory for invite-management operations
+ * @property serverConfig source of the active server URL (used to reconstruct invite URLs)
  */
 class AdminRepositoryImpl(
     private val adminApi: AdminApiContract,
     private val adminUserRpc: AdminUserRpcFactory,
+    private val inviteRpc: InviteRpcFactory,
+    private val serverConfig: ServerConfig,
 ) : AdminRepository {
     // ═══════════════════════════════════════════════════════════════════════
     // USER MANAGEMENT
@@ -147,25 +153,31 @@ class AdminRepositoryImpl(
     // ═══════════════════════════════════════════════════════════════════════
 
     override suspend fun getInvites(): AppResult<List<InviteInfo>> =
-        adminApi.getInvites().map { invites -> invites.map { it.toDomain() } }
+        catching("getInvites") {
+            val serverUrl = serverConfig.getActiveUrl()?.value.orEmpty()
+            inviteRpc.adminService().listInvites().map { list -> list.map { it.toInviteInfo(serverUrl) } }
+        }
 
     override suspend fun createInvite(
         name: String,
         email: String,
         role: String,
         expiresInDays: Int,
-    ): AppResult<InviteInfo> {
-        val request =
-            CreateInviteRequest(
-                name = name,
-                email = email,
-                role = role,
-                expiresInDays = expiresInDays,
-            )
-        return adminApi.createInvite(request).map { it.toDomain() }
-    }
+    ): AppResult<InviteInfo> =
+        catching("createInvite") {
+            val serverUrl = serverConfig.getActiveUrl()?.value.orEmpty()
+            inviteRpc
+                .adminService()
+                .createInvite(
+                    email = email,
+                    displayName = name,
+                    role = UserRole.valueOf(role),
+                    expiresInDays = expiresInDays,
+                ).map { it.toInviteInfo(serverUrl) }
+        }
 
-    override suspend fun deleteInvite(inviteId: String): AppResult<Unit> = adminApi.deleteInvite(inviteId)
+    override suspend fun deleteInvite(inviteId: String): AppResult<Unit> =
+        catching("deleteInvite") { inviteRpc.adminService().revokeInvite(InviteId(inviteId)) }
 
     // ═══════════════════════════════════════════════════════════════════════
     // SERVER SETTINGS
@@ -258,22 +270,6 @@ class AdminRepositoryImpl(
 // ═══════════════════════════════════════════════════════════════════════════
 // CONVERSION FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════
-
-/**
- * Convert AdminInvite API model to InviteInfo domain model.
- */
-private fun AdminInvite.toDomain(): InviteInfo =
-    InviteInfo(
-        id = id,
-        code = code,
-        name = name,
-        email = email,
-        role = role,
-        expiresAt = expiresAt,
-        claimedAt = claimedAt,
-        url = url,
-        createdAt = createdAt,
-    )
 
 /**
  * Convert ServerSettingsResponse API model to ServerSettings domain model.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.api.dto.auth.AdminUserPatch
 import com.calypsan.listenup.api.dto.auth.PendingRegistrationDecision
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserPermissions
 import com.calypsan.listenup.api.dto.auth.UserRole
@@ -122,6 +123,11 @@ class AdminRepositoryImpl(
                 }
             val patch = AdminUserPatch(role = role?.let { UserRole.valueOf(it) }, permissions = permissions)
             adminUserRpc.get().updateUser(UserId(userId), patch).map { it.toAdminUserInfo() }
+        }
+
+    override suspend fun getRegistrationPolicy(): AppResult<Boolean> =
+        catching("getRegistrationPolicy") {
+            adminUserRpc.get().getRegistrationPolicy().map { it == RegistrationPolicy.OPEN }
         }
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InviteMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InviteMapper.kt
@@ -1,0 +1,20 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.dto.invite.InviteDto
+import com.calypsan.listenup.api.dto.invite.InviteSummary
+import com.calypsan.listenup.client.domain.model.InviteInfo
+
+internal fun InviteSummary.toInviteInfo(serverUrl: String): InviteInfo = invite.toInviteInfo(serverUrl)
+
+internal fun InviteDto.toInviteInfo(serverUrl: String): InviteInfo =
+    InviteInfo(
+        id = id.value,
+        code = code,
+        name = displayName,
+        email = email,
+        role = role.name,
+        expiresAt = expiresAt.toString(),
+        claimedAt = claimedAt?.toString(),
+        url = "$serverUrl/invite/$code",
+        createdAt = createdAt.toString(),
+    )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -145,6 +145,7 @@ import com.calypsan.listenup.client.domain.usecase.admin.ApproveUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.CreateInviteUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.DeleteUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.DenyUserUseCase
+import com.calypsan.listenup.client.domain.usecase.admin.GetRegistrationPolicyUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadInvitesUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadPendingUsersUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadServerSettingsUseCase
@@ -515,6 +516,11 @@ val useCaseModule =
         }
         factory {
             DenyUserUseCase(
+                adminRepository = get(),
+            )
+        }
+        factory {
+            GetRegistrationPolicyUseCase(
                 adminRepository = get(),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1058,7 +1058,7 @@ val syncModule =
 
         // AdminRepository for admin operations (SOLID: interface in domain, impl in data)
         single<AdminRepository> {
-            AdminRepositoryImpl(adminApi = get(), adminUserRpc = get())
+            AdminRepositoryImpl(adminApi = get(), adminUserRpc = get(), inviteRpc = get(), serverConfig = get())
         }
 
         // ProfileRepository for public user profiles (SOLID: interface in domain, impl in data)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -90,7 +90,7 @@ val adminPresentationModule =
     module {
         single {
             AdminViewModel(
-                instanceRepository = get(),
+                getRegistrationPolicyUseCase = get(),
                 loadUsersUseCase = get(),
                 loadPendingUsersUseCase = get(),
                 loadInvitesUseCase = get(),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AdminRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AdminRepository.kt
@@ -131,6 +131,17 @@ interface AdminRepository {
     // ═══════════════════════════════════════════════════════════════════════
 
     /**
+     * Get the current registration policy as a simple open/closed boolean.
+     *
+     * Returns `true` when registration policy is [com.calypsan.listenup.api.dto.auth.RegistrationPolicy.OPEN],
+     * `false` for all other policies (approval queue or closed). Callers do not need to
+     * depend on the contract enum — the VM needs only the boolean to drive the UI toggle.
+     *
+     * @return [AppResult] carrying `true` if registration is open, `false` otherwise, or a failure.
+     */
+    suspend fun getRegistrationPolicy(): AppResult<Boolean>
+
+    /**
      * Enable or disable open registration.
      *
      * When enabled, new users can register without an invite.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/admin/GetRegistrationPolicyUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/admin/GetRegistrationPolicyUseCase.kt
@@ -1,0 +1,15 @@
+package com.calypsan.listenup.client.domain.usecase.admin
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.repository.AdminRepository
+
+/**
+ * Retrieves the current registration policy as a simple open/closed boolean.
+ *
+ * Returns `true` when open registration is enabled, `false` otherwise.
+ */
+open class GetRegistrationPolicyUseCase(
+    private val adminRepository: AdminRepository,
+) {
+    open suspend operator fun invoke(): AppResult<Boolean> = adminRepository.getRegistrationPolicy()
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
@@ -8,13 +8,13 @@ import com.calypsan.listenup.client.domain.model.AdminEvent
 import com.calypsan.listenup.client.domain.model.AdminUserInfo
 import com.calypsan.listenup.client.domain.model.InviteInfo
 import com.calypsan.listenup.client.domain.repository.EventStreamRepository
-import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.usecase.admin.ApproveUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.DeleteUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.DenyUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadInvitesUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadPendingUsersUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadUsersUseCase
+import com.calypsan.listenup.client.domain.usecase.admin.GetRegistrationPolicyUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.RevokeInviteUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.SetOpenRegistrationUseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -33,7 +33,7 @@ private val logger = KotlinLogging.logger {}
  * Subscribes to SSE events for real-time updates of pending users.
  */
 class AdminViewModel(
-    private val instanceRepository: InstanceRepository,
+    private val getRegistrationPolicyUseCase: GetRegistrationPolicyUseCase,
     private val loadUsersUseCase: LoadUsersUseCase,
     private val loadPendingUsersUseCase: LoadPendingUsersUseCase,
     private val loadInvitesUseCase: LoadInvitesUseCase,
@@ -104,14 +104,14 @@ class AdminViewModel(
     fun loadData() {
         viewModelScope.launch {
             // Load all data in parallel — no dependencies between these calls
-            val deferredInstance = async { instanceRepository.getInstance() }
+            val deferredOpenReg = async { getRegistrationPolicyUseCase() }
             val deferredUsers = async { loadUsersUseCase() }
             val deferredPending = async { loadPendingUsersUseCase() }
             val deferredInvites = async { loadInvitesUseCase() }
 
             val openRegistration =
-                when (val result = deferredInstance.await()) {
-                    is AppResult.Success -> result.data.openRegistration
+                when (val result = deferredOpenReg.await()) {
+                    is AppResult.Success -> result.data
                     is AppResult.Failure -> false
                 }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplInviteTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplInviteTest.kt
@@ -1,0 +1,218 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.InviteService
+import com.calypsan.listenup.api.InviteServicePublic
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.invite.InviteDto
+import com.calypsan.listenup.api.dto.invite.InviteId
+import com.calypsan.listenup.api.dto.invite.InviteSummary
+import com.calypsan.listenup.api.dto.invite.InviteStatus
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.AdminApiContract
+import com.calypsan.listenup.client.data.remote.AdminUserRpcFactory
+import com.calypsan.listenup.client.data.remote.InviteRpcFactory
+import com.calypsan.listenup.core.ServerUrl
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+// ─── Fakes ────────────────────────────────────────────────────────────────────
+
+private fun testInviteDto(
+    id: String = "inv1",
+    code: String = "code-abc",
+    email: String = "ada@x",
+    displayName: String = "Ada",
+    role: UserRole = UserRole.ADMIN,
+    expiresAt: Long = 9_000_000L,
+    createdAt: Long = 1_000_000L,
+    claimedAt: Long? = null,
+    claimedBy: String? = null,
+) = InviteDto(
+    id = InviteId(id),
+    code = code,
+    email = email,
+    displayName = displayName,
+    role = role,
+    createdBy = "root",
+    expiresAt = expiresAt,
+    createdAt = createdAt,
+    claimedAt = claimedAt,
+    claimedBy = claimedBy,
+)
+
+private class FakeInviteService : InviteService {
+    val createdInvites = mutableListOf<Triple<String, String, UserRole>>()
+    val revokedIds = mutableListOf<String>()
+
+    private val invites = mutableListOf<InviteSummary>()
+
+    fun seedSummary(summary: InviteSummary) {
+        invites += summary
+    }
+
+    override suspend fun listInvites(): AppResult<List<InviteSummary>> = AppResult.Success(invites.toList())
+
+    override suspend fun createInvite(
+        email: String,
+        displayName: String,
+        role: UserRole,
+        expiresInDays: Int?,
+    ): AppResult<InviteDto> {
+        createdInvites += Triple(email, displayName, role)
+        return AppResult.Success(
+            testInviteDto(email = email, displayName = displayName, role = role),
+        )
+    }
+
+    override suspend fun revokeInvite(id: InviteId): AppResult<Unit> {
+        revokedIds += id.value
+        return AppResult.Success(Unit)
+    }
+}
+
+private class FakeInviteRpcFactory(
+    private val service: FakeInviteService,
+) : InviteRpcFactory {
+    override suspend fun publicService(): InviteServicePublic = error("unused in admin invite tests")
+
+    override suspend fun adminService(): InviteService = service
+
+    override suspend fun invalidate() = Unit
+}
+
+private class FakeServerConfig(
+    private val url: String = "https://srv.example",
+) : ServerConfig {
+    override suspend fun setServerUrl(url: ServerUrl) = Unit
+
+    override suspend fun getServerUrl(): ServerUrl? = ServerUrl(url)
+
+    override suspend fun hasServerConfigured(): Boolean = true
+
+    override suspend fun setRemoteUrl(url: String?) = Unit
+
+    override suspend fun getRemoteUrl(): ServerUrl? = null
+
+    override suspend fun getActiveUrl(): ServerUrl? = ServerUrl(url)
+
+    override suspend fun switchToFallbackUrl(): ServerUrl? = null
+
+    override suspend fun preferLocalUrl() = Unit
+
+    override suspend fun disconnectFromServer() = Unit
+
+    override suspend fun clearAll() = Unit
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+class AdminRepositoryImplInviteTest :
+    FunSpec({
+
+        fun buildRepo(
+            service: FakeInviteService,
+            serverUrl: String = "https://srv.example",
+        ): AdminRepositoryImpl {
+            val unusedApi = mock<AdminApiContract>()
+            val unusedUserRpc = mock<AdminUserRpcFactory>()
+            return AdminRepositoryImpl(
+                adminApi = unusedApi,
+                adminUserRpc = unusedUserRpc,
+                inviteRpc = FakeInviteRpcFactory(service),
+                serverConfig = FakeServerConfig(serverUrl),
+            )
+        }
+
+        test("getInvites maps InviteSummary list to InviteInfo with reconstructed url") {
+            val service = FakeInviteService()
+            service.seedSummary(
+                InviteSummary(
+                    invite = testInviteDto(id = "inv1", code = "abc123", displayName = "Ada"),
+                    status = InviteStatus.PENDING,
+                ),
+            )
+            val repo = buildRepo(service)
+
+            val result = repo.getInvites()
+
+            (result is AppResult.Success) shouldBe true
+            val infos = (result as AppResult.Success).data
+            infos.size shouldBe 1
+            val info = infos.first()
+            info.id shouldBe "inv1"
+            info.code shouldBe "abc123"
+            info.name shouldBe "Ada"
+            info.url shouldBe "https://srv.example/invite/abc123"
+            info.claimedAt shouldBe null
+        }
+
+        test("getInvites maps claimedAt when claimed") {
+            val service = FakeInviteService()
+            service.seedSummary(
+                InviteSummary(
+                    invite = testInviteDto(id = "inv2", code = "xyz", claimedAt = 5_000_000L, claimedBy = "user1"),
+                    status = InviteStatus.CLAIMED,
+                ),
+            )
+            val repo = buildRepo(service)
+
+            val result = repo.getInvites()
+
+            (result is AppResult.Success) shouldBe true
+            val info = (result as AppResult.Success).data.first()
+            info.claimedAt shouldBe "5000000"
+        }
+
+        test("createInvite calls RPC with correct args and maps InviteDto to InviteInfo") {
+            val service = FakeInviteService()
+            val repo = buildRepo(service)
+
+            val result = repo.createInvite(name = "Ada", email = "ada@x", role = "ADMIN", expiresInDays = 7)
+
+            (result is AppResult.Success) shouldBe true
+            // Verify args forwarded to RPC
+            service.createdInvites.size shouldBe 1
+            val (email, displayName, role) = service.createdInvites.first()
+            email shouldBe "ada@x"
+            displayName shouldBe "Ada"
+            role shouldBe UserRole.ADMIN
+            // Verify returned domain model
+            val info = (result as AppResult.Success).data
+            info.name shouldBe "Ada"
+            info.email shouldBe "ada@x"
+            info.role shouldBe "ADMIN"
+            info.url shouldBe "https://srv.example/invite/code-abc"
+        }
+
+        test("deleteInvite calls revokeInvite with wrapped InviteId") {
+            val service = FakeInviteService()
+            val repo = buildRepo(service)
+
+            val result = repo.deleteInvite("inv1")
+
+            (result is AppResult.Success) shouldBe true
+            service.revokedIds shouldBe listOf("inv1")
+        }
+
+        test("a transport exception from the invite RPC factory becomes AppResult.Failure, not a throw") {
+            val throwingFactory =
+                object : InviteRpcFactory {
+                    override suspend fun publicService(): InviteServicePublic = error("unused")
+
+                    override suspend fun adminService(): InviteService = throw IllegalStateException("simulated WS 401")
+
+                    override suspend fun invalidate() = Unit
+                }
+            val repo =
+                AdminRepositoryImpl(
+                    adminApi = mock<AdminApiContract>(),
+                    adminUserRpc = mock<AdminUserRpcFactory>(),
+                    inviteRpc = throwingFactory,
+                    serverConfig = FakeServerConfig(),
+                )
+
+            (repo.getInvites() is AppResult.Failure) shouldBe true
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -238,6 +238,15 @@ class AdminRepositoryImplUserTest :
             info.permissions.canShare shouldBe false
         }
 
+        test("getRegistrationPolicy returns Success(true) when policy is OPEN") {
+            val service = FakeAdminUserService()
+            val repo = buildRepo(service)
+
+            val result = repo.getRegistrationPolicy()
+
+            result shouldBe AppResult.Success(true)
+        }
+
         test("a transport exception from the RPC factory becomes AppResult.Failure, not a throw") {
             val throwingFactory =
                 object : AdminUserRpcFactory {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -123,6 +123,8 @@ class AdminRepositoryImplUserTest :
             return AdminRepositoryImpl(
                 adminApi = unusedApi,
                 adminUserRpc = FakeAdminUserRpcFactory(service),
+                inviteRpc = mock<com.calypsan.listenup.client.data.remote.InviteRpcFactory>(),
+                serverConfig = mock<com.calypsan.listenup.client.domain.repository.ServerConfig>(),
             )
         }
 
@@ -247,6 +249,8 @@ class AdminRepositoryImplUserTest :
                 AdminRepositoryImpl(
                     adminApi = mock<com.calypsan.listenup.client.data.remote.AdminApiContract>(),
                     adminUserRpc = throwingFactory,
+                    inviteRpc = mock<com.calypsan.listenup.client.data.remote.InviteRpcFactory>(),
+                    serverConfig = mock<com.calypsan.listenup.client.domain.repository.ServerConfig>(),
                 )
 
             (repo.getUsers() is AppResult.Failure) shouldBe true

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
@@ -4,14 +4,12 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.domain.model.AdminEvent
 import com.calypsan.listenup.client.domain.model.AdminUserInfo
-import com.calypsan.listenup.client.domain.model.Instance
-import com.calypsan.listenup.client.domain.model.InstanceId
 import com.calypsan.listenup.client.domain.model.InviteInfo
 import com.calypsan.listenup.client.domain.repository.EventStreamRepository
-import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.usecase.admin.ApproveUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.DeleteUserUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.DenyUserUseCase
+import com.calypsan.listenup.client.domain.usecase.admin.GetRegistrationPolicyUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadInvitesUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadPendingUsersUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.LoadUsersUseCase
@@ -39,29 +37,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import com.calypsan.listenup.core.Timestamp
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AdminViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
-    private fun createMockInstance(openRegistration: Boolean = false) =
-        Instance(
-            id = InstanceId("test-instance"),
-            name = "Test Server",
-            version = "1.0.0",
-            localUrl = "http://localhost:8080",
-            remoteUrl = null,
-            openRegistration = openRegistration,
-            setupRequired = false,
-            createdAt = Timestamp(0L),
-            updatedAt = Timestamp(0L),
-        )
-
-    private fun createMockInstanceRepository(openRegistration: Boolean = false): InstanceRepository {
-        val instanceRepo: InstanceRepository = mock()
-        everySuspend { instanceRepo.getInstance() } returns AppResult.Success(createMockInstance(openRegistration))
-        return instanceRepo
+    private fun createMockGetRegistrationPolicyUseCase(isOpen: Boolean = false): GetRegistrationPolicyUseCase {
+        val useCase: GetRegistrationPolicyUseCase = mock()
+        everySuspend { useCase() } returns AppResult.Success(isOpen)
+        return useCase
     }
 
     private fun createMockEventStreamRepository(): EventStreamRepository {
@@ -114,7 +98,7 @@ class AdminViewModelTest {
     @Test
     fun `initial state is Loading`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -130,7 +114,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -148,7 +132,7 @@ class AdminViewModelTest {
     @Test
     fun `loadData transitions to Ready with users and invites`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -166,7 +150,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -187,7 +171,7 @@ class AdminViewModelTest {
     @Test
     fun `loadData filters out claimed invites`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -208,7 +192,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -229,7 +213,7 @@ class AdminViewModelTest {
     @Test
     fun `loadData initial users failure transitions to Error`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -245,7 +229,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -265,7 +249,7 @@ class AdminViewModelTest {
     @Test
     fun `deleteUser removes user from list`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -283,7 +267,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -309,7 +293,7 @@ class AdminViewModelTest {
     @Test
     fun `revokeInvite removes invite from list`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -327,7 +311,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -351,7 +335,7 @@ class AdminViewModelTest {
     @Test
     fun `clearError clears error state`() =
         runTest {
-            val instanceRepo = createMockInstanceRepository()
+            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
             val loadUsersUseCase: LoadUsersUseCase = mock()
             val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
             val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -368,7 +352,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,
@@ -392,10 +376,10 @@ class AdminViewModelTest {
     @Test
     fun `loadData fetches all data in parallel`() =
         runTest {
-            val instanceRepo: InstanceRepository = mock()
-            everySuspend { instanceRepo.getInstance() } calls {
+            val getRegistrationPolicyUseCase: GetRegistrationPolicyUseCase = mock()
+            everySuspend { getRegistrationPolicyUseCase() } calls {
                 delay(100)
-                AppResult.Success(createMockInstance())
+                AppResult.Success(false)
             }
 
             val loadUsersUseCase: LoadUsersUseCase = mock()
@@ -422,7 +406,7 @@ class AdminViewModelTest {
 
             val viewModel =
                 AdminViewModel(
-                    instanceRepository = instanceRepo,
+                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
                     loadUsersUseCase = loadUsersUseCase,
                     loadPendingUsersUseCase = loadPendingUsersUseCase,
                     loadInvitesUseCase = loadInvitesUseCase,


### PR DESCRIPTION
Follow-up to #381 (admin users → RPC). Clears the two remaining admin-page error snackbars: **"Can't load invites"** and **"Not Found"**.

## Invites → InviteService RPC ("Can't load invites")
`AdminRepositoryImpl`'s invite methods hit REST `AdminApi` with the old Go envelope; the Kotlin server returns bare types. Migrated to the authed `InviteService` RPC:
- Extended `InviteRpcFactory` with `adminService(): InviteService` over `/api/rpc/authed` (same factory, no new `RemoteCache`).
- `InviteSummary/InviteDto → InviteInfo` mapper. The contract dropped the invite `url`, so the client rebuilds it as `"${serverUrl}/invite/${code}"` (the established deep-link format) from `ServerConfig`.
- `getInvites`/`createInvite`/`deleteInvite` route through the RPC, wrapped in the same `catching{}` transport boundary as the user methods (RPC `get()` throws on a 401 WS handshake; the data layer must never throw).
- REST `AdminApi` invite methods left untouched (parallel surface, like the user methods).

## openRegistration via getRegistrationPolicy ("Not Found")
The admin page read `openRegistration` from `instanceRepository.getInstance()`, which is on a legacy REST path mid-migration to RPC (a separate effort — deliberately not touched here). `getInstance` returns a richer `Instance` model that no RPC currently provides, so it's not a client-only fix.

Instead, sourced `openRegistration` from `AdminUserService.getRegistrationPolicy()` (RPC, `OPEN ⇒ true`) — which lives in the admin domain already wired here:
- Added `AdminRepository.getRegistrationPolicy(): AppResult<Boolean>` (via the existing `adminUserRpc`, `catching{}`-wrapped) + `GetRegistrationPolicyUseCase`.
- `AdminViewModel` now sources openRegistration from the use case and no longer depends on `InstanceRepository`.

The richer `getInstance → RPC` migration is left to the instance-verification effort.

## Tests
- `AdminRepositoryImplInviteTest` (in-memory `InviteService` fake) — invite mapping incl. URL rebuild, create, revoke.
- `AdminRepositoryImplUserTest` — added `getRegistrationPolicy` coverage.
- `AdminViewModelTest` — re-pointed to the registration-policy use case.
- Full Linux client gate green: `:contract:jvmTest :sharedLogic:jvmTest :sharedUI:compileAndroidHostTest spotlessCheck detekt :androidApp:assembleDebug`. iOS gates on CI.