### PR TITLE
🐛 fix(shared): dedup discovered servers by host:port, stop unbounded list growth

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ServerRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ServerRepositoryImpl.kt
@@ -33,8 +33,9 @@ fun interface ServerUrlChangeListener {
  * Repository implementation for managing ListenUp servers.
  *
  * Bridges mDNS discovery with local persistence:
- * - Discovered servers are automatically persisted
- * - Persisted servers show online/offline status based on discovery
+ * - Discovery results surface in the list keyed by host:port (one row per physical server,
+ *   regardless of mDNS id churn); they are persisted only when the user activates one
+ * - Persisted servers show online/offline status based on discovery and follow IP changes
  * - Auth tokens are stored per-server for instant switching
  * - Notifies listeners when active server URL changes (for API client invalidation)
  *
@@ -54,59 +55,68 @@ class ServerRepositoryImpl(
             serverDao.observeAll().distinctUntilChanged(),
             discoveryService.discover().onStart { emit(emptyList()) }.distinctUntilChanged(),
         ) { persisted, discovered ->
-            val discoveredIds = discovered.map { it.id }.toSet()
+            // Follow IP changes for servers the user already saved: when a persisted server's mDNS
+            // id reappears at a new address, refresh its stored URL (and notify the active-server
+            // listener). Discovery-only servers are deliberately NOT persisted here — blindly
+            // persisting every advertised id is what let the list grow without bound as a host's
+            // mDNS id churned across restarts.
+            scope.launch { refreshRediscoveredServers(discovered) }
 
-            // Update local URLs for rediscovered servers
-            scope.launch {
-                for (disc in discovered) {
-                    val existing = serverDao.getById(disc.id)
-                    if (existing != null) {
-                        // Check if this is the active server and URL changed
-                        val urlChanged = existing.isActive && existing.localUrl != disc.localUrl
-                        if (urlChanged) {
-                            logger.info {
-                                "Active server IP changed: ${existing.localUrl} -> ${disc.localUrl}"
-                            }
-                        }
+            val onlineKeys = discovered.mapNotNull { hostPortKey(it.localUrl) }.toSet()
 
-                        // Server exists - update from discovery
-                        serverDao.updateFromDiscovery(
-                            id = disc.id,
-                            name = disc.name,
-                            apiVersion = disc.apiVersion,
-                            serverVersion = disc.serverVersion,
-                            localUrl = disc.localUrl,
-                            remoteUrl = disc.remoteUrl,
+            // One row per physical host: collapse historical duplicate rows (same host, stale ids),
+            // preferring the active server. A host is online when it is currently advertised.
+            val persistedRows =
+                persisted
+                    .groupBy { hostPortKey(it.localUrl ?: it.remoteUrl) ?: "id:${it.id}" }
+                    .values
+                    .map { rows -> rows.firstOrNull { it.isActive } ?: rows.first() }
+                    .map { server ->
+                        ServerWithStatus(
+                            server = server.toDomain(),
+                            isOnline = hostPortKey(server.localUrl ?: server.remoteUrl) in onlineKeys,
                         )
-
-                        // Notify listener if active server's URL changed
-                        if (urlChanged) {
-                            urlChangeListener?.onServerUrlChanged(ServerUrl(disc.localUrl))
-                        }
-                    } else {
-                        // New server - insert it
-                        serverDao.upsert(disc.toEntity())
                     }
-                }
-            }
 
-            // Merge persisted servers with online status
-            val merged =
-                persisted.map { server ->
-                    ServerWithStatus(
-                        server = server.toDomain(),
-                        isOnline = server.id in discoveredIds,
-                    )
-                }
+            val persistedKeys = persisted.mapNotNull { hostPortKey(it.localUrl ?: it.remoteUrl) }.toSet()
 
-            // Add newly discovered servers that aren't persisted yet
-            val newServers =
+            // Discovered servers not already represented by a persisted row, deduped by host.
+            val discoveredRows =
                 discovered
-                    .filter { d -> persisted.none { it.id == d.id } }
+                    .associateBy { hostPortKey(it.localUrl) }
+                    .values
+                    .filter { hostPortKey(it.localUrl) !in persistedKeys }
                     .map { ServerWithStatus(it.toEntity().toDomain(), isOnline = true) }
 
-            merged + newServers
+            persistedRows + discoveredRows
         }
+
+    /**
+     * Refreshes the stored URL of any persisted server whose mDNS id is currently advertised, so a
+     * saved server (notably the active one) follows its address across DHCP/IP changes. Servers not
+     * already persisted are left untouched — they surface in the discovered list and are only
+     * written to the database when the user activates one.
+     */
+    private suspend fun refreshRediscoveredServers(discovered: List<DataDiscoveredServer>) {
+        for (disc in discovered) {
+            val existing = serverDao.getById(disc.id) ?: continue
+            val urlChanged = existing.isActive && existing.localUrl != disc.localUrl
+            if (urlChanged) {
+                logger.info { "Active server IP changed: ${existing.localUrl} -> ${disc.localUrl}" }
+            }
+            serverDao.updateFromDiscovery(
+                id = disc.id,
+                name = disc.name,
+                apiVersion = disc.apiVersion,
+                serverVersion = disc.serverVersion,
+                localUrl = disc.localUrl,
+                remoteUrl = disc.remoteUrl,
+            )
+            if (urlChanged) {
+                urlChangeListener?.onServerUrlChanged(ServerUrl(disc.localUrl))
+            }
+        }
+    }
 
     override fun observeActiveServer(): Flow<Server?> = serverDao.observeActive().map { it?.toDomain() }
 
@@ -217,6 +227,18 @@ class ServerRepositoryImpl(
 // ============================================================
 // Mapping functions
 // ============================================================
+
+/**
+ * Normalizes a server URL to a stable host:port identity — scheme and trailing slash dropped,
+ * lower-cased — so the same physical server is recognized regardless of its (churn-prone) mDNS id.
+ * Returns null for a null/blank URL.
+ */
+private fun hostPortKey(url: String?): String? =
+    url
+        ?.takeIf { it.isNotBlank() }
+        ?.substringAfter("://")
+        ?.trimEnd('/')
+        ?.lowercase()
 
 /**
  * Convert entity to domain model.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ServerDiscoveryDedupTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ServerDiscoveryDedupTest.kt
@@ -1,0 +1,114 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.data.discovery.ServerDiscoveryService
+import com.calypsan.listenup.client.data.local.db.ServerDao
+import com.calypsan.listenup.client.data.local.db.ServerEntity
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import dev.mokkery.verify.VerifyMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import com.calypsan.listenup.client.data.discovery.DiscoveredServer as DataDiscoveredServer
+
+/**
+ * Regression coverage for the mDNS server-list growth bug: the same physical host advertising a
+ * fresh mDNS `id` across restarts (or after a server DB reset) used to accumulate one permanent
+ * Room row per id, so the list grew without bound and showed the same host repeatedly. The list
+ * is now keyed by host:port — one row per physical server — and discovery results are no longer
+ * blindly persisted.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerDiscoveryDedupTest :
+    FunSpec({
+        fun entity(
+            id: String,
+            localUrl: String? = "http://192.168.86.36:8080",
+            isActive: Boolean = false,
+        ) = ServerEntity(
+            id = id,
+            name = "ListenUp",
+            apiVersion = "v1",
+            serverVersion = "0.0.1",
+            localUrl = localUrl,
+            remoteUrl = null,
+            isActive = isActive,
+            lastSeenAt = 0,
+        )
+
+        fun discovered(
+            id: String,
+            host: String = "192.168.86.36",
+            port: Int = 8080,
+        ) = DataDiscoveredServer(
+            id = id,
+            name = "ListenUp",
+            host = host,
+            port = port,
+            apiVersion = "v1",
+            serverVersion = "0.0.1",
+        )
+
+        test("collapses duplicate persisted rows for the same host into one entry") {
+            runTest {
+                val dao = mock<ServerDao>()
+                val discovery = mock<ServerDiscoveryService>()
+                everySuspend { dao.observeAll() } returns
+                    flowOf(listOf(entity(id = "id-a"), entity(id = "id-b"), entity(id = "id-c")))
+                every { discovery.discover() } returns flowOf(emptyList())
+
+                val repository = ServerRepositoryImpl(dao, discovery, this)
+                val servers = repository.observeServers().first()
+
+                servers shouldHaveSize 1
+                servers.first().server.localUrl shouldBe "http://192.168.86.36:8080"
+            }
+        }
+
+        test("a persisted host is online when rediscovered under a different mDNS id") {
+            runTest {
+                val dao = mock<ServerDao>()
+                val discovery = mock<ServerDiscoveryService>()
+                everySuspend { dao.observeAll() } returns MutableStateFlow(listOf(entity(id = "old-id")))
+                everySuspend { dao.getById(any()) } returns null
+                everySuspend { dao.updateFromDiscovery(any(), any(), any(), any(), any(), any(), any()) } returns Unit
+                everySuspend { dao.upsert(any()) } returns Unit
+                every { discovery.discover() } returns MutableStateFlow(listOf(discovered(id = "fresh-id")))
+
+                val repository = ServerRepositoryImpl(dao, discovery, this)
+                advanceUntilIdle()
+                val servers = repository.observeServers().drop(1).first()
+
+                servers shouldHaveSize 1
+                servers.first().isOnline shouldBe true
+            }
+        }
+
+        test("discovered servers are not blindly persisted") {
+            runTest {
+                val dao = mock<ServerDao>()
+                val discovery = mock<ServerDiscoveryService>()
+                everySuspend { dao.observeAll() } returns MutableStateFlow(emptyList())
+                everySuspend { dao.getById(any()) } returns null
+                everySuspend { dao.upsert(any()) } returns Unit
+                every { discovery.discover() } returns MutableStateFlow(listOf(discovered(id = "fresh-id")))
+
+                val repository = ServerRepositoryImpl(dao, discovery, this)
+                repository.observeServers().drop(1).first()
+                advanceUntilIdle()
+
+                verifySuspend(VerifyMode.exactly(0)) { dao.upsert(any()) }
+            }
+        }
+    })


### PR DESCRIPTION
## Problem

On the server-selection screen the list grew without bound — the same physical host (e.g. `192.168.86.36:8080`) appeared dozens of times (46 and climbing), some rows "Online", most "Offline".

## Root cause

`ServerRepositoryImpl.observeServers()` persisted **every** discovered server into Room keyed by the mDNS TXT `id`, and nothing ever expired those rows. That `id` is a server-generated UUID stored in the server's DB, so when the same host advertises a fresh `id` — after a server reinstall or a DB reset (the dev DB was wiped 2026-06-04) — each new `id` became a **permanent** new row. Latest `id` → "Online", every prior `id` for that host → "Offline". Unbounded growth, one host shown many times.

## Fix

Identity is now **host:port**, not the churn-prone mDNS id:

- **Stop blindly persisting discovery.** Discovered-but-unsaved servers surface in the list from live discovery only; they're written to Room when the user actually activates one (`setActiveServer`) — unchanged. This removes the side-effect-inside-`combine` and stops the growth at the source.
- **Render one row per host:port.** Persisted rows are collapsed by host:port (preferring the active server), so historical duplicates from id churn show as a single entry. A host is "Online" when that host:port is currently advertised — even if its mDNS id changed.
- **Keep IP-follow.** A persisted server whose `id` reappears at a new address still has its stored URL refreshed (and the active-server listener notified), so the saved/active server follows DHCP changes.

Existing duplicate rows already in a user's DB are not destructively deleted; they collapse to one row per host in the view and no longer accumulate.

## Tests (TDD)

New Kotest `ServerDiscoveryDedupTest` (written failing first):
- Duplicate persisted rows for the same host collapse to one entry.
- A persisted host is "Online" when rediscovered under a different mDNS id.
- Discovered servers are not blindly persisted (`upsert` not called).

Existing `ServerRepositoryTest` still green. Gate: `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest` all pass.
