### PR TITLE
✅ test(shared): migrate data/domain commonTest specs to Kotest (batch 2/N)

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
@@ -4,12 +4,11 @@ import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.client.checkIs
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.io.IOException
 import kotlinx.serialization.SerializationException
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 /**
  * Tests for ErrorMapper.
@@ -24,155 +23,141 @@ import kotlin.test.assertTrue
  * make them difficult to instantiate in unit tests. Those mappings are verified
  * through HttpClientErrorHandlingTest.
  */
-class ErrorMapperTest {
-    // ========== SerializationException → TransportError.DataMalformed ==========
+class ErrorMapperTest :
+    FunSpec({
+        // ========== SerializationException → TransportError.DataMalformed ==========
 
-    @Test
-    fun `map SerializationException returns DataMalformed`() {
-        val exception = SerializationException("Failed to parse JSON")
-        val error = ErrorMapper.map(exception)
+        test("map SerializationException returns DataMalformed") {
+            val exception = SerializationException("Failed to parse JSON")
+            val error = ErrorMapper.map(exception)
 
-        val dataMalformed = assertIs<TransportError.DataMalformed>(error)
-        assertEquals("Server response was malformed.", dataMalformed.message)
-        assertEquals("TRANSPORT_DATA_MALFORMED", dataMalformed.code)
-        assertEquals("Failed to parse JSON", dataMalformed.detail)
-    }
+            val dataMalformed = error.shouldBeInstanceOf<TransportError.DataMalformed>()
+            dataMalformed.message shouldBe "Server response was malformed."
+            dataMalformed.code shouldBe "TRANSPORT_DATA_MALFORMED"
+            dataMalformed.detail shouldBe "Failed to parse JSON"
+        }
 
-    @Test
-    fun `DataMalformed is not retryable`() {
-        val exception = SerializationException("Parse error")
-        val error = ErrorMapper.map(exception)
+        test("DataMalformed is not retryable") {
+            val exception = SerializationException("Parse error")
+            val error = ErrorMapper.map(exception)
 
-        val dataMalformed = assertIs<TransportError.DataMalformed>(error)
-        assertEquals(false, dataMalformed.isRetryable)
-    }
+            val dataMalformed = error.shouldBeInstanceOf<TransportError.DataMalformed>()
+            dataMalformed.isRetryable shouldBe false
+        }
 
-    @Test
-    fun `map SerializationException includes debug info`() {
-        val exception = SerializationException("Unexpected JSON token")
-        val error = ErrorMapper.map(exception)
+        test("map SerializationException includes debug info") {
+            val exception = SerializationException("Unexpected JSON token")
+            val error = ErrorMapper.map(exception)
 
-        val dataMalformed = assertIs<TransportError.DataMalformed>(error)
-        assertEquals("Unexpected JSON token", dataMalformed.debugInfo)
-    }
+            val dataMalformed = error.shouldBeInstanceOf<TransportError.DataMalformed>()
+            dataMalformed.debugInfo shouldBe "Unexpected JSON token"
+        }
 
-    @Test
-    fun `map SerializationException with null message uses fallback detail`() {
-        val exception = SerializationException(null as String?)
-        val error = ErrorMapper.map(exception)
+        test("map SerializationException with null message uses fallback detail") {
+            val exception = SerializationException(null as String?)
+            val error = ErrorMapper.map(exception)
 
-        val dataMalformed = assertIs<TransportError.DataMalformed>(error)
-        assertEquals("deserialization failed", dataMalformed.detail)
-    }
+            val dataMalformed = error.shouldBeInstanceOf<TransportError.DataMalformed>()
+            dataMalformed.detail shouldBe "deserialization failed"
+        }
 
-    // ========== IOException → TransportError.NetworkUnavailable ==========
+        // ========== IOException → TransportError.NetworkUnavailable ==========
 
-    @Test
-    fun `map IOException returns NetworkUnavailable`() {
-        val exception = IOException("Connection refused")
-        val error = ErrorMapper.map(exception)
+        test("map IOException returns NetworkUnavailable") {
+            val exception = IOException("Connection refused")
+            val error = ErrorMapper.map(exception)
 
-        val networkUnavailable = assertIs<TransportError.NetworkUnavailable>(error)
-        assertEquals("No internet connection. Check your network.", networkUnavailable.message)
-        assertEquals("TRANSPORT_NETWORK_UNAVAILABLE", networkUnavailable.code)
-        assertEquals("Connection refused", networkUnavailable.debugInfo)
-    }
+            val networkUnavailable = error.shouldBeInstanceOf<TransportError.NetworkUnavailable>()
+            networkUnavailable.message shouldBe "No internet connection. Check your network."
+            networkUnavailable.code shouldBe "TRANSPORT_NETWORK_UNAVAILABLE"
+            networkUnavailable.debugInfo shouldBe "Connection refused"
+        }
 
-    @Test
-    fun `NetworkUnavailable is retryable`() {
-        val exception = IOException("Network down")
-        val error = ErrorMapper.map(exception)
+        test("NetworkUnavailable is retryable") {
+            val exception = IOException("Network down")
+            val error = ErrorMapper.map(exception)
 
-        val networkUnavailable = assertIs<TransportError.NetworkUnavailable>(error)
-        assertEquals(true, networkUnavailable.isRetryable)
-    }
+            val networkUnavailable = error.shouldBeInstanceOf<TransportError.NetworkUnavailable>()
+            networkUnavailable.isRetryable shouldBe true
+        }
 
-    // ========== IllegalArgumentException → ValidationError ==========
+        // ========== IllegalArgumentException → ValidationError ==========
 
-    @Test
-    fun `map IllegalArgumentException returns ValidationError preserving message`() {
-        val exception = IllegalArgumentException("Bad argument")
-        val error = ErrorMapper.map(exception)
+        test("map IllegalArgumentException returns ValidationError preserving message") {
+            val exception = IllegalArgumentException("Bad argument")
+            val error = ErrorMapper.map(exception)
 
-        val validationError = assertIs<ValidationError>(error)
-        assertEquals("Bad argument", validationError.message)
-        assertEquals("VALIDATION_ERROR", validationError.code)
-        assertEquals("Bad argument", validationError.debugInfo)
-        assertEquals(false, validationError.isRetryable)
-    }
+            val validationError = error.shouldBeInstanceOf<ValidationError>()
+            validationError.message shouldBe "Bad argument"
+            validationError.code shouldBe "VALIDATION_ERROR"
+            validationError.debugInfo shouldBe "Bad argument"
+            validationError.isRetryable shouldBe false
+        }
 
-    @Test
-    fun `map IllegalArgumentException with null message uses fallback`() {
-        val exception = IllegalArgumentException()
-        val error = ErrorMapper.map(exception)
+        test("map IllegalArgumentException with null message uses fallback") {
+            val exception = IllegalArgumentException()
+            val error = ErrorMapper.map(exception)
 
-        val validationError = assertIs<ValidationError>(error)
-        assertEquals("Invalid input.", validationError.message)
-    }
+            val validationError = error.shouldBeInstanceOf<ValidationError>()
+            validationError.message shouldBe "Invalid input."
+        }
 
-    // ========== Unknown / catch-all → InternalError ==========
+        // ========== Unknown / catch-all → InternalError ==========
 
-    @Test
-    fun `map unknown exception returns InternalError`() {
-        val exception = IllegalStateException("Something went wrong")
-        val error = ErrorMapper.map(exception)
+        test("map unknown exception returns InternalError") {
+            val exception = IllegalStateException("Something went wrong")
+            val error = ErrorMapper.map(exception)
 
-        val internalError = assertIs<InternalError>(error)
-        assertEquals("Something went wrong on the server.", internalError.message)
-        assertEquals("INTERNAL_ERROR", internalError.code)
-    }
+            val internalError = error.shouldBeInstanceOf<InternalError>()
+            internalError.message shouldBe "Something went wrong on the server."
+            internalError.code shouldBe "INTERNAL_ERROR"
+        }
 
-    @Test
-    fun `InternalError is not retryable`() {
-        val exception = RuntimeException("Random error")
-        val error = ErrorMapper.map(exception)
+        test("InternalError is not retryable") {
+            val exception = RuntimeException("Random error")
+            val error = ErrorMapper.map(exception)
 
-        val internalError = assertIs<InternalError>(error)
-        assertEquals(false, internalError.isRetryable)
-    }
+            val internalError = error.shouldBeInstanceOf<InternalError>()
+            internalError.isRetryable shouldBe false
+        }
 
-    @Test
-    fun `map unknown exception preserves throwable text in debug info`() {
-        val exception = RuntimeException("Custom error message")
-        val error = ErrorMapper.map(exception)
+        test("map unknown exception preserves throwable text in debug info") {
+            val exception = RuntimeException("Custom error message")
+            val error = ErrorMapper.map(exception)
 
-        val internalError = assertIs<InternalError>(error)
-        assertTrue(internalError.debugInfo?.contains("Custom error message") == true)
-        assertTrue(internalError.debugInfo?.contains("RuntimeException") == true)
-    }
+            val internalError = error.shouldBeInstanceOf<InternalError>()
+            (internalError.debugInfo?.contains("Custom error message") == true) shouldBe true
+            (internalError.debugInfo?.contains("RuntimeException") == true) shouldBe true
+        }
 
-    @Test
-    fun `map unknown exception with null message produces ClassName-null debug info`() {
-        val error = ErrorMapper.map(RuntimeException())
+        test("map unknown exception with null message produces ClassName-null debug info") {
+            val error = ErrorMapper.map(RuntimeException())
 
-        val internalError = assertIs<InternalError>(error)
-        assertEquals("RuntimeException: null", internalError.debugInfo)
-    }
+            val internalError = error.shouldBeInstanceOf<InternalError>()
+            internalError.debugInfo shouldBe "RuntimeException: null"
+        }
 
-    @Test
-    fun `map custom exception returns InternalError`() {
-        class CustomException(
-            message: String,
-        ) : Exception(message)
-        val exception = CustomException("Custom domain error")
-        val error = ErrorMapper.map(exception)
+        test("map custom exception returns InternalError") {
+            class CustomException(
+                message: String,
+            ) : Exception(message)
+            val exception = CustomException("Custom domain error")
+            val error = ErrorMapper.map(exception)
 
-        checkIs<InternalError>(error)
-    }
+            checkIs<InternalError>(error)
+        }
 
-    @Test
-    fun `map NullPointerException returns InternalError`() {
-        val exception = NullPointerException("null reference")
-        val error = ErrorMapper.map(exception)
+        test("map NullPointerException returns InternalError") {
+            val exception = NullPointerException("null reference")
+            val error = ErrorMapper.map(exception)
 
-        checkIs<InternalError>(error)
-    }
+            checkIs<InternalError>(error)
+        }
 
-    @Test
-    fun `map IndexOutOfBoundsException returns InternalError`() {
-        val exception = IndexOutOfBoundsException("index 5 out of bounds")
-        val error = ErrorMapper.map(exception)
+        test("map IndexOutOfBoundsException returns InternalError") {
+            val exception = IndexOutOfBoundsException("index 5 out of bounds")
+            val error = ErrorMapper.map(exception)
 
-        checkIs<InternalError>(error)
-    }
-}
+            checkIs<InternalError>(error)
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpClientErrorHandlingTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpClientErrorHandlingTest.kt
@@ -3,6 +3,10 @@ package com.calypsan.listenup.client.data.remote
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.test.http.testMockEngine
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
@@ -11,11 +15,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 /**
  * Verifies that [installListenUpErrorHandling] sets `expectSuccess = true` so that
@@ -26,85 +25,86 @@ import kotlin.test.assertTrue
  * boundary, not inside the plugin itself. These tests verify the plugin's single
  * responsibility: raise on non-2xx rather than passing error bodies to the decoder.
  */
-class HttpClientErrorHandlingTest {
-    private fun client(block: com.calypsan.listenup.client.test.http.TestMockEngineBuilder.() -> Unit): HttpClient =
-        HttpClient(testMockEngine(block)) {
-            installListenUpErrorHandling()
+class HttpClientErrorHandlingTest :
+    FunSpec({
+        fun client(block: com.calypsan.listenup.client.test.http.TestMockEngineBuilder.() -> Unit): HttpClient =
+            HttpClient(testMockEngine(block)) {
+                installListenUpErrorHandling()
+            }
+
+        test("successfulResponsePassesThrough") {
+            runTest {
+                val c = client { respondJson("/ok") { """{"status":"ok"}""" } }
+
+                val response = c.get("http://unit.test/ok")
+                response.status.isSuccess() shouldBe true
+                response.bodyAsText() shouldBe """{"status":"ok"}"""
+            }
         }
 
-    @Test
-    fun successfulResponsePassesThrough() =
-        runTest {
-            val c = client { respondJson("/ok") { """{"status":"ok"}""" } }
+        test("serverErrorResponseRaisesResponseException") {
+            runTest {
+                // expectSuccess = true means Ktor raises ResponseException on non-2xx.
+                // The exception type is ResponseException (or a ServerResponseException subtype).
+                val c = client { respondStatus("/boom", HttpStatusCode.InternalServerError) }
 
-            val response = c.get("http://unit.test/ok")
-            assertTrue(response.status.isSuccess())
-            assertEquals("""{"status":"ok"}""", response.bodyAsText())
+                val thrown = shouldThrow<ResponseException> { c.get("http://unit.test/boom") }
+                thrown.response.status.value shouldBe 500
+            }
         }
 
-    @Test
-    fun serverErrorResponseRaisesResponseException() =
-        runTest {
-            // expectSuccess = true means Ktor raises ResponseException on non-2xx.
-            // The exception type is ResponseException (or a ServerResponseException subtype).
-            val c = client { respondStatus("/boom", HttpStatusCode.InternalServerError) }
+        test("unauthorizedResponseRaisesResponseException") {
+            runTest {
+                val c = client { respondStatus("/secret", HttpStatusCode.Unauthorized) }
 
-            val thrown = assertFailsWith<ResponseException> { c.get("http://unit.test/boom") }
-            assertEquals(500, thrown.response.status.value)
+                val thrown = shouldThrow<ResponseException> { c.get("http://unit.test/secret") }
+                thrown.response.status.value shouldBe 401
+            }
         }
 
-    @Test
-    fun unauthorizedResponseRaisesResponseException() =
-        runTest {
-            val c = client { respondStatus("/secret", HttpStatusCode.Unauthorized) }
+        test("notFoundResponseRaisesResponseException") {
+            runTest {
+                val c = client { respondStatus("/missing", HttpStatusCode.NotFound) }
 
-            val thrown = assertFailsWith<ResponseException> { c.get("http://unit.test/secret") }
-            assertEquals(401, thrown.response.status.value)
+                val thrown = shouldThrow<ResponseException> { c.get("http://unit.test/missing") }
+                thrown.response.status.value shouldBe 404
+            }
         }
 
-    @Test
-    fun notFoundResponseRaisesResponseException() =
-        runTest {
-            val c = client { respondStatus("/missing", HttpStatusCode.NotFound) }
+        test("apiCallCatchesResponseExceptionAndProducesTypedFailure") {
+            runTest {
+                // End-to-end: installListenUpErrorHandling raises ResponseException on non-2xx;
+                // apiCall catches it; ErrorMapper produces a typed AppError.
+                // This validates the full boundary contract without reaching any server.
+                val c = client { respondStatus("/boom", HttpStatusCode.InternalServerError) }
 
-            val thrown = assertFailsWith<ResponseException> { c.get("http://unit.test/missing") }
-            assertEquals(404, thrown.response.status.value)
+                val result =
+                    apiCall<String>(errorMessage = "Failed to fetch") {
+                        c.get("http://unit.test/boom").body()
+                    }
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                val error = result.error
+                error.shouldBeInstanceOf<TransportError.Server5xx>()
+                error.statusCode shouldBe 500
+            }
         }
 
-    @Test
-    fun apiCallCatchesResponseExceptionAndProducesTypedFailure() =
-        runTest {
-            // End-to-end: installListenUpErrorHandling raises ResponseException on non-2xx;
-            // apiCall catches it; ErrorMapper produces a typed AppError.
-            // This validates the full boundary contract without reaching any server.
-            val c = client { respondStatus("/boom", HttpStatusCode.InternalServerError) }
+        test("apiCallCatchesForbiddenAndProducesTypedServer4xxFailure") {
+            runTest {
+                // 403 Forbidden → ErrorMapper classifies as TransportError.Server4xx(403).
+                // Auth-specific upgrade (to AuthError) happens at the repository layer.
+                val c = client { respondStatus("/forbidden", HttpStatusCode.Forbidden) }
 
-            val result =
-                apiCall<String>(errorMessage = "Failed to fetch") {
-                    c.get("http://unit.test/boom").body()
-                }
+                val result =
+                    apiCall<String>(errorMessage = "Failed to fetch") {
+                        c.get("http://unit.test/forbidden").body()
+                    }
 
-            assertIs<AppResult.Failure>(result)
-            val error = result.error
-            assertIs<TransportError.Server5xx>(error)
-            assertEquals(500, error.statusCode)
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                val error = result.error
+                error.shouldBeInstanceOf<TransportError.Server4xx>()
+                error.statusCode shouldBe 403
+            }
         }
-
-    @Test
-    fun apiCallCatchesForbiddenAndProducesTypedServer4xxFailure() =
-        runTest {
-            // 403 Forbidden → ErrorMapper classifies as TransportError.Server4xx(403).
-            // Auth-specific upgrade (to AuthError) happens at the repository layer.
-            val c = client { respondStatus("/forbidden", HttpStatusCode.Forbidden) }
-
-            val result =
-                apiCall<String>(errorMessage = "Failed to fetch") {
-                    c.get("http://unit.test/forbidden").body()
-                }
-
-            assertIs<AppResult.Failure>(result)
-            val error = result.error
-            assertIs<TransportError.Server4xx>(error)
-            assertEquals(403, error.statusCode)
-        }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpRetryPolicyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpRetryPolicyTest.kt
@@ -2,6 +2,10 @@ package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.client.test.http.TestMockEngineBuilder
 import com.calypsan.listenup.client.test.http.testMockEngine
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
@@ -20,10 +24,6 @@ import io.ktor.http.headersOf
 import io.ktor.http.isSuccess
 import kotlinx.io.IOException
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
 /**
  * Verifies the retry policy installed by [ApiClientFactory]'s authenticated client:
@@ -35,101 +35,102 @@ import kotlin.test.assertTrue
  * responses surface as [ResponseException] (Ktor's standard exception for non-success HTTP
  * status codes) rather than `AppException`. Tests assert on [ResponseException] accordingly.
  */
-class HttpRetryPolicyTest {
-    private val idempotentMethods =
-        setOf(
-            HttpMethod.Get,
-            HttpMethod.Head,
-            HttpMethod.Put,
-            HttpMethod.Delete,
-            HttpMethod.Options,
-        )
+class HttpRetryPolicyTest :
+    FunSpec({
+        val idempotentMethods =
+            setOf(
+                HttpMethod.Get,
+                HttpMethod.Head,
+                HttpMethod.Put,
+                HttpMethod.Delete,
+                HttpMethod.Options,
+            )
 
-    /** Matches the policy installed by `ApiClientFactory.createClient()` — tiny delay for tests. */
-    private fun clientWithRetryPolicy(engineBlock: TestMockEngineBuilder.() -> Unit): HttpClient =
-        HttpClient(testMockEngine(engineBlock)) {
-            installListenUpErrorHandling()
-            install(HttpRequestRetry) {
-                retryIf(maxRetries = 3) { request, response ->
-                    request.method in idempotentMethods && response.status.value in 500..599
+        // Matches the policy installed by `ApiClientFactory.createClient()` — tiny delay for tests.
+        fun clientWithRetryPolicy(engineBlock: TestMockEngineBuilder.() -> Unit): HttpClient =
+            HttpClient(testMockEngine(engineBlock)) {
+                installListenUpErrorHandling()
+                install(HttpRequestRetry) {
+                    retryIf(maxRetries = 3) { request, response ->
+                        request.method in idempotentMethods && response.status.value in 500..599
+                    }
+                    retryOnExceptionIf(maxRetries = 3) { request, cause ->
+                        request.method in idempotentMethods &&
+                            (cause is IOException || cause is HttpRequestTimeoutException)
+                    }
+                    exponentialDelay(base = 2.0, maxDelayMs = 10L) // tiny for tests
                 }
-                retryOnExceptionIf(maxRetries = 3) { request, cause ->
-                    request.method in idempotentMethods &&
-                        (cause is IOException || cause is HttpRequestTimeoutException)
-                }
-                exponentialDelay(base = 2.0, maxDelayMs = 10L) // tiny for tests
+            }
+
+        test("idempotentGetRetriesOn503ThenSucceeds") {
+            runTest {
+                var attempts = 0
+                val client =
+                    clientWithRetryPolicy {
+                        handle("/flaky") {
+                            attempts++
+                            if (attempts < 3) {
+                                respondError(HttpStatusCode.ServiceUnavailable)
+                            } else {
+                                respondJsonOk("""{"ok":true}""")
+                            }
+                        }
+                    }
+
+                val response: HttpResponse = client.get("http://unit.test/flaky")
+                response.status.isSuccess() shouldBe true
+                withClue("retry should have attempted three times total") { attempts shouldBe 3 }
             }
         }
 
-    @Test
-    fun idempotentGetRetriesOn503ThenSucceeds() =
-        runTest {
-            var attempts = 0
-            val client =
-                clientWithRetryPolicy {
-                    handle("/flaky") {
-                        attempts++
-                        if (attempts < 3) {
+        test("nonIdempotentPostDoesNotRetryOn503") {
+            runTest {
+                var attempts = 0
+                val client =
+                    clientWithRetryPolicy {
+                        handle("/submit") {
+                            attempts++
                             respondError(HttpStatusCode.ServiceUnavailable)
-                        } else {
-                            respondJsonOk("""{"ok":true}""")
                         }
                     }
-                }
 
-            val response: HttpResponse = client.get("http://unit.test/flaky")
-            assertTrue(response.status.isSuccess())
-            assertEquals(3, attempts, "retry should have attempted three times total")
+                shouldThrow<ResponseException> { client.post("http://unit.test/submit") }
+                withClue("POST must not retry on 5xx — only idempotent methods retry") { attempts shouldBe 1 }
+            }
         }
 
-    @Test
-    fun nonIdempotentPostDoesNotRetryOn503() =
-        runTest {
-            var attempts = 0
-            val client =
-                clientWithRetryPolicy {
-                    handle("/submit") {
-                        attempts++
-                        respondError(HttpStatusCode.ServiceUnavailable)
+        test("retryExhaustsAfterMaxAttemptsAndSurfacesFailure") {
+            runTest {
+                var attempts = 0
+                val client =
+                    clientWithRetryPolicy {
+                        handle("/never-ok") {
+                            attempts++
+                            respondError(HttpStatusCode.InternalServerError)
+                        }
                     }
-                }
 
-            assertFailsWith<ResponseException> { client.post("http://unit.test/submit") }
-            assertEquals(1, attempts, "POST must not retry on 5xx — only idempotent methods retry")
+                shouldThrow<ResponseException> { client.get("http://unit.test/never-ok") }
+                withClue("initial attempt + 3 retries = 4 total") { attempts shouldBe 4 }
+            }
         }
 
-    @Test
-    fun retryExhaustsAfterMaxAttemptsAndSurfacesFailure() =
-        runTest {
-            var attempts = 0
-            val client =
-                clientWithRetryPolicy {
-                    handle("/never-ok") {
-                        attempts++
-                        respondError(HttpStatusCode.InternalServerError)
+        test("fourXXResponsesAreNotRetried") {
+            runTest {
+                var attempts = 0
+                val client =
+                    clientWithRetryPolicy {
+                        handle("/forbidden") {
+                            attempts++
+                            respondError(HttpStatusCode.Forbidden)
+                        }
                     }
-                }
 
-            assertFailsWith<ResponseException> { client.get("http://unit.test/never-ok") }
-            assertEquals(4, attempts, "initial attempt + 3 retries = 4 total")
+                shouldThrow<ResponseException> { client.get("http://unit.test/forbidden") }
+                withClue("4xx responses are client errors; retrying doesn't help") { attempts shouldBe 1 }
+            }
         }
-
-    @Test
-    fun fourXXResponsesAreNotRetried() =
-        runTest {
-            var attempts = 0
-            val client =
-                clientWithRetryPolicy {
-                    handle("/forbidden") {
-                        attempts++
-                        respondError(HttpStatusCode.Forbidden)
-                    }
-                }
-
-            assertFailsWith<ResponseException> { client.get("http://unit.test/forbidden") }
-            assertEquals(1, attempts, "4xx responses are client errors; retrying doesn't help")
-        }
-}
+    })
 
 /** Shortcut: a 200 OK response with a JSON body and `Content-Type: application/json`. */
 private fun MockRequestHandleScope.respondJsonOk(body: String) =

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ActivityRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ActivityRepositoryImplTest.kt
@@ -21,15 +21,13 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for ActivityRepositoryImpl.
@@ -44,314 +42,315 @@ import kotlin.test.assertTrue
  *
  * Uses Mokkery for mocking and follows Given-When-Then style.
  */
-class ActivityRepositoryImplTest {
-    // ========== Test Fixtures ==========
+class ActivityRepositoryImplTest :
+    FunSpec({
+        // ========== Test Fixtures ==========
 
-    private fun createMockDao(): ActivityDao = mock<ActivityDao>()
+        fun createMockDao(): ActivityDao = mock<ActivityDao>()
 
-    private fun createMockBookDao(): BookDao = mock<BookDao>()
+        fun createMockBookDao(): BookDao = mock<BookDao>()
 
-    /** A fake [ActivityRpcFactory] that always returns the supplied [service]. */
-    private fun fakeRpcFactory(service: ActivityService): ActivityRpcFactory =
-        object : ActivityRpcFactory {
-            override suspend fun get(): ActivityService = service
+        // A fake [ActivityRpcFactory] that always returns the supplied [service].
+        fun fakeRpcFactory(service: ActivityService): ActivityRpcFactory =
+            object : ActivityRpcFactory {
+                override suspend fun get(): ActivityService = service
 
-            override suspend fun invalidate() = Unit
-        }
-
-    private fun createRepository(
-        dao: ActivityDao = createMockDao(),
-        rpc: ActivityRpcFactory = fakeRpcFactory(mock<ActivityService>()),
-        bookDao: BookDao = createMockBookDao(),
-    ): ActivityRepositoryImpl = ActivityRepositoryImpl(dao = dao, activityRpc = rpc, bookDao = bookDao)
-
-    // ========== Test Data Factories ==========
-
-    private fun bookEvent(
-        id: String = "event-book",
-        userId: String = "11111111-1111-1111-1111-111111111111",
-        bookId: String = "book-1",
-    ): ActivityEvent =
-        ActivityEvent(
-            id = id,
-            userId = userId,
-            displayName = "John Smith",
-            avatarType = "auto",
-            type = ActivityType.FINISHED_BOOK,
-            createdAtMs = 1704067200000L,
-            bookId = bookId,
-            isReread = true,
-            durationMs = 3600000L,
-            milestoneValue = 0,
-            milestoneUnit = null,
-        )
-
-    private fun shelfEvent(
-        id: String = "event-shelf",
-        userId: String = "22222222-2222-2222-2222-222222222222",
-    ): ActivityEvent =
-        ActivityEvent(
-            id = id,
-            userId = userId,
-            displayName = "Jane Doe",
-            avatarType = "auto",
-            type = ActivityType.SHELF_CREATED,
-            createdAtMs = 1704000000000L,
-            shelfId = "shelf-1",
-            shelfName = "Fantasy Favorites",
-        )
-
-    private fun bookSummary(id: String = "book-1"): BookSummary =
-        BookSummary(
-            id = id,
-            title = "The Way of Kings",
-            coverBlurHash = "LKO2?U%2Tw=w]~RBVZRi};RPxuwH",
-            authorName = "Brandon Sanderson",
-        )
-
-    private fun createActivityEntity(
-        id: String = "activity-1",
-        bookId: String? = "book-1",
-        bookTitle: String? = "The Way of Kings",
-    ): ActivityEntity =
-        ActivityEntity(
-            id = id,
-            userId = "user-1",
-            type = "finished_book",
-            createdAt = 1704067200000L,
-            userDisplayName = "John Smith",
-            userAvatarColor = "#FF5733",
-            userAvatarType = "auto",
-            userAvatarValue = null,
-            bookId = bookId,
-            bookTitle = bookTitle,
-            bookAuthorName = "Brandon Sanderson",
-            bookCoverPath = null,
-            isReread = false,
-            durationMs = 3600000L,
-            milestoneValue = 0,
-            milestoneUnit = null,
-            shelfId = null,
-            shelfName = null,
-        )
-
-    // ========== fetchAndCacheActivities (RPC → Room) ==========
-
-    @Test
-    fun `fetchAndCacheActivities maps events to activities and upserts them`() =
-        runTest {
-            // Given - feed yields a book-bearing event and a shelf_created event
-            val dao = createMockDao()
-            everySuspend { dao.upsertAll(any()) } returns Unit
-            val bookDao = createMockBookDao()
-            everySuspend { bookDao.getBookSummary("book-1") } returns bookSummary()
-
-            val service =
-                mock<ActivityService> {
-                    everySuspend { feed(any(), any()) } returns
-                        AppResult.Success(listOf(bookEvent(), shelfEvent()))
-                }
-            val repository = createRepository(dao = dao, rpc = fakeRpcFactory(service), bookDao = bookDao)
-
-            // When
-            val result = repository.fetchAndCacheActivities(limit = 50)
-
-            // Then - success with the mapped count
-            val success = assertIs<AppResult.Success<Int>>(result)
-            assertEquals(2, success.data)
-
-            // And the head was fetched (before = null)
-            verifySuspend { service.feed(null, 50) }
-
-            // And the mapped entities were persisted
-            verifySuspend { dao.upsertAll(any()) }
-        }
-
-    @Test
-    fun `fetchAndCacheActivities maps identity and avatar colour from the DTO`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            val captured = mutableListOf<ActivityEntity>()
-            everySuspend { dao.upsertAll(any()) } calls { args ->
-                @Suppress("UNCHECKED_CAST")
-                captured.addAll(args.arg(0) as List<ActivityEntity>)
+                override suspend fun invalidate() = Unit
             }
-            val bookDao = createMockBookDao()
-            everySuspend { bookDao.getBookSummary("book-1") } returns bookSummary()
 
-            val event = bookEvent()
-            val service =
-                mock<ActivityService> {
-                    everySuspend { feed(any(), any()) } returns AppResult.Success(listOf(event))
-                }
-            val repository = createRepository(dao = dao, rpc = fakeRpcFactory(service), bookDao = bookDao)
+        fun createRepository(
+            dao: ActivityDao = createMockDao(),
+            rpc: ActivityRpcFactory = fakeRpcFactory(mock<ActivityService>()),
+            bookDao: BookDao = createMockBookDao(),
+        ): ActivityRepositoryImpl = ActivityRepositoryImpl(dao = dao, activityRpc = rpc, bookDao = bookDao)
 
-            // When
-            repository.fetchAndCacheActivities(limit = 50)
+        // ========== Test Data Factories ==========
 
-            // Then - identity from the DTO, avatarColor derived, avatarValue null
-            val entity = captured.single()
-            assertEquals("John Smith", entity.userDisplayName)
-            assertEquals("auto", entity.userAvatarType)
-            assertEquals(stableAvatarColorHex(event.userId), entity.userAvatarColor)
-            assertNull(entity.userAvatarValue)
-            // Book card enriched from local Room
-            assertEquals("book-1", entity.bookId)
-            assertEquals("The Way of Kings", entity.bookTitle)
-            assertEquals("Brandon Sanderson", entity.bookAuthorName)
-            // DTO-borne activity fields preserved
-            assertTrue(entity.isReread)
-            assertEquals(3600000L, entity.durationMs)
-        }
+        fun bookEvent(
+            id: String = "event-book",
+            userId: String = "11111111-1111-1111-1111-111111111111",
+            bookId: String = "book-1",
+        ): ActivityEvent =
+            ActivityEvent(
+                id = id,
+                userId = userId,
+                displayName = "John Smith",
+                avatarType = "auto",
+                type = ActivityType.FINISHED_BOOK,
+                createdAtMs = 1704067200000L,
+                bookId = bookId,
+                isReread = true,
+                durationMs = 3600000L,
+                milestoneValue = 0,
+                milestoneUnit = null,
+            )
 
-    @Test
-    fun `fetchAndCacheActivities leaves book null for non-book events`() =
-        runTest {
-            // Given - only the shelf event (no bookId)
-            val dao = createMockDao()
-            val captured = mutableListOf<ActivityEntity>()
-            everySuspend { dao.upsertAll(any()) } calls { args ->
-                @Suppress("UNCHECKED_CAST")
-                captured.addAll(args.arg(0) as List<ActivityEntity>)
+        fun shelfEvent(
+            id: String = "event-shelf",
+            userId: String = "22222222-2222-2222-2222-222222222222",
+        ): ActivityEvent =
+            ActivityEvent(
+                id = id,
+                userId = userId,
+                displayName = "Jane Doe",
+                avatarType = "auto",
+                type = ActivityType.SHELF_CREATED,
+                createdAtMs = 1704000000000L,
+                shelfId = "shelf-1",
+                shelfName = "Fantasy Favorites",
+            )
+
+        fun bookSummary(id: String = "book-1"): BookSummary =
+            BookSummary(
+                id = id,
+                title = "The Way of Kings",
+                coverBlurHash = "LKO2?U%2Tw=w]~RBVZRi};RPxuwH",
+                authorName = "Brandon Sanderson",
+            )
+
+        fun createActivityEntity(
+            id: String = "activity-1",
+            bookId: String? = "book-1",
+            bookTitle: String? = "The Way of Kings",
+        ): ActivityEntity =
+            ActivityEntity(
+                id = id,
+                userId = "user-1",
+                type = "finished_book",
+                createdAt = 1704067200000L,
+                userDisplayName = "John Smith",
+                userAvatarColor = "#FF5733",
+                userAvatarType = "auto",
+                userAvatarValue = null,
+                bookId = bookId,
+                bookTitle = bookTitle,
+                bookAuthorName = "Brandon Sanderson",
+                bookCoverPath = null,
+                isReread = false,
+                durationMs = 3600000L,
+                milestoneValue = 0,
+                milestoneUnit = null,
+                shelfId = null,
+                shelfName = null,
+            )
+
+        // ========== fetchAndCacheActivities (RPC → Room) ==========
+
+        test("fetchAndCacheActivities maps events to activities and upserts them") {
+            runTest {
+                // Given - feed yields a book-bearing event and a shelf_created event
+                val dao = createMockDao()
+                everySuspend { dao.upsertAll(any()) } returns Unit
+                val bookDao = createMockBookDao()
+                everySuspend { bookDao.getBookSummary("book-1") } returns bookSummary()
+
+                val service =
+                    mock<ActivityService> {
+                        everySuspend { feed(any(), any()) } returns
+                            AppResult.Success(listOf(bookEvent(), shelfEvent()))
+                    }
+                val repository = createRepository(dao = dao, rpc = fakeRpcFactory(service), bookDao = bookDao)
+
+                // When
+                val result = repository.fetchAndCacheActivities(limit = 50)
+
+                // Then - success with the mapped count
+                val success = result.shouldBeInstanceOf<AppResult.Success<Int>>()
+                success.data shouldBe 2
+
+                // And the head was fetched (before = null)
+                verifySuspend { service.feed(null, 50) }
+
+                // And the mapped entities were persisted
+                verifySuspend { dao.upsertAll(any()) }
             }
-            val bookDao = createMockBookDao()
-
-            val service =
-                mock<ActivityService> {
-                    everySuspend { feed(any(), any()) } returns AppResult.Success(listOf(shelfEvent()))
-                }
-            val repository = createRepository(dao = dao, rpc = fakeRpcFactory(service), bookDao = bookDao)
-
-            // When
-            repository.fetchAndCacheActivities(limit = 50)
-
-            // Then - no book card, shelf fields from the DTO
-            val entity = captured.single()
-            assertNull(entity.bookId)
-            assertNull(entity.bookTitle)
-            assertEquals("shelf-1", entity.shelfId)
-            assertEquals("Fantasy Favorites", entity.shelfName)
         }
 
-    @Test
-    fun `fetchAndCacheActivities returns Failure when the RPC throws`() =
-        runTest {
-            // Given - feed throws a non-cancellation error
-            val service =
-                mock<ActivityService> {
-                    everySuspend { feed(any(), any()) } throws RuntimeException("rpc down")
+        test("fetchAndCacheActivities maps identity and avatar colour from the DTO") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                val captured = mutableListOf<ActivityEntity>()
+                everySuspend { dao.upsertAll(any()) } calls { args ->
+                    @Suppress("UNCHECKED_CAST")
+                    captured.addAll(args.arg(0) as List<ActivityEntity>)
                 }
-            val repository = createRepository(rpc = fakeRpcFactory(service))
+                val bookDao = createMockBookDao()
+                everySuspend { bookDao.getBookSummary("book-1") } returns bookSummary()
 
-            // When
-            val result = repository.fetchAndCacheActivities(limit = 50)
+                val event = bookEvent()
+                val service =
+                    mock<ActivityService> {
+                        everySuspend { feed(any(), any()) } returns AppResult.Success(listOf(event))
+                    }
+                val repository = createRepository(dao = dao, rpc = fakeRpcFactory(service), bookDao = bookDao)
 
-            // Then - a typed Failure, NOT a thrown exception
-            assertIs<AppResult.Failure>(result)
-        }
-
-    @Test
-    fun `fetchAndCacheActivities re-raises CancellationException`() =
-        runTest {
-            // Given - feed throws CancellationException (structured concurrency must propagate)
-            val service =
-                mock<ActivityService> {
-                    everySuspend { feed(any(), any()) } throws CancellationException("cancelled")
-                }
-            val repository = createRepository(rpc = fakeRpcFactory(service))
-
-            // When / Then - the cancellation propagates rather than being swallowed
-            assertFailsWith<CancellationException> {
+                // When
                 repository.fetchAndCacheActivities(limit = 50)
+
+                // Then - identity from the DTO, avatarColor derived, avatarValue null
+                val entity = captured.single()
+                entity.userDisplayName shouldBe "John Smith"
+                entity.userAvatarType shouldBe "auto"
+                entity.userAvatarColor shouldBe stableAvatarColorHex(event.userId)
+                entity.userAvatarValue shouldBe null
+                // Book card enriched from local Room
+                entity.bookId shouldBe "book-1"
+                entity.bookTitle shouldBe "The Way of Kings"
+                entity.bookAuthorName shouldBe "Brandon Sanderson"
+                // DTO-borne activity fields preserved
+                entity.isReread shouldBe true
+                entity.durationMs shouldBe 3600000L
             }
         }
 
-    // ========== observeRecent (Room read path — unchanged) ==========
+        test("fetchAndCacheActivities leaves book null for non-book events") {
+            runTest {
+                // Given - only the shelf event (no bookId)
+                val dao = createMockDao()
+                val captured = mutableListOf<ActivityEntity>()
+                everySuspend { dao.upsertAll(any()) } calls { args ->
+                    @Suppress("UNCHECKED_CAST")
+                    captured.addAll(args.arg(0) as List<ActivityEntity>)
+                }
+                val bookDao = createMockBookDao()
 
-    @Test
-    fun `observeRecent returns activities from dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            val entities = listOf(createActivityEntity(id = "act-1"), createActivityEntity(id = "act-2"))
-            every { dao.observeRecent(10) } returns flowOf(entities)
-            val repository = createRepository(dao = dao)
+                val service =
+                    mock<ActivityService> {
+                        everySuspend { feed(any(), any()) } returns AppResult.Success(listOf(shelfEvent()))
+                    }
+                val repository = createRepository(dao = dao, rpc = fakeRpcFactory(service), bookDao = bookDao)
 
-            // When
-            val result = repository.observeRecent(10).first()
+                // When
+                repository.fetchAndCacheActivities(limit = 50)
 
-            // Then
-            assertEquals(2, result.size)
-            assertEquals("act-1", result[0].id)
-            assertEquals("act-2", result[1].id)
+                // Then - no book card, shelf fields from the DTO
+                val entity = captured.single()
+                entity.bookId shouldBe null
+                entity.bookTitle shouldBe null
+                entity.shelfId shouldBe "shelf-1"
+                entity.shelfName shouldBe "Fantasy Favorites"
+            }
         }
 
-    @Test
-    fun `observeRecent emits updates when flow updates`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            val flowSource = MutableStateFlow<List<ActivityEntity>>(emptyList())
-            every { dao.observeRecent(any()) } returns flowSource
-            val repository = createRepository(dao = dao)
+        test("fetchAndCacheActivities returns Failure when the RPC throws") {
+            runTest {
+                // Given - feed throws a non-cancellation error
+                val service =
+                    mock<ActivityService> {
+                        everySuspend { feed(any(), any()) } throws RuntimeException("rpc down")
+                    }
+                val repository = createRepository(rpc = fakeRpcFactory(service))
 
-            // When - initial emission
-            assertTrue(repository.observeRecent(10).first().isEmpty())
+                // When
+                val result = repository.fetchAndCacheActivities(limit = 50)
 
-            // When - flow updates
-            flowSource.value = listOf(createActivityEntity(id = "new-activity"))
-
-            // Then - updated list
-            val result2 = repository.observeRecent(10).first()
-            assertEquals(1, result2.size)
-            assertEquals("new-activity", result2[0].id)
+                // Then - a typed Failure, NOT a thrown exception
+                result.shouldBeInstanceOf<AppResult.Failure>()
+            }
         }
 
-    @Test
-    fun `observeRecent maps entity book card to domain`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            every { dao.observeRecent(any()) } returns flowOf(listOf(createActivityEntity(bookId = "book-9", bookTitle = "Mistborn")))
-            val repository = createRepository(dao = dao)
+        test("fetchAndCacheActivities re-raises CancellationException") {
+            runTest {
+                // Given - feed throws CancellationException (structured concurrency must propagate)
+                val service =
+                    mock<ActivityService> {
+                        everySuspend { feed(any(), any()) } throws CancellationException("cancelled")
+                    }
+                val repository = createRepository(rpc = fakeRpcFactory(service))
 
-            // When
-            val activity = repository.observeRecent(10).first().first()
-
-            // Then
-            assertNotNull(activity.book)
-            assertEquals("book-9", activity.book?.id)
-            assertEquals("Mistborn", activity.book?.title)
+                // When / Then - the cancellation propagates rather than being swallowed
+                shouldThrow<CancellationException> {
+                    repository.fetchAndCacheActivities(limit = 50)
+                }
+            }
         }
 
-    // ========== getOlderThan / getNewestTimestamp (Room) ==========
+        // ========== observeRecent (Room read path — unchanged) ==========
 
-    @Test
-    fun `getOlderThan returns activities from dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getOlderThan(1704067200000L, 10) } returns listOf(createActivityEntity(id = "old-1"))
-            val repository = createRepository(dao = dao)
+        test("observeRecent returns activities from dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                val entities = listOf(createActivityEntity(id = "act-1"), createActivityEntity(id = "act-2"))
+                every { dao.observeRecent(10) } returns flowOf(entities)
+                val repository = createRepository(dao = dao)
 
-            // When
-            val result = repository.getOlderThan(beforeMs = 1704067200000L, limit = 10)
+                // When
+                val result = repository.observeRecent(10).first()
 
-            // Then
-            assertEquals(1, result.size)
-            assertEquals("old-1", result[0].id)
+                // Then
+                result.size shouldBe 2
+                result[0].id shouldBe "act-1"
+                result[1].id shouldBe "act-2"
+            }
         }
 
-    @Test
-    fun `getNewestTimestamp returns timestamp from dao`() =
-        runTest {
-            // Given
-            val dao = createMockDao()
-            everySuspend { dao.getNewestTimestamp() } returns 1704067200000L
-            val repository = createRepository(dao = dao)
+        test("observeRecent emits updates when flow updates") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                val flowSource = MutableStateFlow<List<ActivityEntity>>(emptyList())
+                every { dao.observeRecent(any()) } returns flowSource
+                val repository = createRepository(dao = dao)
 
-            // When / Then
-            assertEquals(1704067200000L, repository.getNewestTimestamp())
+                // When - initial emission
+                repository.observeRecent(10).first().isEmpty() shouldBe true
+
+                // When - flow updates
+                flowSource.value = listOf(createActivityEntity(id = "new-activity"))
+
+                // Then - updated list
+                val result2 = repository.observeRecent(10).first()
+                result2.size shouldBe 1
+                result2[0].id shouldBe "new-activity"
+            }
         }
-}
+
+        test("observeRecent maps entity book card to domain") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                every { dao.observeRecent(any()) } returns flowOf(listOf(createActivityEntity(bookId = "book-9", bookTitle = "Mistborn")))
+                val repository = createRepository(dao = dao)
+
+                // When
+                val activity = repository.observeRecent(10).first().first()
+
+                // Then
+                activity.book.shouldNotBeNull()
+                activity.book?.id shouldBe "book-9"
+                activity.book?.title shouldBe "Mistborn"
+            }
+        }
+
+        // ========== getOlderThan / getNewestTimestamp (Room) ==========
+
+        test("getOlderThan returns activities from dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getOlderThan(1704067200000L, 10) } returns listOf(createActivityEntity(id = "old-1"))
+                val repository = createRepository(dao = dao)
+
+                // When
+                val result = repository.getOlderThan(beforeMs = 1704067200000L, limit = 10)
+
+                // Then
+                result.size shouldBe 1
+                result[0].id shouldBe "old-1"
+            }
+        }
+
+        test("getNewestTimestamp returns timestamp from dao") {
+            runTest {
+                // Given
+                val dao = createMockDao()
+                everySuspend { dao.getNewestTimestamp() } returns 1704067200000L
+                val repository = createRepository(dao = dao)
+
+                // When / Then
+                repository.getNewestTimestamp() shouldBe 1704067200000L
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryTest.kt
@@ -15,13 +15,13 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -38,420 +38,418 @@ import kotlin.time.ExperimentalTime
  * Uses Mokkery for mocking BookRepositoryContract and DAOs.
  */
 @OptIn(ExperimentalTime::class)
-class HomeRepositoryTest {
-    // ========== Test Fixtures ==========
+class HomeRepositoryTest :
+    FunSpec({
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val bookRepository: BookRepository = mock()
-        val playbackPositionDao: PlaybackPositionDao = mock()
+        class TestFixture {
+            val bookRepository: BookRepository = mock()
+            val playbackPositionDao: PlaybackPositionDao = mock()
 
-        fun build(): HomeRepositoryImpl =
-            HomeRepositoryImpl(
-                bookRepository = bookRepository,
-                playbackPositionDao = playbackPositionDao,
+            fun build(): HomeRepositoryImpl =
+                HomeRepositoryImpl(
+                    bookRepository = bookRepository,
+                    playbackPositionDao = playbackPositionDao,
+                )
+        }
+
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Default stubs
+            everySuspend { fixture.playbackPositionDao.getRecentPositions(any()) } returns emptyList()
+            every { fixture.playbackPositionDao.observeRecentPositions(any()) } returns flowOf(emptyList())
+            everySuspend { fixture.playbackPositionDao.get(any()) } returns null
+            everySuspend { fixture.playbackPositionDao.save(any()) } returns Unit
+            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns emptyList()
+
+            return fixture
+        }
+
+        // ========== Test Data Factories ==========
+
+        fun createPlaybackPosition(
+            bookId: String,
+            positionMs: Long,
+            updatedAt: Long = Clock.System.now().toEpochMilliseconds(),
+            isFinished: Boolean = false,
+        ): PlaybackPositionEntity =
+            PlaybackPositionEntity(
+                bookId = BookId(bookId),
+                positionMs = positionMs,
+                playbackSpeed = 1.0f,
+                updatedAt = updatedAt,
+                isFinished = isFinished,
             )
-    }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs
-        everySuspend { fixture.playbackPositionDao.getRecentPositions(any()) } returns emptyList()
-        every { fixture.playbackPositionDao.observeRecentPositions(any()) } returns flowOf(emptyList())
-        everySuspend { fixture.playbackPositionDao.get(any()) } returns null
-        everySuspend { fixture.playbackPositionDao.save(any()) } returns Unit
-        everySuspend { fixture.bookRepository.getBookListItems(any()) } returns emptyList()
-
-        return fixture
-    }
-
-    // ========== Test Data Factories ==========
-
-    private fun createPlaybackPosition(
-        bookId: String,
-        positionMs: Long,
-        updatedAt: Long = Clock.System.now().toEpochMilliseconds(),
-        isFinished: Boolean = false,
-    ): PlaybackPositionEntity =
-        PlaybackPositionEntity(
-            bookId = BookId(bookId),
-            positionMs = positionMs,
-            playbackSpeed = 1.0f,
-            updatedAt = updatedAt,
-            isFinished = isFinished,
-        )
-
-    private fun createBook(
-        id: String = "book-1",
-        title: String = "Test Book",
-        duration: Long = 10_000L,
-        authorNames: String = "Author Name",
-        coverPath: String? = null,
-    ): BookListItem =
-        TestData.bookListItem(
-            id = id,
-            title = title,
-            authorName = authorNames,
-            duration = duration,
-            coverPath = coverPath,
-        )
-
-    // ========== Continue Listening Tests ==========
-
-    @Test
-    fun `getContinueListening returns empty list when no positions`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns emptyList()
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            assertTrue((success.data as List<*>).isEmpty())
-        }
-
-    @Test
-    fun `getContinueListening returns books with correct progress`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val position = createPlaybackPosition("book-1", positionMs = 5000L)
-            val book = createBook(id = "book-1", title = "Test Book", duration = 10_000L)
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertEquals(1, books.size)
-            val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
-            assertEquals("book-1", continueBook.bookId)
-            assertEquals("Test Book", continueBook.title)
-            assertEquals(0.5f, continueBook.progress)
-            assertEquals(5000L, continueBook.currentPositionMs)
-            assertEquals(10_000L, continueBook.totalDurationMs)
-        }
-
-    @Test
-    fun `getContinueListening filters out books not found in repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val position1 = createPlaybackPosition("book-1", positionMs = 5000L)
-            val position2 = createPlaybackPosition("book-2", positionMs = 3000L)
-            val book1 = createBook(id = "book-1", title = "Book One", duration = 10_000L)
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position1, position2)
-            // getBooks returns only book1 — book2 is absent (simulates "not found")
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book1)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertEquals(1, books.size)
-        }
-
-    @Test
-    fun `getContinueListening filters out books with isFinished true`() =
-        runTest {
-            // Given: A book marked as finished AND near-complete (>=95%)
-            val fixture = createFixture()
-            val finishedPosition = createPlaybackPosition("book-1", positionMs = 9500L, isFinished = true)
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(finishedPosition)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then: Book should be filtered out because isFinished=true AND position>=95%
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertTrue(books.isEmpty())
-        }
-
-    @Test
-    fun `getContinueListening includes books at 99 percent progress when not marked finished`() =
-        runTest {
-            // Given: A book at 99% progress but NOT marked as finished
-            // This tests the new behavior where isFinished is authoritative, not calculated progress
-            val fixture = createFixture()
-            val almostDone = createPlaybackPosition("book-1", positionMs = 9900L, isFinished = false) // 99% but not marked finished
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(almostDone)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then: Book should be included because isFinished=false (progress doesn't matter)
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertEquals(1, books.size)
-        }
-
-    @Test
-    fun `getContinueListening includes books at 98 percent progress`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val position = createPlaybackPosition("book-1", positionMs = 9800L) // 98%
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertEquals(1, books.size)
-        }
-
-    @Test
-    fun `getContinueListening handles zero duration book`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val position = createPlaybackPosition("book-1", positionMs = 5000L)
-            val book = createBook(id = "book-1", duration = 0L) // Zero duration
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then - progress should be 0, book not filtered (progress < 0.99)
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertEquals(1, books.size)
-            val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
-            assertEquals(0f, continueBook.progress)
-        }
-
-    @Test
-    fun `getContinueListening includes author names`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val position = createPlaybackPosition("book-1", positionMs = 5000L)
-            val book = createBook(id = "book-1", duration = 10_000L, authorNames = "Stephen King")
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
-            assertEquals("Stephen King", continueBook.authorNames)
-        }
-
-    @Test
-    fun `getContinueListening includes cover path`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val position = createPlaybackPosition("book-1", positionMs = 5000L)
-            val book = createBook(id = "book-1", duration = 10_000L, coverPath = "/path/to/cover.jpg")
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
-            assertEquals("/path/to/cover.jpg", continueBook.coverPath)
-        }
-
-    @Test
-    fun `getContinueListening respects limit parameter`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val positions = (1..20).map { createPlaybackPosition("book-$it", positionMs = 5000L) }
-            val books = (1..20).map { createBook(id = "book-$it", duration = 10_000L) }
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(5) } returns positions.take(5)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns books.take(5)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(5)
-
-            // Then
-            val success = assertIs<AppResult.Success<*>>(result)
-            val returnedBooks = success.data as List<*>
-            assertEquals(5, returnedBooks.size)
-        }
-
-    // ========== Regression Test: lastPlayedAt must be ISO 8601 ==========
-
-    @Test
-    fun `getContinueListening returns lastPlayedAt as ISO 8601 timestamp`() =
-        runTest {
-            // Given: A position with specific lastPlayedAt timestamp
-            // Issue #3: lastPlayedAt was being returned as raw epoch milliseconds
-            // instead of ISO 8601 format, breaking UI display
-            val fixture = createFixture()
-            // Jan 1, 2024 12:00:00 UTC = 1704110400000L
-            val lastPlayedAtMs = 1704110400000L
-            val position =
-                PlaybackPositionEntity(
-                    bookId = BookId("book-1"),
-                    positionMs = 5000L,
-                    playbackSpeed = 1.0f,
-                    updatedAt = lastPlayedAtMs - 1000L, // Entity update time (different)
-                    lastPlayedAt = lastPlayedAtMs, // Actual last play time
-                )
-            val book = createBook(id = "book-1", duration = 10_000L)
-
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getContinueListening(10)
-
-            // Then: lastPlayedAt should be ISO 8601, not raw milliseconds
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            assertEquals(1, books.size)
-            val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
-            // Should be ISO 8601 format, not "1704110400000"
-            assertTrue(
-                continueBook.lastPlayedAt.contains("2024-01-01"),
-                "Expected ISO 8601 timestamp containing '2024-01-01', got: ${continueBook.lastPlayedAt}",
+        fun createBook(
+            id: String = "book-1",
+            title: String = "Test Book",
+            duration: Long = 10_000L,
+            authorNames: String = "Author Name",
+            coverPath: String? = null,
+        ): BookListItem =
+            TestData.bookListItem(
+                id = id,
+                title = title,
+                authorName = authorNames,
+                duration = duration,
+                coverPath = coverPath,
             )
-            assertTrue(
-                continueBook.lastPlayedAt.contains("T"),
-                "Expected ISO 8601 timestamp with 'T' separator, got: ${continueBook.lastPlayedAt}",
-            )
+
+        // ========== Continue Listening Tests ==========
+
+        test("getContinueListening returns empty list when no positions") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns emptyList()
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                (success.data as List<*>).isEmpty() shouldBe true
+            }
         }
 
-    @Test
-    fun `getContinueListening uses updatedAt as fallback when lastPlayedAt is null`() =
-        runTest {
-            // Given: A position without lastPlayedAt (legacy data before migration)
-            val fixture = createFixture()
-            val updatedAtMs = 1704110400000L // Jan 1, 2024 12:00:00 UTC
-            val position =
-                PlaybackPositionEntity(
-                    bookId = BookId("book-1"),
-                    positionMs = 5000L,
-                    playbackSpeed = 1.0f,
-                    updatedAt = updatedAtMs,
-                    lastPlayedAt = null, // Not set (legacy data)
-                )
-            val book = createBook(id = "book-1", duration = 10_000L)
+        test("getContinueListening returns books with correct progress") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val position = createPlaybackPosition("book-1", positionMs = 5000L)
+                val book = createBook(id = "book-1", title = "Test Book", duration = 10_000L)
 
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
-            val repository = fixture.build()
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
 
-            // When
-            val result = repository.getContinueListening(10)
+                // When
+                val result = repository.getContinueListening(10)
 
-            // Then: Should fall back to updatedAt, still as ISO 8601
-            val success = assertIs<AppResult.Success<*>>(result)
-            val books = success.data as List<*>
-            val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
-            assertTrue(
-                continueBook.lastPlayedAt.contains("2024-01-01"),
-                "Expected ISO 8601 from updatedAt fallback, got: ${continueBook.lastPlayedAt}",
-            )
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.size shouldBe 1
+                val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
+                continueBook.bookId shouldBe "book-1"
+                continueBook.title shouldBe "Test Book"
+                continueBook.progress shouldBe 0.5f
+                continueBook.currentPositionMs shouldBe 5000L
+                continueBook.totalDurationMs shouldBe 10_000L
+            }
         }
 
-    // ========== Regression Tests: N+1 fix — getBooks called once, not per book ==========
+        test("getContinueListening filters out books not found in repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val position1 = createPlaybackPosition("book-1", positionMs = 5000L)
+                val position2 = createPlaybackPosition("book-2", positionMs = 3000L)
+                val book1 = createBook(id = "book-1", title = "Book One", duration = 10_000L)
 
-    @Test
-    fun `getContinueListening calls getBooks once for multiple positions, not per book`() =
-        runTest {
-            // Given: Three positions — verifies a single batched call replaces N per-book calls
-            val fixture = createFixture()
-            val positions =
-                listOf(
-                    createPlaybackPosition("book-1", positionMs = 1000L),
-                    createPlaybackPosition("book-2", positionMs = 2000L),
-                    createPlaybackPosition("book-3", positionMs = 3000L),
-                )
-            val books =
-                listOf(
-                    createBook(id = "book-1", duration = 10_000L),
-                    createBook(id = "book-2", duration = 10_000L),
-                    createBook(id = "book-3", duration = 10_000L),
-                )
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position1, position2)
+                // getBooks returns only book1 — book2 is absent (simulates "not found")
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book1)
+                val repository = fixture.build()
 
-            everySuspend { fixture.playbackPositionDao.getRecentPositions(any()) } returns positions
-            everySuspend { fixture.bookRepository.getBookListItems(any()) } returns books
-            val repository = fixture.build()
+                // When
+                val result = repository.getContinueListening(10)
 
-            // When
-            repository.getContinueListening(10)
-
-            // Then: getBookListItems called exactly once (batched)
-            verifySuspend(VerifyMode.exactly(1)) { fixture.bookRepository.getBookListItems(any()) }
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.size shouldBe 1
+            }
         }
 
-    @Test
-    fun `observeContinueListening subscribes to observeBookListItems, not getBookListItems`() =
-        runTest {
-            // Given: Three positions emitted as a single list.
-            // The new reactive implementation uses observeBookListItems (Flow) so the book side
-            // stays live — one subscription per position emission, never a per-book suspend call.
-            val fixture = createFixture()
-            val positions =
-                listOf(
-                    createPlaybackPosition("book-1", positionMs = 1000L),
-                    createPlaybackPosition("book-2", positionMs = 2000L),
-                    createPlaybackPosition("book-3", positionMs = 3000L),
-                )
-            val books =
-                listOf(
-                    createBook(id = "book-1", duration = 10_000L),
-                    createBook(id = "book-2", duration = 10_000L),
-                    createBook(id = "book-3", duration = 10_000L),
-                )
+        test("getContinueListening filters out books with isFinished true") {
+            runTest {
+                // Given: A book marked as finished AND near-complete (>=95%)
+                val fixture = createFixture()
+                val finishedPosition = createPlaybackPosition("book-1", positionMs = 9500L, isFinished = true)
+                val book = createBook(id = "book-1", duration = 10_000L)
 
-            every { fixture.playbackPositionDao.observeRecentPositions(any()) } returns flowOf(positions)
-            every { fixture.bookRepository.observeBookListItems(any()) } returns flowOf(books)
-            val repository = fixture.build()
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(finishedPosition)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
 
-            // When: collect one emission
-            repository.observeContinueListening(10).first()
+                // When
+                val result = repository.getContinueListening(10)
 
-            // Then: observeBookListItems was called once (batched — all ids in one subscription)
-            verify(VerifyMode.exactly(1)) { fixture.bookRepository.observeBookListItems(any()) }
+                // Then: Book should be filtered out because isFinished=true AND position>=95%
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.isEmpty() shouldBe true
+            }
         }
-}
+
+        test("getContinueListening includes books at 99 percent progress when not marked finished") {
+            runTest {
+                // Given: A book at 99% progress but NOT marked as finished
+                // This tests the new behavior where isFinished is authoritative, not calculated progress
+                val fixture = createFixture()
+                val almostDone = createPlaybackPosition("book-1", positionMs = 9900L, isFinished = false) // 99% but not marked finished
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(almostDone)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then: Book should be included because isFinished=false (progress doesn't matter)
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.size shouldBe 1
+            }
+        }
+
+        test("getContinueListening includes books at 98 percent progress") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val position = createPlaybackPosition("book-1", positionMs = 9800L) // 98%
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.size shouldBe 1
+            }
+        }
+
+        test("getContinueListening handles zero duration book") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val position = createPlaybackPosition("book-1", positionMs = 5000L)
+                val book = createBook(id = "book-1", duration = 0L) // Zero duration
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then - progress should be 0, book not filtered (progress < 0.99)
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.size shouldBe 1
+                val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
+                continueBook.progress shouldBe 0f
+            }
+        }
+
+        test("getContinueListening includes author names") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val position = createPlaybackPosition("book-1", positionMs = 5000L)
+                val book = createBook(id = "book-1", duration = 10_000L, authorNames = "Stephen King")
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
+                continueBook.authorNames shouldBe "Stephen King"
+            }
+        }
+
+        test("getContinueListening includes cover path") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val position = createPlaybackPosition("book-1", positionMs = 5000L)
+                val book = createBook(id = "book-1", duration = 10_000L, coverPath = "/path/to/cover.jpg")
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
+                continueBook.coverPath shouldBe "/path/to/cover.jpg"
+            }
+        }
+
+        test("getContinueListening respects limit parameter") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val positions = (1..20).map { createPlaybackPosition("book-$it", positionMs = 5000L) }
+                val books = (1..20).map { createBook(id = "book-$it", duration = 10_000L) }
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(5) } returns positions.take(5)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns books.take(5)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(5)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val returnedBooks = success.data as List<*>
+                returnedBooks.size shouldBe 5
+            }
+        }
+
+        // ========== Regression Test: lastPlayedAt must be ISO 8601 ==========
+
+        test("getContinueListening returns lastPlayedAt as ISO 8601 timestamp") {
+            runTest {
+                // Given: A position with specific lastPlayedAt timestamp
+                // Issue #3: lastPlayedAt was being returned as raw epoch milliseconds
+                // instead of ISO 8601 format, breaking UI display
+                val fixture = createFixture()
+                // Jan 1, 2024 12:00:00 UTC = 1704110400000L
+                val lastPlayedAtMs = 1704110400000L
+                val position =
+                    PlaybackPositionEntity(
+                        bookId = BookId("book-1"),
+                        positionMs = 5000L,
+                        playbackSpeed = 1.0f,
+                        updatedAt = lastPlayedAtMs - 1000L, // Entity update time (different)
+                        lastPlayedAt = lastPlayedAtMs, // Actual last play time
+                    )
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then: lastPlayedAt should be ISO 8601, not raw milliseconds
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                books.size shouldBe 1
+                val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
+                // Should be ISO 8601 format, not "1704110400000"
+                withClue("Expected ISO 8601 timestamp containing '2024-01-01', got: ${continueBook.lastPlayedAt}") {
+                    continueBook.lastPlayedAt.contains("2024-01-01") shouldBe true
+                }
+                withClue("Expected ISO 8601 timestamp with 'T' separator, got: ${continueBook.lastPlayedAt}") {
+                    continueBook.lastPlayedAt.contains("T") shouldBe true
+                }
+            }
+        }
+
+        test("getContinueListening uses updatedAt as fallback when lastPlayedAt is null") {
+            runTest {
+                // Given: A position without lastPlayedAt (legacy data before migration)
+                val fixture = createFixture()
+                val updatedAtMs = 1704110400000L // Jan 1, 2024 12:00:00 UTC
+                val position =
+                    PlaybackPositionEntity(
+                        bookId = BookId("book-1"),
+                        positionMs = 5000L,
+                        playbackSpeed = 1.0f,
+                        updatedAt = updatedAtMs,
+                        lastPlayedAt = null, // Not set (legacy data)
+                    )
+                val book = createBook(id = "book-1", duration = 10_000L)
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns listOf(book)
+                val repository = fixture.build()
+
+                // When
+                val result = repository.getContinueListening(10)
+
+                // Then: Should fall back to updatedAt, still as ISO 8601
+                val success = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                val books = success.data as List<*>
+                val continueBook = books[0] as com.calypsan.listenup.client.domain.model.ContinueListeningBook
+                withClue("Expected ISO 8601 from updatedAt fallback, got: ${continueBook.lastPlayedAt}") {
+                    continueBook.lastPlayedAt.contains("2024-01-01") shouldBe true
+                }
+            }
+        }
+
+        // ========== Regression Tests: N+1 fix — getBooks called once, not per book ==========
+
+        test("getContinueListening calls getBooks once for multiple positions, not per book") {
+            runTest {
+                // Given: Three positions — verifies a single batched call replaces N per-book calls
+                val fixture = createFixture()
+                val positions =
+                    listOf(
+                        createPlaybackPosition("book-1", positionMs = 1000L),
+                        createPlaybackPosition("book-2", positionMs = 2000L),
+                        createPlaybackPosition("book-3", positionMs = 3000L),
+                    )
+                val books =
+                    listOf(
+                        createBook(id = "book-1", duration = 10_000L),
+                        createBook(id = "book-2", duration = 10_000L),
+                        createBook(id = "book-3", duration = 10_000L),
+                    )
+
+                everySuspend { fixture.playbackPositionDao.getRecentPositions(any()) } returns positions
+                everySuspend { fixture.bookRepository.getBookListItems(any()) } returns books
+                val repository = fixture.build()
+
+                // When
+                repository.getContinueListening(10)
+
+                // Then: getBookListItems called exactly once (batched)
+                verifySuspend(VerifyMode.exactly(1)) { fixture.bookRepository.getBookListItems(any()) }
+            }
+        }
+
+        test("observeContinueListening subscribes to observeBookListItems, not getBookListItems") {
+            runTest {
+                // Given: Three positions emitted as a single list.
+                // The new reactive implementation uses observeBookListItems (Flow) so the book side
+                // stays live — one subscription per position emission, never a per-book suspend call.
+                val fixture = createFixture()
+                val positions =
+                    listOf(
+                        createPlaybackPosition("book-1", positionMs = 1000L),
+                        createPlaybackPosition("book-2", positionMs = 2000L),
+                        createPlaybackPosition("book-3", positionMs = 3000L),
+                    )
+                val books =
+                    listOf(
+                        createBook(id = "book-1", duration = 10_000L),
+                        createBook(id = "book-2", duration = 10_000L),
+                        createBook(id = "book-3", duration = 10_000L),
+                    )
+
+                every { fixture.playbackPositionDao.observeRecentPositions(any()) } returns flowOf(positions)
+                every { fixture.bookRepository.observeBookListItems(any()) } returns flowOf(books)
+                val repository = fixture.build()
+
+                // When: collect one emission
+                repository.observeContinueListening(10).first()
+
+                // Then: observeBookListItems was called once (batched — all ids in one subscription)
+                verify(VerifyMode.exactly(1)) { fixture.bookRepository.observeBookListItems(any()) }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryTest.kt
@@ -15,14 +15,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import com.calypsan.listenup.client.domain.model.AuthState as DomainAuthState
 
 /**
@@ -31,336 +28,337 @@ import com.calypsan.listenup.client.domain.model.AuthState as DomainAuthState
  * slice has its own test in [AuthSessionStoreTest]; here we mock the
  * `AuthSession` collaborator at the seam.
  */
-class SettingsRepositoryTest {
-    private fun createMockStorage(): SecureStorage = mock<SecureStorage>()
+class SettingsRepositoryTest :
+    FunSpec({
+        fun createMockStorage(): SecureStorage = mock<SecureStorage>()
 
-    private fun createMockAuthSession(): AuthSession = mock<AuthSession>()
+        fun createMockAuthSession(): AuthSession = mock<AuthSession>()
 
-    private fun createRepository(
-        storage: SecureStorage = createMockStorage(),
-        authSession: AuthSession = createMockAuthSession(),
-    ): SettingsRepositoryImpl = SettingsRepositoryImpl(storage, lazyOf(authSession))
+        fun createRepository(
+            storage: SecureStorage = createMockStorage(),
+            authSession: AuthSession = createMockAuthSession(),
+        ): SettingsRepositoryImpl = SettingsRepositoryImpl(storage, lazyOf(authSession))
 
-    @Test
-    fun `setServerUrl persists the URL and triggers offline derive when already authenticated`() =
-        runTest {
-            val storage = createMockStorage()
-            val authSession = createMockAuthSession()
-            everySuspend { storage.save("server_url", "https://api.example.com") } returns Unit
-            everySuspend { storage.read("active_url") } returns null
-            everySuspend { storage.read("server_url") } returns "https://api.example.com"
-            everySuspend { authSession.isAuthenticated() } returns true
-            everySuspend { authSession.initializeAuthState() } returns Unit
-            val repository = createRepository(storage = storage, authSession = authSession)
+        test("setServerUrl persists the URL and triggers offline derive when already authenticated") {
+            runTest {
+                val storage = createMockStorage()
+                val authSession = createMockAuthSession()
+                everySuspend { storage.save("server_url", "https://api.example.com") } returns Unit
+                everySuspend { storage.read("active_url") } returns null
+                everySuspend { storage.read("server_url") } returns "https://api.example.com"
+                everySuspend { authSession.isAuthenticated() } returns true
+                everySuspend { authSession.initializeAuthState() } returns Unit
+                val repository = createRepository(storage = storage, authSession = authSession)
 
-            repository.setServerUrl(ServerUrl("https://api.example.com"))
+                repository.setServerUrl(ServerUrl("https://api.example.com"))
 
-            verifySuspend { storage.save("server_url", "https://api.example.com") }
-            verifySuspend { authSession.initializeAuthState() }
-        }
-
-    @Test
-    fun `setServerUrl persists the URL and asks server status when not yet authenticated`() =
-        runTest {
-            val storage = createMockStorage()
-            val authSession = createMockAuthSession()
-            val authStateFlow: StateFlow<DomainAuthState> = MutableStateFlow(DomainAuthState.Initializing)
-            everySuspend { storage.save("server_url", "https://api.example.com") } returns Unit
-            everySuspend { storage.read("active_url") } returns null
-            everySuspend { storage.read("server_url") } returns "https://api.example.com"
-            everySuspend { authSession.isAuthenticated() } returns false
-            everySuspend { authSession.checkServerStatus() } returns DomainAuthState.NeedsLogin()
-            // checkServerStatus is suspend & returns AuthState; just stub it.
-            val repository = createRepository(storage = storage, authSession = authSession)
-
-            repository.setServerUrl(ServerUrl("https://api.example.com"))
-
-            verifySuspend { storage.save("server_url", "https://api.example.com") }
-            verifySuspend { authSession.checkServerStatus() }
-            // authStateFlow is unused but kept to document the seam shape.
-            assertNull(authStateFlow.value as? DomainAuthState.NeedsLogin)
-        }
-
-    @Test
-    fun `getServerUrl returns stored URL`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("server_url") } returns "https://api.example.com"
-            val repository = createRepository(storage = storage)
-
-            assertEquals(ServerUrl("https://api.example.com"), repository.getServerUrl())
-        }
-
-    @Test
-    fun `getServerUrl returns null when not configured`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("server_url") } returns null
-            val repository = createRepository(storage = storage)
-
-            assertNull(repository.getServerUrl())
-        }
-
-    @Test
-    fun `clearAll wipes secure storage and re-derives auth state`() =
-        runTest {
-            val storage = createMockStorage()
-            val authSession = createMockAuthSession()
-            everySuspend { storage.clear() } returns Unit
-            everySuspend { storage.read(any()) } returns null
-            everySuspend { authSession.initializeAuthState() } returns Unit
-            val repository = createRepository(storage = storage, authSession = authSession)
-
-            repository.clearAll()
-
-            verifySuspend { storage.clear() }
-            verifySuspend { authSession.initializeAuthState() }
-        }
-
-    @Test
-    fun `disconnectFromServer drops auth and URL plumbing then re-derives state`() =
-        runTest {
-            val storage = createMockStorage()
-            val authSession = createMockAuthSession()
-            everySuspend { authSession.clearAuthTokens() } returns Unit
-            everySuspend { authSession.clearPendingRegistration() } returns Unit
-            everySuspend { authSession.initializeAuthState() } returns Unit
-            everySuspend { storage.delete(any()) } returns Unit
-            everySuspend { storage.read(any()) } returns null
-            val repository = createRepository(storage = storage, authSession = authSession)
-
-            repository.disconnectFromServer()
-
-            verifySuspend { authSession.clearAuthTokens() }
-            verifySuspend { authSession.clearPendingRegistration() }
-            verifySuspend { storage.delete("server_url") }
-            verifySuspend { storage.delete("server_remote_url") }
-            verifySuspend { storage.delete("active_url") }
-            verifySuspend { storage.delete("connected_library_id") }
-            verifySuspend { authSession.initializeAuthState() }
-        }
-
-    @Test
-    fun `hasServerConfigured returns true when URL configured`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("server_url") } returns "https://api.example.com"
-            val repository = createRepository(storage = storage)
-
-            assertTrue(repository.hasServerConfigured())
-        }
-
-    @Test
-    fun `hasServerConfigured returns false when URL not configured`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("server_url") } returns null
-            val repository = createRepository(storage = storage)
-
-            assertFalse(repository.hasServerConfigured())
-        }
-
-    // ========== Active URL change-signal ==========
-
-    @Test
-    fun `setActiveUrl persists the active URL and publishes it`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.save("active_url", "http://192.168.1.10:8080") } returns Unit
-            everySuspend { storage.read("active_url") } returns "http://192.168.1.10:8080"
-            val repository = createRepository(storage = storage)
-
-            repository.activeUrl.test {
-                awaitItem() // current value (null initial)
-                repository.setActiveUrl(ServerUrl("http://192.168.1.10:8080"))
-                assertEquals("http://192.168.1.10:8080", awaitItem()?.value)
-                cancelAndIgnoreRemainingEvents()
+                verifySuspend { storage.save("server_url", "https://api.example.com") }
+                verifySuspend { authSession.initializeAuthState() }
             }
         }
 
-    // ========== Connected mDNS server id + local URL follow ==========
+        test("setServerUrl persists the URL and asks server status when not yet authenticated") {
+            runTest {
+                val storage = createMockStorage()
+                val authSession = createMockAuthSession()
+                val authStateFlow: StateFlow<DomainAuthState> = MutableStateFlow(DomainAuthState.Initializing)
+                everySuspend { storage.save("server_url", "https://api.example.com") } returns Unit
+                everySuspend { storage.read("active_url") } returns null
+                everySuspend { storage.read("server_url") } returns "https://api.example.com"
+                everySuspend { authSession.isAuthenticated() } returns false
+                everySuspend { authSession.checkServerStatus() } returns DomainAuthState.NeedsLogin()
+                // checkServerStatus is suspend & returns AuthState; just stub it.
+                val repository = createRepository(storage = storage, authSession = authSession)
 
-    @Test
-    fun `setConnectedServerId persists and getConnectedServerId reads it back`() =
-        runTest {
-            val storage = createMockStorage()
-            val repository = createRepository(storage = storage)
-            everySuspend { storage.save("connected_server_id", "abc-123") } returns Unit
-            everySuspend { storage.read("connected_server_id") } returns "abc-123"
+                repository.setServerUrl(ServerUrl("https://api.example.com"))
 
-            repository.setConnectedServerId("abc-123")
-
-            assertEquals("abc-123", repository.getConnectedServerId())
-        }
-
-    @Test
-    fun `setConnectedServerId null clears it`() =
-        runTest {
-            val storage = createMockStorage()
-            val repository = createRepository(storage = storage)
-            everySuspend { storage.delete("connected_server_id") } returns Unit
-
-            repository.setConnectedServerId(null)
-
-            verifySuspend { storage.delete("connected_server_id") }
-        }
-
-    @Test
-    fun `updateLocalUrl saves the local URL and publishes activeUrl`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.save("server_url", "http://192.168.1.20:8080") } returns Unit
-            everySuspend { storage.read("active_url") } returns null
-            everySuspend { storage.read("server_url") } returns "http://192.168.1.20:8080"
-            everySuspend { storage.read("server_remote_url") } returns null
-            val repository = createRepository(storage = storage)
-
-            repository.activeUrl.test {
-                awaitItem() // current value (null initial)
-                repository.updateLocalUrl(ServerUrl("http://192.168.1.20:8080"))
-                assertEquals("http://192.168.1.20:8080", awaitItem()?.value)
-                cancelAndIgnoreRemainingEvents()
+                verifySuspend { storage.save("server_url", "https://api.example.com") }
+                verifySuspend { authSession.checkServerStatus() }
+                // authStateFlow is unused but kept to document the seam shape.
+                (authStateFlow.value as? DomainAuthState.NeedsLogin) shouldBe null
             }
         }
 
-    // ========== Spatial playback ==========
+        test("getServerUrl returns stored URL") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("server_url") } returns "https://api.example.com"
+                val repository = createRepository(storage = storage)
 
-    @Test
-    fun `getSpatialPlayback returns true by default`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("spatial_playback") } returns null
-            val repository = createRepository(storage = storage)
-
-            assertTrue(repository.getSpatialPlayback())
-        }
-
-    @Test
-    fun `getSpatialPlayback returns false when set to false`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("spatial_playback") } returns "false"
-            val repository = createRepository(storage = storage)
-
-            assertFalse(repository.getSpatialPlayback())
-        }
-
-    @Test
-    fun `getSpatialPlayback returns true when set to true`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("spatial_playback") } returns "true"
-            val repository = createRepository(storage = storage)
-
-            assertTrue(repository.getSpatialPlayback())
-        }
-
-    @Test
-    fun `setSpatialPlayback stores false correctly`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.save("spatial_playback", "false") } returns Unit
-            val repository = createRepository(storage = storage)
-
-            repository.setSpatialPlayback(false)
-
-            verifySuspend { storage.save("spatial_playback", "false") }
-        }
-
-    @Test
-    fun `setSpatialPlayback stores true correctly`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.save("spatial_playback", "true") } returns Unit
-            val repository = createRepository(storage = storage)
-
-            repository.setSpatialPlayback(true)
-
-            verifySuspend { storage.save("spatial_playback", "true") }
-        }
-
-    @Test
-    fun `setSpatialPlayback and getSpatialPlayback persist value correctly`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.save("spatial_playback", "false") } returns Unit
-            everySuspend { storage.read("spatial_playback") } returns "false"
-            val repository = createRepository(storage = storage)
-
-            repository.setSpatialPlayback(false)
-            val result = repository.getSpatialPlayback()
-
-            assertFalse(result)
-            verifySuspend { storage.save("spatial_playback", "false") }
-        }
-
-    // ========== Default playback speed ==========
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun `setDefaultPlaybackSpeed saves speed and emits preference change event`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val storage = createMockStorage()
-            everySuspend { storage.save("default_playback_speed", "1.5") } returns Unit
-            val repository = createRepository(storage = storage)
-
-            // Start collecting before emitting (async starts immediately under UnconfinedTestDispatcher)
-            val eventDeferred = async { repository.preferenceChanges.first() }
-
-            repository.setDefaultPlaybackSpeed(1.5f)
-
-            val receivedEvent = eventDeferred.await()
-            verifySuspend { storage.save("default_playback_speed", "1.5") }
-            val speedChangedEvent = assertIs<PreferenceChangeEvent.PlaybackSpeedChanged>(receivedEvent)
-            assertEquals(1.5f, speedChangedEvent.speed)
-        }
-
-    @Test
-    fun `getDefaultPlaybackSpeed returns default when not set`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("default_playback_speed") } returns null
-            val repository = createRepository(storage = storage)
-
-            assertEquals(1.0f, repository.getDefaultPlaybackSpeed())
-        }
-
-    @Test
-    fun `getDefaultPlaybackSpeed returns stored speed`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("default_playback_speed") } returns "1.25"
-            val repository = createRepository(storage = storage)
-
-            assertEquals(1.25f, repository.getDefaultPlaybackSpeed())
-        }
-
-    @Test
-    fun `observeDefaultPlaybackSpeed emits current value on first collect`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("default_playback_speed") } returns "1.5"
-            val repository = createRepository(storage = storage)
-
-            repository.observeDefaultPlaybackSpeed().test {
-                assertEquals(1.5f, awaitItem())
-                cancelAndIgnoreRemainingEvents()
+                repository.getServerUrl() shouldBe ServerUrl("https://api.example.com")
             }
         }
 
-    @Test
-    fun `observeDefaultPlaybackSpeed re-emits when setDefaultPlaybackSpeed is called`() =
-        runTest {
-            val storage = createMockStorage()
-            everySuspend { storage.read("default_playback_speed") } returns "1.0"
-            everySuspend { storage.save("default_playback_speed", "1.75") } returns Unit
-            val repository = createRepository(storage = storage)
+        test("getServerUrl returns null when not configured") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("server_url") } returns null
+                val repository = createRepository(storage = storage)
 
-            repository.observeDefaultPlaybackSpeed().test {
-                assertEquals(1.0f, awaitItem())
-                repository.setDefaultPlaybackSpeed(1.75f)
-                assertEquals(1.75f, awaitItem())
-                cancelAndIgnoreRemainingEvents()
+                repository.getServerUrl() shouldBe null
             }
         }
-}
+
+        test("clearAll wipes secure storage and re-derives auth state") {
+            runTest {
+                val storage = createMockStorage()
+                val authSession = createMockAuthSession()
+                everySuspend { storage.clear() } returns Unit
+                everySuspend { storage.read(any()) } returns null
+                everySuspend { authSession.initializeAuthState() } returns Unit
+                val repository = createRepository(storage = storage, authSession = authSession)
+
+                repository.clearAll()
+
+                verifySuspend { storage.clear() }
+                verifySuspend { authSession.initializeAuthState() }
+            }
+        }
+
+        test("disconnectFromServer drops auth and URL plumbing then re-derives state") {
+            runTest {
+                val storage = createMockStorage()
+                val authSession = createMockAuthSession()
+                everySuspend { authSession.clearAuthTokens() } returns Unit
+                everySuspend { authSession.clearPendingRegistration() } returns Unit
+                everySuspend { authSession.initializeAuthState() } returns Unit
+                everySuspend { storage.delete(any()) } returns Unit
+                everySuspend { storage.read(any()) } returns null
+                val repository = createRepository(storage = storage, authSession = authSession)
+
+                repository.disconnectFromServer()
+
+                verifySuspend { authSession.clearAuthTokens() }
+                verifySuspend { authSession.clearPendingRegistration() }
+                verifySuspend { storage.delete("server_url") }
+                verifySuspend { storage.delete("server_remote_url") }
+                verifySuspend { storage.delete("active_url") }
+                verifySuspend { storage.delete("connected_library_id") }
+                verifySuspend { authSession.initializeAuthState() }
+            }
+        }
+
+        test("hasServerConfigured returns true when URL configured") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("server_url") } returns "https://api.example.com"
+                val repository = createRepository(storage = storage)
+
+                repository.hasServerConfigured() shouldBe true
+            }
+        }
+
+        test("hasServerConfigured returns false when URL not configured") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("server_url") } returns null
+                val repository = createRepository(storage = storage)
+
+                repository.hasServerConfigured() shouldBe false
+            }
+        }
+
+        // ========== Active URL change-signal ==========
+
+        test("setActiveUrl persists the active URL and publishes it") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.save("active_url", "http://192.168.1.10:8080") } returns Unit
+                everySuspend { storage.read("active_url") } returns "http://192.168.1.10:8080"
+                val repository = createRepository(storage = storage)
+
+                repository.activeUrl.test {
+                    awaitItem() // current value (null initial)
+                    repository.setActiveUrl(ServerUrl("http://192.168.1.10:8080"))
+                    awaitItem()?.value shouldBe "http://192.168.1.10:8080"
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        // ========== Connected mDNS server id + local URL follow ==========
+
+        test("setConnectedServerId persists and getConnectedServerId reads it back") {
+            runTest {
+                val storage = createMockStorage()
+                val repository = createRepository(storage = storage)
+                everySuspend { storage.save("connected_server_id", "abc-123") } returns Unit
+                everySuspend { storage.read("connected_server_id") } returns "abc-123"
+
+                repository.setConnectedServerId("abc-123")
+
+                repository.getConnectedServerId() shouldBe "abc-123"
+            }
+        }
+
+        test("setConnectedServerId null clears it") {
+            runTest {
+                val storage = createMockStorage()
+                val repository = createRepository(storage = storage)
+                everySuspend { storage.delete("connected_server_id") } returns Unit
+
+                repository.setConnectedServerId(null)
+
+                verifySuspend { storage.delete("connected_server_id") }
+            }
+        }
+
+        test("updateLocalUrl saves the local URL and publishes activeUrl") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.save("server_url", "http://192.168.1.20:8080") } returns Unit
+                everySuspend { storage.read("active_url") } returns null
+                everySuspend { storage.read("server_url") } returns "http://192.168.1.20:8080"
+                everySuspend { storage.read("server_remote_url") } returns null
+                val repository = createRepository(storage = storage)
+
+                repository.activeUrl.test {
+                    awaitItem() // current value (null initial)
+                    repository.updateLocalUrl(ServerUrl("http://192.168.1.20:8080"))
+                    awaitItem()?.value shouldBe "http://192.168.1.20:8080"
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        // ========== Spatial playback ==========
+
+        test("getSpatialPlayback returns true by default") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("spatial_playback") } returns null
+                val repository = createRepository(storage = storage)
+
+                repository.getSpatialPlayback() shouldBe true
+            }
+        }
+
+        test("getSpatialPlayback returns false when set to false") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("spatial_playback") } returns "false"
+                val repository = createRepository(storage = storage)
+
+                repository.getSpatialPlayback() shouldBe false
+            }
+        }
+
+        test("getSpatialPlayback returns true when set to true") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("spatial_playback") } returns "true"
+                val repository = createRepository(storage = storage)
+
+                repository.getSpatialPlayback() shouldBe true
+            }
+        }
+
+        test("setSpatialPlayback stores false correctly") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.save("spatial_playback", "false") } returns Unit
+                val repository = createRepository(storage = storage)
+
+                repository.setSpatialPlayback(false)
+
+                verifySuspend { storage.save("spatial_playback", "false") }
+            }
+        }
+
+        test("setSpatialPlayback stores true correctly") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.save("spatial_playback", "true") } returns Unit
+                val repository = createRepository(storage = storage)
+
+                repository.setSpatialPlayback(true)
+
+                verifySuspend { storage.save("spatial_playback", "true") }
+            }
+        }
+
+        test("setSpatialPlayback and getSpatialPlayback persist value correctly") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.save("spatial_playback", "false") } returns Unit
+                everySuspend { storage.read("spatial_playback") } returns "false"
+                val repository = createRepository(storage = storage)
+
+                repository.setSpatialPlayback(false)
+                val result = repository.getSpatialPlayback()
+
+                result shouldBe false
+                verifySuspend { storage.save("spatial_playback", "false") }
+            }
+        }
+
+        // ========== Default playback speed ==========
+
+        test("setDefaultPlaybackSpeed saves speed and emits preference change event") {
+            @OptIn(ExperimentalCoroutinesApi::class)
+            runTest(UnconfinedTestDispatcher()) {
+                val storage = createMockStorage()
+                everySuspend { storage.save("default_playback_speed", "1.5") } returns Unit
+                val repository = createRepository(storage = storage)
+
+                // Start collecting before emitting (async starts immediately under UnconfinedTestDispatcher)
+                val eventDeferred = async { repository.preferenceChanges.first() }
+
+                repository.setDefaultPlaybackSpeed(1.5f)
+
+                val receivedEvent = eventDeferred.await()
+                verifySuspend { storage.save("default_playback_speed", "1.5") }
+                val speedChangedEvent = receivedEvent.shouldBeInstanceOf<PreferenceChangeEvent.PlaybackSpeedChanged>()
+                speedChangedEvent.speed shouldBe 1.5f
+            }
+        }
+
+        test("getDefaultPlaybackSpeed returns default when not set") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("default_playback_speed") } returns null
+                val repository = createRepository(storage = storage)
+
+                repository.getDefaultPlaybackSpeed() shouldBe 1.0f
+            }
+        }
+
+        test("getDefaultPlaybackSpeed returns stored speed") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("default_playback_speed") } returns "1.25"
+                val repository = createRepository(storage = storage)
+
+                repository.getDefaultPlaybackSpeed() shouldBe 1.25f
+            }
+        }
+
+        test("observeDefaultPlaybackSpeed emits current value on first collect") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("default_playback_speed") } returns "1.5"
+                val repository = createRepository(storage = storage)
+
+                repository.observeDefaultPlaybackSpeed().test {
+                    awaitItem() shouldBe 1.5f
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("observeDefaultPlaybackSpeed re-emits when setDefaultPlaybackSpeed is called") {
+            runTest {
+                val storage = createMockStorage()
+                everySuspend { storage.read("default_playback_speed") } returns "1.0"
+                everySuspend { storage.save("default_playback_speed", "1.75") } returns Unit
+                val repository = createRepository(storage = storage)
+
+                repository.observeDefaultPlaybackSpeed().test {
+                    awaitItem() shouldBe 1.0f
+                    repository.setDefaultPlaybackSpeed(1.75f)
+                    awaitItem() shouldBe 1.75f
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorTest.kt
@@ -16,8 +16,8 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
 
 /**
  * Tests for FtsPopulator.
@@ -29,373 +29,374 @@ import kotlin.test.Test
  *
  * Uses Mokkery for mocking all DAOs.
  */
-class FtsPopulatorTest {
-    // ========== Test Fixtures ==========
+class FtsPopulatorTest :
+    FunSpec({
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val bookDao: BookDao = mock()
-        val contributorDao: ContributorDao = mock()
-        val seriesDao: SeriesDao = mock()
-        val searchDao: SearchDao = mock()
+        class TestFixture {
+            val bookDao: BookDao = mock()
+            val contributorDao: ContributorDao = mock()
+            val seriesDao: SeriesDao = mock()
+            val searchDao: SearchDao = mock()
 
-        fun build(): FtsPopulator =
-            FtsPopulator(
-                bookDao = bookDao,
-                contributorDao = contributorDao,
-                seriesDao = seriesDao,
-                searchDao = searchDao,
-            )
-    }
-
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs - empty lists
-        everySuspend { fixture.bookDao.getAllLive() } returns emptyList()
-        everySuspend { fixture.contributorDao.getAll() } returns emptyList()
-        everySuspend { fixture.seriesDao.getAll() } returns emptyList()
-
-        // Stub clear and insert operations
-        everySuspend { fixture.searchDao.clearBooksFts() } returns Unit
-        everySuspend { fixture.searchDao.clearContributorsFts() } returns Unit
-        everySuspend { fixture.searchDao.clearSeriesFts() } returns Unit
-        everySuspend { fixture.searchDao.getPrimaryAuthorName(any()) } returns null
-        everySuspend { fixture.searchDao.getPrimaryNarratorName(any()) } returns null
-        everySuspend { fixture.searchDao.getSeriesNamesForBook(any()) } returns null
-        everySuspend { fixture.searchDao.getGenreNamesForBook(any()) } returns null
-        everySuspend { fixture.searchDao.insertBookFts(any(), any(), any(), any(), any(), any(), any(), any()) } returns
-            Unit
-        everySuspend { fixture.searchDao.insertContributorFts(any(), any(), any()) } returns Unit
-        everySuspend { fixture.searchDao.insertSeriesFts(any(), any(), any()) } returns Unit
-
-        return fixture
-    }
-
-    // ========== Test Data Factories ==========
-
-    private fun createBookEntity(
-        id: String = "book-1",
-        title: String = "Test Book",
-        subtitle: String? = null,
-        description: String? = null,
-    ): BookEntity =
-        BookEntity(
-            id = BookId(id),
-            libraryId = LibraryId("test-library"),
-            folderId = FolderId("test-folder"),
-            title = title,
-            subtitle = subtitle,
-            coverHash = null,
-            totalDuration = 3_600_000L,
-            description = description,
-            publishYear = 2024,
-            createdAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-        )
-
-    private fun createContributorEntity(
-        id: String = "contributor-1",
-        name: String = "Test Author",
-        description: String? = null,
-    ): ContributorEntity =
-        ContributorEntity(
-            id =
-                com.calypsan.listenup.core
-                    .ContributorId(id),
-            name = name,
-            description = description,
-            imagePath = null,
-            createdAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-        )
-
-    private fun createSeriesEntity(
-        id: String = "series-1",
-        name: String = "Test Series",
-        description: String? = null,
-    ): SeriesEntity =
-        SeriesEntity(
-            id =
-                com.calypsan.listenup.core
-                    .SeriesId(id),
-            name = name,
-            description = description,
-            createdAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-        )
-
-    // ========== Rebuild All Tests ==========
-
-    @Test
-    fun `rebuildAll clears all FTS tables`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend { fixture.searchDao.clearBooksFts() }
-            verifySuspend { fixture.searchDao.clearContributorsFts() }
-            verifySuspend { fixture.searchDao.clearSeriesFts() }
+            fun build(): FtsPopulator =
+                FtsPopulator(
+                    bookDao = bookDao,
+                    contributorDao = contributorDao,
+                    seriesDao = seriesDao,
+                    searchDao = searchDao,
+                )
         }
 
-    @Test
-    fun `rebuildAll inserts all books into FTS`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book1 = createBookEntity(id = "book-1", title = "Book One")
-            val book2 = createBookEntity(id = "book-2", title = "Book Two")
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
 
-            everySuspend { fixture.bookDao.getAllLive() } returns listOf(book1, book2)
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend { fixture.searchDao.insertBookFts("book-1", "Book One", null, null, null, null, null, null) }
-            verifySuspend { fixture.searchDao.insertBookFts("book-2", "Book Two", null, null, null, null, null, null) }
-        }
-
-    @Test
-    fun `rebuildAll inserts all contributors into FTS`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor1 = createContributorEntity(id = "contributor-1", name = "Author One")
-            val contributor2 = createContributorEntity(id = "contributor-2", name = "Author Two")
-
-            everySuspend { fixture.contributorDao.getAll() } returns listOf(contributor1, contributor2)
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend { fixture.searchDao.insertContributorFts("contributor-1", "Author One", null) }
-            verifySuspend { fixture.searchDao.insertContributorFts("contributor-2", "Author Two", null) }
-        }
-
-    @Test
-    fun `rebuildAll inserts all series into FTS`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val series1 = createSeriesEntity(id = "series-1", name = "Series One")
-            val series2 = createSeriesEntity(id = "series-2", name = "Series Two")
-
-            everySuspend { fixture.seriesDao.getAll() } returns listOf(series1, series2)
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend { fixture.searchDao.insertSeriesFts("series-1", "Series One", null) }
-            verifySuspend { fixture.searchDao.insertSeriesFts("series-2", "Series Two", null) }
-        }
-
-    @Test
-    fun `rebuildAll includes book subtitle and description`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book =
-                createBookEntity(
-                    id = "book-1",
-                    title = "Main Title",
-                    subtitle = "A Great Subtitle",
-                    description = "This is a description",
-                )
-
-            everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend {
-                fixture.searchDao.insertBookFts(
-                    "book-1",
-                    "Main Title",
-                    "A Great Subtitle",
-                    "This is a description",
-                    null,
-                    null,
-                    null,
-                    null,
-                )
-            }
-        }
-
-    @Test
-    fun `rebuildAll includes author and narrator names from lookup`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val book = createBookEntity(id = "book-1", title = "Test Book")
-
-            everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
-            everySuspend { fixture.searchDao.getPrimaryAuthorName("book-1") } returns "John Author"
-            everySuspend { fixture.searchDao.getPrimaryNarratorName("book-1") } returns "Jane Narrator"
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend {
-                fixture.searchDao.insertBookFts(
-                    "book-1",
-                    "Test Book",
-                    null,
-                    null,
-                    "John Author",
-                    "Jane Narrator",
-                    null,
-                    null,
-                )
-            }
-        }
-
-    @Test
-    fun `rebuildAll includes genres in FTS`() =
-        runTest {
-            // Given - genre names now come from book_genres junction via getGenreNamesForBook
-            val fixture = createFixture()
-            val book =
-                createBookEntity(
-                    id = "book-1",
-                    title = "Fantasy Book",
-                )
-
-            everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
-            everySuspend { fixture.searchDao.getGenreNamesForBook("book-1") } returns "Fantasy, Adventure"
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then - both series and genre names come from junction tables, not BookEntity
-            verifySuspend {
-                fixture.searchDao.insertBookFts(
-                    "book-1",
-                    "Fantasy Book",
-                    null,
-                    null,
-                    null,
-                    null,
-                    null, // Series comes from junction table
-                    "Fantasy, Adventure", // Genres come from junction table
-                )
-            }
-        }
-
-    @Test
-    fun `rebuildAll includes contributor description`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val contributor =
-                createContributorEntity(
-                    id = "contributor-1",
-                    name = "Famous Author",
-                    description = "An award-winning author",
-                )
-
-            everySuspend { fixture.contributorDao.getAll() } returns listOf(contributor)
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend {
-                fixture.searchDao.insertContributorFts(
-                    "contributor-1",
-                    "Famous Author",
-                    "An award-winning author",
-                )
-            }
-        }
-
-    @Test
-    fun `rebuildAll includes series description`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val series =
-                createSeriesEntity(
-                    id = "series-1",
-                    name = "Epic Series",
-                    description = "An epic fantasy saga",
-                )
-
-            everySuspend { fixture.seriesDao.getAll() } returns listOf(series)
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then
-            verifySuspend {
-                fixture.searchDao.insertSeriesFts(
-                    "series-1",
-                    "Epic Series",
-                    "An epic fantasy saga",
-                )
-            }
-        }
-
-    // ========== Empty Data Tests ==========
-
-    @Test
-    fun `rebuildAll handles empty books list`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
+            // Default stubs - empty lists
             everySuspend { fixture.bookDao.getAllLive() } returns emptyList()
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then - should clear but not insert
-            verifySuspend { fixture.searchDao.clearBooksFts() }
-        }
-
-    @Test
-    fun `rebuildAll handles empty contributors list`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
             everySuspend { fixture.contributorDao.getAll() } returns emptyList()
-            val ftsPopulator = fixture.build()
-
-            // When
-            ftsPopulator.rebuildAll()
-
-            // Then - should clear but not insert
-            verifySuspend { fixture.searchDao.clearContributorsFts() }
-        }
-
-    @Test
-    fun `rebuildAll handles empty series list`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
             everySuspend { fixture.seriesDao.getAll() } returns emptyList()
-            val ftsPopulator = fixture.build()
 
-            // When
-            ftsPopulator.rebuildAll()
+            // Stub clear and insert operations
+            everySuspend { fixture.searchDao.clearBooksFts() } returns Unit
+            everySuspend { fixture.searchDao.clearContributorsFts() } returns Unit
+            everySuspend { fixture.searchDao.clearSeriesFts() } returns Unit
+            everySuspend { fixture.searchDao.getPrimaryAuthorName(any()) } returns null
+            everySuspend { fixture.searchDao.getPrimaryNarratorName(any()) } returns null
+            everySuspend { fixture.searchDao.getSeriesNamesForBook(any()) } returns null
+            everySuspend { fixture.searchDao.getGenreNamesForBook(any()) } returns null
+            everySuspend { fixture.searchDao.insertBookFts(any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                Unit
+            everySuspend { fixture.searchDao.insertContributorFts(any(), any(), any()) } returns Unit
+            everySuspend { fixture.searchDao.insertSeriesFts(any(), any(), any()) } returns Unit
 
-            // Then - should clear but not insert
-            verifySuspend { fixture.searchDao.clearSeriesFts() }
+            return fixture
         }
-}
+
+        // ========== Test Data Factories ==========
+
+        fun createBookEntity(
+            id: String = "book-1",
+            title: String = "Test Book",
+            subtitle: String? = null,
+            description: String? = null,
+        ): BookEntity =
+            BookEntity(
+                id = BookId(id),
+                libraryId = LibraryId("test-library"),
+                folderId = FolderId("test-folder"),
+                title = title,
+                subtitle = subtitle,
+                coverHash = null,
+                totalDuration = 3_600_000L,
+                description = description,
+                publishYear = 2024,
+                createdAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
+            )
+
+        fun createContributorEntity(
+            id: String = "contributor-1",
+            name: String = "Test Author",
+            description: String? = null,
+        ): ContributorEntity =
+            ContributorEntity(
+                id =
+                    com.calypsan.listenup.core
+                        .ContributorId(id),
+                name = name,
+                description = description,
+                imagePath = null,
+                createdAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
+            )
+
+        fun createSeriesEntity(
+            id: String = "series-1",
+            name: String = "Test Series",
+            description: String? = null,
+        ): SeriesEntity =
+            SeriesEntity(
+                id =
+                    com.calypsan.listenup.core
+                        .SeriesId(id),
+                name = name,
+                description = description,
+                createdAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
+            )
+
+        // ========== Rebuild All Tests ==========
+
+        test("rebuildAll clears all FTS tables") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend { fixture.searchDao.clearBooksFts() }
+                verifySuspend { fixture.searchDao.clearContributorsFts() }
+                verifySuspend { fixture.searchDao.clearSeriesFts() }
+            }
+        }
+
+        test("rebuildAll inserts all books into FTS") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val book1 = createBookEntity(id = "book-1", title = "Book One")
+                val book2 = createBookEntity(id = "book-2", title = "Book Two")
+
+                everySuspend { fixture.bookDao.getAllLive() } returns listOf(book1, book2)
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend { fixture.searchDao.insertBookFts("book-1", "Book One", null, null, null, null, null, null) }
+                verifySuspend { fixture.searchDao.insertBookFts("book-2", "Book Two", null, null, null, null, null, null) }
+            }
+        }
+
+        test("rebuildAll inserts all contributors into FTS") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor1 = createContributorEntity(id = "contributor-1", name = "Author One")
+                val contributor2 = createContributorEntity(id = "contributor-2", name = "Author Two")
+
+                everySuspend { fixture.contributorDao.getAll() } returns listOf(contributor1, contributor2)
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend { fixture.searchDao.insertContributorFts("contributor-1", "Author One", null) }
+                verifySuspend { fixture.searchDao.insertContributorFts("contributor-2", "Author Two", null) }
+            }
+        }
+
+        test("rebuildAll inserts all series into FTS") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val series1 = createSeriesEntity(id = "series-1", name = "Series One")
+                val series2 = createSeriesEntity(id = "series-2", name = "Series Two")
+
+                everySuspend { fixture.seriesDao.getAll() } returns listOf(series1, series2)
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend { fixture.searchDao.insertSeriesFts("series-1", "Series One", null) }
+                verifySuspend { fixture.searchDao.insertSeriesFts("series-2", "Series Two", null) }
+            }
+        }
+
+        test("rebuildAll includes book subtitle and description") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val book =
+                    createBookEntity(
+                        id = "book-1",
+                        title = "Main Title",
+                        subtitle = "A Great Subtitle",
+                        description = "This is a description",
+                    )
+
+                everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend {
+                    fixture.searchDao.insertBookFts(
+                        "book-1",
+                        "Main Title",
+                        "A Great Subtitle",
+                        "This is a description",
+                        null,
+                        null,
+                        null,
+                        null,
+                    )
+                }
+            }
+        }
+
+        test("rebuildAll includes author and narrator names from lookup") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val book = createBookEntity(id = "book-1", title = "Test Book")
+
+                everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
+                everySuspend { fixture.searchDao.getPrimaryAuthorName("book-1") } returns "John Author"
+                everySuspend { fixture.searchDao.getPrimaryNarratorName("book-1") } returns "Jane Narrator"
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend {
+                    fixture.searchDao.insertBookFts(
+                        "book-1",
+                        "Test Book",
+                        null,
+                        null,
+                        "John Author",
+                        "Jane Narrator",
+                        null,
+                        null,
+                    )
+                }
+            }
+        }
+
+        test("rebuildAll includes genres in FTS") {
+            runTest {
+                // Given - genre names now come from book_genres junction via getGenreNamesForBook
+                val fixture = createFixture()
+                val book =
+                    createBookEntity(
+                        id = "book-1",
+                        title = "Fantasy Book",
+                    )
+
+                everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
+                everySuspend { fixture.searchDao.getGenreNamesForBook("book-1") } returns "Fantasy, Adventure"
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then - both series and genre names come from junction tables, not BookEntity
+                verifySuspend {
+                    fixture.searchDao.insertBookFts(
+                        "book-1",
+                        "Fantasy Book",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null, // Series comes from junction table
+                        "Fantasy, Adventure", // Genres come from junction table
+                    )
+                }
+            }
+        }
+
+        test("rebuildAll includes contributor description") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val contributor =
+                    createContributorEntity(
+                        id = "contributor-1",
+                        name = "Famous Author",
+                        description = "An award-winning author",
+                    )
+
+                everySuspend { fixture.contributorDao.getAll() } returns listOf(contributor)
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend {
+                    fixture.searchDao.insertContributorFts(
+                        "contributor-1",
+                        "Famous Author",
+                        "An award-winning author",
+                    )
+                }
+            }
+        }
+
+        test("rebuildAll includes series description") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val series =
+                    createSeriesEntity(
+                        id = "series-1",
+                        name = "Epic Series",
+                        description = "An epic fantasy saga",
+                    )
+
+                everySuspend { fixture.seriesDao.getAll() } returns listOf(series)
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then
+                verifySuspend {
+                    fixture.searchDao.insertSeriesFts(
+                        "series-1",
+                        "Epic Series",
+                        "An epic fantasy saga",
+                    )
+                }
+            }
+        }
+
+        // ========== Empty Data Tests ==========
+
+        test("rebuildAll handles empty books list") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.bookDao.getAllLive() } returns emptyList()
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then - should clear but not insert
+                verifySuspend { fixture.searchDao.clearBooksFts() }
+            }
+        }
+
+        test("rebuildAll handles empty contributors list") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.contributorDao.getAll() } returns emptyList()
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then - should clear but not insert
+                verifySuspend { fixture.searchDao.clearContributorsFts() }
+            }
+        }
+
+        test("rebuildAll handles empty series list") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.seriesDao.getAll() } returns emptyList()
+                val ftsPopulator = fixture.build()
+
+                // When
+                ftsPopulator.rebuildAll()
+
+                // Then - should clear but not insert
+                verifySuspend { fixture.searchDao.clearSeriesFts() }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
@@ -11,11 +11,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 /**
  * Tests for ImageDownloader.
@@ -26,129 +25,130 @@ import kotlin.test.assertTrue
  *
  * Uses Mokkery for mocking ImageApiContract and ImageStorage.
  */
-class ImageDownloaderTest {
-    // ========== Test Fixtures ==========
+class ImageDownloaderTest :
+    FunSpec({
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val imageApi: ImageApiContract = mock()
-        val imageStorage: ImageStorage = mock()
+        class TestFixture {
+            val imageApi: ImageApiContract = mock()
+            val imageStorage: ImageStorage = mock()
 
-        fun build(): ImageDownloader =
-            ImageDownloader(
-                imageApi = imageApi,
-                imageStorage = imageStorage,
-            )
-    }
-
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs
-        every { fixture.imageStorage.exists(any()) } returns false
-        everySuspend { fixture.imageApi.downloadCover(any()) } returns AppResult.Success(ByteArray(100))
-        everySuspend { fixture.imageStorage.saveCover(any(), any()) } returns AppResult.Success(Unit)
-
-        return fixture
-    }
-
-    // ========== Single Cover Download Tests ==========
-
-    @Test
-    fun `downloadCover returns success with true when cover downloaded and saved`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val imageDownloader = fixture.build()
-            val bookId = BookId("book-1")
-            val imageBytes = ByteArray(100) { it.toByte() }
-
-            everySuspend { fixture.imageApi.downloadCover(bookId) } returns AppResult.Success(imageBytes)
-            everySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) } returns AppResult.Success(Unit)
-
-            // When
-            val result = imageDownloader.downloadCover(bookId)
-
-            // Then
-            val success = assertIs<AppResult.Success<Boolean>>(result)
-            assertTrue(success.data)
-            verifySuspend { fixture.imageApi.downloadCover(bookId) }
-            verifySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) }
-        }
-
-    @Test
-    fun `downloadCover returns success with false when cover already exists`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val bookId = BookId("book-1")
-            every { fixture.imageStorage.exists(bookId) } returns true
-            val imageDownloader = fixture.build()
-
-            // When
-            val result = imageDownloader.downloadCover(bookId)
-
-            // Then
-            val success = assertIs<AppResult.Success<Boolean>>(result)
-            assertEquals(false, success.data)
-        }
-
-    @Test
-    fun `downloadCover returns success with false when API returns failure`() =
-        runTest {
-            // Given - 404 Not Found (no cover available)
-            val fixture = createFixture()
-            val bookId = BookId("book-1")
-            everySuspend { fixture.imageApi.downloadCover(bookId) } returns Failure(Exception("Not found"))
-            val imageDownloader = fixture.build()
-
-            // When
-            val result = imageDownloader.downloadCover(bookId)
-
-            // Then - returns false (non-fatal), not failure
-            val success = assertIs<AppResult.Success<Boolean>>(result)
-            assertEquals(false, success.data)
-        }
-
-    @Test
-    fun `downloadCover returns failure when storage save fails`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val bookId = BookId("book-1")
-            val imageBytes = ByteArray(100)
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation.
-            val storageFailure =
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Disk full"),
+            fun build(): ImageDownloader =
+                ImageDownloader(
+                    imageApi = imageApi,
+                    imageStorage = imageStorage,
                 )
-
-            everySuspend { fixture.imageApi.downloadCover(bookId) } returns AppResult.Success(imageBytes)
-            everySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) } returns storageFailure
-            val imageDownloader = fixture.build()
-
-            // When
-            val result = imageDownloader.downloadCover(bookId)
-
-            // Then - storage failure is fatal
-            val failure = assertIs<AppResult.Failure>(result)
-            assertEquals("Disk full", failure.message)
         }
 
-    @Test
-    fun `downloadCover does not call API when cover already exists`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val bookId = BookId("book-1")
-            every { fixture.imageStorage.exists(bookId) } returns true
-            val imageDownloader = fixture.build()
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
 
-            // When
-            imageDownloader.downloadCover(bookId)
+            // Default stubs
+            every { fixture.imageStorage.exists(any()) } returns false
+            everySuspend { fixture.imageApi.downloadCover(any()) } returns AppResult.Success(ByteArray(100))
+            everySuspend { fixture.imageStorage.saveCover(any(), any()) } returns AppResult.Success(Unit)
 
-            // Then - API should not be called
-            // (verify by not stubbing API - if called, test would fail)
+            return fixture
         }
-}
+
+        // ========== Single Cover Download Tests ==========
+
+        test("downloadCover returns success with true when cover downloaded and saved") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val imageDownloader = fixture.build()
+                val bookId = BookId("book-1")
+                val imageBytes = ByteArray(100) { it.toByte() }
+
+                everySuspend { fixture.imageApi.downloadCover(bookId) } returns AppResult.Success(imageBytes)
+                everySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) } returns AppResult.Success(Unit)
+
+                // When
+                val result = imageDownloader.downloadCover(bookId)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<Boolean>>()
+                success.data shouldBe true
+                verifySuspend { fixture.imageApi.downloadCover(bookId) }
+                verifySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) }
+            }
+        }
+
+        test("downloadCover returns success with false when cover already exists") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                every { fixture.imageStorage.exists(bookId) } returns true
+                val imageDownloader = fixture.build()
+
+                // When
+                val result = imageDownloader.downloadCover(bookId)
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<Boolean>>()
+                success.data shouldBe false
+            }
+        }
+
+        test("downloadCover returns success with false when API returns failure") {
+            runTest {
+                // Given - 404 Not Found (no cover available)
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                everySuspend { fixture.imageApi.downloadCover(bookId) } returns Failure(Exception("Not found"))
+                val imageDownloader = fixture.build()
+
+                // When
+                val result = imageDownloader.downloadCover(bookId)
+
+                // Then - returns false (non-fatal), not failure
+                val success = result.shouldBeInstanceOf<AppResult.Success<Boolean>>()
+                success.data shouldBe false
+            }
+        }
+
+        test("downloadCover returns failure when storage save fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                val imageBytes = ByteArray(100)
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation.
+                val storageFailure =
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Disk full"),
+                    )
+
+                everySuspend { fixture.imageApi.downloadCover(bookId) } returns AppResult.Success(imageBytes)
+                everySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) } returns storageFailure
+                val imageDownloader = fixture.build()
+
+                // When
+                val result = imageDownloader.downloadCover(bookId)
+
+                // Then - storage failure is fatal
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.message shouldBe "Disk full"
+            }
+        }
+
+        test("downloadCover does not call API when cover already exists") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                every { fixture.imageStorage.exists(bookId) } returns true
+                val imageDownloader = fixture.build()
+
+                // When
+                imageDownloader.downloadCover(bookId)
+
+                // Then - API should not be called
+                // (verify by not stubbing API - if called, test would fail)
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/GetInstanceUseCaseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/GetInstanceUseCaseTest.kt
@@ -10,10 +10,10 @@ import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import com.calypsan.listenup.core.Timestamp
 
 /**
@@ -24,149 +24,150 @@ import com.calypsan.listenup.core.Timestamp
  * - Success and failure propagation
  * - ForceRefresh parameter forwarding
  */
-class GetInstanceUseCaseTest {
-    // ========== Test Fixtures ==========
+class GetInstanceUseCaseTest :
+    FunSpec({
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val repository: InstanceRepository = mock()
+        class TestFixture {
+            val repository: InstanceRepository = mock()
 
-        fun build(): GetInstanceUseCase = GetInstanceUseCase(repository = repository)
-    }
-
-    private fun createFixture(): TestFixture = TestFixture()
-
-    // ========== Test Data Factories ==========
-
-    private fun createInstance(
-        id: String = "instance-1",
-        name: String = "Test Server",
-        version: String = "1.0.0",
-    ): Instance =
-        Instance(
-            id = InstanceId(id),
-            name = name,
-            version = version,
-            localUrl = "http://localhost:8080",
-            remoteUrl = null,
-            setupRequired = false,
-            createdAt = Timestamp(1704067200000L),
-            updatedAt = Timestamp(1704067200000L),
-        )
-
-    // ========== Success Tests ==========
-
-    @Test
-    fun `invoke returns success from repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val instance = createInstance(name = "My Server")
-            everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
-            val useCase = fixture.build()
-
-            // When
-            val result = useCase()
-
-            // Then
-            val success = assertIs<AppResult.Success<Instance>>(result)
-            assertEquals("My Server", success.data.name)
+            fun build(): GetInstanceUseCase = GetInstanceUseCase(repository = repository)
         }
 
-    @Test
-    fun `invoke returns failure from repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation.
-            everySuspend { fixture.repository.getInstance(false) } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Network error"),
-                )
-            val useCase = fixture.build()
+        fun createFixture(): TestFixture = TestFixture()
 
-            // When
-            val result = useCase()
+        // ========== Test Data Factories ==========
 
-            // Then
-            val failure = assertIs<AppResult.Failure>(result)
-            assertEquals("Network error", failure.message)
+        fun createInstance(
+            id: String = "instance-1",
+            name: String = "Test Server",
+            version: String = "1.0.0",
+        ): Instance =
+            Instance(
+                id = InstanceId(id),
+                name = name,
+                version = version,
+                localUrl = "http://localhost:8080",
+                remoteUrl = null,
+                setupRequired = false,
+                createdAt = Timestamp(1704067200000L),
+                updatedAt = Timestamp(1704067200000L),
+            )
+
+        // ========== Success Tests ==========
+
+        test("invoke returns success from repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val instance = createInstance(name = "My Server")
+                everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase()
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<Instance>>()
+                success.data.name shouldBe "My Server"
+            }
         }
 
-    // ========== ForceRefresh Parameter Tests ==========
+        test("invoke returns failure from repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation.
+                everySuspend { fixture.repository.getInstance(false) } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Network error"),
+                    )
+                val useCase = fixture.build()
 
-    @Test
-    fun `invoke with forceRefresh true passes parameter to repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val instance = createInstance()
-            everySuspend { fixture.repository.getInstance(true) } returns AppResult.Success(instance)
-            val useCase = fixture.build()
+                // When
+                val result = useCase()
 
-            // When
-            useCase(forceRefresh = true)
-
-            // Then
-            verifySuspend { fixture.repository.getInstance(true) }
+                // Then
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.message shouldBe "Network error"
+            }
         }
 
-    @Test
-    fun `invoke with forceRefresh false passes parameter to repository`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val instance = createInstance()
-            everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
-            val useCase = fixture.build()
+        // ========== ForceRefresh Parameter Tests ==========
 
-            // When
-            useCase(forceRefresh = false)
+        test("invoke with forceRefresh true passes parameter to repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val instance = createInstance()
+                everySuspend { fixture.repository.getInstance(true) } returns AppResult.Success(instance)
+                val useCase = fixture.build()
 
-            // Then
-            verifySuspend { fixture.repository.getInstance(false) }
+                // When
+                useCase(forceRefresh = true)
+
+                // Then
+                verifySuspend { fixture.repository.getInstance(true) }
+            }
         }
 
-    @Test
-    fun `invoke defaults to forceRefresh false`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val instance = createInstance()
-            everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
-            val useCase = fixture.build()
+        test("invoke with forceRefresh false passes parameter to repository") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val instance = createInstance()
+                everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
+                val useCase = fixture.build()
 
-            // When
-            useCase()
+                // When
+                useCase(forceRefresh = false)
 
-            // Then
-            verifySuspend { fixture.repository.getInstance(false) }
+                // Then
+                verifySuspend { fixture.repository.getInstance(false) }
+            }
         }
 
-    // ========== Instance Properties Tests ==========
+        test("invoke defaults to forceRefresh false") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val instance = createInstance()
+                everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
+                val useCase = fixture.build()
 
-    @Test
-    fun `invoke returns complete instance data`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val instance =
-                createInstance(
-                    id = "test-123",
-                    name = "Production Server",
-                    version = "2.5.0",
-                )
-            everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
-            val useCase = fixture.build()
+                // When
+                useCase()
 
-            // When
-            val result = useCase()
-
-            // Then
-            val success = assertIs<AppResult.Success<Instance>>(result)
-            assertEquals("test-123", success.data.id.value)
-            assertEquals("Production Server", success.data.name)
-            assertEquals("2.5.0", success.data.version)
+                // Then
+                verifySuspend { fixture.repository.getInstance(false) }
+            }
         }
-}
+
+        // ========== Instance Properties Tests ==========
+
+        test("invoke returns complete instance data") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val instance =
+                    createInstance(
+                        id = "test-123",
+                        name = "Production Server",
+                        version = "2.5.0",
+                    )
+                everySuspend { fixture.repository.getInstance(false) } returns AppResult.Success(instance)
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase()
+
+                // Then
+                val success = result.shouldBeInstanceOf<AppResult.Success<Instance>>()
+                success.data.id.value shouldBe "test-123"
+                success.data.name shouldBe "Production Server"
+                success.data.version shouldBe "2.5.0"
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/ShelfUseCasesTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/ShelfUseCasesTest.kt
@@ -10,10 +10,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * Tests for Shelf use cases.
@@ -21,234 +21,235 @@ import kotlin.test.assertIs
  * The repository now returns [AppResult] directly; use cases validate then forward
  * the typed result. Covers validation gates plus the new privacy/reorder surface.
  */
-class ShelfUseCasesTest {
-    // ========== Test Fixtures ==========
+class ShelfUseCasesTest :
+    FunSpec({
+        // ========== Test Fixtures ==========
 
-    private fun createShelf(
-        id: String = "shelf-123",
-        name: String = "Test Shelf",
-        description: String? = null,
-        isPrivate: Boolean = false,
-    ) = Shelf(
-        id = id,
-        name = name,
-        description = description,
-        isPrivate = isPrivate,
-        ownerId = "owner-123",
-        ownerDisplayName = "Test User",
-        bookCount = 0,
-        totalDurationSeconds = 0,
-        createdAtMs = 1736208000000L,
-        updatedAtMs = 1736208000000L,
-    )
+        fun createShelf(
+            id: String = "shelf-123",
+            name: String = "Test Shelf",
+            description: String? = null,
+            isPrivate: Boolean = false,
+        ) = Shelf(
+            id = id,
+            name = name,
+            description = description,
+            isPrivate = isPrivate,
+            ownerId = "owner-123",
+            ownerDisplayName = "Test User",
+            bookCount = 0,
+            totalDurationSeconds = 0,
+            createdAtMs = 1736208000000L,
+            updatedAtMs = 1736208000000L,
+        )
 
-    // ========== CreateShelfUseCase Tests ==========
+        // ========== CreateShelfUseCase Tests ==========
 
-    @Test
-    fun `create shelf returns success with valid name`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            val expectedShelf = createShelf(name = "My Reading List")
-            everySuspend { shelfRepository.createShelf(any(), any(), any()) } returns AppResult.Success(expectedShelf)
-            val useCase = CreateShelfUseCase(shelfRepository)
+        test("create shelf returns success with valid name") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                val expectedShelf = createShelf(name = "My Reading List")
+                everySuspend { shelfRepository.createShelf(any(), any(), any()) } returns AppResult.Success(expectedShelf)
+                val useCase = CreateShelfUseCase(shelfRepository)
 
-            val result = useCase(name = "My Reading List", description = null)
+                val result = useCase(name = "My Reading List", description = null)
 
-            val success = assertIs<AppResult.Success<Shelf>>(result)
-            assertEquals("My Reading List", success.data.name)
+                val success = result.shouldBeInstanceOf<AppResult.Success<Shelf>>()
+                success.data.name shouldBe "My Reading List"
+            }
         }
 
-    @Test
-    fun `create shelf calls repository with trimmed name and privacy flag`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend {
-                shelfRepository.createShelf(any(), any(), any())
-            } returns AppResult.Success(createShelf())
-            val useCase = CreateShelfUseCase(shelfRepository)
+        test("create shelf calls repository with trimmed name and privacy flag") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend {
+                    shelfRepository.createShelf(any(), any(), any())
+                } returns AppResult.Success(createShelf())
+                val useCase = CreateShelfUseCase(shelfRepository)
 
-            useCase(name = "  Trimmed Name  ", description = null, isPrivate = true)
+                useCase(name = "  Trimmed Name  ", description = null, isPrivate = true)
 
-            verifySuspend { shelfRepository.createShelf("Trimmed Name", null, true) }
+                verifySuspend { shelfRepository.createShelf("Trimmed Name", null, true) }
+            }
         }
 
-    @Test
-    fun `create shelf returns validation error for blank name`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            val useCase = CreateShelfUseCase(shelfRepository)
+        test("create shelf returns validation error for blank name") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                val useCase = CreateShelfUseCase(shelfRepository)
 
-            val result = useCase(name = "   ", description = null)
+                val result = useCase(name = "   ", description = null)
 
-            val failure = assertIs<AppResult.Failure>(result)
-            assertIs<ValidationError>(failure.error)
-            assertEquals("Shelf name is required", failure.message)
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<ValidationError>()
+                failure.message shouldBe "Shelf name is required"
+            }
         }
 
-    @Test
-    fun `create shelf converts empty description to null`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend {
-                shelfRepository.createShelf(any(), any(), any())
-            } returns AppResult.Success(createShelf())
-            val useCase = CreateShelfUseCase(shelfRepository)
+        test("create shelf converts empty description to null") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend {
+                    shelfRepository.createShelf(any(), any(), any())
+                } returns AppResult.Success(createShelf())
+                val useCase = CreateShelfUseCase(shelfRepository)
 
-            useCase(name = "Test", description = "   ")
+                useCase(name = "Test", description = "   ")
 
-            verifySuspend { shelfRepository.createShelf("Test", null, false) }
+                verifySuspend { shelfRepository.createShelf("Test", null, false) }
+            }
         }
 
-    @Test
-    fun `create shelf forwards repository failure`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend {
-                shelfRepository.createShelf(any(), any(), any())
-            } returns AppResult.Failure(ValidationError(message = "duplicate"))
-            val useCase = CreateShelfUseCase(shelfRepository)
+        test("create shelf forwards repository failure") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend {
+                    shelfRepository.createShelf(any(), any(), any())
+                } returns AppResult.Failure(ValidationError(message = "duplicate"))
+                val useCase = CreateShelfUseCase(shelfRepository)
 
-            val result = useCase(name = "Test", description = null)
+                val result = useCase(name = "Test", description = null)
 
-            assertIs<AppResult.Failure>(result)
+                result.shouldBeInstanceOf<AppResult.Failure>()
+            }
         }
 
-    // ========== UpdateShelfUseCase Tests ==========
+        // ========== UpdateShelfUseCase Tests ==========
 
-    @Test
-    fun `update shelf returns success with valid name`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            val expectedShelf = createShelf(name = "Updated Name")
-            everySuspend {
-                shelfRepository.updateShelf(any(), any(), any(), any())
-            } returns AppResult.Success(expectedShelf)
-            val useCase = UpdateShelfUseCase(shelfRepository)
+        test("update shelf returns success with valid name") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                val expectedShelf = createShelf(name = "Updated Name")
+                everySuspend {
+                    shelfRepository.updateShelf(any(), any(), any(), any())
+                } returns AppResult.Success(expectedShelf)
+                val useCase = UpdateShelfUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-123", name = "Updated Name", description = null)
+                val result = useCase(shelfId = "shelf-123", name = "Updated Name", description = null)
 
-            val success = assertIs<AppResult.Success<Shelf>>(result)
-            assertEquals("Updated Name", success.data.name)
+                val success = result.shouldBeInstanceOf<AppResult.Success<Shelf>>()
+                success.data.name shouldBe "Updated Name"
+            }
         }
 
-    @Test
-    fun `update shelf calls repository with correct parameters and privacy flag`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend {
-                shelfRepository.updateShelf(any(), any(), any(), any())
-            } returns AppResult.Success(createShelf())
-            val useCase = UpdateShelfUseCase(shelfRepository)
+        test("update shelf calls repository with correct parameters and privacy flag") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend {
+                    shelfRepository.updateShelf(any(), any(), any(), any())
+                } returns AppResult.Success(createShelf())
+                val useCase = UpdateShelfUseCase(shelfRepository)
 
-            useCase(shelfId = "shelf-456", name = "New Name", description = "New description", isPrivate = true)
+                useCase(shelfId = "shelf-456", name = "New Name", description = "New description", isPrivate = true)
 
-            verifySuspend { shelfRepository.updateShelf("shelf-456", "New Name", "New description", true) }
+                verifySuspend { shelfRepository.updateShelf("shelf-456", "New Name", "New description", true) }
+            }
         }
 
-    @Test
-    fun `update shelf returns validation error for blank name`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            val useCase = UpdateShelfUseCase(shelfRepository)
+        test("update shelf returns validation error for blank name") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                val useCase = UpdateShelfUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-123", name = "   ", description = null)
+                val result = useCase(shelfId = "shelf-123", name = "   ", description = null)
 
-            val failure = assertIs<AppResult.Failure>(result)
-            assertIs<ValidationError>(failure.error)
-            assertEquals("Shelf name is required", failure.message)
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<ValidationError>()
+                failure.message shouldBe "Shelf name is required"
+            }
         }
 
-    // ========== DeleteShelfUseCase Tests ==========
+        // ========== DeleteShelfUseCase Tests ==========
 
-    @Test
-    fun `delete shelf returns success`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend { shelfRepository.deleteShelf(any()) } returns AppResult.Success(Unit)
-            val useCase = DeleteShelfUseCase(shelfRepository)
+        test("delete shelf returns success") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend { shelfRepository.deleteShelf(any()) } returns AppResult.Success(Unit)
+                val useCase = DeleteShelfUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-123")
+                val result = useCase(shelfId = "shelf-123")
 
-            checkIs<AppResult.Success<Unit>>(result)
+                checkIs<AppResult.Success<Unit>>(result)
+            }
         }
 
