### PR TITLE
✅ test(shared): migrate pure-logic commonTest specs to Kotest (batch 1/N)

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/SyncableTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/SyncableTest.kt
@@ -1,30 +1,27 @@
 package com.calypsan.listenup.client.data.local.db
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class SyncableTest {
-    @Test
-    fun syncState_hasExpectedValues() {
-        // Verify all sync states exist
-        val states = SyncState.entries.toList()
-        assertEquals(4, states.size)
-        assertTrue(states.contains(SyncState.SYNCED))
-        assertTrue(states.contains(SyncState.NOT_SYNCED))
-        assertTrue(states.contains(SyncState.SYNCING))
-        assertTrue(states.contains(SyncState.CONFLICT))
-    }
+class SyncableTest :
+    FunSpec({
+        test("syncState_hasExpectedValues") {
+            // Verify all sync states exist
+            val states = SyncState.entries.toList()
+            states.size shouldBe 4
+            states.contains(SyncState.SYNCED) shouldBe true
+            states.contains(SyncState.NOT_SYNCED) shouldBe true
+            states.contains(SyncState.SYNCING) shouldBe true
+            states.contains(SyncState.CONFLICT) shouldBe true
+        }
 
-    @Test
-    fun syncState_synced_representsCleanState() {
-        val state = SyncState.SYNCED
-        assertEquals("SYNCED", state.name)
-    }
+        test("syncState_synced_representsCleanState") {
+            val state = SyncState.SYNCED
+            state.name shouldBe "SYNCED"
+        }
 
-    @Test
-    fun syncState_notSynced_representsLocalChanges() {
-        val state = SyncState.NOT_SYNCED
-        assertEquals("NOT_SYNCED", state.name)
-    }
-}
+        test("syncState_notSynced_representsLocalChanges") {
+            val state = SyncState.NOT_SYNCED
+            state.name shouldBe "NOT_SYNCED"
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/TypeConvertersTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/TypeConvertersTest.kt
@@ -1,57 +1,49 @@
 package com.calypsan.listenup.client.data.local.db
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class TypeConvertersTest {
-    private val converters = Converters()
+class TypeConvertersTest :
+    FunSpec({
+        val converters = Converters()
 
-    @Test
-    fun fromSyncState_synced_returnsName() {
-        assertEquals("SYNCED", converters.fromSyncState(SyncState.SYNCED))
-    }
-
-    @Test
-    fun fromSyncState_notSynced_returnsName() {
-        assertEquals("NOT_SYNCED", converters.fromSyncState(SyncState.NOT_SYNCED))
-    }
-
-    @Test
-    fun fromSyncState_syncing_returnsName() {
-        assertEquals("SYNCING", converters.fromSyncState(SyncState.SYNCING))
-    }
-
-    @Test
-    fun fromSyncState_conflict_returnsName() {
-        assertEquals("CONFLICT", converters.fromSyncState(SyncState.CONFLICT))
-    }
-
-    @Test
-    fun toSyncState_syncedName_returnsSynced() {
-        assertEquals(SyncState.SYNCED, converters.toSyncState("SYNCED"))
-    }
-
-    @Test
-    fun toSyncState_notSyncedName_returnsNotSynced() {
-        assertEquals(SyncState.NOT_SYNCED, converters.toSyncState("NOT_SYNCED"))
-    }
-
-    @Test
-    fun toSyncState_syncingName_returnsSyncing() {
-        assertEquals(SyncState.SYNCING, converters.toSyncState("SYNCING"))
-    }
-
-    @Test
-    fun toSyncState_conflictName_returnsConflict() {
-        assertEquals(SyncState.CONFLICT, converters.toSyncState("CONFLICT"))
-    }
-
-    @Test
-    fun syncStateConversion_roundTrip_preservesValue() {
-        SyncState.entries.forEach { state ->
-            val name = converters.fromSyncState(state)
-            val restored = converters.toSyncState(name)
-            assertEquals(state, restored)
+        test("fromSyncState_synced_returnsName") {
+            converters.fromSyncState(SyncState.SYNCED) shouldBe "SYNCED"
         }
-    }
-}
+
+        test("fromSyncState_notSynced_returnsName") {
+            converters.fromSyncState(SyncState.NOT_SYNCED) shouldBe "NOT_SYNCED"
+        }
+
+        test("fromSyncState_syncing_returnsName") {
+            converters.fromSyncState(SyncState.SYNCING) shouldBe "SYNCING"
+        }
+
+        test("fromSyncState_conflict_returnsName") {
+            converters.fromSyncState(SyncState.CONFLICT) shouldBe "CONFLICT"
+        }
+
+        test("toSyncState_syncedName_returnsSynced") {
+            converters.toSyncState("SYNCED") shouldBe SyncState.SYNCED
+        }
+
+        test("toSyncState_notSyncedName_returnsNotSynced") {
+            converters.toSyncState("NOT_SYNCED") shouldBe SyncState.NOT_SYNCED
+        }
+
+        test("toSyncState_syncingName_returnsSyncing") {
+            converters.toSyncState("SYNCING") shouldBe SyncState.SYNCING
+        }
+
+        test("toSyncState_conflictName_returnsConflict") {
+            converters.toSyncState("CONFLICT") shouldBe SyncState.CONFLICT
+        }
+
+        test("syncStateConversion_roundTrip_preservesValue") {
+            SyncState.entries.forEach { state ->
+                val name = converters.fromSyncState(state)
+                val restored = converters.toSyncState(name)
+                restored shouldBe state
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/ValueClassesTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/ValueClassesTest.kt
@@ -3,10 +3,10 @@ package com.calypsan.listenup.client.data.local.db
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ChapterId
 import com.calypsan.listenup.core.Timestamp
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
@@ -19,143 +19,126 @@ import kotlin.time.Duration.Companion.milliseconds
  * - toString behavior
  * - Timestamp arithmetic and comparison
  */
-class ValueClassesTest {
-    // ========== BookId Tests ==========
+class ValueClassesTest :
+    FunSpec({
+        // ========== BookId Tests ==========
 
-    @Test
-    fun `BookId stores value correctly`() {
-        val bookId = BookId("book-123")
-        assertEquals("book-123", bookId.value)
-    }
-
-    @Test
-    fun `BookId toString returns value`() {
-        val bookId = BookId("book-abc")
-        assertEquals("book-abc", bookId.toString())
-    }
-
-    @Test
-    fun `BookId rejects blank value`() {
-        assertFailsWith<IllegalArgumentException> {
-            BookId("")
+        test("BookId stores value correctly") {
+            val bookId = BookId("book-123")
+            bookId.value shouldBe "book-123"
         }
-    }
 
-    @Test
-    fun `BookId rejects whitespace-only value`() {
-        assertFailsWith<IllegalArgumentException> {
-            BookId("   ")
+        test("BookId toString returns value") {
+            val bookId = BookId("book-abc")
+            bookId.toString() shouldBe "book-abc"
         }
-    }
 
-    @Test
-    fun `BookId fromString creates valid id`() {
-        val bookId = BookId.fromString("book-456")
-        assertEquals("book-456", bookId.value)
-    }
-
-    @Test
-    fun `BookId equality works correctly`() {
-        val id1 = BookId("book-1")
-        val id2 = BookId("book-1")
-        val id3 = BookId("book-2")
-
-        assertEquals(id1, id2)
-        assertTrue(id1 != id3)
-    }
-
-    // ========== ChapterId Tests ==========
-
-    @Test
-    fun `ChapterId stores value correctly`() {
-        val chapterId = ChapterId("chapter-1")
-        assertEquals("chapter-1", chapterId.value)
-    }
-
-    @Test
-    fun `ChapterId toString returns value`() {
-        val chapterId = ChapterId("ch-abc")
-        assertEquals("ch-abc", chapterId.toString())
-    }
-
-    @Test
-    fun `ChapterId rejects blank value`() {
-        assertFailsWith<IllegalArgumentException> {
-            ChapterId("")
+        test("BookId rejects blank value") {
+            shouldThrow<IllegalArgumentException> {
+                BookId("")
+            }
         }
-    }
 
-    @Test
-    fun `ChapterId rejects whitespace-only value`() {
-        assertFailsWith<IllegalArgumentException> {
-            ChapterId("   ")
+        test("BookId rejects whitespace-only value") {
+            shouldThrow<IllegalArgumentException> {
+                BookId("   ")
+            }
         }
-    }
 
-    // ========== Timestamp Tests ==========
+        test("BookId fromString creates valid id") {
+            val bookId = BookId.fromString("book-456")
+            bookId.value shouldBe "book-456"
+        }
 
-    @Test
-    fun `Timestamp stores epoch millis correctly`() {
-        val ts = Timestamp(1_700_000_000_000L)
-        assertEquals(1_700_000_000_000L, ts.epochMillis)
-    }
+        test("BookId equality works correctly") {
+            val id1 = BookId("book-1")
+            val id2 = BookId("book-1")
+            val id3 = BookId("book-2")
 
-    @Test
-    fun `Timestamp toString returns epoch millis string`() {
-        val ts = Timestamp(1_234_567_890L)
-        assertEquals("1234567890", ts.toString())
-    }
+            id1 shouldBe id2
+            id3 shouldNotBe id1
+        }
 
-    @Test
-    fun `Timestamp now returns current time`() {
-        val before = Clock.System.now().toEpochMilliseconds()
-        val ts = Timestamp.now()
-        val after = Clock.System.now().toEpochMilliseconds()
+        // ========== ChapterId Tests ==========
 
-        assertTrue(ts.epochMillis >= before)
-        assertTrue(ts.epochMillis <= after)
-    }
+        test("ChapterId stores value correctly") {
+            val chapterId = ChapterId("chapter-1")
+            chapterId.value shouldBe "chapter-1"
+        }
 
-    @Test
-    fun `Timestamp compareTo works correctly`() {
-        val earlier = Timestamp(1_000L)
-        val later = Timestamp(2_000L)
+        test("ChapterId toString returns value") {
+            val chapterId = ChapterId("ch-abc")
+            chapterId.toString() shouldBe "ch-abc"
+        }
 
-        assertTrue(earlier < later)
-        assertTrue(later > earlier)
-        assertEquals(0, Timestamp(1_000L).compareTo(Timestamp(1_000L)))
-    }
+        test("ChapterId rejects blank value") {
+            shouldThrow<IllegalArgumentException> {
+                ChapterId("")
+            }
+        }
 
-    @Test
-    fun `Timestamp minus calculates duration between timestamps`() {
-        val earlier = Timestamp(1_000_000L)
-        val later = Timestamp(1_000_000L + 3_600_000L) // 1 hour later (3,600,000ms = 1 hour)
+        test("ChapterId rejects whitespace-only value") {
+            shouldThrow<IllegalArgumentException> {
+                ChapterId("   ")
+            }
+        }
 
-        val duration = later - earlier
-        assertEquals(1.hours, duration)
-    }
+        // ========== Timestamp Tests ==========
 
-    @Test
-    fun `Timestamp plus adds duration`() {
-        val ts = Timestamp(1_000_000L)
-        val result = ts + 1.hours
+        test("Timestamp stores epoch millis correctly") {
+            val ts = Timestamp(1_700_000_000_000L)
+            ts.epochMillis shouldBe 1_700_000_000_000L
+        }
 
-        // 1_000_000 + 3_600_000 = 4_600_000
-        assertEquals(4_600_000L, result.epochMillis)
-    }
+        test("Timestamp toString returns epoch millis string") {
+            val ts = Timestamp(1_234_567_890L)
+            ts.toString() shouldBe "1234567890"
+        }
 
-    @Test
-    fun `Timestamp plus handles milliseconds`() {
-        val ts = Timestamp(1_000_000L)
-        val result = ts + 500.milliseconds
+        test("Timestamp now returns current time") {
+            val before = Clock.System.now().toEpochMilliseconds()
+            val ts = Timestamp.now()
+            val after = Clock.System.now().toEpochMilliseconds()
 
-        assertEquals(1_000_500L, result.epochMillis)
-    }
+            (ts.epochMillis >= before) shouldBe true
+            (ts.epochMillis <= after) shouldBe true
+        }
 
-    @Test
-    fun `Timestamp toIsoString formats correctly`() {
-        // Unix timestamp 0 should format to epoch
-        val ts = Timestamp(0L)
-        assertEquals("1970-01-01T00:00:00Z", ts.toIsoString())
-    }
-}
+        test("Timestamp compareTo works correctly") {
+            val earlier = Timestamp(1_000L)
+            val later = Timestamp(2_000L)
+
+            (earlier < later) shouldBe true
+            (later > earlier) shouldBe true
+            Timestamp(1_000L).compareTo(Timestamp(1_000L)) shouldBe 0
+        }
+
+        test("Timestamp minus calculates duration between timestamps") {
+            val earlier = Timestamp(1_000_000L)
+            val later = Timestamp(1_000_000L + 3_600_000L) // 1 hour later (3,600,000ms = 1 hour)
+
+            val duration = later - earlier
+            duration shouldBe 1.hours
+        }
+
+        test("Timestamp plus adds duration") {
+            val ts = Timestamp(1_000_000L)
+            val result = ts + 1.hours
+
+            // 1_000_000 + 3_600_000 = 4_600_000
+            result.epochMillis shouldBe 4_600_000L
+        }
+
+        test("Timestamp plus handles milliseconds") {
+            val ts = Timestamp(1_000_000L)
+            val result = ts + 500.milliseconds
+
+            result.epochMillis shouldBe 1_000_500L
+        }
+
+        test("Timestamp toIsoString formats correctly") {
+            // Unix timestamp 0 should format to epoch
+            val ts = Timestamp(0L)
+            ts.toIsoString() shouldBe "1970-01-01T00:00:00Z"
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/model/ApiResponseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/model/ApiResponseTest.kt
@@ -2,280 +2,265 @@ package com.calypsan.listenup.client.data.remote.model
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.core.Failure
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
-class ApiResponseTest {
-    private val json = Json { ignoreUnknownKeys = true }
+class ApiResponseTest :
+    FunSpec({
+        val json = Json { ignoreUnknownKeys = true }
 
-    // region Canary Field Validation
+        // region Canary Field Validation
 
-    @Test
-    fun toResult_throwsEnvelopeMismatchException_whenVersionFieldMissing() {
-        val response =
-            ApiResponse<String>(
-                version = null,
-                success = true,
-                data = "test",
-            )
+        test("toResult_throwsEnvelopeMismatchException_whenVersionFieldMissing") {
+            val response =
+                ApiResponse<String>(
+                    version = null,
+                    success = true,
+                    data = "test",
+                )
 
-        val exception =
-            assertFailsWith<EnvelopeMismatchException> {
-                response.toResult()
-            }
+            val exception =
+                shouldThrow<EnvelopeMismatchException> {
+                    response.toResult()
+                }
 
-        assertTrue(exception.message!!.contains("missing 'v' field"))
-    }
-
-    @Test
-    fun toResult_throwsEnvelopeMismatchException_whenVersionIsWrong() {
-        val response =
-            ApiResponse<String>(
-                version = 999,
-                success = true,
-                data = "test",
-            )
-
-        val exception =
-            assertFailsWith<EnvelopeMismatchException> {
-                response.toResult()
-            }
-
-        assertTrue(exception.message!!.contains("Expected v=1"))
-        assertTrue(exception.message!!.contains("got v=999"))
-    }
-
-    // endregion
-
-    // region Success Responses
-
-    @Test
-    fun toResult_returnsSuccess_whenVersionValidAndSuccessTrue() {
-        val response =
-            ApiResponse(
-                version = 1,
-                success = true,
-                data = "test data",
-            )
-
-        val result = response.toResult()
-
-        val success = assertIs<AppResult.Success<String>>(result)
-        assertEquals("test data", success.data)
-    }
-
-    @Test
-    fun toResult_returnsSuccessWithNullData_whenSuccessTrueAndDataNull() {
-        val response =
-            ApiResponse<String?>(
-                version = 1,
-                success = true,
-                data = null,
-            )
-
-        val result = response.toResult()
-
-        val success = assertIs<AppResult.Success<String?>>(result)
-        assertNull(success.data)
-    }
-
-    // endregion
-
-    // region Simple Error Responses
-
-    @Test
-    fun toResult_returnsFailure_whenSuccessFalse() {
-        val response =
-            ApiResponse<String>(
-                version = 1,
-                success = false,
-                error = "Something went wrong",
-            )
-
-        val result = response.toResult()
-
-        // Body-level message convention: ApiException is mapped to InternalError by
-        // ErrorMapper, so the failure surfaces as a Failure (the original `error`
-        // string is now in debugInfo, not message).
-        assertIs<AppResult.Failure>(result)
-    }
-
-    @Test
-    fun toResult_returnsFailureWithDefaultMessage_whenErrorIsNull() {
-        val response =
-            ApiResponse<String>(
-                version = 1,
-                success = false,
-                error = null,
-            )
-
-        val result = response.toResult()
-
-        assertIs<AppResult.Failure>(result)
-    }
-
-    // endregion
-
-    // region Detailed Error Responses (code/message format)
-
-    @Test
-    fun toResult_returnsFailure_whenCodeIsPresent() {
-        val response =
-            ApiResponse<String>(
-                version = 1,
-                code = "conflict",
-                message = "Entity already exists",
-            )
-
-        val result = response.toResult()
-
-        assertIs<AppResult.Failure>(result)
-    }
-
-    @Test
-    fun toResult_returnsFailureWithCode_evenWhenSuccessTrue() {
-        // If code is present, treat it as an error regardless of success field
-        val response =
-            ApiResponse<String>(
-                version = 1,
-                success = true,
-                code = "validation_error",
-                message = "Invalid input",
-            )
-
-        val result = response.toResult()
-
-        assertIs<AppResult.Failure>(result)
-    }
-
-    @Test
-    fun toResult_handlesErrorEnvelopeWithDetails() {
-        val details =
-            buildJsonObject {
-                put("existing_id", "123")
-                put("suggestion", "Use merge instead")
-            }
-
-        val response =
-            ApiResponse<String>(
-                version = 1,
-                code = "disambiguation_required",
-                message = "Multiple matches found",
-                details = details,
-            )
-
-        val result = response.toResult()
-
-        assertIs<AppResult.Failure>(result)
-    }
-
-    // endregion
-
-    // region JSON Deserialization
-
-    @Test
-    fun apiResponse_deserializesSuccessEnvelope() {
-        val jsonString =
-            """
-            {
-                "v": 1,
-                "success": true,
-                "data": "hello world"
-            }
-            """.trimIndent()
-
-        val response = json.decodeFromString<ApiResponse<String>>(jsonString)
-
-        assertEquals(1, response.version)
-        assertTrue(response.success)
-        assertEquals("hello world", response.data)
-    }
-
-    @Test
-    fun apiResponse_deserializesSimpleErrorEnvelope() {
-        val jsonString =
-            """
-            {
-                "v": 1,
-                "success": false,
-                "error": "Not found"
-            }
-            """.trimIndent()
-
-        val response = json.decodeFromString<ApiResponse<String>>(jsonString)
-
-        assertEquals(1, response.version)
-        assertEquals(false, response.success)
-        assertEquals("Not found", response.error)
-    }
-
-    @Test
-    fun apiResponse_deserializesDetailedErrorEnvelope() {
-        val jsonString =
-            """
-            {
-                "v": 1,
-                "code": "conflict",
-                "message": "Entity already exists",
-                "details": {"id": "123"}
-            }
-            """.trimIndent()
-
-        val response = json.decodeFromString<ApiResponse<String>>(jsonString)
-
-        assertEquals(1, response.version)
-        assertEquals("conflict", response.code)
-        assertEquals("Entity already exists", response.message)
-        assertNotNull(response.details)
-    }
-
-    @Test
-    fun apiResponse_deserializesWithMissingOptionalFields() {
-        // Minimal valid envelope - just v and success
-        val jsonString =
-            """
-            {
-                "v": 1,
-                "success": true
-            }
-            """.trimIndent()
-
-        val response = json.decodeFromString<ApiResponse<String?>>(jsonString)
-
-        assertEquals(1, response.version)
-        assertTrue(response.success)
-        assertNull(response.data)
-        assertNull(response.error)
-        assertNull(response.code)
-    }
-
-    @Test
-    fun apiResponse_deserializesLegacyEnvelopeWithoutVersion() {
-        // Old responses without v field should parse but fail on toResult()
-        val jsonString =
-            """
-            {
-                "success": true,
-                "data": "test"
-            }
-            """.trimIndent()
-
-        val response = json.decodeFromString<ApiResponse<String>>(jsonString)
-
-        assertNull(response.version)
-
-        assertFailsWith<EnvelopeMismatchException> {
-            response.toResult()
+            exception.message!!.contains("missing 'v' field") shouldBe true
         }
-    }
 
-    // endregion
-}
+        test("toResult_throwsEnvelopeMismatchException_whenVersionIsWrong") {
+            val response =
+                ApiResponse<String>(
+                    version = 999,
+                    success = true,
+                    data = "test",
+                )
+
+            val exception =
+                shouldThrow<EnvelopeMismatchException> {
+                    response.toResult()
+                }
+
+            exception.message!!.contains("Expected v=1") shouldBe true
+            exception.message!!.contains("got v=999") shouldBe true
+        }
+
+        // endregion
+
+        // region Success Responses
+
+        test("toResult_returnsSuccess_whenVersionValidAndSuccessTrue") {
+            val response =
+                ApiResponse(
+                    version = 1,
+                    success = true,
+                    data = "test data",
+                )
+
+            val result = response.toResult()
+
+            val success = result.shouldBeInstanceOf<AppResult.Success<String>>()
+            success.data shouldBe "test data"
+        }
+
+        test("toResult_returnsSuccessWithNullData_whenSuccessTrueAndDataNull") {
+            val response =
+                ApiResponse<String?>(
+                    version = 1,
+                    success = true,
+                    data = null,
+                )
+
+            val result = response.toResult()
+
+            val success = result.shouldBeInstanceOf<AppResult.Success<String?>>()
+            success.data shouldBe null
+        }
+
+        // endregion
+
+        // region Simple Error Responses
+
+        test("toResult_returnsFailure_whenSuccessFalse") {
+            val response =
+                ApiResponse<String>(
+                    version = 1,
+                    success = false,
+                    error = "Something went wrong",
+                )
+
+            val result = response.toResult()
+
+            // Body-level message convention: ApiException is mapped to InternalError by
+            // ErrorMapper, so the failure surfaces as a Failure (the original `error`
+            // string is now in debugInfo, not message).
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
+
+        test("toResult_returnsFailureWithDefaultMessage_whenErrorIsNull") {
+            val response =
+                ApiResponse<String>(
+                    version = 1,
+                    success = false,
+                    error = null,
+                )
+
+            val result = response.toResult()
+
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
+
+        // endregion
+
+        // region Detailed Error Responses (code/message format)
+
+        test("toResult_returnsFailure_whenCodeIsPresent") {
+            val response =
+                ApiResponse<String>(
+                    version = 1,
+                    code = "conflict",
+                    message = "Entity already exists",
+                )
+
+            val result = response.toResult()
+
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
+
+        test("toResult_returnsFailureWithCode_evenWhenSuccessTrue") {
+            // If code is present, treat it as an error regardless of success field
+            val response =
+                ApiResponse<String>(
+                    version = 1,
+                    success = true,
+                    code = "validation_error",
+                    message = "Invalid input",
+                )
+
+            val result = response.toResult()
+
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
+
+        test("toResult_handlesErrorEnvelopeWithDetails") {
+            val details =
+                buildJsonObject {
+                    put("existing_id", "123")
+                    put("suggestion", "Use merge instead")
+                }
+
+            val response =
+                ApiResponse<String>(
+                    version = 1,
+                    code = "disambiguation_required",
+                    message = "Multiple matches found",
+                    details = details,
+                )
+
+            val result = response.toResult()
+
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
+
+        // endregion
+
+        // region JSON Deserialization
+
+        test("apiResponse_deserializesSuccessEnvelope") {
+            val jsonString =
+                """
+                {
+                    "v": 1,
+                    "success": true,
+                    "data": "hello world"
+                }
+                """.trimIndent()
+
+            val response = json.decodeFromString<ApiResponse<String>>(jsonString)
+
+            response.version shouldBe 1
+            response.success shouldBe true
+            response.data shouldBe "hello world"
+        }
+
+        test("apiResponse_deserializesSimpleErrorEnvelope") {
+            val jsonString =
+                """
+                {
+                    "v": 1,
+                    "success": false,
+                    "error": "Not found"
+                }
+                """.trimIndent()
+
+            val response = json.decodeFromString<ApiResponse<String>>(jsonString)
+
+            response.version shouldBe 1
+            response.success shouldBe false
+            response.error shouldBe "Not found"
+        }
+
+        test("apiResponse_deserializesDetailedErrorEnvelope") {
+            val jsonString =
+                """
+                {
+                    "v": 1,
+                    "code": "conflict",
+                    "message": "Entity already exists",
+                    "details": {"id": "123"}
+                }
+                """.trimIndent()
+
+            val response = json.decodeFromString<ApiResponse<String>>(jsonString)
+
+            response.version shouldBe 1
+            response.code shouldBe "conflict"
+            response.message shouldBe "Entity already exists"
+            response.details shouldNotBe null
+        }
+
+        test("apiResponse_deserializesWithMissingOptionalFields") {
+            // Minimal valid envelope - just v and success
+            val jsonString =
+                """
+                {
+                    "v": 1,
+                    "success": true
+                }
+                """.trimIndent()
+
+            val response = json.decodeFromString<ApiResponse<String?>>(jsonString)
+
+            response.version shouldBe 1
+            response.success shouldBe true
+            response.data shouldBe null
+            response.error shouldBe null
+            response.code shouldBe null
+        }
+
+        test("apiResponse_deserializesLegacyEnvelopeWithoutVersion") {
+            // Old responses without v field should parse but fail on toResult()
+            val jsonString =
+                """
+                {
+                    "success": true,
+                    "data": "test"
+                }
+                """.trimIndent()
+
+            val response = json.decodeFromString<ApiResponse<String>>(jsonString)
+
+            response.version shouldBe null
+
+            shouldThrow<EnvelopeMismatchException> {
+                response.toResult()
+            }
+        }
+
+        // endregion
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/model/EnvelopeContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/model/EnvelopeContractTest.kt
@@ -2,20 +2,21 @@ package com.calypsan.listenup.client.data.remote.model
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.core.Failure
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.json.Json
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 // Contract tests verifying client can parse the exact envelope format produced by the server.
 // The JSON fixtures below MUST match server/testdata/envelope/*.json (the source of truth).
 // If you change the envelope format, update both places and verify both test suites pass.
-class EnvelopeContractTest {
-    private val json = Json { ignoreUnknownKeys = true }
+class EnvelopeContractTest :
+    FunSpec({
+        val json = Json { ignoreUnknownKeys = true }
 
-    private val successFixture = """{
+        val successFixture = """{
   "v": 1,
   "success": true,
   "data": {
@@ -24,18 +25,18 @@ class EnvelopeContractTest {
   }
 }"""
 
-    private val successNullDataFixture = """{
+        val successNullDataFixture = """{
   "v": 1,
   "success": true
 }"""
 
-    private val errorSimpleFixture = """{
+        val errorSimpleFixture = """{
   "v": 1,
   "success": false,
   "error": "Resource not found"
 }"""
 
-    private val errorDetailedFixture = """{
+        val errorDetailedFixture = """{
   "v": 1,
   "code": "conflict",
   "message": "Entity already exists",
@@ -44,56 +45,51 @@ class EnvelopeContractTest {
   }
 }"""
 
-    @Test
-    fun clientCanParseServerSuccessEnvelope() {
-        val response = json.decodeFromString<ApiResponse<Map<String, String>>>(successFixture)
-        assertEquals(1, response.version, "Version field must be parsed as 1")
-        assertTrue(response.success, "Success must be true")
-        assertNotNull(response.data, "Data must be present")
-        val result = response.toResult()
-        val success = assertIs<AppResult.Success<Map<String, String>>>(result)
-        assertEquals("test-123", success.data["id"])
-        assertEquals("Test Item", success.data["name"])
-    }
+        test("clientCanParseServerSuccessEnvelope") {
+            val response = json.decodeFromString<ApiResponse<Map<String, String>>>(successFixture)
+            withClue("Version field must be parsed as 1") { response.version shouldBe 1 }
+            withClue("Success must be true") { response.success shouldBe true }
+            withClue("Data must be present") { response.data shouldNotBe null }
+            val result = response.toResult()
+            val success = result.shouldBeInstanceOf<AppResult.Success<Map<String, String>>>()
+            success.data["id"] shouldBe "test-123"
+            success.data["name"] shouldBe "Test Item"
+        }
 
-    @Test
-    fun clientCanParseServerSuccessNullDataEnvelope() {
-        val response = json.decodeFromString<ApiResponse<Unit?>>(successNullDataFixture)
-        assertEquals(1, response.version)
-        assertTrue(response.success)
-        val result = response.toResult()
+        test("clientCanParseServerSuccessNullDataEnvelope") {
+            val response = json.decodeFromString<ApiResponse<Unit?>>(successNullDataFixture)
+            response.version shouldBe 1
+            response.success shouldBe true
+            val result = response.toResult()
 
-        @Suppress("UNUSED_VARIABLE")
-        val success = assertIs<AppResult.Success<Unit?>>(result)
-    }
+            @Suppress("UNUSED_VARIABLE")
+            val success = result.shouldBeInstanceOf<AppResult.Success<Unit?>>()
+        }
 
-    @Test
-    fun clientCanParseServerSimpleErrorEnvelope() {
-        val response = json.decodeFromString<ApiResponse<Unit>>(errorSimpleFixture)
-        assertEquals(1, response.version)
-        assertEquals(false, response.success)
-        assertEquals("Resource not found", response.error)
-        val result = response.toResult()
-        // Body-level message convention: ApiException is mapped via ErrorMapper
-        // to InternalError; the original `error` text moves to debugInfo.
-        assertIs<AppResult.Failure>(result)
-    }
+        test("clientCanParseServerSimpleErrorEnvelope") {
+            val response = json.decodeFromString<ApiResponse<Unit>>(errorSimpleFixture)
+            response.version shouldBe 1
+            response.success shouldBe false
+            response.error shouldBe "Resource not found"
+            val result = response.toResult()
+            // Body-level message convention: ApiException is mapped via ErrorMapper
+            // to InternalError; the original `error` text moves to debugInfo.
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
 
-    @Test
-    fun clientCanParseServerDetailedErrorEnvelope() {
-        val response = json.decodeFromString<ApiResponse<Unit>>(errorDetailedFixture)
-        assertEquals(1, response.version)
-        assertEquals("conflict", response.code)
-        assertEquals("Entity already exists", response.message)
-        assertNotNull(response.details)
-        val result = response.toResult()
-        assertIs<AppResult.Failure>(result)
-    }
+        test("clientCanParseServerDetailedErrorEnvelope") {
+            val response = json.decodeFromString<ApiResponse<Unit>>(errorDetailedFixture)
+            response.version shouldBe 1
+            response.code shouldBe "conflict"
+            response.message shouldBe "Entity already exists"
+            response.details shouldNotBe null
+            val result = response.toResult()
+            result.shouldBeInstanceOf<AppResult.Failure>()
+        }
 
-    @Test
-    fun versionFieldMustBeNamedV() {
-        val badEnvelope = """{"version": 1, "success": true}"""
-        val response = json.decodeFromString<ApiResponse<Unit?>>(badEnvelope)
-        assertEquals(null, response.version, "Field must be 'v', not 'version'")
-    }
-}
+        test("versionFieldMustBeNamedV") {
+            val badEnvelope = """{"version": 1, "success": true}"""
+            val response = json.decodeFromString<ApiResponse<Unit?>>(badEnvelope)
+            withClue("Field must be 'v', not 'version'") { response.version shouldBe null }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/model/SyncModelsTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/model/SyncModelsTest.kt
@@ -1,90 +1,87 @@
 package com.calypsan.listenup.client.data.remote.model
 
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.serialization.json.Json
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
-class SyncModelsTest {
-    private val json = Json { ignoreUnknownKeys = true }
+class SyncModelsTest :
+    FunSpec({
+        val json = Json { ignoreUnknownKeys = true }
 
-    @Test
-    fun syncManifestResponse_deserializesFromJson() {
-        val jsonString =
-            """
-            {
-                "library_version": "2025-11-22T14:30:45Z",
-                "checkpoint": "2025-11-22T14:30:45Z",
-                "book_ids": ["book-123", "book-456"],
-                "counts": {
-                    "books": 2,
-                    "contributors": 5,
-                    "series": 1
+        test("syncManifestResponse_deserializesFromJson") {
+            val jsonString =
+                """
+                {
+                    "library_version": "2025-11-22T14:30:45Z",
+                    "checkpoint": "2025-11-22T14:30:45Z",
+                    "book_ids": ["book-123", "book-456"],
+                    "counts": {
+                        "books": 2,
+                        "contributors": 5,
+                        "series": 1
+                    }
                 }
-            }
-            """.trimIndent()
+                """.trimIndent()
 
-        val response = json.decodeFromString<SyncManifestResponse>(jsonString)
+            val response = json.decodeFromString<SyncManifestResponse>(jsonString)
 
-        assertEquals("2025-11-22T14:30:45Z", response.libraryVersion)
-        assertEquals("2025-11-22T14:30:45Z", response.checkpoint)
-        assertEquals(2, response.bookIds.size)
-        assertEquals(2, response.counts.books)
-    }
+            response.libraryVersion shouldBe "2025-11-22T14:30:45Z"
+            response.checkpoint shouldBe "2025-11-22T14:30:45Z"
+            response.bookIds.size shouldBe 2
+            response.counts.books shouldBe 2
+        }
 
-    @Test
-    fun bookResponse_deserializesFromJson() {
-        val jsonString =
-            """
-            {
-                "id": "book-123",
-                "created_at": "2025-11-22T10:00:00Z",
-                "updated_at": "2025-11-22T14:30:45Z",
-                "deleted_at": null,
-                "title": "Test Book",
-                "author": "Test Author",
-                "total_duration": 3600000
-            }
-            """.trimIndent()
+        test("bookResponse_deserializesFromJson") {
+            val jsonString =
+                """
+                {
+                    "id": "book-123",
+                    "created_at": "2025-11-22T10:00:00Z",
+                    "updated_at": "2025-11-22T14:30:45Z",
+                    "deleted_at": null,
+                    "title": "Test Book",
+                    "author": "Test Author",
+                    "total_duration": 3600000
+                }
+                """.trimIndent()
 
-        val book = json.decodeFromString<BookResponse>(jsonString)
+            val book = json.decodeFromString<BookResponse>(jsonString)
 
-        assertEquals("book-123", book.id)
-        assertEquals("Test Book", book.title)
-        assertNotNull(book.updatedAt)
-    }
+            book.id shouldBe "book-123"
+            book.title shouldBe "Test Book"
+            book.updatedAt shouldNotBe null
+        }
 
-    @Test
-    fun syncBooksResponse_deserializesFromJson() {
-        val jsonString =
-            """
-            {
-                "next_cursor": "abc123",
-                "books": [],
-                "has_more": true
-            }
-            """.trimIndent()
+        test("syncBooksResponse_deserializesFromJson") {
+            val jsonString =
+                """
+                {
+                    "next_cursor": "abc123",
+                    "books": [],
+                    "has_more": true
+                }
+                """.trimIndent()
 
-        val response = json.decodeFromString<SyncBooksResponse>(jsonString)
+            val response = json.decodeFromString<SyncBooksResponse>(jsonString)
 
-        assertEquals("abc123", response.nextCursor)
-        assertEquals(true, response.hasMore)
-    }
+            response.nextCursor shouldBe "abc123"
+            response.hasMore shouldBe true
+        }
 
-    @Test
-    fun syncBooksResponse_deserializesFromJsonWithMissingCursor() {
-        // Server uses omitempty on next_cursor, so it won't be present when empty
-        val jsonString =
-            """
-            {
-                "books": [],
-                "has_more": false
-            }
-            """.trimIndent()
+        test("syncBooksResponse_deserializesFromJsonWithMissingCursor") {
+            // Server uses omitempty on next_cursor, so it won't be present when empty
+            val jsonString =
+                """
+                {
+                    "books": [],
+                    "has_more": false
+                }
+                """.trimIndent()
 
-        val response = json.decodeFromString<SyncBooksResponse>(jsonString)
+            val response = json.decodeFromString<SyncBooksResponse>(jsonString)
 
-        assertEquals(null, response.nextCursor)
-        assertEquals(false, response.hasMore)
-    }
-}
+            response.nextCursor shouldBe null
+            response.hasMore shouldBe false
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/device/DeviceContextTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/device/DeviceContextTest.kt
@@ -1,139 +1,118 @@
 package com.calypsan.listenup.client.device
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class DeviceContextTest {
-    @Test
-    fun phoneHasTouch() {
-        assertTrue(DeviceContext(DeviceType.Phone).hasTouch)
-    }
-
-    @Test
-    fun phoneCanEdit() {
-        assertTrue(DeviceContext(DeviceType.Phone).canEdit)
-    }
-
-    @Test
-    fun phoneSupportsFullLibrary() {
-        assertTrue(DeviceContext(DeviceType.Phone).supportsFullLibrary)
-    }
-
-    @Test
-    fun phoneHasNoDpad() {
-        assertFalse(DeviceContext(DeviceType.Phone).hasDpad)
-    }
-
-    @Test
-    fun phoneIsNotLeanback() {
-        assertFalse(DeviceContext(DeviceType.Phone).isLeanback)
-    }
-
-    @Test
-    fun tvIsLeanback() {
-        val ctx = DeviceContext(DeviceType.Tv)
-        assertTrue(ctx.isLeanback)
-        assertTrue(ctx.hasDpad)
-        assertTrue(ctx.prefersLargeTargets)
-        assertFalse(ctx.hasTouch)
-        assertFalse(ctx.canEdit)
-        assertTrue(ctx.supportsFullLibrary)
-    }
-
-    @Test
-    fun desktopCanEditButNoDpad() {
-        val ctx = DeviceContext(DeviceType.Desktop)
-        assertTrue(ctx.canEdit)
-        assertFalse(ctx.hasDpad)
-        assertFalse(ctx.hasTouch)
-        assertTrue(ctx.supportsFullLibrary)
-    }
-
-    @Test
-    fun watchIsWearable() {
-        val ctx = DeviceContext(DeviceType.Watch)
-        assertTrue(ctx.isWearable)
-        assertTrue(ctx.hasTouch)
-        assertFalse(ctx.canEdit)
-        assertFalse(ctx.supportsFullLibrary)
-    }
-
-    @Test
-    fun autoHasDpadAndLargeTargets() {
-        val ctx = DeviceContext(DeviceType.Auto)
-        assertTrue(ctx.hasDpad)
-        assertTrue(ctx.prefersLargeTargets)
-        assertFalse(ctx.hasTouch)
-        assertFalse(ctx.canEdit)
-    }
-
-    @Test
-    fun xrHasTouchAndLargeTargets() {
-        val ctx = DeviceContext(DeviceType.Xr)
-        assertTrue(ctx.hasTouch)
-        assertTrue(ctx.prefersLargeTargets)
-        assertFalse(ctx.hasDpad)
-    }
-
-    @Test
-    fun tabletCapabilities() {
-        val ctx = DeviceContext(DeviceType.Tablet)
-        assertTrue(ctx.hasTouch)
-        assertTrue(ctx.canEdit)
-        assertTrue(ctx.supportsFullLibrary)
-        assertFalse(ctx.hasDpad)
-        assertFalse(ctx.isLeanback)
-    }
-
-    @Test
-    fun allDeviceTypes() {
-        // Ensure every DeviceType creates a valid DeviceContext
-        DeviceType.entries.forEach { type ->
-            val ctx = DeviceContext(type)
-            assertEquals(type, ctx.type)
+class DeviceContextTest :
+    FunSpec({
+        test("phoneHasTouch") {
+            DeviceContext(DeviceType.Phone).hasTouch shouldBe true
         }
-    }
 
-    @Test
-    fun `supportsDownloads true for Phone`() {
-        assertTrue(DeviceContext(DeviceType.Phone).supportsDownloads)
-    }
+        test("phoneCanEdit") {
+            DeviceContext(DeviceType.Phone).canEdit shouldBe true
+        }
 
-    @Test
-    fun `supportsDownloads true for Tablet`() {
-        assertTrue(DeviceContext(DeviceType.Tablet).supportsDownloads)
-    }
+        test("phoneSupportsFullLibrary") {
+            DeviceContext(DeviceType.Phone).supportsFullLibrary shouldBe true
+        }
 
-    @Test
-    fun `supportsDownloads true for Watch`() {
-        assertTrue(DeviceContext(DeviceType.Watch).supportsDownloads)
-    }
+        test("phoneHasNoDpad") {
+            DeviceContext(DeviceType.Phone).hasDpad shouldBe false
+        }
 
-    @Test
-    fun `supportsDownloads false for Desktop downloads not implemented UI hides affordance per W8 Phase A`() {
-        assertFalse(DeviceContext(DeviceType.Desktop).supportsDownloads)
-    }
+        test("phoneIsNotLeanback") {
+            DeviceContext(DeviceType.Phone).isLeanback shouldBe false
+        }
 
-    @Test
-    fun `supportsDownloads false for Tv`() {
-        assertFalse(DeviceContext(DeviceType.Tv).supportsDownloads)
-    }
+        test("tvIsLeanback") {
+            val ctx = DeviceContext(DeviceType.Tv)
+            ctx.isLeanback shouldBe true
+            ctx.hasDpad shouldBe true
+            ctx.prefersLargeTargets shouldBe true
+            ctx.hasTouch shouldBe false
+            ctx.canEdit shouldBe false
+            ctx.supportsFullLibrary shouldBe true
+        }
 
-    @Test
-    fun `supportsDownloads false for Auto`() {
-        assertFalse(DeviceContext(DeviceType.Auto).supportsDownloads)
-    }
+        test("desktopCanEditButNoDpad") {
+            val ctx = DeviceContext(DeviceType.Desktop)
+            ctx.canEdit shouldBe true
+            ctx.hasDpad shouldBe false
+            ctx.hasTouch shouldBe false
+            ctx.supportsFullLibrary shouldBe true
+        }
 
-    @Test
-    fun `supportsDownloads false for Xr`() {
-        assertFalse(DeviceContext(DeviceType.Xr).supportsDownloads)
-    }
+        test("watchIsWearable") {
+            val ctx = DeviceContext(DeviceType.Watch)
+            ctx.isWearable shouldBe true
+            ctx.hasTouch shouldBe true
+            ctx.canEdit shouldBe false
+            ctx.supportsFullLibrary shouldBe false
+        }
 
-    @Test
-    fun `supportsDownloads coverage exactly one outcome per DeviceType`() {
-        val all = DeviceType.entries.associateWith { DeviceContext(it).supportsDownloads }
-        assertEquals(DeviceType.entries.size, all.size)
-    }
-}
+        test("autoHasDpadAndLargeTargets") {
+            val ctx = DeviceContext(DeviceType.Auto)
+            ctx.hasDpad shouldBe true
+            ctx.prefersLargeTargets shouldBe true
+            ctx.hasTouch shouldBe false
+            ctx.canEdit shouldBe false
+        }
+
+        test("xrHasTouchAndLargeTargets") {
+            val ctx = DeviceContext(DeviceType.Xr)
+            ctx.hasTouch shouldBe true
+            ctx.prefersLargeTargets shouldBe true
+            ctx.hasDpad shouldBe false
+        }
+
+        test("tabletCapabilities") {
+            val ctx = DeviceContext(DeviceType.Tablet)
+            ctx.hasTouch shouldBe true
+            ctx.canEdit shouldBe true
+            ctx.supportsFullLibrary shouldBe true
+            ctx.hasDpad shouldBe false
+            ctx.isLeanback shouldBe false
+        }
+
+        test("allDeviceTypes") {
+            // Ensure every DeviceType creates a valid DeviceContext
+            DeviceType.entries.forEach { type ->
+                val ctx = DeviceContext(type)
+                ctx.type shouldBe type
+            }
+        }
+
+        test("supportsDownloads true for Phone") {
+            DeviceContext(DeviceType.Phone).supportsDownloads shouldBe true
+        }
+
+        test("supportsDownloads true for Tablet") {
+            DeviceContext(DeviceType.Tablet).supportsDownloads shouldBe true
+        }
+
+        test("supportsDownloads true for Watch") {
+            DeviceContext(DeviceType.Watch).supportsDownloads shouldBe true
+        }
+
+        test("supportsDownloads false for Desktop downloads not implemented UI hides affordance per W8 Phase A") {
+            DeviceContext(DeviceType.Desktop).supportsDownloads shouldBe false
+        }
+
+        test("supportsDownloads false for Tv") {
+            DeviceContext(DeviceType.Tv).supportsDownloads shouldBe false
+        }
+
+        test("supportsDownloads false for Auto") {
+            DeviceContext(DeviceType.Auto).supportsDownloads shouldBe false
+        }
+
+        test("supportsDownloads false for Xr") {
+            DeviceContext(DeviceType.Xr).supportsDownloads shouldBe false
+        }
+
+        test("supportsDownloads coverage exactly one outcome per DeviceType") {
+            val all = DeviceType.entries.associateWith { DeviceContext(it).supportsDownloads }
+            all.size shouldBe DeviceType.entries.size
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/SubtitleFilterTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/SubtitleFilterTest.kt
@@ -1,131 +1,98 @@
 package com.calypsan.listenup.client.presentation.bookdetail
 
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class SubtitleFilterTest {
-    @Test
-    fun `subtitle with just series name and book number is redundant`() {
-        assertTrue(
+class SubtitleFilterTest :
+    FunSpec({
+        test("subtitle with just series name and book number is redundant") {
             testIsSubtitleRedundant(
                 subtitle = "The Stormlight Archive, Book 1",
                 seriesName = "The Stormlight Archive",
                 seriesSequence = "1",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `subtitle with series name and hash number is redundant`() {
-        assertTrue(
+        test("subtitle with series name and hash number is redundant") {
             testIsSubtitleRedundant(
                 subtitle = "Mistborn #3",
                 seriesName = "Mistborn",
                 seriesSequence = "3",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `subtitle with Book X of Series is redundant`() {
-        assertTrue(
+        test("subtitle with Book X of Series is redundant") {
             testIsSubtitleRedundant(
                 subtitle = "Book 2 of The Wheel of Time",
                 seriesName = "The Wheel of Time",
                 seriesSequence = "2",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `subtitle with meaningful content is not redundant`() {
-        assertFalse(
+        test("subtitle with meaningful content is not redundant") {
             testIsSubtitleRedundant(
                 subtitle = "A Novel of the First Law",
                 seriesName = "The First Law",
                 seriesSequence = "1",
-            ),
-        )
-    }
+            ) shouldBe false
+        }
 
-    @Test
-    fun `subtitle without series name is not redundant`() {
-        assertFalse(
+        test("subtitle without series name is not redundant") {
             testIsSubtitleRedundant(
                 subtitle = "An Epic Fantasy Adventure",
                 seriesName = "The Stormlight Archive",
                 seriesSequence = "1",
-            ),
-        )
-    }
+            ) shouldBe false
+        }
 
-    @Test
-    fun `subtitle when no series info is not redundant`() {
-        assertFalse(
+        test("subtitle when no series info is not redundant") {
             testIsSubtitleRedundant(
                 subtitle = "Book 1",
                 seriesName = null,
                 seriesSequence = null,
-            ),
-        )
-    }
+            ) shouldBe false
+        }
 
-    @Test
-    fun `subtitle with volume pattern is redundant`() {
-        assertTrue(
+        test("subtitle with volume pattern is redundant") {
             testIsSubtitleRedundant(
                 subtitle = "Cosmere Collection, Volume 1",
                 seriesName = "Cosmere Collection",
                 seriesSequence = "1",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `subtitle with part pattern is redundant`() {
-        assertTrue(
+        test("subtitle with part pattern is redundant") {
             testIsSubtitleRedundant(
                 subtitle = "The Dark Tower, Part 3",
                 seriesName = "The Dark Tower",
                 seriesSequence = "3",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `subtitle with roman numerals is redundant`() {
-        assertTrue(
+        test("subtitle with roman numerals is redundant") {
             testIsSubtitleRedundant(
                 subtitle = "The Chronicles of Narnia, Book III",
                 seriesName = "The Chronicles of Narnia",
                 seriesSequence = "3",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `case insensitive matching works`() {
-        assertTrue(
+        test("case insensitive matching works") {
             testIsSubtitleRedundant(
                 subtitle = "THE STORMLIGHT ARCHIVE: BOOK ONE",
                 seriesName = "The Stormlight Archive",
                 seriesSequence = "1",
-            ),
-        )
-    }
+            ) shouldBe true
+        }
 
-    @Test
-    fun `subtitle with extra meaningful text is not redundant`() {
-        assertFalse(
+        test("subtitle with extra meaningful text is not redundant") {
             testIsSubtitleRedundant(
                 subtitle = "The Stormlight Archive, Book 1: The Epic Beginning",
                 seriesName = "The Stormlight Archive",
                 seriesSequence = "1",
-            ),
-        )
-    }
-}
+            ) shouldBe false
+        }
+    })
 
 // Test wrapper that uses the same logic as the private function
 private fun testIsSubtitleRedundant(

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/SortStateTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/SortStateTest.kt
@@ -1,9 +1,7 @@
 package com.calypsan.listenup.client.presentation.library
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Tests for SortState, SortDirection, and SortCategory.
@@ -14,251 +12,223 @@ import kotlin.test.assertTrue
  * - Persistence key encoding/decoding
  * - State transitions
  */
-class SortStateTest {
-    // ========== SortDirection Tests ==========
+class SortStateTest :
+    FunSpec({
+        // ========== SortDirection Tests ==========
 
-    @Test
-    fun `SortDirection toggle switches ascending to descending`() {
-        assertEquals(SortDirection.DESCENDING, SortDirection.ASCENDING.toggle())
-    }
+        test("SortDirection toggle switches ascending to descending") {
+            SortDirection.ASCENDING.toggle() shouldBe SortDirection.DESCENDING
+        }
 
-    @Test
-    fun `SortDirection toggle switches descending to ascending`() {
-        assertEquals(SortDirection.ASCENDING, SortDirection.DESCENDING.toggle())
-    }
+        test("SortDirection toggle switches descending to ascending") {
+            SortDirection.DESCENDING.toggle() shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortDirection key returns lowercase name`() {
-        assertEquals("ascending", SortDirection.ASCENDING.key)
-        assertEquals("descending", SortDirection.DESCENDING.key)
-    }
+        test("SortDirection key returns lowercase name") {
+            SortDirection.ASCENDING.key shouldBe "ascending"
+            SortDirection.DESCENDING.key shouldBe "descending"
+        }
 
-    @Test
-    fun `SortDirection fromKey parses valid keys`() {
-        assertEquals(SortDirection.ASCENDING, SortDirection.fromKey("ascending"))
-        assertEquals(SortDirection.DESCENDING, SortDirection.fromKey("descending"))
-    }
+        test("SortDirection fromKey parses valid keys") {
+            SortDirection.fromKey("ascending") shouldBe SortDirection.ASCENDING
+            SortDirection.fromKey("descending") shouldBe SortDirection.DESCENDING
+        }
 
-    @Test
-    fun `SortDirection fromKey returns null for invalid key`() {
-        assertNull(SortDirection.fromKey("invalid"))
-        assertNull(SortDirection.fromKey(""))
-        assertNull(SortDirection.fromKey("ASCENDING"))
-    }
+        test("SortDirection fromKey returns null for invalid key") {
+            SortDirection.fromKey("invalid") shouldBe null
+            SortDirection.fromKey("") shouldBe null
+            SortDirection.fromKey("ASCENDING") shouldBe null
+        }
 
-    // ========== SortCategory Tests ==========
+        // ========== SortCategory Tests ==========
 
-    @Test
-    fun `SortCategory key returns lowercase name`() {
-        assertEquals("title", SortCategory.TITLE.key)
-        assertEquals("author", SortCategory.AUTHOR.key)
-        assertEquals("duration", SortCategory.DURATION.key)
-    }
+        test("SortCategory key returns lowercase name") {
+            SortCategory.TITLE.key shouldBe "title"
+            SortCategory.AUTHOR.key shouldBe "author"
+            SortCategory.DURATION.key shouldBe "duration"
+        }
 
-    @Test
-    fun `SortCategory fromKey parses valid keys`() {
-        assertEquals(SortCategory.TITLE, SortCategory.fromKey("title"))
-        assertEquals(SortCategory.AUTHOR, SortCategory.fromKey("author"))
-        assertEquals(SortCategory.DURATION, SortCategory.fromKey("duration"))
-        assertEquals(SortCategory.YEAR, SortCategory.fromKey("year"))
-        assertEquals(SortCategory.ADDED, SortCategory.fromKey("added"))
-        assertEquals(SortCategory.SERIES, SortCategory.fromKey("series"))
-        assertEquals(SortCategory.NAME, SortCategory.fromKey("name"))
-        assertEquals(SortCategory.BOOK_COUNT, SortCategory.fromKey("book_count"))
-    }
+        test("SortCategory fromKey parses valid keys") {
+            SortCategory.fromKey("title") shouldBe SortCategory.TITLE
+            SortCategory.fromKey("author") shouldBe SortCategory.AUTHOR
+            SortCategory.fromKey("duration") shouldBe SortCategory.DURATION
+            SortCategory.fromKey("year") shouldBe SortCategory.YEAR
+            SortCategory.fromKey("added") shouldBe SortCategory.ADDED
+            SortCategory.fromKey("series") shouldBe SortCategory.SERIES
+            SortCategory.fromKey("name") shouldBe SortCategory.NAME
+            SortCategory.fromKey("book_count") shouldBe SortCategory.BOOK_COUNT
+        }
 
-    @Test
-    fun `SortCategory fromKey returns null for invalid key`() {
-        assertNull(SortCategory.fromKey("invalid"))
-        assertNull(SortCategory.fromKey(""))
-    }
+        test("SortCategory fromKey returns null for invalid key") {
+            SortCategory.fromKey("invalid") shouldBe null
+            SortCategory.fromKey("") shouldBe null
+        }
 
-    @Test
-    fun `SortCategory text sorts default to ascending`() {
-        assertEquals(SortDirection.ASCENDING, SortCategory.TITLE.defaultDirection)
-        assertEquals(SortDirection.ASCENDING, SortCategory.AUTHOR.defaultDirection)
-        assertEquals(SortDirection.ASCENDING, SortCategory.NAME.defaultDirection)
-    }
+        test("SortCategory text sorts default to ascending") {
+            SortCategory.TITLE.defaultDirection shouldBe SortDirection.ASCENDING
+            SortCategory.AUTHOR.defaultDirection shouldBe SortDirection.ASCENDING
+            SortCategory.NAME.defaultDirection shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortCategory numeric sorts default to descending`() {
-        assertEquals(SortDirection.DESCENDING, SortCategory.DURATION.defaultDirection)
-        assertEquals(SortDirection.DESCENDING, SortCategory.YEAR.defaultDirection)
-        assertEquals(SortDirection.DESCENDING, SortCategory.BOOK_COUNT.defaultDirection)
-        assertEquals(SortDirection.DESCENDING, SortCategory.ADDED.defaultDirection)
-    }
+        test("SortCategory numeric sorts default to descending") {
+            SortCategory.DURATION.defaultDirection shouldBe SortDirection.DESCENDING
+            SortCategory.YEAR.defaultDirection shouldBe SortDirection.DESCENDING
+            SortCategory.BOOK_COUNT.defaultDirection shouldBe SortDirection.DESCENDING
+            SortCategory.ADDED.defaultDirection shouldBe SortDirection.DESCENDING
+        }
 
-    @Test
-    fun `SortCategory directionLabel returns correct labels`() {
-        assertEquals("A → Z", SortCategory.TITLE.directionLabel(SortDirection.ASCENDING))
-        assertEquals("Z → A", SortCategory.TITLE.directionLabel(SortDirection.DESCENDING))
+        test("SortCategory directionLabel returns correct labels") {
+            SortCategory.TITLE.directionLabel(SortDirection.ASCENDING) shouldBe "A → Z"
+            SortCategory.TITLE.directionLabel(SortDirection.DESCENDING) shouldBe "Z → A"
 
-        assertEquals("Shortest", SortCategory.DURATION.directionLabel(SortDirection.ASCENDING))
-        assertEquals("Longest", SortCategory.DURATION.directionLabel(SortDirection.DESCENDING))
+            SortCategory.DURATION.directionLabel(SortDirection.ASCENDING) shouldBe "Shortest"
+            SortCategory.DURATION.directionLabel(SortDirection.DESCENDING) shouldBe "Longest"
 
-        assertEquals("Oldest", SortCategory.YEAR.directionLabel(SortDirection.ASCENDING))
-        assertEquals("Newest", SortCategory.YEAR.directionLabel(SortDirection.DESCENDING))
+            SortCategory.YEAR.directionLabel(SortDirection.ASCENDING) shouldBe "Oldest"
+            SortCategory.YEAR.directionLabel(SortDirection.DESCENDING) shouldBe "Newest"
 
-        assertEquals("First", SortCategory.ADDED.directionLabel(SortDirection.ASCENDING))
-        assertEquals("Recent", SortCategory.ADDED.directionLabel(SortDirection.DESCENDING))
+            SortCategory.ADDED.directionLabel(SortDirection.ASCENDING) shouldBe "First"
+            SortCategory.ADDED.directionLabel(SortDirection.DESCENDING) shouldBe "Recent"
 
-        assertEquals("Fewest", SortCategory.BOOK_COUNT.directionLabel(SortDirection.ASCENDING))
-        assertEquals("Most", SortCategory.BOOK_COUNT.directionLabel(SortDirection.DESCENDING))
-    }
+            SortCategory.BOOK_COUNT.directionLabel(SortDirection.ASCENDING) shouldBe "Fewest"
+            SortCategory.BOOK_COUNT.directionLabel(SortDirection.DESCENDING) shouldBe "Most"
+        }
 
-    @Test
-    fun `SortCategory booksCategories contains expected categories`() {
-        val categories = SortCategory.booksCategories
-        assertTrue(SortCategory.TITLE in categories)
-        assertTrue(SortCategory.AUTHOR in categories)
-        assertTrue(SortCategory.DURATION in categories)
-        assertTrue(SortCategory.YEAR in categories)
-        assertTrue(SortCategory.ADDED in categories)
-        assertTrue(SortCategory.SERIES in categories)
-    }
+        test("SortCategory booksCategories contains expected categories") {
+            val categories = SortCategory.booksCategories
+            (SortCategory.TITLE in categories) shouldBe true
+            (SortCategory.AUTHOR in categories) shouldBe true
+            (SortCategory.DURATION in categories) shouldBe true
+            (SortCategory.YEAR in categories) shouldBe true
+            (SortCategory.ADDED in categories) shouldBe true
+            (SortCategory.SERIES in categories) shouldBe true
+        }
 
-    @Test
-    fun `SortCategory seriesCategories contains expected categories`() {
-        val categories = SortCategory.seriesCategories
-        assertTrue(SortCategory.NAME in categories)
-        assertTrue(SortCategory.BOOK_COUNT in categories)
-        assertTrue(SortCategory.ADDED in categories)
-    }
+        test("SortCategory seriesCategories contains expected categories") {
+            val categories = SortCategory.seriesCategories
+            (SortCategory.NAME in categories) shouldBe true
+            (SortCategory.BOOK_COUNT in categories) shouldBe true
+            (SortCategory.ADDED in categories) shouldBe true
+        }
 
-    @Test
-    fun `SortCategory contributorCategories contains expected categories`() {
-        val categories = SortCategory.contributorCategories
-        assertTrue(SortCategory.NAME in categories)
-        assertTrue(SortCategory.BOOK_COUNT in categories)
-    }
+        test("SortCategory contributorCategories contains expected categories") {
+            val categories = SortCategory.contributorCategories
+            (SortCategory.NAME in categories) shouldBe true
+            (SortCategory.BOOK_COUNT in categories) shouldBe true
+        }
 
-    // ========== SortState Tests ==========
+        // ========== SortState Tests ==========
 
-    @Test
-    fun `SortState persistenceKey format is correct`() {
-        val state = SortState(SortCategory.TITLE, SortDirection.ASCENDING)
-        assertEquals("title:ascending", state.persistenceKey)
-    }
+        test("SortState persistenceKey format is correct") {
+            val state = SortState(SortCategory.TITLE, SortDirection.ASCENDING)
+            state.persistenceKey shouldBe "title:ascending"
+        }
 
-    @Test
-    fun `SortState persistenceKey with descending direction`() {
-        val state = SortState(SortCategory.DURATION, SortDirection.DESCENDING)
-        assertEquals("duration:descending", state.persistenceKey)
-    }
+        test("SortState persistenceKey with descending direction") {
+            val state = SortState(SortCategory.DURATION, SortDirection.DESCENDING)
+            state.persistenceKey shouldBe "duration:descending"
+        }
 
-    @Test
-    fun `SortState fromPersistenceKey parses valid key`() {
-        val state = SortState.fromPersistenceKey("title:ascending")
-        assertEquals(SortCategory.TITLE, state?.category)
-        assertEquals(SortDirection.ASCENDING, state?.direction)
-    }
+        test("SortState fromPersistenceKey parses valid key") {
+            val state = SortState.fromPersistenceKey("title:ascending")
+            state?.category shouldBe SortCategory.TITLE
+            state?.direction shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortState fromPersistenceKey parses all category-direction combinations`() {
-        val state = SortState.fromPersistenceKey("duration:descending")
-        assertEquals(SortCategory.DURATION, state?.category)
-        assertEquals(SortDirection.DESCENDING, state?.direction)
-    }
+        test("SortState fromPersistenceKey parses all category-direction combinations") {
+            val state = SortState.fromPersistenceKey("duration:descending")
+            state?.category shouldBe SortCategory.DURATION
+            state?.direction shouldBe SortDirection.DESCENDING
+        }
 
-    @Test
-    fun `SortState fromPersistenceKey returns null for invalid format`() {
-        assertNull(SortState.fromPersistenceKey("invalid"))
-        assertNull(SortState.fromPersistenceKey(""))
-        assertNull(SortState.fromPersistenceKey("title"))
-        assertNull(SortState.fromPersistenceKey("title:"))
-        assertNull(SortState.fromPersistenceKey(":ascending"))
-        assertNull(SortState.fromPersistenceKey("title:invalid"))
-        assertNull(SortState.fromPersistenceKey("invalid:ascending"))
-    }
+        test("SortState fromPersistenceKey returns null for invalid format") {
+            SortState.fromPersistenceKey("invalid") shouldBe null
+            SortState.fromPersistenceKey("") shouldBe null
+            SortState.fromPersistenceKey("title") shouldBe null
+            SortState.fromPersistenceKey("title:") shouldBe null
+            SortState.fromPersistenceKey(":ascending") shouldBe null
+            SortState.fromPersistenceKey("title:invalid") shouldBe null
+            SortState.fromPersistenceKey("invalid:ascending") shouldBe null
+        }
 
-    @Test
-    fun `SortState toggleDirection creates new state with toggled direction`() {
-        val original = SortState(SortCategory.TITLE, SortDirection.ASCENDING)
-        val toggled = original.toggleDirection()
+        test("SortState toggleDirection creates new state with toggled direction") {
+            val original = SortState(SortCategory.TITLE, SortDirection.ASCENDING)
+            val toggled = original.toggleDirection()
 
-        assertEquals(SortCategory.TITLE, toggled.category)
-        assertEquals(SortDirection.DESCENDING, toggled.direction)
-    }
+            toggled.category shouldBe SortCategory.TITLE
+            toggled.direction shouldBe SortDirection.DESCENDING
+        }
 
-    @Test
-    fun `SortState toggleDirection preserves category`() {
-        val original = SortState(SortCategory.DURATION, SortDirection.DESCENDING)
-        val toggled = original.toggleDirection()
+        test("SortState toggleDirection preserves category") {
+            val original = SortState(SortCategory.DURATION, SortDirection.DESCENDING)
+            val toggled = original.toggleDirection()
 
-        assertEquals(SortCategory.DURATION, toggled.category)
-        assertEquals(SortDirection.ASCENDING, toggled.direction)
-    }
+            toggled.category shouldBe SortCategory.DURATION
+            toggled.direction shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortState withCategory changes category and uses default direction`() {
-        val original = SortState(SortCategory.TITLE, SortDirection.DESCENDING)
-        val changed = original.withCategory(SortCategory.DURATION)
+        test("SortState withCategory changes category and uses default direction") {
+            val original = SortState(SortCategory.TITLE, SortDirection.DESCENDING)
+            val changed = original.withCategory(SortCategory.DURATION)
 
-        assertEquals(SortCategory.DURATION, changed.category)
-        // DURATION defaults to DESCENDING
-        assertEquals(SortDirection.DESCENDING, changed.direction)
-    }
+            changed.category shouldBe SortCategory.DURATION
+            // DURATION defaults to DESCENDING
+            changed.direction shouldBe SortDirection.DESCENDING
+        }
 
-    @Test
-    fun `SortState withCategory uses new category default direction`() {
-        val original = SortState(SortCategory.DURATION, SortDirection.ASCENDING)
-        val changed = original.withCategory(SortCategory.TITLE)
+        test("SortState withCategory uses new category default direction") {
+            val original = SortState(SortCategory.DURATION, SortDirection.ASCENDING)
+            val changed = original.withCategory(SortCategory.TITLE)
 
-        assertEquals(SortCategory.TITLE, changed.category)
-        // TITLE defaults to ASCENDING
-        assertEquals(SortDirection.ASCENDING, changed.direction)
-    }
+            changed.category shouldBe SortCategory.TITLE
+            // TITLE defaults to ASCENDING
+            changed.direction shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortState directionLabel delegates to category`() {
-        val state = SortState(SortCategory.TITLE, SortDirection.ASCENDING)
-        assertEquals("A → Z", state.directionLabel)
+        test("SortState directionLabel delegates to category") {
+            val state = SortState(SortCategory.TITLE, SortDirection.ASCENDING)
+            state.directionLabel shouldBe "A → Z"
 
-        val state2 = SortState(SortCategory.DURATION, SortDirection.DESCENDING)
-        assertEquals("Longest", state2.directionLabel)
-    }
+            val state2 = SortState(SortCategory.DURATION, SortDirection.DESCENDING)
+            state2.directionLabel shouldBe "Longest"
+        }
 
-    // ========== Default States Tests ==========
+        // ========== Default States Tests ==========
 
-    @Test
-    fun `SortState booksDefault is title ascending`() {
-        assertEquals(SortCategory.TITLE, SortState.booksDefault.category)
-        assertEquals(SortDirection.ASCENDING, SortState.booksDefault.direction)
-    }
+        test("SortState booksDefault is title ascending") {
+            SortState.booksDefault.category shouldBe SortCategory.TITLE
+            SortState.booksDefault.direction shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortState seriesDefault is name ascending`() {
-        assertEquals(SortCategory.NAME, SortState.seriesDefault.category)
-        assertEquals(SortDirection.ASCENDING, SortState.seriesDefault.direction)
-    }
+        test("SortState seriesDefault is name ascending") {
+            SortState.seriesDefault.category shouldBe SortCategory.NAME
+            SortState.seriesDefault.direction shouldBe SortDirection.ASCENDING
+        }
 
-    @Test
-    fun `SortState contributorDefault is name ascending`() {
-        assertEquals(SortCategory.NAME, SortState.contributorDefault.category)
-        assertEquals(SortDirection.ASCENDING, SortState.contributorDefault.direction)
-    }
+        test("SortState contributorDefault is name ascending") {
+            SortState.contributorDefault.category shouldBe SortCategory.NAME
+            SortState.contributorDefault.direction shouldBe SortDirection.ASCENDING
+        }
 
-    // ========== Round-Trip Tests ==========
+        // ========== Round-Trip Tests ==========
 
-    @Test
-    fun `SortState persistence roundtrip works`() {
-        val original = SortState(SortCategory.YEAR, SortDirection.DESCENDING)
-        val key = original.persistenceKey
-        val restored = SortState.fromPersistenceKey(key)
-
-        assertEquals(original, restored)
-    }
-
-    @Test
-    fun `SortState all defaults can be persisted and restored`() {
-        listOf(
-            SortState.booksDefault,
-            SortState.seriesDefault,
-            SortState.contributorDefault,
-        ).forEach { original ->
+        test("SortState persistence roundtrip works") {
+            val original = SortState(SortCategory.YEAR, SortDirection.DESCENDING)
             val key = original.persistenceKey
             val restored = SortState.fromPersistenceKey(key)
-            assertEquals(original, restored)
+
+            restored shouldBe original
         }
-    }
-}
+
+        test("SortState all defaults can be persisted and restored") {
+            listOf(
+                SortState.booksDefault,
+                SortState.seriesDefault,
+                SortState.contributorDefault,
+            ).forEach { original ->
+                val key = original.persistenceKey
+                val restored = SortState.fromPersistenceKey(key)
+                restored shouldBe original
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/NanoIdTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/NanoIdTest.kt
@@ -1,9 +1,8 @@
 package com.calypsan.listenup.client.util
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Tests for NanoId generator.
@@ -15,115 +14,103 @@ import kotlin.test.assertTrue
  * - Prefixed ID format
  * - Uniqueness (probabilistic)
  */
-class NanoIdTest {
-    // URL-safe alphabet used by NanoId
-    private val validChars = "_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+class NanoIdTest :
+    FunSpec({
+        // URL-safe alphabet used by NanoId
+        val validChars = "_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-    // ========== Default Generation Tests ==========
+        // ========== Default Generation Tests ==========
 
-    @Test
-    fun `generate returns 21 character ID by default`() {
-        val id = NanoId.generate()
-        assertEquals(21, id.length)
-    }
+        test("generate returns 21 character ID by default") {
+            val id = NanoId.generate()
+            id.length shouldBe 21
+        }
 
-    @Test
-    fun `generate returns URL-safe characters only`() {
-        val id = NanoId.generate()
-        assertTrue(id.all { it in validChars })
-    }
+        test("generate returns URL-safe characters only") {
+            val id = NanoId.generate()
+            id.all { it in validChars } shouldBe true
+        }
 
-    @Test
-    fun `generate returns different IDs on each call`() {
-        val ids = (1..100).map { NanoId.generate() }.toSet()
-        assertEquals(100, ids.size, "All 100 generated IDs should be unique")
-    }
+        test("generate returns different IDs on each call") {
+            val ids = (1..100).map { NanoId.generate() }.toSet()
+            withClue("All 100 generated IDs should be unique") { ids.size shouldBe 100 }
+        }
 
-    // ========== Custom Size Tests ==========
+        // ========== Custom Size Tests ==========
 
-    @Test
-    fun `generate with custom size returns correct length`() {
-        val id = NanoId.generate(size = 10)
-        assertEquals(10, id.length)
-    }
+        test("generate with custom size returns correct length") {
+            val id = NanoId.generate(size = 10)
+            id.length shouldBe 10
+        }
 
-    @Test
-    fun `generate with size 1 returns single character`() {
-        val id = NanoId.generate(size = 1)
-        assertEquals(1, id.length)
-        assertTrue(id[0] in validChars)
-    }
+        test("generate with size 1 returns single character") {
+            val id = NanoId.generate(size = 1)
+            id.length shouldBe 1
+            (id[0] in validChars) shouldBe true
+        }
 
-    @Test
-    fun `generate with large size returns correct length`() {
-        val id = NanoId.generate(size = 100)
-        assertEquals(100, id.length)
-        assertTrue(id.all { it in validChars })
-    }
+        test("generate with large size returns correct length") {
+            val id = NanoId.generate(size = 100)
+            id.length shouldBe 100
+            id.all { it in validChars } shouldBe true
+        }
 
-    // ========== Prefixed Generation Tests ==========
+        // ========== Prefixed Generation Tests ==========
 
-    @Test
-    fun `generate with prefix returns prefixed ID`() {
-        val id = NanoId.generate(prefix = "evt")
-        assertTrue(id.startsWith("evt-"))
-        assertEquals(25, id.length) // "evt-" (4 chars) + 21 chars
-    }
+        test("generate with prefix returns prefixed ID") {
+            val id = NanoId.generate(prefix = "evt")
+            id.startsWith("evt-") shouldBe true
+            id.length shouldBe 25 // "evt-" (4 chars) + 21 chars
+        }
 
-    @Test
-    fun `generate with prefix and custom size returns correct format`() {
-        val id = NanoId.generate(prefix = "usr", size = 10)
-        assertTrue(id.startsWith("usr-"))
-        assertEquals(14, id.length) // "usr-" (4 chars) + 10 chars
-    }
+        test("generate with prefix and custom size returns correct format") {
+            val id = NanoId.generate(prefix = "usr", size = 10)
+            id.startsWith("usr-") shouldBe true
+            id.length shouldBe 14 // "usr-" (4 chars) + 10 chars
+        }
 
-    @Test
-    fun `generate with different prefixes produces different formats`() {
-        val evtId = NanoId.generate(prefix = "evt")
-        val usrId = NanoId.generate(prefix = "usr")
-        val bookId = NanoId.generate(prefix = "book")
+        test("generate with different prefixes produces different formats") {
+            val evtId = NanoId.generate(prefix = "evt")
+            val usrId = NanoId.generate(prefix = "usr")
+            val bookId = NanoId.generate(prefix = "book")
 
-        assertTrue(evtId.startsWith("evt-"))
-        assertTrue(usrId.startsWith("usr-"))
-        assertTrue(bookId.startsWith("book-"))
-    }
+            evtId.startsWith("evt-") shouldBe true
+            usrId.startsWith("usr-") shouldBe true
+            bookId.startsWith("book-") shouldBe true
+        }
 
-    @Test
-    fun `prefixed ID contains only valid characters after prefix`() {
-        val id = NanoId.generate(prefix = "test")
-        val suffix = id.removePrefix("test-")
-        assertTrue(suffix.all { it in validChars })
-    }
+        test("prefixed ID contains only valid characters after prefix") {
+            val id = NanoId.generate(prefix = "test")
+            val suffix = id.removePrefix("test-")
+            suffix.all { it in validChars } shouldBe true
+        }
 
-    // ========== Character Distribution Tests ==========
+        // ========== Character Distribution Tests ==========
 
-    @Test
-    fun `generate uses full alphabet range`() {
-        // Generate many IDs and check that we see most characters
-        val allChars =
-            (1..1000)
-                .map { NanoId.generate() }
-                .flatMap { it.toList() }
-                .toSet()
+        test("generate uses full alphabet range") {
+            // Generate many IDs and check that we see most characters
+            val allChars =
+                (1..1000)
+                    .map { NanoId.generate() }
+                    .flatMap { it.toList() }
+                    .toSet()
 
-        // With 1000 IDs of 21 chars each (21000 chars total), we should see
-        // most of the 64 character alphabet. Allow for some statistical variance.
-        assertTrue(allChars.size >= 50, "Should use most of the 64-char alphabet")
-    }
+            // With 1000 IDs of 21 chars each (21000 chars total), we should see
+            // most of the 64 character alphabet. Allow for some statistical variance.
+            withClue("Should use most of the 64-char alphabet") { (allChars.size >= 50) shouldBe true }
+        }
 
-    // ========== Uniqueness Tests ==========
+        // ========== Uniqueness Tests ==========
 
-    @Test
-    fun `generate produces unique IDs in batch`() {
-        val ids = (1..1000).map { NanoId.generate() }
-        val uniqueIds = ids.toSet()
-        assertEquals(ids.size, uniqueIds.size, "All generated IDs should be unique")
-    }
+        test("generate produces unique IDs in batch") {
+            val ids = (1..1000).map { NanoId.generate() }
+            val uniqueIds = ids.toSet()
+            withClue("All generated IDs should be unique") { uniqueIds.size shouldBe ids.size }
+        }
 
-    @Test
-    fun `prefixed generate produces unique IDs`() {
-        val ids = (1..100).map { NanoId.generate(prefix = "test") }
-        val uniqueIds = ids.toSet()
-        assertEquals(ids.size, uniqueIds.size, "All prefixed IDs should be unique")
-    }
-}
+        test("prefixed generate produces unique IDs") {
+            val ids = (1..100).map { NanoId.generate(prefix = "test") }
+            val uniqueIds = ids.toSet()
+            withClue("All prefixed IDs should be unique") { uniqueIds.size shouldBe ids.size }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/TitleSortUtilsTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/TitleSortUtilsTest.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.client.util
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Tests for TitleSortUtils.
@@ -11,176 +11,128 @@ import kotlin.test.assertEquals
  * - Natural number sorting (zero-padding)
  * - Sort letter extraction for section headers
  */
-class TitleSortUtilsTest {
-    // ========== Article Stripping Tests ==========
+class TitleSortUtilsTest :
+    FunSpec({
+        // ========== Article Stripping Tests ==========
 
-    @Test
-    fun `sortableTitle strips leading The when ignoring articles`() {
-        assertEquals(
-            "alchemist",
-            TitleSortUtils.sortableTitle("The Alchemist", ignoreArticles = true),
-        )
-    }
+        test("sortableTitle strips leading The when ignoring articles") {
+            TitleSortUtils.sortableTitle("The Alchemist", ignoreArticles = true) shouldBe "alchemist"
+        }
 
-    @Test
-    fun `sortableTitle strips leading A when ignoring articles`() {
-        assertEquals(
-            "wrinkle in time",
-            TitleSortUtils.sortableTitle("A Wrinkle in Time", ignoreArticles = true),
-        )
-    }
+        test("sortableTitle strips leading A when ignoring articles") {
+            TitleSortUtils.sortableTitle("A Wrinkle in Time", ignoreArticles = true) shouldBe "wrinkle in time"
+        }
 
-    @Test
-    fun `sortableTitle strips leading An when ignoring articles`() {
-        assertEquals(
-            "american tragedy",
-            TitleSortUtils.sortableTitle("An American Tragedy", ignoreArticles = true),
-        )
-    }
+        test("sortableTitle strips leading An when ignoring articles") {
+            TitleSortUtils.sortableTitle("An American Tragedy", ignoreArticles = true) shouldBe "american tragedy"
+        }
 
-    @Test
-    fun `sortableTitle preserves title when not ignoring articles`() {
-        assertEquals(
-            "the alchemist",
-            TitleSortUtils.sortableTitle("The Alchemist", ignoreArticles = false),
-        )
-    }
+        test("sortableTitle preserves title when not ignoring articles") {
+            TitleSortUtils.sortableTitle("The Alchemist", ignoreArticles = false) shouldBe "the alchemist"
+        }
 
-    @Test
-    fun `sortableTitle preserves AI without space after A`() {
-        // "A.I." should not be stripped because there's no space after "A"
-        assertEquals(
-            "a.i.",
-            TitleSortUtils.sortableTitle("A.I.", ignoreArticles = true),
-        )
-    }
+        test("sortableTitle preserves AI without space after A") {
+            // "A.I." should not be stripped because there's no space after "A"
+            TitleSortUtils.sortableTitle("A.I.", ignoreArticles = true) shouldBe "a.i."
+        }
 
-    @Test
-    fun `sortableTitle is case insensitive for articles`() {
-        assertEquals(
-            "hobbit",
-            TitleSortUtils.sortableTitle("THE Hobbit", ignoreArticles = true),
-        )
-    }
+        test("sortableTitle is case insensitive for articles") {
+            TitleSortUtils.sortableTitle("THE Hobbit", ignoreArticles = true) shouldBe "hobbit"
+        }
 
-    @Test
-    fun `sortableTitle handles lowercase articles`() {
-        assertEquals(
-            "lord of the rings",
-            TitleSortUtils.sortableTitle("the Lord of the Rings", ignoreArticles = true),
-        )
-    }
+        test("sortableTitle handles lowercase articles") {
+            TitleSortUtils.sortableTitle("the Lord of the Rings", ignoreArticles = true) shouldBe "lord of the rings"
+        }
 
-    // ========== Natural Number Sorting Tests ==========
+        // ========== Natural Number Sorting Tests ==========
 
-    @Test
-    fun `sortableTitle pads leading numbers for natural sort`() {
-        val result = TitleSortUtils.sortableTitle("1984", ignoreArticles = false)
-        assertEquals("0000001984", result)
-    }
+        test("sortableTitle pads leading numbers for natural sort") {
+            val result = TitleSortUtils.sortableTitle("1984", ignoreArticles = false)
+            result shouldBe "0000001984"
+        }
 
-    @Test
-    fun `sortableTitle pads smaller numbers`() {
-        val result = TitleSortUtils.sortableTitle("12 Rules for Life", ignoreArticles = false)
-        assertEquals("0000000012 rules for life", result)
-    }
+        test("sortableTitle pads smaller numbers") {
+            val result = TitleSortUtils.sortableTitle("12 Rules for Life", ignoreArticles = false)
+            result shouldBe "0000000012 rules for life"
+        }
 
-    @Test
-    fun `sortableTitle ensures 2 sorts before 12`() {
-        val sort2 = TitleSortUtils.sortableTitle("2001: A Space Odyssey", ignoreArticles = false)
-        val sort12 = TitleSortUtils.sortableTitle("12 Angry Men", ignoreArticles = false)
+        test("sortableTitle ensures 2 sorts before 12") {
+            val sort2 = TitleSortUtils.sortableTitle("2001: A Space Odyssey", ignoreArticles = false)
+            val sort12 = TitleSortUtils.sortableTitle("12 Angry Men", ignoreArticles = false)
 
-        // 0000002001 < 0000000012 is false, but sorted numerically 2001 > 12
-        // Actually we're checking padding - let me verify the comparison
-        // "0000002001" > "0000000012" because 2001 > 12 when padded
-        // But the test should be that single-digit numbers sort before double-digit
-        val sort1 = TitleSortUtils.sortableTitle("1 Fish 2 Fish", ignoreArticles = false)
-        val sort100 = TitleSortUtils.sortableTitle("100 Years of Solitude", ignoreArticles = false)
+            // 0000002001 < 0000000012 is false, but sorted numerically 2001 > 12
+            // Actually we're checking padding - let me verify the comparison
+            // "0000002001" > "0000000012" because 2001 > 12 when padded
+            // But the test should be that single-digit numbers sort before double-digit
+            val sort1 = TitleSortUtils.sortableTitle("1 Fish 2 Fish", ignoreArticles = false)
+            val sort100 = TitleSortUtils.sortableTitle("100 Years of Solitude", ignoreArticles = false)
 
-        // With padding: "0000000001" < "0000000100"
-        assertTrue(sort1 < sort100)
-    }
+            // With padding: "0000000001" < "0000000100"
+            (sort1 < sort100) shouldBe true
+        }
 
-    @Test
-    fun `sortableTitle handles title starting with number after article strip`() {
-        // "The 39 Steps" -> "39 Steps" -> "0000000039 steps"
-        val result = TitleSortUtils.sortableTitle("The 39 Steps", ignoreArticles = true)
-        assertEquals("0000000039 steps", result)
-    }
+        test("sortableTitle handles title starting with number after article strip") {
+            // "The 39 Steps" -> "39 Steps" -> "0000000039 steps"
+            val result = TitleSortUtils.sortableTitle("The 39 Steps", ignoreArticles = true)
+            result shouldBe "0000000039 steps"
+        }
 
-    @Test
-    fun `sortableTitle does not pad numbers in middle of title`() {
-        // Only leading numbers are padded
-        val result = TitleSortUtils.sortableTitle("Fahrenheit 451", ignoreArticles = false)
-        assertEquals("fahrenheit 451", result)
-    }
+        test("sortableTitle does not pad numbers in middle of title") {
+            // Only leading numbers are padded
+            val result = TitleSortUtils.sortableTitle("Fahrenheit 451", ignoreArticles = false)
+            result shouldBe "fahrenheit 451"
+        }
 
-    // ========== Sort Letter Tests ==========
+        // ========== Sort Letter Tests ==========
 
-    @Test
-    fun `sortLetter returns first letter uppercase`() {
-        assertEquals('B', TitleSortUtils.sortLetter("Battle Royale", ignoreArticles = false))
-    }
+        test("sortLetter returns first letter uppercase") {
+            TitleSortUtils.sortLetter("Battle Royale", ignoreArticles = false) shouldBe 'B'
+        }
 
-    @Test
-    fun `sortLetter returns hash for numeric titles`() {
-        assertEquals('#', TitleSortUtils.sortLetter("1984", ignoreArticles = false))
-    }
+        test("sortLetter returns hash for numeric titles") {
+            TitleSortUtils.sortLetter("1984", ignoreArticles = false) shouldBe '#'
+        }
 
-    @Test
-    fun `sortLetter ignores articles when enabled`() {
-        // "The Alchemist" -> sortable "alchemist" -> first letter 'A'
-        assertEquals('A', TitleSortUtils.sortLetter("The Alchemist", ignoreArticles = true))
-    }
+        test("sortLetter ignores articles when enabled") {
+            // "The Alchemist" -> sortable "alchemist" -> first letter 'A'
+            TitleSortUtils.sortLetter("The Alchemist", ignoreArticles = true) shouldBe 'A'
+        }
 
-    @Test
-    fun `sortLetter returns T for The when not ignoring articles`() {
-        assertEquals('T', TitleSortUtils.sortLetter("The Alchemist", ignoreArticles = false))
-    }
+        test("sortLetter returns T for The when not ignoring articles") {
+            TitleSortUtils.sortLetter("The Alchemist", ignoreArticles = false) shouldBe 'T'
+        }
 
-    @Test
-    fun `sortLetter returns hash for special characters`() {
-        assertEquals('#', TitleSortUtils.sortLetter("@War", ignoreArticles = false))
-    }
+        test("sortLetter returns hash for special characters") {
+            TitleSortUtils.sortLetter("@War", ignoreArticles = false) shouldBe '#'
+        }
 
-    // ========== Extension Function Tests ==========
+        // ========== Extension Function Tests ==========
 
-    @Test
-    fun `String extension sortableTitle works`() {
-        assertEquals("mistborn", "Mistborn".sortableTitle(ignoreArticles = false))
-    }
+        test("String extension sortableTitle works") {
+            "Mistborn".sortableTitle(ignoreArticles = false) shouldBe "mistborn"
+        }
 
-    @Test
-    fun `String extension sortLetter works`() {
-        assertEquals('M', "Mistborn".sortLetter(ignoreArticles = false))
-    }
+        test("String extension sortLetter works") {
+            "Mistborn".sortLetter(ignoreArticles = false) shouldBe 'M'
+        }
 
-    // ========== Edge Cases ==========
+        // ========== Edge Cases ==========
 
-    @Test
-    fun `sortableTitle handles empty string`() {
-        assertEquals("", TitleSortUtils.sortableTitle("", ignoreArticles = true))
-    }
+        test("sortableTitle handles empty string") {
+            TitleSortUtils.sortableTitle("", ignoreArticles = true) shouldBe ""
+        }
 
-    @Test
-    fun `sortableTitle handles whitespace only`() {
-        assertEquals("", TitleSortUtils.sortableTitle("   ", ignoreArticles = true).trim())
-    }
+        test("sortableTitle handles whitespace only") {
+            TitleSortUtils.sortableTitle("   ", ignoreArticles = true).trim() shouldBe ""
+        }
 
-    @Test
-    fun `sortableTitle handles title that is just article`() {
-        // "The " with trailing space would be stripped to empty
-        // "The" without space is preserved
-        assertEquals("the", TitleSortUtils.sortableTitle("The", ignoreArticles = true))
-    }
+        test("sortableTitle handles title that is just article") {
+            // "The " with trailing space would be stripped to empty
+            // "The" without space is preserved
+            TitleSortUtils.sortableTitle("The", ignoreArticles = true) shouldBe "the"
+        }
 
-    @Test
-    fun `sortLetter returns hash for empty string`() {
-        assertEquals('#', TitleSortUtils.sortLetter("", ignoreArticles = false))
-    }
-
-    // Helper function for comparison tests
-    private fun assertTrue(condition: Boolean) {
-        kotlin.test.assertTrue(condition)
-    }
-}
+        test("sortLetter returns hash for empty string") {
+            TitleSortUtils.sortLetter("", ignoreArticles = false) shouldBe '#'
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/ResumePhraseDetectorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/ResumePhraseDetectorTest.kt
@@ -1,65 +1,61 @@
 package com.calypsan.listenup.client.voice
 
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ResumePhraseDetectorTest {
-    @Test
-    fun `exact resume phrase returns true`() {
-        assertTrue(ResumePhraseDetector.isResumeIntent("resume"))
-        assertTrue(ResumePhraseDetector.isResumeIntent("continue"))
-        assertTrue(ResumePhraseDetector.isResumeIntent("my audiobook"))
-    }
-
-    @Test
-    fun `resume phrase with surrounding text returns true`() {
-        assertTrue(ResumePhraseDetector.isResumeIntent("please resume my book"))
-        assertTrue(ResumePhraseDetector.isResumeIntent("continue listening to my audiobook"))
-    }
-
-    @Test
-    fun `case insensitive matching`() {
-        assertTrue(ResumePhraseDetector.isResumeIntent("RESUME"))
-        assertTrue(ResumePhraseDetector.isResumeIntent("Continue Listening"))
-        assertTrue(ResumePhraseDetector.isResumeIntent("MY AUDIOBOOK"))
-    }
-
-    @Test
-    fun `whitespace trimming`() {
-        assertTrue(ResumePhraseDetector.isResumeIntent("  resume  "))
-        assertTrue(ResumePhraseDetector.isResumeIntent("\tcontinue\n"))
-    }
-
-    @Test
-    fun `specific book title returns false`() {
-        assertFalse(ResumePhraseDetector.isResumeIntent("The Hobbit"))
-        assertFalse(ResumePhraseDetector.isResumeIntent("play Mistborn"))
-    }
-
-    @Test
-    fun `empty query returns false`() {
-        assertFalse(ResumePhraseDetector.isResumeIntent(""))
-        assertFalse(ResumePhraseDetector.isResumeIntent("   "))
-    }
-
-    @Test
-    fun `all supported phrases are detected`() {
-        val phrases =
-            listOf(
-                "resume",
-                "continue",
-                "continue listening",
-                "continue reading",
-                "my audiobook",
-                "my book",
-                "where i left off",
-                "pick up where i left off",
-                "keep playing",
-                "keep listening",
-            )
-        phrases.forEach { phrase ->
-            assertTrue(ResumePhraseDetector.isResumeIntent(phrase), "Expected '$phrase' to be detected")
+class ResumePhraseDetectorTest :
+    FunSpec({
+        test("exact resume phrase returns true") {
+            ResumePhraseDetector.isResumeIntent("resume") shouldBe true
+            ResumePhraseDetector.isResumeIntent("continue") shouldBe true
+            ResumePhraseDetector.isResumeIntent("my audiobook") shouldBe true
         }
-    }
-}
+
+        test("resume phrase with surrounding text returns true") {
+            ResumePhraseDetector.isResumeIntent("please resume my book") shouldBe true
+            ResumePhraseDetector.isResumeIntent("continue listening to my audiobook") shouldBe true
+        }
+
+        test("case insensitive matching") {
+            ResumePhraseDetector.isResumeIntent("RESUME") shouldBe true
+            ResumePhraseDetector.isResumeIntent("Continue Listening") shouldBe true
+            ResumePhraseDetector.isResumeIntent("MY AUDIOBOOK") shouldBe true
+        }
+
+        test("whitespace trimming") {
+            ResumePhraseDetector.isResumeIntent("  resume  ") shouldBe true
+            ResumePhraseDetector.isResumeIntent("\tcontinue\n") shouldBe true
+        }
+
+        test("specific book title returns false") {
+            ResumePhraseDetector.isResumeIntent("The Hobbit") shouldBe false
+            ResumePhraseDetector.isResumeIntent("play Mistborn") shouldBe false
+        }
+
+        test("empty query returns false") {
+            ResumePhraseDetector.isResumeIntent("") shouldBe false
+            ResumePhraseDetector.isResumeIntent("   ") shouldBe false
+        }
+
+        test("all supported phrases are detected") {
+            val phrases =
+                listOf(
+                    "resume",
+                    "continue",
+                    "continue listening",
+                    "continue reading",
+                    "my audiobook",
+                    "my book",
+                    "where i left off",
+                    "pick up where i left off",
+                    "keep playing",
+                    "keep listening",
+                )
+            phrases.forEach { phrase ->
+                withClue("Expected '$phrase' to be detected") {
+                    ResumePhraseDetector.isResumeIntent(phrase) shouldBe true
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/SeriesNavigationDetectorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/SeriesNavigationDetectorTest.kt
@@ -1,69 +1,65 @@
 package com.calypsan.listenup.client.voice
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
-class SeriesNavigationDetectorTest {
-    @Test
-    fun `next book patterns return Next`() {
-        assertIs<SeriesNavigation.Next>(SeriesNavigationDetector.detect("next book"))
-        assertIs<SeriesNavigation.Next>(SeriesNavigationDetector.detect("the next one"))
-        assertIs<SeriesNavigation.Next>(SeriesNavigationDetector.detect("next in series"))
-        assertIs<SeriesNavigation.Next>(SeriesNavigationDetector.detect("play the next one"))
-    }
-
-    @Test
-    fun `first book patterns return First`() {
-        assertIs<SeriesNavigation.First>(SeriesNavigationDetector.detect("first book"))
-        assertIs<SeriesNavigation.First>(SeriesNavigationDetector.detect("start of the series"))
-        assertIs<SeriesNavigation.First>(SeriesNavigationDetector.detect("beginning"))
-    }
-
-    @Test
-    fun `numeric sequence returns BySequence`() {
-        val result = SeriesNavigationDetector.detect("book 2")
-        assertIs<SeriesNavigation.BySequence>(result)
-        assertEquals("2", result.sequence)
-    }
-
-    @Test
-    fun `decimal sequence returns BySequence`() {
-        val result = SeriesNavigationDetector.detect("book 1.5")
-        assertIs<SeriesNavigation.BySequence>(result)
-        assertEquals("1.5", result.sequence)
-    }
-
-    @Test
-    fun `word numbers return BySequence`() {
-        val testCases =
-            listOf(
-                "second book" to "2",
-                "third book" to "3",
-                "fourth book" to "4",
-                "fifth book" to "5",
-            )
-        testCases.forEach { (input, expected) ->
-            val result = SeriesNavigationDetector.detect(input)
-            assertIs<SeriesNavigation.BySequence>(result, "Expected BySequence for '$input'")
-            assertEquals(expected, result.sequence, "Expected sequence '$expected' for '$input'")
+class SeriesNavigationDetectorTest :
+    FunSpec({
+        test("next book patterns return Next") {
+            SeriesNavigationDetector.detect("next book").shouldBeInstanceOf<SeriesNavigation.Next>()
+            SeriesNavigationDetector.detect("the next one").shouldBeInstanceOf<SeriesNavigation.Next>()
+            SeriesNavigationDetector.detect("next in series").shouldBeInstanceOf<SeriesNavigation.Next>()
+            SeriesNavigationDetector.detect("play the next one").shouldBeInstanceOf<SeriesNavigation.Next>()
         }
-    }
 
-    @Test
-    fun `case insensitive matching`() {
-        assertIs<SeriesNavigation.Next>(SeriesNavigationDetector.detect("NEXT BOOK"))
-        assertIs<SeriesNavigation.First>(SeriesNavigationDetector.detect("FIRST BOOK"))
+        test("first book patterns return First") {
+            SeriesNavigationDetector.detect("first book").shouldBeInstanceOf<SeriesNavigation.First>()
+            SeriesNavigationDetector.detect("start of the series").shouldBeInstanceOf<SeriesNavigation.First>()
+            SeriesNavigationDetector.detect("beginning").shouldBeInstanceOf<SeriesNavigation.First>()
+        }
 
-        val result = SeriesNavigationDetector.detect("SECOND BOOK")
-        assertIs<SeriesNavigation.BySequence>(result)
-        assertEquals("2", result.sequence)
-    }
+        test("numeric sequence returns BySequence") {
+            val result = SeriesNavigationDetector.detect("book 2").shouldBeInstanceOf<SeriesNavigation.BySequence>()
+            result.sequence shouldBe "2"
+        }
 
-    @Test
-    fun `unrelated query returns NotSeriesNavigation`() {
-        assertIs<SeriesNavigation.NotSeriesNavigation>(SeriesNavigationDetector.detect("The Hobbit"))
-        assertIs<SeriesNavigation.NotSeriesNavigation>(SeriesNavigationDetector.detect("play something"))
-        assertIs<SeriesNavigation.NotSeriesNavigation>(SeriesNavigationDetector.detect(""))
-    }
-}
+        test("decimal sequence returns BySequence") {
+            val result = SeriesNavigationDetector.detect("book 1.5").shouldBeInstanceOf<SeriesNavigation.BySequence>()
+            result.sequence shouldBe "1.5"
+        }
+
+        test("word numbers return BySequence") {
+            val testCases =
+                listOf(
+                    "second book" to "2",
+                    "third book" to "3",
+                    "fourth book" to "4",
+                    "fifth book" to "5",
+                )
+            testCases.forEach { (input, expected) ->
+                val result =
+                    withClue("Expected BySequence for '$input'") {
+                        SeriesNavigationDetector.detect(input).shouldBeInstanceOf<SeriesNavigation.BySequence>()
+                    }
+                withClue("Expected sequence '$expected' for '$input'") {
+                    result.sequence shouldBe expected
+                }
+            }
+        }
+
+        test("case insensitive matching") {
+            SeriesNavigationDetector.detect("NEXT BOOK").shouldBeInstanceOf<SeriesNavigation.Next>()
+            SeriesNavigationDetector.detect("FIRST BOOK").shouldBeInstanceOf<SeriesNavigation.First>()
+
+            val result = SeriesNavigationDetector.detect("SECOND BOOK").shouldBeInstanceOf<SeriesNavigation.BySequence>()
+            result.sequence shouldBe "2"
+        }
+
+        test("unrelated query returns NotSeriesNavigation") {
+            SeriesNavigationDetector.detect("The Hobbit").shouldBeInstanceOf<SeriesNavigation.NotSeriesNavigation>()
+            SeriesNavigationDetector.detect("play something").shouldBeInstanceOf<SeriesNavigation.NotSeriesNavigation>()
+            SeriesNavigationDetector.detect("").shouldBeInstanceOf<SeriesNavigation.NotSeriesNavigation>()
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/VoiceIntentResolverTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/VoiceIntentResolverTest.kt
@@ -1,453 +1,452 @@
 package com.calypsan.listenup.client.voice
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
-class VoiceIntentResolverTest {
-    private lateinit var searchRepository: FakeSearchRepository
-    private lateinit var homeRepository: FakeHomeRepository
-    private lateinit var seriesRepository: FakeSeriesRepository
-    private lateinit var bookRepository: FakeBookRepository
-    private lateinit var resolver: VoiceIntentResolver
+class VoiceIntentResolverTest :
+    FunSpec({
+        lateinit var searchRepository: FakeSearchRepository
+        lateinit var homeRepository: FakeHomeRepository
+        lateinit var seriesRepository: FakeSeriesRepository
+        lateinit var bookRepository: FakeBookRepository
+        lateinit var resolver: VoiceIntentResolver
 
-    private fun setup() {
-        searchRepository = FakeSearchRepository()
-        homeRepository = FakeHomeRepository()
-        seriesRepository = FakeSeriesRepository()
-        bookRepository = FakeBookRepository()
-        resolver =
-            VoiceIntentResolver(
-                searchRepository = searchRepository,
-                homeRepository = homeRepository,
-                seriesRepository = seriesRepository,
-                bookRepository = bookRepository,
-            )
-    }
-
-    // ========== Resume Intent Tests ==========
-
-    @Test
-    fun `resume phrase returns Resume intent`() =
-        runTest {
-            setup()
-            val result = resolver.resolve("resume")
-            assertIs<PlaybackIntent.Resume>(result)
-        }
-
-    @Test
-    fun `continue my audiobook returns Resume intent`() =
-        runTest {
-            setup()
-            val result = resolver.resolve("continue my audiobook")
-            assertIs<PlaybackIntent.Resume>(result)
-        }
-
-    @Test
-    fun `where I left off returns Resume intent`() =
-        runTest {
-            setup()
-            val result = resolver.resolve("where I left off")
-            assertIs<PlaybackIntent.Resume>(result)
-        }
-
-    // ========== Search Resolution Tests ==========
-
-    @Test
-    fun `exact title match returns PlayBook with high confidence`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit", score = 1.0f),
-            )
-
-            val result = resolver.resolve("The Hobbit")
-
-            assertIs<PlaybackIntent.PlayBook>(result)
-            assertEquals("book1", result.bookId)
-        }
-
-    @Test
-    fun `partial title match with high score returns PlayBook`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit", score = 0.9f),
-            )
-
-            val result = resolver.resolve("Hobbit")
-
-            assertIs<PlaybackIntent.PlayBook>(result)
-            assertEquals("book1", result.bookId)
-        }
-
-    @Test
-    fun `multiple matches returns Ambiguous with bestGuess`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit", score = 0.7f),
-                testSearchHit(id = "book2", name = "The Hobbit: An Unexpected Journey", score = 0.6f),
-            )
-
-            val result = resolver.resolve("Hobbit")
-
-            assertIs<PlaybackIntent.Ambiguous>(result)
-            assertEquals(2, result.candidates.size)
-            assertNotNull(result.bestGuess)
-            assertEquals("book1", result.bestGuess?.bookId)
-        }
-
-    @Test
-    fun `no matches returns NotFound`() =
-        runTest {
-            setup()
-            searchRepository.setResults() // empty
-
-            val result = resolver.resolve("xyzzy gibberish")
-
-            assertIs<PlaybackIntent.NotFound>(result)
-            assertEquals("xyzzy gibberish", result.originalQuery)
-        }
-
-    @Test
-    fun `title hint boosts exact match confidence`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit", score = 0.5f),
-            )
-
-            val result =
-                resolver.resolve(
-                    query = "The Hobbit",
-                    hints = VoiceHints(title = "The Hobbit"),
+        fun setup() {
+            searchRepository = FakeSearchRepository()
+            homeRepository = FakeHomeRepository()
+            seriesRepository = FakeSeriesRepository()
+            bookRepository = FakeBookRepository()
+            resolver =
+                VoiceIntentResolver(
+                    searchRepository = searchRepository,
+                    homeRepository = homeRepository,
+                    seriesRepository = seriesRepository,
+                    bookRepository = bookRepository,
                 )
-
-            // With title hint matching exactly, confidence should be high enough for PlayBook
-            assertIs<PlaybackIntent.PlayBook>(result)
         }
 
-    // ========== Series Navigation Tests ==========
+        // ========== Resume Intent Tests ==========
 
-    @Test
-    fun `next book with series context returns PlaySeriesFrom`() =
-        runTest {
-            setup()
-            // Setup: User has been listening to book 1 of a series
-            val series = testSeries("series1", "Lord of the Rings")
-            val book1 =
-                testBook(
-                    id = "book1",
-                    title = "The Fellowship of the Ring",
-                    series = listOf(testBookSeries("series1", "Lord of the Rings", "1")),
-                )
-            val book2 =
-                testBook(
-                    id = "book2",
-                    title = "The Two Towers",
-                    series = listOf(testBookSeries("series1", "Lord of the Rings", "2")),
-                )
-
-            bookRepository.addBook(book1)
-            bookRepository.addBook(book2)
-            seriesRepository.addSeries(series, listOf("book1", "book2"))
-            homeRepository.setContinueListening(testContinueListeningBook("book1", "The Fellowship of the Ring"))
-
-            val result = resolver.resolve("next book")
-
-            assertIs<PlaybackIntent.PlaySeriesFrom>(result)
-            assertEquals("series1", result.seriesId)
-            assertEquals("book2", result.startBookId)
-        }
-
-    @Test
-    fun `book 2 with series context returns PlaySeriesFrom`() =
-        runTest {
-            setup()
-            val series = testSeries("series1", "Mistborn")
-            val book1 =
-                testBook(
-                    id = "book1",
-                    title = "The Final Empire",
-                    series = listOf(testBookSeries("series1", "Mistborn", "1")),
-                )
-            val book2 =
-                testBook(
-                    id = "book2",
-                    title = "The Well of Ascension",
-                    series = listOf(testBookSeries("series1", "Mistborn", "2")),
-                )
-
-            bookRepository.addBook(book1)
-            bookRepository.addBook(book2)
-            seriesRepository.addSeries(series, listOf("book1", "book2"))
-            homeRepository.setContinueListening(testContinueListeningBook("book1", "The Final Empire"))
-
-            val result = resolver.resolve("book 2")
-
-            assertIs<PlaybackIntent.PlaySeriesFrom>(result)
-            assertEquals("book2", result.startBookId)
-        }
-
-    @Test
-    fun `next book without series context falls back to search`() =
-        runTest {
-            setup()
-            // No continue listening, no series context
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "Next Book: A Novel", score = 0.9f),
-            )
-
-            val result = resolver.resolve("next book")
-
-            // Should fall back to search since there's no series context
-            assertIs<PlaybackIntent.PlayBook>(result)
-        }
-
-    @Test
-    fun `first book in series returns PlaySeriesFrom`() =
-        runTest {
-            setup()
-            val series = testSeries("series1", "Harry Potter")
-            val book1 =
-                testBook(
-                    id = "book1",
-                    title = "Philosopher's Stone",
-                    series = listOf(testBookSeries("series1", "Harry Potter", "1")),
-                )
-            val book3 =
-                testBook(
-                    id = "book3",
-                    title = "Prisoner of Azkaban",
-                    series = listOf(testBookSeries("series1", "Harry Potter", "3")),
-                )
-
-            bookRepository.addBook(book1)
-            bookRepository.addBook(book3)
-            seriesRepository.addSeries(series, listOf("book1", "book3"))
-            homeRepository.setContinueListening(testContinueListeningBook("book3", "Prisoner of Azkaban"))
-
-            val result = resolver.resolve("first book")
-
-            assertIs<PlaybackIntent.PlaySeriesFrom>(result)
-            assertEquals("book1", result.startBookId)
-        }
-
-    // ========== Error Handling Tests ==========
-
-    @Test
-    fun `search exception propagates to caller`() =
-        runTest {
-            setup()
-            searchRepository.setError(RuntimeException("Network error"))
-
-            assertFailsWith<RuntimeException> {
-                resolver.resolve("The Hobbit")
+        test("resume phrase returns Resume intent") {
+            runTest {
+                setup()
+                val result = resolver.resolve("resume")
+                result.shouldBeInstanceOf<PlaybackIntent.Resume>()
             }
         }
 
-    @Test
-    fun `empty query falls through to search and returns NotFound`() =
-        runTest {
-            setup()
-            searchRepository.setResults() // empty results
-
-            val result = resolver.resolve("")
-
-            assertIs<PlaybackIntent.NotFound>(result)
-        }
-
-    @Test
-    fun `whitespace-only query falls through to search`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "Some Book", score = 0.9f),
-            )
-
-            val result = resolver.resolve("   ")
-
-            // Whitespace query goes to search, returns whatever search finds
-            assertIs<PlaybackIntent.PlayBook>(result)
-        }
-
-    // ========== Confidence Scoring Edge Cases ==========
-
-    @Test
-    fun `very low score with no boosts returns NotFound`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "Completely Different Title", score = 0.1f),
-            )
-
-            val result = resolver.resolve("The Hobbit")
-
-            // Low score + no title match = below ambiguous threshold = NotFound
-            assertIs<PlaybackIntent.NotFound>(result)
-        }
-
-    @Test
-    fun `author hint boosts confidence`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit", author = "J.R.R. Tolkien", score = 0.5f),
-            )
-
-            val result =
-                resolver.resolve(
-                    query = "Hobbit",
-                    hints = VoiceHints(artist = "Tolkien"),
-                )
-
-            // Author hint should boost confidence enough for PlayBook
-            assertIs<PlaybackIntent.PlayBook>(result)
-        }
-
-    @Test
-    fun `title starts with query boosts confidence`() =
-        runTest {
-            setup()
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit: An Unexpected Journey", score = 0.5f),
-            )
-
-            val result = resolver.resolve("The Hobbit")
-
-            // "The Hobbit: An Unexpected Journey" starts with "the hobbit"
-            // Should get TITLE_STARTS_WITH_BOOST + base score
-            assertIs<PlaybackIntent.PlayBook>(result)
-        }
-
-    @Test
-    fun `single match above ambiguous but below high confidence still plays`() =
-        runTest {
-            setup()
-            // Score 0.6f * 0.5 = 0.3 base, + 0.3 title starts with = 0.6 total
-            // Above 0.5 (ambiguous) but below 0.8 (high confidence)
-            // Single match should still play
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "The Hobbit", score = 0.6f),
-            )
-
-            val result = resolver.resolve("Hobbit")
-
-            assertIs<PlaybackIntent.PlayBook>(result)
-        }
-
-    // ========== Series Navigation Edge Cases ==========
-
-    @Test
-    fun `next book at end of series returns null and falls back to search`() =
-        runTest {
-            setup()
-            val series = testSeries("series1", "Duology")
-            val book1 =
-                testBook(
-                    id = "book1",
-                    title = "Book One",
-                    series = listOf(testBookSeries("series1", "Duology", "1")),
-                )
-            val book2 =
-                testBook(
-                    id = "book2",
-                    title = "Book Two",
-                    series = listOf(testBookSeries("series1", "Duology", "2")),
-                )
-
-            bookRepository.addBook(book1)
-            bookRepository.addBook(book2)
-            seriesRepository.addSeries(series, listOf("book1", "book2"))
-            // User is on the LAST book
-            homeRepository.setContinueListening(testContinueListeningBook("book2", "Book Two"))
-
-            // Set up search fallback
-            searchRepository.setResults(
-                testSearchHit(id = "other", name = "Next Book: A Novel", score = 0.9f),
-            )
-
-            val result = resolver.resolve("next book")
-
-            // No next book in series, falls back to search
-            assertIs<PlaybackIntent.PlayBook>(result)
-            assertEquals("other", result.bookId)
-        }
-
-    @Test
-    fun `book by sequence not found returns null and falls back to search`() =
-        runTest {
-            setup()
-            val series = testSeries("series1", "Trilogy")
-            val book1 =
-                testBook(
-                    id = "book1",
-                    title = "Book One",
-                    series = listOf(testBookSeries("series1", "Trilogy", "1")),
-                )
-
-            bookRepository.addBook(book1)
-            seriesRepository.addSeries(series, listOf("book1"))
-            homeRepository.setContinueListening(testContinueListeningBook("book1", "Book One"))
-
-            searchRepository.setResults(
-                testSearchHit(id = "other", name = "Book 5", score = 0.9f),
-            )
-
-            val result = resolver.resolve("book 5") // No book 5 in series
-
-            // Book 5 not found in series, falls back to search
-            assertIs<PlaybackIntent.PlayBook>(result)
-            assertEquals("other", result.bookId)
-        }
-
-    @Test
-    fun `ambiguous result has candidates sorted by confidence`() =
-        runTest {
-            setup()
-            // Use scores that result in ambiguous range (0.5-0.8) after boosts
-            // Query "adventure" - all titles contain it, so all get TITLE_CONTAINS_QUERY_BOOST (+0.2)
-            // Base scores: 0.7*0.5=0.35, 0.6*0.5=0.3, 0.5*0.5=0.25
-            // With +0.2 boost: 0.55, 0.5, 0.45
-            // book3 at 0.45 is below 0.5 threshold, so only 2 viable
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "Adventure Time", score = 0.7f),
-                testSearchHit(id = "book2", name = "The Grand Adventure", score = 0.6f),
-                testSearchHit(id = "book3", name = "Adventure Awaits", score = 0.65f),
-            )
-
-            val result = resolver.resolve("adventure")
-
-            assertIs<PlaybackIntent.Ambiguous>(result)
-            assertTrue(result.candidates.size >= 2)
-            // Candidates should be sorted by confidence (highest first)
-            for (i in 0 until result.candidates.size - 1) {
-                assertTrue(
-                    result.candidates[i].confidence >= result.candidates[i + 1].confidence,
-                    "Candidates should be sorted by confidence descending",
-                )
+        test("continue my audiobook returns Resume intent") {
+            runTest {
+                setup()
+                val result = resolver.resolve("continue my audiobook")
+                result.shouldBeInstanceOf<PlaybackIntent.Resume>()
             }
         }
 
-    @Test
-    fun `ambiguous result bestGuess is null when top match below threshold`() =
-        runTest {
-            setup()
-            // All matches below ambiguous threshold
-            searchRepository.setResults(
-                testSearchHit(id = "book1", name = "Something Else", score = 0.3f),
-                testSearchHit(id = "book2", name = "Another Thing", score = 0.2f),
-            )
-
-            val result = resolver.resolve("The Hobbit")
-
-            // Both below 0.5 threshold, should return NotFound
-            assertIs<PlaybackIntent.NotFound>(result)
+        test("where I left off returns Resume intent") {
+            runTest {
+                setup()
+                val result = resolver.resolve("where I left off")
+                result.shouldBeInstanceOf<PlaybackIntent.Resume>()
+            }
         }
-}
+
+        // ========== Search Resolution Tests ==========
+
+        test("exact title match returns PlayBook with high confidence") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit", score = 1.0f),
+                )
+
+                val result = resolver.resolve("The Hobbit")
+
+                val playBook = result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+                playBook.bookId shouldBe "book1"
+            }
+        }
+
+        test("partial title match with high score returns PlayBook") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit", score = 0.9f),
+                )
+
+                val result = resolver.resolve("Hobbit")
+
+                val playBook = result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+                playBook.bookId shouldBe "book1"
+            }
+        }
+
+        test("multiple matches returns Ambiguous with bestGuess") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit", score = 0.7f),
+                    testSearchHit(id = "book2", name = "The Hobbit: An Unexpected Journey", score = 0.6f),
+                )
+
+                val result = resolver.resolve("Hobbit")
+
+                val ambiguous = result.shouldBeInstanceOf<PlaybackIntent.Ambiguous>()
+                ambiguous.candidates.size shouldBe 2
+                ambiguous.bestGuess shouldNotBe null
+                ambiguous.bestGuess?.bookId shouldBe "book1"
+            }
+        }
+
+        test("no matches returns NotFound") {
+            runTest {
+                setup()
+                searchRepository.setResults() // empty
+
+                val result = resolver.resolve("xyzzy gibberish")
+
+                val notFound = result.shouldBeInstanceOf<PlaybackIntent.NotFound>()
+                notFound.originalQuery shouldBe "xyzzy gibberish"
+            }
+        }
+
+        test("title hint boosts exact match confidence") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit", score = 0.5f),
+                )
+
+                val result =
+                    resolver.resolve(
+                        query = "The Hobbit",
+                        hints = VoiceHints(title = "The Hobbit"),
+                    )
+
+                // With title hint matching exactly, confidence should be high enough for PlayBook
+                result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+            }
+        }
+
+        // ========== Series Navigation Tests ==========
+
+        test("next book with series context returns PlaySeriesFrom") {
+            runTest {
+                setup()
+                // Setup: User has been listening to book 1 of a series
+                val series = testSeries("series1", "Lord of the Rings")
+                val book1 =
+                    testBook(
+                        id = "book1",
+                        title = "The Fellowship of the Ring",
+                        series = listOf(testBookSeries("series1", "Lord of the Rings", "1")),
+                    )
+                val book2 =
+                    testBook(
+                        id = "book2",
+                        title = "The Two Towers",
+                        series = listOf(testBookSeries("series1", "Lord of the Rings", "2")),
+                    )
+
+                bookRepository.addBook(book1)
+                bookRepository.addBook(book2)
+                seriesRepository.addSeries(series, listOf("book1", "book2"))
+                homeRepository.setContinueListening(testContinueListeningBook("book1", "The Fellowship of the Ring"))
+
+                val result = resolver.resolve("next book")
+
+                val playSeries = result.shouldBeInstanceOf<PlaybackIntent.PlaySeriesFrom>()
+                playSeries.seriesId shouldBe "series1"
+                playSeries.startBookId shouldBe "book2"
+            }
+        }
+
+        test("book 2 with series context returns PlaySeriesFrom") {
+            runTest {
+                setup()
+                val series = testSeries("series1", "Mistborn")
+                val book1 =
+                    testBook(
+                        id = "book1",
+                        title = "The Final Empire",
+                        series = listOf(testBookSeries("series1", "Mistborn", "1")),
+                    )
+                val book2 =
+                    testBook(
+                        id = "book2",
+                        title = "The Well of Ascension",
+                        series = listOf(testBookSeries("series1", "Mistborn", "2")),
+                    )
+
+                bookRepository.addBook(book1)
+                bookRepository.addBook(book2)
+                seriesRepository.addSeries(series, listOf("book1", "book2"))
+                homeRepository.setContinueListening(testContinueListeningBook("book1", "The Final Empire"))
+
+                val result = resolver.resolve("book 2")
+
+                val playSeries = result.shouldBeInstanceOf<PlaybackIntent.PlaySeriesFrom>()
+                playSeries.startBookId shouldBe "book2"
+            }
+        }
+
+        test("next book without series context falls back to search") {
+            runTest {
+                setup()
+                // No continue listening, no series context
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "Next Book: A Novel", score = 0.9f),
+                )
+
+                val result = resolver.resolve("next book")
+
+                // Should fall back to search since there's no series context
+                result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+            }
+        }
+
+        test("first book in series returns PlaySeriesFrom") {
+            runTest {
+                setup()
+                val series = testSeries("series1", "Harry Potter")
+                val book1 =
+                    testBook(
+                        id = "book1",
+                        title = "Philosopher's Stone",
+                        series = listOf(testBookSeries("series1", "Harry Potter", "1")),
+                    )
+                val book3 =
+                    testBook(
+                        id = "book3",
+                        title = "Prisoner of Azkaban",
+                        series = listOf(testBookSeries("series1", "Harry Potter", "3")),
+                    )
+
+                bookRepository.addBook(book1)
+                bookRepository.addBook(book3)
+                seriesRepository.addSeries(series, listOf("book1", "book3"))
+                homeRepository.setContinueListening(testContinueListeningBook("book3", "Prisoner of Azkaban"))
+
+                val result = resolver.resolve("first book")
+
+                val playSeries = result.shouldBeInstanceOf<PlaybackIntent.PlaySeriesFrom>()
+                playSeries.startBookId shouldBe "book1"
+            }
+        }
+
+        // ========== Error Handling Tests ==========
+
+        test("search exception propagates to caller") {
+            runTest {
+                setup()
+                searchRepository.setError(RuntimeException("Network error"))
+
+                shouldThrow<RuntimeException> {
+                    resolver.resolve("The Hobbit")
+                }
+            }
+        }
+
+        test("empty query falls through to search and returns NotFound") {
+            runTest {
+                setup()
+                searchRepository.setResults() // empty results
+
+                val result = resolver.resolve("")
+
+                result.shouldBeInstanceOf<PlaybackIntent.NotFound>()
+            }
+        }
+
+        test("whitespace-only query falls through to search") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "Some Book", score = 0.9f),
+                )
+
+                val result = resolver.resolve("   ")
+
+                // Whitespace query goes to search, returns whatever search finds
+                result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+            }
+        }
+
+        // ========== Confidence Scoring Edge Cases ==========
+
+        test("very low score with no boosts returns NotFound") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "Completely Different Title", score = 0.1f),
+                )
+
+                val result = resolver.resolve("The Hobbit")
+
+                // Low score + no title match = below ambiguous threshold = NotFound
+                result.shouldBeInstanceOf<PlaybackIntent.NotFound>()
+            }
+        }
+
+        test("author hint boosts confidence") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit", author = "J.R.R. Tolkien", score = 0.5f),
+                )
+
+                val result =
+                    resolver.resolve(
+                        query = "Hobbit",
+                        hints = VoiceHints(artist = "Tolkien"),
+                    )
+
+                // Author hint should boost confidence enough for PlayBook
+                result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+            }
+        }
+
+        test("title starts with query boosts confidence") {
+            runTest {
+                setup()
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit: An Unexpected Journey", score = 0.5f),
+                )
+
+                val result = resolver.resolve("The Hobbit")
+
+                // "The Hobbit: An Unexpected Journey" starts with "the hobbit"
+                // Should get TITLE_STARTS_WITH_BOOST + base score
+                result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+            }
+        }
+
+        test("single match above ambiguous but below high confidence still plays") {
+            runTest {
+                setup()
+                // Score 0.6f * 0.5 = 0.3 base, + 0.3 title starts with = 0.6 total
+                // Above 0.5 (ambiguous) but below 0.8 (high confidence)
+                // Single match should still play
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "The Hobbit", score = 0.6f),
+                )
+
+                val result = resolver.resolve("Hobbit")
+
+                result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+            }
+        }
+
+        // ========== Series Navigation Edge Cases ==========
+
+        test("next book at end of series returns null and falls back to search") {
+            runTest {
+                setup()
+                val series = testSeries("series1", "Duology")
+                val book1 =
+                    testBook(
+                        id = "book1",
+                        title = "Book One",
+                        series = listOf(testBookSeries("series1", "Duology", "1")),
+                    )
+                val book2 =
+                    testBook(
+                        id = "book2",
+                        title = "Book Two",
+                        series = listOf(testBookSeries("series1", "Duology", "2")),
+                    )
+
+                bookRepository.addBook(book1)
+                bookRepository.addBook(book2)
+                seriesRepository.addSeries(series, listOf("book1", "book2"))
+                // User is on the LAST book
+                homeRepository.setContinueListening(testContinueListeningBook("book2", "Book Two"))
+
+                // Set up search fallback
+                searchRepository.setResults(
+                    testSearchHit(id = "other", name = "Next Book: A Novel", score = 0.9f),
+                )
+
+                val result = resolver.resolve("next book")
+
+                // No next book in series, falls back to search
+                val playBook = result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+                playBook.bookId shouldBe "other"
+            }
+        }
+
+        test("book by sequence not found returns null and falls back to search") {
+            runTest {
+                setup()
+                val series = testSeries("series1", "Trilogy")
+                val book1 =
+                    testBook(
+                        id = "book1",
+                        title = "Book One",
+                        series = listOf(testBookSeries("series1", "Trilogy", "1")),
+                    )
+
+                bookRepository.addBook(book1)
+                seriesRepository.addSeries(series, listOf("book1"))
+                homeRepository.setContinueListening(testContinueListeningBook("book1", "Book One"))
+
+                searchRepository.setResults(
+                    testSearchHit(id = "other", name = "Book 5", score = 0.9f),
+                )
+
+                val result = resolver.resolve("book 5") // No book 5 in series
+
+                // Book 5 not found in series, falls back to search
+                val playBook = result.shouldBeInstanceOf<PlaybackIntent.PlayBook>()
+                playBook.bookId shouldBe "other"
+            }
+        }
+
+        test("ambiguous result has candidates sorted by confidence") {
+            runTest {
+                setup()
+                // Use scores that result in ambiguous range (0.5-0.8) after boosts
+                // Query "adventure" - all titles contain it, so all get TITLE_CONTAINS_QUERY_BOOST (+0.2)
+                // Base scores: 0.7*0.5=0.35, 0.6*0.5=0.3, 0.5*0.5=0.25
+                // With +0.2 boost: 0.55, 0.5, 0.45
+                // book3 at 0.45 is below 0.5 threshold, so only 2 viable
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "Adventure Time", score = 0.7f),
+                    testSearchHit(id = "book2", name = "The Grand Adventure", score = 0.6f),
+                    testSearchHit(id = "book3", name = "Adventure Awaits", score = 0.65f),
+                )
+
+                val result = resolver.resolve("adventure")
+
+                val ambiguous = result.shouldBeInstanceOf<PlaybackIntent.Ambiguous>()
+                (ambiguous.candidates.size >= 2) shouldBe true
+                // Candidates should be sorted by confidence (highest first)
+                for (i in 0 until ambiguous.candidates.size - 1) {
+                    withClue("Candidates should be sorted by confidence descending") {
+                        (ambiguous.candidates[i].confidence >= ambiguous.candidates[i + 1].confidence) shouldBe true
+                    }
+                }
+            }
+        }
+
+        test("ambiguous result bestGuess is null when top match below threshold") {
+            runTest {
+                setup()
+                // All matches below ambiguous threshold
+                searchRepository.setResults(
+                    testSearchHit(id = "book1", name = "Something Else", score = 0.3f),
+                    testSearchHit(id = "book2", name = "Another Thing", score = 0.2f),
+                )
+
+                val result = resolver.resolve("The Hobbit")
+
+                // Both below 0.5 threshold, should return NotFound
+                result.shouldBeInstanceOf<PlaybackIntent.NotFound>()
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/core/AppResultTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/core/AppResultTest.kt
@@ -17,12 +17,10 @@ import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 /**
  * Tests for [AppResult] — the canonical result type.
@@ -31,143 +29,125 @@ import kotlin.test.assertTrue
  * models ([Result], `AsyncState`, [AppError]) with no conversion path. [AppResult] is
  * the single sealed hierarchy carrying [AppError] directly.
  */
-class AppResultTest {
-    @Test
-    fun successHoldsData() {
-        val result: AppResult<String> = AppResult.Success("hello")
-        assertIs<AppResult.Success<String>>(result)
-        assertEquals("hello", result.data)
-    }
+class AppResultTest :
+    FunSpec({
+        test("successHoldsData") {
+            val result: AppResult<String> = AppResult.Success("hello")
+            result.shouldBeInstanceOf<AppResult.Success<String>>()
+            result.data shouldBe "hello"
+        }
 
-    @Test
-    fun failureHoldsAppError() {
-        val err: AppError = TransportError.NetworkUnavailable(debugInfo = "timeout")
-        val result: AppResult<String> = AppResult.Failure(err)
-        assertIs<AppResult.Failure>(result)
-        assertSame(err, result.error)
-    }
+        test("failureHoldsAppError") {
+            val err: AppError = TransportError.NetworkUnavailable(debugInfo = "timeout")
+            val result: AppResult<String> = AppResult.Failure(err)
+            result.shouldBeInstanceOf<AppResult.Failure>()
+            result.error shouldBeSameInstanceAs err
+        }
 
-    @Test
-    fun mapTransformsSuccess() {
-        val result: AppResult<Int> = AppResult.Success(5)
-        val mapped = result.map { it * 2 }
-        assertEquals(AppResult.Success(10), mapped)
-    }
+        test("mapTransformsSuccess") {
+            val result: AppResult<Int> = AppResult.Success(5)
+            val mapped = result.map { it * 2 }
+            mapped shouldBe AppResult.Success(10)
+        }
 
-    @Test
-    fun mapPreservesFailure() {
-        val err: AppError = TransportError.NetworkUnavailable()
-        val result: AppResult<Int> = AppResult.Failure(err)
-        val mapped = result.map { it * 2 }
-        assertIs<AppResult.Failure>(mapped)
-        assertSame(err, mapped.error)
-    }
+        test("mapPreservesFailure") {
+            val err: AppError = TransportError.NetworkUnavailable()
+            val result: AppResult<Int> = AppResult.Failure(err)
+            val mapped = result.map { it * 2 }
+            mapped.shouldBeInstanceOf<AppResult.Failure>()
+            mapped.error shouldBeSameInstanceAs err
+        }
 
-    @Test
-    fun flatMapChainsSuccesses() {
-        val result: AppResult<Int> = AppResult.Success(5)
-        val chained: AppResult<String> = result.flatMap { AppResult.Success(it.toString()) }
-        assertEquals(AppResult.Success("5"), chained)
-    }
+        test("flatMapChainsSuccesses") {
+            val result: AppResult<Int> = AppResult.Success(5)
+            val chained: AppResult<String> = result.flatMap { AppResult.Success(it.toString()) }
+            chained shouldBe AppResult.Success("5")
+        }
 
-    @Test
-    fun flatMapShortCircuitsOnFailure() {
-        val err: AppError = ValidationError(message = "bad")
-        val result: AppResult<Int> = AppResult.Failure(err)
-        val chained: AppResult<String> = result.flatMap { error("should not be called") }
-        assertIs<AppResult.Failure>(chained)
-        assertSame(err, chained.error)
-    }
+        test("flatMapShortCircuitsOnFailure") {
+            val err: AppError = ValidationError(message = "bad")
+            val result: AppResult<Int> = AppResult.Failure(err)
+            val chained: AppResult<String> = result.flatMap { error("should not be called") }
+            chained.shouldBeInstanceOf<AppResult.Failure>()
+            chained.error shouldBeSameInstanceAs err
+        }
 
-    @Test
-    fun flatMapSurfacesInnerFailure() {
-        val inner: AppError = AuthError.SessionExpired()
-        val result: AppResult<Int> = AppResult.Success(5)
-        val chained = result.flatMap<Int, String> { AppResult.Failure(inner) }
-        assertIs<AppResult.Failure>(chained)
-        assertSame(inner, chained.error)
-    }
+        test("flatMapSurfacesInnerFailure") {
+            val inner: AppError = AuthError.SessionExpired()
+            val result: AppResult<Int> = AppResult.Success(5)
+            val chained = result.flatMap<Int, String> { AppResult.Failure(inner) }
+            chained.shouldBeInstanceOf<AppResult.Failure>()
+            chained.error shouldBeSameInstanceAs inner
+        }
 
-    @Test
-    fun foldDispatchesSuccess() {
-        val result: AppResult<Int> = AppResult.Success(5)
-        val folded = result.fold(onSuccess = { "got $it" }, onFailure = { "err ${it.code}" })
-        assertEquals("got 5", folded)
-    }
+        test("foldDispatchesSuccess") {
+            val result: AppResult<Int> = AppResult.Success(5)
+            val folded = result.fold(onSuccess = { "got $it" }, onFailure = { "err ${it.code}" })
+            folded shouldBe "got 5"
+        }
 
-    @Test
-    fun foldDispatchesFailure() {
-        val result: AppResult<Int> = AppResult.Failure(AuthError.SessionExpired())
-        val folded = result.fold(onSuccess = { "got $it" }, onFailure = { "err ${it.code}" })
-        assertEquals("err AUTH_SESSION_EXPIRED", folded)
-    }
+        test("foldDispatchesFailure") {
+            val result: AppResult<Int> = AppResult.Failure(AuthError.SessionExpired())
+            val folded = result.fold(onSuccess = { "got $it" }, onFailure = { "err ${it.code}" })
+            folded shouldBe "err AUTH_SESSION_EXPIRED"
+        }
 
-    @Test
-    fun getOrNullReturnsDataOnSuccess() {
-        val result: AppResult<Int> = AppResult.Success(5)
-        assertEquals(5, result.getOrNull())
-    }
+        test("getOrNullReturnsDataOnSuccess") {
+            val result: AppResult<Int> = AppResult.Success(5)
+            result.getOrNull() shouldBe 5
+        }
 
-    @Test
-    fun getOrNullReturnsNullOnFailure() {
-        val result: AppResult<Int> = AppResult.Failure(TransportError.NetworkUnavailable())
-        assertNull(result.getOrNull())
-    }
+        test("getOrNullReturnsNullOnFailure") {
+            val result: AppResult<Int> = AppResult.Failure(TransportError.NetworkUnavailable())
+            result.getOrNull() shouldBe null
+        }
 
-    @Test
-    fun errorOrNullReturnsErrorOnFailure() {
-        val err: AppError = TransportError.NetworkUnavailable()
-        val result: AppResult<Int> = AppResult.Failure(err)
-        assertSame(err, result.errorOrNull())
-    }
+        test("errorOrNullReturnsErrorOnFailure") {
+            val err: AppError = TransportError.NetworkUnavailable()
+            val result: AppResult<Int> = AppResult.Failure(err)
+            result.errorOrNull() shouldBeSameInstanceAs err
+        }
 
-    @Test
-    fun errorOrNullReturnsNullOnSuccess() {
-        val result: AppResult<Int> = AppResult.Success(5)
-        assertNull(result.errorOrNull())
-    }
+        test("errorOrNullReturnsNullOnSuccess") {
+            val result: AppResult<Int> = AppResult.Success(5)
+            result.errorOrNull() shouldBe null
+        }
 
-    @Test
-    fun onSuccessRunsOnlyOnSuccess() {
-        var ran = false
-        val result: AppResult<Int> = AppResult.Success(5)
-        result.onSuccess { ran = true }
-        assertTrue(ran)
-    }
+        test("onSuccessRunsOnlyOnSuccess") {
+            var ran = false
+            val result: AppResult<Int> = AppResult.Success(5)
+            result.onSuccess { ran = true }
+            ran shouldBe true
+        }
 
-    @Test
-    fun onFailureRunsOnlyOnFailure() {
-        var captured: AppError? = null
-        val err: AppError = AuthError.SessionExpired()
-        AppResult.Failure(err).onFailure { captured = it }
-        assertSame(err, captured)
-    }
+        test("onFailureRunsOnlyOnFailure") {
+            var captured: AppError? = null
+            val err: AppError = AuthError.SessionExpired()
+            AppResult.Failure(err).onFailure { captured = it }
+            captured shouldBeSameInstanceAs err
+        }
 
-    @Test
-    fun failureFromThrowableMapsViaErrorMapper() {
-        val ex = IllegalStateException("boom")
-        val failure = Failure(ex)
-        val internal = assertIs<InternalError>(failure.error)
-        assertTrue(internal.debugInfo?.contains("boom") == true)
-        assertTrue(internal.debugInfo?.contains("IllegalStateException") == true)
-    }
+        test("failureFromThrowableMapsViaErrorMapper") {
+            val ex = IllegalStateException("boom")
+            val failure = Failure(ex)
+            val internal = failure.error.shouldBeInstanceOf<InternalError>()
+            (internal.debugInfo?.contains("boom") == true) shouldBe true
+            (internal.debugInfo?.contains("IllegalStateException") == true) shouldBe true
+        }
 
-    @Test
-    fun validationErrorBuildsValidationErrorFailure() {
-        val failure = validationError("bad input")
-        assertIs<ValidationError>(failure.error)
-        assertEquals("bad input", failure.message)
-    }
+        test("validationErrorBuildsValidationErrorFailure") {
+            val failure = validationError("bad input")
+            failure.error.shouldBeInstanceOf<ValidationError>()
+            failure.message shouldBe "bad input"
+        }
 
-    @Test
-    fun networkErrorHelperBuildsNetworkUnavailableFailure() {
-        val failure = networkError("offline")
-        assertIs<TransportError.NetworkUnavailable>(failure.error)
-    }
+        test("networkErrorHelperBuildsNetworkUnavailableFailure") {
+            val failure = networkError("offline")
+            failure.error.shouldBeInstanceOf<TransportError.NetworkUnavailable>()
+        }
 
-    @Test
-    fun unauthorizedHelperBuildsSessionExpiredFailure() {
-        val failure = unauthorizedError()
-        assertIs<AuthError.SessionExpired>(failure.error)
-    }
-}
+        test("unauthorizedHelperBuildsSessionExpiredFailure") {
+            val failure = unauthorizedError()
+            failure.error.shouldBeInstanceOf<AuthError.SessionExpired>()
+        }
+    })


### PR DESCRIPTION
## What

First batch of the `kotlin-test` → **Kotest FunSpec** migration (the canonical test framework per `client/CLAUDE.md`; `kotlin-test` is slated to leave the catalog in Phase 8). 15 pure-logic `commonTest` specs — the lowest-risk files (no Koin, DB fixtures, or coroutine-test complexity).

Files: `util/{TitleSortUtils,NanoId}`, `core/AppResult`, `voice/{VoiceIntentResolver,SeriesNavigationDetector,ResumePhraseDetector}`, `data/remote/model/{ApiResponse,EnvelopeContract,SyncModels}`, `data/local/db/{ValueClasses,TypeConverters,Syncable}`, `presentation/library/SortState`, `presentation/bookdetail/SubtitleFilter`, `device/DeviceContext`.

## How

Pure framework migration — every assertion's meaning preserved, no test logic changed:
- `class X { @Test fun \`name\`() }` → `class X : FunSpec({ test("name") { } })`
- `assertEquals(expected, actual)` → `actual shouldBe expected` (argument order flips)
- `assertTrue/False/Null/NotNull/Is/FailsWith/Same` → the matching Kotest matcher
- `kotlin.test.*` imports removed; Kotest matcher imports added

## Verification

`:sharedLogic:jvmTest` green, spotless + detekt clean. No production code touched.

## Scope note

~66 `kotlin-test` files remain (this is a deliberately incremental sweep, not a one-shot burn-down). `build-logic` tests are excluded (Gradle-plugin context, outside the app's Kotest-canonical surface). `TestAssertions.kt`'s `checkIs` helper is dead code (zero callers) — left untouched here; worth deleting separately.
