### PR TITLE
✅ test(import): de-flake ImportRpcE2ETest (nested runTest tore down the upload)

### DIFF
--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/ImportRpcE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/ImportRpcE2ETest.kt
@@ -43,7 +43,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.test.runTest
 import kotlinx.rpc.krpc.ktor.client.installKrpc
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.krpc.ktor.client.rpcConfig
@@ -146,37 +145,41 @@ class ImportRpcE2ETest :
                             clientFactory = clientFactory,
                         )
 
-                    runTest {
-                        // 1. upload — must return a non-blank importId (proves the route is reachable
-                        //    and the correct path constant is used — not the old 404 path).
-                        val summary =
-                            repository
-                                .upload(buildMinimalAbsZipSource())
-                                .shouldBeInstanceOf<AppResult.Success<ImportSummary>>()
-                                .data
-                        summary.id.value.shouldNotBeBlank()
+                    // Drive the flow directly in the testApplication suspend scope — do NOT wrap in
+                    // runTest. runTest installs a virtual-time TestScope whose completion/cancellation
+                    // races the real-dispatcher HTTP transport: under load it tears down the multipart
+                    // upload's body coroutine mid-write, surfacing as an intermittent
+                    // ClosedWriteChannelException on step 1. The plain suspend scope has no such clock.
 
-                        val importId: ImportId = summary.id
-
-                        // 2. analyze — proves the RPC route is reachable post-upload.
+                    // 1. upload — must return a non-blank importId (proves the route is reachable
+                    //    and the correct path constant is used — not the old 404 path).
+                    val summary =
                         repository
-                            .analyze(importId)
-                            .shouldBeInstanceOf<AppResult.Success<ImportAnalysis>>()
+                            .upload(buildMinimalAbsZipSource())
+                            .shouldBeInstanceOf<AppResult.Success<ImportSummary>>()
+                            .data
+                    summary.id.value.shouldNotBeBlank()
 
-                        // 3. confirmMapping — empty maps are valid for a zero-row ABS backup.
+                    val importId: ImportId = summary.id
+
+                    // 2. analyze — proves the RPC route is reachable post-upload.
+                    repository
+                        .analyze(importId)
+                        .shouldBeInstanceOf<AppResult.Success<ImportAnalysis>>()
+
+                    // 3. confirmMapping — empty maps are valid for a zero-row ABS backup.
+                    repository
+                        .confirmMapping(importId, emptyMap(), emptyMap())
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    // 4. apply — proves the full lifecycle completes end-to-end.
+                    val applyResult =
                         repository
-                            .confirmMapping(importId, emptyMap(), emptyMap())
-                            .shouldBeInstanceOf<AppResult.Success<Unit>>()
-
-                        // 4. apply — proves the full lifecycle completes end-to-end.
-                        val applyResult =
-                            repository
-                                .apply(importId)
-                                .shouldBeInstanceOf<AppResult.Success<ImportResult>>()
-                                .data
-                        applyResult.importedCount shouldBe 0
-                        applyResult.skippedCount shouldBe 0
-                    }
+                            .apply(importId)
+                            .shouldBeInstanceOf<AppResult.Success<ImportResult>>()
+                            .data
+                    applyResult.importedCount shouldBe 0
+                    applyResult.skippedCount shouldBe 0
                 }
             } finally {
                 homeDir.toFile().deleteRecursively()


### PR DESCRIPTION
## The flake

`ImportRpcE2ETest > upload → analyze → confirmMapping → apply` has been intermittently red in CI all week. It blocked otherwise-green PRs (#509 failed it twice in a row).

## Root cause (reproduced, not guessed)

Stress-looping the test locally with `--rerun-tasks` reproduced it at **3/12 (25%)**. The failure is always an `io.ktor.utils.io.ClosedWriteChannelException` on **step 1 (the multipart upload)** — not a server/DB error.

The test wrapped its body in `runTest { }` **inside** `testApplication { }`. `runTest` installs a virtual-time `TestScope`; the multipart upload streams its body on the real-dispatcher HTTP transport. Under load, `runTest`'s scope completion/cancellation races the in-flight upload and tears down its body coroutine mid-write → `ClosedWriteChannelException` → the `upload()` result is a `Failure` → `shouldBeInstanceOf<Success>` throws. Locally (fast) the upload usually finishes before the race; under CI load it doesn't.

## Fix

Run the four steps directly in the `testApplication { }` suspend scope (it already is a coroutine context) and drop the nested `runTest`. No virtual clock, no scope race.

## Validation

Same 12× stress harness, after the fix: **0/12**. (Before: 3/12.) Lint + detekt green.

## Note

`BackupRpcE2ETest` uses the same nested-`runTest` pattern but doesn't flake — it makes only RPC calls, never a streaming multipart upload, so it never hits the write-channel teardown. Left as-is to keep this change surgical; worth the same treatment if it ever flakes.