-    @Test
-    fun `delete shelf calls repository with correct ID`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend { shelfRepository.deleteShelf(any()) } returns AppResult.Success(Unit)
-            val useCase = DeleteShelfUseCase(shelfRepository)
+        test("delete shelf calls repository with correct ID") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend { shelfRepository.deleteShelf(any()) } returns AppResult.Success(Unit)
+                val useCase = DeleteShelfUseCase(shelfRepository)
 
-            useCase(shelfId = "shelf-456")
+                useCase(shelfId = "shelf-456")
 
-            verifySuspend { shelfRepository.deleteShelf("shelf-456") }
+                verifySuspend { shelfRepository.deleteShelf("shelf-456") }
+            }
         }
 
-    @Test
-    fun `delete shelf forwards repository failure`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend {
-                shelfRepository.deleteShelf(any())
-            } returns AppResult.Failure(ValidationError(message = "boom"))
-            val useCase = DeleteShelfUseCase(shelfRepository)
+        test("delete shelf forwards repository failure") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend {
+                    shelfRepository.deleteShelf(any())
+                } returns AppResult.Failure(ValidationError(message = "boom"))
+                val useCase = DeleteShelfUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-123")
+                val result = useCase(shelfId = "shelf-123")
 
-            assertIs<AppResult.Failure>(result)
+                result.shouldBeInstanceOf<AppResult.Failure>()
+            }
         }
 
