### PR TITLE
⚡ perf(library): move library sort off the main thread + conflate progress + grid contentType

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
@@ -23,12 +23,16 @@ import com.calypsan.listenup.client.domain.repository.SyncStatusRepository
 import com.calypsan.listenup.client.util.sortableTitle
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.concurrent.Volatile
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -98,6 +102,9 @@ class LibraryViewModel(
     private val libraryPreferences: LibraryPreferences,
     private val syncStatusRepository: SyncStatusRepository,
     private val selectionManager: LibrarySelectionManager,
+    // CPU-bound sort/filter of the library runs on this dispatcher, off the main thread. Defaulted
+    // for production; tests inject their scheduler-backed dispatcher so the pipeline stays controllable.
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
     // ═══════════════════════════════════════════════════════════════════════
     // INTENT
@@ -153,7 +160,7 @@ class LibraryViewModel(
                 },
         ) { content, positions ->
             computeProgress(content.books, positions)
-        }
+        }.conflate()
 
     private val syncSnapshot: Flow<SyncSnapshot> =
         combine(
@@ -174,14 +181,18 @@ class LibraryViewModel(
             val loaded: LibraryUiState =
                 buildLoaded(intentValue, content, progress, sync, selection)
             loaded
-        }.fallbackTo { e ->
-            logger.error(e) { "Library state pipeline failed" }
-            LibraryUiState.Error("Failed to load library")
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
-            initialValue = LibraryUiState.Loading,
-        )
+        }
+            // Sorting/filtering ~1000 books runs in this transform; keep it off the main thread so a
+            // burst of position updates (e.g. the post-import sync flood) can't stall input dispatch.
+            .flowOn(backgroundDispatcher)
+            .fallbackTo { e ->
+                logger.error(e) { "Library state pipeline failed" }
+                LibraryUiState.Error("Failed to load library")
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
+                initialValue = LibraryUiState.Loading,
+            )
 
     // ═══════════════════════════════════════════════════════════════════════
     // INITIALIZATION

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -177,6 +177,7 @@ class LibraryViewModelTest :
                     libraryPreferences = libraryPreferences,
                     syncStatusRepository = syncStatusRepository,
                     selectionManager = selectionManager,
+                    backgroundDispatcher = testDispatcher,
                 )
         }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BooksContent.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BooksContent.kt
@@ -366,6 +366,14 @@ private fun BookGrid(
                         is BookGridItem.BookItem -> gridItem.book.id.value
                     }
                 },
+                // Distinct content types so Compose reuses the right slot on scroll instead of
+                // re-creating layouts when a header and a book swap positions.
+                contentType = { gridItem ->
+                    when (gridItem) {
+                        is BookGridItem.Header -> "header"
+                        is BookGridItem.BookItem -> "book"
+                    }
+                },
                 span = { gridItem ->
                     when (gridItem) {
                         is BookGridItem.Header -> GridItemSpan(maxLineSpan)


### PR DESCRIPTION
## What
Browsing the library (especially right after a large import) froze the app with an ANR ("Input dispatching timed out, waited 5000ms") and stuttered persistently on scroll.

## Why
Three compounding causes, confirmed in code:
1. **The library sort ran on the main thread.** `LibraryViewModel.uiState`'s `combine` transform calls `buildLoaded`, which sorts/filters the whole library (~1000+ books). The combine collects on `viewModelScope` (Main), so every emission re-sorts on the main thread.
2. **Progress updates weren't conflated.** `observeAll()` positions feed `progressSnapshot`; during a sync burst (e.g. the post-import position flood) the whole library re-sorted on *every* position tick.
3. **The grid had no `contentType`.** Mixed header/book items forced Compose to re-create layouts when item types swapped on scroll.

After an import these align perfectly: a freshly-imported library streams a flood of positions while you scroll a cover-less grid → main-thread re-sort storm → ANR.

## Fix
- `LibraryViewModel`: `.flowOn(backgroundDispatcher)` moves the `combine` + `buildLoaded` sort **off the main thread** (injected `CoroutineDispatcher`, defaulting to `Dispatchers.Default`; tests inject their test dispatcher).
- `.conflate()` on `progressSnapshot` collapses position bursts so a flood of updates does at most one re-sort per settle.
- `BooksContent`: add `contentType` to the grid `items()` so Compose reuses slots by type on scroll.

Semantics are unchanged, so the existing `LibraryViewModelTest` is the regression guard (passes with the injected dispatcher). The remaining main-thread cost — `BookCoverImage`'s per-tile `GlobalContext.get()` service-location on the slow (cover-less) path — is noted as a follow-up.

spotless, detekt, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` all green. Perf is best confirmed on-device / via Perfetto.