### PR TITLE
🐛 fix(profile): bust the avatar cache on re-upload via updatedAt-versioned key

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImpl.kt
@@ -29,4 +29,5 @@ private fun UserProfileEntity.toDomain(): CachedUserProfile =
         avatarType = avatarType,
         avatarValue = avatarValue,
         avatarColor = avatarColor,
+        updatedAt = updatedAt,
     )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/CachedUserProfile.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/CachedUserProfile.kt
@@ -13,4 +13,11 @@ data class CachedUserProfile(
     val avatarType: String,
     val avatarValue: String?,
     val avatarColor: String,
+    /**
+     * Last-update timestamp (epoch ms). The server bumps it whenever the profile changes —
+     * including on avatar upload — so it doubles as the avatar's content version: folded into
+     * the Coil cache key, a re-uploaded avatar busts the stale cached bitmap instead of
+     * rendering the old one.
+     */
+    val updatedAt: Long,
 )

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarStateTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarStateTest.kt
@@ -9,12 +9,14 @@ private fun profile(
     avatarType: String = "auto",
     displayName: String = "Ada Lovelace",
     avatarColor: String = "#3949AB",
+    updatedAt: Long = 100L,
 ) = CachedUserProfile(
     id = "u1",
     displayName = displayName,
     avatarType = avatarType,
     avatarValue = null,
     avatarColor = avatarColor,
+    updatedAt = updatedAt,
 )
 
 class UserAvatarStateTest :
@@ -24,18 +26,34 @@ class UserAvatarStateTest :
                 UserAvatarUiState.Loading
         }
 
-        test("image type with a local file maps to Image with the avatar cache key") {
+        test("image type with a local file maps to Image with a version-stamped avatar cache key") {
             val state =
                 userAvatarUiState(
-                    profile = profile(avatarType = "image", displayName = "Ada Lovelace"),
+                    profile = profile(avatarType = "image", displayName = "Ada Lovelace", updatedAt = 100L),
                     hasLocalAvatar = true,
                     localPath = "/avatars/u1.webp",
                     userId = "u1",
                 )
             state.shouldBeInstanceOf<UserAvatarUiState.Image>()
             state.localPath shouldBe "/avatars/u1.webp"
-            state.cacheKey shouldBe "u1-avatar"
+            // The profile's updatedAt is folded into the key so a re-uploaded avatar (server bumps
+            // updatedAt) busts the cached bitmap instead of rendering the stale one.
+            state.cacheKey shouldBe "u1-avatar-100"
             state.contentDescription shouldBe "Ada Lovelace"
+        }
+
+        test("a changed updatedAt yields a different avatar cache key (busts the stale bitmap)") {
+            fun keyAt(updatedAt: Long) =
+                (
+                    userAvatarUiState(
+                        profile = profile(avatarType = "image", updatedAt = updatedAt),
+                        hasLocalAvatar = true,
+                        localPath = "/avatars/u1.webp",
+                        userId = "u1",
+                    ) as UserAvatarUiState.Image
+                ).cacheKey
+            keyAt(100L) shouldBe "u1-avatar-100"
+            keyAt(200L) shouldBe "u1-avatar-200"
         }
 
         test("image content description falls back when display name is blank") {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
@@ -289,7 +289,10 @@ internal fun userAvatarUiState(
         profile.avatarType == "image" && hasLocalAvatar -> {
             UserAvatarUiState.Image(
                 localPath = localPath,
-                cacheKey = "$userId-avatar",
+                // Version the key on the profile's updatedAt: the server bumps it on avatar upload,
+                // so a re-uploaded avatar gets a fresh key and Coil re-decodes the new local file
+                // instead of serving the stale cached bitmap.
+                cacheKey = "$userId-avatar-${profile.updatedAt}",
                 contentDescription = profile.displayName.ifBlank { "User avatar" },
             )
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatarMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatarMenu.kt
@@ -191,14 +191,16 @@ private fun UserAvatarCircle(
                 }
 
             if (localPath != null) {
-                // Cache key matches the canonical UserAvatar key so Coil shares the cache entry.
+                // Version the key on updatedAtMs (bumped on avatar upload) so a re-uploaded avatar
+                // busts the stale cached bitmap — mirrors the canonical UserAvatar key shape.
+                val avatarKey = "${user.id.value}-avatar-${user.updatedAtMs}"
                 AsyncImage(
                     model =
                         ImageRequest
                             .Builder(platformContext)
                             .data(localPath)
-                            .memoryCacheKey("${user.id}-avatar")
-                            .diskCacheKey("${user.id}-avatar")
+                            .memoryCacheKey(avatarKey)
+                            .diskCacheKey(avatarKey)
                             .build(),
                     contentDescription = stringResource(Res.string.common_displayname_avatar, user.displayName),
                     modifier =


### PR DESCRIPTION
## Problem

Re-uploading a profile avatar didn't change what rendered — the old photo stuck around. Same staleness class as the book-cover (#504) and contributor-photo (#509) fixes, on the `profile/avatar` surface.

The avatar's local file *was* being invalidated (own-profile refresh calls `queueAvatarForceRefresh`, which deletes + re-downloads), but the **Coil cache key was unversioned** (`"$userId-avatar"`), so Coil kept serving the cached old bitmap from the new file.

## Fix

Version the avatar Coil cache key on the profile's `updatedAt` — which the server already bumps on avatar upload (`ProfileRoutes` stamps `UserEntity.updatedAt = now`). A re-uploaded avatar advances the timestamp, the key changes, and Coil re-decodes the fresh local file.

- `CachedUserProfile` now carries `updatedAt`; `UserProfileRepositoryImpl` maps it from the Room entity.
- `userAvatarUiState` builds the key as `"$userId-avatar-$updatedAt"`.
- `UserAvatarMenu` (the header avatar pill, a second render path) keyed off `user.updatedAtMs` to match.
- `UserProfileScreen` already busted on `avatarCacheBuster = user.updatedAtMs` — unchanged, and the precedent this fix follows.

## Scope note

Series covers were the other Phase-2 candidate but were **deferred**: the Kotlin server has no series-cover write path yet (no metadata applier, the `PATCH` never sends `coverPath`, `PUT /series/{id}/cover` is unimplemented), so there's nothing to bust against. Revisit when a series-cover write path lands.

## Tests

- `UserAvatarStateTest`: the cache key is version-stamped and changes when `updatedAt` advances.
- JVM + server tests, detekt/spotless, and Android assemble all green.