-    // ========== ReorderShelfBooksUseCase Tests ==========
+        // ========== ReorderShelfBooksUseCase Tests ==========
 
-    @Test
-    fun `reorder books forwards the new order to the repository`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend { shelfRepository.reorderBooks(any(), any()) } returns AppResult.Success(Unit)
-            val useCase = ReorderShelfBooksUseCase(shelfRepository)
+        test("reorder books forwards the new order to the repository") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend { shelfRepository.reorderBooks(any(), any()) } returns AppResult.Success(Unit)
+                val useCase = ReorderShelfBooksUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-1", orderedBookIds = listOf("b2", "b1", "b3"))
+                val result = useCase(shelfId = "shelf-1", orderedBookIds = listOf("b2", "b1", "b3"))
 
-            checkIs<AppResult.Success<Unit>>(result)
-            verifySuspend { shelfRepository.reorderBooks("shelf-1", listOf("b2", "b1", "b3")) }
+                checkIs<AppResult.Success<Unit>>(result)
+                verifySuspend { shelfRepository.reorderBooks("shelf-1", listOf("b2", "b1", "b3")) }
+            }
         }
 
-    @Test
-    fun `reorder books returns validation error for empty list`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            val useCase = ReorderShelfBooksUseCase(shelfRepository)
+        test("reorder books returns validation error for empty list") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                val useCase = ReorderShelfBooksUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-1", orderedBookIds = emptyList())
+                val result = useCase(shelfId = "shelf-1", orderedBookIds = emptyList())
 
