### PR TITLE
🐛 fix(search): serve search from local FTS + self-heal the empty index

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
@@ -126,6 +126,14 @@ interface SearchDao {
     // ==================== FTS POPULATION ====================
 
     /**
+     * Count the rows in the book FTS index. Drives the startup self-heal: a populated library
+     * with an empty index (e.g. an install that pre-dates index population) triggers a rebuild.
+     */
+    @SkipQueryVerification
+    @Query("SELECT COUNT(*) FROM books_fts")
+    suspend fun countBooksFts(): Int
+
+    /**
      * Clear all book FTS entries.
      */
     @SkipQueryVerification

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryImpl.kt
@@ -1,19 +1,13 @@
 
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.client.data.local.db.BookSearchResult
 import com.calypsan.listenup.client.data.local.db.ContributorEntity
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesEntity
 import com.calypsan.listenup.client.data.local.db.TagEntity
-import com.calypsan.listenup.client.data.remote.SearchApiContract
-import com.calypsan.listenup.client.data.remote.SearchFacetsResponse
-import com.calypsan.listenup.client.data.remote.SearchHitResponse
-import com.calypsan.listenup.client.data.remote.SearchResponse
 import com.calypsan.listenup.client.data.repository.common.QueryUtils
-import com.calypsan.listenup.client.domain.model.FacetCount
 import com.calypsan.listenup.client.domain.model.SearchFacets
 import com.calypsan.listenup.client.domain.model.SearchHit
 import com.calypsan.listenup.client.domain.model.SearchHitType
@@ -27,38 +21,31 @@ import kotlin.time.measureTimedValue
 private val logger = KotlinLogging.logger {}
 
 /**
- * Repository for search operations.
+ * Repository for search operations, backed entirely by the local Room FTS5 index.
  *
- * Implements "never stranded" pattern:
- * - Primary: Use server Bleve search (fuzzy, faceted, hierarchical)
- * - Fallback: Local Room FTS5 (simpler but always works)
+ * The server runs the identical FTS5 algorithm over the same library, so for a client that already
+ * holds the library in Room there is nothing to gain from a network round-trip — search reads the
+ * local index directly. This is faster, works offline by construction, and is correctly scoped to
+ * the books this client can see. (The server's REST search endpoint remains for data-less clients,
+ * e.g. web, that have no local index.)
  *
- * Always tries server first because the server may be on a local network
- * without internet access. Falls back to local search on any error.
+ * The local index is kept in sync by [com.calypsan.listenup.client.data.sync.FtsPopulator], which
+ * rebuilds it after each catch-up/scan and self-heals an empty index on startup.
  *
- * The caller doesn't need to know which path was taken—both return
- * the same SearchResult type. The `isOfflineResult` flag indicates
- * which was used (for optional UI indication).
- *
- * @property searchApi Server search API client
  * @property searchDao Local FTS5 search DAO
  * @property imageStorage For resolving local cover paths
  */
 class SearchRepositoryImpl(
-    private val searchApi: SearchApiContract,
     private val searchDao: SearchDao,
     private val imageStorage: ImageStorage,
 ) : com.calypsan.listenup.client.domain.repository.SearchRepository {
     /**
-     * Search across books, contributors, and series.
-     *
-     * Tries server search first if online. Falls back to local FTS
-     * on network error or if offline.
+     * Search across books, contributors, series, and tags against the local FTS5 index.
      *
      * @param query Search query string
      * @param types Types to search (null = all)
-     * @param genres Genre slugs to filter by
-     * @param genrePath Genre path prefix for hierarchical filtering
+     * @param genres Unused locally (server-only genre faceting); accepted for interface parity
+     * @param genrePath Unused locally; accepted for interface parity
      * @param limit Max results per type
      */
     override suspend fun search(
@@ -68,7 +55,6 @@ class SearchRepositoryImpl(
         genrePath: String?,
         limit: Int,
     ): SearchResult {
-        // Sanitize query
         val sanitizedQuery = QueryUtils.sanitize(query)
         if (sanitizedQuery.isBlank()) {
             return SearchResult(
@@ -78,47 +64,8 @@ class SearchRepositoryImpl(
                 hits = emptyList(),
             )
         }
-
-        // Always try server search first, fall back to local on failure
-        // We don't check isOnline() because the server may be on a local network
-        // without internet access, which would cause isOnline() to return false
-        // even though the server is reachable.
-        return try {
-            searchServer(sanitizedQuery, types, genres, genrePath, limit)
-        } catch (e: CancellationException) {
-            // Preserve structured concurrency - re-throw cancellation
-            throw e
-        } catch (e: Exception) {
-            logger.warn(e) { "Server search failed for '$sanitizedQuery', falling back to local search" }
-            searchLocal(sanitizedQuery, types, limit)
-        }
+        return searchLocal(sanitizedQuery, types, limit)
     }
-
-    /**
-     * Server-side Bleve search.
-     */
-    private suspend fun searchServer(
-        query: String,
-        types: List<SearchHitType>?,
-        genres: List<String>?,
-        genrePath: String?,
-        limit: Int,
-    ): SearchResult =
-        withContext(IODispatcher) {
-            val typesParam = types?.joinToString(",") { it.name.lowercase() }
-            val genresParam = genres?.joinToString(",")
-
-            val response =
-                searchApi.search(
-                    query = query,
-                    types = typesParam,
-                    genres = genresParam,
-                    genrePath = genrePath,
-                    limit = limit,
-                )
-
-            response.toDomain(imageStorage)
-        }
 
     /**
      * Local Room FTS5 search.
@@ -177,7 +124,7 @@ class SearchRepositoryImpl(
                 tookMs = duration.inWholeMilliseconds,
                 hits = result,
                 facets = SearchFacets(), // No facets in local search
-                isOfflineResult = true,
+                isOfflineResult = false,
             )
         }
 
@@ -201,61 +148,6 @@ class SearchRepositoryImpl(
 }
 
 // --- Extension functions for mapping ---
-
-private fun SearchResponse.toDomain(imageStorage: ImageStorage): SearchResult =
-    SearchResult(
-        query = query,
-        total = total.toInt(),
-        tookMs = tookMs,
-        hits = hits.map { it.toDomain(imageStorage) },
-        facets = facets?.toDomain() ?: SearchFacets(),
-        isOfflineResult = false,
-    )
-
-private fun SearchHitResponse.toDomain(imageStorage: ImageStorage): SearchHit {
-    val hitType =
-        when (type.lowercase()) {
-            "book" -> SearchHitType.BOOK
-            "contributor" -> SearchHitType.CONTRIBUTOR
-            "series" -> SearchHitType.SERIES
-            "tag" -> SearchHitType.TAG
-            else -> SearchHitType.BOOK
-        }
-
-    // Resolve cover path for books (convert String to BookId)
-    val coverPath =
-        if (hitType == SearchHitType.BOOK && id.isNotBlank()) {
-            val bookId = BookId(id)
-            if (imageStorage.exists(bookId)) imageStorage.getCoverPath(bookId) else null
-        } else {
-            null
-        }
-
-    return SearchHit(
-        id = id,
-        type = hitType,
-        name = name,
-        subtitle = subtitle,
-        author = author,
-        narrator = narrator,
-        seriesName = seriesName,
-        duration = duration,
-        bookCount = bookCount,
-        genreSlugs = genreSlugs,
-        tags = tags,
-        coverPath = coverPath,
-        score = score,
-        highlight = highlights?.values?.firstOrNull(),
-    )
-}
-
-private fun SearchFacetsResponse.toDomain(): SearchFacets =
-    SearchFacets(
-        types = types?.map { FacetCount(it.value, it.count) } ?: emptyList(),
-        genres = genres?.map { FacetCount(it.value, it.count) } ?: emptyList(),
-        authors = authors?.map { FacetCount(it.value, it.count) } ?: emptyList(),
-        narrators = narrators?.map { FacetCount(it.value, it.count) } ?: emptyList(),
-    )
 
 private fun BookSearchResult.toSearchHit(imageStorage: ImageStorage): SearchHit {
     val coverPath = if (imageStorage.exists(book.id)) imageStorage.getCoverPath(book.id) else null

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.streaming.RpcEvent
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.remote.ScannerRpcFactory
 import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.FtsPopulatorContract
 import com.calypsan.listenup.client.data.sync.SyncEngine
 import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.model.ScanProgressState
@@ -51,6 +52,7 @@ class SyncRepositoryImpl(
     private val listeningEventRecorder: ListeningEventRecorder,
     private val scannerRpcFactory: ScannerRpcFactory,
     private val bookDao: BookDao,
+    private val ftsPopulator: FtsPopulatorContract,
     private val scope: CoroutineScope,
 ) : SyncRepository {
     /** Ensures [ListeningEventRecorder.recoverOrphan] runs at most once per process lifetime. */
@@ -119,15 +121,48 @@ class SyncRepositoryImpl(
 
     override suspend fun forceFullResync(): AppResult<Unit> =
         when (val started = startEngineForCurrentUser()) {
-            is AppResult.Success -> suspendRunCatching { syncEngine.forceReconcile() }
-            is AppResult.Failure -> started
+            is AppResult.Success -> {
+                suspendRunCatching {
+                    syncEngine.forceReconcile()
+                    // The resync pulled fresh rows; refresh the search index so search reflects them.
+                    refreshSearchIndex()
+                }
+            }
+
+            is AppResult.Failure -> {
+                started
+            }
         }
+
+    /**
+     * Rebuild the local search index, isolating failure — a search-index hiccup must never fail or
+     * strand a sync. Used after a catch-up/reconcile lands fresh rows into Room.
+     */
+    private suspend fun refreshSearchIndex() {
+        try {
+            ftsPopulator.rebuildAll()
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Search index rebuild failed; search may be stale until the next sync" }
+        }
+    }
 
     private suspend fun startEngineForCurrentUser(): AppResult<Unit> =
         suspendRunCatching {
             val userId = authSession.getUserId() ?: return@suspendRunCatching Unit
             syncEngine.start(userId)
             startScanProgressObserver()
+            // Self-heal: an install whose library is already in Room but whose search index was
+            // never populated rebuilds it here. A no-op once the index has rows, so it is safe on
+            // every start. Isolated — a failure here must not fail engine startup.
+            try {
+                ftsPopulator.rebuildIfEmpty()
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Search index self-heal failed; will retry on next startup" }
+            }
             if (!orphanRecovered) {
                 orphanRecovered = true
                 try {
@@ -191,7 +226,10 @@ class SyncRepositoryImpl(
                 isInitialScanComplete = { hasCompletedInitialScan },
                 isScanning = { _isServerScanning.value },
                 confirmScanFinished = { isInitialScanFinishedOnServer() },
-                reconcile = { syncEngine.handleCursorStale() },
+                reconcile = {
+                    syncEngine.handleCursorStale()
+                    refreshSearchIndex()
+                },
                 setScanning = { _isServerScanning.value = it },
                 setProgress = { _scanProgress.value = it },
                 markInitialScanComplete = { hasCompletedInitialScan = true },
@@ -219,8 +257,12 @@ class SyncRepositoryImpl(
                         // Parking this collector for the duration is safe — [SyncEngine.handleCursorStale]
                         // is mutex-guarded + coalescing (no concurrent catch-up spin), Completed is
                         // already consumed, and the cold RPC stream applies backpressure rather than
-                        // dropping any later event.
-                        reconcile = { syncEngine.handleCursorStale() },
+                        // dropping any later event. The freshly-scanned books then feed the search
+                        // index so search works without an app restart.
+                        reconcile = {
+                            syncEngine.handleCursorStale()
+                            refreshSearchIndex()
+                        },
                         nowMs = { currentEpochMilliseconds() },
                         getStartedAt = { scanStartedAtMs },
                         setStartedAt = { scanStartedAtMs = it },

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulator.kt
@@ -61,6 +61,19 @@ class FtsPopulator(
         }
 
     /**
+     * Rebuild the index only if it is empty. Detects an install whose library is already in Room but
+     * whose FTS index was never populated (e.g. it pre-dates index population) and heals it; a no-op
+     * once the index has rows, so it is cheap to call on every engine start.
+     */
+    override suspend fun rebuildIfEmpty() =
+        withContext(IODispatcher) {
+            if (searchDao.countBooksFts() == 0) {
+                logger.info { "Search index empty — rebuilding from local tables" }
+                rebuildAll()
+            }
+        }
+
+    /**
      * Rebuild book FTS entries.
      *
      * Denormalizes author, narrator, and series name into the FTS table

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSupportContracts.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSupportContracts.kt
@@ -32,4 +32,10 @@ interface ImageDownloaderContract {
 /** Utility contract for rebuilding local full-text-search tables. */
 interface FtsPopulatorContract {
     suspend fun rebuildAll()
+
+    /**
+     * Rebuild the search index only when it is empty — the startup self-heal. A no-op when the
+     * index is already populated, so it is cheap to call on every engine start.
+     */
+    suspend fun rebuildIfEmpty()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -97,6 +97,7 @@ val libraryModule: Module =
                 listeningEventRecorder = get(),
                 scannerRpcFactory = get(),
                 bookDao = get(),
+                ftsPopulator = get(),
                 scope =
                     get(
                         qualifier =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SearchModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SearchModule.kt
@@ -39,10 +39,9 @@ val searchModule: Module =
             )
         } bind FtsPopulatorContract::class
 
-        // SearchRepository for offline-first search
+        // SearchRepository — local FTS5 search (no network round-trip; server runs the same algorithm)
         single<SearchRepository> {
             SearchRepositoryImpl(
-                searchApi = get(),
                 searchDao = get(),
                 imageStorage = get(),
             )

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryTest.kt
@@ -1,19 +1,16 @@
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ContributorId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.SeriesId
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.BookSearchResult
 import com.calypsan.listenup.client.data.local.db.ContributorEntity
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesEntity
-import com.calypsan.listenup.client.data.remote.SearchApiContract
-import com.calypsan.listenup.client.data.remote.SearchException
-import com.calypsan.listenup.client.data.remote.SearchFacetsResponse
-import com.calypsan.listenup.client.data.remote.SearchHitResponse
-import com.calypsan.listenup.client.data.remote.SearchResponse
 import com.calypsan.listenup.client.domain.model.SearchHitType
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import dev.mokkery.MockMode
@@ -23,35 +20,29 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
- * Tests for SearchRepository.
+ * Tests for [SearchRepositoryImpl] — local FTS5 search.
  *
- * Tests the "never stranded" pattern:
- * - Primary: Use server Bleve search
- * - Fallback: Local Room FTS5 on server failure
+ * Search is served entirely from the local Room index (the server runs the same FTS5 algorithm, so a
+ * client holding the library locally has nothing to gain from a round-trip). These tests verify the
+ * blank-query short-circuit, the federated mapping across the four hit types, that results are not
+ * flagged as a degraded "offline" fallback, and that one failing per-type query can't sink the rest.
  */
-class SearchRepositoryTest {
-    // --- Helper functions for creating mocks ---
+class SearchRepositoryTest :
+    FunSpec({
 
-    private fun createMockSearchApi(): SearchApiContract = mock<SearchApiContract>()
-
-    private fun createMockSearchDao(): SearchDao = mock<SearchDao>(MockMode.autoUnit)
-
-    private fun createMockImageStorage(): ImageStorage = mock<ImageStorage>()
-
-    private fun createTestBookSearchResult(
-        id: String = "book-1",
-        title: String = "Test Book",
-        authorName: String? = "Test Author",
-    ): BookSearchResult =
-        BookSearchResult(
+        fun bookResult(
+            id: String = "book-1",
+            title: String = "Test Book",
+            authorName: String? = "Test Author",
+        ) = BookSearchResult(
             book =
                 BookEntity(
                     id = BookId(id),
@@ -60,7 +51,7 @@ class SearchRepositoryTest {
                     title = title,
                     subtitle = null,
                     coverHash = null,
-                    totalDuration = 3600000,
+                    totalDuration = 3_600_000,
                     description = null,
                     publishYear = null,
                     createdAt = Timestamp(0),
@@ -69,399 +60,88 @@ class SearchRepositoryTest {
             authorName = authorName,
         )
 
-    private fun createSearchResponse(
-        query: String = "test",
-        hits: List<SearchHitResponse> = emptyList(),
-    ): SearchResponse =
-        SearchResponse(
-            query = query,
-            total = hits.size.toLong(),
-            tookMs = 10,
-            hits = hits,
-            facets = SearchFacetsResponse(),
-        )
-
-    private fun createSearchHitResponse(
-        id: String = "book-1",
-        type: String = "book",
-        name: String = "Test Book",
-    ): SearchHitResponse =
-        SearchHitResponse(
-            id = id,
-            type = type,
-            score = 1.0f,
+        fun contributor(
+            id: String = "c1",
+            name: String = "Author",
+        ) = ContributorEntity(
+            id = ContributorId(id),
             name = name,
-            subtitle = null,
-            author = "Test Author",
-            narrator = "Test Narrator",
+            description = null,
+            imagePath = null,
+            createdAt = Timestamp(0),
+            updatedAt = Timestamp(0),
         )
 
-    // --- Empty/blank query tests ---
+        fun series(
+            id: String = "s1",
+            name: String = "Series",
+        ) = SeriesEntity(
+            id = SeriesId(id),
+            name = name,
+            description = null,
+            createdAt = Timestamp(0),
+            updatedAt = Timestamp(0),
+        )
 
-    @Test
-    fun `empty query returns empty result`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            // When
-            val result = repository.search("")
-
-            // Then
-            assertEquals(0, result.total)
-            assertTrue(result.hits.isEmpty())
+        fun repository(configure: SearchDao.() -> Unit): SearchRepositoryImpl {
+            val imageStorage = mock<ImageStorage> { every { exists(any()) } returns false }
+            val searchDao = mock<SearchDao>(MockMode.autoUnit) { configure() }
+            return SearchRepositoryImpl(searchDao, imageStorage)
         }
 
-    @Test
-    fun `whitespace-only query returns empty result`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            // When
-            val result = repository.search("   ")
-
-            // Then
-            assertEquals(0, result.total)
-            assertTrue(result.hits.isEmpty())
-        }
-
-    // --- Server search tests ---
-
-    @Test
-    fun `search calls server API first`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            every { imageStorage.exists(any()) } returns false
-
-            val serverResponse =
-                createSearchResponse(
-                    query = "sanderson",
-                    hits =
-                        listOf(
-                            createSearchHitResponse(id = "book-1", name = "Mistborn"),
-                            createSearchHitResponse(id = "book-2", name = "Elantris"),
-                        ),
-                )
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } returns serverResponse
-
-            // When
-            val result = repository.search("sanderson")
-
-            // Then
-            assertEquals(2, result.hits.size)
-            assertEquals("Mistborn", result.hits[0].name)
-            assertEquals("Elantris", result.hits[1].name)
-            assertFalse(result.isOfflineResult)
-        }
-
-    @Test
-    fun `search with types parameter filters correctly`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            every { imageStorage.exists(any()) } returns false
-
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } returns createSearchResponse()
-
-            // When
-            repository.search("test", types = listOf(SearchHitType.BOOK))
-
-            // Then - verify API was called (with types param passed)
-            verifySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
+        test("blank query short-circuits to an empty result without touching the index") {
+            runTest {
+                val result = repository { }.search("   ")
+                result.total shouldBe 0
+                result.hits.shouldBeEmpty()
             }
         }
 
-    // --- Fallback tests ---
+        test("federates across books, contributors, series, and tags") {
+            runTest {
+                val repo =
+                    repository {
+                        everySuspend { searchBooks(any(), any()) } returns listOf(bookResult(title = "Mistborn"))
+                        everySuspend { searchContributors(any(), any()) } returns listOf(contributor(name = "Sanderson"))
+                        everySuspend { searchSeries(any(), any()) } returns listOf(series(name = "Stormlight"))
+                        everySuspend { searchTags(any(), any()) } returns emptyList()
+                    }
 
-    @Test
-    fun `server error falls back to local FTS`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
+                val result = repo.search("brandon")
 
-            every { imageStorage.exists(any()) } returns false
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } throws SearchException("Server error")
-            everySuspend { searchDao.searchBooks(any(), any()) } returns
-                listOf(createTestBookSearchResult(id = "book-1", title = "Fallback Book"))
-            everySuspend { searchDao.searchContributors(any(), any()) } returns emptyList()
-            everySuspend { searchDao.searchSeries(any(), any()) } returns emptyList()
-            everySuspend { searchDao.searchTags(any(), any()) } returns emptyList()
-
-            // When
-            val result = repository.search("fallback")
-
-            // Then
-            assertEquals(1, result.hits.size)
-            assertEquals("Fallback Book", result.hits[0].name)
-            assertTrue(result.isOfflineResult)
+                result.hits.map { it.type } shouldContainExactlyInAnyOrder
+                    listOf(SearchHitType.BOOK, SearchHitType.CONTRIBUTOR, SearchHitType.SERIES)
+                result.hits.first { it.type == SearchHitType.BOOK }.name shouldBe "Mistborn"
+            }
         }
 
-    @Test
-    fun `network error falls back to local FTS`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
+        test("local results are not flagged as an offline fallback") {
+            runTest {
+                val repo =
+                    repository {
+                        everySuspend { searchBooks(any(), any()) } returns listOf(bookResult())
+                        everySuspend { searchContributors(any(), any()) } returns emptyList()
+                        everySuspend { searchSeries(any(), any()) } returns emptyList()
+                        everySuspend { searchTags(any(), any()) } returns emptyList()
+                    }
 
-            every { imageStorage.exists(any()) } returns false
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } throws RuntimeException("No network")
-            everySuspend { searchDao.searchBooks(any(), any()) } returns
-                listOf(createTestBookSearchResult(id = "book-1", title = "Local Book"))
-            everySuspend { searchDao.searchContributors(any(), any()) } returns emptyList()
-            everySuspend { searchDao.searchSeries(any(), any()) } returns emptyList()
-            everySuspend { searchDao.searchTags(any(), any()) } returns emptyList()
-
-            // When
-            val result = repository.search("local")
-
-            // Then
-            assertEquals(1, result.hits.size)
-            assertEquals("Local Book", result.hits[0].name)
-            assertTrue(result.isOfflineResult)
+                repo.search("test").isOfflineResult.shouldBeFalse()
+            }
         }
 
-    // --- Query sanitization tests ---
+        test("a failing per-type query does not sink the rest of the search") {
+            runTest {
+                val repo =
+                    repository {
+                        everySuspend { searchBooks(any(), any()) } throws RuntimeException("FTS boom")
+                        everySuspend { searchContributors(any(), any()) } returns listOf(contributor(name = "Survivor"))
+                        everySuspend { searchSeries(any(), any()) } returns emptyList()
+                        everySuspend { searchTags(any(), any()) } returns emptyList()
+                    }
 
-    @Test
-    fun `query with special characters is sanitized`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
+                val result = repo.search("test", types = listOf(SearchHitType.BOOK, SearchHitType.CONTRIBUTOR))
 
-            every { imageStorage.exists(any()) } returns false
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } returns createSearchResponse()
-
-            // When - query with FTS special chars that should be stripped
-            val result = repository.search("test*()\":")
-
-            // Then - should not throw, search executes
-            // The special chars are sanitized before API call
+                result.hits.map { it.name } shouldBe listOf("Survivor")
+            }
         }
-
-    @Test
-    fun `very long query is truncated`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            every { imageStorage.exists(any()) } returns false
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } returns createSearchResponse()
-
-            // When - query longer than 100 chars
-            val longQuery = "a".repeat(200)
-            val result = repository.search(longQuery)
-
-            // Then - should not throw, search executes with truncated query
-        }
-
-    // --- Result mapping tests ---
-
-    @Test
-    fun `server response maps hit types correctly`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            every { imageStorage.exists(any()) } returns false
-
-            val serverResponse =
-                createSearchResponse(
-                    query = "test",
-                    hits =
-                        listOf(
-                            createSearchHitResponse(id = "book-1", type = "book", name = "Book"),
-                            createSearchHitResponse(id = "contrib-1", type = "contributor", name = "Author"),
-                            createSearchHitResponse(id = "series-1", type = "series", name = "Series"),
-                        ),
-                )
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } returns serverResponse
-
-            // When
-            val result = repository.search("test")
-
-            // Then
-            assertEquals(3, result.hits.size)
-            assertEquals(SearchHitType.BOOK, result.hits[0].type)
-            assertEquals(SearchHitType.CONTRIBUTOR, result.hits[1].type)
-            assertEquals(SearchHitType.SERIES, result.hits[2].type)
-        }
-
-    @Test
-    fun `local search returns correct hit types`() =
-        runTest {
-            // Given
-            val searchApi = createMockSearchApi()
-            val searchDao = createMockSearchDao()
-            val imageStorage = createMockImageStorage()
-            val repository = SearchRepositoryImpl(searchApi, searchDao, imageStorage)
-
-            every { imageStorage.exists(any()) } returns false
-            // Server throws to trigger local fallback
-            everySuspend {
-                searchApi.search(
-                    query = any(),
-                    types = any(),
-                    genres = any(),
-                    genrePath = any(),
-                    minDuration = any(),
-                    maxDuration = any(),
-                    limit = any(),
-                    offset = any(),
-                )
-            } throws SearchException("Server unavailable")
-            everySuspend { searchDao.searchBooks(any(), any()) } returns
-                listOf(createTestBookSearchResult(title = "Book"))
-            everySuspend { searchDao.searchContributors(any(), any()) } returns
-                listOf(
-                    ContributorEntity(
-                        id =
-                            com.calypsan.listenup.core
-                                .ContributorId("c1"),
-                        name = "Author",
-                        description = null,
-                        imagePath = null,
-                        createdAt = Timestamp(0),
-                        updatedAt = Timestamp(0),
-                    ),
-                )
-            everySuspend { searchDao.searchSeries(any(), any()) } returns
-                listOf(
-                    SeriesEntity(
-                        id =
-                            com.calypsan.listenup.core
-                                .SeriesId("s1"),
-                        name = "Series",
-                        description = null,
-                        createdAt = Timestamp(0),
-                        updatedAt = Timestamp(0),
-                    ),
-                )
-            everySuspend { searchDao.searchTags(any(), any()) } returns emptyList()
-
-            // When
-            val result = repository.search("test")
-
-            // Then
-            assertEquals(3, result.hits.size)
-            assertTrue(result.hits.any { it.type == SearchHitType.BOOK })
-            assertTrue(result.hits.any { it.type == SearchHitType.CONTRIBUTOR })
-            assertTrue(result.hits.any { it.type == SearchHitType.SERIES })
-        }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorRebuildIfEmptyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorRebuildIfEmptyTest.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.data.local.db.ContributorDao
+import com.calypsan.listenup.client.data.local.db.SearchDao
+import com.calypsan.listenup.client.data.local.db.SeriesDao
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [FtsPopulator.rebuildIfEmpty] — the startup self-heal that (re)builds the local search
+ * index only when it is empty. This is what makes search work for an install whose library is
+ * already in Room but whose FTS index was never populated: the next launch detects the empty index
+ * and rebuilds it, with no wasteful rebuild when the index is already populated.
+ */
+class FtsPopulatorRebuildIfEmptyTest :
+    FunSpec({
+
+        fun populator(
+            searchDao: SearchDao,
+            bookDao: BookDao = mock { everySuspend { getAllLive() } returns emptyList() },
+            contributorDao: ContributorDao = mock { everySuspend { getAll() } returns emptyList() },
+            seriesDao: SeriesDao = mock { everySuspend { getAll() } returns emptyList() },
+        ) = FtsPopulator(
+            bookDao = bookDao,
+            contributorDao = contributorDao,
+            seriesDao = seriesDao,
+            searchDao = searchDao,
+        )
+
+        test("rebuildIfEmpty rebuilds the index when it is empty") {
+            runTest {
+                val searchDao =
+                    mock<SearchDao> {
+                        everySuspend { countBooksFts() } returns 0
+                        everySuspend { clearBooksFts() } returns Unit
+                        everySuspend { clearContributorsFts() } returns Unit
+                        everySuspend { clearSeriesFts() } returns Unit
+                    }
+
+                populator(searchDao).rebuildIfEmpty()
+
+                // An empty index → a full rebuild runs (clears the tables on its way to repopulating).
+                verifySuspend { searchDao.clearBooksFts() }
+            }
+        }
+
+        test("rebuildIfEmpty does nothing when the index is already populated") {
+            runTest {
+                val searchDao =
+                    mock<SearchDao> {
+                        everySuspend { countBooksFts() } returns 42
+                    }
+
+                populator(searchDao).rebuildIfEmpty()
+
+                // No rebuild — the clear/insert path must not run when the index already has rows.
+                verifySuspend(VerifyMode.not) { searchDao.clearBooksFts() }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryModuleVerifyTest.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.local.db.dao.LibraryDao
 import com.calypsan.listenup.client.data.local.db.dao.LibraryFolderDao
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
+import com.calypsan.listenup.client.data.sync.FtsPopulatorContract
 import com.calypsan.listenup.client.data.sync.SyncEngine
 import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -37,6 +38,7 @@ import org.koin.test.verify.verify
  *  - [ListenUpDatabase] — owned by `platformDatabaseModule`.
  *  - [TransactionRunner] — owned by `persistenceModule`.
  *  - [LibrarySync] — owned by `settingsModule`.
+ *  - [FtsPopulatorContract] — owned by `searchModule`.
  */
 @OptIn(KoinExperimentalAPI::class)
 class LibraryModuleVerifyTest :
@@ -60,6 +62,7 @@ class LibraryModuleVerifyTest :
                         ApiClientFactory::class,
                         LibraryDao::class,
                         LibraryFolderDao::class,
+                        FtsPopulatorContract::class,
                     ),
             )
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.Book
-import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material3.Card
@@ -51,7 +50,6 @@ import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.book_detail_tags
 import listenup.composeapp.generated.resources.common_series
-import listenup.composeapp.generated.resources.book_edit_showing_offline_results
 import listenup.composeapp.generated.resources.genre_book_count
 import listenup.composeapp.generated.resources.genre_books_count
 import listenup.composeapp.generated.resources.library_books
@@ -93,10 +91,6 @@ fun SearchResultsOverlay(
                     onToggle = onTypeFilterToggle,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
-
-                if (state is SearchUiState.Results && state.result.isOfflineResult) {
-                    OfflineIndicator(modifier = Modifier.padding(horizontal = 16.dp))
-                }
 
                 when (state) {
                     is SearchUiState.Idle -> {
@@ -210,33 +204,6 @@ private fun TypeFilterRow(
                     modifier = Modifier.size(18.dp),
                 )
             },
-        )
-    }
-}
-
-@Composable
-private fun OfflineIndicator(modifier: Modifier = Modifier) {
-    Row(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .background(
-                    MaterialTheme.colorScheme.secondaryContainer,
-                    RoundedCornerShape(8.dp),
-                ).padding(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            Icons.Default.CloudOff,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-            modifier = Modifier.size(16.dp),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = stringResource(Res.string.book_edit_showing_offline_results),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
         )
     }
 }


### PR DESCRIPTION
## What
The search screen never returned any results.

## Why (two stacked causes)
1. **Dead server path.** The client's `SearchApi`/`SearchRepositoryImpl` expected a Go-era `ApiResponse<SearchResponse>` envelope (`q`/`hits`/`took_ms`), but the Kotlin server returns a **bare `SearchResults`** (`books`/`contributors`/`series`/`tags`) from `SearchRoutes.kt`. Every server search failed to deserialize → silent fallback to local.
2. **Empty local index.** `FtsPopulator.rebuildAll()` was wired in DI but **never called anywhere** outside tests, so the FTS5 tables were always empty — the fallback returned nothing.

## Decision
The Kotlin server runs **FTS5** (same algorithm as the client's Room FTS5 — Bleve died with the Go server) and no first-party UI uses facets. So there's no value in a network round-trip: search goes **local-only** for Room-backed clients. The server's REST `SearchService` stays for data-less clients (e.g. web).

## Fix
- `FtsPopulator.rebuildIfEmpty()` (+ `SearchDao.countBooksFts()`): startup self-heal that rebuilds only when the index is empty — fixes existing installs whose library is already in Room but whose index was never populated.
- `SyncRepositoryImpl` injects `FtsPopulatorContract`: `rebuildIfEmpty()` on engine start; `rebuildAll()` after scan-completion reconcile, never-stranded recovery, and `forceFullResync`.
- `SearchRepositoryImpl` is now local-only (dropped the always-failing server round-trip, server DTO mappings, and the misleading "offline" badge in `SearchResultsOverlay`).

## Tests
New Kotest `FtsPopulatorRebuildIfEmptyTest`; rewrote `SearchRepositoryTest` to Kotest local-only (−389 net lines). spotless, detekt, `:sharedLogic:jvmTest`, `:server:test`, `:androidApp:assembleDebug` all green.