### PR TITLE
🐛 fix(contributors): bust contributor photo cache on re-scrape via content-addressed paths

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplier.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplier.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.server.services.MetadataService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.io.files.Path
+import java.security.MessageDigest
 
 private val log = KotlinLogging.logger {}
 
@@ -85,13 +86,17 @@ internal class ContributorMetadataApplier(
      */
     private suspend fun AudibleContributorProfile.downloadImage(contributorId: ContributorId): String? {
         val url = imageUrl.takeIf { it.isNotBlank() } ?: return null
-        val relPath = "contributors/${contributorId.value}.jpg"
         val dir = Path(imageHome.toString(), "contributors")
         return try {
             kotlinx.io.files.SystemFileSystem
                 .createDirectories(dir)
-            val dest = Path(imageHome.toString(), relPath)
-            imageStorage.download(url, dest)
+            val bytes = imageStorage.downloadBytes(url)
+            // Content-addressed filename: a re-scrape with a different photo yields a new `imagePath`,
+            // which is what the client keys its image cache on (the path is the version). With a stable
+            // id-based name the path never changes and clients keep rendering the old photo.
+            val sha = MessageDigest.getInstance("SHA-256").digest(bytes).toHexString()
+            val relPath = "contributors/$sha.jpg"
+            imageStorage.writeBytes(bytes, Path(imageHome.toString(), relPath))
             relPath
         } catch (e: CancellationException) {
             throw e

--- a/server/src/main/kotlin/com/calypsan/listenup/server/metadata/ImageStorage.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/metadata/ImageStorage.kt
@@ -42,14 +42,25 @@ class ImageStorage(
         url: String,
         destination: Path,
     ): ByteArray {
-        val tmp = Path(destination.parent!!.toString(), "${destination.name}.tmp")
         val bytes = httpClient.get(url).bodyAsBytes()
+        writeBytes(bytes, destination)
+        return bytes
+    }
+
+    /**
+     * Writes [bytes] to [destination] via a sibling temp file + atomic rename — readers never see a
+     * half-written file. The destination directory must already exist. Cleans up the temp on failure.
+     */
+    fun writeBytes(
+        bytes: ByteArray,
+        destination: Path,
+    ) {
+        val tmp = Path(destination.parent!!.toString(), "${destination.name}.tmp")
         try {
             SystemFileSystem.sink(tmp).buffered().use { sink ->
                 sink.write(bytes)
             }
             SystemFileSystem.atomicMove(tmp, destination)
-            return bytes
         } catch (e: Throwable) {
             SystemFileSystem.delete(tmp, mustExist = false)
             throw e

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/ContributorSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/ContributorSyncDomainHandler.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.local.db.ContributorEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
+import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 
@@ -45,6 +46,7 @@ private val logger = KotlinLogging.logger {}
 class ContributorSyncDomainHandler(
     private val database: ListenUpDatabase,
     private val transactionRunner: TransactionRunner,
+    private val imageStorage: ImageStorage,
     registry: ClientSyncDomainRegistry,
 ) : SyncDomainHandler<ContributorSyncPayload> {
     override val domainName: String = "contributors"
@@ -133,6 +135,13 @@ class ContributorSyncDomainHandler(
      */
     private suspend fun upsert(payload: ContributorSyncPayload) {
         val existing = database.contributorDao().getById(payload.id)
+        val newImagePath = payload.imagePath ?: existing?.imagePath
+        // The server stores contributor photos content-addressed, so a re-scrape changes imagePath.
+        // The local copy is otherwise never re-downloaded (the downloader skips when a file exists),
+        // so drop it on change: the render then re-fetches the new photo. Best-effort.
+        if (existing != null && existing.imagePath != newImagePath) {
+            imageStorage.deleteContributorImage(payload.id)
+        }
         database.contributorDao().upsert(
             ContributorEntity(
                 id = ContributorId(payload.id),
@@ -140,7 +149,7 @@ class ContributorSyncDomainHandler(
                 sortName = payload.sortName,
                 asin = payload.asin ?: existing?.asin,
                 description = payload.description ?: existing?.description,
-                imagePath = payload.imagePath ?: existing?.imagePath,
+                imagePath = newImagePath,
                 imageBlurHash = payload.imageBlurHash ?: existing?.imageBlurHash,
                 website = payload.website ?: existing?.website,
                 birthDate = payload.birthDate ?: existing?.birthDate,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -216,6 +216,7 @@ val clientSyncRenovationModule =
             ContributorSyncDomainHandler(
                 database = get(),
                 transactionRunner = get(),
+                imageStorage = get(),
                 registry = get(),
             )
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryFallbackTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryFallbackTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.client.data.sync.handlers.ContributorSyncDomainHand
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.stubImageStorage
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -132,7 +133,7 @@ private fun withTestRepo(
         every { imageStorage.exists(any()) } returns false
 
         val transactionRunner = RoomTransactionRunner(db)
-        val syncHandler = ContributorSyncDomainHandler(db, transactionRunner, ClientSyncDomainRegistry())
+        val syncHandler = ContributorSyncDomainHandler(db, transactionRunner, stubImageStorage(), ClientSyncDomainRegistry())
 
         val repo =
             ContributorRepositoryImpl(
@@ -158,7 +159,7 @@ private suspend fun seedRoom(
     id: String,
     name: String,
 ) {
-    val handler = ContributorSyncDomainHandler(db, RoomTransactionRunner(db), ClientSyncDomainRegistry())
+    val handler = ContributorSyncDomainHandler(db, RoomTransactionRunner(db), stubImageStorage(), ClientSyncDomainRegistry())
     handler.onCatchUpItem(payload(id = id, name = name), isTombstone = false)
 }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorSelfHealIntegrationTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorSelfHealIntegrationTest.kt
@@ -43,7 +43,7 @@ class ContributorSelfHealIntegrationTest :
                     val bookHandler =
                         BookSyncDomainHandler(db, BookEntityMapper(), RoomTransactionRunner(db), stubImageStorage(), registry)
                     val contributorHandler =
-                        ContributorSyncDomainHandler(db, RoomTransactionRunner(db), registry)
+                        ContributorSyncDomainHandler(db, RoomTransactionRunner(db), stubImageStorage(), registry)
 
                     // 1. Book event arrives first — contributor "c1" is not yet in Room.
                     bookHandler.onEvent(
@@ -87,7 +87,7 @@ class ContributorSelfHealIntegrationTest :
                     val bookHandler =
                         BookSyncDomainHandler(db, BookEntityMapper(), RoomTransactionRunner(db), stubImageStorage(), registry)
                     val contributorHandler =
-                        ContributorSyncDomainHandler(db, RoomTransactionRunner(db), registry)
+                        ContributorSyncDomainHandler(db, RoomTransactionRunner(db), stubImageStorage(), registry)
 
                     // 1. Real contributor event arrives first.
                     contributorHandler.onEvent(

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorSyncDomainHandlerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorSyncDomainHandlerTest.kt
@@ -10,6 +10,14 @@ import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.sync.handlers.ContributorSyncDomainHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.test.stubImageStorage
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
@@ -186,20 +194,72 @@ class ContributorSyncDomainHandlerTest :
             val registry = ClientSyncDomainRegistry()
             val db = createInMemoryTestDatabase()
             try {
-                val handler = ContributorSyncDomainHandler(db, RoomTransactionRunner(db), registry)
+                val handler = ContributorSyncDomainHandler(db, RoomTransactionRunner(db), stubImageStorage(), registry)
                 handler.domainName shouldBe "contributors"
                 registry.lookup("contributors") shouldBe handler
             } finally {
                 db.close()
             }
         }
+
+        // The server stores contributor photos content-addressed, so a re-scrape changes imagePath. The
+        // local copy is id-named and never otherwise re-downloaded, so it must be dropped on change.
+        test("a changed contributor imagePath drops the stale local photo") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val imageStorage =
+                        mock<ImageStorage> { everySuspend { deleteContributorImage(any()) } returns AppResult.Success(Unit) }
+                    val handler =
+                        ContributorSyncDomainHandler(db, RoomTransactionRunner(db), imageStorage, ClientSyncDomainRegistry())
+
+                    handler.onEvent(created(photo("c1", "h1")), isOwnEcho = false)
+                    handler.onEvent(updated(photo("c1", "h2", revision = 2)), isOwnEcho = false)
+
+                    verifySuspend(VerifyMode.exactly(1)) { imageStorage.deleteContributorImage("c1") }
+                } finally {
+                    db.close()
+                }
+            }
+        }
+
+        test("an unchanged contributor imagePath leaves the local photo in place") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val imageStorage =
+                        mock<ImageStorage> { everySuspend { deleteContributorImage(any()) } returns AppResult.Success(Unit) }
+                    val handler =
+                        ContributorSyncDomainHandler(db, RoomTransactionRunner(db), imageStorage, ClientSyncDomainRegistry())
+
+                    handler.onEvent(created(photo("c1", "h1")), isOwnEcho = false)
+                    handler.onEvent(updated(photo("c1", "h1", name = "Renamed", revision = 2)), isOwnEcho = false)
+
+                    verifySuspend(VerifyMode.not) { imageStorage.deleteContributorImage(any()) }
+                } finally {
+                    db.close()
+                }
+            }
+        }
     })
+
+private fun updated(p: ContributorSyncPayload) =
+    SyncEvent.Updated(
+        id = p.id,
+        revision = p.revision,
+        occurredAt = p.updatedAt,
+        clientOpId = null,
+        payload = p,
+    )
 
 private fun withHandler(block: suspend (ContributorSyncDomainHandler, ListenUpDatabase) -> Unit) =
     runTest {
         val db = createInMemoryTestDatabase()
         try {
-            block(ContributorSyncDomainHandler(db, RoomTransactionRunner(db), ClientSyncDomainRegistry()), db)
+            block(
+                ContributorSyncDomainHandler(db, RoomTransactionRunner(db), stubImageStorage(), ClientSyncDomainRegistry()),
+                db,
+            )
         } finally {
             db.close()
         }
@@ -213,6 +273,13 @@ private fun created(p: ContributorSyncPayload) =
         clientOpId = null,
         payload = p,
     )
+
+private fun photo(
+    id: String,
+    hash: String,
+    name: String = "Sanderson",
+    revision: Long = 1L,
+) = payload(id, name, revision = revision).copy(imagePath = "contributors/$hash.jpg")
 
 private fun payload(
     id: String,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestOptOutSetTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestOptOutSetTest.kt
@@ -54,7 +54,12 @@ class DigestOptOutSetTest :
                         imageStorage = stubImageStorage(),
                         registry = registry,
                     )
-                    ContributorSyncDomainHandler(database = clientDb, transactionRunner = txRunner, registry = registry)
+                    ContributorSyncDomainHandler(
+                        database = clientDb,
+                        transactionRunner = txRunner,
+                        imageStorage = stubImageStorage(),
+                        registry = registry,
+                    )
                     SeriesSyncDomainHandler(database = clientDb, transactionRunner = txRunner, registry = registry)
                     GenreSyncDomainHandler(database = clientDb, transactionRunner = txRunner, registry = registry)
                     PlaybackPositionSyncDomainHandler(database = clientDb, transactionRunner = txRunner, registry = registry)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -553,6 +553,7 @@ private fun registerClientSyncHandlers(
     ContributorSyncDomainHandler(
         database = clientDb,
         transactionRunner = RoomTransactionRunner(clientDb),
+        imageStorage = stubImageStorage(),
         registry = registry,
     )
     SeriesSyncDomainHandler(

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
@@ -187,6 +187,7 @@ fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -> Unit)
             ContributorSyncDomainHandler(
                 database = clientDb,
                 transactionRunner = RoomTransactionRunner(clientDb),
+                imageStorage = stubImageStorage(),
                 registry = registry,
             )
             SeriesSyncDomainHandler(

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/StubImageStorage.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/StubImageStorage.kt
@@ -12,4 +12,9 @@ import dev.mokkery.mock
  * cover-cache-invalidation side effect. The handler only calls [ImageStorage.deleteCover]; that is
  * stubbed to succeed. Tests that assert on the deletion build their own recording mock instead.
  */
-fun stubImageStorage(): ImageStorage = mock { everySuspend { deleteCover(any()) } returns AppResult.Success(Unit) }
+fun stubImageStorage(): ImageStorage =
+    mock {
+        everySuspend { deleteCover(any()) } returns AppResult.Success(Unit)
+        everySuspend { deleteContributorImage(any()) } returns AppResult.Success(Unit)
+        everySuspend { deleteSeriesCover(any()) } returns AppResult.Success(Unit)
+    }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
@@ -21,7 +21,12 @@ import kotlinx.coroutines.withContext
 
 private val logger = KotlinLogging.logger {}
 
-private fun contributorCacheKey(contributorId: String) = "$contributorId:contributor"
+// Folds the content-addressed [imagePath] into the key so a re-scraped photo (new path) busts the
+// Coil cache instead of serving the cached old one. Null path → the legacy per-contributor key.
+private fun contributorCacheKey(
+    contributorId: String,
+    imagePath: String?,
+) = "$contributorId:${imagePath ?: "contributor"}"
 
 /**
  * Smart contributor image with server URL fallback.
@@ -50,8 +55,8 @@ fun ContributorCoverImage(
                 ImageRequest
                     .Builder(context)
                     .data(it)
-                    .memoryCacheKey(contributorCacheKey(contributorId))
-                    .diskCacheKey(contributorCacheKey(contributorId))
+                    .memoryCacheKey(contributorCacheKey(contributorId, imagePath))
+                    .diskCacheKey(contributorCacheKey(contributorId, imagePath))
                     .build()
             }
         }
@@ -86,8 +91,8 @@ fun ContributorCoverImage(
                     ImageRequest
                         .Builder(context)
                         .data(localPath)
-                        .memoryCacheKey(contributorCacheKey(contributorId))
-                        .diskCacheKey(contributorCacheKey(contributorId))
+                        .memoryCacheKey(contributorCacheKey(contributorId, imagePath))
+                        .diskCacheKey(contributorCacheKey(contributorId, imagePath))
                         .build()
                 } else {
                     val baseUrl = serverConfig.getActiveUrl()?.value


### PR DESCRIPTION
## Problem

Re-scraping a contributor's photo (e.g. applying new Audible metadata) didn't change what the client rendered — the old photo stuck around. Same root cause as the book-cover staleness fixed in #504, applied to the `contributors` domain.

Three layers conspired to serve the stale image:
1. **Coil cache key** was keyed on contributor id alone, so a new photo at the same id hit the cached bitmap.
2. **Server filename** was id-based (`contributors/{id}.jpg`) — the synced `imagePath` never changed, so nothing downstream could tell the photo was new.
3. **Local file** is id-named and the downloader skips when a file already exists, so the old bytes were never replaced.

## Fix

- **Server — content-addressed photos.** `ContributorMetadataApplier` now stores the photo at `contributors/{sha256}.jpg`. A different photo yields a different path, so the synced `imagePath` *is* the version. Adds `ImageStorage.writeBytes(bytes, dest)` (atomic temp+rename, extracted from `download()`).
- **Client — drop the stale local copy on change.** `ContributorSyncDomainHandler.upsert` calls `imageStorage.deleteContributorImage(id)` when the incoming `imagePath` differs from the stored one, so the render re-fetches.
- **Client — version the Coil key.** `ContributorCoverImage` folds `imagePath` into the memory/disk cache key.

This fans out to every client via the existing sync path (the new `imagePath` rides the `ContributorSyncPayload`).

## Tests

- `ContributorSyncDomainHandlerTest`: a changed `imagePath` drops the stale local photo (exactly once); an unchanged path leaves it in place.
- All JVM + server + Android gates green.