-            val failure = assertIs<AppResult.Failure>(result)
-            assertIs<ValidationError>(failure.error)
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<ValidationError>()
+            }
         }
 
-    // ========== AddBooksToShelfUseCase Tests ==========
+        // ========== AddBooksToShelfUseCase Tests ==========
 
-    @Test
-    fun `add books returns validation error for empty list`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            val useCase = AddBooksToShelfUseCase(shelfRepository)
+        test("add books returns validation error for empty list") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                val useCase = AddBooksToShelfUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-1", bookIds = emptyList())
+                val result = useCase(shelfId = "shelf-1", bookIds = emptyList())
 
-            val failure = assertIs<AppResult.Failure>(result)
-            assertIs<ValidationError>(failure.error)
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<ValidationError>()
+            }
         }
 
-    @Test
-    fun `add books forwards to the repository`() =
-        runTest {
-            val shelfRepository: ShelfRepository = mock()
-            everySuspend { shelfRepository.addBooksToShelf(any(), any()) } returns AppResult.Success(Unit)
-            val useCase = AddBooksToShelfUseCase(shelfRepository)
+        test("add books forwards to the repository") {
+            runTest {
+                val shelfRepository: ShelfRepository = mock()
+                everySuspend { shelfRepository.addBooksToShelf(any(), any()) } returns AppResult.Success(Unit)
+                val useCase = AddBooksToShelfUseCase(shelfRepository)
 
-            val result = useCase(shelfId = "shelf-1", bookIds = listOf("b1", "b2"))
+                val result = useCase(shelfId = "shelf-1", bookIds = listOf("b1", "b2"))
 
-            checkIs<AppResult.Success<Unit>>(result)
-            verifySuspend { shelfRepository.addBooksToShelf("shelf-1", listOf("b1", "b2")) }
+                checkIs<AppResult.Success<Unit>>(result)
+                verifySuspend { shelfRepository.addBooksToShelf("shelf-1", listOf("b1", "b2")) }
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadCancelFlowTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadCancelFlowTest.kt
@@ -4,9 +4,9 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Seam-level tests for [FakeDownloadRepository.cancelForBook]. Per project memory
@@ -16,79 +16,80 @@ import kotlin.test.assertEquals
  * [com.calypsan.listenup.client.data.repository.DownloadRepositoryImpl] behavior; production tests
  * for the impl live in `DownloadRepositoryImplTest`.
  */
-class DownloadCancelFlowTest {
-    private fun entity(
-        audioFileId: String,
-        bookId: String = "book-1",
-        state: DownloadState = DownloadState.QUEUED,
-        totalBytes: Long = 1000L,
-        downloadedBytes: Long = 0L,
-    ) = DownloadEntity(
-        audioFileId = audioFileId,
-        bookId = bookId,
-        filename = "$audioFileId.mp3",
-        fileIndex = 0,
-        state = state,
-        localPath = null,
-        totalBytes = totalBytes,
-        downloadedBytes = downloadedBytes,
-        queuedAt = 0L,
-        startedAt = null,
-        completedAt = null,
-        errorMessage = null,
-        retryCount = 0,
-    )
+class DownloadCancelFlowTest :
+    FunSpec({
+        fun entity(
+            audioFileId: String,
+            bookId: String = "book-1",
+            state: DownloadState = DownloadState.QUEUED,
+            totalBytes: Long = 1000L,
+            downloadedBytes: Long = 0L,
+        ) = DownloadEntity(
+            audioFileId = audioFileId,
+            bookId = bookId,
+            filename = "$audioFileId.mp3",
+            fileIndex = 0,
+            state = state,
+            localPath = null,
+            totalBytes = totalBytes,
+            downloadedBytes = downloadedBytes,
+            queuedAt = 0L,
+            startedAt = null,
+            completedAt = null,
+            errorMessage = null,
+            retryCount = 0,
+        )
 
-    @Test
-    fun `cancelForBook transitions all non-terminal rows to CANCELLED`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", state = DownloadState.DOWNLOADING),
-                            entity("file-2", state = DownloadState.PAUSED),
-                            entity("file-3", state = DownloadState.QUEUED),
-                        ),
-                )
-            fake.cancelForBook(BookId("book-1"))
-            val final = fake.entities.associateBy { it.audioFileId }
-            assertEquals(DownloadState.CANCELLED, final["file-1"]!!.state)
-            assertEquals(DownloadState.CANCELLED, final["file-2"]!!.state)
-            assertEquals(DownloadState.CANCELLED, final["file-3"]!!.state)
+        test("cancelForBook transitions all non-terminal rows to CANCELLED") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", state = DownloadState.DOWNLOADING),
+                                entity("file-2", state = DownloadState.PAUSED),
+                                entity("file-3", state = DownloadState.QUEUED),
+                            ),
+                    )
+                fake.cancelForBook(BookId("book-1"))
+                val final = fake.entities.associateBy { it.audioFileId }
+                final["file-1"]!!.state shouldBe DownloadState.CANCELLED
+                final["file-2"]!!.state shouldBe DownloadState.CANCELLED
+                final["file-3"]!!.state shouldBe DownloadState.CANCELLED
+            }
         }
 
