### PR TITLE
🐛 fix(scan): accumulate scan carousel books — grow, never loop or swap

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.core.suspendRunCatching
+import com.calypsan.listenup.api.event.ScanBookRef
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.streaming.RpcEvent
 import com.calypsan.listenup.client.data.local.db.BookDao
@@ -33,6 +34,14 @@ private val logger = KotlinLogging.logger {}
 
 /** Backoff between scan-progress stream re-subscriptions after the stream drops or completes. */
 private const val SCAN_STREAM_RESUBSCRIBE_DELAY_MS = 2_000L
+
+/**
+ * Upper bound on the accumulated "recently matched" carousel. The server streams a small rolling
+ * window per [ScanEvent.Progress]; the client accumulates across events (see [mergeRecentBooks]) so
+ * the strip grows instead of looping the same few titles. This cap keeps that growth bounded on a
+ * large library — the oldest matches scroll off and are dropped.
+ */
+internal const val MAX_ACCUMULATED_RECENT_BOOKS = 60
 
 /**
  * Bridges the domain sync facade to the renovated client sync engine.
@@ -224,6 +233,7 @@ class SyncRepositoryImpl(
                         nowMs = { currentEpochMilliseconds() },
                         getStartedAt = { scanStartedAtMs },
                         setStartedAt = { scanStartedAtMs = it },
+                        getProgress = { _scanProgress.value },
                     )
                 }
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
@@ -291,6 +301,7 @@ internal suspend fun applyScanEvent(
     nowMs: () -> Long = { 0L },
     getStartedAt: () -> Long = { 0L },
     setStartedAt: (Long) -> Unit = {},
+    getProgress: () -> ScanProgressState? = { null },
 ) {
     when (event) {
         is ScanEvent.Started -> {
@@ -317,7 +328,10 @@ internal suspend fun applyScanEvent(
                         authors = event.authorsMatched,
                         durationMs = event.totalDurationMs,
                         currentFile = event.currentFile,
-                        recentBooks = event.recentBooks,
+                        // Accumulate across events rather than render the server's rolling window:
+                        // the carousel grows and an already-shown title keeps its place — it never
+                        // gets swapped out by a freshly-matched book.
+                        recentBooks = mergeRecentBooks(getProgress()?.recentBooks.orEmpty(), event.recentBooks),
                         startedAtMs = getStartedAt(),
                     ),
                 )
@@ -344,6 +358,28 @@ internal suspend fun applyScanEvent(
         is ScanEvent.Change -> {
             // No-op: the live tail plus the Completed reconcile cover applied changes.
         }
+    }
+}
+
+/**
+ * Merge a freshly-streamed [incoming] window of matched books into the already-accumulated
+ * [existing] strip for the "recently matched" carousel. New titles append at the end; books already
+ * present keep their position (dedupe by [ScanBookRef] value — title + author), so a tile never gets
+ * its contents swapped for a different book just because that book was just scanned. The result is
+ * trimmed to the newest [MAX_ACCUMULATED_RECENT_BOOKS], dropping the oldest off the front.
+ */
+internal fun mergeRecentBooks(
+    existing: List<ScanBookRef>,
+    incoming: List<ScanBookRef>,
+): List<ScanBookRef> {
+    if (incoming.isEmpty()) return existing
+    val seen = existing.toHashSet()
+    val merged = existing.toMutableList()
+    for (book in incoming) if (seen.add(book)) merged += book
+    return if (merged.size > MAX_ACCUMULATED_RECENT_BOOKS) {
+        merged.subList(merged.size - MAX_ACCUMULATED_RECENT_BOOKS, merged.size).toList()
+    } else {
+        merged
     }
 }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -29,6 +29,7 @@ class SyncRepositoryScanProgressTest :
         fun progressEvent(
             booksAnalyzed: Int,
             filesWalked: Int,
+            recentBooks: List<ScanBookRef> = emptyList(),
         ) = ScanEvent.Progress(
             correlationId = "c1",
             libraryId = LibraryId("lib-1"),
@@ -36,6 +37,7 @@ class SyncRepositoryScanProgressTest :
             filesWalked = filesWalked,
             booksAnalyzed = booksAnalyzed,
             errors = 0,
+            recentBooks = recentBooks,
         )
 
         fun completedEvent() =
