### PR TITLE
🐛 fix(sharedUI): adaptive Home/shell at tablet & foldable widths

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SectionTitle.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SectionTitle.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 
 /**
  * Canonical section header: a bold title with an optional coral "See all" action on the trailing
@@ -31,7 +33,7 @@ fun SectionTitle(
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.Bottom,
     ) {
         Text(
@@ -39,13 +41,19 @@ fun SectionTitle(
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.ExtraBold,
             color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
         )
         if (onSeeAll != null) {
             Text(
+                // Never wrap — the title yields space (above) so "See all" stays a single line.
                 text = "See all",
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                softWrap = false,
                 modifier = Modifier.clickable(onClick = onSeeAll),
             )
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomePreviews.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomePreviews.kt
@@ -138,7 +138,7 @@ private fun StatsCardPreview(
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
     ) {
-        Box(Modifier.padding(if (isWide) 28.dp else 22.dp)) { HomeStatsContent(state, isWide) }
+        Box(Modifier.padding(if (isWide) 28.dp else 22.dp)) { HomeStatsContent(state) }
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeStatsSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/HomeStatsSection.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.features.home.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -68,11 +69,11 @@ fun HomeStatsSection(
                     HomeStatsUiState.Empty -> {
                         // Render the card at zero (chart + "0m") rather than a placeholder; streak and
                         // genres collapse until there's data.
-                        HomeStatsContent(state = EmptyWeekStats, isWide = isWide)
+                        HomeStatsContent(state = EmptyWeekStats)
                     }
 
                     is HomeStatsUiState.Data -> {
-                        HomeStatsContent(state = s, isWide = isWide)
+                        HomeStatsContent(state = s)
                     }
 
                     is HomeStatsUiState.Error -> {
@@ -93,80 +94,82 @@ private fun StatsPlaceholder(
 }
 
 @Composable
-internal fun HomeStatsContent(
-    state: HomeStatsUiState.Data,
-    isWide: Boolean,
-) {
-    val totalSeconds = state.dailyBuckets.sumOf { it.totalSeconds }
-    val hours = totalSeconds / 3600
-    val minutes = totalSeconds % 3600 / 60
+internal fun HomeStatsContent(state: HomeStatsUiState.Data) {
+    // Two columns only when the card is actually wide enough; a narrow card (phone landscape,
+    // portrait tablet) stacks. Actual width beats the window size class here.
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val twoColumn = maxWidth >= 520.dp
+        val totalSeconds = state.dailyBuckets.sumOf { it.totalSeconds }
+        val hours = totalSeconds / 3600
+        val minutes = totalSeconds % 3600 / 60
 
-    val chartColumn: @Composable () -> Unit = {
-        Column {
-            Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(
-                    text = "${hours}h ${minutes}m",
-                    style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.ExtraBold,
-                    letterSpacing = (-1.5).sp,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                )
-                Text(
-                    text = "listened",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    modifier = Modifier.padding(bottom = 6.dp),
-                )
-            }
-            Spacer(Modifier.height(18.dp))
-            if (state.dailyBuckets.isNotEmpty()) {
-                DailyListeningChart(
-                    dailyBuckets = state.dailyBuckets,
-                    modifier = Modifier.fillMaxWidth(),
-                    chartHeight = if (isWide) 150.dp else 124.dp,
-                )
-            }
-        }
-    }
-
-    val detailColumn: @Composable () -> Unit = {
-        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-            if (state.hasStreak) {
-                StreakIndicator(currentStreak = state.currentStreakDays, longestStreak = state.longestStreakDays)
-            }
-            if (state.hasGenreData) {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Overline("Top genres")
-                    GenreBreakdownBars(genres = state.topGenres)
+        val chartColumn: @Composable () -> Unit = {
+            Column {
+                Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "${hours}h ${minutes}m",
+                        style = MaterialTheme.typography.displaySmall,
+                        fontWeight = FontWeight.ExtraBold,
+                        letterSpacing = (-1.5).sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                    )
+                    Text(
+                        text = "listened",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        modifier = Modifier.padding(bottom = 6.dp),
+                    )
+                }
+                Spacer(Modifier.height(18.dp))
+                if (state.dailyBuckets.isNotEmpty()) {
+                    DailyListeningChart(
+                        dailyBuckets = state.dailyBuckets,
+                        modifier = Modifier.fillMaxWidth(),
+                        chartHeight = if (twoColumn) 150.dp else 124.dp,
+                    )
                 }
             }
         }
-    }
 
-    val hasDetail = state.hasStreak || state.hasGenreData
-    when {
-        // No streak/genres yet — show only the chart column (collapse the detail side).
-        !hasDetail -> {
-            chartColumn()
-        }
-
-        isWide -> {
-            // height(IntrinsicSize.Min) gives the VerticalDivider the tallest column's height;
-            // without it the divider collapses to nothing (it has no intrinsic height of its own).
-            Row(modifier = Modifier.height(IntrinsicSize.Min)) {
-                Box(Modifier.weight(1.3f)) { chartColumn() }
-                VerticalDivider(modifier = Modifier.padding(horizontal = 24.dp))
-                Box(Modifier.weight(1f)) { detailColumn() }
+        val detailColumn: @Composable () -> Unit = {
+            Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+                if (state.hasStreak) {
+                    StreakIndicator(currentStreak = state.currentStreakDays, longestStreak = state.longestStreakDays)
+                }
+                if (state.hasGenreData) {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Overline("Top genres")
+                        GenreBreakdownBars(genres = state.topGenres)
+                    }
+                }
             }
         }
 
-        else -> {
-            Column {
+        val hasDetail = state.hasStreak || state.hasGenreData
+        when {
+            // No streak/genres yet — show only the chart column (collapse the detail side).
+            !hasDetail -> {
                 chartColumn()
-                HorizontalDivider(modifier = Modifier.padding(vertical = 20.dp))
-                detailColumn()
+            }
+
+            twoColumn -> {
+                // height(IntrinsicSize.Min) gives the VerticalDivider the tallest column's height;
+                // without it the divider collapses to nothing (it has no intrinsic height of its own).
+                Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+                    Box(Modifier.weight(1.3f)) { chartColumn() }
+                    VerticalDivider(modifier = Modifier.padding(horizontal = 24.dp))
+                    Box(Modifier.weight(1f)) { detailColumn() }
+                }
+            }
+
+            else -> {
+                Column {
+                    chartColumn()
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 20.dp))
+                    detailColumn()
+                }
             }
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/components/AppHeader.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/components/AppHeader.kt
@@ -122,9 +122,11 @@ fun AppHeader(
     showAvatarLabel: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
+    // The persistent inline search box needs real room beside the hero + avatar — only show it on
+    // genuinely wide (expanded) chrome. Medium widths (e.g. tablet portrait) keep the compact icon.
     val isWide =
         currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND,
+            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND,
         )
     AnimatedContent(
         // On wide windows search is a persistent inline field (below); never run the compact


### PR DESCRIPTION
Follow-up to #391. Fixes responsive issues surfaced on tablet-portrait and foldable widths:

- **Stats card stacks by *actual* width** — `HomeStatsContent` now uses `BoxWithConstraints` (stacks the chart/streak columns below ~520dp) instead of the window size class, so a narrow stats card (phone-landscape, portrait tablet, or when sharing width with My Shelves) no longer compresses.
- **Search bar collapses below expanded** — the persistent inline search box only shows at expanded width; medium widths (tablet portrait) keep the compact search icon, so the top bar no longer overflows.
- **`SectionTitle` "See all" never wraps** — the title yields space + ellipsizes; the trailing link stays a single line.

Verified on emulator at tablet-portrait and foldable-unfolded widths.