-    @Test
-    fun `cancelForBook preserves COMPLETED rows`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", state = DownloadState.DOWNLOADING),
-                            entity("file-2", state = DownloadState.COMPLETED),
-                        ),
-                )
-            fake.cancelForBook(BookId("book-1"))
-            val final = fake.entities.associateBy { it.audioFileId }
-            assertEquals(DownloadState.CANCELLED, final["file-1"]!!.state)
-            assertEquals(DownloadState.COMPLETED, final["file-2"]!!.state)
+        test("cancelForBook preserves COMPLETED rows") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", state = DownloadState.DOWNLOADING),
+                                entity("file-2", state = DownloadState.COMPLETED),
+                            ),
+                    )
+                fake.cancelForBook(BookId("book-1"))
+                val final = fake.entities.associateBy { it.audioFileId }
+                final["file-1"]!!.state shouldBe DownloadState.CANCELLED
+                final["file-2"]!!.state shouldBe DownloadState.COMPLETED
+            }
         }
 
-    @Test
-    fun `cancelForBook only affects the target book`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", bookId = "book-1", state = DownloadState.DOWNLOADING),
-                            entity("file-2", bookId = "book-2", state = DownloadState.DOWNLOADING),
-                        ),
-                )
-            fake.cancelForBook(BookId("book-1"))
-            val final = fake.entities.associateBy { it.audioFileId }
-            assertEquals(DownloadState.CANCELLED, final["file-1"]!!.state)
-            assertEquals(DownloadState.DOWNLOADING, final["file-2"]!!.state)
+        test("cancelForBook only affects the target book") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", bookId = "book-1", state = DownloadState.DOWNLOADING),
+                                entity("file-2", bookId = "book-2", state = DownloadState.DOWNLOADING),
+                            ),
+                    )
+                fake.cancelForBook(BookId("book-1"))
+                val final = fake.entities.associateBy { it.audioFileId }
+                final["file-1"]!!.state shouldBe DownloadState.CANCELLED
+                final["file-2"]!!.state shouldBe DownloadState.DOWNLOADING
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadStateResumeTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadStateResumeTest.kt
@@ -1,10 +1,8 @@
 package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.client.data.local.db.DownloadState
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Regression tests for the download state reset logic in DownloadManager.resumeIncompleteDownloads().
@@ -18,53 +16,39 @@ import kotlin.test.assertTrue
  *
  * Fix: only reset PAUSED → QUEUED. Leave DOWNLOADING entries untouched.
  */
