### PR TITLE
✅ test(shared): migrate jvmTest playback/db/download specs to Kotest (batch 3/N)

### DIFF
--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDaoTest.kt
@@ -1,111 +1,127 @@
 package com.calypsan.listenup.client.data.local.db
 
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 /**
  * Regression tests for [DownloadDao] queries. Running against a real in-memory
  * [ListenUpDatabase] ensures Room's generated SQL and the type-converter round-trip
  * are both exercised.
  */
-class DownloadDaoTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val dao: DownloadDao = db.downloadDao()
+class DownloadDaoTest :
+    FunSpec({
+        fun entity(
+            audioFileId: String,
+            bookId: String = "book-1",
+            state: DownloadState = DownloadState.QUEUED,
+            startedAt: Long? = null,
+        ) = DownloadEntity(
+            audioFileId = audioFileId,
+            bookId = bookId,
+            filename = "$audioFileId.mp3",
+            fileIndex = 0,
+            state = state,
+            localPath = null,
+            totalBytes = 1000L,
+            downloadedBytes = 0L,
+            queuedAt = 0L,
+            startedAt = startedAt,
+            completedAt = null,
+            errorMessage = null,
+            retryCount = 0,
+        )
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    private fun entity(
-        audioFileId: String,
-        bookId: String = "book-1",
-        state: DownloadState = DownloadState.QUEUED,
-        startedAt: Long? = null,
-    ) = DownloadEntity(
-        audioFileId = audioFileId,
-        bookId = bookId,
-        filename = "$audioFileId.mp3",
-        fileIndex = 0,
-        state = state,
-        localPath = null,
-        totalBytes = 1000L,
-        downloadedBytes = 0L,
-        queuedAt = 0L,
-        startedAt = startedAt,
-        completedAt = null,
-        errorMessage = null,
-        retryCount = 0,
-    )
-
-    @Test
-    fun `getIncomplete returns rows not COMPLETED and not DELETED`() =
-        runTest {
-            dao.insertAll(
-                listOf(
-                    entity("file-1", state = DownloadState.QUEUED),
-                    entity("file-2", state = DownloadState.DOWNLOADING),
-                    entity("file-3", state = DownloadState.COMPLETED),
-                    entity("file-4", state = DownloadState.DELETED),
-                    entity("file-5", state = DownloadState.PAUSED),
-                ),
-            )
-            val incomplete = dao.getIncomplete()
-            // Expect: file-1, file-2, file-5 (QUEUED, DOWNLOADING, PAUSED)
-            // Reject: file-3 (COMPLETED), file-4 (DELETED)
-            assertEquals(3, incomplete.size)
-            assertEquals(setOf("file-1", "file-2", "file-5"), incomplete.map { it.audioFileId }.toSet())
+        test("getIncomplete returns rows not COMPLETED and not DELETED") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("file-1", state = DownloadState.QUEUED),
+                            entity("file-2", state = DownloadState.DOWNLOADING),
+                            entity("file-3", state = DownloadState.COMPLETED),
+                            entity("file-4", state = DownloadState.DELETED),
+                            entity("file-5", state = DownloadState.PAUSED),
+                        ),
+                    )
+                    val incomplete = dao.getIncomplete()
+                    // Expect: file-1, file-2, file-5 (QUEUED, DOWNLOADING, PAUSED)
+                    // Reject: file-3 (COMPLETED), file-4 (DELETED)
+                    incomplete.size shouldBe 3
+                    incomplete.map { it.audioFileId }.toSet() shouldBe setOf("file-1", "file-2", "file-5")
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    @Test
-    fun `getLocalPath returns localPath for COMPLETED rows only`() =
-        runTest {
-            dao.insertAll(
-                listOf(
-                    entity("file-1", state = DownloadState.COMPLETED).copy(localPath = "/path/to/file-1"),
-                    entity("file-2", state = DownloadState.DOWNLOADING).copy(localPath = "/path/to/file-2"),
-                ),
-            )
-            assertEquals("/path/to/file-1", dao.getLocalPath("file-1"))
-            // For non-COMPLETED rows, query should return null even if localPath is set.
-            assertNull(dao.getLocalPath("file-2"))
+        test("getLocalPath returns localPath for COMPLETED rows only") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("file-1", state = DownloadState.COMPLETED).copy(localPath = "/path/to/file-1"),
+                            entity("file-2", state = DownloadState.DOWNLOADING).copy(localPath = "/path/to/file-2"),
+                        ),
+                    )
+                    dao.getLocalPath("file-1") shouldBe "/path/to/file-1"
+                    // For non-COMPLETED rows, query should return null even if localPath is set.
+                    dao.getLocalPath("file-2") shouldBe null
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    @Test
-    fun `markDeletedForBook transitions all rows for a book to DELETED`() =
-        runTest {
-            dao.insertAll(
-                listOf(
-                    entity("file-1", bookId = "book-1", state = DownloadState.COMPLETED).copy(localPath = "/path"),
-                    entity("file-2", bookId = "book-1", state = DownloadState.DOWNLOADING),
-                    entity("file-3", bookId = "book-2", state = DownloadState.QUEUED), // different book
-                ),
-            )
-            dao.markDeletedForBook("book-1")
-            val all = dao.observeAll().first()
-            val byId = all.associateBy { it.audioFileId }
-            assertEquals(DownloadState.DELETED, byId["file-1"]!!.state)
-            assertEquals(DownloadState.DELETED, byId["file-2"]!!.state)
-            assertNull(byId["file-1"]!!.localPath) // should be cleared
-            assertEquals(DownloadState.QUEUED, byId["file-3"]!!.state) // book-2 unaffected
+        test("markDeletedForBook transitions all rows for a book to DELETED") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("file-1", bookId = "book-1", state = DownloadState.COMPLETED)
+                                .copy(localPath = "/path"),
+                            entity("file-2", bookId = "book-1", state = DownloadState.DOWNLOADING),
+                            entity("file-3", bookId = "book-2", state = DownloadState.QUEUED), // different book
+                        ),
+                    )
+                    dao.markDeletedForBook("book-1")
+                    val all = dao.observeAll().first()
+                    val byId = all.associateBy { it.audioFileId }
+                    byId["file-1"]!!.state shouldBe DownloadState.DELETED
+                    byId["file-2"]!!.state shouldBe DownloadState.DELETED
+                    byId["file-1"]!!.localPath shouldBe null // should be cleared
+                    byId["file-3"]!!.state shouldBe DownloadState.QUEUED // book-2 unaffected
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    @Test
-    fun `hasDeletedRecords returns true if any DELETED row exists for a book`() =
-        runTest {
-            dao.insertAll(
-                listOf(
-                    entity("file-1", bookId = "book-1", state = DownloadState.DELETED),
-                    entity("file-2", bookId = "book-2", state = DownloadState.COMPLETED),
-                ),
-            )
-            assertEquals(true, dao.hasDeletedRecords("book-1"))
-            assertEquals(false, dao.hasDeletedRecords("book-2"))
-            assertEquals(false, dao.hasDeletedRecords("book-3")) // non-existent book
+        test("hasDeletedRecords returns true if any DELETED row exists for a book") {
+            val db = createInMemoryTestDatabase()
+            val dao = db.downloadDao()
+            try {
+                runTest {
+                    dao.insertAll(
+                        listOf(
+                            entity("file-1", bookId = "book-1", state = DownloadState.DELETED),
+                            entity("file-2", bookId = "book-2", state = DownloadState.COMPLETED),
+                        ),
+                    )
+                    dao.hasDeletedRecords("book-1") shouldBe true
+                    dao.hasDeletedRecords("book-2") shouldBe false
+                    dao.hasDeletedRecords("book-3") shouldBe false // non-existent book
+                }
+            } finally {
+                db.close()
+            }
         }
-}
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/GenreDaoNameResolutionTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/GenreDaoNameResolutionTest.kt
@@ -1,11 +1,10 @@
 package com.calypsan.listenup.client.data.local.db
 
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Verifies [GenreDao.getIdsByNames] against a real in-memory [ListenUpDatabase].
@@ -14,76 +13,94 @@ import kotlin.test.assertTrue
  * server-sent genre names to local genre IDs. Case-insensitive via `COLLATE NOCASE`;
  * unknown names simply don't appear in the result set.
  */
-class GenreDaoNameResolutionTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val genreDao = db.genreDao()
-
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    private suspend fun seedGenre(
-        id: String,
-        name: String,
-        slug: String = id,
-    ) {
-        genreDao.upsertAll(
-            listOf(
-                GenreEntity(
-                    id = id,
-                    name = name,
-                    slug = slug,
-                    path = "/$slug",
-                    parentId = null,
-                    depth = 0,
-                    sortOrder = 0,
+class GenreDaoNameResolutionTest :
+    FunSpec({
+        suspend fun seedGenre(
+            genreDao: GenreDao,
+            id: String,
+            name: String,
+            slug: String = id,
+        ) {
+            genreDao.upsertAll(
+                listOf(
+                    GenreEntity(
+                        id = id,
+                        name = name,
+                        slug = slug,
+                        path = "/$slug",
+                        parentId = null,
+                        depth = 0,
+                        sortOrder = 0,
+                    ),
                 ),
-            ),
-        )
-    }
-
-    @Test
-    fun `getIdsByNames returns matching id-name pairs`() =
-        runTest {
-            seedGenre(id = "g1", name = "Fantasy")
-            seedGenre(id = "g2", name = "Science Fiction")
-            seedGenre(id = "g3", name = "Horror")
-
-            val result = genreDao.getIdsByNames(listOf("Fantasy", "Horror"))
-
-            assertEquals(2, result.size)
-            assertEquals(setOf("g1", "g3"), result.map { it.id }.toSet())
+            )
         }
 
-    @Test
-    fun `getIdsByNames matches case-insensitively`() =
-        runTest {
-            seedGenre(id = "g1", name = "Epic Fantasy")
+        test("getIdsByNames returns matching id-name pairs") {
+            val db = createInMemoryTestDatabase()
+            val genreDao = db.genreDao()
+            try {
+                runTest {
+                    seedGenre(genreDao, id = "g1", name = "Fantasy")
+                    seedGenre(genreDao, id = "g2", name = "Science Fiction")
+                    seedGenre(genreDao, id = "g3", name = "Horror")
 
-            val result = genreDao.getIdsByNames(listOf("epic fantasy", "EPIC FANTASY"))
+                    val result = genreDao.getIdsByNames(listOf("Fantasy", "Horror"))
 
-            assertEquals(1, result.size, "COLLATE NOCASE dedups both spellings to the same row")
-            assertEquals("g1", result.first().id)
-            assertEquals("Epic Fantasy", result.first().name, "stored name preserves original casing")
+                    result.size shouldBe 2
+                    result.map { it.id }.toSet() shouldBe setOf("g1", "g3")
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    @Test
-    fun `getIdsByNames drops unknown names silently`() =
-        runTest {
-            seedGenre(id = "g1", name = "Fantasy")
+        test("getIdsByNames matches case-insensitively") {
+            val db = createInMemoryTestDatabase()
+            val genreDao = db.genreDao()
+            try {
+                runTest {
+                    seedGenre(genreDao, id = "g1", name = "Epic Fantasy")
 
-            val result = genreDao.getIdsByNames(listOf("Fantasy", "NoSuchGenre"))
+                    val result = genreDao.getIdsByNames(listOf("epic fantasy", "EPIC FANTASY"))
 
-            assertEquals(1, result.size)
-            assertEquals("g1", result.first().id)
+                    withClue("COLLATE NOCASE dedups both spellings to the same row") { result.size shouldBe 1 }
+                    result.first().id shouldBe "g1"
+                    withClue("stored name preserves original casing") { result.first().name shouldBe "Epic Fantasy" }
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    @Test
-    fun `getIdsByNames returns empty list for empty input`() =
-        runTest {
-            seedGenre(id = "g1", name = "Fantasy")
+        test("getIdsByNames drops unknown names silently") {
+            val db = createInMemoryTestDatabase()
+            val genreDao = db.genreDao()
+            try {
+                runTest {
+                    seedGenre(genreDao, id = "g1", name = "Fantasy")
 
-            assertTrue(genreDao.getIdsByNames(emptyList()).isEmpty())
+                    val result = genreDao.getIdsByNames(listOf("Fantasy", "NoSuchGenre"))
+
+                    result.size shouldBe 1
+                    result.first().id shouldBe "g1"
+                }
+            } finally {
+                db.close()
+            }
         }
-}
+
+        test("getIdsByNames returns empty list for empty input") {
+            val db = createInMemoryTestDatabase()
+            val genreDao = db.genreDao()
+            try {
+                runTest {
+                    seedGenre(genreDao, id = "g1", name = "Fantasy")
+
+                    genreDao.getIdsByNames(emptyList()).isEmpty() shouldBe true
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/SearchDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/SearchDaoTest.kt
@@ -6,11 +6,9 @@ import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.core.SeriesId
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 /**
  * Verifies [SearchDao]'s two GROUP_CONCAT queries against a real in-memory
@@ -24,157 +22,190 @@ import kotlin.test.assertNull
  * rows. FU-A1 closes that gap and also verifies the `ORDER BY name COLLATE NOCASE`
  * added to make FTS content deterministic across sync runs.
  */
-class SearchDaoTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val bookDao = db.bookDao()
-    private val seriesDao = db.seriesDao()
-    private val genreDao = db.genreDao()
-    private val bookSeriesDao = db.bookSeriesDao()
-    private val searchDao = db.searchDao()
+class SearchDaoTest :
+    FunSpec({
+        suspend fun seedBook(
+            bookDao: BookDao,
+            id: String = "b1",
+        ) {
+            bookDao.upsert(
+                BookEntity(
+                    id = BookId(id),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = "Test $id",
+                    sortTitle = "Test $id",
+                    subtitle = null,
+                    coverHash = null,
+                    coverBlurHash = null,
+                    dominantColor = null,
+                    darkMutedColor = null,
+                    vibrantColor = null,
+                    totalDuration = 0L,
+                    description = null,
+                    publishYear = null,
+                    publisher = null,
+                    language = null,
+                    isbn = null,
+                    asin = null,
+                    abridged = false,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
+        }
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    private suspend fun seedBook(id: String = "b1") {
-        bookDao.upsert(
-            BookEntity(
-                id = BookId(id),
-                libraryId = LibraryId("test-library"),
-                folderId = FolderId("test-folder"),
-                title = "Test $id",
-                sortTitle = "Test $id",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 0L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
-
-    private suspend fun seedSeries(
-        id: String,
-        name: String,
-    ) {
-        seriesDao.upsert(
-            SeriesEntity(
-                id = SeriesId(id),
-                name = name,
-                description = null,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
-
-    private suspend fun seedGenre(
-        id: String,
-        name: String,
-    ) {
-        genreDao.upsertAll(
-            listOf(
-                GenreEntity(
-                    id = id,
+        suspend fun seedSeries(
+            seriesDao: SeriesDao,
+            id: String,
+            name: String,
+        ) {
+            seriesDao.upsert(
+                SeriesEntity(
+                    id = SeriesId(id),
                     name = name,
-                    slug = id,
-                    path = "/$id",
-                    parentId = null,
-                    depth = 0,
-                    sortOrder = 0,
-                ),
-            ),
-        )
-    }
-
-    // ========== getGenreNamesForBook ==========
-
-    @Test
-    fun `getGenreNamesForBook returns alphabetically-sorted comma-joined names`() =
-        runTest {
-            seedBook()
-            seedGenre(id = "g1", name = "Horror")
-            seedGenre(id = "g2", name = "Fantasy")
-            seedGenre(id = "g3", name = "Adventure")
-            genreDao.insertAllBookGenres(
-                listOf(
-                    BookGenreCrossRef(bookId = BookId("b1"), genreId = "g1"),
-                    BookGenreCrossRef(bookId = BookId("b1"), genreId = "g2"),
-                    BookGenreCrossRef(bookId = BookId("b1"), genreId = "g3"),
+                    description = null,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
                 ),
             )
-
-            val result = searchDao.getGenreNamesForBook("b1")
-
-            assertEquals("Adventure, Fantasy, Horror", result)
         }
 
-    @Test
-    fun `getGenreNamesForBook sort is case-insensitive`() =
-        runTest {
-            seedBook()
-            seedGenre(id = "g1", name = "biography")
-            seedGenre(id = "g2", name = "Action")
-            genreDao.insertAllBookGenres(
+        suspend fun seedGenre(
+            genreDao: GenreDao,
+            id: String,
+            name: String,
+        ) {
+            genreDao.upsertAll(
                 listOf(
-                    BookGenreCrossRef(bookId = BookId("b1"), genreId = "g1"),
-                    BookGenreCrossRef(bookId = BookId("b1"), genreId = "g2"),
+                    GenreEntity(
+                        id = id,
+                        name = name,
+                        slug = id,
+                        path = "/$id",
+                        parentId = null,
+                        depth = 0,
+                        sortOrder = 0,
+                    ),
                 ),
             )
-
-            val result = searchDao.getGenreNamesForBook("b1")
-
-            // "Action" before "biography" under NOCASE collation despite uppercase A < lowercase b.
-            assertEquals("Action, biography", result)
         }
 
-    @Test
-    fun `getGenreNamesForBook returns null when book has no genres`() =
-        runTest {
-            seedBook()
+        // ========== getGenreNamesForBook ==========
 
-            assertNull(searchDao.getGenreNamesForBook("b1"))
+        test("getGenreNamesForBook returns alphabetically-sorted comma-joined names") {
+            val db = createInMemoryTestDatabase()
+            val bookDao = db.bookDao()
+            val genreDao = db.genreDao()
+            val searchDao = db.searchDao()
+            try {
+                runTest {
+                    seedBook(bookDao)
+                    seedGenre(genreDao, id = "g1", name = "Horror")
+                    seedGenre(genreDao, id = "g2", name = "Fantasy")
+                    seedGenre(genreDao, id = "g3", name = "Adventure")
+                    genreDao.insertAllBookGenres(
+                        listOf(
+                            BookGenreCrossRef(bookId = BookId("b1"), genreId = "g1"),
+                            BookGenreCrossRef(bookId = BookId("b1"), genreId = "g2"),
+                            BookGenreCrossRef(bookId = BookId("b1"), genreId = "g3"),
+                        ),
+                    )
+
+                    val result = searchDao.getGenreNamesForBook("b1")
+
+                    result shouldBe "Adventure, Fantasy, Horror"
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    // ========== getSeriesNamesForBook ==========
+        test("getGenreNamesForBook sort is case-insensitive") {
+            val db = createInMemoryTestDatabase()
+            val bookDao = db.bookDao()
+            val genreDao = db.genreDao()
+            val searchDao = db.searchDao()
+            try {
+                runTest {
+                    seedBook(bookDao)
+                    seedGenre(genreDao, id = "g1", name = "biography")
+                    seedGenre(genreDao, id = "g2", name = "Action")
+                    genreDao.insertAllBookGenres(
+                        listOf(
+                            BookGenreCrossRef(bookId = BookId("b1"), genreId = "g1"),
+                            BookGenreCrossRef(bookId = BookId("b1"), genreId = "g2"),
+                        ),
+                    )
 
-    @Test
-    fun `getSeriesNamesForBook returns alphabetically-sorted comma-joined names`() =
-        runTest {
-            seedBook()
-            seedSeries(id = "s1", name = "Mistborn Era 1")
-            seedSeries(id = "s2", name = "The Cosmere")
-            seedSeries(id = "s3", name = "Mistborn")
-            bookSeriesDao.insertAll(
-                listOf(
-                    BookSeriesCrossRef(bookId = BookId("b1"), seriesId = SeriesId("s1")),
-                    BookSeriesCrossRef(bookId = BookId("b1"), seriesId = SeriesId("s2")),
-                    BookSeriesCrossRef(bookId = BookId("b1"), seriesId = SeriesId("s3")),
-                ),
-            )
+                    val result = searchDao.getGenreNamesForBook("b1")
 
-            val result = searchDao.getSeriesNamesForBook("b1")
-
-            assertEquals("Mistborn, Mistborn Era 1, The Cosmere", result)
+                    // "Action" before "biography" under NOCASE collation despite uppercase A < lowercase b.
+                    result shouldBe "Action, biography"
+                }
+            } finally {
+                db.close()
+            }
         }
 
-    @Test
-    fun `getSeriesNamesForBook returns null when book has no series`() =
-        runTest {
-            seedBook()
+        test("getGenreNamesForBook returns null when book has no genres") {
+            val db = createInMemoryTestDatabase()
+            val bookDao = db.bookDao()
+            val searchDao = db.searchDao()
+            try {
+                runTest {
+                    seedBook(bookDao)
 
-            assertNull(searchDao.getSeriesNamesForBook("b1"))
+                    searchDao.getGenreNamesForBook("b1") shouldBe null
+                }
+            } finally {
+                db.close()
+            }
         }
-}
+
+        // ========== getSeriesNamesForBook ==========
+
+        test("getSeriesNamesForBook returns alphabetically-sorted comma-joined names") {
+            val db = createInMemoryTestDatabase()
+            val bookDao = db.bookDao()
+            val seriesDao = db.seriesDao()
+            val bookSeriesDao = db.bookSeriesDao()
+            val searchDao = db.searchDao()
+            try {
+                runTest {
+                    seedBook(bookDao)
+                    seedSeries(seriesDao, id = "s1", name = "Mistborn Era 1")
+                    seedSeries(seriesDao, id = "s2", name = "The Cosmere")
+                    seedSeries(seriesDao, id = "s3", name = "Mistborn")
+                    bookSeriesDao.insertAll(
+                        listOf(
+                            BookSeriesCrossRef(bookId = BookId("b1"), seriesId = SeriesId("s1")),
+                            BookSeriesCrossRef(bookId = BookId("b1"), seriesId = SeriesId("s2")),
+                            BookSeriesCrossRef(bookId = BookId("b1"), seriesId = SeriesId("s3")),
+                        ),
+                    )
+
+                    val result = searchDao.getSeriesNamesForBook("b1")
+
+                    result shouldBe "Mistborn, Mistborn Era 1, The Cosmere"
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("getSeriesNamesForBook returns null when book has no series") {
+            val db = createInMemoryTestDatabase()
+            val bookDao = db.bookDao()
+            val searchDao = db.searchDao()
+            try {
+                runTest {
+                    seedBook(bookDao)
+
+                    searchDao.getSeriesNamesForBook("b1") shouldBe null
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
@@ -1,9 +1,9 @@
 package com.calypsan.listenup.client.data.local.db.migration
 
 import com.calypsan.listenup.client.test.db.createMigrationTestHelper
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertTrue
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Smoke test for the Room [androidx.room.testing.MigrationTestHelper] harness.
@@ -14,30 +14,27 @@ import kotlin.test.assertTrue
  * scaffolding a helper from scratch. When v2 ships, replace this smoke test
  * with an actual migration-and-validate assertion.
  */
-class SchemaMigrationSmokeTest {
-    private val helper = createMigrationTestHelper()
-
-    @AfterTest
-    fun tearDown() {
-        helper.close()
-    }
-
-    @Test
-    fun `creates current schema database and opens a live connection`() {
-        // Pin to the latest exported schema — when W4.4 lands further schema
-        // changes, bump this and start asserting actual v(N-1) → v(N) migration
-        // behaviour. For now this just proves the harness can load the schema
-        // bundle and drive [androidx.sqlite.SQLiteConnection].
-        val connection = helper.createDatabase(version = 10)
-        connection.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").use { stmt ->
-            val tables =
-                buildList {
-                    while (stmt.step()) add(stmt.getText(0))
+class SchemaMigrationSmokeTest :
+    FunSpec({
+        test("creates current schema database and opens a live connection") {
+            val helper = createMigrationTestHelper()
+            try {
+                // Pin to the latest exported schema — when W4.4 lands further schema
+                // changes, bump this and start asserting actual v(N-1) → v(N) migration
+                // behaviour. For now this just proves the harness can load the schema
+                // bundle and drive [androidx.sqlite.SQLiteConnection].
+                val connection = helper.createDatabase(version = 10)
+                connection.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").use { stmt ->
+                    val tables =
+                        buildList {
+                            while (stmt.step()) add(stmt.getText(0))
+                        }
+                    withClue("schema must define the `books` table — saw $tables") {
+                        ("books" in tables) shouldBe true
+                    }
                 }
-            assertTrue(
-                "books" in tables,
-                "schema must define the `books` table — saw $tables",
-            )
+            } finally {
+                helper.close()
+            }
         }
-    }
-}
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/JvmStoragePathsTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/JvmStoragePathsTest.kt
@@ -1,8 +1,9 @@
 package com.calypsan.listenup.client.data.local.images
 
-import kotlin.test.Test
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Tests for JvmStoragePaths.
@@ -10,185 +11,189 @@ import kotlin.test.assertTrue
  * Verifies that storage paths are correctly resolved for the current platform
  * and that directories are created as expected.
  */
-class JvmStoragePathsTest {
-    private val storagePaths = JvmStoragePaths()
+class JvmStoragePathsTest :
+    FunSpec({
+        val storagePaths = JvmStoragePaths()
 
-    @Test
-    fun `filesDir returns non-null path`() {
-        // When
-        val filesDir = storagePaths.filesDir
+        test("filesDir returns non-null path") {
+            // When
+            val filesDir = storagePaths.filesDir
 
-        // Then
-        assertNotNull(filesDir)
-        assertTrue(filesDir.toString().isNotEmpty())
-    }
-
-    @Test
-    fun `filesDir contains listenup in path`() {
-        // When
-        val filesDir = storagePaths.filesDir.toString().lowercase()
-
-        // Then
-        assertTrue(
-            filesDir.contains("listenup"),
-            "Path should contain 'listenup': $filesDir",
-        )
-    }
-
-    @Test
-    fun `filesDir uses appropriate base on Linux`() {
-        val os = System.getProperty("os.name", "").lowercase()
-        if (!os.contains("linux")) {
-            println("Skipping Linux-specific test on $os")
-            return
+            // Then
+            filesDir shouldNotBe null
+            filesDir.toString().isNotEmpty() shouldBe true
         }
 
-        // When
-        val filesDir = storagePaths.filesDir.toString()
+        test("filesDir contains listenup in path") {
+            // When
+            val filesDir = storagePaths.filesDir.toString().lowercase()
 
-        // Then - should use XDG_DATA_HOME or ~/.local/share
-        val xdgData = System.getenv("XDG_DATA_HOME")
-        val expectedBase = xdgData ?: "${System.getProperty("user.home")}/.local/share"
-
-        assertTrue(
-            filesDir.startsWith(expectedBase),
-            "Linux path should start with $expectedBase: $filesDir",
-        )
-    }
-
-    @Test
-    fun `filesDir uses appropriate base on Windows`() {
-        val os = System.getProperty("os.name", "").lowercase()
-        if (!os.contains("windows")) {
-            println("Skipping Windows-specific test on $os")
-            return
+            // Then
+            withClue("Path should contain 'listenup': $filesDir") {
+                filesDir.contains("listenup") shouldBe true
+            }
         }
 
-        // When
-        val filesDir = storagePaths.filesDir.toString()
+        test("filesDir uses appropriate base on Linux") {
+            val os = System.getProperty("os.name", "").lowercase()
+            if (!os.contains("linux")) {
+                println("Skipping Linux-specific test on $os")
+                return@test
+            }
 
-        // Then - should use APPDATA
-        val appData =
-            System.getenv("APPDATA")
-                ?: "${System.getProperty("user.home")}/AppData/Roaming"
+            // When
+            val filesDir = storagePaths.filesDir.toString()
 
-        assertTrue(
-            filesDir.startsWith(appData),
-            "Windows path should start with $appData: $filesDir",
-        )
-    }
+            // Then - should use XDG_DATA_HOME or ~/.local/share
+            val xdgData = System.getenv("XDG_DATA_HOME")
+            val expectedBase = xdgData ?: "${System.getProperty("user.home")}/.local/share"
 
-    @Test
-    fun `getDatabaseDirectory returns valid path`() {
-        // When
-        val dbDir = storagePaths.getDatabaseDirectory()
-
-        // Then
-        assertNotNull(dbDir)
-        assertTrue(dbDir.absolutePath.contains("data"), "DB dir should contain 'data': ${dbDir.absolutePath}")
-    }
-
-    @Test
-    fun `getDatabasePath returns path ending in listenup db`() {
-        // When
-        val dbPath = storagePaths.getDatabasePath()
-
-        // Then
-        assertTrue(
-            dbPath.endsWith("listenup.db"),
-            "DB path should end with 'listenup.db': $dbPath",
-        )
-    }
-
-    @Test
-    fun `getSecureStoragePath returns path ending in auth enc`() {
-        // When
-        val authPath = storagePaths.getSecureStoragePath()
-
-        // Then
-        assertTrue(
-            authPath.absolutePath.endsWith("auth.enc"),
-            "Auth path should end with 'auth.enc': ${authPath.absolutePath}",
-        )
-    }
-
-    @Test
-    fun `getCacheDirectory returns valid path`() {
-        // When
-        val cacheDir = storagePaths.getCacheDirectory()
-
-        // Then
-        assertNotNull(cacheDir)
-        assertTrue(cacheDir.absolutePath.isNotEmpty())
-    }
-
-    @Test
-    fun `getCacheDirectory uses appropriate base on Linux`() {
-        val os = System.getProperty("os.name", "").lowercase()
-        if (!os.contains("linux")) {
-            println("Skipping Linux-specific test on $os")
-            return
+            withClue("Linux path should start with $expectedBase: $filesDir") {
+                filesDir.startsWith(expectedBase) shouldBe true
+            }
         }
 
-        // When
-        val cacheDir = storagePaths.getCacheDirectory().absolutePath
+        test("filesDir uses appropriate base on Windows") {
+            val os = System.getProperty("os.name", "").lowercase()
+            if (!os.contains("windows")) {
+                println("Skipping Windows-specific test on $os")
+                return@test
+            }
 
-        // Then - should use XDG_CACHE_HOME or ~/.cache
-        val xdgCache = System.getenv("XDG_CACHE_HOME")
-        val expectedBase = xdgCache ?: "${System.getProperty("user.home")}/.cache"
+            // When
+            val filesDir = storagePaths.filesDir.toString()
 
-        assertTrue(
-            cacheDir.startsWith(expectedBase),
-            "Linux cache path should start with $expectedBase: $cacheDir",
-        )
-    }
+            // Then - should use APPDATA
+            val appData =
+                System.getenv("APPDATA")
+                    ?: "${System.getProperty("user.home")}/AppData/Roaming"
 
-    @Test
-    fun `directories are created when accessed`() {
-        // Given - a fresh instance
-        val paths = JvmStoragePaths()
+            withClue("Windows path should start with $appData: $filesDir") {
+                filesDir.startsWith(appData) shouldBe true
+            }
+        }
 
-        // When - access filesDir
-        val filesDir = paths.filesDir
+        test("getDatabaseDirectory returns valid path") {
+            // When
+            val dbDir = storagePaths.getDatabaseDirectory()
 
-        // Then - directory should exist (created lazily)
-        val file = java.io.File(filesDir.toString())
-        assertTrue(file.exists(), "filesDir should be created: $filesDir")
-        assertTrue(file.isDirectory, "filesDir should be a directory")
-    }
+            // Then
+            dbDir shouldNotBe null
+            withClue("DB dir should contain 'data': ${dbDir.absolutePath}") {
+                dbDir.absolutePath.contains("data") shouldBe true
+            }
+        }
 
-    @Test
-    fun `database directory is created when accessed`() {
-        // When
-        val dbDir = storagePaths.getDatabaseDirectory()
+        test("getDatabasePath returns path ending in listenup db") {
+            // When
+            val dbPath = storagePaths.getDatabasePath()
 
-        // Then
-        assertTrue(dbDir.exists(), "Database directory should be created")
-        assertTrue(dbDir.isDirectory, "Database directory should be a directory")
-    }
+            // Then
+            withClue("DB path should end with 'listenup.db': $dbPath") {
+                dbPath.endsWith("listenup.db") shouldBe true
+            }
+        }
 
-    @Test
-    fun `cache directory is created when accessed`() {
-        // When
-        val cacheDir = storagePaths.getCacheDirectory()
+        test("getSecureStoragePath returns path ending in auth enc") {
+            // When
+            val authPath = storagePaths.getSecureStoragePath()
 
-        // Then
-        assertTrue(cacheDir.exists(), "Cache directory should be created")
-        assertTrue(cacheDir.isDirectory, "Cache directory should be a directory")
-    }
+            // Then
+            withClue("Auth path should end with 'auth.enc': ${authPath.absolutePath}") {
+                authPath.absolutePath.endsWith("auth.enc") shouldBe true
+            }
+        }
 
-    @Test
-    fun `paths do not contain double slashes`() {
-        // When
-        val filesDir = storagePaths.filesDir.toString()
-        val dbPath = storagePaths.getDatabasePath()
-        val authPath = storagePaths.getSecureStoragePath().absolutePath
-        val cachePath = storagePaths.getCacheDirectory().absolutePath
+        test("getCacheDirectory returns valid path") {
+            // When
+            val cacheDir = storagePaths.getCacheDirectory()
 
-        // Then - no double slashes (path construction error)
-        assertTrue(!filesDir.contains("//"), "filesDir has double slashes: $filesDir")
-        assertTrue(!dbPath.contains("//"), "dbPath has double slashes: $dbPath")
-        assertTrue(!authPath.contains("//"), "authPath has double slashes: $authPath")
-        assertTrue(!cachePath.contains("//"), "cachePath has double slashes: $cachePath")
-    }
-}
+            // Then
+            cacheDir shouldNotBe null
+            cacheDir.absolutePath.isNotEmpty() shouldBe true
+        }
+
+        test("getCacheDirectory uses appropriate base on Linux") {
+            val os = System.getProperty("os.name", "").lowercase()
+            if (!os.contains("linux")) {
+                println("Skipping Linux-specific test on $os")
+                return@test
+            }
+
+            // When
+            val cacheDir = storagePaths.getCacheDirectory().absolutePath
+
+            // Then - should use XDG_CACHE_HOME or ~/.cache
+            val xdgCache = System.getenv("XDG_CACHE_HOME")
+            val expectedBase = xdgCache ?: "${System.getProperty("user.home")}/.cache"
+
+            withClue("Linux cache path should start with $expectedBase: $cacheDir") {
+                cacheDir.startsWith(expectedBase) shouldBe true
+            }
+        }
+
+        test("directories are created when accessed") {
+            // Given - a fresh instance
+            val paths = JvmStoragePaths()
+
+            // When - access filesDir
+            val filesDir = paths.filesDir
+
+            // Then - directory should exist (created lazily)
+            val file = java.io.File(filesDir.toString())
+            withClue("filesDir should be created: $filesDir") {
+                file.exists() shouldBe true
+            }
+            withClue("filesDir should be a directory") {
+                file.isDirectory shouldBe true
+            }
+        }
+
+        test("database directory is created when accessed") {
+            // When
+            val dbDir = storagePaths.getDatabaseDirectory()
+
+            // Then
+            withClue("Database directory should be created") {
+                dbDir.exists() shouldBe true
+            }
+            withClue("Database directory should be a directory") {
+                dbDir.isDirectory shouldBe true
+            }
+        }
+
+        test("cache directory is created when accessed") {
+            // When
+            val cacheDir = storagePaths.getCacheDirectory()
+
+            // Then
+            withClue("Cache directory should be created") {
+                cacheDir.exists() shouldBe true
+            }
+            withClue("Cache directory should be a directory") {
+                cacheDir.isDirectory shouldBe true
+            }
+        }
+
+        test("paths do not contain double slashes") {
+            // When
+            val filesDir = storagePaths.filesDir.toString()
+            val dbPath = storagePaths.getDatabasePath()
+            val authPath = storagePaths.getSecureStoragePath().absolutePath
+            val cachePath = storagePaths.getCacheDirectory().absolutePath
+
+            // Then - no double slashes (path construction error)
+            withClue("filesDir has double slashes: $filesDir") {
+                !filesDir.contains("//") shouldBe true
+            }
+            withClue("dbPath has double slashes: $dbPath") {
+                !dbPath.contains("//") shouldBe true
+            }
+            withClue("authPath has double slashes: $authPath") {
+                !authPath.contains("//") shouldBe true
+            }
+            withClue("cachePath has double slashes: $cachePath") {
+                !cachePath.contains("//") shouldBe true
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -11,7 +11,6 @@ import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
-import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDetail
 import com.calypsan.listenup.client.domain.model.BookListItem
@@ -19,211 +18,303 @@ import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DiscoveryBook
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-class DownloadRepositoryImplTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-    private val downloadDao = db.downloadDao()
-    private val bookRepository = FakeBookRepository()
-    private val enqueuer = FakeDownloadEnqueuer()
-    private val sut =
-        DownloadRepositoryImpl(
-            downloadDao = downloadDao,
-            bookRepository = bookRepository,
-            enqueuer = enqueuer,
-        )
+class DownloadRepositoryImplTest :
+    FunSpec({
+        test("empty downloads emits empty list") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    @Test
-    fun `empty downloads emits empty list`() =
-        runTest {
-            sut.observeDownloadedBooks().test {
-                assertEquals(emptyList(), awaitItem())
-                cancelAndIgnoreRemainingEvents()
+                    sut.observeDownloadedBooks().test {
+                        awaitItem() shouldBe emptyList()
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `single completed download becomes one summary row`() =
-        runTest {
-            bookRepository.books = listOf(fakeBook(id = "b1", title = "Dune", authors = listOf("Frank Herbert")))
-            downloadDao.insert(
-                makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 1_000_000L),
-            )
+        test("single completed download becomes one summary row") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-            sut.observeDownloadedBooks().test {
-                val items = awaitItem()
-                assertEquals(1, items.size)
-                val summary = items.first()
-                assertEquals("b1", summary.bookId)
-                assertEquals("Dune", summary.title)
-                assertEquals("Frank Herbert", summary.authorNames)
-                assertEquals(1_000_000L, summary.sizeBytes)
-                assertEquals(1, summary.fileCount)
-                cancelAndIgnoreRemainingEvents()
+                    bookRepository.books =
+                        listOf(fakeBook(id = "b1", title = "Dune", authors = listOf("Frank Herbert")))
+                    downloadDao.insert(
+                        makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 1_000_000L),
+                    )
+
+                    sut.observeDownloadedBooks().test {
+                        val items = awaitItem()
+                        items.size shouldBe 1
+                        val summary = items.first()
+                        summary.bookId shouldBe "b1"
+                        summary.title shouldBe "Dune"
+                        summary.authorNames shouldBe "Frank Herbert"
+                        summary.sizeBytes shouldBe 1_000_000L
+                        summary.fileCount shouldBe 1
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `multi-file book aggregates size and file count`() =
-        runTest {
-            bookRepository.books = listOf(fakeBook(id = "b1", title = "Foundation", authors = listOf("Isaac Asimov")))
-            downloadDao.insertAll(
-                listOf(
-                    makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 500_000L),
-                    makeDownload(id = "f2", bookId = "b1", state = DownloadState.COMPLETED, bytes = 300_000L),
-                    makeDownload(id = "f3", bookId = "b1", state = DownloadState.COMPLETED, bytes = 200_000L),
-                ),
-            )
+        test("multi-file book aggregates size and file count") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-            sut.observeDownloadedBooks().test {
-                val items = awaitItem()
-                assertEquals(1, items.size)
-                val summary = items.first()
-                assertEquals(1_000_000L, summary.sizeBytes)
-                assertEquals(3, summary.fileCount)
-                cancelAndIgnoreRemainingEvents()
+                    bookRepository.books =
+                        listOf(fakeBook(id = "b1", title = "Foundation", authors = listOf("Isaac Asimov")))
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 500_000L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.COMPLETED, bytes = 300_000L),
+                            makeDownload(id = "f3", bookId = "b1", state = DownloadState.COMPLETED, bytes = 200_000L),
+                        ),
+                    )
+
+                    sut.observeDownloadedBooks().test {
+                        val items = awaitItem()
+                        items.size shouldBe 1
+                        val summary = items.first()
+                        summary.sizeBytes shouldBe 1_000_000L
+                        summary.fileCount shouldBe 3
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `non-completed downloads are filtered out`() =
-        runTest {
-            bookRepository.books = listOf(fakeBook(id = "b1", title = "Neverwhere", authors = listOf("Neil Gaiman")))
-            downloadDao.insertAll(
-                listOf(
-                    makeDownload(id = "f1", bookId = "b1", state = DownloadState.QUEUED, bytes = 100_000L),
-                    makeDownload(id = "f2", bookId = "b1", state = DownloadState.DOWNLOADING, bytes = 200_000L),
-                    makeDownload(id = "f3", bookId = "b1", state = DownloadState.FAILED, bytes = 300_000L),
-                    makeDownload(id = "f4", bookId = "b1", state = DownloadState.PAUSED, bytes = 400_000L),
-                ),
-            )
+        test("non-completed downloads are filtered out") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-            sut.observeDownloadedBooks().test {
-                assertEquals(emptyList(), awaitItem())
-                cancelAndIgnoreRemainingEvents()
+                    bookRepository.books =
+                        listOf(fakeBook(id = "b1", title = "Neverwhere", authors = listOf("Neil Gaiman")))
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.QUEUED, bytes = 100_000L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.DOWNLOADING, bytes = 200_000L),
+                            makeDownload(id = "f3", bookId = "b1", state = DownloadState.FAILED, bytes = 300_000L),
+                            makeDownload(id = "f4", bookId = "b1", state = DownloadState.PAUSED, bytes = 400_000L),
+                        ),
+                    )
+
+                    sut.observeDownloadedBooks().test {
+                        awaitItem() shouldBe emptyList()
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `summaries are sorted by size descending`() =
-        runTest {
-            bookRepository.books =
-                listOf(
-                    fakeBook(id = "b1", title = "Small Book", authors = listOf("Author A")),
-                    fakeBook(id = "b2", title = "Big Book", authors = listOf("Author B")),
-                )
-            downloadDao.insertAll(
-                listOf(
-                    makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100_000L),
-                    makeDownload(id = "f2", bookId = "b2", state = DownloadState.COMPLETED, bytes = 900_000L),
-                ),
-            )
+        test("summaries are sorted by size descending") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-            sut.observeDownloadedBooks().test {
-                val items = awaitItem()
-                assertEquals(2, items.size)
-                assertEquals("b2", items[0].bookId)
-                assertEquals("b1", items[1].bookId)
-                cancelAndIgnoreRemainingEvents()
+                    bookRepository.books =
+                        listOf(
+                            fakeBook(id = "b1", title = "Small Book", authors = listOf("Author A")),
+                            fakeBook(id = "b2", title = "Big Book", authors = listOf("Author B")),
+                        )
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100_000L),
+                            makeDownload(id = "f2", bookId = "b2", state = DownloadState.COMPLETED, bytes = 900_000L),
+                        ),
+                    )
+
+                    sut.observeDownloadedBooks().test {
+                        val items = awaitItem()
+                        items.size shouldBe 2
+                        items[0].bookId shouldBe "b2"
+                        items[1].bookId shouldBe "b1"
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `deleteForBook removes all download rows for that book`() =
-        runTest {
-            bookRepository.books =
-                listOf(
-                    fakeBook(id = "b1", title = "Deleted", authors = listOf("Author A")),
-                    fakeBook(id = "b2", title = "Remaining", authors = listOf("Author B")),
-                )
-            downloadDao.insertAll(
-                listOf(
-                    makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100_000L),
-                    makeDownload(id = "f2", bookId = "b1", state = DownloadState.QUEUED, bytes = 200_000L),
-                    makeDownload(id = "f3", bookId = "b2", state = DownloadState.COMPLETED, bytes = 300_000L),
-                ),
-            )
+        test("deleteForBook removes all download rows for that book") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-            sut.deleteForBook("b1")
+                    bookRepository.books =
+                        listOf(
+                            fakeBook(id = "b1", title = "Deleted", authors = listOf("Author A")),
+                            fakeBook(id = "b2", title = "Remaining", authors = listOf("Author B")),
+                        )
+                    downloadDao.insertAll(
+                        listOf(
+                            makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100_000L),
+                            makeDownload(id = "f2", bookId = "b1", state = DownloadState.QUEUED, bytes = 200_000L),
+                            makeDownload(id = "f3", bookId = "b2", state = DownloadState.COMPLETED, bytes = 300_000L),
+                        ),
+                    )
 
-            // b1 rows are gone; b2 row is untouched
-            sut.observeDownloadedBooks().test {
-                val items = awaitItem()
-                assertEquals(1, items.size)
-                assertEquals("b2", items.first().bookId)
-                cancelAndIgnoreRemainingEvents()
+                    sut.deleteForBook("b1")
+
+                    // b1 rows are gone; b2 row is untouched
+                    sut.observeDownloadedBooks().test {
+                        val items = awaitItem()
+                        items.size shouldBe 1
+                        items.first().bookId shouldBe "b2"
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `downloads whose book is missing from repository are silently dropped`() =
-        runTest {
-            bookRepository.books = emptyList()
-            downloadDao.insert(
-                makeDownload(id = "f1", bookId = "orphan", state = DownloadState.COMPLETED, bytes = 500_000L),
-            )
+        test("downloads whose book is missing from repository are silently dropped") {
+            val db = createInMemoryTestDatabase()
+            val downloadDao = db.downloadDao()
+            try {
+                runTest {
+                    val bookRepository = FakeBookRepository()
+                    val enqueuer = FakeDownloadEnqueuer()
+                    val sut =
+                        DownloadRepositoryImpl(
+                            downloadDao = downloadDao,
+                            bookRepository = bookRepository,
+                            enqueuer = enqueuer,
+                        )
 
-            sut.observeDownloadedBooks().test {
-                assertEquals(emptyList(), awaitItem())
-                cancelAndIgnoreRemainingEvents()
+                    bookRepository.books = emptyList()
+                    downloadDao.insert(
+                        makeDownload(id = "f1", bookId = "orphan", state = DownloadState.COMPLETED, bytes = 500_000L),
+                    )
+
+                    sut.observeDownloadedBooks().test {
+                        awaitItem() shouldBe emptyList()
+                        cancelAndIgnoreRemainingEvents()
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
+    })
 
-    // ---- Helper factories ----------------------------------------------------------------
+// ---- Helper factories ----------------------------------------------------------------
 
-    private fun makeDownload(
-        id: String,
-        bookId: String,
-        state: DownloadState,
-        bytes: Long,
-    ): DownloadEntity =
-        DownloadEntity(
-            audioFileId = id,
-            bookId = bookId,
-            filename = "$id.mp3",
-            fileIndex = 0,
-            state = state,
-            localPath = if (state == DownloadState.COMPLETED) "/audio/$id.mp3" else null,
-            totalBytes = bytes,
-            downloadedBytes = if (state == DownloadState.COMPLETED) bytes else 0L,
-            queuedAt = 1_000_000L,
-            startedAt = null,
-            completedAt = if (state == DownloadState.COMPLETED) 2_000_000L else null,
-            errorMessage = null,
-            retryCount = 0,
-        )
+private fun makeDownload(
+    id: String,
+    bookId: String,
+    state: DownloadState,
+    bytes: Long,
+): DownloadEntity =
+    DownloadEntity(
+        audioFileId = id,
+        bookId = bookId,
+        filename = "$id.mp3",
+        fileIndex = 0,
+        state = state,
+        localPath = if (state == DownloadState.COMPLETED) "/audio/$id.mp3" else null,
+        totalBytes = bytes,
+        downloadedBytes = if (state == DownloadState.COMPLETED) bytes else 0L,
+        queuedAt = 1_000_000L,
+        startedAt = null,
+        completedAt = if (state == DownloadState.COMPLETED) 2_000_000L else null,
+        errorMessage = null,
+        retryCount = 0,
+    )
 
-    private fun fakeBook(
-        id: String,
-        title: String,
-        authors: List<String>,
-    ): BookListItem =
-        BookListItem(
-            id = BookId(id),
-            libraryId = LibraryId("test-library"),
-            folderId = FolderId("test-folder"),
-            title = title,
-            authors =
-                authors.mapIndexed { index, name ->
-                    BookContributor(id = "c$index", name = name)
-                },
-            narrators = emptyList(),
-            duration = 0L,
-            coverPath = null,
-            addedAt = Timestamp(0L),
-            updatedAt = Timestamp(0L),
-        )
-}
+private fun fakeBook(
+    id: String,
+    title: String,
+    authors: List<String>,
+): BookListItem =
+    BookListItem(
+        id = BookId(id),
+        libraryId = LibraryId("test-library"),
+        folderId = FolderId("test-folder"),
+        title = title,
+        authors =
+            authors.mapIndexed { index, name ->
+                BookContributor(id = "c$index", name = name)
+            },
+        narrators = emptyList(),
+        duration = 0L,
+        coverPath = null,
+        addedAt = Timestamp(0L),
+        updatedAt = Timestamp(0L),
+    )
 
 private class FakeDownloadEnqueuer : DownloadEnqueuer {
     override suspend fun enqueue(entity: com.calypsan.listenup.client.data.local.db.DownloadEntity): AppResult<Unit> = AppResult.Success(Unit)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -21,6 +21,11 @@ import com.calypsan.listenup.client.data.local.images.StoragePaths
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
 import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.mock.MockEngine
@@ -45,11 +50,6 @@ import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.write
 import java.io.File
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 /**
  * Seam-level contract tests for [downloadAudioFile]. Runs on JVM via :shared:jvmTest so it can
@@ -64,382 +64,336 @@ import kotlin.test.assertTrue
  *
  * Download URL is resolved via PlaybackService.prepare signed URLs.
  */
-class DownloadWorkerLogicTest {
-    // ---- Fixtures ----
+class DownloadWorkerLogicTest :
+    FunSpec({
+        // ---- Fixtures ----
 
-    private fun entity(
-        audioFileId: String,
-        bookId: String = "book-1",
-        state: DownloadState = DownloadState.QUEUED,
-        totalBytes: Long = 1000L,
-        downloadedBytes: Long = 0L,
-    ) = DownloadEntity(
-        audioFileId = audioFileId,
-        bookId = bookId,
-        filename = "$audioFileId.mp3",
-        fileIndex = 0,
-        state = state,
-        localPath = null,
-        totalBytes = totalBytes,
-        downloadedBytes = downloadedBytes,
-        queuedAt = 0L,
-        startedAt = null,
-        completedAt = null,
-        errorMessage = null,
-        retryCount = 0,
-    )
-
-    /** Base client: ContentNegotiation + timeout. No Auth or Retry plugins. */
-    private fun productionLikeClient(engine: HttpClientEngine): HttpClient =
-        HttpClient(engine) {
-            install(ContentNegotiation) { json(appJson) }
-            install(HttpTimeout) {
-                requestTimeoutMillis = 30_000
-                connectTimeoutMillis = 10_000
-                socketTimeoutMillis = 30_000
-            }
-        }
-
-    /**
-     * Client with Bearer Auth plugin for 401 scenarios.
-     *
-     * Mirrors the production ApiClientFactory client: installs [installListenUpErrorHandling] so
-     * non-2xx responses raise [io.ktor.client.plugins.ResponseException] (via
-     * `expectSuccess = true`); the surrounding `apiCall { ... }` boundary catches it and routes
-     * through `ErrorMapper` to produce an `AppResult.Failure(TransportError.Server4xx(401))`
-     * after a failed refresh. Without this, the 401 leaks through the success-decoder path.
-     */
-    private fun authProductionLikeClient(
-        engine: HttpClientEngine,
-        refreshTokens: suspend () -> BearerTokens?,
-    ): HttpClient =
-        HttpClient(engine) {
-            installListenUpErrorHandling()
-            install(ContentNegotiation) { json(appJson) }
-            install(Auth) {
-                bearer {
-                    loadTokens { BearerTokens("initial-token", "refresh-token") }
-                    refreshTokens { refreshTokens() }
-                }
-            }
-        }
-
-    /** Client with HttpRequestRetry for 5xx scenarios. Minimum delay for fast test execution. */
-    private fun retryProductionLikeClient(engine: HttpClientEngine): HttpClient =
-        HttpClient(engine) {
-            install(ContentNegotiation) { json(appJson) }
-            install(HttpRequestRetry) {
-                retryIf(maxRetries = 3) { _, response ->
-                    response.status.value in 500..599
-                }
-                constantDelay(millis = 1, randomizationMs = 0)
-            }
-        }
-
-    /** A ready [FakePlaybackRpcFactory] for standard test setup. */
-    private fun readyRpcFactory(
-        audioFileId: String = "file-1",
-        bookId: String = "book-1",
-        streamUrl: String = "/api/v1/audio/$bookId/$audioFileId",
-    ) = FakePlaybackRpcFactory(
-        AppResult.Success(
-            PreparedPlayback(
-                bookId = bookId,
-                audioFiles =
-                    listOf(
-                        PreparedAudioFile(
-                            fileId = audioFileId,
-                            index = 0,
-                            url = streamUrl,
-                            format = "mp3",
-                            durationMs = 1000L,
-                            sizeBytes = 1000L,
-                        ),
-                    ),
-                resumePosition = null,
-            ),
-        ),
-    )
-
-    /** Create a DownloadFileManager backed by [tmpRoot]. */
-    private fun fileManagerFor(tmpRoot: File): DownloadFileManager {
-        val path = Path(tmpRoot.absolutePath)
-        return DownloadFileManager(
-            storagePaths =
-                object : StoragePaths {
-                    override val filesDir: Path = path
-                },
+        fun entity(
+            audioFileId: String,
+            bookId: String = "book-1",
+            state: DownloadState = DownloadState.QUEUED,
+            totalBytes: Long = 1000L,
+            downloadedBytes: Long = 0L,
+        ) = DownloadEntity(
+            audioFileId = audioFileId,
+            bookId = bookId,
+            filename = "$audioFileId.mp3",
+            fileIndex = 0,
+            state = state,
+            localPath = null,
+            totalBytes = totalBytes,
+            downloadedBytes = downloadedBytes,
+            queuedAt = 0L,
+            startedAt = null,
+            completedAt = null,
+            errorMessage = null,
+            retryCount = 0,
         )
-    }
 
-    // ---- Scenario 1 ----
-
-    /**
-     * 200 happy path: bytes flow through and markCompleted is called.
-     * Final entity state = COMPLETED, localPath != null, downloadedBytes == expected.
-     */
-    @Test
-    fun `200 happy path — bytes flow and markCompleted`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                val binaryEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteArray(1000) { 0x42 },
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
-                        )
-                    }
-
-                downloadAudioFile(
-                    audioFileId = "file-1",
-                    bookId = "book-1",
-                    filename = "file-1.mp3",
-                    expectedSize = 1000L,
-                    httpClient = productionLikeClient(binaryEngine),
-                    repository = fakeRepo,
-                    fileManager = fileManagerFor(tmpRoot),
-                    playbackRpcFactory = readyRpcFactory(),
-                )
-
-                val final = fakeRepo.entities.single()
-                assertEquals(DownloadState.COMPLETED, final.state)
-                assertNotNull(final.localPath)
-                assertEquals(1000L, final.downloadedBytes)
-            } finally {
-                tmpRoot.deleteRecursively()
-            }
-        }
-
-    // ---- Scenario 2 ----
-
-    /**
-     * 206 partial-content resume: pre-existing temp file causes Range header in request.
-     * MockEngine verifies the Range header and returns 206; final state = COMPLETED.
-     */
-    @Test
-    fun `206 partial-content resume — Range header sent for partial tempFile`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                val fileManager = fileManagerFor(tmpRoot)
-
-                // Pre-write 400 bytes to the temp path so startByte = 400
-                val tempPath = fileManager.getAudioFilePath("book-1", "file-1", "file-1.mp3", isTemp = true)
-                SystemFileSystem.sink(tempPath).buffered().use { sink ->
-                    sink.write(ByteArray(400) { 0x41 })
+        // Base client: ContentNegotiation + timeout. No Auth or Retry plugins.
+        fun productionLikeClient(engine: HttpClientEngine): HttpClient =
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(appJson) }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 30_000
+                    connectTimeoutMillis = 10_000
+                    socketTimeoutMillis = 30_000
                 }
-
-                var capturedRangeHeader: String? = null
-                val partialEngine =
-                    MockEngine { request ->
-                        capturedRangeHeader = request.headers[HttpHeaders.Range]
-                        respond(
-                            content = ByteArray(600) { 0x42 },
-                            status = HttpStatusCode.PartialContent,
-                            headers = headersOf(HttpHeaders.ContentLength, "600"),
-                        )
-                    }
-
-                downloadAudioFile(
-                    audioFileId = "file-1",
-                    bookId = "book-1",
-                    filename = "file-1.mp3",
-                    expectedSize = 1000L,
-                    httpClient = productionLikeClient(partialEngine),
-                    repository = fakeRepo,
-                    fileManager = fileManager,
-                    playbackRpcFactory = readyRpcFactory(),
-                )
-
-                assertEquals("bytes=400-", capturedRangeHeader)
-                val final = fakeRepo.entities.single()
-                assertEquals(DownloadState.COMPLETED, final.state)
-            } finally {
-                tmpRoot.deleteRecursively()
             }
+
+        // Client with Bearer Auth plugin for 401 scenarios.
+        //
+        // Mirrors the production ApiClientFactory client: installs [installListenUpErrorHandling] so
+        // non-2xx responses raise [io.ktor.client.plugins.ResponseException] (via
+        // `expectSuccess = true`); the surrounding `apiCall { ... }` boundary catches it and routes
+        // through `ErrorMapper` to produce an `AppResult.Failure(TransportError.Server4xx(401))`
+        // after a failed refresh. Without this, the 401 leaks through the success-decoder path.
+        fun authProductionLikeClient(
+            engine: HttpClientEngine,
+            refreshTokens: suspend () -> BearerTokens?,
+        ): HttpClient =
+            HttpClient(engine) {
+                installListenUpErrorHandling()
+                install(ContentNegotiation) { json(appJson) }
+                install(Auth) {
+                    bearer {
+                        loadTokens { BearerTokens("initial-token", "refresh-token") }
+                        refreshTokens { refreshTokens() }
+                    }
+                }
+            }
+
+        // Client with HttpRequestRetry for 5xx scenarios. Minimum delay for fast test execution.
+        fun retryProductionLikeClient(engine: HttpClientEngine): HttpClient =
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(appJson) }
+                install(HttpRequestRetry) {
+                    retryIf(maxRetries = 3) { _, response ->
+                        response.status.value in 500..599
+                    }
+                    constantDelay(millis = 1, randomizationMs = 0)
+                }
+            }
+
+        // A ready [FakePlaybackRpcFactory] for standard test setup.
+        fun readyRpcFactory(
+            audioFileId: String = "file-1",
+            bookId: String = "book-1",
+            streamUrl: String = "/api/v1/audio/$bookId/$audioFileId",
+        ) = FakePlaybackRpcFactory(
+            AppResult.Success(
+                PreparedPlayback(
+                    bookId = bookId,
+                    audioFiles =
+                        listOf(
+                            PreparedAudioFile(
+                                fileId = audioFileId,
+                                index = 0,
+                                url = streamUrl,
+                                format = "mp3",
+                                durationMs = 1000L,
+                                sizeBytes = 1000L,
+                            ),
+                        ),
+                    resumePosition = null,
+                ),
+            ),
+        )
+
+        // Create a DownloadFileManager backed by [tmpRoot].
+        fun fileManagerFor(tmpRoot: File): DownloadFileManager {
+            val path = Path(tmpRoot.absolutePath)
+            return DownloadFileManager(
+                storagePaths =
+                    object : StoragePaths {
+                        override val filesDir: Path = path
+                    },
+            )
         }
 
-    // ---- Scenario 3 ----
+        // ---- Utility ----
 
-    /**
-     * 401 once → refresh succeeds → 200: Auth plugin triggers token refresh.
-     * Second attempt returns 200; final state = COMPLETED.
-     */
-    @Test
-    fun `401 once then refresh succeeds — final state COMPLETED`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                var attemptCount = 0
+        fun tempDir(): File = File(System.getProperty("java.io.tmpdir"), "dwlt-${System.nanoTime()}").also { it.mkdirs() }
 
-                val authEngine =
-                    MockEngine { _ ->
-                        attemptCount++
-                        if (attemptCount == 1) {
-                            respond(
-                                content = "",
-                                status = HttpStatusCode.Unauthorized,
-                                headers = headersOf(HttpHeaders.WWWAuthenticate, "Bearer realm=\"api\""),
-                            )
-                        } else {
+        // ---- Scenario 1 ----
+
+        // 200 happy path: bytes flow through and markCompleted is called.
+        // Final entity state = COMPLETED, localPath != null, downloadedBytes == expected.
+        test("200 happy path — bytes flow and markCompleted") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    val binaryEngine =
+                        MockEngine { _ ->
                             respond(
                                 content = ByteArray(1000) { 0x42 },
                                 status = HttpStatusCode.OK,
                                 headers = headersOf(HttpHeaders.ContentLength, "1000"),
                             )
                         }
-                    }
 
-                downloadAudioFile(
-                    audioFileId = "file-1",
-                    bookId = "book-1",
-                    filename = "file-1.mp3",
-                    expectedSize = 1000L,
-                    httpClient =
-                        authProductionLikeClient(authEngine) {
-                            BearerTokens("refreshed-token", "new-refresh-token")
-                        },
-                    repository = fakeRepo,
-                    fileManager = fileManagerFor(tmpRoot),
-                    playbackRpcFactory = readyRpcFactory(),
-                )
-
-                val final = fakeRepo.entities.single()
-                assertEquals(DownloadState.COMPLETED, final.state)
-                assertTrue(attemptCount >= 2, "Expected >=2 attempts but got $attemptCount")
-            } finally {
-                tmpRoot.deleteRecursively()
-            }
-        }
-
-    // ---- Scenario 4 ----
-
-    /**
-     * 401 persistent → refresh returns null → returns AppResult.Failure(TransportError.Server4xx(401)).
-     *
-     * Production path: installListenUpErrorHandling raises ResponseException on the non-2xx
-     * response; the surrounding apiCall boundary catches it and produces
-     * AppResult.Failure(TransportError.Server4xx(statusCode=401)). The worker inspects the
-     * AppResult and on a 401 calls markPaused. This test asserts the typed-failure contract —
-     * catching a bug where the old dead-code ResponseException catch caused FAILED instead.
-     */
-    @Test
-    fun `401 persistent with null refresh — returns AppResult Failure and worker would markPaused`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
-                val authEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = "",
-                            status = HttpStatusCode.Unauthorized,
-                            headers = headersOf(HttpHeaders.WWWAuthenticate, "Bearer realm=\"api\""),
-                        )
-                    }
-
-                // Replicate the worker's failure-handling: on TransportError.Server4xx(401),
-                // the worker calls markPaused. Test this contract without WorkManager involvement.
-                val result =
                     downloadAudioFile(
                         audioFileId = "file-1",
                         bookId = "book-1",
                         filename = "file-1.mp3",
                         expectedSize = 1000L,
-                        httpClient = authProductionLikeClient(authEngine) { null },
+                        httpClient = productionLikeClient(binaryEngine),
                         repository = fakeRepo,
                         fileManager = fileManagerFor(tmpRoot),
                         playbackRpcFactory = readyRpcFactory(),
                     )
 
-                assertIs<AppResult.Failure>(result)
-                val server4xx = result.error as? TransportError.Server4xx
-                assertIs<TransportError.Server4xx>(
-                    result.error,
-                    "Expected TransportError.Server4xx but got ${result.error::class.simpleName}",
-                )
-                assertEquals(HttpStatusCode.Unauthorized.value, server4xx?.statusCode)
-                // Replicate worker's auth-failure path: markPaused (not markFailed).
-                fakeRepo.markPaused("file-1")
-
-                assertEquals(DownloadState.PAUSED, fakeRepo.entities.single().state)
-            } finally {
-                tmpRoot.deleteRecursively()
+                    val final = fakeRepo.entities.single()
+                    final.state shouldBe DownloadState.COMPLETED
+                    final.localPath shouldNotBe null
+                    final.downloadedBytes shouldBe 1000L
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
             }
         }
 
-    // ---- Scenario 5 ----
+        // ---- Scenario 2 ----
 
-    /**
-     * 500 once → HttpRequestRetry retries → 200.
-     * Second attempt returns 200; final state = COMPLETED.
-     */
-    @Test
-    fun `500 once then retry succeeds — final state COMPLETED`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                var attemptCount = 0
+        // 206 partial-content resume: pre-existing temp file causes Range header in request.
+        // MockEngine verifies the Range header and returns 206; final state = COMPLETED.
+        test("206 partial-content resume — Range header sent for partial tempFile") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    val fileManager = fileManagerFor(tmpRoot)
 
-                val retryEngine =
-                    MockEngine { _ ->
-                        attemptCount++
-                        if (attemptCount == 1) {
-                            respondError(HttpStatusCode.InternalServerError)
-                        } else {
+                    // Pre-write 400 bytes to the temp path so startByte = 400
+                    val tempPath = fileManager.getAudioFilePath("book-1", "file-1", "file-1.mp3", isTemp = true)
+                    SystemFileSystem.sink(tempPath).buffered().use { sink ->
+                        sink.write(ByteArray(400) { 0x41 })
+                    }
+
+                    var capturedRangeHeader: String? = null
+                    val partialEngine =
+                        MockEngine { request ->
+                            capturedRangeHeader = request.headers[HttpHeaders.Range]
                             respond(
-                                content = ByteArray(1000) { 0x42 },
-                                status = HttpStatusCode.OK,
-                                headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                                content = ByteArray(600) { 0x42 },
+                                status = HttpStatusCode.PartialContent,
+                                headers = headersOf(HttpHeaders.ContentLength, "600"),
                             )
                         }
-                    }
 
-                downloadAudioFile(
-                    audioFileId = "file-1",
-                    bookId = "book-1",
-                    filename = "file-1.mp3",
-                    expectedSize = 1000L,
-                    httpClient = retryProductionLikeClient(retryEngine),
-                    repository = fakeRepo,
-                    fileManager = fileManagerFor(tmpRoot),
-                    playbackRpcFactory = readyRpcFactory(),
-                )
+                    downloadAudioFile(
+                        audioFileId = "file-1",
+                        bookId = "book-1",
+                        filename = "file-1.mp3",
+                        expectedSize = 1000L,
+                        httpClient = productionLikeClient(partialEngine),
+                        repository = fakeRepo,
+                        fileManager = fileManager,
+                        playbackRpcFactory = readyRpcFactory(),
+                    )
 
-                assertEquals(DownloadState.COMPLETED, fakeRepo.entities.single().state)
-                assertEquals(2, attemptCount)
-            } finally {
-                tmpRoot.deleteRecursively()
+                    capturedRangeHeader shouldBe "bytes=400-"
+                    val final = fakeRepo.entities.single()
+                    final.state shouldBe DownloadState.COMPLETED
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
             }
         }
 
-    // ---- Scenario 6 ----
+        // ---- Scenario 3 ----
 
-    /**
-     * 500 persistent → 3 retries exhausted → throws.
-     * 1 original + 3 retries = 4 total engine invocations before exception.
-     */
-    @Test
-    fun `500 persistent — retries exhausted and throws`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
-                var attemptCount = 0
+        // 401 once → refresh succeeds → 200: Auth plugin triggers token refresh.
+        // Second attempt returns 200; final state = COMPLETED.
+        test("401 once then refresh succeeds — final state COMPLETED") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    var attemptCount = 0
 
-                val retryEngine =
-                    MockEngine { _ ->
-                        attemptCount++
-                        respondError(HttpStatusCode.InternalServerError)
+                    val authEngine =
+                        MockEngine { _ ->
+                            attemptCount++
+                            if (attemptCount == 1) {
+                                respond(
+                                    content = "",
+                                    status = HttpStatusCode.Unauthorized,
+                                    headers = headersOf(HttpHeaders.WWWAuthenticate, "Bearer realm=\"api\""),
+                                )
+                            } else {
+                                respond(
+                                    content = ByteArray(1000) { 0x42 },
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                                )
+                            }
+                        }
+
+                    downloadAudioFile(
+                        audioFileId = "file-1",
+                        bookId = "book-1",
+                        filename = "file-1.mp3",
+                        expectedSize = 1000L,
+                        httpClient =
+                            authProductionLikeClient(authEngine) {
+                                BearerTokens("refreshed-token", "new-refresh-token")
+                            },
+                        repository = fakeRepo,
+                        fileManager = fileManagerFor(tmpRoot),
+                        playbackRpcFactory = readyRpcFactory(),
+                    )
+
+                    val final = fakeRepo.entities.single()
+                    final.state shouldBe DownloadState.COMPLETED
+                    withClue("Expected >=2 attempts but got $attemptCount") {
+                        (attemptCount >= 2) shouldBe true
                     }
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
 
-                val result =
+        // ---- Scenario 4 ----
+
+        // 401 persistent → refresh returns null → returns AppResult.Failure(TransportError.Server4xx(401)).
+        //
+        // Production path: installListenUpErrorHandling raises ResponseException on the non-2xx
+        // response; the surrounding apiCall boundary catches it and produces
+        // AppResult.Failure(TransportError.Server4xx(statusCode=401)). The worker inspects the
+        // AppResult and on a 401 calls markPaused. This test asserts the typed-failure contract —
+        // catching a bug where the old dead-code ResponseException catch caused FAILED instead.
+        test("401 persistent with null refresh — returns AppResult Failure and worker would markPaused") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                    val authEngine =
+                        MockEngine { _ ->
+                            respond(
+                                content = "",
+                                status = HttpStatusCode.Unauthorized,
+                                headers = headersOf(HttpHeaders.WWWAuthenticate, "Bearer realm=\"api\""),
+                            )
+                        }
+
+                    // Replicate the worker's failure-handling: on TransportError.Server4xx(401),
+                    // the worker calls markPaused. Test this contract without WorkManager involvement.
+                    val result =
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = authProductionLikeClient(authEngine) { null },
+                            repository = fakeRepo,
+                            fileManager = fileManagerFor(tmpRoot),
+                            playbackRpcFactory = readyRpcFactory(),
+                        )
+
+                    val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                    val server4xx = failure.error as? TransportError.Server4xx
+                    withClue("Expected TransportError.Server4xx but got ${failure.error::class.simpleName}") {
+                        failure.error.shouldBeInstanceOf<TransportError.Server4xx>()
+                    }
+                    server4xx?.statusCode shouldBe HttpStatusCode.Unauthorized.value
+                    // Replicate worker's auth-failure path: markPaused (not markFailed).
+                    fakeRepo.markPaused("file-1")
+
+                    fakeRepo.entities.single().state shouldBe DownloadState.PAUSED
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+
+        // ---- Scenario 5 ----
+
+        // 500 once → HttpRequestRetry retries → 200.
+        // Second attempt returns 200; final state = COMPLETED.
+        test("500 once then retry succeeds — final state COMPLETED") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    var attemptCount = 0
+
+                    val retryEngine =
+                        MockEngine { _ ->
+                            attemptCount++
+                            if (attemptCount == 1) {
+                                respondError(HttpStatusCode.InternalServerError)
+                            } else {
+                                respond(
+                                    content = ByteArray(1000) { 0x42 },
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                                )
+                            }
+                        }
+
                     downloadAudioFile(
                         audioFileId = "file-1",
                         bookId = "book-1",
@@ -451,385 +405,409 @@ class DownloadWorkerLogicTest {
                         playbackRpcFactory = readyRpcFactory(),
                     )
 
-                assertIs<AppResult.Failure>(result)
-                assertEquals(4, attemptCount) // 1 original + 3 retries
-            } finally {
-                tmpRoot.deleteRecursively()
-            }
-        }
-
-    // ---- Scenario 7 ----
-
-    /**
-     * Network drop mid-stream: response body is shorter than Content-Length.
-     * Size mismatch triggers IOException from the function.
-     *
-     * The function throws; the worker's IOException catch calls handleRetryableError which
-     * calls markFailed. This test replicates that catch to assert FAILED — catching a
-     * regression where an incorrect handler could silently swallow the error.
-     */
-    @Test
-    fun `network drop mid-stream — IOException on size mismatch`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
-                // Server claims 1000 bytes but only sends 200 → size mismatch IOException
-                val dropEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteReadChannel(ByteArray(200) { 0x42 }),
-                            status = HttpStatusCode.OK,
-                            headers =
-                                headersOf(
-                                    HttpHeaders.ContentLength to listOf("1000"),
-                                    HttpHeaders.ContentType to listOf(ContentType.Application.OctetStream.toString()),
-                                ),
-                        )
-                    }
-
-                // Replicate the worker's failure path: handleFailure calls markFailed for IO-class
-                // failures (ErrorMapper maps IOException → TransportError.NetworkUnavailable).
-                val result =
-                    downloadAudioFile(
-                        audioFileId = "file-1",
-                        bookId = "book-1",
-                        filename = "file-1.mp3",
-                        expectedSize = 1000L,
-                        httpClient = productionLikeClient(dropEngine),
-                        repository = fakeRepo,
-                        fileManager = fileManagerFor(tmpRoot),
-                        playbackRpcFactory = readyRpcFactory(),
-                    )
-
-                assertIs<AppResult.Failure>(result)
-                fakeRepo.markFailed("file-1", DownloadError.DownloadFailed(debugInfo = result.error.debugInfo))
-
-                assertEquals(DownloadState.FAILED, fakeRepo.entities.single().state)
-            } finally {
-                tmpRoot.deleteRecursively()
-            }
-        }
-
-    // ---- Scenario 8 ----
-
-    /**
-     * Disk full on moveFile: FakeDownloadFileManager.moveFile throws IOException("ENOSPC").
-     * Function propagates it.
-     */
-    @Test
-    fun `disk full on move — IOException with ENOSPC message`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                val binaryEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteArray(1000) { 0x42 },
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
-                        )
-                    }
-
-                val result =
-                    downloadAudioFile(
-                        audioFileId = "file-1",
-                        bookId = "book-1",
-                        filename = "file-1.mp3",
-                        expectedSize = 1000L,
-                        httpClient = productionLikeClient(binaryEngine),
-                        repository = fakeRepo,
-                        fileManager = FailingMoveFileManager(tmpRoot),
-                        playbackRpcFactory = readyRpcFactory(),
-                    )
-
-                // The internal IOException("Failed to move...") is caught by suspendRunCatching
-                // and routed through ErrorMapper, which classifies IOException as
-                // TransportError.NetworkUnavailable. The user-actionable detail (failed-to-move
-                // message) lives in [debugInfo]; the worker's storage-keyword string-match runs
-                // against debugInfo to detect ENOSPC-class failures.
-                assertIs<AppResult.Failure>(result)
-                assertIs<TransportError.NetworkUnavailable>(result.error)
-                assertTrue(
-                    result.error.debugInfo?.contains("Failed to move") == true,
-                    "Expected 'Failed to move' in debugInfo: ${result.error.debugInfo}",
-                )
-            } finally {
-                tmpRoot.deleteRecursively()
-            }
-        }
-
-    // ---- Scenario 9 ----
-
-    /**
-     * Cancellation: isStopped = { true } causes CancellationException in the stream loop.
-     *
-     * The function throws; the worker's CancellationException catch calls markPaused. This
-     * test replicates that catch to assert PAUSED — catching a regression where an incorrect
-     * handler could burn the retry budget on a user-initiated pause.
-     */
-    @Test
-    fun `cancellation via isStopped — throws CancellationException`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
-                val binaryEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteArray(1000) { 0x42 },
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
-                        )
-                    }
-
-                // Replicate the worker's CancellationException catch: markPaused on isStopped.
-                try {
-                    downloadAudioFile(
-                        audioFileId = "file-1",
-                        bookId = "book-1",
-                        filename = "file-1.mp3",
-                        expectedSize = 1000L,
-                        httpClient = productionLikeClient(binaryEngine),
-                        repository = fakeRepo,
-                        fileManager = fileManagerFor(tmpRoot),
-                        playbackRpcFactory = readyRpcFactory(),
-                        isStopped = { true },
-                    )
-                } catch (e: CancellationException) {
-                    // Replicate worker's cancellation catch: markPaused (not markFailed).
-                    fakeRepo.markPaused("file-1")
+                    fakeRepo.entities.single().state shouldBe DownloadState.COMPLETED
+                    attemptCount shouldBe 2
+                } finally {
+                    tmpRoot.deleteRecursively()
                 }
-
-                assertEquals(DownloadState.PAUSED, fakeRepo.entities.single().state)
-            } finally {
-                tmpRoot.deleteRecursively()
             }
         }
 
-    // ---- Scenario 10 ----
+        // ---- Scenario 6 ----
 
-    /**
-     * Progress throttling: 2 MB body; updateProgress should be called far fewer times than
-     * the number of 8KB chunks (256 chunks). Throttle logic: 256 KB or 500 ms interval.
-     * runTest virtual clock means time-based throttle does not fire; only byte-count threshold
-     * applies → at most ~8 progress emits for 2MB (every 256KB).
-     */
-    @Test
-    fun `progress throttling — updateProgress called sparsely not per-chunk`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val bodySize = 2 * 1024 * 1024 // 2MB
-                var progressCallCount = 0
-                val trackingRepo =
-                    object : FakeDownloadRepository(
-                        initial = listOf(entity("file-1", totalBytes = bodySize.toLong())),
-                    ) {
-                        override suspend fun updateProgress(
-                            audioFileId: String,
-                            downloadedBytes: Long,
-                            totalBytes: Long,
-                        ): AppResult<Unit> {
-                            progressCallCount++
-                            return super.updateProgress(audioFileId, downloadedBytes, totalBytes)
+        // 500 persistent → 3 retries exhausted → throws.
+        // 1 original + 3 retries = 4 total engine invocations before exception.
+        test("500 persistent — retries exhausted and throws") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                    var attemptCount = 0
+
+                    val retryEngine =
+                        MockEngine { _ ->
+                            attemptCount++
+                            respondError(HttpStatusCode.InternalServerError)
                         }
-                    }
 
-                val binaryEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteArray(bodySize) { 0x42 },
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentLength, bodySize.toString()),
+                    val result =
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = retryProductionLikeClient(retryEngine),
+                            repository = fakeRepo,
+                            fileManager = fileManagerFor(tmpRoot),
+                            playbackRpcFactory = readyRpcFactory(),
                         )
-                    }
 
-                downloadAudioFile(
-                    audioFileId = "file-1",
-                    bookId = "book-1",
-                    filename = "file-1.mp3",
-                    expectedSize = bodySize.toLong(),
-                    httpClient = productionLikeClient(binaryEngine),
-                    repository = trackingRepo,
-                    fileManager = fileManagerFor(tmpRoot),
-                    playbackRpcFactory = readyRpcFactory(),
-                )
-
-                assertEquals(DownloadState.COMPLETED, trackingRepo.entities.single().state)
-                // 2MB / 256KB threshold = 8 byte-interval triggers + 1 initial = ≤9.
-                // Allow up to 20 to accommodate rounding; strict bound is 256 (one per chunk).
-                assertTrue(
-                    progressCallCount < 20,
-                    "Expected sparse progress (<20 calls) for 2MB but got $progressCallCount",
-                )
-            } finally {
-                tmpRoot.deleteRecursively()
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+                    attemptCount shouldBe 4 // 1 original + 3 retries
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
             }
         }
 
-    // ---- Scenario 11 ----
+        // ---- Scenario 7 ----
 
-    /**
-     * prepare() returns Failure → downloadAudioFile returns AppResult.Failure.
-     *
-     * When prepare() fails (RPC error, network, etc.), the download fails cleanly rather than
-     * falling back to a bare URL.
-     */
-    @Test
-    fun `prepare failure propagates as AppResult Failure`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                val failingRpcFactory =
-                    FakePlaybackRpcFactory(
-                        AppResult.Failure(
-                            com.calypsan.listenup.api.error.TransportError.NetworkUnavailable(
-                                debugInfo = "simulated rpc failure",
-                            ),
-                        ),
-                    )
+        // Network drop mid-stream: response body is shorter than Content-Length.
+        // Size mismatch triggers IOException from the function.
+        //
+        // The function throws; the worker's IOException catch calls handleRetryableError which
+        // calls markFailed. This test replicates that catch to assert FAILED — catching a
+        // regression where an incorrect handler could silently swallow the error.
+        test("network drop mid-stream — IOException on size mismatch") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                    // Server claims 1000 bytes but only sends 200 → size mismatch IOException
+                    val dropEngine =
+                        MockEngine { _ ->
+                            respond(
+                                content = ByteReadChannel(ByteArray(200) { 0x42 }),
+                                status = HttpStatusCode.OK,
+                                headers =
+                                    headersOf(
+                                        HttpHeaders.ContentLength to listOf("1000"),
+                                        HttpHeaders.ContentType to listOf(ContentType.Application.OctetStream.toString()),
+                                    ),
+                            )
+                        }
 
-                val unusedEngine =
-                    MockEngine { request ->
-                        error("Unexpected HTTP request: ${request.url} — worker should have failed before download")
-                    }
+                    // Replicate the worker's failure path: handleFailure calls markFailed for IO-class
+                    // failures (ErrorMapper maps IOException → TransportError.NetworkUnavailable).
+                    val result =
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = productionLikeClient(dropEngine),
+                            repository = fakeRepo,
+                            fileManager = fileManagerFor(tmpRoot),
+                            playbackRpcFactory = readyRpcFactory(),
+                        )
 
-                val result =
-                    downloadAudioFile(
-                        audioFileId = "file-1",
-                        bookId = "book-1",
-                        filename = "file-1.mp3",
-                        expectedSize = 1000L,
-                        httpClient = productionLikeClient(unusedEngine),
-                        repository = fakeRepo,
-                        fileManager = fileManagerFor(tmpRoot),
-                        playbackRpcFactory = failingRpcFactory,
-                    )
+                    val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                    fakeRepo.markFailed("file-1", DownloadError.DownloadFailed(debugInfo = failure.error.debugInfo))
 
-                assertIs<AppResult.Failure>(result)
-            } finally {
-                tmpRoot.deleteRecursively()
+                    fakeRepo.entities.single().state shouldBe DownloadState.FAILED
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
             }
         }
 
-    // ---- Scenario 12 ----
+        // ---- Scenario 8 ----
 
-    /**
-     * prepare() resolves a signed URL: MockEngine verifies the path is the signed URL from prepare.
-     */
-    @Test
-    fun `signed URL from prepare is used for download`() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
-                val signedPath = "/api/v1/audio/book-1/file-1"
-                val signedQuery = "u=&exp=123&sig=abc"
-                val rpcFactory = readyRpcFactory(streamUrl = "$signedPath?$signedQuery")
-
-                var resolvedPathHit = false
-                val resolvedEngine =
-                    MockEngine { request ->
-                        val fullPath = request.url.encodedPath + "?" + (request.url.encodedQuery ?: "")
-                        if (request.url.encodedPath == signedPath) {
-                            resolvedPathHit = true
+        // Disk full on moveFile: FakeDownloadFileManager.moveFile throws IOException("ENOSPC").
+        // Function propagates it.
+        test("disk full on move — IOException with ENOSPC message") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    val binaryEngine =
+                        MockEngine { _ ->
                             respond(
                                 content = ByteArray(1000) { 0x42 },
                                 status = HttpStatusCode.OK,
                                 headers = headersOf(HttpHeaders.ContentLength, "1000"),
                             )
-                        } else {
-                            error("Unexpected path: $fullPath (expected $signedPath)")
                         }
+
+                    val result =
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = productionLikeClient(binaryEngine),
+                            repository = fakeRepo,
+                            fileManager = FailingMoveFileManager(tmpRoot),
+                            playbackRpcFactory = readyRpcFactory(),
+                        )
+
+                    // The internal IOException("Failed to move...") is caught by suspendRunCatching
+                    // and routed through ErrorMapper, which classifies IOException as
+                    // TransportError.NetworkUnavailable. The user-actionable detail (failed-to-move
+                    // message) lives in [debugInfo]; the worker's storage-keyword string-match runs
+                    // against debugInfo to detect ENOSPC-class failures.
+                    val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                    failure.error.shouldBeInstanceOf<TransportError.NetworkUnavailable>()
+                    withClue("Expected 'Failed to move' in debugInfo: ${failure.error.debugInfo}") {
+                        (failure.error.debugInfo?.contains("Failed to move") == true) shouldBe true
                     }
-
-                downloadAudioFile(
-                    audioFileId = "file-1",
-                    bookId = "book-1",
-                    filename = "file-1.mp3",
-                    expectedSize = 1000L,
-                    httpClient = productionLikeClient(resolvedEngine),
-                    repository = fakeRepo,
-                    fileManager = fileManagerFor(tmpRoot),
-                    playbackRpcFactory = rpcFactory,
-                )
-
-                assertTrue(resolvedPathHit, "Expected download to hit signed URL path $signedPath")
-                assertEquals(DownloadState.COMPLETED, fakeRepo.entities.single().state)
-            } finally {
-                tmpRoot.deleteRecursively()
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
             }
         }
 
-    // ---- Scenario 13 ----
+        // ---- Scenario 9 ----
 
-    /**
-     * User-cancel path: cancellation leaves a .tmp on disk; sweepOrphanedTempFiles removes it.
-     *
-     * The worker's CancellationException catch block lives in [DownloadWorker.doWork], which is
-     * Android-only and not reachable from [downloadAudioFile]. The sweep is the durable cleanup
-     * path (called from resumeIncompleteDownloads on startup). This test asserts that invariant:
-     * after a cancelled download, the .tmp is absent from active ids and the sweep removes it.
-     */
-    @Test
-    fun sweepRemovesOrphanedTmpPartial() =
-        runTest {
-            val tmpRoot = tempDir()
-            try {
-                val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
-                val binaryEngine =
-                    MockEngine { _ ->
-                        respond(
-                            content = ByteArray(1000) { 0x42 },
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentLength, "1000"),
-                        )
-                    }
-                val fileManager = fileManagerFor(tmpRoot)
-
-                // Run the download but stop it immediately — simulates a mid-download cancellation.
+        // Cancellation: isStopped = { true } causes CancellationException in the stream loop.
+        //
+        // The function throws; the worker's CancellationException catch calls markPaused. This
+        // test replicates that catch to assert PAUSED — catching a regression where an incorrect
+        // handler could burn the retry budget on a user-initiated pause.
+        test("cancellation via isStopped — throws CancellationException") {
+            runTest {
+                val tmpRoot = tempDir()
                 try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                    val binaryEngine =
+                        MockEngine { _ ->
+                            respond(
+                                content = ByteArray(1000) { 0x42 },
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                            )
+                        }
+
+                    // Replicate the worker's CancellationException catch: markPaused on isStopped.
+                    try {
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = productionLikeClient(binaryEngine),
+                            repository = fakeRepo,
+                            fileManager = fileManagerFor(tmpRoot),
+                            playbackRpcFactory = readyRpcFactory(),
+                            isStopped = { true },
+                        )
+                    } catch (e: CancellationException) {
+                        // Replicate worker's cancellation catch: markPaused (not markFailed).
+                        fakeRepo.markPaused("file-1")
+                    }
+
+                    fakeRepo.entities.single().state shouldBe DownloadState.PAUSED
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+
+        // ---- Scenario 10 ----
+
+        // Progress throttling: 2 MB body; updateProgress should be called far fewer times than
+        // the number of 8KB chunks (256 chunks). Throttle logic: 256 KB or 500 ms interval.
+        // runTest virtual clock means time-based throttle does not fire; only byte-count threshold
+        // applies → at most ~8 progress emits for 2MB (every 256KB).
+        test("progress throttling — updateProgress called sparsely not per-chunk") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val bodySize = 2 * 1024 * 1024 // 2MB
+                    var progressCallCount = 0
+                    val trackingRepo =
+                        object : FakeDownloadRepository(
+                            initial = listOf(entity("file-1", totalBytes = bodySize.toLong())),
+                        ) {
+                            override suspend fun updateProgress(
+                                audioFileId: String,
+                                downloadedBytes: Long,
+                                totalBytes: Long,
+                            ): AppResult<Unit> {
+                                progressCallCount++
+                                return super.updateProgress(audioFileId, downloadedBytes, totalBytes)
+                            }
+                        }
+
+                    val binaryEngine =
+                        MockEngine { _ ->
+                            respond(
+                                content = ByteArray(bodySize) { 0x42 },
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentLength, bodySize.toString()),
+                            )
+                        }
+
+                    downloadAudioFile(
+                        audioFileId = "file-1",
+                        bookId = "book-1",
+                        filename = "file-1.mp3",
+                        expectedSize = bodySize.toLong(),
+                        httpClient = productionLikeClient(binaryEngine),
+                        repository = trackingRepo,
+                        fileManager = fileManagerFor(tmpRoot),
+                        playbackRpcFactory = readyRpcFactory(),
+                    )
+
+                    trackingRepo.entities.single().state shouldBe DownloadState.COMPLETED
+                    // 2MB / 256KB threshold = 8 byte-interval triggers + 1 initial = ≤9.
+                    // Allow up to 20 to accommodate rounding; strict bound is 256 (one per chunk).
+                    withClue("Expected sparse progress (<20 calls) for 2MB but got $progressCallCount") {
+                        (progressCallCount < 20) shouldBe true
+                    }
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+
+        // ---- Scenario 11 ----
+
+        // prepare() returns Failure → downloadAudioFile returns AppResult.Failure.
+        //
+        // When prepare() fails (RPC error, network, etc.), the download fails cleanly rather than
+        // falling back to a bare URL.
+        test("prepare failure propagates as AppResult Failure") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    val failingRpcFactory =
+                        FakePlaybackRpcFactory(
+                            AppResult.Failure(
+                                com.calypsan.listenup.api.error.TransportError.NetworkUnavailable(
+                                    debugInfo = "simulated rpc failure",
+                                ),
+                            ),
+                        )
+
+                    val unusedEngine =
+                        MockEngine { request ->
+                            error("Unexpected HTTP request: ${request.url} — worker should have failed before download")
+                        }
+
+                    val result =
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = productionLikeClient(unusedEngine),
+                            repository = fakeRepo,
+                            fileManager = fileManagerFor(tmpRoot),
+                            playbackRpcFactory = failingRpcFactory,
+                        )
+
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+
+        // ---- Scenario 12 ----
+
+        // prepare() resolves a signed URL: MockEngine verifies the path is the signed URL from prepare.
+        test("signed URL from prepare is used for download") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1", totalBytes = 1000L)))
+                    val signedPath = "/api/v1/audio/book-1/file-1"
+                    val signedQuery = "u=&exp=123&sig=abc"
+                    val rpcFactory = readyRpcFactory(streamUrl = "$signedPath?$signedQuery")
+
+                    var resolvedPathHit = false
+                    val resolvedEngine =
+                        MockEngine { request ->
+                            val fullPath = request.url.encodedPath + "?" + (request.url.encodedQuery ?: "")
+                            if (request.url.encodedPath == signedPath) {
+                                resolvedPathHit = true
+                                respond(
+                                    content = ByteArray(1000) { 0x42 },
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                                )
+                            } else {
+                                error("Unexpected path: $fullPath (expected $signedPath)")
+                            }
+                        }
+
                     downloadAudioFile(
                         audioFileId = "file-1",
                         bookId = "book-1",
                         filename = "file-1.mp3",
                         expectedSize = 1000L,
-                        httpClient = productionLikeClient(binaryEngine),
+                        httpClient = productionLikeClient(resolvedEngine),
                         repository = fakeRepo,
-                        fileManager = fileManager,
-                        playbackRpcFactory = readyRpcFactory(),
-                        isStopped = { true },
+                        fileManager = fileManagerFor(tmpRoot),
+                        playbackRpcFactory = rpcFactory,
                     )
-                } catch (_: CancellationException) {
-                    // Replicate the user-cancel path: DownloadManager.cancelDownload writes CANCELLED.
-                    fakeRepo.markCancelled("file-1")
+
+                    withClue("Expected download to hit signed URL path $signedPath") {
+                        resolvedPathHit shouldBe true
+                    }
+                    fakeRepo.entities.single().state shouldBe DownloadState.COMPLETED
+                } finally {
+                    tmpRoot.deleteRecursively()
                 }
-
-                val tempPath = fileManager.getAudioFilePath("book-1", "file-1", "file-1.mp3", isTemp = true)
-                // The .tmp may or may not exist depending on how many bytes were written before
-                // isStopped fired. Either way, sweepOrphanedTempFiles must not leave it behind.
-                // Seed a known orphan .tmp to guarantee there is something for the sweep to delete.
-                if (!SystemFileSystem.exists(tempPath)) {
-                    SystemFileSystem.sink(tempPath).use { it }
-                }
-
-                // Sweep with empty activeIds (all cancelled → no active download ids).
-                val swept = fileManager.sweepOrphanedTempFiles(emptySet())
-
-                assertTrue(swept >= 1, "Expected sweep to delete at least 1 orphaned .tmp, got $swept")
-                assertTrue(!SystemFileSystem.exists(tempPath), "Expected .tmp to be deleted by sweep")
-            } finally {
-                tmpRoot.deleteRecursively()
             }
         }
 
-    // ---- Utility ----
+        // ---- Scenario 13 ----
 
-    private fun tempDir(): File = File(System.getProperty("java.io.tmpdir"), "dwlt-${System.nanoTime()}").also { it.mkdirs() }
-}
+        // User-cancel path: cancellation leaves a .tmp on disk; sweepOrphanedTempFiles removes it.
+        //
+        // The worker's CancellationException catch block lives in [DownloadWorker.doWork], which is
+        // Android-only and not reachable from [downloadAudioFile]. The sweep is the durable cleanup
+        // path (called from resumeIncompleteDownloads on startup). This test asserts that invariant:
+        // after a cancelled download, the .tmp is absent from active ids and the sweep removes it.
+        test("sweepRemovesOrphanedTmpPartial") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val fakeRepo = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                    val binaryEngine =
+                        MockEngine { _ ->
+                            respond(
+                                content = ByteArray(1000) { 0x42 },
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentLength, "1000"),
+                            )
+                        }
+                    val fileManager = fileManagerFor(tmpRoot)
+
+                    // Run the download but stop it immediately — simulates a mid-download cancellation.
+                    try {
+                        downloadAudioFile(
+                            audioFileId = "file-1",
+                            bookId = "book-1",
+                            filename = "file-1.mp3",
+                            expectedSize = 1000L,
+                            httpClient = productionLikeClient(binaryEngine),
+                            repository = fakeRepo,
+                            fileManager = fileManager,
+                            playbackRpcFactory = readyRpcFactory(),
+                            isStopped = { true },
+                        )
+                    } catch (_: CancellationException) {
+                        // Replicate the user-cancel path: DownloadManager.cancelDownload writes CANCELLED.
+                        fakeRepo.markCancelled("file-1")
+                    }
+
+                    val tempPath = fileManager.getAudioFilePath("book-1", "file-1", "file-1.mp3", isTemp = true)
+                    // The .tmp may or may not exist depending on how many bytes were written before
+                    // isStopped fired. Either way, sweepOrphanedTempFiles must not leave it behind.
+                    // Seed a known orphan .tmp to guarantee there is something for the sweep to delete.
+                    if (!SystemFileSystem.exists(tempPath)) {
+                        SystemFileSystem.sink(tempPath).use { it }
+                    }
+
+                    // Sweep with empty activeIds (all cancelled → no active download ids).
+                    val swept = fileManager.sweepOrphanedTempFiles(emptySet())
+
+                    withClue("Expected sweep to delete at least 1 orphaned .tmp, got $swept") {
+                        (swept >= 1) shouldBe true
+                    }
+                    withClue("Expected .tmp to be deleted by sweep") {
+                        !SystemFileSystem.exists(tempPath) shouldBe true
+                    }
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+    })
 
 // ---- Fakes ----
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -24,18 +24,15 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Verifies the isBuffering and playbackState flows added in W7 Phase E2.1 Task 1,
@@ -46,368 +43,411 @@ import kotlin.test.assertTrue
  * observation in startPlayback.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class PlaybackManagerBufferingStateTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+class PlaybackManagerBufferingStateTest :
+    FunSpec({
+        fun createPlaybackManager(
+            db: ListenUpDatabase,
+            scope: CoroutineScope = CoroutineScope(Job()),
+            progressTracker: ProgressTracker = buildProgressTracker(scope = scope),
+        ): PlaybackManager {
+            val tokenProvider: AudioTokenProvider = mock()
+            everySuspend { tokenProvider.prepareForPlayback() } returns Unit
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
+            val serverConfig: ServerConfig = mock()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
 
-    @Test
-    fun `setBuffering updates isBuffering flow`() =
-        runTest {
-            val sut = createPlaybackManager()
+            val imageStorage: ImageStorage = mock()
+            every { imageStorage.exists(any()) } returns false
 
-            assertEquals(false, sut.isBuffering.value)
+            val downloadService: DownloadService = mock()
+            everySuspend { downloadService.getLocalPath(any()) } returns null
+            everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+            everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
-            sut.setBuffering(true)
-            assertEquals(true, sut.isBuffering.value)
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
 
-            sut.setBuffering(false)
-            assertEquals(false, sut.isBuffering.value)
-        }
-
-    @Test
-    fun `setPlaybackState updates playbackState flow`() =
-        runTest {
-            val sut = createPlaybackManager()
-
-            assertEquals(PlaybackState.Idle, sut.playbackState.value)
-
-            sut.setPlaybackState(PlaybackState.Playing)
-            assertEquals(PlaybackState.Playing, sut.playbackState.value)
-
-            sut.setPlaybackState(PlaybackState.Buffering)
-            assertEquals(PlaybackState.Buffering, sut.playbackState.value)
-        }
-
-    @Test
-    fun `startPlayback subscribes to AudioPlayer state and forwards to PlaybackManager`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            // Use coroutineContext + Job() so launched coroutines share the
-            // TestCoroutineScheduler (and are advanced by advanceUntilIdle()) while the
-            // Job is independent of the TestScope — allowing explicit cancellation at the
-            // end without tearing down the test harness.
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val sut = createPlaybackManager(scope = managerScope)
-
-            val player = FakePlayer()
-
-            val prepareResult = sut.prepareForPlayback(BookId("book-1"))
-            checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
-            sut.activateBook(BookId("book-1"))
-
-            // startPlayback launches the observation coroutines on managerScope.
-            sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
-
-            // FakePlayer.load() drives state → Buffering; play() drives state → Playing.
-            // Drain pending coroutines so the collectors process the latest emission.
-            advanceUntilIdle()
-
-            // After play(), FakePlayer emits Playing — expect state forwarded.
-            assertEquals(PlaybackState.Playing, sut.playbackState.value)
-            assertFalse(sut.isBuffering.value, "Playing state must clear isBuffering")
-
-            // Now drive the player to Buffering and verify forwarding.
-            player.emitState(PlaybackState.Buffering)
-            advanceUntilIdle()
-
-            assertEquals(PlaybackState.Buffering, sut.playbackState.value)
-            assertEquals(true, sut.isBuffering.value)
-
-            // clearPlayback must cancel observations — further emissions must not propagate.
-            sut.clearPlayback()
-            player.emitState(PlaybackState.Playing)
-            advanceUntilIdle()
-
-            // clearPlayback resets to Idle regardless of what the player emits.
-            assertEquals(PlaybackState.Idle, sut.playbackState.value)
-            assertFalse(sut.isBuffering.value, "clearPlayback must reset isBuffering to false")
-
-            // Cancel to stop the infinite collect coroutines and let runTest complete.
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    @Test
-    fun `playerObservationJob surfaces PlaybackState_Error as PlaybackError on playbackError flow`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val sut = createPlaybackManager(scope = managerScope)
-            val player = FakePlayer()
-
-            val prepareResult = sut.prepareForPlayback(BookId("book-1"))
-            checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
-            sut.activateBook(BookId("book-1"))
-
-            sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
-            advanceUntilIdle()
-
-            assertNull(sut.playbackError.value)
-
-            player.emitState(PlaybackState.Error(message = "GStreamer hosed", isRecoverable = false))
-            advanceUntilIdle()
-
-            val error = sut.playbackError.value
-            assertNotNull(error)
-            assertEquals("GStreamer hosed", error.message)
-            assertEquals(false, error.isRecoverable)
-
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    @Test
-    fun `playerObservationJob clears playbackError on transition to Playing`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val sut = createPlaybackManager(scope = managerScope)
-            val player = FakePlayer()
-
-            val prepareResult = sut.prepareForPlayback(BookId("book-1"))
-            checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
-            sut.activateBook(BookId("book-1"))
-
-            sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
-            advanceUntilIdle()
-
-            player.emitState(PlaybackState.Error(message = "transient", isRecoverable = true))
-            advanceUntilIdle()
-            val midError = sut.playbackError.value
-            assertNotNull(midError)
-            assertEquals(true, midError.isRecoverable)
-
-            player.emitState(PlaybackState.Playing)
-            advanceUntilIdle()
-            assertNull(sut.playbackError.value)
-
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    @Test
-    fun `playerObservationJob notifies progressTracker onPlaybackStarted when player transitions to Playing`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val progressTracker = buildFakeProgressTracker(scope = managerScope)
-
-            val sut = createPlaybackManager(scope = managerScope, progressTracker = progressTracker)
-            val player = FakePlayer()
-
-            val prepareResult = sut.prepareForPlayback(BookId("book-1"))
-            checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
-            sut.activateBook(BookId("book-1"))
-            sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
-            advanceUntilIdle()
-
-            // FakePlayer's play() emits Playing — verify progressTracker was notified.
-            val startedCount = progressTracker.onPlaybackStartedCalls.count { it.first == BookId("book-1") }
-            assertTrue(
-                startedCount >= 1,
-                "expected at least one onPlaybackStarted(BookId(\"book-1\"), …) invocation, got $startedCount",
+            return PlaybackManagerImpl(
+                serverConfig = serverConfig,
+                playbackPreferences = playbackPreferences,
+                bookDao = db.bookDao(),
+                audioFileDao = db.audioFileDao(),
+                chapterDao = db.chapterDao(),
+                imageStorage = imageStorage,
+                progressTracker = progressTracker,
+                tokenProvider = tokenProvider,
+                deviceContext = DeviceContext(type = DeviceType.Phone),
+                downloadService = downloadService,
+                playbackRpcFactory = testPlaybackRpcFactory("af-0"),
+                syncApi = null,
+                scope = scope,
+                bookRepository = mock<BookRepository>(),
             )
-
-            managerScope.coroutineContext[Job]?.cancel()
         }
 
-    @Test
-    fun `playerObservationJob notifies progressTracker onPlaybackPaused when player transitions to Paused`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val progressTracker = buildFakeProgressTracker(scope = managerScope)
-
-            val sut = createPlaybackManager(scope = managerScope, progressTracker = progressTracker)
-            val player = FakePlayer()
-
-            val prepareResult = sut.prepareForPlayback(BookId("book-1"))
-            checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
-            sut.activateBook(BookId("book-1"))
-            sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
-            advanceUntilIdle()
-
-            player.emitState(PlaybackState.Paused)
-            advanceUntilIdle()
-
-            val pausedCount = progressTracker.onPlaybackPausedCalls.count { it.first == BookId("book-1") }
-            assertTrue(
-                pausedCount >= 1,
-                "expected at least one onPlaybackPaused(BookId(\"book-1\"), …) invocation, got $pausedCount",
-            )
-
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    // -------------------------------------------------------------------------
-    // Drift #28 — Android arm. PlaybackStateWriter (implemented by PlaybackManager)
-    // is the seam Android's MediaControllerHolder.Player.Listener pushes state
-    // changes through. Verify setPlaybackState routes Playing/Paused transitions
-    // to the progressTracker so VMs no longer call it directly. MediaControllerHolder
-    // → PlaybackStateWriter forwarding is independently covered by
-    // MediaControllerHolderTest in composeApp/src/androidHostTest.
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `setPlaybackState Playing notifies progressTracker onPlaybackStarted`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val progressTracker = buildFakeProgressTracker(scope = managerScope)
-
-            val sut = createPlaybackManager(scope = managerScope, progressTracker = progressTracker)
-
-            // Activate the book WITHOUT starting an AudioPlayer — this mirrors the
-            // Android path where Media3 drives state transitions and the writer
-            // pushes them into PlaybackManager.
-            checkNotNull(sut.prepareForPlayback(BookId("book-1")))
-            sut.activateBook(BookId("book-1"))
-
-            sut.setPlaybackState(PlaybackState.Playing)
-            advanceUntilIdle()
-
-            val startedCount = progressTracker.onPlaybackStartedCalls.count { it.first == BookId("book-1") }
-            assertTrue(
-                startedCount >= 1,
-                "expected at least one onPlaybackStarted(BookId(\"book-1\"), …) invocation, got $startedCount",
-            )
-
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    @Test
-    fun `setPlaybackState Paused notifies progressTracker onPlaybackPaused`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val progressTracker = buildFakeProgressTracker(scope = managerScope)
-
-            val sut = createPlaybackManager(scope = managerScope, progressTracker = progressTracker)
-
-            checkNotNull(sut.prepareForPlayback(BookId("book-1")))
-            sut.activateBook(BookId("book-1"))
-
-            sut.setPlaybackState(PlaybackState.Paused)
-            advanceUntilIdle()
-
-            val pausedCount = progressTracker.onPlaybackPausedCalls.count { it.first == BookId("book-1") }
-            assertTrue(
-                pausedCount >= 1,
-                "expected at least one onPlaybackPaused(BookId(\"book-1\"), …) invocation, got $pausedCount",
-            )
-
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    @Test
-    fun `setPlaybackState does not notify progressTracker when no book is active`() =
-        runTest {
-            val managerScope = CoroutineScope(coroutineContext + Job())
-            val progressTracker = buildFakeProgressTracker(scope = managerScope)
-
-            val sut = createPlaybackManager(scope = managerScope, progressTracker = progressTracker)
-
-            // No activateBook() — currentBookId is null.
-            sut.setPlaybackState(PlaybackState.Playing)
-            sut.setPlaybackState(PlaybackState.Paused)
-            advanceUntilIdle()
-
-            assertEquals(0, progressTracker.onPlaybackStartedCalls.size)
-            assertEquals(0, progressTracker.onPlaybackPausedCalls.size)
-
-            managerScope.coroutineContext[Job]?.cancel()
-        }
-
-    // =========================================================================
-    // Fixture helpers
-    // =========================================================================
-
-    private fun createPlaybackManager(
-        scope: CoroutineScope = CoroutineScope(Job()),
-        progressTracker: ProgressTracker = buildProgressTracker(scope = scope),
-    ): PlaybackManager {
-        val tokenProvider: AudioTokenProvider = mock()
-        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
-
-        val serverConfig: ServerConfig = mock()
-        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
-
-        val imageStorage: ImageStorage = mock()
-        every { imageStorage.exists(any()) } returns false
-
-        val downloadService: DownloadService = mock()
-        everySuspend { downloadService.getLocalPath(any()) } returns null
-        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
-
-        val playbackPreferences: PlaybackPreferences = mock()
-        everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
-
-        return PlaybackManagerImpl(
-            serverConfig = serverConfig,
-            playbackPreferences = playbackPreferences,
-            bookDao = db.bookDao(),
-            audioFileDao = db.audioFileDao(),
-            chapterDao = db.chapterDao(),
-            imageStorage = imageStorage,
-            progressTracker = progressTracker,
-            tokenProvider = tokenProvider,
-            deviceContext = DeviceContext(type = DeviceType.Phone),
-            downloadService = downloadService,
-            playbackRpcFactory = testPlaybackRpcFactory("af-0"),
-            syncApi = null,
-            scope = scope,
-            bookRepository = mock<BookRepository>(),
-        )
-    }
-
-    private suspend fun seedBookAndAudioFiles() {
-        db.bookDao().upsert(
-            BookEntity(
-                id = BookId("book-1"),
-                libraryId = LibraryId("test-library"),
-                folderId = FolderId("test-folder"),
-                title = "Test Book",
-                sortTitle = "Test Book",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 1_800_000L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-        db.audioFileDao().upsertAll(
-            listOf(
-                AudioFileEntity(
-                    bookId = BookId("book-1"),
-                    index = 0,
-                    id = "af-0",
-                    filename = "chapter1.m4b",
-                    format = "m4b",
-                    codec = "aac",
-                    duration = 1_800_000L,
-                    size = 45_000_000L,
+        suspend fun seedBookAndAudioFiles(db: ListenUpDatabase) {
+            db.bookDao().upsert(
+                BookEntity(
+                    id = BookId("book-1"),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = "Test Book",
+                    sortTitle = "Test Book",
+                    subtitle = null,
+                    coverHash = null,
+                    coverBlurHash = null,
+                    dominantColor = null,
+                    darkMutedColor = null,
+                    vibrantColor = null,
+                    totalDuration = 1_800_000L,
+                    description = null,
+                    publishYear = null,
+                    publisher = null,
+                    language = null,
+                    isbn = null,
+                    asin = null,
+                    abridged = false,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
                 ),
-            ),
-        )
-    }
-}
+            )
+            db.audioFileDao().upsertAll(
+                listOf(
+                    AudioFileEntity(
+                        bookId = BookId("book-1"),
+                        index = 0,
+                        id = "af-0",
+                        filename = "chapter1.m4b",
+                        format = "m4b",
+                        codec = "aac",
+                        duration = 1_800_000L,
+                        size = 45_000_000L,
+                    ),
+                ),
+            )
+        }
+
+        test("setBuffering updates isBuffering flow") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val sut = createPlaybackManager(db)
+
+                    sut.isBuffering.value shouldBe false
+
+                    sut.setBuffering(true)
+                    sut.isBuffering.value shouldBe true
+
+                    sut.setBuffering(false)
+                    sut.isBuffering.value shouldBe false
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("setPlaybackState updates playbackState flow") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val sut = createPlaybackManager(db)
+
+                    sut.playbackState.value shouldBe PlaybackState.Idle
+
+                    sut.setPlaybackState(PlaybackState.Playing)
+                    sut.playbackState.value shouldBe PlaybackState.Playing
+
+                    sut.setPlaybackState(PlaybackState.Buffering)
+                    sut.playbackState.value shouldBe PlaybackState.Buffering
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("startPlayback subscribes to AudioPlayer state and forwards to PlaybackManager") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    // Use coroutineContext + Job() so launched coroutines share the
+                    // TestCoroutineScheduler (and are advanced by advanceUntilIdle()) while the
+                    // Job is independent of the TestScope — allowing explicit cancellation at the
+                    // end without tearing down the test harness.
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val sut = createPlaybackManager(db, scope = managerScope)
+
+                    val player = FakePlayer()
+
+                    val prepareResult = sut.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
+                    sut.activateBook(BookId("book-1"))
+
+                    // startPlayback launches the observation coroutines on managerScope.
+                    sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
+
+                    // FakePlayer.load() drives state → Buffering; play() drives state → Playing.
+                    // Drain pending coroutines so the collectors process the latest emission.
+                    advanceUntilIdle()
+
+                    // After play(), FakePlayer emits Playing — expect state forwarded.
+                    sut.playbackState.value shouldBe PlaybackState.Playing
+                    withClue("Playing state must clear isBuffering") { sut.isBuffering.value shouldBe false }
+
+                    // Now drive the player to Buffering and verify forwarding.
+                    player.emitState(PlaybackState.Buffering)
+                    advanceUntilIdle()
+
+                    sut.playbackState.value shouldBe PlaybackState.Buffering
+                    sut.isBuffering.value shouldBe true
+
+                    // clearPlayback must cancel observations — further emissions must not propagate.
+                    sut.clearPlayback()
+                    player.emitState(PlaybackState.Playing)
+                    advanceUntilIdle()
+
+                    // clearPlayback resets to Idle regardless of what the player emits.
+                    sut.playbackState.value shouldBe PlaybackState.Idle
+                    withClue("clearPlayback must reset isBuffering to false") { sut.isBuffering.value shouldBe false }
+
+                    // Cancel to stop the infinite collect coroutines and let runTest complete.
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("playerObservationJob surfaces PlaybackState_Error as PlaybackError on playbackError flow") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val sut = createPlaybackManager(db, scope = managerScope)
+                    val player = FakePlayer()
+
+                    val prepareResult = sut.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
+                    sut.activateBook(BookId("book-1"))
+
+                    sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
+                    advanceUntilIdle()
+
+                    sut.playbackError.value shouldBe null
+
+                    player.emitState(PlaybackState.Error(message = "GStreamer hosed", isRecoverable = false))
+                    advanceUntilIdle()
+
+                    val error = sut.playbackError.value.shouldNotBeNull()
+                    error.message shouldBe "GStreamer hosed"
+                    error.isRecoverable shouldBe false
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("playerObservationJob clears playbackError on transition to Playing") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val sut = createPlaybackManager(db, scope = managerScope)
+                    val player = FakePlayer()
+
+                    val prepareResult = sut.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
+                    sut.activateBook(BookId("book-1"))
+
+                    sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
+                    advanceUntilIdle()
+
+                    player.emitState(PlaybackState.Error(message = "transient", isRecoverable = true))
+                    advanceUntilIdle()
+                    val midError = sut.playbackError.value.shouldNotBeNull()
+                    midError.isRecoverable shouldBe true
+
+                    player.emitState(PlaybackState.Playing)
+                    advanceUntilIdle()
+                    sut.playbackError.value shouldBe null
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("playerObservationJob notifies progressTracker onPlaybackStarted when player transitions to Playing") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val progressTracker = buildFakeProgressTracker(scope = managerScope)
+
+                    val sut = createPlaybackManager(db, scope = managerScope, progressTracker = progressTracker)
+                    val player = FakePlayer()
+
+                    val prepareResult = sut.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
+                    sut.activateBook(BookId("book-1"))
+                    sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
+                    advanceUntilIdle()
+
+                    // FakePlayer's play() emits Playing — verify progressTracker was notified.
+                    val startedCount = progressTracker.onPlaybackStartedCalls.count { it.first == BookId("book-1") }
+                    withClue(
+                        "expected at least one onPlaybackStarted(BookId(\"book-1\"), …) invocation, got $startedCount",
+                    ) {
+                        (startedCount >= 1) shouldBe true
+                    }
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("playerObservationJob notifies progressTracker onPlaybackPaused when player transitions to Paused") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val progressTracker = buildFakeProgressTracker(scope = managerScope)
+
+                    val sut = createPlaybackManager(db, scope = managerScope, progressTracker = progressTracker)
+                    val player = FakePlayer()
+
+                    val prepareResult = sut.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(prepareResult) { "prepareForPlayback must succeed" }
+                    sut.activateBook(BookId("book-1"))
+                    sut.startPlayback(player = player, resumePositionMs = 0L, resumeSpeed = 1.0f)
+                    advanceUntilIdle()
+
+                    player.emitState(PlaybackState.Paused)
+                    advanceUntilIdle()
+
+                    val pausedCount = progressTracker.onPlaybackPausedCalls.count { it.first == BookId("book-1") }
+                    withClue(
+                        "expected at least one onPlaybackPaused(BookId(\"book-1\"), …) invocation, got $pausedCount",
+                    ) {
+                        (pausedCount >= 1) shouldBe true
+                    }
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // -------------------------------------------------------------------------
+        // Drift #28 — Android arm. PlaybackStateWriter (implemented by PlaybackManager)
+        // is the seam Android's MediaControllerHolder.Player.Listener pushes state
+        // changes through. Verify setPlaybackState routes Playing/Paused transitions
+        // to the progressTracker so VMs no longer call it directly. MediaControllerHolder
+        // → PlaybackStateWriter forwarding is independently covered by
+        // MediaControllerHolderTest in composeApp/src/androidHostTest.
+        // -------------------------------------------------------------------------
+
+        test("setPlaybackState Playing notifies progressTracker onPlaybackStarted") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val progressTracker = buildFakeProgressTracker(scope = managerScope)
+
+                    val sut = createPlaybackManager(db, scope = managerScope, progressTracker = progressTracker)
+
+                    // Activate the book WITHOUT starting an AudioPlayer — this mirrors the
+                    // Android path where Media3 drives state transitions and the writer
+                    // pushes them into PlaybackManager.
+                    checkNotNull(sut.prepareForPlayback(BookId("book-1")))
+                    sut.activateBook(BookId("book-1"))
+
+                    sut.setPlaybackState(PlaybackState.Playing)
+                    advanceUntilIdle()
+
+                    val startedCount = progressTracker.onPlaybackStartedCalls.count { it.first == BookId("book-1") }
+                    withClue(
+                        "expected at least one onPlaybackStarted(BookId(\"book-1\"), …) invocation, got $startedCount",
+                    ) {
+                        (startedCount >= 1) shouldBe true
+                    }
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("setPlaybackState Paused notifies progressTracker onPlaybackPaused") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val progressTracker = buildFakeProgressTracker(scope = managerScope)
+
+                    val sut = createPlaybackManager(db, scope = managerScope, progressTracker = progressTracker)
+
+                    checkNotNull(sut.prepareForPlayback(BookId("book-1")))
+                    sut.activateBook(BookId("book-1"))
+
+                    sut.setPlaybackState(PlaybackState.Paused)
+                    advanceUntilIdle()
+
+                    val pausedCount = progressTracker.onPlaybackPausedCalls.count { it.first == BookId("book-1") }
+                    withClue(
+                        "expected at least one onPlaybackPaused(BookId(\"book-1\"), …) invocation, got $pausedCount",
+                    ) {
+                        (pausedCount >= 1) shouldBe true
+                    }
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("setPlaybackState does not notify progressTracker when no book is active") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val managerScope = CoroutineScope(coroutineContext + Job())
+                    val progressTracker = buildFakeProgressTracker(scope = managerScope)
+
+                    val sut = createPlaybackManager(db, scope = managerScope, progressTracker = progressTracker)
+
+                    // No activateBook() — currentBookId is null.
+                    sut.setPlaybackState(PlaybackState.Playing)
+                    sut.setPlaybackState(PlaybackState.Paused)
+                    advanceUntilIdle()
+
+                    progressTracker.onPlaybackStartedCalls.size shouldBe 0
+                    progressTracker.onPlaybackPausedCalls.size shouldBe 0
+
+                    managerScope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -5,7 +5,6 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.api.result.failureOf
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
@@ -19,13 +18,12 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * Proves [PlaybackPreparer.fetchBookFromServer] delegates the write to
@@ -38,148 +36,150 @@ import kotlin.test.assertTrue
  * Landed as part of W4 Item B (direct DAO writes); updated in W7 Phase B
  * Task 3 to reflect the route-through-repo refactor (drift #9).
  */
-class PlaybackManagerFallbackFetchAtomicityTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+class PlaybackManagerFallbackFetchAtomicityTest :
+    FunSpec({
+        // Minimal-valid [BookResponse] factory. Only `id` and `audioFiles` matter for
+        // this test — everything else is defaulted to empty/null/zero so the test is
+        // insulated from future BookResponse field additions as long as they carry
+        // their own defaults.
+        //
+        // Mirrors the shape used by BookPullerTest.createBookResponse and
+        // BookPullerAtomicityTest's inline construction.
+        fun bookResponseWithAudioFiles(
+            id: String,
+            audioFiles: List<AudioFileResponse>,
+        ): BookResponse =
+            BookResponse(
+                id = id,
+                title = "Rollback Test",
+                subtitle = null,
+                coverImage = null,
+                totalDuration = 3_600_000L,
+                description = null,
+                genres = null,
+                publishYear = null,
+                seriesInfo = emptyList(),
+                chapters = emptyList(),
+                audioFiles = audioFiles,
+                contributors = emptyList(),
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-01-01T00:00:00Z",
+            )
 
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
+        test("fetchBookFromServer delegates write to bookRepository upsertWithAudioFiles") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val syncApi: SyncApiContract = mock()
+                    val bookRepository: BookRepository = mock()
 
-    @Test
-    fun `fetchBookFromServer delegates write to bookRepository upsertWithAudioFiles`() =
-        runTest {
-            val syncApi: SyncApiContract = mock()
-            val bookRepository: BookRepository = mock()
+                    everySuspend { bookRepository.upsertWithAudioFiles(any(), any()) } returns AppResult.Success(Unit)
 
-            everySuspend { bookRepository.upsertWithAudioFiles(any(), any()) } returns AppResult.Success(Unit)
-
-            everySuspend { syncApi.getBook(any()) } returns
-                AppResult.Success(
-                    bookResponseWithAudioFiles(
-                        id = "book-rollback",
-                        audioFiles =
-                            listOf(
-                                AudioFileResponse(
-                                    id = "af-1",
-                                    filename = "chapter01.m4b",
-                                    format = "m4b",
-                                    codec = "aac",
-                                    duration = 1_800_000L,
-                                    size = 45_000_000L,
-                                ),
+                    everySuspend { syncApi.getBook(any()) } returns
+                        AppResult.Success(
+                            bookResponseWithAudioFiles(
+                                id = "book-rollback",
+                                audioFiles =
+                                    listOf(
+                                        AudioFileResponse(
+                                            id = "af-1",
+                                            filename = "chapter01.m4b",
+                                            format = "m4b",
+                                            codec = "aac",
+                                            duration = 1_800_000L,
+                                            size = 45_000_000L,
+                                        ),
+                                    ),
                             ),
-                    ),
-                )
+                        )
 
-            // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
-            val preparer =
-                PlaybackPreparer(
-                    serverConfig = mock(),
-                    playbackPreferences = mock(),
-                    bookDao = db.bookDao(),
-                    audioFileDao = db.audioFileDao(),
-                    chapterDao = db.chapterDao(),
-                    imageStorage = mock(),
-                    progressTracker = buildProgressTracker(),
-                    tokenProvider = mock(),
-                    deviceContext = DeviceContext(type = DeviceType.Phone),
-                    downloadService = mock(),
-                    playbackRpcFactory = testPlaybackRpcFactory("af-1"),
-                    syncApi = syncApi,
-                    scope = CoroutineScope(Job()),
-                    bookRepository = bookRepository,
-                )
+                    // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
+                    val preparer =
+                        PlaybackPreparer(
+                            serverConfig = mock(),
+                            playbackPreferences = mock(),
+                            bookDao = db.bookDao(),
+                            audioFileDao = db.audioFileDao(),
+                            chapterDao = db.chapterDao(),
+                            imageStorage = mock(),
+                            progressTracker = buildProgressTracker(),
+                            tokenProvider = mock(),
+                            deviceContext = DeviceContext(type = DeviceType.Phone),
+                            downloadService = mock(),
+                            playbackRpcFactory = testPlaybackRpcFactory("af-1"),
+                            syncApi = syncApi,
+                            scope = CoroutineScope(Job()),
+                            bookRepository = bookRepository,
+                        )
 
-            val result = preparer.fetchBookFromServer(BookId("book-rollback"))
+                    val result = preparer.fetchBookFromServer(BookId("book-rollback"))
 
-            assertTrue(result, "fetchBookFromServer should return true on success")
-            verifySuspend(VerifyMode.exactly(1)) {
-                bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
+                    withClue("fetchBookFromServer should return true on success") { result shouldBe true }
+                    verifySuspend(VerifyMode.exactly(1)) {
+                        bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
 
-    @Test
-    fun `fetchBookFromServer returns false when upsertWithAudioFiles returns Failure`() =
-        runTest {
-            val syncApi: SyncApiContract = mock()
-            val bookRepository: BookRepository = mock()
+        test("fetchBookFromServer returns false when upsertWithAudioFiles returns Failure") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val syncApi: SyncApiContract = mock()
+                    val bookRepository: BookRepository = mock()
 
-            everySuspend { bookRepository.upsertWithAudioFiles(any(), any()) } returns
-                failureOf("persistence error")
+                    everySuspend { bookRepository.upsertWithAudioFiles(any(), any()) } returns
+                        failureOf("persistence error")
 
-            everySuspend { syncApi.getBook(any()) } returns
-                AppResult.Success(
-                    bookResponseWithAudioFiles(
-                        id = "book-fail",
-                        audioFiles =
-                            listOf(
-                                AudioFileResponse(
-                                    id = "af-1",
-                                    filename = "chapter01.m4b",
-                                    format = "m4b",
-                                    codec = "aac",
-                                    duration = 1_800_000L,
-                                    size = 45_000_000L,
-                                ),
+                    everySuspend { syncApi.getBook(any()) } returns
+                        AppResult.Success(
+                            bookResponseWithAudioFiles(
+                                id = "book-fail",
+                                audioFiles =
+                                    listOf(
+                                        AudioFileResponse(
+                                            id = "af-1",
+                                            filename = "chapter01.m4b",
+                                            format = "m4b",
+                                            codec = "aac",
+                                            duration = 1_800_000L,
+                                            size = 45_000_000L,
+                                        ),
+                                    ),
                             ),
-                    ),
-                )
+                        )
 
-            // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
-            val preparer =
-                PlaybackPreparer(
-                    serverConfig = mock(),
-                    playbackPreferences = mock(),
-                    bookDao = db.bookDao(),
-                    audioFileDao = db.audioFileDao(),
-                    chapterDao = db.chapterDao(),
-                    imageStorage = mock(),
-                    progressTracker = buildProgressTracker(),
-                    tokenProvider = mock(),
-                    deviceContext = DeviceContext(type = DeviceType.Phone),
-                    downloadService = mock(),
-                    playbackRpcFactory = testPlaybackRpcFactory("af-1"),
-                    syncApi = syncApi,
-                    scope = CoroutineScope(Job()),
-                    bookRepository = bookRepository,
-                )
+                    // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
+                    val preparer =
+                        PlaybackPreparer(
+                            serverConfig = mock(),
+                            playbackPreferences = mock(),
+                            bookDao = db.bookDao(),
+                            audioFileDao = db.audioFileDao(),
+                            chapterDao = db.chapterDao(),
+                            imageStorage = mock(),
+                            progressTracker = buildProgressTracker(),
+                            tokenProvider = mock(),
+                            deviceContext = DeviceContext(type = DeviceType.Phone),
+                            downloadService = mock(),
+                            playbackRpcFactory = testPlaybackRpcFactory("af-1"),
+                            syncApi = syncApi,
+                            scope = CoroutineScope(Job()),
+                            bookRepository = bookRepository,
+                        )
 
-            val result = preparer.fetchBookFromServer(BookId("book-fail"))
+                    val result = preparer.fetchBookFromServer(BookId("book-fail"))
 
-            assertFalse(result, "fetchBookFromServer should return false when persistence fails")
-            verifySuspend(VerifyMode.exactly(1)) {
-                bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
+                    withClue("fetchBookFromServer should return false when persistence fails") { result shouldBe false }
+                    verifySuspend(VerifyMode.exactly(1)) {
+                        bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
+                    }
+                }
+            } finally {
+                db.close()
             }
         }
-
-    /**
-     * Minimal-valid [BookResponse] factory. Only `id` and `audioFiles` matter for
-     * this test — everything else is defaulted to empty/null/zero so the test is
-     * insulated from future BookResponse field additions as long as they carry
-     * their own defaults.
-     *
-     * Mirrors the shape used by BookPullerTest.createBookResponse and
-     * BookPullerAtomicityTest's inline construction.
-     */
-    private fun bookResponseWithAudioFiles(
-        id: String,
-        audioFiles: List<AudioFileResponse>,
-    ): BookResponse =
-        BookResponse(
-            id = id,
-            title = "Rollback Test",
-            subtitle = null,
-            coverImage = null,
-            totalDuration = 3_600_000L,
-            description = null,
-            genres = null,
-            publishYear = null,
-            seriesInfo = emptyList(),
-            chapters = emptyList(),
-            audioFiles = audioFiles,
-            contributors = emptyList(),
-            createdAt = "2024-01-01T00:00:00Z",
-            updatedAt = "2024-01-01T00:00:00Z",
-        )
-}
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -6,8 +6,8 @@ import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.core.ServerUrl
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.BookEntityMapper
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
 import com.calypsan.listenup.client.data.sync.handlers.BookSyncDomainHandler
@@ -31,12 +31,11 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Verifies fallback-fetch populates the audio_files junction when local data
@@ -45,178 +44,179 @@ import kotlin.test.assertEquals
  * prepareForPlayback; asserts the junction is populated after the fallback
  * runs.
  */
-class PlaybackManagerFallbackFetchTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    @Test
-    fun `fallback fetch populates audio_files junction when local is empty`() =
-        runTest {
-            val syncApi: SyncApiContract = mock()
-
-            seedBookWithoutAudioFiles()
-
-            everySuspend { syncApi.getBook(any()) } returns
-                AppResult.Success(
-                    bookResponseWithAudioFiles(
-                        id = "book-1",
-                        audioFiles =
-                            listOf(
-                                AudioFileResponse(
-                                    id = "af-1",
-                                    filename = "chapter01.m4b",
-                                    format = "m4b",
-                                    codec = "aac",
-                                    duration = 1_800_000L,
-                                    size = 45_000_000L,
-                                ),
-                                AudioFileResponse(
-                                    id = "af-2",
-                                    filename = "chapter02.m4b",
-                                    format = "m4b",
-                                    codec = "aac",
-                                    duration = 1_800_000L,
-                                    size = 45_000_000L,
-                                ),
-                            ),
-                    ),
-                )
-
-            val playbackManager = createPlaybackManager(syncApi = syncApi)
-
-            playbackManager.prepareForPlayback(BookId("book-1"))
-
-            // After fallback fetch, the junction should be populated.
-            val rows = db.audioFileDao().getForBook("book-1")
-            assertEquals(2, rows.size)
-            assertEquals(listOf("af-1", "af-2"), rows.map { it.id })
-            assertEquals(listOf(0, 1), rows.map { it.index })
+class PlaybackManagerFallbackFetchTest :
+    FunSpec({
+        // Seed the book but do NOT seed audio files.
+        suspend fun seedBookWithoutAudioFiles(db: ListenUpDatabase) {
+            db.bookDao().upsert(
+                BookEntity(
+                    id = BookId("book-1"),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = "Test Book",
+                    sortTitle = "Test Book",
+                    subtitle = null,
+                    coverHash = null,
+                    coverBlurHash = null,
+                    dominantColor = null,
+                    darkMutedColor = null,
+                    vibrantColor = null,
+                    totalDuration = 3_600_000L,
+                    description = null,
+                    publishYear = null,
+                    publisher = null,
+                    language = null,
+                    isbn = null,
+                    asin = null,
+                    abridged = false,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
         }
 
-    private suspend fun seedBookWithoutAudioFiles() {
-        // Seed the book but do NOT seed audio files.
-        db.bookDao().upsert(
-            BookEntity(
-                id = BookId("book-1"),
-                libraryId = LibraryId("test-library"),
-                folderId = FolderId("test-folder"),
-                title = "Test Book",
-                sortTitle = "Test Book",
+        // Minimal-valid [BookResponse] factory. Only `id` and `audioFiles` matter for
+        // this test — everything else is defaulted so the test is insulated from
+        // future BookResponse field additions as long as they carry their own
+        // defaults. Mirrors the helper in [PlaybackManagerFallbackFetchAtomicityTest].
+        fun bookResponseWithAudioFiles(
+            id: String,
+            audioFiles: List<AudioFileResponse>,
+        ): BookResponse =
+            BookResponse(
+                id = id,
+                title = "Fallback Test",
                 subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
+                coverImage = null,
                 totalDuration = 3_600_000L,
                 description = null,
+                genres = null,
                 publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-    }
-
-    /**
-     * Minimal-valid [BookResponse] factory. Only `id` and `audioFiles` matter for
-     * this test — everything else is defaulted so the test is insulated from
-     * future BookResponse field additions as long as they carry their own
-     * defaults. Mirrors the helper in [PlaybackManagerFallbackFetchAtomicityTest].
-     */
-    private fun bookResponseWithAudioFiles(
-        id: String,
-        audioFiles: List<AudioFileResponse>,
-    ): BookResponse =
-        BookResponse(
-            id = id,
-            title = "Fallback Test",
-            subtitle = null,
-            coverImage = null,
-            totalDuration = 3_600_000L,
-            description = null,
-            genres = null,
-            publishYear = null,
-            seriesInfo = emptyList(),
-            chapters = emptyList(),
-            audioFiles = audioFiles,
-            contributors = emptyList(),
-            createdAt = "2024-01-01T00:00:00Z",
-            updatedAt = "2024-01-01T00:00:00Z",
-        )
-
-    private fun createPlaybackManager(syncApi: SyncApiContract): PlaybackManager {
-        val tokenProvider: AudioTokenProvider = mock()
-        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
-
-        val serverConfig: ServerConfig = mock()
-        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
-
-        val imageStorage: ImageStorage = mock()
-        every { imageStorage.exists(any()) } returns false
-
-        val downloadService: DownloadService = mock()
-        everySuspend { downloadService.getLocalPath(any()) } returns null
-        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
-
-        val playbackPreferences: PlaybackPreferences = mock()
-        everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
-
-        // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
-        // prepareForPlayback reads positionRepository; defaultPositionRepository() stubs it to
-        // return null (no saved position), which exercises the fresh-playback path.
-        val progressTracker = buildProgressTracker()
-
-        // Real BookRepositoryImpl backed by the same in-memory DB so that
-        // fetchBookFromServer's call to upsertWithAudioFiles actually writes
-        // to the DB and the junction assertion passes.
-        val txRunner = RoomTransactionRunner(db)
-        val bookRepository: BookRepository =
-            BookRepositoryImpl(
-                bookDao = db.bookDao(),
-                chapterDao = db.chapterDao(),
-                audioFileDao = db.audioFileDao(),
-                searchDao = db.searchDao(),
-                transactionRunner = txRunner,
-                imageStorage = imageStorage,
-                genreRepository = mock(),
-                tagRepository = mock(),
-                networkMonitor = mock(), // intentionally unstubbed — this test exercises upsertWithAudioFiles, not the RPC fallback paths
-                bookRpcFactory = mock(),
-                bookSyncDomainHandler =
-                    BookSyncDomainHandler(
-                        database = db,
-                        mapper = BookEntityMapper(),
-                        transactionRunner = txRunner,
-                        imageStorage = stubImageStorage(),
-                        registry = ClientSyncDomainRegistry(),
-                    ),
+                seriesInfo = emptyList(),
+                chapters = emptyList(),
+                audioFiles = audioFiles,
+                contributors = emptyList(),
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-01-01T00:00:00Z",
             )
 
-        return PlaybackManagerImpl(
-            serverConfig = serverConfig,
-            playbackPreferences = playbackPreferences,
-            bookDao = db.bookDao(),
-            audioFileDao = db.audioFileDao(),
-            chapterDao = db.chapterDao(),
-            imageStorage = imageStorage,
-            progressTracker = progressTracker,
-            tokenProvider = tokenProvider,
-            deviceContext = DeviceContext(type = DeviceType.Phone),
-            downloadService = downloadService,
-            playbackRpcFactory = testPlaybackRpcFactory("af-1", "af-2"),
-            syncApi = syncApi,
-            scope = CoroutineScope(Job()),
-            bookRepository = bookRepository,
-        )
-    }
-}
+        fun createPlaybackManager(
+            db: ListenUpDatabase,
+            syncApi: SyncApiContract,
+        ): PlaybackManager {
+            val tokenProvider: AudioTokenProvider = mock()
+            everySuspend { tokenProvider.prepareForPlayback() } returns Unit
+
+            val serverConfig: ServerConfig = mock()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
+
+            val imageStorage: ImageStorage = mock()
+            every { imageStorage.exists(any()) } returns false
+
+            val downloadService: DownloadService = mock()
+            everySuspend { downloadService.getLocalPath(any()) } returns null
+            everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+            everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+
+            // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
+            // prepareForPlayback reads positionRepository; defaultPositionRepository() stubs it to
+            // return null (no saved position), which exercises the fresh-playback path.
+            val progressTracker = buildProgressTracker()
+
+            // Real BookRepositoryImpl backed by the same in-memory DB so that
+            // fetchBookFromServer's call to upsertWithAudioFiles actually writes
+            // to the DB and the junction assertion passes.
+            val txRunner = RoomTransactionRunner(db)
+            val bookRepository: BookRepository =
+                BookRepositoryImpl(
+                    bookDao = db.bookDao(),
+                    chapterDao = db.chapterDao(),
+                    audioFileDao = db.audioFileDao(),
+                    searchDao = db.searchDao(),
+                    transactionRunner = txRunner,
+                    imageStorage = imageStorage,
+                    genreRepository = mock(),
+                    tagRepository = mock(),
+                    // intentionally unstubbed — this test exercises upsertWithAudioFiles, not the RPC fallback paths
+                    networkMonitor = mock(),
+                    bookRpcFactory = mock(),
+                    bookSyncDomainHandler =
+                        BookSyncDomainHandler(
+                            database = db,
+                            mapper = BookEntityMapper(),
+                            transactionRunner = txRunner,
+                            imageStorage = stubImageStorage(),
+                            registry = ClientSyncDomainRegistry(),
+                        ),
+                )
+
+            return PlaybackManagerImpl(
+                serverConfig = serverConfig,
+                playbackPreferences = playbackPreferences,
+                bookDao = db.bookDao(),
+                audioFileDao = db.audioFileDao(),
+                chapterDao = db.chapterDao(),
+                imageStorage = imageStorage,
+                progressTracker = progressTracker,
+                tokenProvider = tokenProvider,
+                deviceContext = DeviceContext(type = DeviceType.Phone),
+                downloadService = downloadService,
+                playbackRpcFactory = testPlaybackRpcFactory("af-1", "af-2"),
+                syncApi = syncApi,
+                scope = CoroutineScope(Job()),
+                bookRepository = bookRepository,
+            )
+        }
+
+        test("fallback fetch populates audio_files junction when local is empty") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val syncApi: SyncApiContract = mock()
+
+                    seedBookWithoutAudioFiles(db)
+
+                    everySuspend { syncApi.getBook(any()) } returns
+                        AppResult.Success(
+                            bookResponseWithAudioFiles(
+                                id = "book-1",
+                                audioFiles =
+                                    listOf(
+                                        AudioFileResponse(
+                                            id = "af-1",
+                                            filename = "chapter01.m4b",
+                                            format = "m4b",
+                                            codec = "aac",
+                                            duration = 1_800_000L,
+                                            size = 45_000_000L,
+                                        ),
+                                        AudioFileResponse(
+                                            id = "af-2",
+                                            filename = "chapter02.m4b",
+                                            format = "m4b",
+                                            codec = "aac",
+                                            duration = 1_800_000L,
+                                            size = 45_000_000L,
+                                        ),
+                                    ),
+                            ),
+                        )
+
+                    val playbackManager = createPlaybackManager(db = db, syncApi = syncApi)
+
+                    playbackManager.prepareForPlayback(BookId("book-1"))
+
+                    // After fallback fetch, the junction should be populated.
+                    val rows = db.audioFileDao().getForBook("book-1")
+                    rows.size shouldBe 2
+                    rows.map { it.id } shouldBe listOf("af-1", "af-2")
+                    rows.map { it.index } shouldBe listOf(0, 1)
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -23,13 +23,13 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 /**
  * Verifies the DAO → PlaybackManager.prepareForPlayback contract.
@@ -42,119 +42,117 @@ import kotlin.test.assertNotNull
  * test. The acceptance test for actual playback is a manual checkpoint on a
  * real device before push (see plan Task 9).
  */
-class PlaybackManagerPrepareTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    @Test
-    fun `prepareForPlayback builds timeline from junction rows in index order`() =
-        runTest {
-            seedBookAndAudioFiles()
-
-            val playbackManager = createPlaybackManager()
-
-            val result = playbackManager.prepareForPlayback(BookId("book-1"))
-
-            assertNotNull(result)
-            assertEquals(3, result.timeline.files.size, "timeline should have 3 segments")
-            // Verify ordering: segments should be in index order (0, 1, 2)
-            assertEquals("af-0", result.timeline.files[0].audioFileId)
-            assertEquals("af-1", result.timeline.files[1].audioFileId)
-            assertEquals("af-2", result.timeline.files[2].audioFileId)
+class PlaybackManagerPrepareTest :
+    FunSpec({
+        suspend fun seedBookAndAudioFiles(db: ListenUpDatabase) {
+            db.bookDao().upsert(
+                BookEntity(
+                    id = BookId("book-1"),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = "Test Book",
+                    sortTitle = "Test Book",
+                    subtitle = null,
+                    coverHash = null,
+                    coverBlurHash = null,
+                    dominantColor = null,
+                    darkMutedColor = null,
+                    vibrantColor = null,
+                    totalDuration = 5_400_000L,
+                    description = null,
+                    publishYear = null,
+                    publisher = null,
+                    language = null,
+                    isbn = null,
+                    asin = null,
+                    abridged = false,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
+            db.audioFileDao().upsertAll(
+                listOf(
+                    audioFile(index = 0, id = "af-0"),
+                    audioFile(index = 1, id = "af-1"),
+                    audioFile(index = 2, id = "af-2"),
+                ),
+            )
         }
 
-    private suspend fun seedBookAndAudioFiles() {
-        db.bookDao().upsert(
-            BookEntity(
-                id = BookId("book-1"),
-                libraryId = LibraryId("test-library"),
-                folderId = FolderId("test-folder"),
-                title = "Test Book",
-                sortTitle = "Test Book",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 5_400_000L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-        db.audioFileDao().upsertAll(
-            listOf(
-                audioFile(index = 0, id = "af-0"),
-                audioFile(index = 1, id = "af-1"),
-                audioFile(index = 2, id = "af-2"),
-            ),
-        )
-    }
+        fun createPlaybackManager(db: ListenUpDatabase): PlaybackManager {
+            val tokenProvider: AudioTokenProvider = mock()
+            everySuspend { tokenProvider.prepareForPlayback() } returns Unit
 
-    private fun audioFile(
-        index: Int,
-        id: String,
-    ): AudioFileEntity =
-        AudioFileEntity(
-            bookId = BookId("book-1"),
-            index = index,
-            id = id,
-            filename = "chapter${index + 1}.m4b",
-            format = "m4b",
-            codec = "aac",
-            duration = 1_800_000L,
-            size = 45_000_000L,
-        )
+            val serverConfig: ServerConfig = mock()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
 
-    private fun createPlaybackManager(): PlaybackManager {
-        val tokenProvider: AudioTokenProvider = mock()
-        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
+            val imageStorage: ImageStorage = mock()
+            every { imageStorage.exists(any()) } returns false
 
-        val serverConfig: ServerConfig = mock()
-        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
+            val downloadService: DownloadService = mock()
+            everySuspend { downloadService.getLocalPath(any()) } returns null
+            everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+            everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
 
-        val imageStorage: ImageStorage = mock()
-        every { imageStorage.exists(any()) } returns false
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
 
-        val downloadService: DownloadService = mock()
-        everySuspend { downloadService.getLocalPath(any()) } returns null
-        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+            // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
+            // prepareForPlayback reads positionRepository; defaultPositionRepository() stubs it to
+            // return null (no saved position), exercising the fresh-playback path.
+            val progressTracker = buildProgressTracker()
 
-        val playbackPreferences: PlaybackPreferences = mock()
-        everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+            return PlaybackManagerImpl(
+                serverConfig = serverConfig,
+                playbackPreferences = playbackPreferences,
+                bookDao = db.bookDao(),
+                audioFileDao = db.audioFileDao(),
+                chapterDao = db.chapterDao(),
+                imageStorage = imageStorage,
+                progressTracker = progressTracker,
+                tokenProvider = tokenProvider,
+                deviceContext = DeviceContext(type = DeviceType.Phone),
+                downloadService = downloadService,
+                playbackRpcFactory = testPlaybackRpcFactory("af-0", "af-1", "af-2"),
+                syncApi = null,
+                scope = CoroutineScope(Job()),
+                bookRepository = mock<BookRepository>(),
+            )
+        }
 
-        // ProgressTracker is a final class — use the shared helper from PlaybackManagerTestSupport.
-        // prepareForPlayback reads positionRepository; defaultPositionRepository() stubs it to
-        // return null (no saved position), exercising the fresh-playback path.
-        val progressTracker = buildProgressTracker()
+        test("prepareForPlayback builds timeline from junction rows in index order") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
 
-        return PlaybackManagerImpl(
-            serverConfig = serverConfig,
-            playbackPreferences = playbackPreferences,
-            bookDao = db.bookDao(),
-            audioFileDao = db.audioFileDao(),
-            chapterDao = db.chapterDao(),
-            imageStorage = imageStorage,
-            progressTracker = progressTracker,
-            tokenProvider = tokenProvider,
-            deviceContext = DeviceContext(type = DeviceType.Phone),
-            downloadService = downloadService,
-            playbackRpcFactory = testPlaybackRpcFactory("af-0", "af-1", "af-2"),
-            syncApi = null,
-            scope = CoroutineScope(Job()),
-            bookRepository = mock<BookRepository>(),
-        )
-    }
-}
+                    val playbackManager = createPlaybackManager(db)
+
+                    val result = playbackManager.prepareForPlayback(BookId("book-1")).shouldNotBeNull()
+
+                    withClue("timeline should have 3 segments") { result.timeline.files.size shouldBe 3 }
+                    // Verify ordering: segments should be in index order (0, 1, 2)
+                    result.timeline.files[0].audioFileId shouldBe "af-0"
+                    result.timeline.files[1].audioFileId shouldBe "af-1"
+                    result.timeline.files[2].audioFileId shouldBe "af-2"
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })
+
+private fun audioFile(
+    index: Int,
+    id: String,
+): AudioFileEntity =
+    AudioFileEntity(
+        bookId = BookId("book-1"),
+        index = index,
+        id = id,
+        filename = "chapter${index + 1}.m4b",
+        format = "m4b",
+        codec = "aac",
+        duration = 1_800_000L,
+        size = 45_000_000L,
+    )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -29,6 +29,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -36,8 +37,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
 
 /**
  * Bug 3 regression tests for PlaybackManager speed paths.
@@ -56,239 +55,248 @@ import kotlin.test.Test
  * deletion was likely re-introduced. Investigate before "fixing" the test.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class PlaybackManagerSpeedTest {
-    private val db: ListenUpDatabase = createInMemoryTestDatabase()
-
-    @AfterTest
-    fun tearDown() {
-        db.close()
-    }
-
-    // -------------------------------------------------------------------------
-    // Test 1 — progressTracker write is always invoked regardless of speed value
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `onSpeedChanged with 1_0f propagates progressTracker write`() =
-        runTest {
-            val positionRepository = defaultPositionRepository()
-
-            val (manager, _) =
-                createPlaybackManagerWithScope(
-                    positionRepository = positionRepository,
-                )
-
-            manager.activateBook(BookId("book-1"))
-            manager.onSpeedChanged(1.0f)
-
-            // Drain the scope.launch inside ProgressTracker.onSpeedChanged
-            advanceUntilIdle()
-
-            verifySuspend(VerifyMode.exactly(1)) {
-                positionRepository.savePlaybackState(
-                    any(),
-                    matches<PlaybackUpdate>({ "Speed(speed=1.0, custom=true)" }) {
-                        it is PlaybackUpdate.Speed && it.speed == 1.0f && it.custom
-                    },
-                )
-            }
+class PlaybackManagerSpeedTest :
+    FunSpec({
+        fun defaultPlaybackPreferences(): PlaybackPreferences {
+            val prefs: PlaybackPreferences = mock()
+            everySuspend { prefs.getDefaultPlaybackSpeed() } returns 1.0f
+            everySuspend { prefs.setDefaultPlaybackSpeed(any()) } returns Unit
+            return prefs
         }
 
-    // -------------------------------------------------------------------------
-    // Test 2 — startPlayback always calls setSpeed, even when speed == 1.0f
-    // -------------------------------------------------------------------------
+        fun createPlaybackManager(
+            db: ListenUpDatabase,
+            playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
+            progressTracker: ProgressTracker = buildProgressTracker(scope = CoroutineScope(Job())),
+            scope: CoroutineScope = CoroutineScope(Job()),
+        ): PlaybackManager {
+            val tokenProvider: AudioTokenProvider = mock()
+            everySuspend { tokenProvider.prepareForPlayback() } returns Unit
 
-    @Test
-    fun `startPlayback with effective speed 1_0f calls audioPlayer setSpeed 1_0f`() =
-        runTest {
-            seedBookAndAudioFiles()
+            val serverConfig: ServerConfig = mock()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
 
-            val playbackPreferences: PlaybackPreferences = mock()
-            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+            val imageStorage: ImageStorage = mock()
+            every { imageStorage.exists(any()) } returns false
+
+            val downloadService: DownloadService = mock()
+            everySuspend { downloadService.getLocalPath(any()) } returns null
+            everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+            everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+
+            return PlaybackManagerImpl(
+                serverConfig = serverConfig,
+                playbackPreferences = playbackPreferences,
+                bookDao = db.bookDao(),
+                audioFileDao = db.audioFileDao(),
+                chapterDao = db.chapterDao(),
+                imageStorage = imageStorage,
+                progressTracker = progressTracker,
+                tokenProvider = tokenProvider,
+                deviceContext = DeviceContext(type = DeviceType.Phone),
+                downloadService = downloadService,
+                playbackRpcFactory = testPlaybackRpcFactory("af-0"),
+                syncApi = null,
+                scope = scope,
+                bookRepository = mock<BookRepository>(),
+            )
+        }
+
+        // Creates a [PlaybackManager] whose internal [CoroutineScope] is backed by the
+        // [TestScope] from [runTest]. Use this for tests that need [advanceUntilIdle]
+        // to drain coroutines launched inside [PlaybackManager] or [ProgressTracker].
+        //
+        // Returns both the manager and the [PlaybackPositionRepository] mock so tests
+        // can assert on it.
+        fun TestScope.createPlaybackManagerWithScope(
+            db: ListenUpDatabase,
+            playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
+            positionRepository: PlaybackPositionRepository = defaultPositionRepository(),
+        ): Pair<PlaybackManager, PlaybackPositionRepository> {
+            val progressTrackerScope = CoroutineScope(coroutineContext)
+            val managerScope = CoroutineScope(coroutineContext)
+
+            val progressTracker =
+                buildProgressTracker(
+                    scope = progressTrackerScope,
+                    positionRepository = positionRepository,
+                )
 
             val manager =
                 createPlaybackManager(
+                    db = db,
                     playbackPreferences = playbackPreferences,
-                    // Use a detached scope so the positionMs.collect launch does not
-                    // keep the TestScope alive and block runTest completion.
-                    scope = CoroutineScope(Job()),
+                    progressTracker = progressTracker,
+                    scope = managerScope,
                 )
 
-            val result = manager.prepareForPlayback(BookId("book-1"))
-            checkNotNull(result) { "prepareForPlayback must succeed" }
-            manager.activateBook(BookId("book-1"))
-
-            val audioPlayer: AudioPlayer = mock()
-            everySuspend { audioPlayer.load(any()) } returns Unit
-            every { audioPlayer.positionMs } returns MutableStateFlow(0L)
-            every { audioPlayer.state } returns MutableStateFlow(PlaybackState.Idle)
-            every { audioPlayer.setSpeed(any()) } returns Unit
-            every { audioPlayer.play() } returns Unit
-
-            manager.startPlayback(
-                player = audioPlayer,
-                resumePositionMs = 0L,
-                resumeSpeed = 1.0f,
-            )
-
-            verify(VerifyMode.exactly(1)) { audioPlayer.setSpeed(1.0f) }
+            return manager to positionRepository
         }
 
-    // -------------------------------------------------------------------------
-    // Test 3 — onSpeedChanged writes per-book ONLY; global default stays clean
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `onSpeedChanged does not call playbackPreferences setDefaultPlaybackSpeed`() =
-        runTest {
-            val playbackPreferences: PlaybackPreferences = mock()
-            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
-            everySuspend { playbackPreferences.setDefaultPlaybackSpeed(any()) } returns Unit
-
-            val positionRepository = defaultPositionRepository()
-
-            val (manager, _) =
-                createPlaybackManagerWithScope(
-                    playbackPreferences = playbackPreferences,
-                    positionRepository = positionRepository,
-                )
-
-            manager.activateBook(BookId("book-1"))
-            manager.onSpeedChanged(2.0f)
-
-            // Drain all pending coroutines so any rogue setDefaultPlaybackSpeed call
-            // has had a chance to run before we assert it didn't.
-            advanceUntilIdle()
-
-            verifySuspend(VerifyMode.exactly(1)) {
-                positionRepository.savePlaybackState(
-                    any(),
-                    matches<PlaybackUpdate>({ "Speed(speed=2.0, custom=true)" }) {
-                        it is PlaybackUpdate.Speed && it.speed == 2.0f && it.custom
-                    },
-                )
-            }
-            verifySuspend(VerifyMode.exactly(0)) { playbackPreferences.setDefaultPlaybackSpeed(any()) }
-        }
-
-    // =========================================================================
-    // Fixture helpers
-    // =========================================================================
-
-    /**
-     * Creates a [PlaybackManager] whose internal [CoroutineScope] is backed by the
-     * [TestScope] from [runTest]. Use this for tests that need [advanceUntilIdle]
-     * to drain coroutines launched inside [PlaybackManager] or [ProgressTracker].
-     *
-     * Returns both the manager and the [PlaybackPositionRepository] mock so tests
-     * can assert on it.
-     */
-    private fun TestScope.createPlaybackManagerWithScope(
-        playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
-        positionRepository: PlaybackPositionRepository = defaultPositionRepository(),
-    ): Pair<PlaybackManager, PlaybackPositionRepository> {
-        val progressTrackerScope = CoroutineScope(coroutineContext)
-        val managerScope = CoroutineScope(coroutineContext)
-
-        val progressTracker =
-            buildProgressTracker(
-                scope = progressTrackerScope,
-                positionRepository = positionRepository,
-            )
-
-        val manager =
-            createPlaybackManager(
-                playbackPreferences = playbackPreferences,
-                progressTracker = progressTracker,
-                scope = managerScope,
-            )
-
-        return manager to positionRepository
-    }
-
-    private fun defaultPlaybackPreferences(): PlaybackPreferences {
-        val prefs: PlaybackPreferences = mock()
-        everySuspend { prefs.getDefaultPlaybackSpeed() } returns 1.0f
-        everySuspend { prefs.setDefaultPlaybackSpeed(any()) } returns Unit
-        return prefs
-    }
-
-    private fun createPlaybackManager(
-        playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
-        progressTracker: ProgressTracker = buildProgressTracker(scope = CoroutineScope(Job())),
-        scope: CoroutineScope = CoroutineScope(Job()),
-    ): PlaybackManager {
-        val tokenProvider: AudioTokenProvider = mock()
-        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
-
-        val serverConfig: ServerConfig = mock()
-        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
-
-        val imageStorage: ImageStorage = mock()
-        every { imageStorage.exists(any()) } returns false
-
-        val downloadService: DownloadService = mock()
-        everySuspend { downloadService.getLocalPath(any()) } returns null
-        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
-        everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
-
-        return PlaybackManagerImpl(
-            serverConfig = serverConfig,
-            playbackPreferences = playbackPreferences,
-            bookDao = db.bookDao(),
-            audioFileDao = db.audioFileDao(),
-            chapterDao = db.chapterDao(),
-            imageStorage = imageStorage,
-            progressTracker = progressTracker,
-            tokenProvider = tokenProvider,
-            deviceContext = DeviceContext(type = DeviceType.Phone),
-            downloadService = downloadService,
-            playbackRpcFactory = testPlaybackRpcFactory("af-0"),
-            syncApi = null,
-            scope = scope,
-            bookRepository = mock<BookRepository>(),
-        )
-    }
-
-    private suspend fun seedBookAndAudioFiles() {
-        db.bookDao().upsert(
-            BookEntity(
-                id = BookId("book-1"),
-                libraryId = LibraryId("test-library"),
-                folderId = FolderId("test-folder"),
-                title = "Test Book",
-                sortTitle = "Test Book",
-                subtitle = null,
-                coverHash = null,
-                coverBlurHash = null,
-                dominantColor = null,
-                darkMutedColor = null,
-                vibrantColor = null,
-                totalDuration = 1_800_000L,
-                description = null,
-                publishYear = null,
-                publisher = null,
-                language = null,
-                isbn = null,
-                asin = null,
-                abridged = false,
-                createdAt = Timestamp(1L),
-                updatedAt = Timestamp(1L),
-            ),
-        )
-        db.audioFileDao().upsertAll(
-            listOf(
-                AudioFileEntity(
-                    bookId = BookId("book-1"),
-                    index = 0,
-                    id = "af-0",
-                    filename = "chapter1.m4b",
-                    format = "m4b",
-                    codec = "aac",
-                    duration = 1_800_000L,
-                    size = 45_000_000L,
+        suspend fun seedBookAndAudioFiles(db: ListenUpDatabase) {
+            db.bookDao().upsert(
+                BookEntity(
+                    id = BookId("book-1"),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = "Test Book",
+                    sortTitle = "Test Book",
+                    subtitle = null,
+                    coverHash = null,
+                    coverBlurHash = null,
+                    dominantColor = null,
+                    darkMutedColor = null,
+                    vibrantColor = null,
+                    totalDuration = 1_800_000L,
+                    description = null,
+                    publishYear = null,
+                    publisher = null,
+                    language = null,
+                    isbn = null,
+                    asin = null,
+                    abridged = false,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
                 ),
-            ),
-        )
-    }
-}
+            )
+            db.audioFileDao().upsertAll(
+                listOf(
+                    AudioFileEntity(
+                        bookId = BookId("book-1"),
+                        index = 0,
+                        id = "af-0",
+                        filename = "chapter1.m4b",
+                        format = "m4b",
+                        codec = "aac",
+                        duration = 1_800_000L,
+                        size = 45_000_000L,
+                    ),
+                ),
+            )
+        }
+
+        // -------------------------------------------------------------------------
+        // Test 1 — progressTracker write is always invoked regardless of speed value
+        // -------------------------------------------------------------------------
+
+        test("onSpeedChanged with 1_0f propagates progressTracker write") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val positionRepository = defaultPositionRepository()
+
+                    val (manager, _) =
+                        createPlaybackManagerWithScope(
+                            db = db,
+                            positionRepository = positionRepository,
+                        )
+
+                    manager.activateBook(BookId("book-1"))
+                    manager.onSpeedChanged(1.0f)
+
+                    // Drain the scope.launch inside ProgressTracker.onSpeedChanged
+                    advanceUntilIdle()
+
+                    verifySuspend(VerifyMode.exactly(1)) {
+                        positionRepository.savePlaybackState(
+                            any(),
+                            matches<PlaybackUpdate>({ "Speed(speed=1.0, custom=true)" }) {
+                                it is PlaybackUpdate.Speed && it.speed == 1.0f && it.custom
+                            },
+                        )
+                    }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // -------------------------------------------------------------------------
+        // Test 2 — startPlayback always calls setSpeed, even when speed == 1.0f
+        // -------------------------------------------------------------------------
+
+        test("startPlayback with effective speed 1_0f calls audioPlayer setSpeed 1_0f") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBookAndAudioFiles(db)
+
+                    val playbackPreferences: PlaybackPreferences = mock()
+                    everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+
+                    val manager =
+                        createPlaybackManager(
+                            db = db,
+                            playbackPreferences = playbackPreferences,
+                            // Use a detached scope so the positionMs.collect launch does not
+                            // keep the TestScope alive and block runTest completion.
+                            scope = CoroutineScope(Job()),
+                        )
+
+                    val result = manager.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(result) { "prepareForPlayback must succeed" }
+                    manager.activateBook(BookId("book-1"))
+
+                    val audioPlayer: AudioPlayer = mock()
+                    everySuspend { audioPlayer.load(any()) } returns Unit
+                    every { audioPlayer.positionMs } returns MutableStateFlow(0L)
+                    every { audioPlayer.state } returns MutableStateFlow(PlaybackState.Idle)
+                    every { audioPlayer.setSpeed(any()) } returns Unit
+                    every { audioPlayer.play() } returns Unit
+
+                    manager.startPlayback(
+                        player = audioPlayer,
+                        resumePositionMs = 0L,
+                        resumeSpeed = 1.0f,
+                    )
+
+                    verify(VerifyMode.exactly(1)) { audioPlayer.setSpeed(1.0f) }
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // -------------------------------------------------------------------------
+        // Test 3 — onSpeedChanged writes per-book ONLY; global default stays clean
+        // -------------------------------------------------------------------------
+
+        test("onSpeedChanged does not call playbackPreferences setDefaultPlaybackSpeed") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val playbackPreferences: PlaybackPreferences = mock()
+                    everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+                    everySuspend { playbackPreferences.setDefaultPlaybackSpeed(any()) } returns Unit
+
+                    val positionRepository = defaultPositionRepository()
+
+                    val (manager, _) =
+                        createPlaybackManagerWithScope(
+                            db = db,
+                            playbackPreferences = playbackPreferences,
+                            positionRepository = positionRepository,
+                        )
+
+                    manager.activateBook(BookId("book-1"))
+                    manager.onSpeedChanged(2.0f)
+
+                    // Drain all pending coroutines so any rogue setDefaultPlaybackSpeed call
+                    // has had a chance to run before we assert it didn't.
+                    advanceUntilIdle()
+
+                    verifySuspend(VerifyMode.exactly(1)) {
+                        positionRepository.savePlaybackState(
+                            any(),
+                            matches<PlaybackUpdate>({ "Speed(speed=2.0, custom=true)" }) {
+                                it is PlaybackUpdate.Speed && it.speed == 2.0f && it.custom
+                            },
+                        )
+                    }
+                    verifySuspend(VerifyMode.exactly(0)) { playbackPreferences.setDefaultPlaybackSpeed(any()) }
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabaseTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabaseTest.kt
@@ -1,9 +1,8 @@
 package com.calypsan.listenup.client.test.db
 
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertNotNull
 
 /**
  * Verifies [createInMemoryTestDatabase] constructs a usable [com.calypsan.listenup.client.data.local.db.ListenUpDatabase]
@@ -12,31 +11,34 @@ import kotlin.test.assertNotNull
  * Lives in jvmTest (not commonTest) until W4 proves out a cross-platform test-DB seam — see the
  * W1 plan's checkpoint resolution on in-memory Room placement.
  */
-class TestDatabaseTest {
-    private val db = createInMemoryTestDatabase()
-
-    @AfterTest
-    fun afterTest() {
-        db.close()
-    }
-
-    @Test
-    fun exposesAllDaos() {
-        assertNotNull(db.userDao())
-        assertNotNull(db.bookDao())
-        assertNotNull(db.playbackPositionDao())
-    }
-
-    @Test
-    fun isIsolatedBetweenInstances() =
-        runTest {
-            val db2 = createInMemoryTestDatabase()
+class TestDatabaseTest :
+    FunSpec({
+        test("exposesAllDaos") {
+            val db = createInMemoryTestDatabase()
             try {
-                // Two separately-built in-memory databases must not share state — otherwise
-                // parallel tests would leak data across each other.
-                assertNotNull(db2.userDao())
+                db.userDao() shouldNotBe null
+                db.bookDao() shouldNotBe null
+                db.playbackPositionDao() shouldNotBe null
             } finally {
-                db2.close()
+                db.close()
             }
         }
-}
+
+        test("isIsolatedBetweenInstances") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val db2 = createInMemoryTestDatabase()
+                    try {
+                        // Two separately-built in-memory databases must not share state — otherwise
+                        // parallel tests would leak data across each other.
+                        db2.userDao() shouldNotBe null
+                    } finally {
+                        db2.close()
+                    }
+                } finally {
+                    db.close()
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## What

Batch 3 of the `kotlin-test` → **Kotest FunSpec** migration (follows #514, #517). 14 `jvmTest` specs — playback, Room DAO, and download:

`playback/{PlaybackManagerSpeed,PlaybackManagerPrepare,PlaybackManagerBufferingState,PlaybackManagerFallbackFetch,PlaybackManagerFallbackFetchAtomicity}`, `data/local/db/{DownloadDao,SearchDao,GenreDaoNameResolution,migration/SchemaMigrationSmoke}`, `data/local/images/JvmStoragePaths`, `data/repository/DownloadRepositoryImpl`, `download/DownloadWorkerLogic`, `test/db/TestDatabase`.

## How

Pure framework migration — no test logic/values/fixtures/mocks changed. `@Test`-classes → `FunSpec`; assertions → Kotest matchers (`assertEquals(expected, actual)` → `actual shouldBe expected`).

**Fixture lifecycle:** the originals created a fresh Room DB per test (kotlin-test instantiates the class per test) and closed it in `@AfterTest`. Reproduced faithfully by creating the DB (and any stateful fakes/SUT) as locals inside each `test {}` with `try { runTest { … } } finally { db.close() }` — no `lateinit` (detekt bans it), no shared mutable state across tests. Method KDocs that moved into the `FunSpec` lambda became line comments (ktlint).

## Verification

`:sharedLogic:jvmTest` green (all DB-isolation preserved — a leaked/closed DB would fail loudly), spotless + detekt clean. No production code touched.

## Remaining

~43 `kotlin-test` files left — presentation ViewModels (need `MainDispatcherRule` → Kotest lifecycle handling), test-infra, `sharedUI` androidHostTest. Continuing in later batches.
