### PR TITLE
✨ feat(sharedUI): redesign Shelf detail — M3 Expressive hero, adaptive cover grid, sort pill

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfBookSort.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfBookSort.kt
@@ -1,0 +1,33 @@
+package com.calypsan.listenup.client.presentation.shelf
+
+import com.calypsan.listenup.client.domain.model.ShelfBook
+
+/**
+ * Display-only sort options for a shelf's books, surfaced by the shelf-detail sort pill. [label] is
+ * the pill's text. The default is [ADDED_NEWEST] — the shelf's natural order is added oldest-first,
+ * so "newest" reverses it.
+ */
+enum class ShelfBookSort(
+    val label: String,
+) {
+    ADDED_NEWEST("Added · Newest"),
+    ADDED_OLDEST("Added · Oldest"),
+    TITLE("Title · A–Z"),
+    AUTHOR("Author · A–Z"),
+}
+
+/**
+ * Returns [books] ordered for [sort]. Pure and display-only — the incoming list is the shelf's
+ * natural added order (oldest first), so [ShelfBookSort.ADDED_OLDEST] is the identity. Title/author
+ * sorts are case-insensitive; a book with no author sorts last under [ShelfBookSort.AUTHOR].
+ */
+fun sortShelfBooks(
+    books: List<ShelfBook>,
+    sort: ShelfBookSort,
+): List<ShelfBook> =
+    when (sort) {
+        ShelfBookSort.ADDED_OLDEST -> books
+        ShelfBookSort.ADDED_NEWEST -> books.reversed()
+        ShelfBookSort.TITLE -> books.sortedBy { it.title.lowercase() }
+        ShelfBookSort.AUTHOR -> books.sortedWith(compareBy(nullsLast()) { it.authorNames.firstOrNull()?.lowercase() })
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfGrid.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfGrid.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.client.presentation.shelf
+
+/** Width buckets that drive the Shelf-detail cover-grid column count. */
+enum class ShelfGridWidth { Compact, Medium, Expanded }
+
+private const val COMPACT_COLUMNS = 2
+private const val MEDIUM_COLUMNS = 4
+private const val EXPANDED_COLUMNS = 6
+
+/** Number of cover-grid columns for a given screen-width [width] bucket. */
+fun shelfGridColumns(width: ShelfGridWidth): Int =
+    when (width) {
+        ShelfGridWidth.Compact -> COMPACT_COLUMNS
+        ShelfGridWidth.Medium -> MEDIUM_COLUMNS
+        ShelfGridWidth.Expanded -> EXPANDED_COLUMNS
+    }

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -414,7 +414,7 @@
   },
   "shelf": {
     "add_books_from_the_library": "Add books from the library",
-    "books_in_shelf": "Books in Shelf",
+    "books_in_shelf": "Books in shelf",
     "delete_shelf": "Delete Shelf",
     "description_optional": "Description (optional)",
     "edit_shelf": "Edit shelf",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfBookSortTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfBookSortTest.kt
@@ -1,0 +1,47 @@
+package com.calypsan.listenup.client.presentation.shelf
+
+import com.calypsan.listenup.client.domain.model.ShelfBook
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [sortShelfBooks] — the pure reducer behind the shelf-detail sort pill. The
+ * incoming list is the shelf's natural added order (oldest first); the sort is display-only.
+ */
+class ShelfBookSortTest :
+    FunSpec({
+        fun book(
+            id: String,
+            title: String,
+            author: String,
+        ) = ShelfBook(id = id, title = title, authorNames = listOf(author), coverPath = null)
+
+        // Natural order = added oldest → newest.
+        val first = book("1", "Mistborn", "Brandon Sanderson")
+        val second = book("2", "dune", "Frank Herbert") // lower-case title → case-insensitivity check
+        val third = book("3", "The Way of Kings", "Andy Weir")
+        val natural = listOf(first, second, third)
+
+        test("ADDED_OLDEST keeps the natural added order") {
+            sortShelfBooks(natural, ShelfBookSort.ADDED_OLDEST).map { it.id } shouldBe listOf("1", "2", "3")
+        }
+
+        test("ADDED_NEWEST reverses to newest-first") {
+            sortShelfBooks(natural, ShelfBookSort.ADDED_NEWEST).map { it.id } shouldBe listOf("3", "2", "1")
+        }
+
+        test("TITLE sorts case-insensitively A–Z") {
+            sortShelfBooks(natural, ShelfBookSort.TITLE).map { it.title } shouldBe
+                listOf("dune", "Mistborn", "The Way of Kings")
+        }
+
+        test("AUTHOR sorts by first author A–Z") {
+            sortShelfBooks(natural, ShelfBookSort.AUTHOR).map { it.authorNames.first() } shouldBe
+                listOf("Andy Weir", "Brandon Sanderson", "Frank Herbert")
+        }
+
+        test("a book with no authors sorts last under AUTHOR without crashing") {
+            val orphan = ShelfBook(id = "x", title = "Orphan", authorNames = emptyList(), coverPath = null)
+            sortShelfBooks(listOf(orphan, third), ShelfBookSort.AUTHOR).map { it.id } shouldBe listOf("3", "x")
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfGridColumnsTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfGridColumnsTest.kt
@@ -3,14 +3,15 @@ package com.calypsan.listenup.client.presentation.shelf
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class ShelfGridColumnsTest : FunSpec({
-    test("compact width yields 2 columns") {
-        shelfGridColumns(ShelfGridWidth.Compact) shouldBe 2
-    }
-    test("medium width yields 4 columns") {
-        shelfGridColumns(ShelfGridWidth.Medium) shouldBe 4
-    }
-    test("expanded width yields 6 columns") {
-        shelfGridColumns(ShelfGridWidth.Expanded) shouldBe 6
-    }
-})
+class ShelfGridColumnsTest :
+    FunSpec({
+        test("compact width yields 2 columns") {
+            shelfGridColumns(ShelfGridWidth.Compact) shouldBe 2
+        }
+        test("medium width yields 4 columns") {
+            shelfGridColumns(ShelfGridWidth.Medium) shouldBe 4
+        }
+        test("expanded width yields 6 columns") {
+            shelfGridColumns(ShelfGridWidth.Expanded) shouldBe 6
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfGridColumnsTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfGridColumnsTest.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.client.presentation.shelf
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ShelfGridColumnsTest : FunSpec({
+    test("compact width yields 2 columns") {
+        shelfGridColumns(ShelfGridWidth.Compact) shouldBe 2
+    }
+    test("medium width yields 4 columns") {
+        shelfGridColumns(ShelfGridWidth.Medium) shouldBe 4
+    }
+    test("expanded width yields 6 columns") {
+        shelfGridColumns(ShelfGridWidth.Expanded) shouldBe 6
+    }
+})

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
@@ -8,22 +8,25 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -31,14 +34,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,42 +54,41 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowSizeClass
 import com.calypsan.listenup.client.design.components.BookCoverImage
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
-import com.calypsan.listenup.client.design.util.stableColorForId
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
+import com.calypsan.listenup.client.design.components.cookieScallopShape
 import com.calypsan.listenup.client.domain.model.ShelfBook
 import com.calypsan.listenup.client.domain.model.ShelfDetail
 import com.calypsan.listenup.client.presentation.shelf.ShelfDetailUiState
 import com.calypsan.listenup.client.presentation.shelf.ShelfDetailViewModel
-import org.koin.compose.viewmodel.koinViewModel
-import org.jetbrains.compose.resources.stringResource
+import com.calypsan.listenup.client.presentation.shelf.ShelfGridWidth
+import com.calypsan.listenup.client.presentation.shelf.shelfGridColumns
 import listenup.composeapp.generated.resources.Res
-import listenup.composeapp.generated.resources.common_back
 import listenup.composeapp.generated.resources.common_about
+import listenup.composeapp.generated.resources.common_back
+import listenup.composeapp.generated.resources.common_no_items_yet
 import listenup.composeapp.generated.resources.shelf_add_books_from_the_library
 import listenup.composeapp.generated.resources.shelf_books_in_shelf
 import listenup.composeapp.generated.resources.shelf_edit_shelf
-import listenup.composeapp.generated.resources.common_no_items_yet
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
 
 /**
- * Screen displaying shelf details with its books.
+ * Screen displaying a shelf's details and its books.
  *
- * Features:
- * - Hero section with shelf icon and stats
- * - Shelf name as title
- * - Owner info with avatar
- * - Optional description (expandable)
- * - List of books in the shelf with covers
- * - Book items are clickable to navigate to book detail
+ * A color-blocked hero (scalloped shelf badge + Books/Total stat chips) sits above a
+ * responsive square-cover grid. Pushed full-screen route: keeps a back affordance and an
+ * owner-only Edit action; no navigation rail.
  *
- * @param shelfId The ID of the shelf to display
- * @param onBack Callback when back button is clicked
- * @param onBookClick Callback when a book is clicked
- * @param viewModel The ViewModel for shelf detail data
+ * @param shelfId The ID of the shelf to display.
+ * @param onBack Callback when the back button is clicked.
+ * @param onBookClick Callback when a book cover is clicked.
+ * @param onEditClick Owner-only edit callback (navigates to shelf edit).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -181,9 +184,14 @@ fun ShelfDetailScreen(
     }
 }
 
+/** Description length beyond which the expandable "Read more" toggle is shown. */
+private const val DESCRIPTION_EXPAND_THRESHOLD = 150
+
 /**
- * Content for shelf detail screen.
+ * Ready-state content: an adaptive cover grid with full-span hero, optional description,
+ * and a "Books in shelf" header.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ShelfDetailContent(
     detail: ShelfDetail,
@@ -193,181 +201,148 @@ private fun ShelfDetailContent(
 ) {
     var isDescriptionExpanded by rememberSaveable { mutableStateOf(false) }
 
-    LazyColumn(
-        contentPadding = PaddingValues(bottom = 16.dp),
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val gridWidth =
+        when {
+            windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) -> {
+                ShelfGridWidth.Expanded
+            }
+
+            windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND) -> {
+                ShelfGridWidth.Medium
+            }
+
+            else -> {
+                ShelfGridWidth.Compact
+            }
+        }
+    val columns = shelfGridColumns(gridWidth)
+    val isWide = gridWidth != ShelfGridWidth.Compact
+
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columns),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
         modifier = Modifier.fillMaxSize(),
     ) {
-        // Hero section with shelf icon and stats
-        item {
-            ShelfHeroSection(
-                shelfId = detail.id,
-                isPrivate = detail.isPrivate,
-                bookCount = detail.bookCount,
+        item(span = { GridItemSpan(maxLineSpan) }) {
+            ShelfHero(
+                detail = detail,
+                isWide = isWide,
                 totalDuration = formatDuration(detail.totalDurationSeconds),
             )
         }
 
-        // Description section (if available)
         detail.description?.takeIf { it.isNotBlank() }?.let { description ->
-            descriptionSection(
-                description = description,
-                isExpanded = isDescriptionExpanded,
-                onToggleExpanded = { isDescriptionExpanded = !isDescriptionExpanded },
-            )
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                ShelfDescription(
+                    description = description,
+                    isExpanded = isDescriptionExpanded,
+                    onToggle = { isDescriptionExpanded = !isDescriptionExpanded },
+                )
+            }
         }
 
-        // Books section header
-        item {
-            Text(
-                text = stringResource(Res.string.shelf_books_in_shelf),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier =
-                    Modifier
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 24.dp, bottom = 8.dp),
-            )
+        item(span = { GridItemSpan(maxLineSpan) }) {
+            ShelfBooksHeader(count = detail.bookCount)
         }
 
-        // Empty state
         if (detail.books.isEmpty()) {
-            emptyBooksSection(isOwner = isOwner)
-        }
-
-        // Books list
-        items(
-            items = detail.books,
-            key = { it.id },
-        ) { book ->
-            ShelfBookItem(
-                book = book,
-                onClick = { onBookClick(book.id) },
-            )
-        }
-    }
-}
-
-/** Description length beyond which the expandable "Read more" toggle is shown. */
-private const val DESCRIPTION_EXPAND_THRESHOLD = 150
-
-/**
- * Expandable "About" description block within the shelf-detail list.
- */
-private fun LazyListScope.descriptionSection(
-    description: String,
-    isExpanded: Boolean,
-    onToggleExpanded: () -> Unit,
-) {
-    item {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 16.dp),
-        ) {
-            Text(
-                text = stringResource(Res.string.common_about),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = if (isExpanded) Int.MAX_VALUE else 3,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (description.length > DESCRIPTION_EXPAND_THRESHOLD) {
-                TextButton(
-                    onClick = onToggleExpanded,
-                    contentPadding = PaddingValues(0.dp),
-                ) {
-                    Text(if (isExpanded) "Read less" else "Read more")
-                }
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                ShelfEmptyState(isOwner = isOwner)
+            }
+        } else {
+            items(items = detail.books, key = { it.id }) { book ->
+                ShelfBookGridItem(book = book, onClick = { onBookClick(book.id) })
             }
         }
     }
 }
 
-/**
- * Empty-state block shown when the shelf has no books.
- */
-private fun LazyListScope.emptyBooksSection(isOwner: Boolean) {
-    item {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(32.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Book,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                    modifier = Modifier.size(48.dp),
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = stringResource(Res.string.common_no_items_yet, "books"),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                if (isOwner) {
-                    Text(
-                        text = stringResource(Res.string.shelf_add_books_from_the_library),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-    }
-}
-
-/**
- * Hero section with shelf icon, privacy indicator, and aggregate stats.
- */
+/** Color-blocked hero: scalloped shelf badge, name, and Books/Total stat chips. */
 @Composable
-private fun ShelfHeroSection(
-    shelfId: String,
-    isPrivate: Boolean,
-    bookCount: Int,
+private fun ShelfHero(
+    detail: ShelfDetail,
+    isWide: Boolean,
     totalDuration: String,
 ) {
-    val color = remember(shelfId) { stableColorForId(shelfId) }
-
-    Column(
+    Box(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+                .clip(RoundedCornerShape(28.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer),
     ) {
-        // Shelf icon
+        // Decorative brand "blob" bleeding off the top-right corner.
         Box(
             modifier =
                 Modifier
-                    .size(120.dp)
-                    .clip(RoundedCornerShape(24.dp))
-                    .background(color.copy(alpha = 0.15f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Default.FilterList,
-                contentDescription = null,
-                tint = color,
-                modifier = Modifier.size(48.dp),
-            )
-        }
+                    .align(Alignment.TopEnd)
+                    .offset(x = 60.dp, y = (-50).dp)
+                    .size(200.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+        )
 
-        if (isPrivate) {
-            Spacer(modifier = Modifier.height(12.dp))
+        if (isWide) {
+            Row(
+                modifier = Modifier.padding(32.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(28.dp),
+            ) {
+                ShelfBadge()
+                Column(modifier = Modifier.weight(1f)) {
+                    ShelfHeroTexts(detail = detail, totalDuration = totalDuration, center = false)
+                }
+            }
+        } else {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 28.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                ShelfBadge()
+                Spacer(Modifier.height(16.dp))
+                ShelfHeroTexts(detail = detail, totalDuration = totalDuration, center = true)
+            }
+        }
+    }
+}
+
+/** The scalloped (cookie) shelf badge with a library glyph. */
+@Composable
+private fun ShelfBadge() {
+    Box(
+        modifier =
+            Modifier
+                .size(110.dp)
+                .clip(cookieScallopShape())
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.LibraryBooks,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(46.dp),
+        )
+    }
+}
+
+/** Private indicator + title + stat chips, aligned for compact (centered) or wide (start). */
+@Composable
+private fun ShelfHeroTexts(
+    detail: ShelfDetail,
+    totalDuration: String,
+    center: Boolean,
+) {
+    Column(
+        horizontalAlignment = if (center) Alignment.CenterHorizontally else Alignment.Start,
+    ) {
+        if (detail.isPrivate) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -375,30 +350,35 @@ private fun ShelfHeroSection(
                 Icon(
                     imageVector = Icons.Default.Lock,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
                     modifier = Modifier.size(16.dp),
                 )
                 Text(
                     text = "Private",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
                 )
             }
+            Spacer(Modifier.height(6.dp))
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = detail.name,
+            style = MaterialTheme.typography.displaySmall,
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            textAlign = if (center) TextAlign.Center else TextAlign.Start,
+        )
 
-        // Stats row
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(32.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            StatItem(
+        Spacer(Modifier.height(16.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            ShelfStatChip(
                 icon = Icons.AutoMirrored.Filled.LibraryBooks,
-                value = "$bookCount",
-                label = if (bookCount == 1) "Book" else "Books",
+                value = "${detail.bookCount}",
+                label = if (detail.bookCount == 1) "Book" else "Books",
             )
-            StatItem(
+            ShelfStatChip(
                 icon = Icons.Default.Schedule,
                 value = totalDuration,
                 label = "Total",
@@ -407,117 +387,188 @@ private fun ShelfHeroSection(
     }
 }
 
-/**
- * Single stat item with icon, value, and label.
- */
+/** A filled stat pill: icon + bold value + muted label. */
 @Composable
-private fun StatItem(
+private fun ShelfStatChip(
     icon: ImageVector,
     value: String,
     label: String,
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Row(
+        modifier =
+            Modifier
+                .height(46.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(start = 14.dp, end = 18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(18.dp),
-            )
-            Text(
-                text = value,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-            )
-        }
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
         Text(
             text = label,
-            style = MaterialTheme.typography.labelSmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
 
-/**
- * List item for a book in the shelf.
- */
+/** "Books in shelf" title with a tertiary count pill. */
 @Composable
-private fun ShelfBookItem(
+private fun ShelfBooksHeader(count: Int) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.shelf_books_in_shelf),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Box(
+            modifier =
+                Modifier
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.tertiaryContainer)
+                    .defaultMinSize(minWidth = 28.dp)
+                    .height(26.dp)
+                    .padding(horizontal = 10.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "$count",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.ExtraBold,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+        }
+    }
+}
+
+/** A single book cell: square cover with title + author beneath. */
+@Composable
+private fun ShelfBookGridItem(
     book: ShelfBook,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    Surface(
+    val author = book.authorNames.joinToString(", ")
+    Column(modifier = Modifier.clickable(onClick = onClick)) {
+        BookCoverImage(
+            bookId = book.id,
+            coverPath = book.coverPath,
+            contentDescription = book.title,
+            title = book.title,
+            author = author,
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .clip(RoundedCornerShape(20.dp)),
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = book.title,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = author,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/** Empty-state block shown when the shelf has no books. */
+@Composable
+private fun ShelfEmptyState(isOwner: Boolean) {
+    Column(
         modifier =
-            modifier
+            Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 4.dp)
-                .clickable(onClick = onClick),
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                .padding(vertical = 40.dp, horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Row(
-            modifier = Modifier.padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
+        Box(
+            modifier =
+                Modifier
+                    .size(104.dp)
+                    .clip(cookieScallopShape())
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center,
         ) {
-            // Book cover
-            Box(
-                modifier =
-                    Modifier
-                        .size(80.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-                contentAlignment = Alignment.Center,
+            Icon(
+                imageVector = Icons.Default.Book,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(46.dp),
+            )
+        }
+        Spacer(Modifier.height(20.dp))
+        Text(
+            text = stringResource(Res.string.common_no_items_yet, "books"),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (isOwner) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(Res.string.shelf_add_books_from_the_library),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/** Expandable "About" description block. */
+@Composable
+private fun ShelfDescription(
+    description: String,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(Res.string.common_about),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = if (isExpanded) Int.MAX_VALUE else 3,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (description.length > DESCRIPTION_EXPAND_THRESHOLD) {
+            TextButton(
+                onClick = onToggle,
+                contentPadding = PaddingValues(0.dp),
             ) {
-                if (true) { // Always render — BookCoverImage handles server URL fallback
-                    BookCoverImage(
-                        bookId = book.id,
-                        coverPath = book.coverPath,
-                        contentDescription = book.title,
-                        contentScale = ContentScale.Crop,
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .clip(RoundedCornerShape(8.dp)),
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Default.Book,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                        modifier = Modifier.size(32.dp),
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.width(16.dp))
-
-            // Book info
-            Column(modifier = Modifier.weight(1f)) {
-                // Title
-                Text(
-                    text = book.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                // Author
-                Text(
-                    text = book.authorNames.joinToString(", "),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                Text(if (isExpanded) "Read less" else "Read more")
             }
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -25,17 +24,22 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -64,10 +68,12 @@ import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.cookieScallopShape
 import com.calypsan.listenup.client.domain.model.ShelfBook
 import com.calypsan.listenup.client.domain.model.ShelfDetail
+import com.calypsan.listenup.client.presentation.shelf.ShelfBookSort
 import com.calypsan.listenup.client.presentation.shelf.ShelfDetailUiState
 import com.calypsan.listenup.client.presentation.shelf.ShelfDetailViewModel
 import com.calypsan.listenup.client.presentation.shelf.ShelfGridWidth
 import com.calypsan.listenup.client.presentation.shelf.shelfGridColumns
+import com.calypsan.listenup.client.presentation.shelf.sortShelfBooks
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.common_about
 import listenup.composeapp.generated.resources.common_back
@@ -200,6 +206,8 @@ private fun ShelfDetailContent(
     formatDuration: (Long) -> String,
 ) {
     var isDescriptionExpanded by rememberSaveable { mutableStateOf(false) }
+    var sort by rememberSaveable { mutableStateOf(ShelfBookSort.ADDED_NEWEST) }
+    val sortedBooks = sortShelfBooks(detail.books, sort)
 
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     val gridWidth =
@@ -245,7 +253,11 @@ private fun ShelfDetailContent(
         }
 
         item(span = { GridItemSpan(maxLineSpan) }) {
-            ShelfBooksHeader(count = detail.bookCount)
+            ShelfBooksHeader(
+                sort = sort,
+                onSortChange = { sort = it },
+                showSortPill = detail.books.isNotEmpty(),
+            )
         }
 
         if (detail.books.isEmpty()) {
@@ -253,7 +265,7 @@ private fun ShelfDetailContent(
                 ShelfEmptyState(isOwner = isOwner)
             }
         } else {
-            items(items = detail.books, key = { it.id }) { book ->
+            items(items = sortedBooks, key = { it.id }) { book ->
                 ShelfBookGridItem(book = book, onClick = { onBookClick(book.id) })
             }
         }
@@ -424,9 +436,13 @@ private fun ShelfStatChip(
     }
 }
 
-/** "Books in shelf" title with a tertiary count pill. */
+/** "Books in shelf" title on the left; sort pill on the right (hidden when the shelf is empty). */
 @Composable
-private fun ShelfBooksHeader(count: Int) {
+private fun ShelfBooksHeader(
+    sort: ShelfBookSort,
+    onSortChange: (ShelfBookSort) -> Unit,
+    showSortPill: Boolean,
+) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -437,23 +453,61 @@ private fun ShelfBooksHeader(count: Int) {
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.ExtraBold,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
         )
-        Box(
-            modifier =
-                Modifier
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.tertiaryContainer)
-                    .defaultMinSize(minWidth = 28.dp)
-                    .height(26.dp)
-                    .padding(horizontal = 10.dp),
-            contentAlignment = Alignment.Center,
+        if (showSortPill) {
+            ShelfSortPill(sort = sort, onSortChange = onSortChange)
+        }
+    }
+}
+
+/** Pill showing the current [ShelfBookSort]; tap to pick another from a dropdown. */
+@Composable
+private fun ShelfSortPill(
+    sort: ShelfBookSort,
+    onSortChange: (ShelfBookSort) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        Surface(
+            onClick = { expanded = true },
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
-            Text(
-                text = "$count",
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.ExtraBold,
-                color = MaterialTheme.colorScheme.onTertiaryContainer,
-            )
+            Row(
+                modifier = Modifier.padding(start = 14.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Sort,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    text = sort.label,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            ShelfBookSort.entries.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        onSortChange(option)
+                        expanded = false
+                    },
+                    trailingIcon =
+                        if (option == sort) {
+                            { Icon(Icons.Default.Check, contentDescription = null) }
+                        } else {
+                            null
+                        },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Restyles the Shelf detail screen to Material 3 Expressive, matching the design bundle.

## What's new
- **Color-blocked hero**: scalloped shelf badge, name, and `Books` / `Total` stat chips.
- **Adaptive cover grid**: 2 / 4 / 6 columns at compact / medium / expanded widths (`shelfGridColumns`, unit-tested), square cover cells with title + author.
- **Sort pill** (`Books in shelf` header, right side): `Added · Newest` (default), `Added · Oldest`, `Title · A–Z`, `Author · A–Z`. Sort is display-only via the pure, unit-tested `sortShelfBooks`.
- **Header cleanup**: dropped the redundant count pill (the count already lives in the hero `Books` chip) and switched the title to sentence case ("Books in shelf").
- Empty state: book icon + "Add books from the library" guidance (no add button — books are added from the book/library side).

## Testing
- Unit (Kotest): `ShelfGridColumnsTest` (2/4/6 columns) + `ShelfBookSortTest` (each sort, case-insensitivity, no-author-last).
- On-device (Pixel 9 emulator, real ~1.1k-book library): populated **× {compact, expanded} × {light, dark}** + empty; sort pill default → dropdown → Title-sort re-orders and updates the label.
- Full local gate green: `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:server:test`, `:androidApp:assembleDebug`. iOS lane on CI.

Shelf detail is a pushed full-screen route (back + owner-only Edit), so the mockup's nav rail is canvas chrome, not rendered.