### PR TITLE
✨ feat(server): replace kfswatch with a native recursive WatchService watcher (fixes real-time file-add)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,7 +78,6 @@ flyway = "12.8.1"
 hikari = "7.0.2"
 password4j = "1.8.4"
 konsist = "0.17.3"
-kfswatch = "1.4.0"
 micrometer = "1.17.0"
 ksp-symbol-processing-api = "2.3.9" # matches project ksp version — bump in lockstep with `ksp`
 kctfork = "0.13.0" # dev.zacsweers.kctfork — maintained fork of kotlin-compile-testing with KSP support
@@ -244,8 +243,6 @@ markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-
 kmpalette-core = { module = "com.kmpalette:kmpalette-core", version.ref = "kmpalette" }
 # Konsist — architectural assertions
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
-# kfswatch — KMP filesystem watcher (inotify / FSEvents / ReadDirectoryChangesW)
-kfswatch = { module = "io.github.irgaly.kfswatch:kfswatch", version.ref = "kfswatch" }
 # Micrometer — metrics for Prometheus
 micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp-symbol-processing-api" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -77,9 +77,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.slf4j)
     implementation(libs.micrometer.core)
 
-    // Phase 2 scanner — filesystem watching across Linux/macOS/Windows.
-    implementation(libs.kfswatch)
-
     // Ktor HTTP client — used by AudibleClient to call the Audible catalog API.
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.cio)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -104,6 +104,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.dto.CreateLibraryRequest
 import com.calypsan.listenup.server.db.DatabaseHandle
 import com.calypsan.listenup.server.db.resolveListenupHome
+import com.calypsan.listenup.server.scanner.RescanScheduler
 import com.calypsan.listenup.server.scanner.ScanOrchestrator
 import com.calypsan.listenup.server.scanner.WatcherSupervisorPort
 import com.calypsan.listenup.server.scanner.metadata.MetadataPrecedence
@@ -119,6 +120,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
+import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.autohead.AutoHeadResponse
 import io.ktor.server.plugins.partialcontent.PartialContent
@@ -132,6 +134,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import kotlinx.rpc.krpc.ktor.server.Krpc
@@ -611,18 +614,27 @@ private fun Application.startBackgroundTasks(
     val orphanImageCleanupTask by inject<OrphanImageCleanupTask>()
     orphanImageCleanupTask.start(scope)
 
+    val rescanOnStartup = environment.config.rescanOnStartup()
     scope.launch {
         runCatching {
             bootstrapLibraries(
                 libraryAdminService = libraryAdminService,
                 scanOrchestrator = orchestrator,
                 libraryPath = libraryPath?.toString(),
+                rescanOnStartup = rescanOnStartup,
             )
         }.onFailure { e ->
             if (e is kotlinx.coroutines.CancellationException) throw e
             logger.error(e) { "library bootstrap failed — server keeps running" }
         }
     }
+
+    RescanScheduler(
+        scope = scope,
+        interval = environment.config.periodicRescanInterval(),
+        libraryIds = { orchestrator.registeredLibraryIds() },
+        rescan = { orchestrator.scanLibraryAsync(it) },
+    ).start()
 
     // mDNS advertisement — best-effort, non-fatal. Resolve the persistent instance id, then start the
     // advertiser; register its stop on shutdown. A failure here must never break startup — manual
@@ -652,6 +664,16 @@ private fun Application.startBackgroundTasks(
     }
 }
 
+private fun ApplicationConfig.rescanOnStartup(): Boolean =
+    propertyOrNull("scan.rescanOnStartup")?.getString()?.toBoolean() ?: true
+
+private fun ApplicationConfig.periodicRescanInterval(): Duration =
+    propertyOrNull("scan.periodicRescanInterval")
+        ?.getString()
+        ?.takeIf { it.isNotBlank() }
+        ?.let { runCatching { Duration.parse(it) }.getOrNull() }
+        ?: Duration.ZERO
+
 // The synthetic ROOT principal used by [bootstrapLibraries]. Startup library bootstrap
 // has no signed-in caller — it is the system acting as administrator — so it binds the
 // admin-gated LibraryAdminService to this principal to pass the structural-op gate.
@@ -666,7 +688,9 @@ private val SYSTEM_BOOTSTRAP_PRINCIPAL =
  * Rules (Task 18):
  *  - If libraries already exist → register each with [scanOrchestrator] via
  *    [ScanOrchestrator.onLibraryAdded] so the watcher and scanner bundle are