-class DownloadStateResumeTest {
-    /**
-     * The core rule: DOWNLOADING must NOT be reset to QUEUED on resume.
-     * A running worker uses KEEP policy and won't re-call updateState(DOWNLOADING).
-     */
-    @Test
-    fun `DOWNLOADING state should not be reset to QUEUED on resume`() {
-        assertFalse(shouldResetToQueued(DownloadState.DOWNLOADING))
-    }
+class DownloadStateResumeTest :
+    FunSpec({
+        // ---- mirrors the logic in DownloadManager.resumeIncompleteDownloads() ----
+        fun shouldResetToQueued(state: DownloadState): Boolean = state == DownloadState.PAUSED
 
-    /**
-     * PAUSED is the only state that resume should reset to QUEUED.
-     */
-    @Test
-    fun `PAUSED state should be reset to QUEUED on resume`() {
-        assertTrue(shouldResetToQueued(DownloadState.PAUSED))
-    }
+        // The core rule: DOWNLOADING must NOT be reset to QUEUED on resume.
+        // A running worker uses KEEP policy and won't re-call updateState(DOWNLOADING).
+        test("DOWNLOADING state should not be reset to QUEUED on resume") {
+            shouldResetToQueued(DownloadState.DOWNLOADING) shouldBe false
+        }
 
-    /**
-     * QUEUED is already QUEUED — no reset needed (and the DownloadManager skips it).
-     */
-    @Test
-    fun `QUEUED state should not trigger a redundant state write`() {
-        assertFalse(shouldResetToQueued(DownloadState.QUEUED))
-    }
+        // PAUSED is the only state that resume should reset to QUEUED.
+        test("PAUSED state should be reset to QUEUED on resume") {
+            shouldResetToQueued(DownloadState.PAUSED) shouldBe true
+        }
 
-    /**
-     * Terminal states (COMPLETED, FAILED, DELETED) should never be reset to QUEUED by resume.
-     * These have explicit user actions or separate recovery flows.
-     */
-    @Test
-    fun `terminal states should not be reset to QUEUED on resume`() {
-        assertFalse(shouldResetToQueued(DownloadState.COMPLETED))
-        assertFalse(shouldResetToQueued(DownloadState.FAILED))
-        assertFalse(shouldResetToQueued(DownloadState.DELETED))
-    }
+        // QUEUED is already QUEUED — no reset needed (and the DownloadManager skips it).
+        test("QUEUED state should not trigger a redundant state write") {
+            shouldResetToQueued(DownloadState.QUEUED) shouldBe false
+        }
 
-    /**
-     * Documents the complete intended behaviour for all states.
-     * Update this if the reset policy intentionally changes.
-     */
-    @Test
-    fun `only PAUSED state should be reset to QUEUED on resume`() {
-        val resetStates = DownloadState.entries.filter { shouldResetToQueued(it) }
-        assertEquals(listOf(DownloadState.PAUSED), resetStates)
-    }
+        // Terminal states (COMPLETED, FAILED, DELETED) should never be reset to QUEUED by resume.
+        // These have explicit user actions or separate recovery flows.
+        test("terminal states should not be reset to QUEUED on resume") {
+            shouldResetToQueued(DownloadState.COMPLETED) shouldBe false
+            shouldResetToQueued(DownloadState.FAILED) shouldBe false
+            shouldResetToQueued(DownloadState.DELETED) shouldBe false
+        }
 
-    // ---- mirrors the logic in DownloadManager.resumeIncompleteDownloads() ----
-    private fun shouldResetToQueued(state: DownloadState): Boolean = state == DownloadState.PAUSED
-}
+        // Documents the complete intended behaviour for all states.
+        // Update this if the reset policy intentionally changes.
+        test("only PAUSED state should be reset to QUEUED on resume") {
+            val resetStates = DownloadState.entries.filter { shouldResetToQueued(it) }
+            resetStates shouldBe listOf(DownloadState.PAUSED)
+        }
+    })