@@ -181,6 +183,64 @@ class SyncRepositoryScanProgressTest :
                 scanning shouldBe false
                 apply(progressEvent(booksAnalyzed = 1, filesWalked = 1))
                 scanning shouldBe false
+            }
+        }
+
+        // The "Building your library" carousel bug: the server streams a small ROLLING WINDOW of
+        // recentBooks (capped per event), so rendering only the latest window showed ~8 books that
+        // changed in place and looped. The client must ACCUMULATE across Progress events — dedupe by
+        // (title, author), append new ones at the end — so the strip grows and never resets.
+        test("Progress accumulates recentBooks across events — deduped, appended at the end") {
+            runTest {
+                var progress: ScanProgressState? = null
+                val apply: suspend (List<ScanBookRef>) -> Unit = { window ->
+                    applyScanEvent(
+                        event = progressEvent(booksAnalyzed = 1, filesWalked = 1, recentBooks = window),
+                        isInitialScanComplete = { false },
+                        setScanning = {},
+                        setProgress = { progress = it },
+                        markInitialScanComplete = {},
+                        reconcile = {},
+                        getProgress = { progress },
+                    )
+                }
+
+                apply(listOf(ScanBookRef("Dune", "Herbert"), ScanBookRef("Hyperion", "Simmons")))
+                apply(listOf(ScanBookRef("Hyperion", "Simmons"), ScanBookRef("Neuromancer", "Gibson")))
+
+                // The overlapping "Hyperion" is not duplicated; the new "Neuromancer" appends at the end.
+                progress!!.recentBooks shouldBe
+                    listOf(
+                        ScanBookRef("Dune", "Herbert"),
+                        ScanBookRef("Hyperion", "Simmons"),
+                        ScanBookRef("Neuromancer", "Gibson"),
+                    )
+            }
+        }
+
+        test("recentBooks accumulation caps at MAX_ACCUMULATED_RECENT_BOOKS, dropping the oldest") {
+            runTest {
+                var progress: ScanProgressState? = null
+                val apply: suspend (ScanBookRef) -> Unit = { book ->
+                    applyScanEvent(
+                        event = progressEvent(booksAnalyzed = 1, filesWalked = 1, recentBooks = listOf(book)),
+                        isInitialScanComplete = { false },
+                        setScanning = {},
+                        setProgress = { progress = it },
+                        markInitialScanComplete = {},
+                        reconcile = {},
+                        getProgress = { progress },
+                    )
+                }
+
+                val total = MAX_ACCUMULATED_RECENT_BOOKS + 5
+                repeat(total) { i -> apply(ScanBookRef("Book $i", "Author")) }
+
+                val recent = progress!!.recentBooks
+                recent.size shouldBe MAX_ACCUMULATED_RECENT_BOOKS
+                // Oldest five dropped; the newest is last.
+                recent.first() shouldBe ScanBookRef("Book 5", "Author")
+                recent.last() shouldBe ScanBookRef("Book ${total - 1}", "Author")
             }
         }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/ScanComponents.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/ScanComponents.kt
@@ -17,6 +17,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -25,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +58,6 @@ import org.jetbrains.compose.resources.stringResource
 private const val OUTER_ROTATION_MS = 9_000
 private const val INNER_ROTATION_MS = 7_000
 private const val CORE_PULSE_MS = 1_100
-private const val MARQUEE_SCROLL_MS = 14_000
 private const val FILE_LINE_PULSE_MS = 700
 private const val PATH_TAIL_LENGTH = 48
 
