### PR TITLE
🐛 fix(sharedLogic): never-strand the populating gate on a missed scan Completed

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -18,11 +18,11 @@ import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -30,6 +30,9 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 private val logger = KotlinLogging.logger {}
+
+/** Backoff between scan-progress stream re-subscriptions after the stream drops or completes. */
+private const val SCAN_STREAM_RESUBSCRIBE_DELAY_MS = 2_000L
 
 /**
  * Bridges the domain sync facade to the renovated client sync engine.
@@ -159,41 +162,87 @@ class SyncRepositoryImpl(
         if (!shouldStart) return
         scope.launch {
             try {
-                scannerRpcFactory
-                    .get()
-                    .observeProgress()
-                    .catch { e ->
-                        if (e is kotlin.coroutines.cancellation.CancellationException) throw e
-                        logger.warn(e) { "Scan-progress stream failed; scan UI/reconcile paused" }
-                        resetScanObserver()
-                    }.collect { rpcEvent ->
-                        val event = (rpcEvent as? RpcEvent.Data)?.value ?: return@collect
-                        applyScanEvent(
-                            event = event,
-                            isInitialScanComplete = { hasCompletedInitialScan },
-                            setScanning = { _isServerScanning.value = it },
-                            setProgress = { _scanProgress.value = it },
-                            markInitialScanComplete = { hasCompletedInitialScan = true },
-                            // Awaited, not fire-and-forget: the initial populating gate must stay up
-                            // until this reconcile actually lands the books in Room (see applyScanEvent).
-                            // Parking this collector for the duration is safe — [SyncEngine.handleCursorStale]
-                            // is mutex-guarded + coalescing (no concurrent catch-up spin), Completed is
-                            // already consumed, and the cold RPC stream applies backpressure rather than
-                            // dropping any later event.
-                            reconcile = { syncEngine.handleCursorStale() },
-                            nowMs = { currentEpochMilliseconds() },
-                            getStartedAt = { scanStartedAtMs },
-                            setStartedAt = { scanStartedAtMs = it },
-                        )
-                    }
+                observeScanProgressResiliently()
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                 throw e
             } catch (e: Exception) {
                 logger.warn(e) { "Scan-progress observer stopped unexpectedly" }
+            } finally {
                 resetScanObserver()
             }
         }
     }
+
+    /**
+     * Resilient for the process lifetime. The terminal [ScanEvent.Completed] rides a `replay = 0`
+     * bus (see `ScannerServiceImpl.observeProgress`), so a single subscription that drops — or
+     * silently re-establishes — mid-scan can miss it, latching the populating gate forever. So we
+     * re-subscribe on every termination, and on each one run the never-stranded recovery: a missed
+     * Completed must not strand the user on the populating screen (see [recoverFromScanStreamEnd]).
+     */
+    private suspend fun observeScanProgressResiliently() {
+        while (true) {
+            collectScanProgressUntilStreamEnds()
+            recoverFromScanStreamEnd(
+                isInitialScanComplete = { hasCompletedInitialScan },
+                isScanning = { _isServerScanning.value },
+                confirmScanFinished = { isInitialScanFinishedOnServer() },
+                reconcile = { syncEngine.handleCursorStale() },
+                setScanning = { _isServerScanning.value = it },
+                setProgress = { _scanProgress.value = it },
+                markInitialScanComplete = { hasCompletedInitialScan = true },
+            )
+            delay(SCAN_STREAM_RESUBSCRIBE_DELAY_MS)
+        }
+    }
+
+    /** Collects one subscription to the scan-progress stream until it errors or completes. */
+    private suspend fun collectScanProgressUntilStreamEnds() {
+        try {
+            scannerRpcFactory
+                .get()
+                .observeProgress()
+                .collect { rpcEvent ->
+                    val event = (rpcEvent as? RpcEvent.Data)?.value ?: return@collect
+                    applyScanEvent(
+                        event = event,
+                        isInitialScanComplete = { hasCompletedInitialScan },
+                        setScanning = { _isServerScanning.value = it },
+                        setProgress = { _scanProgress.value = it },
+                        markInitialScanComplete = { hasCompletedInitialScan = true },
+                        // Awaited, not fire-and-forget: the initial populating gate must stay up
+                        // until this reconcile actually lands the books in Room (see applyScanEvent).
+                        // Parking this collector for the duration is safe — [SyncEngine.handleCursorStale]
+                        // is mutex-guarded + coalescing (no concurrent catch-up spin), Completed is
+                        // already consumed, and the cold RPC stream applies backpressure rather than
+                        // dropping any later event.
+                        reconcile = { syncEngine.handleCursorStale() },
+                        nowMs = { currentEpochMilliseconds() },
+                        getStartedAt = { scanStartedAtMs },
+                        setStartedAt = { scanStartedAtMs = it },
+                    )
+                }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Scan-progress stream dropped; recovering and re-subscribing" }
+        }
+    }
+
+    /**
+     * Probe the server's authoritative last-scan result to confirm the initial population finished.
+     * The RPC proxy throws (e.g. `WebSocketException`) on transport failure; treat any such failure
+     * as "not finished" so recovery keeps the gate up and re-subscribes rather than latching early.
+     */
+    private suspend fun isInitialScanFinishedOnServer(): Boolean =
+        try {
+            scannerRpcFactory.get().lastScanResult() is AppResult.Success
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "lastScanResult probe failed during scan recovery" }
+            false
+        }
 
     /** Never-stranded reset: a dropped progress stream must not leave the shell blocked. */
     private suspend fun resetScanObserver() {
@@ -292,4 +341,39 @@ internal suspend fun applyScanEvent(
             // No-op: the live tail plus the Completed reconcile cover applied changes.
         }
     }
