### PR TITLE
🔧 chore(quality): load the Kotlin Gradle plugin once for build-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,8 @@
+// Declare the Kotlin JVM plugin once for the whole build-logic build so its subprojects apply it
+// without their own version. :convention pulls Kotlin transitively via `kotlin-dsl` (Gradle's
+// embedded Kotlin), and :detekt-rules applies `org.jetbrains.kotlin.jvm` with no version — keeping
+// the Kotlin Gradle plugin from being loaded with an explicit version in more than one subproject
+// (which Gradle warns about and which can break the build).
+plugins {
+    alias(libs.plugins.kotlinJvm) apply false
+}

--- a/build-logic/detekt-rules/build.gradle.kts
+++ b/build-logic/detekt-rules/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
-    alias(libs.plugins.kotlinJvm)
+    // Version is declared once at the build-logic root (apply false); applying it here without a
+    // version keeps the Kotlin Gradle plugin from being loaded with an explicit version in more
+    // than one subproject.
+    id("org.jetbrains.kotlin.jvm")
 }
 
 group = "com.calypsan.listenup.build-logic"


### PR DESCRIPTION
## Problem
Every Gradle invocation printed:
> The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build. … loaded in the following projects: ':convention', ':detekt-rules'

## Root cause
`:convention` pulls Kotlin transitively via `kotlin-dsl` (Gradle 9.5's embedded Kotlin, which is `2.3.20` — same as the catalog), while `:detekt-rules` applied `org.jetbrains.kotlin.jvm` with an **explicit catalog version** in its own `plugins {}` block. Gradle warns when the Kotlin plugin is declared with an explicit version in more than one subproject — even when the versions match.

## Fix
Declare the Kotlin JVM plugin once at the build-logic **root** (`apply false`) and apply it in `:detekt-rules` **without** a version. No behavioural change — same Kotlin `2.3.20` everywhere.

## Testing
Warning confirmed gone (`./gradlew help` + `detekt` no longer print it). Full local gate green: `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:server:test`, `:androidApp:assembleDebug`.