### PR TITLE
🐛 fix(sharedUI): restore shell tab switching — read destination/readiness reactively in the Shell entry

### DIFF
--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -605,10 +605,12 @@ private fun AuthenticatedNavigation(
                 entryProvider =
                     authenticatedNavEntries(
                         backStack = backStack,
-                        currentShellDestination = currentShellDestination,
+                        // Deferred reads: the entry content reads these inside the Shell composable so
+                        // tab/readiness changes recompose it (NavDisplay won't re-invoke the builder).
+                        currentShellDestination = { currentShellDestination },
                         onShellDestinationChange = { currentShellDestination = it },
                         nowPlayingViewModel = nowPlayingViewModel,
-                        readiness = readiness,
+                        readiness = { readiness },
                         onSignOut = onSignOut,
                         startupViewModel = startupViewModel,
                         scope = scope,
@@ -638,10 +640,10 @@ private fun AuthenticatedNavigation(
  */
 private fun authenticatedNavEntries(
     backStack: NavBackStack<NavKey>,
-    currentShellDestination: ShellDestination,
+    currentShellDestination: () -> ShellDestination,
     onShellDestinationChange: (ShellDestination) -> Unit,
     nowPlayingViewModel: NowPlayingViewModel,
-    readiness: LibraryReadiness,
+    readiness: () -> LibraryReadiness,
     onSignOut: () -> Unit,
     startupViewModel: AppStartupViewModel,
     scope: CoroutineScope,

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/ShellEntry.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/ShellEntry.kt
@@ -30,20 +30,26 @@ import org.koin.compose.viewmodel.koinViewModel
 /** Shell (root) navigation entry — the main app scaffold with bottom nav. */
 internal fun EntryProviderScope<NavKey>.shellEntry(
     backStack: NavBackStack<NavKey>,
-    currentShellDestination: ShellDestination,
+    currentShellDestination: () -> ShellDestination,
     onDestinationChange: (ShellDestination) -> Unit,
     nowPlayingViewModel: NowPlayingViewModel,
-    readiness: LibraryReadiness,
+    readiness: () -> LibraryReadiness,
     onSignOut: () -> Unit,
 ) {
     entry<Shell> {
+        // Read the hoisted state INSIDE the entry content (not as a captured parameter) so the
+        // shell recomposes when the selected tab or readiness changes. NavDisplay does not
+        // re-invoke this entry builder when only those values change (the Shell back-stack key is
+        // unchanged), so a captured snapshot would go stale — bottom-nav taps would no-op.
+        val readinessState = readiness()
+
         // Readiness gate: while the initial library population is running we show a
         // dedicated full-screen progress screen and DO NOT mount the shell — so the
         // user never navigates an empty app, and the Library grid + Coil don't decode
         // a thousand covers while the sync/catch-up is still churning (which exhausted
         // the heap → OOM). Populating spans the server scan AND the client import, so
         // when it clears the books are already in Room (see applyScanEvent).
-        (readiness as? LibraryReadiness.Populating)?.let { populating ->
+        (readinessState as? LibraryReadiness.Populating)?.let { populating ->
             LibraryScanScreen(scanProgress = populating.progress)
             return@entry
         }
@@ -54,7 +60,7 @@ internal fun EntryProviderScope<NavKey>.shellEntry(
 
         // Get search state for overlay
         AppShell(
-            currentDestination = currentShellDestination,
+            currentDestination = currentShellDestination(),
             onDestinationChange = onDestinationChange,
             nowPlayingContent = {
                 val nowPlayingScreenState by nowPlayingViewModel


### PR DESCRIPTION
## Problem
Tapping the **Library** or **Discover** bottom-nav tabs (and the Home "Browse Library" button) does nothing — the shell stays on Home. Shell tab navigation is fully broken.

## Root cause
A regression from #446 (decomposing `AuthenticatedNavigation` into per-feature entry extensions). `currentShellDestination` and `readiness` are now read in `AuthenticatedNavigation` and passed into `shellEntry` as **plain captured values**. `NavDisplay` does not re-invoke the entry builder when only those values change (the `Shell` back-stack key is unchanged), so the rendered Shell content holds a stale destination and tab taps are silently dropped. The same staleness also meant the populating/scan gate (`readiness`) couldn't react inside the shell.

## Fix
Pass `currentShellDestination` and `readiness` as **deferred reads** (`() -> T`) and invoke them **inside** the `entry<Shell>` content. The snapshot reads now happen in the entry's own composable scope, so Compose recomposes the shell when either changes — independent of `NavDisplay`'s entry caching.

## Testing
On-device (Pixel 9 emulator): Library (1136 titles), Discover (Recently Added / Leaderboard), and Home all switch correctly. `spotlessCheck` + `detekt` + `:androidApp:assembleDebug` green. (Nav/Compose behaviour isn't covered by the JVM/Kotest lanes — verified on device, per the repo's navigation-verification approach.)