### PR TITLE
✅ test(quality): isolate global Koin between specs + fail on empty/duplicate specs

### DIFF
--- a/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,47 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.names.DuplicateTestNameMode
+import io.kotest.core.spec.Spec
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.stopKoin
+
+/**
+ * Kotest project configuration for the JVM test run (auto-discovered by Kotest as
+ * `io.kotest.provided.ProjectConfig`).
+ *
+ * - [extensions]: global-Koin isolation between specs — see [GlobalKoinIsolationListener].
+ * - [failOnEmptyTestSuite]: a spec that registers zero tests is almost always a mistake
+ *   (a misnamed `test`, a `context` that never adds leaves) — fail instead of passing silently.
+ * - [duplicateTestNameMode]: two tests with the same name inside one spec silently shadow each
+ *   other's results — make it an error so the copy-paste is caught.
+ */
+class ProjectConfig : AbstractProjectConfig() {
+    override val extensions: List<Extension> = listOf(GlobalKoinIsolationListener)
+    override val failOnEmptyTestSuite: Boolean = true
+    override val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Error
+}
+
+/**
+ * Guarantees every spec starts with a clean **global** Koin context.
+ *
+ * Two kinds of spec start the global Koin: server end-to-end specs boot Ktor's `install(Koin)` on
+ * the global context (via `testApplication { module() }`), and some client specs start it through
+ * `KoinTestRule`. If any spec leaves it running — a crash mid-spec, an ordering gap, a teardown that
+ * doesn't fire — the next server boot **reuses that stale context** and can't resolve server-only
+ * definitions, surfacing as a `NoDefinitionFoundException` (e.g. for `BookAccessPolicy`) or a hung
+ * request. That made `ImportRpcE2ETest` flake on CI: the failure depended purely on which spec ran
+ * before it.
+ *
+ * Stopping any leaked context **before** each spec makes the suite order-independent — every spec,
+ * server or client, begins from a clean slate and is then free to start its own Koin.
+ */
+private object GlobalKoinIsolationListener : BeforeSpecListener {
+    override suspend fun beforeSpec(spec: Spec) {
+        if (GlobalContext.getKoinApplicationOrNull() != null) {
+            stopKoin()
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds the project's first Kotest `io.kotest.provided.ProjectConfig` (JVM test run) and uses it to fix a CI flake plus tighten two suite-wide guards.

## Why — the flake
`ImportRpcE2ETest` (and any server E2E booting `testApplication { module() }`) starts Ktor's `install(Koin)` on the **global** Koin context. Some client specs also start the global Koin via `KoinTestRule`. Nothing guaranteed a spec *began* with a clean global context, so if a prior spec left one running, the next server boot reused that stale context and couldn't resolve server-only definitions — surfacing as `NoDefinitionFoundException: BookAccessPolicy` or a hung request. The failure depended purely on spec ordering, which is why it only bit on CI and only on PRs that add/convert specs (it reproducibly broke #493 and #497, while PRs that add no new specs stayed green).

## Fix
`ProjectConfig`:
- **`extensions`** — a `BeforeSpecListener` that stops any leaked global Koin before each spec, making the suite order-independent. Server and client specs alike start from a clean slate.
- **`failOnEmptyTestSuite = true`** — a spec that registers zero tests (misnamed `test`, empty `context`) now fails instead of passing silently.
- **`duplicateTestNameMode = Error`** — two same-named tests in one spec silently shadow each other; now an error.

Deliberately left out: `assertionMode`/`globalAssertSoftly` (would break the many mokkery `verify`-based specs) and global timeouts (risk introducing new timeout flakes).

## Verification
- Full `:sharedLogic:jvmTest` green with all three settings — so the suite has no pre-existing empty/duplicate-name specs to clean up.
- Confirmed the config is actually discovered: a throwaway duplicate-name spec failed with `DuplicateTestNameException`, then removed.
- spotless, detekt green. Once merged, #493 and #497 rebase onto it and their JVM runs go order-independent.