### PR TITLE
✨ feat: automatic server reconnection (re-resolve + identity-verified re-auth)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/ServerInfo.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/ServerInfo.kt
@@ -33,4 +33,11 @@ data class ServerInfo(
     /** Operator-set remote (WAN) URL for off-LAN access; null when unset. Clients persist it as the reconnect fallback. */
     @SerialName("remoteUrl")
     val remoteUrl: String? = null,
+    /**
+     * Stable server-instance id (the mDNS TXT `id`), persisted server-side so it survives restarts.
+     * Clients compare it on reconnect to tell a restart of the *same* server (stay signed in) from a
+     * *different* server (clean re-auth).
+     */
+    @SerialName("instanceId")
+    val instanceId: String,
 )

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/AuthError.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/AuthError.kt
@@ -107,6 +107,22 @@ sealed interface AuthError : AppError {
         override val isRetryable: Boolean = false
     }
 
+    /**
+     * The server we reconnected to is a *different* instance than the one this
+     * session was issued for (its persisted `instanceId` changed — DB recreated,
+     * or a different server at the same URL). The session cannot be reused.
+     */
+    @Serializable
+    @SerialName("AuthError.ServerInstanceChanged")
+    data class ServerInstanceChanged(
+        override val correlationId: String? = null,
+        override val debugInfo: String? = null,
+    ) : AuthError {
+        override val message: String = "This server was reset or replaced. Please sign in again."
+        override val code: String = "AUTH_SERVER_INSTANCE_CHANGED"
+        override val isRetryable: Boolean = false
+    }
+
     /** JWT decoded fine but no matching session row exists. */
     @Serializable
     @SerialName("AuthError.SessionNotFound")

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/AuthErrorServerInstanceChangedTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/AuthErrorServerInstanceChangedTest.kt
@@ -1,0 +1,20 @@
+package com.calypsan.listenup.api
+
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.AuthError
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.encodeToString
+
+class AuthErrorServerInstanceChangedTest :
+    FunSpec({
+        test("ServerInstanceChanged round-trips as AppError and is non-retryable") {
+            val original: AppError = AuthError.ServerInstanceChanged()
+            val json = contractJson.encodeToString(original)
+            val decoded = contractJson.decodeFromString<AppError>(json)
+            decoded.shouldBeInstanceOf<AuthError.ServerInstanceChanged>()
+            decoded.isRetryable shouldBe false
+            decoded.code shouldBe "AUTH_SERVER_INSTANCE_CHANGED"
+        }
+    })

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/ServerInfoContractTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/ServerInfoContractTest.kt
@@ -17,6 +17,7 @@ class ServerInfoContractTest :
                     setupRequired = false,
                     registrationPolicy = RegistrationPolicy.OPEN,
                     remoteUrl = "https://library.example.com",
+                    instanceId = "test-instance",
                 )
             contractJson.decodeFromString<ServerInfo>(contractJson.encodeToString(info)) shouldBe info
         }
@@ -30,7 +31,24 @@ class ServerInfoContractTest :
                     setupRequired = true,
                     registrationPolicy = RegistrationPolicy.CLOSED,
                     remoteUrl = null,
+                    instanceId = "test-instance",
                 )
             contractJson.decodeFromString<ServerInfo>(contractJson.encodeToString(info)) shouldBe info
+        }
+
+        test("ServerInfo round-trips instanceId") {
+            val original =
+                ServerInfo(
+                    name = "ListenUp",
+                    version = "0.0.1",
+                    apiVersion = "v1",
+                    setupRequired = false,
+                    registrationPolicy = RegistrationPolicy.CLOSED,
+                    remoteUrl = null,
+                    instanceId = "inst-123",
+                )
+            val decoded = contractJson.decodeFromString<ServerInfo>(contractJson.encodeToString(original))
+            decoded.instanceId shouldBe "inst-123"
+            decoded shouldBe original
         }
     })

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/InstanceServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/InstanceServiceImpl.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.InstanceService
 import com.calypsan.listenup.api.dto.ServerInfo
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.db.UserEntity
+import com.calypsan.listenup.server.mdns.InstanceIdentity
 import com.calypsan.listenup.server.settings.ServerSettingsRepository
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
@@ -20,6 +21,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 class InstanceServiceImpl(
     private val db: Database,
     private val settings: ServerSettingsRepository,
+    private val instanceIdentity: InstanceIdentity,
 ) : InstanceService {
     override suspend fun getServerInfo(): AppResult<ServerInfo> {
         val setupRequired = suspendTransaction(db) { UserEntity.all().limit(1).empty() }
@@ -31,6 +33,7 @@ class InstanceServiceImpl(
                 setupRequired = setupRequired,
                 registrationPolicy = settings.registrationPolicy(),
                 remoteUrl = settings.remoteUrl(),
+                instanceId = instanceIdentity.instanceId(),
             ),
         )
     }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/InstanceServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/InstanceServiceImpl.kt
@@ -15,8 +15,9 @@ import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
  * [ServerInfo.setupRequired] is derived, not stored: a fresh instance with no
  * users needs root setup. [ServerInfo.registrationPolicy] is read live from
  * [ServerSettingsRepository] so an admin's `setRegistrationPolicy` is reflected
- * on the next verification without a restart. The remaining fields are static
- * server identity.
+ * on the next verification without a restart. [ServerInfo.instanceId] is the
+ * stable, DB-persisted instance id (read-or-created via [InstanceIdentity], the
+ * same id advertised over mDNS). The remaining fields are static server identity.
  */
 class InstanceServiceImpl(
     private val db: Database,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -135,6 +135,7 @@ fun authModule(config: ApplicationConfig): Module =
             InstanceServiceImpl(
                 db = get(),
                 settings = get(),
+                instanceIdentity = get(),
             )
         }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -260,6 +260,7 @@ private fun AuthError.toHttpStatus(): HttpStatusCode =
         is AuthError.PendingApproval -> HttpStatusCode.Forbidden
         is AuthError.AccountDenied -> HttpStatusCode.Forbidden
         is AuthError.SessionExpired -> HttpStatusCode.Unauthorized
