### PR TITLE
✨ feat(server,shared): push admin server-settings changes to clients via SSE nudge

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
@@ -69,4 +69,14 @@ sealed interface SyncControl {
     @Serializable
     @SerialName("SyncControl.ActivityChanged")
     data object ActivityChanged : SyncControl
+
+    /**
+     * Content-free broadcast nudge: server-identity settings (display name / remote URL) changed.
+     * Clients re-fetch [com.calypsan.listenup.api.InstanceService.getServerInfo] and silently update
+     * their stored remote-URL fallback — so an admin's new domain reaches connected clients without a
+     * cold start. No payload: the value travels on the existing getServerInfo probe (one source of truth).
+     */
+    @Serializable
+    @SerialName("SyncControl.ServerInfoChanged")
+    data object ServerInfoChanged : SyncControl
 }

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/SyncControlContractTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/SyncControlContractTest.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.api
+
+import com.calypsan.listenup.api.sync.SyncControl
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SyncControlContractTest :
+    FunSpec({
+        test("ServerInfoChanged round-trips on the polymorphic SyncControl surface") {
+            val original: SyncControl = SyncControl.ServerInfoChanged
+            val json = contractJson.encodeToString(SyncControl.serializer(), original)
+            val decoded = contractJson.decodeFromString(SyncControl.serializer(), json)
+            decoded shouldBe SyncControl.ServerInfoChanged
+        }
+
+        test("ServerInfoChanged encodes its stable discriminator") {
+            val json = contractJson.encodeToString(SyncControl.serializer(), SyncControl.ServerInfoChanged)
+            json.contains("SyncControl.ServerInfoChanged") shouldBe true
+        }
+    })

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/AdminSettingsServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/AdminSettingsServiceImpl.kt
@@ -7,8 +7,10 @@ import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.error.AdminError
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.settings.ServerSettingsRepository
+import com.calypsan.listenup.server.sync.ChangeBus
 
 /** Max length for the operator-set server name. */
 private const val MAX_SERVER_NAME = 100
