### PR TITLE
🐛 fix(book-detail): strip Markdown markers from the collapsed description teaser

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DescriptionPreview.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DescriptionPreview.kt
@@ -1,0 +1,48 @@
+package com.calypsan.listenup.client.util
+
+private val MD_IMAGE = Regex("""!\[([^\]]*)\]\([^)]*\)""")
+private val MD_LINK = Regex("""\[([^\]]+)\]\([^)]*\)""")
+private val MD_HEADING = Regex("""^\s{0,3}#{1,6}\s+""", RegexOption.MULTILINE)
+private val MD_BLOCKQUOTE = Regex("""^\s{0,3}>\s?""", RegexOption.MULTILINE)
+private val MD_BULLET = Regex("""^\s{0,3}[-*+]\s+""", RegexOption.MULTILINE)
+private val MD_ORDERED = Regex("""^\s{0,3}\d+\.\s+""", RegexOption.MULTILINE)
+private val MD_BOLD_STAR = Regex("""\*\*(.+?)\*\*""")
+private val MD_BOLD_UNDERSCORE = Regex("""__(.+?)__""")
+private val MD_STRIKE = Regex("""~~(.+?)~~""")
+private val MD_CODE = Regex("""`([^`]+)`""")
+private val MD_ITALIC_STAR = Regex("""\*(.+?)\*""")
+private val HTML_TAG = Regex("<[^>]+>")
+private val WHITESPACE_RUN = Regex("""\s+""")
+private val SPACE_BEFORE_PUNCTUATION = Regex(" ([,.;:!?])")
+
+/**
+ * Flattens an HTML/Markdown [String] into a single run of plain text for a clamped preview teaser:
+ * tags and emphasis markers are removed (keeping their inner text), links collapse to their label,
+ * list/heading/quote markers are dropped, and whitespace is normalised.
+ *
+ * This is deliberately a lightweight flattener, not a parser — the full *styled* rendering is the
+ * caller's job (e.g. a Markdown renderer in the expanded view). The patterns avoid look-around so
+ * they behave identically on Kotlin/Native.
+ */
+fun String.toPlainTextPreview(): String {
+    var text = this
+    // Inline links/images first — they carry the brackets the emphasis passes would trip over.
+    text = MD_IMAGE.replace(text) { it.groupValues[1] }
+    text = MD_LINK.replace(text) { it.groupValues[1] }
+    // Line-anchored block markers.
+    text = MD_HEADING.replace(text, "")
+    text = MD_BLOCKQUOTE.replace(text, "")
+    text = MD_BULLET.replace(text, "")
+    text = MD_ORDERED.replace(text, "")
+    // Inline emphasis — bold before italic so `**x**` isn't half-eaten by the single-`*` pass.
+    text = MD_BOLD_STAR.replace(text) { it.groupValues[1] }
+    text = MD_BOLD_UNDERSCORE.replace(text) { it.groupValues[1] }
+    text = MD_STRIKE.replace(text) { it.groupValues[1] }
+    text = MD_CODE.replace(text) { it.groupValues[1] }
+    text = MD_ITALIC_STAR.replace(text) { it.groupValues[1] }
+    // Any remaining HTML, then tidy whitespace and the gaps stripped markup leaves behind.
+    text = HTML_TAG.replace(text, " ")
+    text = WHITESPACE_RUN.replace(text, " ")
+    text = SPACE_BEFORE_PUNCTUATION.replace(text, "$1")
+    return text.trim()
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/DescriptionPreviewTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/DescriptionPreviewTest.kt
@@ -1,0 +1,53 @@
+package com.calypsan.listenup.client.util
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [toPlainTextPreview] — the flattener behind the Book Detail "About" collapsed teaser.
+ * The expanded view renders full Markdown; the clamped teaser must show clean prose, so HTML tags
+ * AND Markdown emphasis markers are removed (keeping their inner text) rather than leaking through
+ * as literal `**` / `#` / `<i>` symbols.
+ */
+class DescriptionPreviewTest :
+    FunSpec({
+
+        test("strips bold and italic asterisks, keeping the inner text") {
+            "**bold**".toPlainTextPreview() shouldBe "bold"
+            "*italic*".toPlainTextPreview() shouldBe "italic"
+        }
+
+        test("strips underscore bold, strikethrough, and inline code") {
+            "__bold__".toPlainTextPreview() shouldBe "bold"
+            "~~gone~~".toPlainTextPreview() shouldBe "gone"
+            "`code`".toPlainTextPreview() shouldBe "code"
+        }
+
+        test("strips heading, blockquote, and list markers") {
+            "# Heading".toPlainTextPreview() shouldBe "Heading"
+            "> quoted".toPlainTextPreview() shouldBe "quoted"
+            "- item".toPlainTextPreview() shouldBe "item"
+            "1. first".toPlainTextPreview() shouldBe "first"
+        }
+
+        test("reduces a link to its label") {
+            "See [Audible](https://audible.com) now".toPlainTextPreview() shouldBe "See Audible now"
+        }
+
+        test("still strips HTML tags and collapses whitespace") {
+            "<i>Italic</i>   <b>Bold</b>".toPlainTextPreview() shouldBe "Italic Bold"
+        }
+
+        test("removes the space a stripped tag leaves before punctuation") {
+            "Ends in emphasis <i>here</i>.".toPlainTextPreview() shouldBe "Ends in emphasis here."
+        }
+
+        test("flattens a real-world mixed HTML + Markdown description") {
+            val raw = "**The apocalypse will be televised!** A man. His ex-girlfriend's cat."
+            raw.toPlainTextPreview() shouldBe "The apocalypse will be televised! A man. His ex-girlfriend's cat."
+        }
+
+        test("leaves clean prose untouched") {
+            "Just a plain sentence.".toPlainTextPreview() shouldBe "Just a plain sentence."
+        }
+    })

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/AboutSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/AboutSection.kt
@@ -25,6 +25,7 @@ import com.calypsan.listenup.client.design.theme.DisplayFontFamily
 import com.calypsan.listenup.client.design.theme.Spacing
 import com.calypsan.listenup.client.domain.model.Tag
 import com.calypsan.listenup.client.features.bookdetail.TagsSection
+import com.calypsan.listenup.client.util.toPlainTextPreview
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.book_detail_about_this_book
 import listenup.composeapp.generated.resources.book_detail_credits
@@ -36,21 +37,6 @@ import org.jetbrains.compose.resources.stringResource
 
 private const val DESCRIPTION_PREVIEW_MAX_LINES = 4
 private const val DESCRIPTION_EXPAND_THRESHOLD = 200
-
-private val MARKUP_TAG_REGEX = Regex("<[^>]+>")
-private val WHITESPACE_RUN_REGEX = Regex("\\s+")
-private val SPACE_BEFORE_PUNCTUATION_REGEX = Regex(" ([,.;:!?])")
-
-/**
- * Strips HTML/markdown tags (e.g. `<em>`, `<p>`), collapses whitespace runs, and removes spaces
- * left before punctuation, so the collapsed description teaser reads as clean plain text. The
- * expanded view renders full markdown via [MarkdownText].
- */
-private fun String.toPlainPreview(): String =
-    replace(MARKUP_TAG_REGEX, " ")
-        .replace(WHITESPACE_RUN_REGEX, " ")
-        .replace(SPACE_BEFORE_PUNCTUATION_REGEX, "$1")
-        .trim()
 
 /**
  * Grouped "About" section combining description, optional credits, genres, and tags.
@@ -163,7 +149,7 @@ private fun AboutDescriptionBlock(
         // the markdown renderer can't clamp by line, so the teaser renders as plain text with
         // HTML/markdown markup stripped.
         Text(
-            text = description.toPlainPreview(),
+            text = description.toPlainTextPreview(),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = DESCRIPTION_PREVIEW_MAX_LINES,


### PR DESCRIPTION
## What
On Book Detail, the collapsed "About this book" teaser showed raw Markdown markers — e.g. `**The apocalypse will be televised!**` instead of clean prose. (Screenshot-confirmed on the emulator.)

## Why
The collapsed teaser can't line-clamp rendered Markdown, so it flattens the description to plain text via a stripper. That stripper removed **HTML** tags (`<[^>]+>`) but not **Markdown** markers (`**`, `*`, `__`, `#`, `~~`, `` ` ``, links…), so Markdown descriptions leaked their syntax into the teaser. The *expanded* view already renders full Markdown correctly via `MarkdownText` — only the teaser was affected.

## Fix
- New `String.toPlainTextPreview()` in `sharedLogic` `util/DescriptionPreview.kt`: flattens HTML **and** Markdown to clean prose (emphasis/code/strike markers removed keeping inner text, links → label, heading/quote/list markers dropped, whitespace normalised). Pure logic, no look-around (Kotlin/Native-safe).
- `AboutSection` now calls it; its local HTML-only stripper + regexes are removed.

## Tests
New Kotest `DescriptionPreviewTest` (8 cases incl. the real-world mixed HTML+Markdown string). spotless, detekt, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` all green.

Not re-verified on-device this round (the emulator had a newer version code, and a downgrade-install would have disrupted the live session); the change is pure, fully covered by the TDD cases above, and the expanded Markdown render was confirmed on-device.