### PR TITLE
🚨 chore(quality): opt-in ExperimentalCoroutinesApi on coroutine-test specs

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthRepositoryImplTest.kt
@@ -19,6 +19,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -29,6 +30,7 @@ import kotlinx.coroutines.test.runTest
  * [AuthServiceAuthed] — no network. Pins the thin delegation: each repo method
  * forwards to its authed-proxy counterpart and returns its result verbatim.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AuthRepositoryImplTest :
     FunSpec({
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.model.ScanProgressState
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -21,6 +22,7 @@ import kotlinx.coroutines.test.runTest
  * books the lossy live tail dropped during the scan burst) — without it, a just-scanned library
  * shows no books until the app is relaunched.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class SyncRepositoryScanProgressTest :
     FunSpec({
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelTest.kt
@@ -29,6 +29,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -44,6 +45,7 @@ import kotlinx.coroutines.test.setMain
  * [CollectionRepository]; rename / remove-book / share / revoke-share dispatch to the
  * repository, with failures surfacing on [ErrorBus] plus a transient `error`.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AdminCollectionDetailViewModelTest :
     FunSpec({
         val dispatcher = StandardTestDispatcher()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionsViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionsViewModelTest.kt
@@ -18,6 +18,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -32,6 +33,7 @@ import kotlinx.coroutines.test.setMain
  * dispatch to the repository, and failures surface on [ErrorBus] plus a transient
  * `error` on [AdminCollectionsUiState.Ready].
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AdminCollectionsViewModelTest :
     FunSpec({
         val dispatcher = StandardTestDispatcher()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminInboxViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminInboxViewModelTest.kt
@@ -30,6 +30,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -47,6 +48,7 @@ import kotlinx.coroutines.test.setMain
  * Release maps every selected id to an empty target-collection list (all inbox releases are
  * public/uncollected) and dispatches a single [InboxRepository.releaseBooks].
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AdminInboxViewModelTest :
     FunSpec({
         val dispatcher = StandardTestDispatcher()


### PR DESCRIPTION
Silences the `This declaration needs opt-in` (`ExperimentalCoroutinesApi`) compiler warnings emitted by five `:sharedLogic` coroutine-test specs that use `StandardTestDispatcher` / `advanceUntilIdle` / `runCurrent` / `setMain`.

Adds `@OptIn(ExperimentalCoroutinesApi::class)` (matching the convention already used by e.g. `SeriesDetailViewModelTest`) to:
- AdminInboxViewModelTest
- AdminCollectionDetailViewModelTest
- AdminCollectionsViewModelTest
- AuthRepositoryImplTest
- SyncRepositoryScanProgressTest

Test-only; no behaviour change. `compileTestKotlinJvm` now emits zero opt-in warnings; `spotlessCheck` + `detekt` green.