@@ -23,10 +25,12 @@ private const val MAX_REMOTE_URL = 2048
  */
 class AdminSettingsServiceImpl(
     private val settings: ServerSettingsRepository,
+    private val changeBus: ChangeBus,
     private val principal: PrincipalProvider = PrincipalProvider.None,
 ) : AdminSettingsService {
     /** Returns a copy scoped to the given [provider]. Route handlers call this per-request. */
-    fun copyWith(provider: PrincipalProvider): AdminSettingsServiceImpl = AdminSettingsServiceImpl(settings, provider)
+    fun copyWith(provider: PrincipalProvider): AdminSettingsServiceImpl =
+        AdminSettingsServiceImpl(settings, changeBus, provider)
 
     override suspend fun getServerSettings(): AppResult<AdminServerSettings> {
         requireAdmin()?.let { return it }
@@ -35,17 +39,23 @@ class AdminSettingsServiceImpl(
 
     override suspend fun updateServerSettings(patch: AdminServerSettingsPatch): AppResult<AdminServerSettings> {
         requireAdmin()?.let { return it }
+        var changed = false
         patch.serverName?.let { name ->
             val trimmed = name.trim()
             if (trimmed.isBlank() || trimmed.length > MAX_SERVER_NAME) {
                 return AppResult.Failure(AdminError.InvalidInput())
             }
             settings.setServerName(trimmed)
+            changed = true
         }
         patch.remoteUrl?.let { url ->
             if (url.length > MAX_REMOTE_URL) return AppResult.Failure(AdminError.InvalidInput())
             settings.setRemoteUrl(url)
+            changed = true
         }
+        // Nudge every connected client to re-fetch getServerInfo so an admin's new name/remote URL
+        // reaches them without a cold start. Content-free broadcast — carries no per-user data.
+        if (changed) changeBus.broadcastControl(SyncControl.ServerInfoChanged)
         return AppResult.Success(current())
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -115,7 +115,7 @@ fun authModule(config: ApplicationConfig): Module =
             )
         }
 
-        single { AdminSettingsServiceImpl(settings = get()) }
+        single { AdminSettingsServiceImpl(settings = get(), changeBus = get()) }
         single<AdminSettingsService> { get<AdminSettingsServiceImpl>() }
 
         single { InviteCodeGenerator() }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/AdminSettingsServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/AdminSettingsServiceImplTest.kt
@@ -9,10 +9,13 @@ import com.calypsan.listenup.api.error.AdminError
 import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPrincipal
 import com.calypsan.listenup.server.settings.ServerSettingsRepository
+import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import app.cash.turbine.test
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -42,8 +45,10 @@ class AdminSettingsServiceImplTest :
             withInMemoryDatabase {
                 runTest {
                     val svc =
-                        AdminSettingsServiceImpl(ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN))
-                            .copyWith(principalFor("root1", UserRole.ROOT))
+                        AdminSettingsServiceImpl(
+                            ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN),
+                            ChangeBus(),
+                        ).copyWith(principalFor("root1", UserRole.ROOT))
                     val settings = svc.getServerSettings().shouldSucceed()
                     settings.serverName shouldBe ServerIdentity.NAME
                     settings.remoteUrl.shouldBeNull()
@@ -56,8 +61,10 @@ class AdminSettingsServiceImplTest :
             withInMemoryDatabase {
                 runTest {
                     val svc =
-                        AdminSettingsServiceImpl(ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN))
-                            .copyWith(principalFor("a1", UserRole.ADMIN))
+                        AdminSettingsServiceImpl(
+                            ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN),
+                            ChangeBus(),
+                        ).copyWith(principalFor("a1", UserRole.ADMIN))
                     val updated =
                         svc
                             .updateServerSettings(
@@ -79,8 +86,10 @@ class AdminSettingsServiceImplTest :
             withInMemoryDatabase {
                 runTest {
                     val svc =
-                        AdminSettingsServiceImpl(ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN))
-                            .copyWith(principalFor("m1", UserRole.MEMBER))
+                        AdminSettingsServiceImpl(
+                            ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN),
+                            ChangeBus(),
+                        ).copyWith(principalFor("m1", UserRole.MEMBER))
                     svc.getServerSettings().shouldFail<AuthError.PermissionDenied>()
                 }
             }
@@ -91,8 +100,10 @@ class AdminSettingsServiceImplTest :
             withInMemoryDatabase {
                 runTest {
                     val svc =
-                        AdminSettingsServiceImpl(ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN))
-                            .copyWith(principalFor("root1", UserRole.ROOT))
+                        AdminSettingsServiceImpl(
+                            ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN),
+                            ChangeBus(),
+                        ).copyWith(principalFor("root1", UserRole.ROOT))
                     svc
                         .updateServerSettings(AdminServerSettingsPatch(serverName = "   "))
                         .shouldFail<AdminError.InvalidInput>()
@@ -105,7 +116,7 @@ class AdminSettingsServiceImplTest :
             withInMemoryDatabase {
                 runTest {
                     val repo = ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN)
-                    val svc = AdminSettingsServiceImpl(repo).copyWith(principalFor("root1", UserRole.ROOT))
+                    val svc = AdminSettingsServiceImpl(repo, ChangeBus()).copyWith(principalFor("root1", UserRole.ROOT))
 
                     // first set a URL
                     svc.updateServerSettings(AdminServerSettingsPatch(remoteUrl = "https://example.com")).shouldSucceed()
@@ -116,6 +127,47 @@ class AdminSettingsServiceImplTest :
                     svc.updateServerSettings(AdminServerSettingsPatch(remoteUrl = "")).shouldSucceed()
                     val cleared = svc.getServerSettings().shouldSucceed()
                     cleared.remoteUrl.shouldBeNull()
+                }
+            }
+        }
+
+        // (f) a successful change broadcasts a content-free ServerInfoChanged nudge to all clients
+        test("updateServerSettings broadcasts ServerInfoChanged on a successful change") {
+            withInMemoryDatabase {
+                runTest {
+                    val bus = ChangeBus()
+                    val svc =
+                        AdminSettingsServiceImpl(
+                            ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN),
+                            bus,
+                        ).copyWith(principalFor("a1", UserRole.ADMIN))
+
+                    bus.subscribeControl().test {
+                        svc.updateServerSettings(AdminServerSettingsPatch(remoteUrl = "https://new.example.com")).shouldSucceed()
+                        val frame = awaitItem()
+                        frame.control shouldBe SyncControl.ServerInfoChanged
+                        frame.userId shouldBe ChangeBus.BROADCAST
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            }
+        }
+
+        // (g) a no-op patch (no fields) writes nothing and broadcasts nothing
+        test("updateServerSettings with an empty patch broadcasts no nudge") {
+            withInMemoryDatabase {
+                runTest {
+                    val bus = ChangeBus()
+                    val svc =
+                        AdminSettingsServiceImpl(
+                            ServerSettingsRepository(this@withInMemoryDatabase, default = RegistrationPolicy.OPEN),
+                            bus,
+                        ).copyWith(principalFor("a1", UserRole.ADMIN))
+
+                    bus.subscribeControl().test {
+                        svc.updateServerSettings(AdminServerSettingsPatch()).shouldSucceed()
+                        expectNoEvents()
+                    }
                 }
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -25,6 +25,7 @@ class SyncEventDispatcher(
     private val onUserDeleted: suspend (reason: String?) -> Unit = {},
     private val onActiveSessionsChanged: () -> Unit = {},
     private val onActivityChanged: () -> Unit = {},
+    private val onServerInfoChanged: suspend () -> Unit = {},
 ) {
     /** Route a parsed SSE frame: control events, data events, or no-op for missing event lines. */
     suspend fun handle(frame: ParsedSseFrame) {
@@ -76,6 +77,11 @@ class SyncEventDispatcher(
             SyncControl.ActivityChanged -> {
                 logger.debug { "activity nudge" }
                 onActivityChanged()
+            }
+
+            SyncControl.ServerInfoChanged -> {
+                logger.debug { "server-info nudge; re-fetching getServerInfo" }
+                onServerInfoChanged()
             }
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -46,6 +46,7 @@ import com.calypsan.listenup.client.data.repository.DefaultBookAvailability
 import com.calypsan.listenup.client.data.repository.SseServerReachability
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.BookAvailability
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.repository.ServerReachability
@@ -179,6 +180,10 @@ val clientSyncRenovationModule =
                 // The server's content-free activity nudge pings the shared signal so the activity
                 // feed re-fetches its ACL-filtered RPC page.
                 onActivityChanged = { get<ActivityRefreshSignal>().ping() },
+                // The server's content-free server-info nudge (admin changed name / remote URL):
+                // re-fetch getServerInfo, whose persistRemoteUrl side-effect updates the stored
+                // remote-URL fallback so an admin's new domain reaches us without a cold start.
+                onServerInfoChanged = { get<InstanceRepository>().getServerInfo(forceRefresh = true) },
             )
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
@@ -183,6 +183,34 @@ class SyncEventDispatcherTest :
             }
         }
 
+        test("control: SyncControl.ServerInfoChanged invokes onServerInfoChanged") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var refreshed = false
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = ClientSyncDomainRegistry(),
+                        queue =
+                            PendingOperationQueue(
+                                dao = db.pendingOperationV2Dao(),
+                                sender = PendingOperationSender { AppResult.Success(Unit) },
+                            ),
+                        state = SyncEngineState(),
+                        cursorAdvance = { _, _ -> },
+                        onServerInfoChanged = { refreshed = true },
+                    )
+                val frame =
+                    ParsedSseFrame(
+                        id = null,
+                        event = "control",
+                        data = contractJson.encodeToString(SyncControl.serializer(), SyncControl.ServerInfoChanged),
+                    )
+                dispatcher.handle(frame)
+                refreshed shouldBe true
+                db.close()
+            }
+        }
+
         test("control: SyncControl.UserDeleted invokes onUserDeleted with the reason") {
             runTest {
                 val db = createInMemoryTestDatabase()

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -557,7 +557,7 @@
     <string name="settings_view_thirdparty_licenses">View third-party licenses</string>
     <string name="settings_you_can_redownload_books_anytime">You can re-download books anytime.</string>
     <string name="shelf_add_books_from_the_library">Add books from the library</string>
-    <string name="shelf_books_in_shelf">Books in Shelf</string>
+    <string name="shelf_books_in_shelf">Books in shelf</string>
     <string name="shelf_delete_shelf">Delete Shelf</string>
     <string name="shelf_description_optional">Description (optional)</string>
     <string name="shelf_edit_shelf">Edit shelf</string>


### PR DESCRIPTION
## Summary
Follow-up to the server-reconnection work (#447). When an admin changes server settings (display name / **remote URL**), the server now broadcasts a content-free `SyncControl.ServerInfoChanged` nudge over the SSE firehose. Every connected client re-fetches `getServerInfo`, whose `persistRemoteUrl` side-effect silently updates its stored remote-URL fallback — so an admin's new domain reaches connected clients without a cold start. No user-facing surface.

- **Contract** — add `SyncControl.ServerInfoChanged` data object (`@SerialName "SyncControl.ServerInfoChanged"`), mirroring `ActiveSessionsChanged`.
- **Server** — `AdminSettingsServiceImpl` takes `ChangeBus` (threaded through `copyWith`); broadcasts `ServerInfoChanged` only when a field was actually written.
- **Client** — `SyncEventDispatcher` gains an `onServerInfoChanged` branch; DI wires it to `InstanceRepository.getServerInfo(forceRefresh = true)`.

One source of truth: the nudge carries no payload — the value travels on the existing `getServerInfo` probe.

## Test Plan
- [x] `:contract:jvmTest` — `ServerInfoChanged` round-trips + stable discriminator
- [x] `:server:test` — broadcasts exactly one nudge on a real change; empty patch broadcasts none (Turbine)
- [x] `:sharedLogic:jvmTest` — a `ServerInfoChanged` control frame invokes the dispatcher lambda
- [x] Full gates green: `spotlessCheck detekt :contract:jvmTest :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`