+}
+
+/**
+ * Never-stranded recovery for the initial-population gate when the scan-progress stream terminates
+ * (drops with an error OR completes) before delivering [ScanEvent.Completed]. That terminal event
+ * rides a `replay = 0` bus (see `ScannerServiceImpl.observeProgress`), so a subscription that drops
+ * or silently re-establishes mid-scan can miss it — which would latch `isServerScanning` forever and
+ * strand the user on the "Building your library" screen.
+ *
+ * **Confirm-then-clear.** Only acts while the initial gate is still up. It confirms the scan really
+ * finished via the server's authoritative last-scan result ([confirmScanFinished]) before doing
+ * anything — during the initial population that result is absent until the books are persisted, so
+ * it is a precise "is the initial scan done?" signal. Only on a confirmed-finished scan does it run
+ * the catch-up [reconcile] (pulling the books the missed Completed would have) and then clear + latch
+ * the gate. An unconfirmed result (scan still running, or the server unreachable) leaves the gate up
+ * so the caller re-subscribes — never latching the shell mid-import, never stranding it after one.
+ *
+ * Extracted as a top-level function — like [applyScanEvent] — so it is testable with recording
+ * lambdas, no [SyncEngine] or RPC mock required.
+ */
+internal suspend fun recoverFromScanStreamEnd(
+    isInitialScanComplete: () -> Boolean,
+    isScanning: () -> Boolean,
+    confirmScanFinished: suspend () -> Boolean,
+    reconcile: suspend () -> Unit,
+    setScanning: (Boolean) -> Unit,
+    setProgress: (ScanProgressState?) -> Unit,
+    markInitialScanComplete: () -> Unit,
+) {
+    if (isInitialScanComplete() || !isScanning()) return
+    if (!confirmScanFinished()) return
+    reconcile()
+    setProgress(null)
+    setScanning(false)
+    markInitialScanComplete()
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -238,4 +238,76 @@ class SyncRepositoryScanProgressTest :
                 started shouldBe 1_234L
             }
         }