@@ -170,10 +173,13 @@ fun StatChip(
 }
 
 /**
- * An infinite, seamless left-scrolling strip of [BookCoverFallback] tiles for the books matched so
- * far. Covers aren't available mid-scan, so each tile is a deterministic title/author placeholder.
- * The list is duplicated end-to-end so the wrap is invisible, and the edges fade via a [BlendMode.DstIn]
- * gradient mask. Renders nothing when [books] is empty.
+ * A growing strip of [BookCoverFallback] tiles for the books matched so far, newest at the end. As
+ * the accumulated [books] list grows, the row auto-scrolls to follow the tail, so each freshly-matched
+ * book slides in from the right while older covers drift off the left — it never loops or resets. Each
+ * tile is keyed by the book it shows, so an already-displayed title keeps its exact place and contents;
+ * a newly-scanned book is appended, never swapped in over an existing tile. Covers aren't available
+ * mid-scan, so each tile is a deterministic title/author placeholder. The edges fade via a
+ * [BlendMode.DstIn] gradient mask. Renders nothing when [books] is empty.
  */
 @Composable
 fun ScanCoversMarquee(
@@ -182,14 +188,13 @@ fun ScanCoversMarquee(
     tile: Dp = 54.dp,
 ) {
     if (books.isEmpty()) return
-    val loop = books + books
-    val transition = rememberInfiniteTransition(label = "marquee")
-    val shift by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(MARQUEE_SCROLL_MS, easing = LinearEasing)),
-        label = "shift",
-    )
+    val listState = rememberLazyListState()
+    // Follow the newest match: scrolling to the last index clamps to the end of the content, keeping
+    // the tail in view so new covers enter from the right. Keyed on the list so it advances on every
+    // append but stays put when an event carries no new book (idle = still).
+    LaunchedEffect(books) {
+        listState.animateScrollToItem(books.lastIndex)
+    }
     val fade =
         Brush.horizontalGradient(
             0f to Color.Transparent,
@@ -197,7 +202,8 @@ fun ScanCoversMarquee(
             0.92f to Color.Black,
             1f to Color.Transparent,
         )
-    Box(
+    LazyRow(
+        state = listState,
         modifier =
             modifier
                 .fillMaxWidth()
@@ -207,22 +213,16 @@ fun ScanCoversMarquee(
                     drawContent()
                     drawRect(brush = fade, blendMode = BlendMode.DstIn)
                 },
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        userScrollEnabled = false,
     ) {
-        Row(
-            modifier =
-                Modifier.graphicsLayer {
-                    translationX = -shift * (tile.toPx() + 10.dp.toPx()) * books.size
-                },
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            loop.forEach { book ->
-                BookCoverFallback(
-                    title = book.title,
-                    author = book.author,
-                    modifier = Modifier.size(tile),
-                    seed = book.title + book.author,
-                )
-            }
+        items(items = books, key = { "${it.title} ${it.author}" }) { book ->
+            BookCoverFallback(
+                title = book.title,
+                author = book.author,
+                modifier = Modifier.size(tile),
+                seed = book.title + book.author,
+            )
         }
     }
 }


### PR DESCRIPTION
## What
The "Building your library" scan carousel only showed ~8 books, swapped tile contents as new books were scanned, and looped/flashed the same few covers.

## Why
The client rendered `ScanEvent.Progress.recentBooks` directly — but that's the server's small **rolling window** (capped in `Scanner.kt`), copied verbatim on every event. The marquee then duplicated that window (`books + books`) and infinite-looped it, so the same ~8 cycled forever and emptied/re-mounted between events.

## Fix
- **State:** `applyScanEvent` now **accumulates** `recentBooks` across events via `mergeRecentBooks` — dedupe by `(title, author)`, append new at the end, cap at 60 (drop oldest). An already-shown tile keeps its place; a freshly-scanned book is appended, never swapped in over an existing tile.
- **UI:** `ScanCoversMarquee` rebuilt from a looping `Row` to a keyed `LazyRow` that auto-scrolls to the newest item — new covers slide in from the right, older drift off the left; sits still when idle. No loop, no flash.

## Tests
3 new Kotest cases (accumulate + dedupe + append; cap drops oldest). `:sharedLogic:jvmTest`, `:server:test`, spotless, detekt, `:androidApp:assembleDebug` all green.