### PR TITLE
🐛 fix(shared): reconcile on import completion so imported listening progress lands without a restart

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -126,7 +126,11 @@ class SyncRepositoryImpl(
 
     override suspend fun resetForNewLibrary(newLibraryId: String): AppResult<Unit> = startEngineForCurrentUser()
 
-    override suspend fun refreshListeningHistory(): AppResult<Unit> = AppResult.Success(Unit)
+    override suspend fun refreshListeningHistory(): AppResult<Unit> =
+        // Import completion writes playback positions server-side under `FirehoseSuppressed` (no live
+        // push), so a full reconcile is what lands the freshly-imported listening progress in Room —
+        // without it the data only surfaces after an app restart.
+        forceFullResync()
 
     override suspend fun forceFullResync(): AppResult<Unit> =
         when (val started = startEngineForCurrentUser()) {


### PR DESCRIPTION
## What
After a successful ABS import, the user's listening progress didn't appear in Continue Listening or on Book Detail until the app was restarted.

## Why
The import writes per-user playback positions server-side via a sync-tracked `upsert`, but the whole import runs under `FirehoseSuppressed` — so there's no live push to the client. The import-completion paths (`ImportFlowViewModel`, `ImportDelegate`, `ABSImportHubViewModel`) already call `SyncRepository.refreshListeningHistory()` to pull that data... but the implementation was a **no-op stub** (`= AppResult.Success(Unit)`). So nothing pulled the positions; they only surfaced on the next app start, when the normal catch-up runs. (Confirmed: a manual restart did show the progress.)

## Fix
`refreshListeningHistory()` now performs a full reconcile (`forceFullResync()`) — the same catch-up an app restart would do — so the freshly-imported positions (and any matched books) land in Room immediately on import completion. Continue Listening and Book Detail read local Room (`playback_positions`), so they update as soon as the reconcile completes.

## Tests
The import → `refreshListeningHistory()` call is already covered by `ImportFlowViewModelTest`. The repository→engine link can't be unit-tested in isolation (`SyncEngine` is a final, non-mockable class with a large constructor); the behavior is the same reconcile a restart triggers, which the user already verified surfaces the data. spotless, detekt, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` all green.

Note: this refreshes the importing device. A server-side post-import nudge (one cursor-stale to all affected users) would also cover other devices/users live — deferred, and it touches the server import flow that's owned elsewhere.