+
+        // The strand: the terminal `ScanEvent.Completed` travels over a replay=0 bus, so a
+        // progress stream that drops or re-establishes mid-scan can miss it — latching the
+        // populating gate (`isServerScanning`) forever. [recoverFromScanStreamEnd] is the
+        // never-stranded recovery run whenever the stream terminates while the initial gate is
+        // still up: confirm the scan really finished (the server's authoritative lastScanResult),
+        // then reconcile + clear + latch. Confirm-then-clear — never strands, never latches early.
+        test("recovery clears the gate when the missed-Completed scan is confirmed finished") {
+            runTest {
+                var scanning = true
+                var progress: ScanProgressState? = ScanProgressState("ANALYZING", 72, 1647, 0, 0, 0)
+                var initialComplete = false
+                var reconciled = false
+
+                recoverFromScanStreamEnd(
+                    isInitialScanComplete = { initialComplete },
+                    isScanning = { scanning },
+                    confirmScanFinished = { true },
+                    reconcile = { reconciled = true },
+                    setScanning = { scanning = it },
+                    setProgress = { progress = it },
+                    markInitialScanComplete = { initialComplete = true },
+                )
+
+                reconciled shouldBe true // pulled the books the missed Completed would have
+                scanning shouldBe false // gate cleared — user escapes the populating screen
+                progress shouldBe null
+                initialComplete shouldBe true // latched so a later incremental can't re-block
+            }
+        }
+
+        test("recovery keeps the gate up when completion is not confirmed (scan still running / server unreachable)") {
+            runTest {
+                var scanning = true
+                var initialComplete = false
+                var reconciled = false
+
+                recoverFromScanStreamEnd(
+                    isInitialScanComplete = { initialComplete },
+                    isScanning = { scanning },
+                    confirmScanFinished = { false },
+                    reconcile = { reconciled = true },
+                    setScanning = { scanning = it },
+                    setProgress = { },
+                    markInitialScanComplete = { initialComplete = true },
+                )
+
+                scanning shouldBe true // genuinely mid-scan — keep the gate, re-subscribe
+                initialComplete shouldBe false
+                reconciled shouldBe false // confirm-first: no wasted catch-up while still scanning
+            }
+        }
+
+        test("recovery is a no-op once the initial population has already latched") {
+            runTest {
+                var reconciled = false
+                var scanningWrites = 0
+
+                recoverFromScanStreamEnd(
+                    isInitialScanComplete = { true },
+                    isScanning = { false },
+                    confirmScanFinished = { true },
+                    reconcile = { reconciled = true },
+                    setScanning = { scanningWrites++ },
+                    setProgress = { },
+                    markInitialScanComplete = { },
+                )
+
+                reconciled shouldBe false
+                scanningWrites shouldBe 0
+            }
+        }
     })


### PR DESCRIPTION
## Problem
On a fresh library scan the client could stay stuck forever on the "Building your library" screen — frozen at stale counts — even though the server finished scanning and persisted every book.

## Root cause
The terminal `ScanEvent.Completed` is emitted by `BookPersister` over a `replay = 0` `SharedFlow` (`ScannerServiceImpl.observeProgress`). The client's scan-progress observer was at-most-once and only recovered on a *thrown* stream error (`.catch`). A stream that **completes or silently re-establishes before delivering `Completed`** left `isServerScanning` latched `true` with no recovery, so the populating gate never cleared. It only reproduces at library scale, where the long persist widens the window to miss the event.

## Fix
- The observer now **re-subscribes for the process lifetime** instead of at-most-once.
- On every stream termination while the initial gate is still up, it runs `recoverFromScanStreamEnd` — **confirm-then-clear**: confirm the scan actually finished via the server's authoritative `lastScanResult()`, then `reconcile()` (pull the books a missed `Completed` would have) and clear + latch the gate. An unconfirmed result (scan still running / server unreachable) leaves the gate up and re-subscribes — never stranding, never latching the shell mid-import.

## Testing
- 3 new reducer-level tests for `recoverFromScanStreamEnd` (confirmed-finished clears; unconfirmed keeps the gate; no-op once latched).
- `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:server:test`, `:androidApp:assembleDebug` all green locally.