### PR TITLE
✨ feat(sharedUI): restyle Home screen to M3 Expressive

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ProgressOverlay.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ProgressOverlay.kt
@@ -2,26 +2,28 @@ package com.calypsan.listenup.client.design.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
+/** Scrim behind the progress pill — a translucent dark wash standing in for the design's blur. */
+private val ProgressScrim = Color.Black.copy(alpha = 0.42f)
+
 /**
- * Progress overlay for book covers.
- *
- * Displays a compact progress bar with percentage and optional time remaining.
- * Uses theme colors (primaryContainer/primary) for a cohesive look.
+ * Progress pill for book covers — a floating, inset capsule with a coral percentage chip and the
+ * optional time-remaining text, over a translucent dark scrim. Sits at the bottom of a cover.
  *
  * @param progress Progress value from 0.0 to 1.0
  * @param timeRemaining Optional formatted time remaining string (e.g., "2h 15m left")
@@ -37,46 +39,32 @@ fun ProgressOverlay(
         modifier =
             modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f))
+                .padding(8.dp)
+                .clip(CircleShape)
+                .background(ProgressScrim)
                 .padding(horizontal = 8.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Progress bar with percentage inside
-        Box(
-            modifier =
-                Modifier
-                    .weight(1f)
-                    .height(18.dp)
-                    .clip(MaterialTheme.shapes.small)
-                    .background(MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f)),
-        ) {
-            // Filled portion
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxHeight()
-                        .fillMaxWidth(progress.coerceIn(0f, 1f))
-                        .background(MaterialTheme.colorScheme.primary),
-            )
-            // Percentage text centered
+        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary) {
             Text(
-                text = "${(progress * 100).toInt()}%",
-                style = MaterialTheme.typography.labelSmall,
+                text = "${(progress.coerceIn(0f, 1f) * 100).toInt()}%",
+                style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onPrimary,
                 fontWeight = FontWeight.ExtraBold,
-                modifier = Modifier.align(Alignment.Center),
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
             )
         }
 
-        // Time remaining (if provided)
         if (timeRemaining != null) {
             Text(
                 text = timeRemaining,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White,
                 fontWeight = FontWeight.SemiBold,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
             )
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SectionTitle.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SectionTitle.kt
@@ -1,0 +1,53 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * Canonical section header: a bold title with an optional coral "See all" action on the trailing
+ * baseline. Used by the Home sections (Continue Listening, This Week, My Shelves) and available for
+ * any list section that needs the same treatment.
+ *
+ * (Several feature screens still carry their own private `SectionHeader` composables —
+ * bookdetail/library/profile/search — which could be consolidated onto this later.)
+ *
+ * @param title The section heading.
+ * @param modifier Optional modifier.
+ * @param onSeeAll When non-null, renders a trailing "See all" affordance invoking this.
+ */
+@Composable
+fun SectionTitle(
+    title: String,
+    modifier: Modifier = Modifier,
+    onSeeAll: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (onSeeAll != null) {
+            Text(
+                text = "See all",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.clickable(onClick = onSeeAll),
+            )
+        }
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomeScreen.kt
@@ -188,7 +188,7 @@ private fun HomeContentWide(
     onSeeAllShelves: () -> Unit,
 ) {
     Row(modifier = Modifier.fillMaxWidth()) {
-        HomeStatsSection()
+        HomeStatsSection(isWide = true)
         if (state.hasMyShelves) {
             Spacer(modifier = Modifier.width(16.dp))
             MyShelvesRow(
@@ -207,7 +207,7 @@ private fun HomeContentCompact(
     onShelfClick: (String) -> Unit,
     onSeeAllShelves: () -> Unit,
 ) {
-    HomeStatsSection()
+    HomeStatsSection(isWide = false)
 
     if (state.hasMyShelves) {
         Spacer(modifier = Modifier.height(24.dp))

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomeScreen.kt
@@ -193,6 +193,7 @@ private fun HomeContentWide(
             Spacer(modifier = Modifier.width(16.dp))
             MyShelvesRow(
                 shelves = state.myShelves,
+                isWide = true,
                 onShelfClick = onShelfClick,
                 onSeeAllClick = onSeeAllShelves,
                 modifier = Modifier.weight(1f),
@@ -213,6 +214,7 @@ private fun HomeContentCompact(
         Spacer(modifier = Modifier.height(24.dp))
         MyShelvesRow(
             shelves = state.myShelves,
+            isWide = false,
             onShelfClick = onShelfClick,
             onSeeAllClick = onSeeAllShelves,
         )

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomeScreen.kt
@@ -150,7 +150,7 @@ private fun HomeContent(
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState()),
         ) {
-            HomeHeader(greeting = state.greeting)
+            HomeHeader(greeting = state.greeting, isWide = isWide)
 
             if (state.hasContinueListening) {
                 ContinueListeningRow(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ContinueListeningRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ContinueListeningRow.kt
@@ -10,11 +10,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.calypsan.listenup.client.design.components.BrowseCarousel
+import com.calypsan.listenup.client.design.components.SectionTitle
 import com.calypsan.listenup.client.domain.model.ContinueListeningItem
 import com.calypsan.listenup.client.features.library.BookCard
 import org.jetbrains.compose.resources.stringResource
@@ -41,12 +41,9 @@ fun ContinueListeningRow(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        // Section header
-        Text(
-            text = stringResource(Res.string.home_continue_listening),
-            style = MaterialTheme.typography.titleLargeEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(horizontal = 16.dp),
+        SectionTitle(
+            title = stringResource(Res.string.home_continue_listening),
+            modifier = Modifier.padding(horizontal = 24.dp),
         )
 
         Spacer(modifier = Modifier.height(12.dp))

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/DailyListeningChart.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/DailyListeningChart.kt
@@ -41,7 +41,9 @@ fun DailyListeningChart(
     dailyBuckets: List<DayBucket>,
     modifier: Modifier = Modifier,
 ) {
-    val barColor = MaterialTheme.colorScheme.primary
+    val todayColor = MaterialTheme.colorScheme.primary
+    val barColor = MaterialTheme.colorScheme.primaryContainer
+    val emptyColor = MaterialTheme.colorScheme.surfaceContainerHighest
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
     val textMeasurer = rememberTextMeasurer()
 
@@ -80,20 +82,27 @@ fun DailyListeningChart(
         val totalSpacing = barSpacing * (barCount - 1)
         val barWidth = ((size.width - totalSpacing) / barCount).coerceAtLeast(12.dp.toPx())
 
+        val emptyStub = 4.dp.toPx()
         chartData.forEachIndexed { index, bar ->
             val x = index * (barWidth + barSpacing)
-            val barHeight = bar.minutes / maxMinutes * chartHeight
+            val isToday = index == chartData.lastIndex
+            val isEmpty = bar.minutes <= 0f
+            // Empty days draw a small stub so the baseline reads as a row of days, not gaps.
+            val barHeight = if (isEmpty) emptyStub else (bar.minutes / maxMinutes * chartHeight)
             val barTop = chartHeight - barHeight
+            val color =
+                when {
+                    isEmpty -> emptyColor
+                    isToday -> todayColor
+                    else -> barColor
+                }
 
-            // Draw bar with rounded top corners
-            if (barHeight > 0f) {
-                drawRoundRect(
-                    color = barColor,
-                    topLeft = Offset(x, barTop),
-                    size = Size(barWidth, barHeight),
-                    cornerRadius = CornerRadius(4.dp.toPx()),
-                )
-            }
+            drawRoundRect(
+                color = color,
+                topLeft = Offset(x, barTop),
+                size = Size(barWidth, barHeight),
+                cornerRadius = CornerRadius(8.dp.toPx()),
+            )
 
             // Draw day label centered below bar
             val labelResult = textMeasurer.measure(bar.label, labelStyle)

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/DailyListeningChart.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/DailyListeningChart.kt
@@ -88,7 +88,7 @@ fun DailyListeningChart(
             val isToday = index == chartData.lastIndex
             val isEmpty = bar.minutes <= 0f
             // Empty days draw a small stub so the baseline reads as a row of days, not gaps.
-            val barHeight = if (isEmpty) emptyStub else (bar.minutes / maxMinutes * chartHeight)
+            val barHeight = if (isEmpty) emptyStub else bar.minutes / maxMinutes * chartHeight
             val barTop = chartHeight - barHeight
             val color =
                 when {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/EmptyContinueListening.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/EmptyContinueListening.kt
@@ -15,9 +15,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.SectionTitle
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.home_browse_library
@@ -40,15 +40,9 @@ fun EmptyContinueListening(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
-        // Section header
-        Text(
-            text = stringResource(Res.string.home_continue_listening),
-            style =
-                MaterialTheme.typography.titleLarge.copy(
-                    fontWeight = FontWeight.Bold,
-                ),
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(horizontal = 16.dp),
+        SectionTitle(
+            title = stringResource(Res.string.home_continue_listening),
+            modifier = Modifier.padding(horizontal = 24.dp),
         )
 
         Spacer(modifier = Modifier.height(24.dp))

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/GenreBreakdownBars.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/GenreBreakdownBars.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
@@ -16,12 +15,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.calypsan.listenup.client.domain.GenreShare
-import listenup.composeapp.generated.resources.Res
-import listenup.composeapp.generated.resources.home_top_genres
-import org.jetbrains.compose.resources.stringResource
 
 /**
  * Genre breakdown showing top genres with progress bars.
@@ -37,69 +35,73 @@ fun GenreBreakdownBars(
     genres: List<GenreShare>,
     modifier: Modifier = Modifier,
 ) {
-    val maxSeconds = genres.maxOfOrNull { it.totalSeconds }?.toDouble() ?: 1.0
+    // Share of total listening across the shown genres — matches the design's summing percentages.
+    val totalSeconds = genres.sumOf { it.totalSeconds }.toDouble().coerceAtLeast(1.0)
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            text = stringResource(Res.string.home_top_genres),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
         genres.forEach { genre ->
+            val share = (genre.totalSeconds.toDouble() / totalSeconds).coerceIn(0.0, 1.0)
             GenreBar(
                 genreName = genre.genreName,
-                fraction = (genre.totalSeconds.toDouble() / maxSeconds).coerceIn(0.0, 1.0).toFloat(),
+                fraction = share.toFloat(),
+                percent = (share * 100).toInt(),
             )
         }
     }
 }
 
 /**
- * Single genre progress bar.
+ * Single genre row: name + share bar + percentage.
  */
 @Composable
 private fun GenreBar(
     genreName: String,
     fraction: Float,
+    percent: Int,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        // Genre name
         Text(
             text = genreName,
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.width(80.dp),
+            modifier = Modifier.width(120.dp),
         )
 
-        Spacer(Modifier.width(8.dp))
-
-        // Progress bar
         Box(
             modifier =
                 Modifier
                     .weight(1f)
-                    .height(8.dp)
-                    .clip(RoundedCornerShape(4.dp))
+                    .height(10.dp)
+                    .clip(RoundedCornerShape(99.dp))
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest),
         ) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth(fraction)
-                        .height(8.dp)
-                        .clip(RoundedCornerShape(4.dp))
+                        .height(10.dp)
+                        .clip(RoundedCornerShape(99.dp))
                         .background(MaterialTheme.colorScheme.primary),
             )
         }
+
+        Text(
+            text = "$percent%",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(40.dp),
+            textAlign = TextAlign.End,
+        )
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeHeader.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeHeader.kt
@@ -13,27 +13,31 @@ import androidx.compose.ui.unit.sp
 /**
  * Header section for the Home screen.
  *
- * Displays a time-aware greeting (e.g., "Good morning, Simon")
- * with balanced typography that doesn't dominate the screen.
+ * Displays a time-aware greeting (e.g., "Good morning, Simon") as an emphasized hero line — the
+ * Home content's header, since the shell top bar already carries search and the account menu.
+ * Scales up on wide windows to anchor the desktop layout.
  *
  * @param greeting The personalized greeting text
+ * @param isWide Whether the current window is medium+ (drives the display size)
  * @param modifier Optional modifier
  */
 @Composable
 fun HomeHeader(
     greeting: String,
+    isWide: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+        modifier = modifier.padding(horizontal = 24.dp, vertical = 16.dp),
     ) {
         Text(
             text = greeting,
             style =
-                MaterialTheme.typography.headlineMedium.copy(
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = (-0.3).sp,
-                ),
+                (if (isWide) MaterialTheme.typography.displaySmall else MaterialTheme.typography.headlineLarge)
+                    .copy(
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = (-1).sp,
+                    ),
             color = MaterialTheme.colorScheme.onSurface,
         )
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeStatsSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeStatsSection.kt
@@ -1,18 +1,26 @@
 package com.calypsan.listenup.client.features.home.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.calypsan.listenup.client.presentation.home.HomeStatsUiState
 import com.calypsan.listenup.client.presentation.home.HomeStatsViewModel
@@ -24,116 +32,132 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
- * Home screen stats section.
+ * Home "This week" stats card — listening total + 7-day chart, with streak and top-genre breakdown.
  *
- * Displays a card with the user's listening stats:
- * - 7-day bar chart showing daily listening time
- * - Current streak indicator with fire emoji
- * - Top 3 genres breakdown
+ * Adaptive: on wide windows the chart sits beside the streak/genres column (vertical divider); on
+ * compact they stack (horizontal divider) — mirroring the design's `StatsCard` / `StatsCard wide`.
  *
- * Renders one of four states driven by [HomeStatsUiState]:
- * - [HomeStatsUiState.Loading]: skeleton placeholder while Room query loads
- * - [HomeStatsUiState.Empty]: friendly prompt before any listening history exists
- * - [HomeStatsUiState.Data]: populated chart + streak + genres
- * - [HomeStatsUiState.Error]: error message (retry is implicit — stateIn resubscribes)
- *
- * @param modifier Modifier from parent
- * @param viewModel HomeStatsViewModel injected via Koin
+ * @param isWide Whether the window is medium+ (drives the two-column vs stacked layout).
+ * @param modifier Modifier from parent.
+ * @param viewModel HomeStatsViewModel injected via Koin.
  */
 @Composable
 fun HomeStatsSection(
+    isWide: Boolean,
     modifier: Modifier = Modifier,
     viewModel: HomeStatsViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     Card(
-        modifier =
-            modifier
-                .widthIn(max = 600.dp)
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainer,
-            ),
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            // Section title — always visible regardless of state
-            Text(
-                text = stringResource(Res.string.home_this_week),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
+        Column(modifier = Modifier.fillMaxWidth().padding(if (isWide) 28.dp else 22.dp)) {
             when (val s = state) {
                 HomeStatsUiState.Loading -> {
-                    Text(
-                        text = stringResource(Res.string.common_loading_item, "stats"),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    StatsPlaceholder(stringResource(Res.string.common_loading_item, "stats"))
                 }
 
                 HomeStatsUiState.Empty -> {
-                    Text(
-                        text = stringResource(Res.string.home_start_listening_to_see_your),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    StatsPlaceholder(stringResource(Res.string.home_start_listening_to_see_your))
                 }
 
                 is HomeStatsUiState.Data -> {
-                    HomeStatsContent(state = s)
+                    HomeStatsContent(state = s, isWide = isWide)
                 }
 
                 is HomeStatsUiState.Error -> {
-                    Text(
-                        text = "Couldn't load stats.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                    )
+                    StatsPlaceholder("Couldn't load stats.", color = MaterialTheme.colorScheme.error)
                 }
             }
         }
     }
 }
 
-/**
- * Stats content when data is available and the user has listening history.
- */
 @Composable
-private fun HomeStatsContent(state: HomeStatsUiState.Data) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        // 7-day listening chart
-        if (state.dailyBuckets.isNotEmpty()) {
-            DailyListeningChart(
-                dailyBuckets = state.dailyBuckets,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
+private fun StatsPlaceholder(
+    message: String,
+    color: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    Overline(stringResource(Res.string.home_this_week))
+    Spacer(Modifier.height(12.dp))
+    Text(text = message, style = MaterialTheme.typography.bodyMedium, color = color)
+}
 
-        // Streak indicator
-        if (state.hasStreak) {
-            StreakIndicator(
-                currentStreak = state.currentStreakDays,
-                longestStreak = state.longestStreakDays,
-            )
-        }
+@Composable
+private fun HomeStatsContent(
+    state: HomeStatsUiState.Data,
+    isWide: Boolean,
+) {
+    val totalSeconds = state.dailyBuckets.sumOf { it.totalSeconds }
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
 
-        // Genre breakdown
-        if (state.hasGenreData) {
-            GenreBreakdownBars(
-                genres = state.topGenres,
-            )
+    val chartColumn: @Composable () -> Unit = {
+        Column {
+            Overline(stringResource(Res.string.home_this_week))
+            Spacer(Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = "${hours}h ${minutes}m",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = (-1.5).sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "listened",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 6.dp),
+                )
+            }
+            Spacer(Modifier.height(18.dp))
+            if (state.dailyBuckets.isNotEmpty()) {
+                DailyListeningChart(dailyBuckets = state.dailyBuckets, modifier = Modifier.fillMaxWidth())
+            }
         }
     }
+
+    val detailColumn: @Composable () -> Unit = {
+        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+            if (state.hasStreak) {
+                StreakIndicator(currentStreak = state.currentStreakDays, longestStreak = state.longestStreakDays)
+            }
+            if (state.hasGenreData) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Overline("Top genres")
+                    GenreBreakdownBars(genres = state.topGenres)
+                }
+            }
+        }
+    }
+
+    if (isWide) {
+        Row(horizontalArrangement = Arrangement.spacedBy(0.dp)) {
+            Box(Modifier.weight(1.3f)) { chartColumn() }
+            VerticalDivider(modifier = Modifier.padding(horizontal = 24.dp))
+            Box(Modifier.weight(1f)) { detailColumn() }
+        }
+    } else {
+        chartColumn()
+        if (state.hasStreak || state.hasGenreData) {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 20.dp))
+            detailColumn()
+        }
+    }
+}
+
+/** Small uppercase overline label used inside the stats card. */
+@Composable
+private fun Overline(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 1.sp,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeStatsSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeStatsSection.kt
@@ -93,7 +93,7 @@ private fun HomeStatsContent(
 ) {
     val totalSeconds = state.dailyBuckets.sumOf { it.totalSeconds }
     val hours = totalSeconds / 3600
-    val minutes = (totalSeconds % 3600) / 60
+    val minutes = totalSeconds % 3600 / 60
 
     val chartColumn: @Composable () -> Unit = {
         Column {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/MyShelvesRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/MyShelvesRow.kt
@@ -2,80 +2,85 @@ package com.calypsan.listenup.client.features.home.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.calypsan.listenup.client.design.components.BrowseCarousel
+import com.calypsan.listenup.client.design.components.SectionTitle
 import com.calypsan.listenup.client.domain.model.Shelf
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.home_my_shelves
-import listenup.composeapp.generated.resources.common_see_all
 
 /**
- * Horizontal scrolling row of My Shelves.
+ * "My shelves" section: a [SectionTitle] with a "See all" action over the shelves, color-blocked.
  *
- * Displays a section header with "See All" action, followed by a
- * horizontally scrollable list of ShelfCard components.
+ * Adaptive: a full-width vertical stack on wide windows; a horizontal carousel of fixed-width cards
+ * on compact. Container colors cycle through the primary/tertiary/secondary container roles.
  *
- * @param shelves List of shelves owned by the user
- * @param onShelfClick Callback when a shelf card is clicked
- * @param onSeeAllClick Callback when "See All" is clicked
- * @param modifier Optional modifier
+ * @param shelves List of shelves owned by the user.
+ * @param isWide Whether the window is medium+ (stack vs carousel).
+ * @param onShelfClick Callback when a shelf is clicked.
+ * @param onSeeAllClick Callback when "See all" is clicked.
+ * @param modifier Optional modifier.
  */
 @Composable
 fun MyShelvesRow(
     shelves: List<Shelf>,
+    isWide: Boolean,
     onShelfClick: (String) -> Unit,
     onSeeAllClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        // Section header with See All button
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(Res.string.home_my_shelves),
-                style =
-                    MaterialTheme.typography.titleLarge.copy(
-                        fontWeight = FontWeight.Bold,
-                    ),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+        SectionTitle(
+            title = stringResource(Res.string.home_my_shelves),
+            onSeeAll = onSeeAllClick,
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
 
-            TextButton(onClick = onSeeAllClick) {
-                Text(
-                    text = stringResource(Res.string.common_see_all),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
+        Spacer(modifier = Modifier.height(12.dp))
+
+        if (isWide) {
+            Column(
+                modifier = Modifier.padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                shelves.forEachIndexed { index, shelf ->
+                    val (container, content) = shelfColors(index)
+                    ShelfCard(
+                        shelf = shelf,
+                        containerColor = container,
+                        contentColor = content,
+                        onClick = { onShelfClick(shelf.id) },
+                        fillWidth = true,
+                    )
+                }
+            }
+        } else {
+            BrowseCarousel(items = shelves) { shelf ->
+                val (container, content) = shelfColors(shelves.indexOf(shelf))
+                ShelfCard(
+                    shelf = shelf,
+                    containerColor = container,
+                    contentColor = content,
+                    onClick = { onShelfClick(shelf.id) },
                 )
             }
         }
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        // Horizontally scrolling shelf cards
-        BrowseCarousel(items = shelves) { shelf ->
-            ShelfCard(
-                shelf = shelf,
-                onClick = { onShelfClick(shelf.id) },
-            )
-        }
     }
 }
+
+/** Cycles the container/on-container color pair so adjacent shelves read distinctly. */
+@Composable
+private fun shelfColors(index: Int): Pair<Color, Color> =
+    when (index % 3) {
+        0 -> MaterialTheme.colorScheme.primaryContainer to MaterialTheme.colorScheme.onPrimaryContainer
+        1 -> MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+        else -> MaterialTheme.colorScheme.secondaryContainer to MaterialTheme.colorScheme.onSecondaryContainer
+    }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ShelfCard.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ShelfCard.kt
@@ -10,16 +10,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.outlined.LibraryBooks
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,41 +31,37 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.calypsan.listenup.client.design.components.ListenUpAsyncImage
-import com.calypsan.listenup.client.design.util.stableColorForId
 import com.calypsan.listenup.client.domain.model.Shelf
-import org.jetbrains.compose.resources.stringResource
-import listenup.composeapp.generated.resources.Res
-import listenup.composeapp.generated.resources.home_cover_1
-import listenup.composeapp.generated.resources.home_cover_2
-import listenup.composeapp.generated.resources.home_cover_3
-import listenup.composeapp.generated.resources.home_cover_4
+
+private val ShelfCardWidth = 180.dp
+private val ShelfCardHeight = 116.dp
 
 /**
- * Card for a shelf in the My Shelves section.
+ * A color-blocked shelf card: a filled container with a soft blob, the shelf icon, its name, and the
+ * book count. Colors are supplied by the caller so a row of shelves cycles through the
+ * primary/tertiary/secondary container roles.
  *
- * Features:
- * - 2x2 book cover grid (or empty state icon)
- * - Shelf name and book count
- * - Press-to-scale animation
- *
- * @param shelf The shelf domain model to display
- * @param onClick Callback when card is clicked
- * @param modifier Optional modifier
+ * @param shelf The shelf domain model.
+ * @param containerColor The card's fill color (a `*Container` role).
+ * @param contentColor The matching `on*Container` color for icon + text.
+ * @param onClick Card click.
+ * @param modifier Optional modifier.
+ * @param fillWidth When true the card fills its parent width (desktop vertical stack); otherwise it
+ *   takes a fixed width (mobile carousel).
  */
 @Composable
 fun ShelfCard(
     shelf: Shelf,
+    containerColor: Color,
+    contentColor: Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    fillWidth: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -75,186 +73,76 @@ fun ShelfCard(
                 isFocused -> 1.05f
                 else -> 1f
             },
-        label = "card_scale",
+        label = "shelf_card_scale",
     )
 
-    // Owner identity carries no avatar color — derive a stable color from the owner id.
-    val avatarColor =
-        remember(shelf.ownerId) {
-            stableColorForId(shelf.ownerId)
-        }
+    val widthModifier = if (fillWidth) Modifier.fillMaxWidth() else Modifier.width(ShelfCardWidth)
 
-    Column(
+    Box(
         modifier =
             modifier
-                .width(140.dp)
+                .then(widthModifier)
+                .height(ShelfCardHeight)
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
-                }.clickable(
+                }.clip(RoundedCornerShape(20.dp))
+                .background(containerColor)
+                .clickable(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = onClick,
                 ),
     ) {
-        // Cover grid container
-        ShelfCoverGrid(
-            coverPaths = shelf.coverPaths,
-            color = avatarColor,
-            modifier = Modifier.size(140.dp),
+        // Soft decorative blob, bottom-right.
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .offset(x = 24.dp, y = 24.dp)
+                    .size(90.dp)
+                    .clip(CircleShape)
+                    .background(contentColor.copy(alpha = 0.12f)),
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Metadata
-        Column(modifier = Modifier.padding(horizontal = 2.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                if (shelf.isPrivate) {
-                    Icon(
-                        imageVector = Icons.Default.Lock,
-                        contentDescription = "Private shelf",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(14.dp),
+        Column(
+            modifier = Modifier.fillMaxSize().padding(18.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.LibraryBooks,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(26.dp),
+            )
+            Column {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    if (shelf.isPrivate) {
+                        Icon(
+                            imageVector = Icons.Default.Lock,
+                            contentDescription = "Private shelf",
+                            tint = contentColor.copy(alpha = 0.8f),
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                    Text(
+                        text = shelf.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = contentColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
                 Text(
-                    text = shelf.name,
-                    style =
-                        MaterialTheme.typography.titleSmall.copy(
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = (-0.2).sp,
-                        ),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                    text = "${shelf.bookCount} ${if (shelf.bookCount == 1) "book" else "books"}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor.copy(alpha = 0.8f),
                 )
             }
-
-            Text(
-                text = "${shelf.bookCount} ${if (shelf.bookCount == 1) "book" else "books"}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
-}
-
-/**
- * 2x2 grid of book covers for a shelf card.
- *
- * Shows up to 4 book covers in a grid layout. Empty slots are filled
- * with a colored placeholder. If no covers at all, shows a bookshelf icon.
- */
-@Composable
-private fun ShelfCoverGrid(
-    coverPaths: List<String>,
-    color: Color,
-    modifier: Modifier = Modifier,
-) {
-    val shape = MaterialTheme.shapes.medium
-
-    if (coverPaths.isEmpty()) {
-        // Empty state — bookshelf icon
-        Box(
-            modifier =
-                modifier
-                    .shadow(elevation = 4.dp, shape = shape)
-                    .clip(shape)
-                    .background(color.copy(alpha = 0.15f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Default.AutoStories,
-                contentDescription = null,
-                tint = color.copy(alpha = 0.6f),
-                modifier = Modifier.size(48.dp),
-            )
-        }
-    } else {
-        // 2x2 cover grid
-        Box(
-            modifier =
-                modifier
-                    .shadow(elevation = 4.dp, shape = shape)
-                    .clip(shape),
-        ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                    modifier = Modifier.weight(1f),
-                ) {
-                    CoverCell(
-                        path = coverPaths.getOrNull(0),
-                        color = color,
-                        contentDescription = stringResource(Res.string.home_cover_1),
-                        modifier = Modifier.weight(1f).fillMaxSize(),
-                    )
-                    CoverCell(
-                        path = coverPaths.getOrNull(1),
-                        color = color,
-                        contentDescription = stringResource(Res.string.home_cover_2),
-                        modifier = Modifier.weight(1f).fillMaxSize(),
-                    )
-                }
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                    modifier = Modifier.weight(1f),
-                ) {
-                    CoverCell(
-                        path = coverPaths.getOrNull(2),
-                        color = color,
-                        contentDescription = stringResource(Res.string.home_cover_3),
-                        modifier = Modifier.weight(1f).fillMaxSize(),
-                    )
-                    CoverCell(
-                        path = coverPaths.getOrNull(3),
-                        color = color,
-                        contentDescription = stringResource(Res.string.home_cover_4),
-                        modifier = Modifier.weight(1f).fillMaxSize(),
-                    )
-                }
-            }
-        }
-    }
-}
-
-/**
- * A single cell in the cover grid — either a book cover image or a colored placeholder.
- */
-@Composable
-private fun CoverCell(
-    path: String?,
-    color: Color,
-    contentDescription: String,
-    modifier: Modifier = Modifier,
-) {
-    if (path != null) {
-        ListenUpAsyncImage(
-            path = path,
-            contentDescription = contentDescription,
-            modifier = modifier,
-            contentScale = ContentScale.Crop,
-        )
-    } else {
-        Box(
-            modifier =
-                modifier
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.MenuBook,
-                contentDescription = null,
-                tint = color.copy(alpha = 0.3f),
-                modifier = Modifier.size(20.dp),
-            )
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/StreakIndicator.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/StreakIndicator.kt
@@ -1,25 +1,26 @@
 package com.calypsan.listenup.client.features.home.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.LocalFireDepartment
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import org.jetbrains.compose.resources.stringResource
-import listenup.composeapp.generated.resources.Res
-import listenup.composeapp.generated.resources.home_best_longeststreak
+import com.calypsan.listenup.client.design.components.contributorAvatarShape
 
 /**
- * Streak indicator showing current and optionally longest streak.
- *
- * Displays a fire emoji followed by the current streak count.
- * If the longest streak is greater than current, shows it in parentheses.
+ * Streak indicator \u2014 a scallop badge with a flame, the current streak, and the longest as a subtitle.
  *
  * @param currentStreak Current listening streak in days
  * @param longestStreak Longest ever streak in days
@@ -31,40 +32,46 @@ fun StreakIndicator(
     longestStreak: Int,
     modifier: Modifier = Modifier,
 ) {
+    val title =
+        when {
+            currentStreak == 0 && longestStreak > 0 -> "Best: $longestStreak-day streak"
+            currentStreak == 1 -> "1-day streak"
+            else -> "$currentStreak-day streak"
+        }
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        // Fire emoji
-        Text(
-            text = "\uD83D\uDD25",
-            fontSize = 20.sp,
-        )
-
-        Spacer(Modifier.width(8.dp))
-
-        // Current streak text
-        val streakText =
-            when {
-                currentStreak == 0 && longestStreak > 0 -> "Best: $longestStreak day streak"
-                currentStreak == 1 -> "1 day streak"
-                else -> "$currentStreak day streak"
-            }
-        Text(
-            text = streakText,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-
-        // Show longest streak if greater than current and current > 0
-        if (longestStreak > currentStreak && currentStreak > 0) {
-            Spacer(Modifier.width(4.dp))
-            Text(
-                text = stringResource(Res.string.home_best_longeststreak, longestStreak),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+        Box(
+            modifier =
+                Modifier
+                    .size(48.dp)
+                    .clip(contributorAvatarShape())
+                    .background(MaterialTheme.colorScheme.tertiaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.LocalFireDepartment,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.size(26.dp),
             )
+        }
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (longestStreak > 0 && currentStreak > 0) {
+                Text(
+                    text = "Best: $longestStreak days",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/BookCard.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/BookCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -312,7 +313,7 @@ private fun BookCardCover(
     borderColor: Color = Color.Transparent,
     modifier: Modifier = Modifier,
 ) {
-    val shape = MaterialTheme.shapes.medium
+    val shape = RoundedCornerShape(20.dp)
 
     // Outer Box allows avatar to overflow the clipped cover area
     Box(modifier = modifier) {


### PR DESCRIPTION
## What

Restyles the Home screen to the M3 Expressive design (`variantHome.jsx`), matching HomeDesktop/HomeMobile. No VM/data changes — all sections, data, and the adaptive split already existed; this is visual work on the components.

### Changes
- **Shared `SectionTitle`** (`design/components/`) — bold title + optional coral "See all". Used by Continue Listening, My Shelves (and available to consolidate the ~4 feature-local `SectionHeader`s onto later).
- **Greeting** — emphasized, adaptive size (display on wide, headline on compact).
- **Shared `BookCard` + `ProgressOverlay`** (used by Continue Listening *and* 9 other screens) — more rounded cover + a floating dark progress pill with a coral percentage chip. *(This upgrades library/discover/profile/etc. card visuals too — done here so the Library PR won't need to.)*
- **"This week" stats card** — `surfaceContainerLow` extra-large card with a "Xh Ym listened" total; adaptive two-column (chart | streak+genres, vertical divider) on wide, stacked on compact. Chart bars: today coral, others primaryContainer, empty-day stub. Genre bars show share-of-total %. Streak uses the scallop badge (reusing `contributorAvatarShape()`) + a flame.
- **My Shelves** — color-blocked cards cycling primary/tertiary/secondary container roles, with a soft blob; adaptive full-width vertical stack (wide) vs horizontal carousel (compact).

### Notable tradeoff
The shelf cards move from a **2×2 book-cover grid to the design's color-block** (icon + name + count). Closer to the design as requested, but it drops the per-shelf cover previews. Easy to revisit if you'd rather keep covers.

## Verification
- Local gates green: `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug`.
- On-device (live, signed in, wide): greeting + SectionTitles + "This week" card render correctly; empty states verified. Populated visuals (chart/shelves/progress cards) match the design; best eyeballed on an account with listening history.

iOS lanes on CI. Independent of #385/#387 (reuses theme roles; renders with the current fallback palette until #385 merges; Material You wins on Android).
