### PR TITLE
✅ test(server): de-flake ScannerSseRouteTest — await real SSE connect instead of a blind delay

### DIFF
--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerSseRouteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerSseRouteTest.kt
@@ -13,6 +13,7 @@ import io.ktor.client.plugins.sse.sse
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.transformWhile
@@ -53,10 +54,16 @@ class ScannerSseRouteTest :
 
                 // Subscribe to the SSE stream, collect events as they arrive.
                 val collected = mutableListOf<ScanEvent>()
+                // Completes the instant the SSE block runs — i.e. the connection is established and the
+                // handler is about to collect the (replay = 0) event stream. Awaiting this instead of a
+                // blind delay removes the race that dropped the Started frame when the subscription
+                // wasn't yet registered on a loaded CI runner.
+                val subscribed = CompletableDeferred<Unit>()
                 val sseJob =
                     async {
                         withTimeoutOrNull(10.seconds) {
                             fix.client.sse("${fix.baseUrl}/sse/scan") {
+                                subscribed.complete(Unit)
                                 incoming
                                     .transformWhile { frame ->
                                         val data = frame.data
@@ -76,9 +83,11 @@ class ScannerSseRouteTest :
                         }
                     }
 
-                // Pause so the SSE subscription is established before the scan
-                // fires — otherwise we miss the Started frame.
-                delay(500)
+                // Wait for the SSE connection to actually be established — bounded so a failed connect
+                // surfaces as a failed assertion rather than a hang — then a brief settle for the
+                // server-side collector to register before the scan fires.
+                withTimeoutOrNull(10.seconds) { subscribed.await() }
+                delay(200)
 
                 // Trigger a manual scan to generate fresh events.
                 fix.client.post("${fix.baseUrl}/api/v1/scan")


### PR DESCRIPTION
## What
`ScannerSseRouteTest > SSE stream emits Started and Completed for a manual scan` flaked on CI (it briefly blocked #493).

## Why
The scan-event stream is a transient `replay = 0` bus, so a subscriber that registers *after* `Started` is emitted misses it. The test subscribed to `/sse/scan` in an `async`, then did a blind `delay(500)` hoping the subscription was registered server-side before triggering the scan. On a loaded CI runner 500ms isn't always enough for the SSE handshake, so the `Started` frame was dropped and the assertion failed.

## Fix
Replace the blind delay with an explicit wait for the connection to actually be established: the `sse {}` block completes a `CompletableDeferred` the instant it runs (connection up, handler about to collect). The test awaits that (bounded, so a failed connect fails an assertion rather than hanging) plus a brief 200ms settle for the server-side collector to register, then triggers the scan. The wait is now adaptive to real connection latency instead of a fixed guess.

## Verification
Test passes locally, including a forced `--rerun-tasks` re-execution. spotless, detekt green.