- *    warmed up. No scan is triggered.
+ *    warmed up. When [rescanOnStartup] is true each library is also kicked off
+ *    via [ScanOrchestrator.scanLibraryAsync] to catch changes made while the
+ *    server was down.
  *  - If no libraries exist and [libraryPath] is non-null → create a single
  *    default "My Library" pointing at that path. [LibraryAdminServiceImpl.createLibrary]
  *    internally calls [ScanOrchestrator.onLibraryAdded], so we don't need to.
@@ -674,17 +698,18 @@ private val SYSTEM_BOOTSTRAP_PRINCIPAL =
  *    (e.g. a test fixture seeding the DB) inserts the same root_path between
  *    our `listLibraries` check and the `createLibrary` insert. On any error,
  *    we re-read the table and call `onLibraryAdded` for whatever ended up there.
+ *    When [rescanOnStartup] is true the library is scanned immediately after.
  *  - If no libraries exist and [libraryPath] is null → log and return; the
  *    operator must create a library via the LibraryAdmin REST surface.
  *
- * **No auto-scan is ever triggered.** Scans are user-initiated (POST /scan) or
- * file-watcher-triggered. This keeps startup fast and avoids racing against
- * test fixtures that insert their own library rows.
+ * Startup scans are gated by [rescanOnStartup] so tests can opt out and avoid
+ * racing scanner coroutines against test fixture assertions.
  */
 internal suspend fun bootstrapLibraries(
     libraryAdminService: LibraryAdminService,
     scanOrchestrator: ScanOrchestrator,
     libraryPath: String?,
+    rescanOnStartup: Boolean = true,
 ) {
     // Startup bootstrap is a system operation — it creates the default library from the
     // env var before any user has signed in. Scope the admin-gated service to a synthetic
@@ -700,11 +725,14 @@ internal suspend fun bootstrapLibraries(
     when {
         existing.isNotEmpty() -> {
             logger.info { "bootstrap: ${existing.size} library(s) already configured; env var ignored" }
-            existing.forEach { library -> scanOrchestrator.onLibraryAdded(library) }
+            existing.forEach { library ->
+                scanOrchestrator.onLibraryAdded(library)
+                if (rescanOnStartup) scanOrchestrator.scanLibraryAsync(library.id)
+            }
         }
 
         libraryPath != null -> {
-            bootstrapCreateDefaultLibrary(service, scanOrchestrator, libraryPath)
+            bootstrapCreateDefaultLibrary(service, scanOrchestrator, libraryPath, rescanOnStartup)
         }
 
         else -> {
@@ -712,6 +740,27 @@ internal suspend fun bootstrapLibraries(
                 "bootstrap: no libraries and no env var; awaiting client onboarding via LibraryAdminService.createLibrary"
             }
         }
+    }
+}
+
+/**
+ * Re-reads the library table after a failed [bootstrapCreateDefaultLibrary] attempt
+ * and registers whatever ended up there (handles the concurrent-insert race). When
+ * [rescanOnStartup] is true each library is also kicked off via
+ * [ScanOrchestrator.scanLibraryAsync].
+ */
+private suspend fun bootstrapRecheckAndRegister(
+    libraryAdminService: LibraryAdminService,
+    scanOrchestrator: ScanOrchestrator,
+    rescanOnStartup: Boolean,
+) {
+    val recheck = libraryAdminService.listLibraries()
+    if (recheck is AppResult.Success && recheck.data.isNotEmpty()) {
+        logger.info {
+            "bootstrap: found ${recheck.data.size} library(s) after re-check; registering with orchestrator"
+        }
+        recheck.data.forEach { library -> scanOrchestrator.onLibraryAdded(library) }
+        if (rescanOnStartup) recheck.data.forEach { library -> scanOrchestrator.scanLibraryAsync(library.id) }
     }
 }
 
@@ -726,6 +775,7 @@ private suspend fun bootstrapCreateDefaultLibrary(
     libraryAdminService: LibraryAdminService,
     scanOrchestrator: ScanOrchestrator,
     libraryPath: String,
+    rescanOnStartup: Boolean = true,
 ) {
     logger.info { "bootstrap: no libraries configured; creating default from env var path=$libraryPath" }
     val created =
@@ -737,6 +787,7 @@ private suspend fun bootstrapCreateDefaultLibrary(
             .getOrNull()
     if (created is AppResult.Success) {
         logger.info { "bootstrap: default library created id=${created.data.id.value}" }
+        if (rescanOnStartup) scanOrchestrator.scanLibraryAsync(created.data.id)
     } else {
         // Either createLibrary returned Failure or threw — re-check the DB.
         // A concurrent insert (test fixture race) may have already added a library.
@@ -745,12 +796,6 @@ private suspend fun bootstrapCreateDefaultLibrary(
         } else {
             logger.warn { "bootstrap: createLibrary threw — re-checking for concurrent inserts" }
         }
-        val recheck = libraryAdminService.listLibraries()
-        if (recheck is AppResult.Success && recheck.data.isNotEmpty()) {
-            logger.info {
-                "bootstrap: found ${recheck.data.size} library(s) after re-check; registering with orchestrator"
-            }
-            recheck.data.forEach { library -> scanOrchestrator.onLibraryAdded(library) }
-        }
+        bootstrapRecheckAndRegister(libraryAdminService, scanOrchestrator, rescanOnStartup)
     }
 }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -334,7 +334,7 @@ fun Application.module() {
  * `testApplication` teardown. Order: unmount watchers (close native FS handles), cancel the
  * background-task [applicationScope] (cleanup loops, the BookPersister scan-result collector,
  * bootstrap), then close the Hikari pool. Each step is best-effort and CANCELS rather than
- * joins: joining the kfswatch native read would time out Ktor's application disposal. Ktor
+ * joins: joining the watcher's blocking read would time out Ktor's application disposal. Ktor
  * drains in-flight requests before firing [ApplicationStopped], so nothing is using the pool.
  */
 private fun Application.installGracefulShutdown(applicationScope: CoroutineScope) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/RescanScheduler.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/RescanScheduler.kt
@@ -1,0 +1,50 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.core.LibraryId
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Never-Stranded backstop: periodically full-rescans every registered library so
+ * anything the live watcher missed (kernel OVERFLOW, a dropped mount, downtime)
+ * is reconciled. Reuses the single-flight scan trigger, so a periodic pass that
+ * collides with an in-flight scan is simply skipped.
+ *
+ * A non-positive [interval] disables the loop (start returns null).
+ */
+internal class RescanScheduler(
+    private val scope: CoroutineScope,
+    private val interval: Duration,
+    private val libraryIds: suspend () -> List<LibraryId>,
+    private val rescan: suspend (LibraryId) -> Unit,
+) {
+    fun start(): Job? {
+        if (interval <= Duration.ZERO) {
+            logger.info { "periodic rescan disabled (interval <= 0)" }
+            return null
+        }
+        logger.info { "periodic rescan enabled every $interval" }
+        return scope.launch {
+            while (isActive) {
+                delay(interval)
+                for (id in libraryIds()) {
+                    try {
+                        rescan(id)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn(e) { "periodic rescan failed for library ${id.value} — continuing" }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
@@ -204,6 +204,9 @@ internal class ScanOrchestrator(
             .mapNotNull { it.scanner.lastResult() }
             .maxByOrNull { it.durationMs }
 
+    /** Snapshot of every library currently registered with a scanner bundle. */
+    fun registeredLibraryIds(): List<LibraryId> = bundlesByLibrary.keys.toList()
+
     private fun onFileChanged(
         libraryId: LibraryId,
         subtreePath: Path,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
@@ -2,9 +2,6 @@ package com.calypsan.listenup.server.scanner.watcher
 
 import com.calypsan.listenup.server.scanner.inference.MultiDiscPattern
 import com.calypsan.listenup.server.scanner.inference.SkipRules
-import io.github.irgaly.kfswatch.KfsDirectoryWatcher
-import io.github.irgaly.kfswatch.KfsDirectoryWatcherEvent
-import io.github.irgaly.kfswatch.KfsEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -29,11 +26,10 @@ private val logger = KotlinLogging.logger {}
  *
  * Implementation notes:
  *
- *  - **Recursive watching is opt-in.** kfswatch's API watches a fixed list
- *    of directories — it doesn't recurse on its own. We walk the library
- *    tree at [start] and register every non-skipped directory. New
- *    directories created during runtime are registered when their `Create`
- *    event arrives.
+ *  - **Recursive watching.** The watcher engine tracks an explicit set of
+ *    directories rather than recursing globally. We walk the library tree at
+ *    [start] and register every non-skipped directory; directories created at
+ *    runtime are picked up when their `Create` event arrives.
  *  - **Per-book coalescing.** Multiple events under the same book root
  *    within the [debouncer]'s settle window collapse to a single emission.
  *    Implementation: a map from book root → pending emission [Job]; a new
@@ -57,7 +53,7 @@ internal class FolderWatcher(
     private val scope: CoroutineScope,
     private val debouncer: StableSizeDebouncer = StableSizeDebouncer(),
     private val skipRules: (Path) -> Boolean = SkipRules::shouldSkip,
-    private val watcher: KfsDirectoryWatcher = KfsDirectoryWatcher(scope),
+    private val watcher: LowLevelDirectoryWatcher = RecursiveDirectoryWatcher(scope),
 ) {
     private val emissions = MutableSharedFlow<Path>(extraBufferCapacity = 64)
     val events: Flow<Path> = emissions.asSharedFlow()
@@ -109,18 +105,19 @@ internal class FolderWatcher(
         return collected
     }
 
-    private suspend fun handle(event: KfsDirectoryWatcherEvent) {
+    private suspend fun handle(event: DirectoryWatchEvent) {
         val fullPath = Path.of(event.targetDirectory).resolve(event.path)
         if (skipRules(fullPath)) return
 
-        // A newly-created directory needs to be added to the watch set so
-        // events on its children surface. kfswatch does not recurse for us.
-        if (event.event == KfsEvent.Create && Files.isDirectory(fullPath)) {
+        // A newly-created directory needs to be added to the watch set so events on
+        // its children surface. The recursive watcher already registers new subtrees
+        // itself, so this is a no-op guard kept for clarity of intent.
+        if (event.kind == DirectoryWatchEventKind.Create && Files.isDirectory(fullPath)) {
             watcher.add(fullPath.toString())
         }
 
         val bookRoot = computeBookRoot(fullPath)
-        scheduleEmission(bookRoot, fullPath, isDelete = event.event == KfsEvent.Delete)
+        scheduleEmission(bookRoot, fullPath, isDelete = event.kind == DirectoryWatchEventKind.Delete)
     }
 
     private fun scheduleEmission(

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/LowLevelDirectoryWatcher.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/LowLevelDirectoryWatcher.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import kotlinx.coroutines.flow.Flow
+
+/** A filesystem change under a watched directory, normalized across platforms. */
+internal data class DirectoryWatchEvent(
+    val targetDirectory: String,
+    val path: String,
+    val kind: DirectoryWatchEventKind,
+)
+
+/** The three change kinds the watcher surfaces (platform events collapse to these). */
+internal enum class DirectoryWatchEventKind { Create, Modify, Delete }
+
+/**
+ * Minimal directory-watch seam that [FolderWatcher] depends on, decoupling it
+ * from any concrete watcher engine.
+ *
+ * Replaces kfswatch's `KfsDirectoryWatcher`, whose hard `FileWatcherMaxTargets = 63`
+ * cap silently dropped every `add()` past the 63rd directory — so on a large
+ * library only the first 63 directories were ever watched.
+ */
+internal interface LowLevelDirectoryWatcher {
+    /** Hot stream of changes across every added directory. */
+    val onEventFlow: Flow<DirectoryWatchEvent>
+
+    /** Begins watching [directory] (non-recursive; callers add each directory). */
+    suspend fun add(directory: String)
+
+    /** Releases the underlying OS handle and stops the event loop. */
+    suspend fun close()
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/RecursiveDirectoryWatcher.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/RecursiveDirectoryWatcher.kt
@@ -1,0 +1,158 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import java.io.IOException
+import java.nio.file.ClosedWatchServiceException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_DELETE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.StandardWatchEventKinds.OVERFLOW
+import java.nio.file.WatchEvent
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+import java.util.concurrent.ConcurrentHashMap
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * JVM-native recursive directory watcher over [java.nio.file.WatchService].
+ *
+ * Linux = inotify, Windows = ReadDirectoryChangesW (both event-driven, no
+ * artificial cap — bounded only by `fs.inotify.max_user_watches`). macOS falls
+ * back to the JDK's polling WatchService (~10s latency); a native FSEvents path
+ * is a deferred upgrade.
+ *
+ * Improvements over kfswatch:
+ *  - **No 63-target cap** — the whole library tree is watchable.
+ *  - **New-subdir contents surfaced.** When a directory is created, it is
+ *    registered AND walked, emitting synthetic [DirectoryWatchEventKind.Create]
+ *    events for files already inside it — closing the race where a freshly-copied
+ *    book's file lands before the watch attaches and would otherwise be invisible.
+ *  - **OVERFLOW recovery.** A kernel event-buffer overrun re-emits a Create for
+ *    the affected directory so its subtree is re-walked, rather than silently
+ *    dropping events.
+ */
+internal class RecursiveDirectoryWatcher(
+    private val scope: CoroutineScope,
+    private val watchService: WatchService = FileSystems.getDefault().newWatchService(),
+) : LowLevelDirectoryWatcher {
+    private val emissions = MutableSharedFlow<DirectoryWatchEvent>(extraBufferCapacity = 256)
+    override val onEventFlow: Flow<DirectoryWatchEvent> = emissions.asSharedFlow()
+
+    private val keyToDir = ConcurrentHashMap<WatchKey, Path>()
+
+    private val loopLock = Any()
+
+    @Volatile private var loop: Job? = null
+
+    /**
+     * Begins watching [directory]. Registration is concurrency-safe; the single
+     * consumer loop is started exactly once (guarded by [loopLock]) on the first add.
+     */
+    override suspend fun add(directory: String) {
+        register(Path.of(directory))
+        synchronized(loopLock) {
+            if (loop == null) loop = startLoop()
+        }
+    }
+
+    private fun register(dir: Path) {
+        val key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)
+        keyToDir[key] = dir
+    }
+
+    private fun startLoop(): Job =
+        scope.launch(Dispatchers.IO) {
+            while (isActive) {
+                val key =
+                    try {
+                        runInterruptible { watchService.take() }
+                    } catch (_: ClosedWatchServiceException) {
+                        return@launch
+                    }
+                val dir = keyToDir[key]
+                if (dir == null) {
+                    key.reset()
+                    continue
+                }
+                for (event in key.pollEvents()) {
+                    when (event.kind()) {
+                        OVERFLOW -> {
+                            // Events for this dir were lost — re-emit it so the subtree re-walks.
+                            emissions.emit(
+                                DirectoryWatchEvent(dir.toString(), dir.toString(), DirectoryWatchEventKind.Create),
+                            )
+                        }
+
+                        ENTRY_CREATE -> {
+                            emitChild(dir, event, DirectoryWatchEventKind.Create)
+                        }
+
+                        ENTRY_MODIFY -> {
+                            emitChild(dir, event, DirectoryWatchEventKind.Modify)
+                        }
+
+                        ENTRY_DELETE -> {
+                            emitChild(dir, event, DirectoryWatchEventKind.Delete)
+                        }
+                    }
+                }
+                if (!key.reset()) keyToDir.remove(key)
+            }
+        }
+
+    private suspend fun emitChild(
+        dir: Path,
+        event: WatchEvent<*>,
+        kind: DirectoryWatchEventKind,
+    ) {
+        val name = event.context() as? Path ?: return
+        val child = dir.resolve(name)
+        emissions.emit(DirectoryWatchEvent(dir.toString(), child.toString(), kind))
+        if (kind == DirectoryWatchEventKind.Create && Files.isDirectory(child)) {
+            registerNewSubtree(child)
+        }
+    }
+
+    /**
+     * Registers [root] and every existing descendant directory, emitting synthetic
+     * Create events for files already present (they predate the watch, so no native
+     * event will ever fire for them).
+     */
+    private suspend fun registerNewSubtree(root: Path) {
+        val entries =
+            try {
+                Files.walk(root).use { it.toList() }
+            } catch (e: IOException) {
+                logger.warn(e) { "walk failed for new subtree $root — skipping" }
+                return
+            }
+        for (p in entries) {
+            if (Files.isDirectory(p)) {
+                runCatching { register(p) }
+                    .onFailure { logger.warn(it) { "register failed for $p" } }
+            } else {
+                val parent = p.parent ?: continue
+                emissions.emit(DirectoryWatchEvent(parent.toString(), p.toString(), DirectoryWatchEventKind.Create))
+            }
+        }
+    }
+
+    override suspend fun close() {
+        runCatching { watchService.close() } // unblocks take() with ClosedWatchServiceException
+        loop?.cancelAndJoin()
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncer.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncer.kt
@@ -12,8 +12,8 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Uniform "done writing" detector across Linux/macOS/Windows.
  *
- * kfswatch translates platform events into a uniform Create/Modify/Delete
- * model, but the *semantics* of those events differ:
+ * The recursive WatchService watcher translates platform events into a uniform
+ * Create/Modify/Delete model, but the *semantics* of those events differ:
  *
  *  - **Linux** (inotify): `IN_CLOSE_WRITE` fires once after the writer's
  *    fd is closed — already a "done writing" signal.

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/WatcherSupervisor.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/watcher/WatcherSupervisor.kt
@@ -100,7 +100,7 @@ internal class WatcherSupervisor(
 
     /**
      * Stops and removes EVERY active watcher across all libraries. Called on server
-     * shutdown so native kfswatch handles are released deterministically — it *closes*
+     * shutdown so the native WatchService handles are released deterministically — it *closes*
      * each handle (releasing the native FS handle) rather than joining its event loop,
      * which would block disposal. Idempotent: a second call is a no-op.
      */

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -72,3 +72,14 @@ seed {
     profile = ""
     profile = ${?LISTENUP_SEED_PROFILE}
 }
+
+scan {
+    # Re-walk every library once on startup to catch changes made while the server was down.
+    rescanOnStartup = true
+    rescanOnStartup = ${?LISTENUP_SCAN_RESCAN_ON_STARTUP}
+
+    # Periodic full-rescan backstop interval (Kotlin Duration format, e.g. "6h", "30m").
+    # "0" or blank disables the periodic loop; the live watcher still runs.
+    periodicRescanInterval = "6h"
+    periodicRescanInterval = ${?LISTENUP_SCAN_PERIODIC_RESCAN_INTERVAL}
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/RescanSchedulerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/RescanSchedulerTest.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.core.LibraryId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class RescanSchedulerTest :
+    FunSpec({
+
+        test("rescans every registered library once per interval") {
+            runTest {
+                val calls = AtomicInteger(0)
+                val scheduler =
+                    RescanScheduler(
+                        scope = backgroundScope,
+                        interval = 1.hours,
+                        libraryIds = { listOf(LibraryId("lib-a"), LibraryId("lib-b")) },
+                        rescan = { calls.incrementAndGet() },
+                    )
+                val job = scheduler.start()
+                testScheduler.advanceTimeBy(1.hours + 1.minutes)
+                testScheduler.runCurrent()
+                calls.get() shouldBe 2 // two libraries, one interval elapsed
+                job!!.cancelAndJoin()
+            }
+        }
+
+        test("a failing rescan does not kill the loop") {
+            runTest {
+                val calls = AtomicInteger(0)
+                val scheduler =
+                    RescanScheduler(
+                        scope = backgroundScope,
+                        interval = 1.hours,
+                        libraryIds = { listOf(LibraryId("lib-a")) },
+                        rescan = {
+                            calls.incrementAndGet()
+                            error("boom")
+                        },
+                    )
+                val job = scheduler.start()
+                testScheduler.advanceTimeBy(2.hours + 1.minutes)
+                testScheduler.runCurrent()
+                calls.get() shouldBe 2 // survived the first failure, fired again next interval
+                job!!.cancelAndJoin()
+            }
+        }
+
+        test("a non-positive interval disables the loop") {
+            runTest {
+                val scheduler =
+                    RescanScheduler(
+                        scope = backgroundScope,
+                        interval = kotlin.time.Duration.ZERO,
+                        libraryIds = { listOf(LibraryId("lib-a")) },
+                        rescan = { error("should never run") },
+                    )
+                scheduler.start() shouldBe null
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcherTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcherTest.kt
@@ -30,8 +30,6 @@ import kotlin.time.Duration.Companion.seconds
  * **Test pattern:** the directory tree is created BEFORE the watcher is
  * started, so the initial walk-and-register picks up every directory.
  * Tests then write/modify files in the existing tree to trigger events.
- * This sidesteps the inherent race between "newly-created directory" and
- * "kfswatch finishes adding inotify watch on it".
  */
 class FolderWatcherTest :
     FunSpec({
@@ -129,6 +127,26 @@ class FolderWatcherTest :
                             }
 
                             collectorJob.cancel()
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("a book under the 100th directory still emits its book root (no 63-dir cap)") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("listenup-watcher-cap-")
+                    // 99 filler author dirs walked first, then the real one — past kfswatch's 63.
+                    (1..99).forEach { (tmp / "Filler-%03d".format(it) / "Book").createDirectories() }
+                    val bookDir = (tmp / "ZZZ Author/Late Book").apply { createDirectories() }
+                    try {
+                        withWatcher(tmp) { watcher ->
+                            watcher.events.test(timeout = 5.seconds) {
+                                (bookDir / "track.mp3").writeBytes(byteArrayOf(1, 2, 3))
+                                awaitItem() shouldBe bookDir
+                                cancelAndIgnoreRemainingEvents()
+                            }
                         }
                     } finally {
                         tmp.toFile().deleteRecursively()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/RecursiveDirectoryWatcherTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/RecursiveDirectoryWatcherTest.kt
@@ -1,0 +1,155 @@
+package com.calypsan.listenup.server.scanner.watcher
+
+import app.cash.turbine.test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.io.path.writeBytes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Real-filesystem tests for the JVM-native recursive watcher. Linux-only in CI
+ * (inotify); the Windows/macOS WatchService backends behave equivalently but are
+ * a developer-machine concern.
+ */
+class RecursiveDirectoryWatcherTest :
+    FunSpec({
+
+        val isLinux = System.getProperty("os.name").lowercase().contains("linux")
+
+        if (!isLinux) {
+            test("RecursiveDirectoryWatcher tests are Linux-only — skipping suite") { /* no-op */ }
+        } else {
+            test("emits a Create when a file appears in a watched directory") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("rdw-")
+                    try {
+                        withWatcher { watcher ->
+                            watcher.add(tmp.toString())
+                            watcher.onEventFlow.test(timeout = 5.seconds) {
+                                (tmp / "track.mp3").writeBytes(byteArrayOf(1))
+                                val ev = awaitFor(tmp)
+                                ev.kind shouldBe DirectoryWatchEventKind.Create
+                                ev.path shouldBe (tmp / "track.mp3").toString()
+                                cancelAndIgnoreRemainingEvents()
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            // THE REGRESSION: kfswatch capped at 63. Register 100 dirs and prove the
+            // 100th still fires — this is exactly what silently failed before.
+            test("watches far more than kfswatch's 63-target cap — the 100th dir still fires") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("rdw-cap-")
+                    try {
+                        withWatcher { watcher ->
+                            val dirs = (1..100).map { (tmp / "dir-%03d".format(it)).apply { createDirectories() } }
+                            dirs.forEach { watcher.add(it.toString()) }
+                            val target = dirs.last()
+                            watcher.onEventFlow.test(timeout = 5.seconds) {
+                                (target / "file.mp3").writeBytes(byteArrayOf(1))
+                                awaitFor(target).kind shouldBe DirectoryWatchEventKind.Create
+                                cancelAndIgnoreRemainingEvents()
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            // A new subdir whose file already exists at registration time: the file
+            // predates the watch, so only a synthetic Create can surface it.
+            test("surfaces a file already inside a newly-created subdirectory") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("rdw-race-")
+                    try {
+                        withWatcher { watcher ->
+                            watcher.add(tmp.toString())
+                            watcher.onEventFlow.test(timeout = 5.seconds) {
+                                val book = (tmp / "New Book").apply { createDirectories() }
+                                (book / "audio.m4b").writeBytes(byteArrayOf(1, 2, 3))
+                                var sawFile = false
+                                run {
+                                    repeat(20) {
+                                        val ev = awaitItem()
+                                        if (ev.path == (book / "audio.m4b").toString() &&
+                                            ev.kind == DirectoryWatchEventKind.Create
+                                        ) {
+                                            sawFile = true
+                                            return@run
+                                        }
+                                    }
+                                }
+                                sawFile shouldBe true
+                                cancelAndIgnoreRemainingEvents()
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+
+            test("emits a Delete when a watched file is removed") {
+                runBlocking {
+                    val tmp = Files.createTempDirectory("rdw-del-")
+                    try {
+                        val f = (tmp / "gone.mp3").apply { writeBytes(byteArrayOf(1)) }
+                        withWatcher { watcher ->
+                            watcher.add(tmp.toString())
+                            watcher.onEventFlow.test(timeout = 5.seconds) {
+                                Files.delete(f)
+                                var sawDelete = false
+                                run {
+                                    repeat(20) {
+                                        val ev = awaitItem()
+                                        if (ev.path == f.toString() && ev.kind == DirectoryWatchEventKind.Delete) {
+                                            sawDelete = true
+                                            return@run
+                                        }
+                                    }
+                                }
+                                sawDelete shouldBe true
+                                cancelAndIgnoreRemainingEvents()
+                            }
+                        }
+                    } finally {
+                        tmp.toFile().deleteRecursively()
+                    }
+                }
+            }
+        }
+    })
+
+private suspend fun withWatcher(block: suspend (RecursiveDirectoryWatcher) -> Unit) {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val watcher = RecursiveDirectoryWatcher(scope)
+    try {
+        block(watcher)
+    } finally {
+        watcher.close()
+        scope.cancel()
+    }
+}
+
+/** Awaits the next event whose targetDirectory is [dir], skipping unrelated noise. */
+private suspend fun app.cash.turbine.ReceiveTurbine<DirectoryWatchEvent>.awaitFor(dir: Path): DirectoryWatchEvent {
+    repeat(20) {
+        val ev = awaitItem()
+        if (ev.targetDirectory == dir.toString()) return ev
+    }
+    error("no event for $dir within 20 items")
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/WatcherSupervisorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/watcher/WatcherSupervisorTest.kt
@@ -17,7 +17,7 @@ import java.nio.file.Path
  * Unit tests for [WatcherSupervisor].
  *
  * Uses [FakeFolderWatcher] as the test seam in place of [FolderWatcher] —
- * [FolderWatcher] embeds kfswatch (a native FS-event listener) and cannot
+ * [FolderWatcher] embeds a native WatchService event listener and cannot
  * be easily stubbed at the class level. The fake tracks start/close calls
  * and provides a way to simulate emission callbacks.
  */


### PR DESCRIPTION
## Problem
Real-time library updates on file-add were silently dead for non-trivial libraries. Root-caused: **kfswatch 1.4.0 has a hard `FileWatcherMaxTargets = 63` cap** (a cross-platform floor, not exposed via its API). `FolderWatcher.registerExistingTree()` registers a watch per directory, so on a ~1600-directory library only the **first 63** were ever watched — a book added under any of the other ~1537 dirs produced zero server-side reaction (no reflow, no logs, no DB write).

Proven via live test: the kernel delivered every inotify event, but the server JVM held exactly 63 watch descriptors; decompiling `kfswatch-jvm-1.4.0.jar` shows the `max = 63` constant. `ntfs3` and the new-subdir race were both exonerated.

## Fix
Replace kfswatch (server-only) with a **Kotlin-native recursive `java.nio.file.WatchService` watcher** — inotify on Linux, native `ReadDirectoryChangesW` on Windows, polling on macOS (documented future-upgrade point). No artificial cap (bounded only by `fs.inotify.max_user_watches`).

- **`LowLevelDirectoryWatcher` seam** + `RecursiveDirectoryWatcher` engine. `FolderWatcher` swaps engines behind the seam; its debouncer, per-book coalescing, `computeBookRoot`, and `SkipRules` are unchanged, as is everything downstream (`WatcherSupervisor` → `ScanOrchestrator` → `ScanCoordinator` → `Scanner.runIncremental`).
- The engine also **surfaces files already inside a newly-created directory** (closes the freshly-copied-book race) and **recovers from `OVERFLOW`** by re-walking the affected subtree.
- **Never-Stranded backstop:** an on-startup full rescan (catches changes made while the server was down) + a periodic `RescanScheduler` (default `6h`, configurable via `scan.periodicRescanInterval`; `scan.rescanOnStartup` toggles the startup pass). Both reuse the existing single-flight scan trigger.
- **kfswatch removed entirely** from the catalog and `:server` build.

## Tests
- `RecursiveDirectoryWatcherTest` — real-filesystem, incl. **the regression that proves the cap is gone: register 100 directories, assert the 100th still fires.** Plus new-subdir race, create/delete.
- `FolderWatcherTest` — new end-to-end "book under the 100th directory still emits its book root".
- `RescanSchedulerTest` — virtual-time: fires per library per interval, survives a failing rescan, disables on non-positive interval.
- Full gates green: `spotlessCheck detekt :contract:jvmTest :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`.

## Live verification (real 1141-book library on ntfs3)
- Boot: `Mounted watcher ... path=/mnt/Igni/Audiobooks` + `periodic rescan enabled every 6h` (confirms `Duration.parse("6h")` resolves in prod).
- **Startup rescan** reconciled 2 books added while the server was down (1139 → 1141).
- **Live watcher** caught a book added while running (1141 → 1142), no manual scan — the exact reported failure, fixed.