+        is AuthError.ServerInstanceChanged -> HttpStatusCode.Unauthorized
         is AuthError.SessionNotFound -> HttpStatusCode.Unauthorized
         is AuthError.InvalidRefreshToken -> HttpStatusCode.Unauthorized
         is AuthError.RateLimited -> HttpStatusCode.TooManyRequests
@@ -287,6 +288,7 @@ private fun AuthError.withCorrelationId(id: String?): AuthError =
         is AuthError.PendingApproval -> copy(correlationId = id)
         is AuthError.AccountDenied -> copy(correlationId = id)
         is AuthError.SessionExpired -> copy(correlationId = id)
+        is AuthError.ServerInstanceChanged -> copy(correlationId = id)
         is AuthError.SessionNotFound -> copy(correlationId = id)
         is AuthError.InvalidRefreshToken -> copy(correlationId = id)
         is AuthError.RateLimited -> copy(correlationId = id)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/InstanceServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/InstanceServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.server.api
 
 import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.mdns.InstanceIdentity
 import com.calypsan.listenup.server.settings.ServerSettingsRepository
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
@@ -15,7 +16,7 @@ class InstanceServiceImplTest :
                 val db = this
                 runTest {
                     val settings = ServerSettingsRepository(db, default = RegistrationPolicy.OPEN)
-                    val svc = InstanceServiceImpl(db, settings)
+                    val svc = InstanceServiceImpl(db, settings, InstanceIdentity(settings))
                     (svc.getServerInfo() as AppResult.Success).data.name shouldBe ServerIdentity.NAME
                     settings.setServerName("Renamed")
                     (svc.getServerInfo() as AppResult.Success).data.name shouldBe "Renamed"
@@ -28,7 +29,7 @@ class InstanceServiceImplTest :
                 val db = this
                 runTest {
                     val settings = ServerSettingsRepository(db, default = RegistrationPolicy.OPEN)
-                    val svc = InstanceServiceImpl(db, settings)
+                    val svc = InstanceServiceImpl(db, settings, InstanceIdentity(settings))
                     settings.setValue("remote_url", "https://library.example.com")
                     (svc.getServerInfo() as AppResult.Success).data.remoteUrl shouldBe "https://library.example.com"
                 }
@@ -40,8 +41,27 @@ class InstanceServiceImplTest :
                 val db = this
                 runTest {
                     val settings = ServerSettingsRepository(db, default = RegistrationPolicy.OPEN)
-                    val svc = InstanceServiceImpl(db, settings)
+                    val svc = InstanceServiceImpl(db, settings, InstanceIdentity(settings))
                     (svc.getServerInfo() as AppResult.Success).data.remoteUrl shouldBe null
+                }
+            }
+        }
+
+        test("getServerInfo returns the persisted instanceId, stable across instances") {
+            withInMemoryDatabase {
+                val db = this
+                runTest {
+                    val settings = ServerSettingsRepository(db, default = RegistrationPolicy.OPEN)
+                    val identity = InstanceIdentity(settings)
+                    val expectedId = identity.instanceId()
+
+                    val service = InstanceServiceImpl(db, settings, InstanceIdentity(settings))
+                    val info = (service.getServerInfo() as AppResult.Success).data
+                    info.instanceId shouldBe expectedId
+
+                    val service2 = InstanceServiceImpl(db, settings, InstanceIdentity(settings))
+                    val info2 = (service2.getServerInfo() as AppResult.Success).data
+                    info2.instanceId shouldBe expectedId
                 }
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
@@ -1,0 +1,101 @@
+package com.calypsan.listenup.client.data.connection
+
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.SseClient
+import com.calypsan.listenup.client.data.sync.SyncEngineState
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.error.ErrorBus
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Drives automatic reconnection while the SSE firehose is down.
+ *
+ * Reachability is derived purely from the SSE connection, and the SSE loop only ever retries the
+ * *stored* URL — so a server that returns at a new IP/port (or after a restart) can leave the client
+ * stuck offline. This supervisor closes that gap: whenever the firehose is not connected, it
+ * periodically (1) re-resolves the live server URL ([reevaluate] → mDNS relocation + remote fallback),
+ * (2) probes it with the unauthenticated [InstanceRepository.getServerInfo], and (3) either kicks an
+ * immediate reconnect ([SseClient.reconnectNow]) when it's the same instance, or triggers a clean
+ * re-auth when the server's instanceId changed.
+ *
+ * Offline-first / never-stranded: never blocks, never clears the configured URL; the manual
+ * "Change Server" path remains the explicit fallback.
+ *
+ * @param reevaluate re-points the active URL at a reachable address (wired to
+ *   `ConnectionCoordinator.reevaluate`); a lambda so this stays unit-testable.
+ */
+class ReconnectionSupervisor(
+    private val engineState: SyncEngineState,
+    private val instanceRepository: InstanceRepository,
+    private val serverConfig: ServerConfig,
+    private val sseClient: SseClient,
+    private val authSession: AuthSession,
+    private val errorBus: ErrorBus,
+    private val reevaluate: suspend () -> Unit,
+    private val scope: CoroutineScope,
+    private val probeIntervalMillis: Long = DEFAULT_PROBE_INTERVAL_MS,
+) {
+    /** Start observing connection state. Call once at app start. */
+    fun start() {
+        scope.launch {
+            engineState
+                .observe()
+                .map { it.connection }
+                .distinctUntilChanged()
+                .collectLatest { connection ->
+                    // collectLatest cancels the running recovery loop the moment the connection
+                    // state changes (e.g. back to Connected) — clean stop.
+                    if (connection !is ConnectionState.Connected) {
+                        recoveryLoop()
+                    }
+                }
+        }
+    }
+
+    private suspend fun recoveryLoop() {
+        while (currentCoroutineContext().isActive) {
+            serverConfig.getActiveUrl() ?: return // no server configured — nothing to recover
+
+            reevaluate()
+
+            when (val probe = instanceRepository.getServerInfo(forceRefresh = true)) {
+                is AppResult.Success -> {
+                    val connectedId = serverConfig.getConnectedServerId()
+                    if (connectedId != null && probe.data.instanceId != connectedId) {
+                        logger.info {
+                            "Server instance changed ($connectedId -> ${probe.data.instanceId}); re-auth required"
+                        }
+                        authSession.clearAuthTokens()
+                        errorBus.emit(AuthError.ServerInstanceChanged())
+                        return // stop hammering a server we can't use this session against
+                    }
+                    sseClient.reconnectNow()
+                }
+
+                is AppResult.Failure -> {
+                    logger.debug { "Reconnect probe failed: ${probe.error.code}" }
+                }
+            }
+
+            delay(probeIntervalMillis)
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_PROBE_INTERVAL_MS = 5_000L
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
@@ -28,12 +28,16 @@ private val logger = KotlinLogging.logger {}
  * *stored* URL — so a server that returns at a new IP/port (or after a restart) can leave the client
  * stuck offline. This supervisor closes that gap: whenever the firehose is not connected, it
  * periodically (1) re-resolves the live server URL ([reevaluate] → mDNS relocation + remote fallback),
- * (2) probes it with the unauthenticated [InstanceRepository.getServerInfo], and (3) either kicks an
- * immediate reconnect ([SseClient.reconnectNow]) when it's the same instance, or triggers a clean
- * re-auth when the server's instanceId changed.
+ * (2) probes the resolved active URL with the unauthenticated [InstanceRepository.verifyServer], and
+ * (3) either kicks an immediate reconnect ([SseClient.reconnectNow]) when it's the same instance, or
+ * triggers a clean re-auth when the server's instanceId changed.
  *
  * Offline-first / never-stranded: never blocks, never clears the configured URL; the manual
  * "Change Server" path remains the explicit fallback.
+ *
+ * The loop is gated on a boolean "is connected" (not the raw [ConnectionState]) so the SSE client's
+ * Connecting↔Disconnected backoff oscillation doesn't restart it; the probe interval escalates on
+ * sustained failure so a long outage doesn't sweep mDNS every few seconds.
  *
  * @param reevaluate re-points the active URL at a reachable address (wired to
  *   `ConnectionCoordinator.reevaluate`); a lambda so this stays unit-testable.
@@ -54,48 +58,54 @@ class ReconnectionSupervisor(
         scope.launch {
             engineState
                 .observe()
-                .map { it.connection }
+                .map { it.connection is ConnectionState.Connected }
                 .distinctUntilChanged()
-                .collectLatest { connection ->
-                    // collectLatest cancels the running recovery loop the moment the connection
-                    // state changes (e.g. back to Connected) — clean stop.
-                    if (connection !is ConnectionState.Connected) {
-                        recoveryLoop()
-                    }
+                .collectLatest { connected ->
+                    // collectLatest cancels the running recovery loop the moment we become Connected.
+                    // Gating on the Boolean (not the raw ConnectionState) means the SSE client's
+                    // Connecting<->Disconnected backoff flapping does NOT keep restarting the loop.
+                    if (!connected) recoveryLoop()
                 }
         }
     }
 
     private suspend fun recoveryLoop() {
+        var interval = probeIntervalMillis
         while (currentCoroutineContext().isActive) {
-            serverConfig.getActiveUrl() ?: return // no server configured — nothing to recover
+            val active =
+                run {
+                    reevaluate() // re-point the active URL at a reachable address first
+                    serverConfig.getActiveUrl()
+                } ?: return // no server configured — nothing to recover
 
-            reevaluate()
-
-            when (val probe = instanceRepository.getServerInfo(forceRefresh = true)) {
+            when (val probe = instanceRepository.verifyServer(active.value)) {
                 is AppResult.Success -> {
                     val connectedId = serverConfig.getConnectedServerId()
-                    if (connectedId != null && probe.data.instanceId != connectedId) {
-                        logger.info {
-                            "Server instance changed ($connectedId -> ${probe.data.instanceId}); re-auth required"
-                        }
+                    val serverId = probe.data.serverInfo.instanceId
+                    if (connectedId != null && serverId != connectedId) {
+                        logger.info { "Server instance changed ($connectedId -> $serverId); re-auth required" }
                         authSession.clearAuthTokens()
                         errorBus.emit(AuthError.ServerInstanceChanged())
                         return // stop hammering a server we can't use this session against
                     }
+                    // Same instance (or no stored id to compare): server is live — kick the SSE loop
+                    // now. On success the connection flips to Connected and collectLatest cancels us.
                     sseClient.reconnectNow()
+                    interval = probeIntervalMillis // reachable again → probe promptly until Connected
                 }
 
                 is AppResult.Failure -> {
                     logger.debug { "Reconnect probe failed: ${probe.error.code}" }
+                    interval = (interval * 2).coerceAtMost(MAX_PROBE_INTERVAL_MS) // back off while down
                 }
             }
 
-            delay(probeIntervalMillis)
+            delay(interval)
         }
     }
 
     private companion object {
         const val DEFAULT_PROBE_INTERVAL_MS = 5_000L
+        const val MAX_PROBE_INTERVAL_MS = 60_000L
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SseClient.kt
@@ -29,4 +29,12 @@ interface SseClient {
      * rather than looping forever with the pre-stale value.
      */
     suspend fun reseed(newLastEventId: Long?)
+
+    /**
+     * Reset the reconnect backoff to zero and wake the retry loop so the next
+     * connect attempt fires immediately. Called by the reconnection supervisor
+     * once it has confirmed the server is live again (possibly at a new URL),
+     * turning "recover within up to 60s" into "recover within seconds".
+     */
+    fun reconnectNow()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
@@ -18,12 +18,13 @@ import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val logger = KotlinLogging.logger {}
 
@@ -122,6 +123,12 @@ class SyncSseClient(
     /** Highest `id:` seen this session; sent as `Last-Event-Id` on reconnect. */
     private var lastEventId: Long? = null
 
+    /** Reconnect-backoff attempt counter; reset to 0 by [reconnectNow]. */
+    private var reconnectAttempt = 0
+
+    /** Conflated wake signal: [reconnectNow] sends; the backoff wait races it against the delay. */
+    private val wakeSignal = Channel<Unit>(Channel.CONFLATED)
+
     /** Seed [lastEventId] from the persisted highest cursor before the first connect. */
     override fun seedLastEventId(initial: Long?) {
         if (initial != null) lastEventId = initial
@@ -144,9 +151,9 @@ class SyncSseClient(
     /** Open an SSE connection (or no-op if one is already active). */
     override fun connect() {
         if (connectionJob?.isActive == true) return
+        reconnectAttempt = 0
         connectionJob =
             scope.launch {
-                var attempt = 0
                 while (isActive) {
                     state.setConnection(ConnectionState.Connecting)
                     when (runOnce()) {
@@ -164,23 +171,17 @@ class SyncSseClient(
                             // through to the same backoff+retry as Reconnect.
                             state.setConnection(ConnectionState.Disconnected("auth-transient"))
                             state.recordError(SyncError.RealtimeDisconnected())
-                            val delayMs = reconnectDelayMillis(attempt)
-                            logger.debug { "SSE reconnect after auth-transient in ${delayMs}ms (attempt $attempt)" }
-                            attempt++
-                            delay(delayMs)
+                            backoffWait()
                         }
 
                         ConnectAttempt.Reconnect -> {
                             state.setConnection(ConnectionState.Disconnected("reconnecting"))
                             state.recordError(SyncError.RealtimeDisconnected())
-                            val delayMs = reconnectDelayMillis(attempt)
-                            logger.debug { "SSE reconnect in ${delayMs}ms (attempt $attempt)" }
-                            attempt++
-                            delay(delayMs)
+                            backoffWait()
                         }
 
                         ConnectAttempt.Connected -> {
-                            attempt = 0
+                            reconnectAttempt = 0
                             state.recordSuccess(nowMillis())
                         }
                     }
@@ -188,11 +189,28 @@ class SyncSseClient(
             }
     }
 
+    /**
+     * Wait out the current backoff, returning early if [reconnectNow] signals.
+     * Computes the delay from the current attempt, increments, then waits — so a
+     * [reconnectNow] (which resets [reconnectAttempt] to 0) shortens this wait and the next.
+     */
+    private suspend fun backoffWait() {
+        val delayMs = reconnectDelayMillis(reconnectAttempt)
+        logger.debug { "SSE reconnect in ${delayMs}ms (attempt $reconnectAttempt)" }
+        reconnectAttempt++
+        withTimeoutOrNull(delayMs) { wakeSignal.receive() }
+    }
+
     /** Close the SSE connection and stop the reconnect loop. */
     override fun disconnect() {
         connectionJob?.cancel()
         connectionJob = null
         state.setConnection(ConnectionState.Disconnected("closed"))
+    }
+
+    override fun reconnectNow() {
+        reconnectAttempt = 0
+        wakeSignal.trySend(Unit)
     }
 
     @Suppress("ReturnCount", "TooGenericExceptionCaught")

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
@@ -123,7 +123,12 @@ class SyncSseClient(
     /** Highest `id:` seen this session; sent as `Last-Event-Id` on reconnect. */
     private var lastEventId: Long? = null
 
-    /** Reconnect-backoff attempt counter; reset to 0 by [reconnectNow]. */
+    /**
+     * Reconnect-backoff attempt counter; reset to 0 by [reconnectNow]. Deliberately unsynchronized:
+     * it is best-effort backoff state, and the only cross-coroutine race (a reset briefly unobserved
+     * by the loop) merely lengthens one backoff. The real wake hand-off is [wakeSignal], which is
+     * thread-safe — don't add a lock here.
+     */
     private var reconnectAttempt = 0
 
     /** Conflated wake signal: [reconnectNow] sends; the backoff wait races it against the delay. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -5,6 +5,8 @@ import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.remote.KtorPlaybackRpcFactory
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
+import com.calypsan.listenup.client.data.connection.ConnectionCoordinator
+import com.calypsan.listenup.client.data.connection.ReconnectionSupervisor
 import com.calypsan.listenup.client.data.sync.ActivityRefreshSignal
 import com.calypsan.listenup.client.data.sync.CatchUp
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
@@ -328,5 +330,19 @@ val clientSyncRenovationModule =
                 activityRefreshSignal = get(),
                 scope = get(qualifier = named(APP_SCOPE)),
             )
+        }
+
+        single(createdAtStart = true) {
+            val coordinator: ConnectionCoordinator = get()
+            ReconnectionSupervisor(
+                engineState = get(),
+                instanceRepository = get(),
+                serverConfig = get(),
+                sseClient = get(),
+                authSession = get(),
+                errorBus = get(),
+                reevaluate = { coordinator.reevaluate() },
+                scope = get(qualifier = named(APP_SCOPE)),
+            ).apply { start() }
         }
     }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/InstanceContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/InstanceContractTest.kt
@@ -27,6 +27,7 @@ class InstanceContractTest :
                     apiVersion = "v1",
                     setupRequired = true,
                     registrationPolicy = RegistrationPolicy.OPEN,
+                    instanceId = "test-instance",
                 )
             roundTrip(original) shouldBe original
         }
@@ -40,6 +41,7 @@ class InstanceContractTest :
                         apiVersion = "v1",
                         setupRequired = false,
                         registrationPolicy = RegistrationPolicy.APPROVAL_QUEUE,
+                        instanceId = "test-instance",
                     ),
                 )
             decoded.setupRequired shouldBe false

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisorTest.kt
@@ -13,12 +13,16 @@ import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.domain.repository.VerifiedServer
 import com.calypsan.listenup.core.ServerUrl
 import com.calypsan.listenup.core.error.ErrorBus
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.atLeast
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
@@ -48,12 +52,14 @@ class ReconnectionSupervisorTest :
                 instanceId = instanceId,
             )
 
+        fun verified(instanceId: String) = VerifiedServer(serverInfo = serverInfo(instanceId), verifiedUrl = activeUrl)
+
         test("disconnected + same instance triggers reconnectNow without logout") {
             val scope = TestScope(StandardTestDispatcher())
             val engineState = SyncEngineState() // starts Disconnected
             val instance =
                 mock<InstanceRepository> {
-                    everySuspend { getServerInfo(any()) } returns AppResult.Success(serverInfo("inst-1"))
+                    everySuspend { verifyServer(any()) } returns AppResult.Success(verified("inst-1"))
                 }
             val serverConfig =
                 mock<ServerConfig> {
@@ -62,7 +68,7 @@ class ReconnectionSupervisorTest :
                 }
             val sseClient =
                 mock<SseClient> {
-                    everySuspend { reconnectNow() } returns Unit
+                    every { reconnectNow() } returns Unit
                 }
             val authSession =
                 mock<AuthSession> {
@@ -88,7 +94,7 @@ class ReconnectionSupervisorTest :
             engineState.setConnection(ConnectionState.Connected(lastEventId = 1L))
             scope.testScheduler.advanceUntilIdle()
 
-            verifySuspend { sseClient.reconnectNow() }
+            verify { sseClient.reconnectNow() }
             verifySuspend(exactly(0)) { authSession.clearAuthTokens() }
             check(reevaluateCount >= 1) { "reevaluate should have run at least once" }
         }
@@ -98,7 +104,7 @@ class ReconnectionSupervisorTest :
             val engineState = SyncEngineState()
             val instance =
                 mock<InstanceRepository> {
-                    everySuspend { getServerInfo(any()) } returns AppResult.Success(serverInfo("inst-NEW"))
+                    everySuspend { verifyServer(any()) } returns AppResult.Success(verified("inst-NEW"))
                 }
             val serverConfig =
                 mock<ServerConfig> {
@@ -107,7 +113,7 @@ class ReconnectionSupervisorTest :
                 }
             val sseClient =
                 mock<SseClient> {
-                    everySuspend { reconnectNow() } returns Unit
+                    every { reconnectNow() } returns Unit
                 }
             val authSession =
                 mock<AuthSession> {
@@ -134,7 +140,7 @@ class ReconnectionSupervisorTest :
             scope.testScheduler.advanceUntilIdle()
 
             verifySuspend { authSession.clearAuthTokens() }
-            verifySuspend(exactly(0)) { sseClient.reconnectNow() }
+            verify(exactly(0)) { sseClient.reconnectNow() }
             emitted.map { it.code } shouldContain AuthError.ServerInstanceChanged().code
         }
 
@@ -144,7 +150,7 @@ class ReconnectionSupervisorTest :
             engineState.setConnection(ConnectionState.Connected(lastEventId = 1L))
             val instance =
                 mock<InstanceRepository> {
-                    everySuspend { getServerInfo(any()) } returns AppResult.Success(serverInfo("inst-1"))
+                    everySuspend { verifyServer(any()) } returns AppResult.Success(verified("inst-1"))
                 }
             val serverConfig =
                 mock<ServerConfig> {
@@ -153,7 +159,7 @@ class ReconnectionSupervisorTest :
                 }
             val sseClient =
                 mock<SseClient> {
-                    everySuspend { reconnectNow() } returns Unit
+                    every { reconnectNow() } returns Unit
                 }
             val authSession =
                 mock<AuthSession> {
@@ -175,16 +181,16 @@ class ReconnectionSupervisorTest :
             supervisor.start()
             scope.testScheduler.advanceUntilIdle()
 
-            verifySuspend(exactly(0)) { instance.getServerInfo(any()) }
-            verifySuspend(exactly(0)) { sseClient.reconnectNow() }
+            verifySuspend(exactly(0)) { instance.verifyServer(any()) }
+            verify(exactly(0)) { sseClient.reconnectNow() }
         }
 
-        test("unreachable server retries on the interval") {
+        test("unreachable server retries with escalating interval") {
             val scope = TestScope(StandardTestDispatcher())
             val engineState = SyncEngineState()
             val instance =
                 mock<InstanceRepository> {
-                    everySuspend { getServerInfo(any()) } returns
+                    everySuspend { verifyServer(any()) } returns
                         AppResult.Failure(TransportError.NetworkUnavailable())
                 }
             val serverConfig =
@@ -194,7 +200,7 @@ class ReconnectionSupervisorTest :
                 }
             val sseClient =
                 mock<SseClient> {
-                    everySuspend { reconnectNow() } returns Unit
+                    every { reconnectNow() } returns Unit
                 }
             val authSession =
                 mock<AuthSession> {
@@ -215,9 +221,108 @@ class ReconnectionSupervisorTest :
 
             supervisor.start()
             // Don't advanceUntilIdle — the retry loop is infinite. Drive bounded virtual time.
-            scope.testScheduler.advanceTimeBy(interval * 3 + 1)
+            // First probe at t0, then waits `interval` (base), then `interval * 2` (escalated).
+            // Advancing base + 2*base covers at least the first two waits → 3 probes by then.
+            scope.testScheduler.advanceTimeBy(interval + interval * 2 + 1)
             scope.testScheduler.runCurrent()
 
-            verifySuspend(atLeast(3)) { instance.getServerInfo(any()) }
+            verifySuspend(atLeast(2)) { instance.verifyServer(any()) }
+        }
+
+        test("no active url: returns early without probing or clearing auth") {
+            val scope = TestScope(StandardTestDispatcher())
+            val engineState = SyncEngineState() // Disconnected
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { verifyServer(any()) } returns AppResult.Success(verified("inst-1"))
+                }
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns null
+                    everySuspend { getConnectedServerId() } returns null
+                }
+            val sseClient =
+                mock<SseClient> {
+                    every { reconnectNow() } returns Unit
+                }
+            val authSession =
+                mock<AuthSession> {
+                    everySuspend { clearAuthTokens() } returns Unit
+                }
+            val supervisor =
+                ReconnectionSupervisor(
+                    engineState = engineState,
+                    instanceRepository = instance,
+                    serverConfig = serverConfig,
+                    sseClient = sseClient,
+                    authSession = authSession,
+                    errorBus = ErrorBus(),
+                    reevaluate = { },
+                    scope = scope,
+                    probeIntervalMillis = interval,
+                )
+
+            supervisor.start()
+            scope.testScheduler.advanceUntilIdle()
+
+            verifySuspend(exactly(0)) { instance.verifyServer(any()) }
+            verifySuspend(exactly(0)) { authSession.clearAuthTokens() }
+            verify(exactly(0)) { sseClient.reconnectNow() }
+        }
+
+        test("loop is cancelled once the connection becomes Connected") {
+            val scope = TestScope(StandardTestDispatcher())
+            val engineState = SyncEngineState() // Disconnected
+            // Keep failing so the loop would otherwise probe forever; count actual probes.
+            var probeCount = 0
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { verifyServer(any()) } calls
+                        {
+                            probeCount++
+                            AppResult.Failure(TransportError.NetworkUnavailable())
+                        }
+                }
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns ServerUrl(activeUrl)
+                    everySuspend { getConnectedServerId() } returns "inst-1"
+                }
+            val sseClient =
+                mock<SseClient> {
+                    every { reconnectNow() } returns Unit
+                }
+            val authSession =
+                mock<AuthSession> {
+                    everySuspend { clearAuthTokens() } returns Unit
+                }
+            val supervisor =
+                ReconnectionSupervisor(
+                    engineState = engineState,
+                    instanceRepository = instance,
+                    serverConfig = serverConfig,
+                    sseClient = sseClient,
+                    authSession = authSession,
+                    errorBus = ErrorBus(),
+                    reevaluate = { },
+                    scope = scope,
+                    probeIntervalMillis = interval,
+                )
+
+            supervisor.start()
+            scope.testScheduler.runCurrent() // one probe runs
+            engineState.setConnection(ConnectionState.Connected(lastEventId = 1L))
+            scope.testScheduler.runCurrent() // let collectLatest cancel the loop
+
+            // Capture the count after cancellation, then advance well past several intervals.
+            // If the loop were still alive it would fire many more probes.
+            val countAtConnect = probeCount
+            scope.testScheduler.advanceTimeBy(interval * 10)
+            scope.testScheduler.runCurrent()
+
+            check(probeCount == countAtConnect) {
+                "expected no further probes after Connected, but probeCount grew from " +
+                    "$countAtConnect to $probeCount"
+            }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisorTest.kt
@@ -221,8 +221,8 @@ class ReconnectionSupervisorTest :
 
             supervisor.start()
             // Don't advanceUntilIdle — the retry loop is infinite. Drive bounded virtual time.
-            // First probe at t0, then waits `interval` (base), then `interval * 2` (escalated).
-            // Advancing base + 2*base covers at least the first two waits → 3 probes by then.
+            // First probe at t0; each failure escalates the wait BEFORE delaying, so the first
+            // wait is already `interval * 2`. Advancing base + 2*base covers the first two waits.
             scope.testScheduler.advanceTimeBy(interval + interval * 2 + 1)
             scope.testScheduler.runCurrent()
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisorTest.kt
@@ -1,0 +1,223 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.client.data.connection
+
+import com.calypsan.listenup.api.dto.ServerInfo
+import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.SseClient
+import com.calypsan.listenup.client.data.sync.SyncEngineState
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.ServerUrl
+import com.calypsan.listenup.core.error.ErrorBus
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.atLeast
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+
+class ReconnectionSupervisorTest :
+    FunSpec({
+
+        val activeUrl = "http://192.168.1.10:8080"
+        val interval = 5_000L
+
+        fun serverInfo(instanceId: String) =
+            ServerInfo(
+                name = "ListenUp",
+                version = "0.0.1",
+                apiVersion = "v1",
+                setupRequired = false,
+                registrationPolicy = RegistrationPolicy.CLOSED,
+                instanceId = instanceId,
+            )
+
+        test("disconnected + same instance triggers reconnectNow without logout") {
+            val scope = TestScope(StandardTestDispatcher())
+            val engineState = SyncEngineState() // starts Disconnected
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { getServerInfo(any()) } returns AppResult.Success(serverInfo("inst-1"))
+                }
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns ServerUrl(activeUrl)
+                    everySuspend { getConnectedServerId() } returns "inst-1"
+                }
+            val sseClient =
+                mock<SseClient> {
+                    everySuspend { reconnectNow() } returns Unit
+                }
+            val authSession =
+                mock<AuthSession> {
+                    everySuspend { clearAuthTokens() } returns Unit
+                }
+            var reevaluateCount = 0
+            val supervisor =
+                ReconnectionSupervisor(
+                    engineState = engineState,
+                    instanceRepository = instance,
+                    serverConfig = serverConfig,
+                    sseClient = sseClient,
+                    authSession = authSession,
+                    errorBus = ErrorBus(),
+                    reevaluate = { reevaluateCount++ },
+                    scope = scope,
+                    probeIntervalMillis = interval,
+                )
+
+            supervisor.start()
+            // Let one probe cycle run, then stop the loop by going Connected.
+            scope.testScheduler.runCurrent()
+            engineState.setConnection(ConnectionState.Connected(lastEventId = 1L))
+            scope.testScheduler.advanceUntilIdle()
+
+            verifySuspend { sseClient.reconnectNow() }
+            verifySuspend(exactly(0)) { authSession.clearAuthTokens() }
+            check(reevaluateCount >= 1) { "reevaluate should have run at least once" }
+        }
+
+        test("disconnected + different instance clears auth, emits ServerInstanceChanged, stops") {
+            val scope = TestScope(StandardTestDispatcher())
+            val engineState = SyncEngineState()
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { getServerInfo(any()) } returns AppResult.Success(serverInfo("inst-NEW"))
+                }
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns ServerUrl(activeUrl)
+                    everySuspend { getConnectedServerId() } returns "inst-OLD"
+                }
+            val sseClient =
+                mock<SseClient> {
+                    everySuspend { reconnectNow() } returns Unit
+                }
+            val authSession =
+                mock<AuthSession> {
+                    everySuspend { clearAuthTokens() } returns Unit
+                }
+            val errorBus = ErrorBus()
+            val emitted = mutableListOf<com.calypsan.listenup.api.error.AppError>()
+            scope.backgroundScope.launch { errorBus.errors.collect { emitted.add(it) } }
+
+            val supervisor =
+                ReconnectionSupervisor(
+                    engineState = engineState,
+                    instanceRepository = instance,
+                    serverConfig = serverConfig,
+                    sseClient = sseClient,
+                    authSession = authSession,
+                    errorBus = errorBus,
+                    reevaluate = { },
+                    scope = scope,
+                    probeIntervalMillis = interval,
+                )
+
+            supervisor.start()
+            scope.testScheduler.advanceUntilIdle()
+
+            verifySuspend { authSession.clearAuthTokens() }
+            verifySuspend(exactly(0)) { sseClient.reconnectNow() }
+            emitted.map { it.code } shouldContain AuthError.ServerInstanceChanged().code
+        }
+
+        test("connected stays idle: no probe, no reconnect") {
+            val scope = TestScope(StandardTestDispatcher())
+            val engineState = SyncEngineState()
+            engineState.setConnection(ConnectionState.Connected(lastEventId = 1L))
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { getServerInfo(any()) } returns AppResult.Success(serverInfo("inst-1"))
+                }
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns ServerUrl(activeUrl)
+                    everySuspend { getConnectedServerId() } returns "inst-1"
+                }
+            val sseClient =
+                mock<SseClient> {
+                    everySuspend { reconnectNow() } returns Unit
+                }
+            val authSession =
+                mock<AuthSession> {
+                    everySuspend { clearAuthTokens() } returns Unit
+                }
+            val supervisor =
+                ReconnectionSupervisor(
+                    engineState = engineState,
+                    instanceRepository = instance,
+                    serverConfig = serverConfig,
+                    sseClient = sseClient,
+                    authSession = authSession,
+                    errorBus = ErrorBus(),
+                    reevaluate = { },
+                    scope = scope,
+                    probeIntervalMillis = interval,
+                )
+
+            supervisor.start()
+            scope.testScheduler.advanceUntilIdle()
+
+            verifySuspend(exactly(0)) { instance.getServerInfo(any()) }
+            verifySuspend(exactly(0)) { sseClient.reconnectNow() }
+        }
+
+        test("unreachable server retries on the interval") {
+            val scope = TestScope(StandardTestDispatcher())
+            val engineState = SyncEngineState()
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { getServerInfo(any()) } returns
+                        AppResult.Failure(TransportError.NetworkUnavailable())
+                }
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns ServerUrl(activeUrl)
+                    everySuspend { getConnectedServerId() } returns "inst-1"
+                }
+            val sseClient =
+                mock<SseClient> {
+                    everySuspend { reconnectNow() } returns Unit
+                }
+            val authSession =
+                mock<AuthSession> {
+                    everySuspend { clearAuthTokens() } returns Unit
+                }
+            val supervisor =
+                ReconnectionSupervisor(
+                    engineState = engineState,
+                    instanceRepository = instance,
+                    serverConfig = serverConfig,
+                    sseClient = sseClient,
+                    authSession = authSession,
+                    errorBus = ErrorBus(),
+                    reevaluate = { },
+                    scope = scope,
+                    probeIntervalMillis = interval,
+                )
+
+            supervisor.start()
+            // Don't advanceUntilIdle — the retry loop is infinite. Drive bounded virtual time.
+            scope.testScheduler.advanceTimeBy(interval * 3 + 1)
+            scope.testScheduler.runCurrent()
+
+            verifySuspend(atLeast(3)) { instance.getServerInfo(any()) }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
@@ -31,6 +31,7 @@ private fun createTestServerInfo(
         apiVersion = "v1",
         setupRequired = setupRequired,
         registrationPolicy = registrationPolicy,
+        instanceId = "test-instance",
     )
 
 private fun createMockStorage(): SecureStorage = mock<SecureStorage>()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImplTest.kt
@@ -32,6 +32,7 @@ class InstanceRepositoryImplTest :
                 apiVersion = "v1",
                 setupRequired = true,
                 registrationPolicy = RegistrationPolicy.OPEN,
+                instanceId = "test-instance",
             )
 
         /** Fake factory: records the ws URL it was asked for, returns a canned result. */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientReconnectNowTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientReconnectNowTest.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.client.data.sync
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+
+class SyncSseClientReconnectNowTest :
+    FunSpec({
+        test("reconnectNow wakes the backoff wait and resets the delay") {
+            val scope = TestScope(StandardTestDispatcher())
+            var attempts = 0
+            val state = SyncEngineState()
+            val client =
+                SyncSseClient(
+                    serverUrlProvider = { "http://test" },
+                    streamingClientProvider = {
+                        attempts++
+                        error("boom") // always fail → drives the Reconnect backoff path
+                    },
+                    state = state,
+                    scope = scope,
+                    nowMillis = { 0L },
+                )
+
+            client.connect()
+            scope.testScheduler.runCurrent()
+            val afterFirst = attempts
+            afterFirst shouldBeGreaterThan 0
+
+            scope.testScheduler.advanceTimeBy(500)
+            scope.testScheduler.runCurrent()
+            attempts shouldBe afterFirst // still waiting out the backoff
+
+            client.reconnectNow()
+            scope.testScheduler.runCurrent()
+            attempts shouldBeGreaterThan afterFirst // woke immediately
+
+            client.disconnect()
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientReconnectNowTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientReconnectNowTest.kt
@@ -40,7 +40,7 @@ class SyncSseClientReconnectNowTest :
 
             client.reconnectNow()
             scope.testScheduler.runCurrent()
-            attempts shouldBeGreaterThan afterFirst // woke immediately
+            attempts shouldBe afterFirst + 1 // woke immediately, exactly one more attempt (no busy-loop)
 
             client.disconnect()
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModuleVerifyTest.kt
@@ -2,9 +2,12 @@ package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.connection.ConnectionCoordinator
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.error.ErrorBus
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.CoroutineScope
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -34,6 +37,12 @@ import org.koin.test.verify.verify
  *    `false` on Desktop. Declared here so `verify()` does not fail on the qualified lookup.
  *  - [AuthSession] — owned by `dataModule` (bound to SettingsRepositoryImpl). The listening-event
  *    sync handler reads the signed-in user id from it to stamp synced cross-device events.
+ *  - [ConnectionCoordinator] — owned by the main `Koin.kt` module; [ReconnectionSupervisor]
+ *    drives `reevaluate` through it to re-point the active URL during an outage.
+ *  - [InstanceRepository] — owned by the main `Koin.kt` module; [ReconnectionSupervisor] probes
+ *    the resolved URL with its unauthenticated `verifyServer` to detect instance identity changes.
+ *  - [ErrorBus] — owned by the main `Koin.kt` module; [ReconnectionSupervisor] surfaces an
+ *    instance-changed signal through it.
  */
 @OptIn(KoinExperimentalAPI::class)
 class ClientSyncRenovationModuleVerifyTest :
@@ -49,6 +58,9 @@ class ClientSyncRenovationModuleVerifyTest :
                         ServerConfig::class,
                         CoroutineScope::class,
                         AuthSession::class,
+                        ConnectionCoordinator::class,
+                        InstanceRepository::class,
+                        ErrorBus::class,
                         Function1::class,
                         Function2::class,
                         Function3::class,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -156,6 +156,8 @@ private class FakeReconcileSse : SseClient {
     override fun currentLastEventId(): Long? = null
 
     override suspend fun reseed(newLastEventId: Long?) = Unit
+
+    override fun reconnectNow() = Unit
 }
 
 private data class ReconcileHarness(

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleReentrancyTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleReentrancyTest.kt
@@ -159,4 +159,6 @@ private class NoopSseClient(
     override suspend fun reseed(newLastEventId: Long?) {
         seeded = newLastEventId
     }
+
+    override fun reconnectNow() = Unit
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -387,4 +387,6 @@ private class FakeSseClient(
         disconnect()
         seeded = newLastEventId
     }
+
+    override fun reconnectNow() = Unit
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleTest.kt
@@ -390,6 +390,8 @@ private class FakeSse : SseClient {
         seededLastEventId = newLastEventId
     }
 
+    override fun reconnectNow() = Unit
+
     suspend fun emit(frame: ParsedSseFrame) {
         flow.emit(frame)
     }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStartIdempotencyTest.kt
@@ -297,4 +297,6 @@ private class FakeIdempotencySseClient(
         disconnect()
         seeded = newLastEventId
     }
+
+    override fun reconnectNow() = Unit
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineStateObserversTest.kt
@@ -204,4 +204,6 @@ private class FakeStateSseClient(
         disconnect()
         seeded = newLastEventId
     }
+
+    override fun reconnectNow() = Unit
 }


### PR DESCRIPTION
## Why

A server restart — especially one that comes back at a different IP/port — could leave the client **stuck offline indefinitely**, or log the user out confusingly. Two root-caused failure modes:

- **Mode 1 (stuck offline):** reachability is derived *solely* from the SSE connection, and the SSE loop only ever retries the *stored* URL. If the server returns at a new address and mDNS can't update it, the client hammers the dead URL forever — reachability never recovers. Reproduced live (endless `ECONNREFUSED` after the server moved ports).
- **Mode 2 (confusing logout):** a normal same-server restart already keeps you signed in (stable jwt secret/pepper, persisted sessions). But the client couldn't tell "same server, restarted" from "different server" over HTTP, because the stable `instanceId` wasn't exposed in `ServerInfo` — so a reset-DB restart produced a silent, unexplained logout.

This is Offline-first / Never-Stranded in action: recover the connection automatically whenever the server is alive, at the old address or a new one.

## What

- **Contract:** add stable `instanceId` to `ServerInfo`; server populates it from the DB-persisted `InstanceIdentity` (the same id advertised over mDNS). `getServerInfo` is unauthenticated, so it works as a probe even when the access token is dead.
- **SSE:** `SseClient.reconnectNow()` — interruptible backoff (CONFLATED wake channel + reset attempt) so recovery is seconds, not up to 60s.
- **`ReconnectionSupervisor`** (new): while the firehose is down, it re-resolves the live URL (reusing `ConnectionCoordinator.reevaluate()` → mDNS relocation + remote fallback), probes the **active** URL via `verifyServer`, then either kicks an immediate reconnect (same instance → stays signed in) or triggers a clean re-auth (`AuthError.ServerInstanceChanged` → "This server was reset or replaced. Please sign in again."). Boolean-gated on connection state (no restart-storm from SSE backoff flapping); interval escalates on sustained failure.
- Reachability *computation* is unchanged (still SSE-derived).

## Test plan

- [x] `spotlessCheck`, `detekt`
- [x] `:contract:jvmTest`, `:sharedLogic:jvmTest`, full `:server:test`
- [x] `:androidApp:assembleDebug`
- [x] Unit coverage: contract round-trips; server returns persisted/stable `instanceId`; `reconnectNow` wakes the backoff; supervisor (same-instance reconnect, different-instance re-auth+stop, connected→idle, unreachable→escalating retry, no-active-url early return, cancels-on-Connected)
- [ ] **On-device** happy-path (server outage → reconnect in seconds while staying signed in) — pending a signed-in session; iOS gates via remote CI.

## Out of scope (noted)
- ShelfDetail (and similar RPC screens) hard-failing offline instead of reading Room — separate offline-first workstream.