### PR DESCRIPTION
## What

Batch 2 of the `kotlin-test` → **Kotest FunSpec** migration (follows #514). 12 `commonTest` data/domain specs:

`core/error/ErrorMapper`, `data/remote/{HttpRetryPolicy,HttpClientErrorHandling}`, `data/sync/{ImageDownloader,FtsPopulator}`, `download/{DownloadStateResume,DownloadCancelFlow}`, `domain/usecase/GetInstanceUseCase`, `domain/usecase/shelf/ShelfUseCases`, `data/repository/{SettingsRepository,HomeRepository,ActivityRepositoryImpl}`.

## How

Pure framework migration — no test logic/values/fixtures/mocks changed. `@Test`-method classes → `FunSpec({ test("...") })`; `assertEquals(expected, actual)` → `actual shouldBe expected` (order flips); other `assert*` → matching Kotest matchers. Mokkery, Turbine, `runTest`, and all fixtures preserved verbatim. Method KDocs that moved inside the `FunSpec` lambda became line comments (ktlint disallows KDoc inside a block).

## Verification

`:sharedLogic:jvmTest` green, spotless + detekt clean. No production code touched.

## Remaining

~54 `kotlin-test` files left (presentation ViewModels, `jvmTest` playback/db, `sharedUI` androidHostTest, test-infra). Continuing in subsequent batches.
