### PR TITLE
🐛 fix(search): close search overlay on system back + add an in-overlay back button

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.CloudOff
@@ -31,6 +32,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -61,6 +63,7 @@ import listenup.composeapp.generated.resources.search_no_results_for_query
 import listenup.composeapp.generated.resources.search_people
 import listenup.composeapp.generated.resources.search_section_count
 import listenup.composeapp.generated.resources.search_try_a_different_search_term
+import listenup.composeapp.generated.resources.shell_close_search
 
 /**
  * Full-screen overlay for search results.
@@ -73,6 +76,7 @@ import listenup.composeapp.generated.resources.search_try_a_different_search_ter
 fun SearchResultsOverlay(
     state: SearchUiState,
     isExpanded: Boolean,
+    onClose: () -> Unit,
     onResultClick: (SearchHit) -> Unit,
     onTypeFilterToggle: (SearchHitType) -> Unit,
     modifier: Modifier = Modifier,
@@ -88,6 +92,10 @@ fun SearchResultsOverlay(
             color = MaterialTheme.colorScheme.background,
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
+                // The overlay covers the shell header (and its back arrow), so it carries its own
+                // back affordance — the visible counterpart to the system-back handler in AppShell.
+                SearchOverlayTopBar(query = state.query, onClose = onClose)
+
                 TypeFilterRow(
                     selectedTypes = state.selectedTypes,
                     onToggle = onTypeFilterToggle,
@@ -151,6 +159,36 @@ private fun ResultsContent(
         onResultClick = onResultClick,
         modifier = modifier,
     )
+}
+
+@Composable
+private fun SearchOverlayTopBar(
+    query: String,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, end = 16.dp, top = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onClose) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(Res.string.shell_close_search),
+            )
+        }
+        Text(
+            text = query,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+    }
 }
 
 @Composable

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/AppShell.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/AppShell.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.calypsan.listenup.client.design.components.ListenUpDestructiveDialog
+import com.calypsan.listenup.client.design.util.PlatformBackHandler
 import com.calypsan.listenup.client.domain.model.SyncState
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.SyncRepository
@@ -146,11 +147,22 @@ fun AppShell(
     // Search overlay expansion lives in the UI — purely presentational state.
     var isSearchExpanded by rememberSaveable { mutableStateOf(false) }
 
+    // The single way search closes: collapse the overlay and clear the query. Shared by the header
+    // back arrow, the overlay's own back affordance, and the system back gesture below.
+    val collapseSearch: () -> Unit = {
+        isSearchExpanded = false
+        searchViewModel.clearQuery()
+    }
+
+    // The search overlay is a full-screen layer over the shell, not a nav-stack entry, so the system
+    // back gesture would otherwise fall through to the shell root and exit the app. While search is
+    // open, intercept back to close it instead.
+    PlatformBackHandler(enabled = isSearchExpanded) { collapseSearch() }
+
     // Handle search navigation: collapse the overlay and clear the query before navigating away.
     LaunchedEffect(searchViewModel) {
         searchViewModel.navActions.collect { action ->
-            isSearchExpanded = false
-            searchViewModel.clearQuery()
+            collapseSearch()
             when (action) {
                 is SearchNavAction.NavigateToBook -> onBookClick(action.bookId)
                 is SearchNavAction.NavigateToContributor -> onContributorClick(action.contributorId)
@@ -220,8 +232,7 @@ fun AppShell(
             isSearchExpanded = isSearchExpanded,
             searchQuery = searchState.query,
             onSearchExpandedChange = { expanded ->
-                isSearchExpanded = expanded
-                if (!expanded) searchViewModel.clearQuery()
+                if (expanded) isSearchExpanded = true else collapseSearch()
             },
             onSearchQueryChange = { query ->
                 searchViewModel.onQueryChanged(query)
@@ -278,6 +289,7 @@ fun AppShell(
             SearchResultsOverlay(
                 state = searchState,
                 isExpanded = isSearchExpanded,
+                onClose = collapseSearch,
                 onResultClick = { hit ->
                     searchViewModel.onResultClicked(hit)
                 },


### PR DESCRIPTION
## What
On the search results screen there was no back button, and swiping back exited the app instead of returning to the previous screen.

## Why
`SearchResultsOverlay` is the **last child of the shell `Box`** at `fillMaxSize()` (`AppShell.kt`), so when the query is non-blank it draws **over the shell header** — hiding the header's back arrow ("no back button"). And nothing intercepted the system back gesture while search was open, so it fell through to `NavDisplay`, which sees a back-stack of size 1 at the shell root and doesn't pop → the system treats it as back-to-home and **exits the app**.

## Fix
- A shared `collapseSearch` lambda in `AppShell` (collapse + clear query), routed through the header's `onSearchExpandedChange(false)`, a new `PlatformBackHandler(enabled = isSearchExpanded)`, and the overlay's new `onClose`.
- `SearchResultsOverlay` gains an `onClose` param and a `SearchOverlayTopBar` (back arrow + the current query) — a visible exit, since the header it covers is unreachable.

## Notes
- Platform back-gesture wiring is `expect`/`actual` Android glue — verified on-device, not unit-testable in `commonTest`.
- Editing the query while results show is still not possible (the overlay covers the header) — pre-existing, out of scope; back now cleanly exits search.

spotless, detekt, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` all green (touches only `sharedUI`).