### PR TITLE
✅ test(shared): migrate ViewModel commonTest specs to Kotest (batch 4/N)

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportHubViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportHubViewModelTest.kt
@@ -20,212 +20,202 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import com.calypsan.listenup.core.error.ErrorBus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ABSImportHubViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ABSImportHubViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private val testImport =
-        ABSImportResponse(
-            id = "import-1",
-            name = "Test Import",
-            backupPath = "/test/backup.zip",
-            status = "active",
-            createdAt = "2024-01-01T00:00:00Z",
-            updatedAt = "2024-01-01T00:00:00Z",
-            totalUsers = 1,
-            totalBooks = 1,
-            totalSessions = 0,
-            usersMapped = 0,
-            booksMapped = 0,
-            sessionsImported = 0,
+        val testImport =
+            ABSImportResponse(
+                id = "import-1",
+                name = "Test Import",
+                backupPath = "/test/backup.zip",
+                status = "active",
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-01-01T00:00:00Z",
+                totalUsers = 1,
+                totalBooks = 1,
+                totalSessions = 0,
+                usersMapped = 0,
+                booksMapped = 0,
+                sessionsImported = 0,
+            )
+
+        fun createUser(
+            absUserId: String = "abs-user-1",
+            absUsername: String = "testuser",
+            isMapped: Boolean = false,
+        ) = ABSImportUser(
+            absUserId = absUserId,
+            absUsername = absUsername,
+            isMapped = isMapped,
         )
 
-    private fun createUser(
-        absUserId: String = "abs-user-1",
-        absUsername: String = "testuser",
-        isMapped: Boolean = false,
-    ) = ABSImportUser(
-        absUserId = absUserId,
-        absUsername = absUsername,
-        isMapped = isMapped,
-    )
+        fun createBook(
+            absMediaId: String = "abs-book-1",
+            absTitle: String = "Test Book",
+            absAuthor: String = "Author",
+            isMapped: Boolean = false,
+        ) = ABSImportBook(
+            absMediaId = absMediaId,
+            absTitle = absTitle,
+            absAuthor = absAuthor,
+            isMapped = isMapped,
+        )
 
-    private fun createBook(
-        absMediaId: String = "abs-book-1",
-        absTitle: String = "Test Book",
-        absAuthor: String = "Author",
-        isMapped: Boolean = false,
-    ) = ABSImportBook(
-        absMediaId = absMediaId,
-        absTitle = absTitle,
-        absAuthor = absAuthor,
-        isMapped = isMapped,
-    )
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    private fun createMockedApi(): ABSImportApiContract {
-        val api: ABSImportApiContract = mock()
-        everySuspend { api.listImports() } returns AppResult.Success(emptyList())
-        everySuspend { api.getImport("import-1") } returns AppResult.Success(testImport)
-        everySuspend { api.listImportUsers("import-1", any()) } returns AppResult.Success(listOf(createUser()))
-        everySuspend { api.listImportBooks("import-1", any()) } returns AppResult.Success(listOf(createBook()))
-        return api
-    }
-
-    // ========== mapBook in-flight state ==========
-
-    @Test
-    fun `mapBook adds absMediaId to mappingInFlightBooks during request`() =
-        runTest {
-            val api = createMockedApi()
-            val mappedBook = createBook(isMapped = true)
-            everySuspend { api.mapBook("import-1", "abs-book-1", "lu-book-1") } returns AppResult.Success(mappedBook)
-
-            val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
-            advanceUntilIdle()
-
-            // Open import to set importId
-            vm.openImport("import-1")
-            advanceUntilIdle()
-
-            // Switch to books tab to load books
-            vm.setBooksFilter(MappingFilter.ALL)
-            advanceUntilIdle()
-
-            // Trigger mapBook — in-flight set should be populated synchronously
-            vm.mapBook("abs-book-1", "lu-book-1")
-            val inFlight = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertTrue(inFlight.mappingInFlightBooks.contains("abs-book-1"))
-
-            advanceUntilIdle()
-
-            // After completion, in-flight set should be cleared
-            val after = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertFalse(after.mappingInFlightBooks.contains("abs-book-1"))
+        fun createMockedApi(): ABSImportApiContract {
+            val api: ABSImportApiContract = mock()
+            everySuspend { api.listImports() } returns AppResult.Success(emptyList())
+            everySuspend { api.getImport("import-1") } returns AppResult.Success(testImport)
+            everySuspend { api.listImportUsers("import-1", any()) } returns AppResult.Success(listOf(createUser()))
+            everySuspend { api.listImportBooks("import-1", any()) } returns AppResult.Success(listOf(createBook()))
+            return api
         }
 
-    @Test
-    fun `mapBook clears in-flight on failure`() =
-        runTest {
-            val api = createMockedApi()
-            everySuspend { api.mapBook("import-1", "abs-book-1", "lu-book-1") } returns
-                Failure(Exception("Server error"))
+        // ========== mapBook in-flight state ==========
 
-            val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
-            advanceUntilIdle()
+        test("mapBook adds absMediaId to mappingInFlightBooks during request") {
+            runTest {
+                val api = createMockedApi()
+                val mappedBook = createBook(isMapped = true)
+                everySuspend { api.mapBook("import-1", "abs-book-1", "lu-book-1") } returns AppResult.Success(mappedBook)
 
-            vm.openImport("import-1")
-            advanceUntilIdle()
+                val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
+                advanceUntilIdle()
 
-            vm.mapBook("abs-book-1", "lu-book-1")
-            val inFlight = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertTrue(inFlight.mappingInFlightBooks.contains("abs-book-1"))
+                // Open import to set importId
+                vm.openImport("import-1")
+                advanceUntilIdle()
 
-            advanceUntilIdle()
+                // Switch to books tab to load books
+                vm.setBooksFilter(MappingFilter.ALL)
+                advanceUntilIdle()
 
-            val after = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertFalse(after.mappingInFlightBooks.contains("abs-book-1"))
-            assertEquals("Failed to map book", after.error)
+                // Trigger mapBook — in-flight set should be populated synchronously
+                vm.mapBook("abs-book-1", "lu-book-1")
+                val inFlight = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                inFlight.mappingInFlightBooks.contains("abs-book-1") shouldBe true
+
+                advanceUntilIdle()
+
+                // After completion, in-flight set should be cleared
+                val after = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                after.mappingInFlightBooks.contains("abs-book-1") shouldBe false
+            }
         }
 
-    // ========== mapUser in-flight state ==========
+        test("mapBook clears in-flight on failure") {
+            runTest {
+                val api = createMockedApi()
+                everySuspend { api.mapBook("import-1", "abs-book-1", "lu-book-1") } returns
+                    Failure(Exception("Server error"))
 
-    @Test
-    fun `mapUser adds absUserId to mappingInFlightUsers during request`() =
-        runTest {
-            val api = createMockedApi()
-            val mappedUser = createUser(isMapped = true)
-            everySuspend { api.mapUser("import-1", "abs-user-1", "lu-user-1") } returns AppResult.Success(mappedUser)
+                val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
+                advanceUntilIdle()
 
-            val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
-            advanceUntilIdle()
+                vm.openImport("import-1")
+                advanceUntilIdle()
 
-            vm.openImport("import-1")
-            advanceUntilIdle()
+                vm.mapBook("abs-book-1", "lu-book-1")
+                val inFlight = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                inFlight.mappingInFlightBooks.contains("abs-book-1") shouldBe true
 
-            vm.mapUser("abs-user-1", "lu-user-1")
-            val inFlight = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertTrue(inFlight.mappingInFlightUsers.contains("abs-user-1"))
+                advanceUntilIdle()
 
-            advanceUntilIdle()
-
-            val after = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertFalse(after.mappingInFlightUsers.contains("abs-user-1"))
+                val after = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                after.mappingInFlightBooks.contains("abs-book-1") shouldBe false
+                after.error shouldBe "Failed to map book"
+            }
         }
 
-    @Test
-    fun `mapUser clears in-flight on failure`() =
-        runTest {
-            val api = createMockedApi()
-            everySuspend { api.mapUser("import-1", "abs-user-1", "lu-user-1") } returns
-                Failure(Exception("Server error"))
+        // ========== mapUser in-flight state ==========
 
-            val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
-            advanceUntilIdle()
+        test("mapUser adds absUserId to mappingInFlightUsers during request") {
+            runTest {
+                val api = createMockedApi()
+                val mappedUser = createUser(isMapped = true)
+                everySuspend { api.mapUser("import-1", "abs-user-1", "lu-user-1") } returns AppResult.Success(mappedUser)
 
-            vm.openImport("import-1")
-            advanceUntilIdle()
+                val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
+                advanceUntilIdle()
 
-            vm.mapUser("abs-user-1", "lu-user-1")
-            val inFlight = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertTrue(inFlight.mappingInFlightUsers.contains("abs-user-1"))
+                vm.openImport("import-1")
+                advanceUntilIdle()
 
-            advanceUntilIdle()
+                vm.mapUser("abs-user-1", "lu-user-1")
+                val inFlight = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                inFlight.mappingInFlightUsers.contains("abs-user-1") shouldBe true
 
-            val after = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertFalse(after.mappingInFlightUsers.contains("abs-user-1"))
-            assertEquals("Failed to map user", after.error)
+                advanceUntilIdle()
+
+                val after = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                after.mappingInFlightUsers.contains("abs-user-1") shouldBe false
+            }
         }
 
-    // ========== openImport polling behavior ==========
+        test("mapUser clears in-flight on failure") {
+            runTest {
+                val api = createMockedApi()
+                everySuspend { api.mapUser("import-1", "abs-user-1", "lu-user-1") } returns
+                    Failure(Exception("Server error"))
 
-    @Test
-    fun `openImport starts polling when status is analyzing`() =
-        runTest {
-            val api = createMockedApi()
-            val analyzingImport = testImport.copy(status = "analyzing")
-            val completedImport = testImport.copy(status = "active")
+                val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
+                advanceUntilIdle()
 
-            // openImport will get "analyzing" → triggers startAnalysisPolling
-            everySuspend { api.getImport("import-1") } returns AppResult.Success(analyzingImport)
+                vm.openImport("import-1")
+                advanceUntilIdle()
 
-            val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
-            advanceUntilIdle() // drain init (loadImports)
+                vm.mapUser("abs-user-1", "lu-user-1")
+                val inFlight = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                inFlight.mappingInFlightUsers.contains("abs-user-1") shouldBe true
 
-            vm.openImport("import-1")
-            // Use runCurrent() — NOT advanceUntilIdle() — to execute the openImport
-            // coroutine without advancing virtual time into the infinite polling loop
-            testScheduler.runCurrent()
+                advanceUntilIdle()
 
-            val analyzing = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertEquals("analyzing", analyzing.import.status)
-
-            // Re-stub so the next poll returns "active" — polling loop exits naturally
-            everySuspend { api.getImport("import-1") } returns AppResult.Success(completedImport)
-
-            // Advance past the 3-second polling interval so the poll fires
-            testScheduler.advanceTimeBy(3_100)
-            testScheduler.runCurrent()
-
-            val completed = assertIs<ABSImportHubUiState.Ready>(vm.hubState.value)
-            assertEquals("active", completed.import.status)
+                val after = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                after.mappingInFlightUsers.contains("abs-user-1") shouldBe false
+                after.error shouldBe "Failed to map user"
+            }
         }
-}
+
+        // ========== openImport polling behavior ==========
+
+        test("openImport starts polling when status is analyzing") {
+            runTest {
+                val api = createMockedApi()
+                val analyzingImport = testImport.copy(status = "analyzing")
+                val completedImport = testImport.copy(status = "active")
+
+                // openImport will get "analyzing" → triggers startAnalysisPolling
+                everySuspend { api.getImport("import-1") } returns AppResult.Success(analyzingImport)
+
+                val vm = ABSImportHubViewModel(api, mock(), mock(), errorBus = ErrorBus())
+                advanceUntilIdle() // drain init (loadImports)
+
+                vm.openImport("import-1")
+                // Use runCurrent() — NOT advanceUntilIdle() — to execute the openImport
+                // coroutine without advancing virtual time into the infinite polling loop
+                testScheduler.runCurrent()
+
+                val analyzing = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                analyzing.import.status shouldBe "analyzing"
+
+                // Re-stub so the next poll returns "active" — polling loop exits naturally
+                everySuspend { api.getImport("import-1") } returns AppResult.Success(completedImport)
+
+                // Advance past the 3-second polling interval so the poll fires
+                testScheduler.advanceTimeBy(3_100)
+                testScheduler.runCurrent()
+
+                val completed = vm.hubState.value.shouldBeInstanceOf<ABSImportHubUiState.Ready>()
+                completed.import.status shouldBe "active"
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportViewModelAnalysisCountsTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportViewModelAnalysisCountsTest.kt
@@ -22,211 +22,205 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import com.calypsan.listenup.core.error.ErrorBus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Tests that totalBooks/totalUsers from AnalysisStatusResponse
  * are propagated to the ViewModel state during the ANALYZING step.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ABSImportViewModelAnalysisCountsTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ABSImportViewModelAnalysisCountsTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private lateinit var backupApi: BackupApiContract
-    private lateinit var searchApi: SearchApiContract
-    private lateinit var absImportApi: ABSImportApiContract
-    private lateinit var syncRepository: SyncRepository
+        fun completedAnalysisResponse() =
+            AnalyzeABSResponse(
+                backupPath = "/tmp/backup.audiobookshelf",
+                analyzedAt = "2025-01-01T00:00:00Z",
+                summary = "Test",
+                totalUsers = 5,
+                totalBooks = 1011,
+                totalSessions = 200,
+                usersMatched = 5,
+                usersPending = 0,
+                booksMatched = 900,
+                booksPending = 111,
+                sessionsReady = 150,
+                sessionsPending = 50,
+                progressReady = 100,
+                progressPending = 100,
+                userMatches = emptyList(),
+                bookMatches = emptyList(),
+            )
 
-    private fun completedAnalysisResponse() =
-        AnalyzeABSResponse(
-            backupPath = "/tmp/backup.audiobookshelf",
-            analyzedAt = "2025-01-01T00:00:00Z",
-            summary = "Test",
-            totalUsers = 5,
-            totalBooks = 1011,
-            totalSessions = 200,
-            usersMatched = 5,
-            usersPending = 0,
-            booksMatched = 900,
-            booksPending = 111,
-            sessionsReady = 150,
-            sessionsPending = 50,
-            progressReady = 100,
-            progressPending = 100,
-            userMatches = emptyList(),
-            bookMatches = emptyList(),
-        )
+        // Fresh mocks per test, mirroring the original @BeforeTest lifecycle.
+        class TestFixture {
+            val backupApi: BackupApiContract = mock()
+            val searchApi: SearchApiContract = mock()
+            val absImportApi: ABSImportApiContract = mock()
+            val syncRepository: SyncRepository = mock()
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-        backupApi = mock()
-        searchApi = mock()
-        absImportApi = mock()
-        syncRepository = mock()
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    private fun createViewModel() =
-        ABSImportViewModel(
-            backupApi = backupApi,
-            searchApi = searchApi,
-            absImportApi = absImportApi,
-            syncRepository = syncRepository,
-            errorBus = ErrorBus(),
-        )
-
-    @Test
-    fun `analyzing state shows totalBooks and totalUsers when server provides counts`() =
-        runTest {
-            val analysisResult = completedAnalysisResponse()
-
-            everySuspend { backupApi.analyzeABSBackupAsync(any()) } returns
-                AppResult.Success(AsyncAnalyzeResponse(analysisId = "a1"))
-
-            everySuspend { backupApi.getAnalysisStatus("a1") } sequentiallyReturns
-                listOf(
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "running",
-                            phase = "matching_books",
-                            current = 100,
-                            total = 1011,
-                            totalBooks = 1011,
-                            totalUsers = 5,
-                        ),
-                    ),
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "completed",
-                            phase = "done",
-                            result = analysisResult,
-                        ),
-                    ),
+            fun createViewModel() =
+                ABSImportViewModel(
+                    backupApi = backupApi,
+                    searchApi = searchApi,
+                    absImportApi = absImportApi,
+                    syncRepository = syncRepository,
+                    errorBus = ErrorBus(),
                 )
-
-            val viewModel = createViewModel()
-            viewModel.setFullRemotePath("/tmp/backup.audiobookshelf")
-
-            // Advance past the first poll (launch + analyzeABSBackupAsync + first getAnalysisStatus)
-            advanceTimeBy(100)
-
-            val stateAfterFirstPoll = assertIs<ABSImportUiState.Ready>(viewModel.state.value)
-            assertEquals(ABSImportStep.ANALYZING, stateAfterFirstPoll.step)
-            assertEquals(1011, stateAfterFirstPoll.totalBooks)
-            assertEquals(5, stateAfterFirstPoll.totalUsers)
-
-            // Advance past the delay(1500) and second poll to complete analysis
-            advanceUntilIdle()
-
-            // After completion, counts should still be populated
-            val finalState = assertIs<ABSImportUiState.Ready>(viewModel.state.value)
-            assertEquals(1011, finalState.totalBooks)
-            assertEquals(5, finalState.totalUsers)
         }
 
-    @Test
-    fun `analyzing state has zero counts when server does not provide them`() =
-        runTest {
-            val analysisResult = completedAnalysisResponse()
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-            everySuspend { backupApi.analyzeABSBackupAsync(any()) } returns
-                AppResult.Success(AsyncAnalyzeResponse(analysisId = "a2"))
+        test("analyzing state shows totalBooks and totalUsers when server provides counts") {
+            runTest {
+                val fixture = TestFixture()
+                val analysisResult = completedAnalysisResponse()
 
-            everySuspend { backupApi.getAnalysisStatus("a2") } sequentiallyReturns
-                listOf(
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "running",
-                            phase = "parsing",
-                            current = 0,
-                            total = 0,
-                            totalBooks = 0,
-                            totalUsers = 0,
+                everySuspend { fixture.backupApi.analyzeABSBackupAsync(any()) } returns
+                    AppResult.Success(AsyncAnalyzeResponse(analysisId = "a1"))
+
+                everySuspend { fixture.backupApi.getAnalysisStatus("a1") } sequentiallyReturns
+                    listOf(
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "running",
+                                phase = "matching_books",
+                                current = 100,
+                                total = 1011,
+                                totalBooks = 1011,
+                                totalUsers = 5,
+                            ),
                         ),
-                    ),
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "completed",
-                            phase = "done",
-                            result = analysisResult,
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "completed",
+                                phase = "done",
+                                result = analysisResult,
+                            ),
                         ),
-                    ),
-                )
+                    )
 
-            val viewModel = createViewModel()
-            viewModel.setFullRemotePath("/tmp/backup.audiobookshelf")
+                val viewModel = fixture.createViewModel()
+                viewModel.setFullRemotePath("/tmp/backup.audiobookshelf")
 
-            // Advance past the first poll
-            advanceTimeBy(100)
+                // Advance past the first poll (launch + analyzeABSBackupAsync + first getAnalysisStatus)
+                advanceTimeBy(100)
 
-            val stateAfterFirstPoll = assertIs<ABSImportUiState.Ready>(viewModel.state.value)
-            assertEquals(ABSImportStep.ANALYZING, stateAfterFirstPoll.step)
-            assertEquals(0, stateAfterFirstPoll.totalBooks)
-            assertEquals(0, stateAfterFirstPoll.totalUsers)
+                val stateAfterFirstPoll = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                stateAfterFirstPoll.step shouldBe ABSImportStep.ANALYZING
+                stateAfterFirstPoll.totalBooks shouldBe 1011
+                stateAfterFirstPoll.totalUsers shouldBe 5
+
+                // Advance past the delay(1500) and second poll to complete analysis
+                advanceUntilIdle()
+
+                // After completion, counts should still be populated
+                val finalState = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                finalState.totalBooks shouldBe 1011
+                finalState.totalUsers shouldBe 5
+            }
         }
 
-    @Test
-    fun `counts use max value across polling responses`() =
-        runTest {
-            val analysisResult = completedAnalysisResponse()
+        test("analyzing state has zero counts when server does not provide them") {
+            runTest {
+                val fixture = TestFixture()
+                val analysisResult = completedAnalysisResponse()
 
-            everySuspend { backupApi.analyzeABSBackupAsync(any()) } returns
-                AppResult.Success(AsyncAnalyzeResponse(analysisId = "a3"))
+                everySuspend { fixture.backupApi.analyzeABSBackupAsync(any()) } returns
+                    AppResult.Success(AsyncAnalyzeResponse(analysisId = "a2"))
 
-            everySuspend { backupApi.getAnalysisStatus("a3") } sequentiallyReturns
-                listOf(
-                    // First poll: only users known
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "running",
-                            phase = "matching_users",
-                            totalBooks = 0,
-                            totalUsers = 5,
+                everySuspend { fixture.backupApi.getAnalysisStatus("a2") } sequentiallyReturns
+                    listOf(
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "running",
+                                phase = "parsing",
+                                current = 0,
+                                total = 0,
+                                totalBooks = 0,
+                                totalUsers = 0,
+                            ),
                         ),
-                    ),
-                    // Second poll: books now known too
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "running",
-                            phase = "matching_books",
-                            current = 50,
-                            total = 1011,
-                            totalBooks = 1011,
-                            totalUsers = 5,
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "completed",
+                                phase = "done",
+                                result = analysisResult,
+                            ),
                         ),
-                    ),
-                    AppResult.Success(
-                        AnalysisStatusResponse(
-                            status = "completed",
-                            phase = "done",
-                            result = analysisResult,
-                        ),
-                    ),
-                )
+                    )
 
-            val viewModel = createViewModel()
-            viewModel.setFullRemotePath("/tmp/backup.audiobookshelf")
+                val viewModel = fixture.createViewModel()
+                viewModel.setFullRemotePath("/tmp/backup.audiobookshelf")
 
-            // First poll sees users only
-            advanceTimeBy(100)
-            val afterFirst = assertIs<ABSImportUiState.Ready>(viewModel.state.value)
-            assertEquals(5, afterFirst.totalUsers)
-            assertEquals(0, afterFirst.totalBooks)
+                // Advance past the first poll
+                advanceTimeBy(100)
 
-            // Second poll sees both
-            advanceTimeBy(1600)
-            val afterSecond = assertIs<ABSImportUiState.Ready>(viewModel.state.value)
-            assertEquals(5, afterSecond.totalUsers)
-            assertEquals(1011, afterSecond.totalBooks)
+                val stateAfterFirstPoll = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                stateAfterFirstPoll.step shouldBe ABSImportStep.ANALYZING
+                stateAfterFirstPoll.totalBooks shouldBe 0
+                stateAfterFirstPoll.totalUsers shouldBe 0
+            }
         }
-}
+
+        test("counts use max value across polling responses") {
+            runTest {
+                val fixture = TestFixture()
+                val analysisResult = completedAnalysisResponse()
+
+                everySuspend { fixture.backupApi.analyzeABSBackupAsync(any()) } returns
+                    AppResult.Success(AsyncAnalyzeResponse(analysisId = "a3"))
+
+                everySuspend { fixture.backupApi.getAnalysisStatus("a3") } sequentiallyReturns
+                    listOf(
+                        // First poll: only users known
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "running",
+                                phase = "matching_users",
+                                totalBooks = 0,
+                                totalUsers = 5,
+                            ),
+                        ),
+                        // Second poll: books now known too
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "running",
+                                phase = "matching_books",
+                                current = 50,
+                                total = 1011,
+                                totalBooks = 1011,
+                                totalUsers = 5,
+                            ),
+                        ),
+                        AppResult.Success(
+                            AnalysisStatusResponse(
+                                status = "completed",
+                                phase = "done",
+                                result = analysisResult,
+                            ),
+                        ),
+                    )
+
+                val viewModel = fixture.createViewModel()
+                viewModel.setFullRemotePath("/tmp/backup.audiobookshelf")
+
+                // First poll sees users only
+                advanceTimeBy(100)
+                val afterFirst = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                afterFirst.totalUsers shouldBe 5
+                afterFirst.totalBooks shouldBe 0
+
+                // Second poll sees both
+                advanceTimeBy(1600)
+                val afterSecond = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                afterSecond.totalUsers shouldBe 5
+                afterSecond.totalBooks shouldBe 1011
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCategoriesViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCategoriesViewModelTest.kt
@@ -20,14 +20,10 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import com.calypsan.listenup.core.error.ErrorBus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Tests for AdminCategoriesViewModel.
@@ -42,36 +38,36 @@ import com.calypsan.listenup.core.error.ErrorBus
  * - `clearError` clears the transient error on Ready
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class AdminCategoriesViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class AdminCategoriesViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    // ========== Test Fixtures ==========
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val genreRepository: GenreRepository = mock()
-        val genresFlow = MutableStateFlow<List<Genre>>(emptyList())
+        class TestFixture {
+            val genreRepository: GenreRepository = mock()
+            val genresFlow = MutableStateFlow<List<Genre>>(emptyList())
 
-        fun build(): AdminCategoriesViewModel = AdminCategoriesViewModel(genreRepository, errorBus = ErrorBus())
-    }
+            fun build(): AdminCategoriesViewModel = AdminCategoriesViewModel(genreRepository, errorBus = ErrorBus())
+        }
 
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-        every { fixture.genreRepository.observeAll() } returns fixture.genresFlow
-        everySuspend { fixture.genreRepository.createGenre(any(), any(), any()) } returns
-            AppResult.Success(
-                com.calypsan.listenup.core
-                    .GenreId("created"),
-            )
-        everySuspend { fixture.genreRepository.updateGenre(any(), any()) } returns AppResult.Success(Unit)
-        everySuspend { fixture.genreRepository.deleteGenre(any()) } returns AppResult.Success(Unit)
-        everySuspend { fixture.genreRepository.moveGenre(any(), any()) } returns AppResult.Success(Unit)
-        return fixture
-    }
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+            every { fixture.genreRepository.observeAll() } returns fixture.genresFlow
+            everySuspend { fixture.genreRepository.createGenre(any(), any(), any()) } returns
+                AppResult.Success(
+                    com.calypsan.listenup.core
+                        .GenreId("created"),
+                )
+            everySuspend { fixture.genreRepository.updateGenre(any(), any()) } returns AppResult.Success(Unit)
+            everySuspend { fixture.genreRepository.deleteGenre(any()) } returns AppResult.Success(Unit)
+            everySuspend { fixture.genreRepository.moveGenre(any(), any()) } returns AppResult.Success(Unit)
+            return fixture
+        }
 
-    // ========== Test Data Factories ==========
+        // ========== Test Data Factories ==========
 
-    companion object {
-        private fun createGenre(
+        fun createGenre(
             id: String = "g1",
             name: String = "Fiction",
             slug: String = "fiction",
@@ -85,185 +81,173 @@ class AdminCategoriesViewModelTest {
                 path = path,
                 bookCount = bookCount,
             )
-    }
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+        // ========== Initial State ==========
 
-    // ========== Initial State ==========
+        test("initial state is Loading before observeAll emits") {
+            runTest {
+                // Given a repository whose observeAll never emits
+                val genreRepository: GenreRepository = mock()
+                every { genreRepository.observeAll() } returns
+                    flow {
+                        // suspend forever — no emission
+                        kotlinx.coroutines.awaitCancellation()
+                    }
 
-    @Test
-    fun `initial state is Loading before observeAll emits`() =
-        runTest {
-            // Given a repository whose observeAll never emits
-            val genreRepository: GenreRepository = mock()
-            every { genreRepository.observeAll() } returns
-                flow {
-                    // suspend forever — no emission
-                    kotlinx.coroutines.awaitCancellation()
-                }
+                // When
+                val viewModel = AdminCategoriesViewModel(genreRepository, errorBus = ErrorBus())
 
-            // When
-            val viewModel = AdminCategoriesViewModel(genreRepository, errorBus = ErrorBus())
-
-            // Then
-            assertIs<AdminCategoriesUiState.Loading>(viewModel.state.value)
+                // Then
+                viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Loading>()
+            }
         }
 
-    // ========== Reactive Observation ==========
+        // ========== Reactive Observation ==========
 
-    @Test
-    fun `Ready emitted with genres tree and totalBookCount after first emission`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val fiction = createGenre(id = "fiction", name = "Fiction", path = "/fiction", bookCount = 3)
-            val fantasy =
-                createGenre(id = "fantasy", name = "Fantasy", path = "/fiction/fantasy", bookCount = 5)
-            fixture.genresFlow.value = listOf(fiction, fantasy)
+        test("Ready emitted with genres tree and totalBookCount after first emission") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val fiction = createGenre(id = "fiction", name = "Fiction", path = "/fiction", bookCount = 3)
+                val fantasy =
+                    createGenre(id = "fantasy", name = "Fantasy", path = "/fiction/fantasy", bookCount = 5)
+                fixture.genresFlow.value = listOf(fiction, fantasy)
 
-            // When
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+                // When
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then
-            val ready = assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value)
-            assertEquals(listOf(fiction, fantasy), ready.genres)
-            assertEquals(8, ready.totalBookCount)
-            // Tree has one root ("Fiction") with one child ("Fantasy")
-            assertEquals(1, ready.tree.size)
-            assertEquals("fiction", ready.tree[0].genre.id)
-            assertEquals(1, ready.tree[0].children.size)
-            assertEquals(
-                "fantasy",
+                // Then
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                ready.genres shouldBe listOf(fiction, fantasy)
+                ready.totalBookCount shouldBe 8
+                // Tree has one root ("Fiction") with one child ("Fantasy")
+                ready.tree.size shouldBe 1
+                ready.tree[0].genre.id shouldBe "fiction"
+                ready.tree[0].children.size shouldBe 1
                 ready.tree[0]
                     .children[0]
-                    .genre.id,
-            )
-            assertTrue(ready.expandedIds.isEmpty())
-            assertNull(ready.error)
+                    .genre.id shouldBe "fantasy"
+                ready.expandedIds.isEmpty() shouldBe true
+                ready.error shouldBe null
+            }
         }
 
-    // ========== Error Handling ==========
+        // ========== Error Handling ==========
 
-    @Test
-    fun `Error state emitted when observeAll flow throws`() =
-        runTest {
-            // Given
-            val genreRepository: GenreRepository = mock()
-            every { genreRepository.observeAll() } returns
-                flow {
-                    throw RuntimeException("db broken")
-                }
+        test("Error state emitted when observeAll flow throws") {
+            runTest {
+                // Given
+                val genreRepository: GenreRepository = mock()
+                every { genreRepository.observeAll() } returns
+                    flow {
+                        throw RuntimeException("db broken")
+                    }
 
-            // When
-            val viewModel = AdminCategoriesViewModel(genreRepository, errorBus = ErrorBus())
-            advanceUntilIdle()
+                // When
+                val viewModel = AdminCategoriesViewModel(genreRepository, errorBus = ErrorBus())
+                advanceUntilIdle()
 
-            // Then — the thrown Throwable is mapped to a typed AppError (InternalError),
-            // with the original message preserved in debugInfo for diagnostics.
-            val err = assertIs<AdminCategoriesUiState.Error>(viewModel.state.value)
-            val internal = assertIs<InternalError>(err.error)
-            assertTrue(internal.debugInfo?.contains("db broken") == true)
+                // Then — the thrown Throwable is mapped to a typed AppError (InternalError),
+                // with the original message preserved in debugInfo for diagnostics.
+                val err = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Error>()
+                val internal = err.error.shouldBeInstanceOf<InternalError>()
+                (internal.debugInfo?.contains("db broken") == true) shouldBe true
+            }
         }
 
-    // ========== Expand / Collapse ==========
+        // ========== Expand / Collapse ==========
 
-    @Test
-    fun `toggleExpanded adds then removes id from Ready expandedIds`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("toggleExpanded adds then removes id from Ready expandedIds") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When — first toggle adds
-            viewModel.toggleExpanded("fiction")
-            val afterAdd = assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value)
-            assertEquals(setOf("fiction"), afterAdd.expandedIds)
+                // When — first toggle adds
+                viewModel.toggleExpanded("fiction")
+                val afterAdd = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                afterAdd.expandedIds shouldBe setOf("fiction")
 
-            // When — second toggle removes
-            viewModel.toggleExpanded("fiction")
-            val afterRemove = assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value)
-            assertTrue(afterRemove.expandedIds.isEmpty())
+                // When — second toggle removes
+                viewModel.toggleExpanded("fiction")
+                val afterRemove = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                afterRemove.expandedIds.isEmpty() shouldBe true
+            }
         }
 
-    // ========== Mutations ==========
+        // ========== Mutations ==========
 
-    @Test
-    fun `createGenre delegates to repository and auto-expands parent`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("createGenre delegates to repository and auto-expands parent") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.createGenre(name = "Fantasy", parentId = "fiction")
-            advanceUntilIdle()
+                // When
+                viewModel.createGenre(name = "Fantasy", parentId = "fiction")
+                advanceUntilIdle()
 
-            // Then
-            verifySuspend { fixture.genreRepository.createGenre(any(), any(), any()) }
-            val ready = assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value)
-            assertTrue(ready.expandedIds.contains("fiction"))
-            assertEquals(false, ready.isSaving)
-            assertNull(ready.error)
+                // Then
+                verifySuspend { fixture.genreRepository.createGenre(any(), any(), any()) }
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                ready.expandedIds.contains("fiction") shouldBe true
+                ready.isSaving shouldBe false
+                ready.error shouldBe null
+            }
         }
 
-    @Test
-    fun `createGenre failure surfaces as transient error on Ready`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
-            val failureError = TransportError.Server4xx(statusCode = 409, debugInfo = "duplicate name")
-            everySuspend { fixture.genreRepository.createGenre(any(), any()) } returns
-                AppResult.Failure(failureError)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("createGenre failure surfaces as transient error on Ready") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
+                val failureError = TransportError.Server4xx(statusCode = 409, debugInfo = "duplicate name")
+                everySuspend { fixture.genreRepository.createGenre(any(), any()) } returns
+                    AppResult.Failure(failureError)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.createGenre(name = "Fiction", parentId = null)
-            advanceUntilIdle()
+                // When
+                viewModel.createGenre(name = "Fiction", parentId = null)
+                advanceUntilIdle()
 
-            // Then — the typed AppError itself is carried in state (no longer flattened to a string).
-            val ready = assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value)
-            assertEquals(failureError, ready.error)
-            assertEquals(false, ready.isSaving)
+                // Then — the typed AppError itself is carried in state (no longer flattened to a string).
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                ready.error shouldBe failureError
+                ready.isSaving shouldBe false
+            }
         }
 
-    @Test
-    fun `clearError resets Ready error to null`() =
-        runTest {
-            // Given — a Ready state with an error
-            val fixture = createFixture()
-            fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
-            val failureError = TransportError.Server4xx(statusCode = 500, debugInfo = "boom")
-            everySuspend { fixture.genreRepository.createGenre(any(), any()) } returns
-                AppResult.Failure(failureError)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-            viewModel.createGenre(name = "X", parentId = null)
-            advanceUntilIdle()
-            assertEquals(
-                failureError,
-                assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value).error,
-            )
+        test("clearError resets Ready error to null") {
+            runTest {
+                // Given — a Ready state with an error
+                val fixture = createFixture()
+                fixture.genresFlow.value = listOf(createGenre(id = "fiction"))
+                val failureError = TransportError.Server4xx(statusCode = 500, debugInfo = "boom")
+                everySuspend { fixture.genreRepository.createGenre(any(), any()) } returns
+                    AppResult.Failure(failureError)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+                viewModel.createGenre(name = "X", parentId = null)
+                advanceUntilIdle()
+                viewModel.state.value
+                    .shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                    .error shouldBe failureError
 
-            // When
-            viewModel.clearError()
+                // When
+                viewModel.clearError()
 
-            // Then
-            val ready = assertIs<AdminCategoriesUiState.Ready>(viewModel.state.value)
-            assertNull(ready.error)
+                // Then
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminCategoriesUiState.Ready>()
+                ready.error shouldBe null
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminSettingsViewModelTest.kt
@@ -17,15 +17,10 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import com.calypsan.listenup.core.error.ErrorBus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Tests for AdminSettingsViewModel.
@@ -41,210 +36,203 @@ import com.calypsan.listenup.core.error.ErrorBus
  * - `clearError` clears the transient error on Ready
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class AdminSettingsViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class AdminSettingsViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    // ========== Test Fixtures ==========
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val loadServerSettingsUseCase: LoadServerSettingsUseCase = mock()
-        val updateServerSettingsUseCase: UpdateServerSettingsUseCase = mock()
-
-        fun build(): AdminSettingsViewModel =
-            AdminSettingsViewModel(
-                loadServerSettingsUseCase = loadServerSettingsUseCase,
-                updateServerSettingsUseCase = updateServerSettingsUseCase,
-                errorBus = ErrorBus(),
+        // createServerSettings is declared before TestFixture so createFixture's default arg resolves.
+        fun createServerSettings(
+            serverName: String = "My Server",
+            remoteUrl: String? = null,
+        ): ServerSettings =
+            ServerSettings(
+                serverName = serverName,
+                remoteUrl = remoteUrl,
             )
-    }
 
-    private fun createFixture(settings: ServerSettings = createServerSettings()): TestFixture {
-        val fixture = TestFixture()
-        everySuspend { fixture.loadServerSettingsUseCase() } returns AppResult.Success(settings)
-        return fixture
-    }
+        class TestFixture {
+            val loadServerSettingsUseCase: LoadServerSettingsUseCase = mock()
+            val updateServerSettingsUseCase: UpdateServerSettingsUseCase = mock()
 
-    // ========== Test Data Factories ==========
-
-    private fun createServerSettings(
-        serverName: String = "My Server",
-        remoteUrl: String? = null,
-    ): ServerSettings =
-        ServerSettings(
-            serverName = serverName,
-            remoteUrl = remoteUrl,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State ==========
-
-    @Test
-    fun `initial state is Loading`() =
-        runTest {
-            val fixture = createFixture()
-            // Do not advance — we want to observe the state before init completes.
-            val viewModel = fixture.build()
-
-            assertIs<AdminSettingsUiState.Loading>(viewModel.state.value)
-        }
-
-    // ========== Load ==========
-
-    @Test
-    fun `load transitions to Ready with server settings`() =
-        runTest {
-            val fixture =
-                createFixture(
-                    settings = createServerSettings(serverName = "ListenUp Prod", remoteUrl = "https://audio.example.com"),
+            fun build(): AdminSettingsViewModel =
+                AdminSettingsViewModel(
+                    loadServerSettingsUseCase = loadServerSettingsUseCase,
+                    updateServerSettingsUseCase = updateServerSettingsUseCase,
+                    errorBus = ErrorBus(),
                 )
-
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-
-            val ready = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertEquals("ListenUp Prod", ready.serverName)
-            assertEquals("https://audio.example.com", ready.remoteUrl)
-            assertFalse(ready.isDirty)
-            assertFalse(ready.isSaving)
-            assertNull(ready.error)
         }
 
-    @Test
-    fun `load failure transitions to Error`() =
-        runTest {
+        fun createFixture(settings: ServerSettings = createServerSettings()): TestFixture {
             val fixture = TestFixture()
-            // Body-level message convention: pass a typed AppError so the
-            // user-facing message survives delegation to the ViewModel.
-            everySuspend { fixture.loadServerSettingsUseCase() } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Network down"),
-                )
-
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-
-            val error = assertIs<AdminSettingsUiState.Error>(viewModel.state.value)
-            assertEquals("Network down", error.error.message)
+            everySuspend { fixture.loadServerSettingsUseCase() } returns AppResult.Success(settings)
+            return fixture
         }
 
-    // ========== Edit Buffer Mutations ==========
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-    @Test
-    fun `setServerName updates Ready and marks dirty`() =
-        runTest {
-            val fixture = createFixture(settings = createServerSettings(serverName = "Old Name"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== Initial State ==========
 
-            viewModel.setServerName("New Name")
+        test("initial state is Loading") {
+            runTest {
+                val fixture = createFixture()
+                // Do not advance — we want to observe the state before init completes.
+                val viewModel = fixture.build()
 
-            val ready = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertEquals("New Name", ready.serverName)
-            assertTrue(ready.isDirty)
-        }
-
-    // ========== Save ==========
-
-    @Test
-    fun `saveAll happy-path persists server name changes and resets dirty`() =
-        runTest {
-            val fixture = createFixture(settings = createServerSettings(serverName = "Original"))
-            everySuspend { fixture.updateServerSettingsUseCase.updateServerName("Renamed") } returns
-                AppResult.Success(createServerSettings(serverName = "Renamed"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-
-            viewModel.setServerName("Renamed")
-            viewModel.saveAll()
-            advanceUntilIdle()
-
-            val ready = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertEquals("Renamed", ready.serverName)
-            assertFalse(ready.isSaving)
-            assertFalse(ready.isDirty)
-            assertNull(ready.error)
-            verifySuspend(VerifyMode.atLeast(1)) {
-                fixture.updateServerSettingsUseCase.updateServerName("Renamed")
+                viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Loading>()
             }
         }
 
-    @Test
-    fun `saveAll happy-path persists remote URL changes and resets dirty`() =
-        runTest {
-            val fixture = createFixture(settings = createServerSettings(remoteUrl = "https://old.example.com"))
-            everySuspend { fixture.updateServerSettingsUseCase.updateRemoteUrl("https://new.example.com") } returns
-                AppResult.Success(createServerSettings(remoteUrl = "https://new.example.com"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== Load ==========
 
-            viewModel.setRemoteUrl("https://new.example.com")
-            viewModel.saveAll()
-            advanceUntilIdle()
+        test("load transitions to Ready with server settings") {
+            runTest {
+                val fixture =
+                    createFixture(
+                        settings = createServerSettings(serverName = "ListenUp Prod", remoteUrl = "https://audio.example.com"),
+                    )
 
-            val ready = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.isSaving)
-            assertFalse(ready.isDirty)
-            assertNull(ready.error)
-            verifySuspend(VerifyMode.atLeast(1)) {
-                fixture.updateServerSettingsUseCase.updateRemoteUrl("https://new.example.com")
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                ready.serverName shouldBe "ListenUp Prod"
+                ready.remoteUrl shouldBe "https://audio.example.com"
+                ready.isDirty shouldBe false
+                ready.isSaving shouldBe false
+                ready.error shouldBe null
             }
         }
 
-    @Test
-    fun `saveAll failure surfaces as transient error on Ready`() =
-        runTest {
-            val fixture = createFixture(settings = createServerSettings(serverName = "Original"))
-            // Body-level message convention: pass a typed AppError so the
-            // "Forbidden" text surfaces directly as the typed Ready.error.
-            everySuspend { fixture.updateServerSettingsUseCase.updateServerName("Renamed") } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Forbidden"),
-                )
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("load failure transitions to Error") {
+            runTest {
+                val fixture = TestFixture()
+                // Body-level message convention: pass a typed AppError so the
+                // user-facing message survives delegation to the ViewModel.
+                everySuspend { fixture.loadServerSettingsUseCase() } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Network down"),
+                    )
 
-            viewModel.setServerName("Renamed")
-            viewModel.saveAll()
-            advanceUntilIdle()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            val ready = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.isSaving)
-            assertTrue(ready.error?.message?.contains("Forbidden") == true)
-            // Dirty remains true because buffer diverges from baseline after failed save.
-            assertTrue(ready.isDirty)
+                val error = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Error>()
+                error.error.message shouldBe "Network down"
+            }
         }
 
-    // ========== Transient State Clearing ==========
+        // ========== Edit Buffer Mutations ==========
 
-    @Test
-    fun `clearError clears Ready error to null`() =
-        runTest {
-            val fixture = createFixture(settings = createServerSettings(serverName = "Original"))
-            everySuspend { fixture.updateServerSettingsUseCase.updateServerName("Renamed") } returns
-                Failure(RuntimeException("boom"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("setServerName updates Ready and marks dirty") {
+            runTest {
+                val fixture = createFixture(settings = createServerSettings(serverName = "Old Name"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            viewModel.setServerName("Renamed")
-            viewModel.saveAll()
-            advanceUntilIdle()
-            val withError = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertTrue(withError.error != null)
+                viewModel.setServerName("New Name")
 
-            viewModel.clearError()
-
-            val cleared = assertIs<AdminSettingsUiState.Ready>(viewModel.state.value)
-            assertNull(cleared.error)
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                ready.serverName shouldBe "New Name"
+                ready.isDirty shouldBe true
+            }
         }
-}
+
+        // ========== Save ==========
+
+        test("saveAll happy-path persists server name changes and resets dirty") {
+            runTest {
+                val fixture = createFixture(settings = createServerSettings(serverName = "Original"))
+                everySuspend { fixture.updateServerSettingsUseCase.updateServerName("Renamed") } returns
+                    AppResult.Success(createServerSettings(serverName = "Renamed"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                viewModel.setServerName("Renamed")
+                viewModel.saveAll()
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                ready.serverName shouldBe "Renamed"
+                ready.isSaving shouldBe false
+                ready.isDirty shouldBe false
+                ready.error shouldBe null
+                verifySuspend(VerifyMode.atLeast(1)) {
+                    fixture.updateServerSettingsUseCase.updateServerName("Renamed")
+                }
+            }
+        }
+
+        test("saveAll happy-path persists remote URL changes and resets dirty") {
+            runTest {
+                val fixture = createFixture(settings = createServerSettings(remoteUrl = "https://old.example.com"))
+                everySuspend { fixture.updateServerSettingsUseCase.updateRemoteUrl("https://new.example.com") } returns
+                    AppResult.Success(createServerSettings(remoteUrl = "https://new.example.com"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                viewModel.setRemoteUrl("https://new.example.com")
+                viewModel.saveAll()
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                ready.isSaving shouldBe false
+                ready.isDirty shouldBe false
+                ready.error shouldBe null
+                verifySuspend(VerifyMode.atLeast(1)) {
+                    fixture.updateServerSettingsUseCase.updateRemoteUrl("https://new.example.com")
+                }
+            }
+        }
+
+        test("saveAll failure surfaces as transient error on Ready") {
+            runTest {
+                val fixture = createFixture(settings = createServerSettings(serverName = "Original"))
+                // Body-level message convention: pass a typed AppError so the
+                // "Forbidden" text surfaces directly as the typed Ready.error.
+                everySuspend { fixture.updateServerSettingsUseCase.updateServerName("Renamed") } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Forbidden"),
+                    )
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                viewModel.setServerName("Renamed")
+                viewModel.saveAll()
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                ready.isSaving shouldBe false
+                (ready.error?.message?.contains("Forbidden") == true) shouldBe true
+                // Dirty remains true because buffer diverges from baseline after failed save.
+                ready.isDirty shouldBe true
+            }
+        }
+
+        // ========== Transient State Clearing ==========
+
+        test("clearError clears Ready error to null") {
+            runTest {
+                val fixture = createFixture(settings = createServerSettings(serverName = "Original"))
+                everySuspend { fixture.updateServerSettingsUseCase.updateServerName("Renamed") } returns
+                    Failure(RuntimeException("boom"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                viewModel.setServerName("Renamed")
+                viewModel.saveAll()
+                advanceUntilIdle()
+                val withError = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                (withError.error != null) shouldBe true
+
+                viewModel.clearError()
+
+                val cleared = viewModel.state.value.shouldBeInstanceOf<AdminSettingsUiState.Ready>()
+                cleared.error shouldBe null
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
@@ -20,6 +20,10 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -30,401 +34,393 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AdminViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class AdminViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private fun createMockGetRegistrationPolicyUseCase(isOpen: Boolean = false): GetRegistrationPolicyUseCase {
-        val useCase: GetRegistrationPolicyUseCase = mock()
-        everySuspend { useCase() } returns AppResult.Success(isOpen)
-        return useCase
-    }
-
-    private fun createMockEventStreamRepository(): EventStreamRepository {
-        val eventStreamRepo: EventStreamRepository = mock()
-        val adminEvents = MutableSharedFlow<AdminEvent>()
-        every { eventStreamRepo.adminEvents } returns adminEvents
-        return eventStreamRepo
-    }
-
-    private fun createUser(
-        id: String = "user-1",
-        email: String = "test@example.com",
-    ) = AdminUserInfo(
-        id = id,
-        email = email,
-        displayName = "Test User",
-        firstName = "Test",
-        lastName = "User",
-        isRoot = false,
-        role = "user",
-        status = "active",
-        createdAt = "2024-01-01T00:00:00Z",
-    )
-
-    private fun createInvite(
-        id: String = "invite-1",
-        claimedAt: String? = null,
-    ) = InviteInfo(
-        id = id,
-        code = "ABC123",
-        name = "Invited User",
-        email = "invited@example.com",
-        role = "user",
-        expiresAt = "2024-02-01T00:00:00Z",
-        claimedAt = claimedAt,
-        url = "https://example.com/invite/ABC123",
-        createdAt = "2024-01-01T00:00:00Z",
-    )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `initial state is Loading`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
-
-            everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
-
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-
-            assertIs<AdminUiState.Loading>(viewModel.state.value)
+        fun createMockGetRegistrationPolicyUseCase(isOpen: Boolean = false): GetRegistrationPolicyUseCase {
+            val useCase: GetRegistrationPolicyUseCase = mock()
+            everySuspend { useCase() } returns AppResult.Success(isOpen)
+            return useCase
         }
 
-    @Test
-    fun `loadData transitions to Ready with users and invites`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
-
-            val users = listOf(createUser("user-1"), createUser("user-2"))
-            val invites = listOf(createInvite("invite-1"))
-            everySuspend { loadUsersUseCase() } returns AppResult.Success(users)
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns AppResult.Success(invites)
-
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-            advanceUntilIdle()
-
-            val ready = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertEquals(2, ready.users.size)
-            assertEquals(1, ready.pendingInvites.size)
+        fun createMockEventStreamRepository(): EventStreamRepository {
+            val eventStreamRepo: EventStreamRepository = mock()
+            val adminEvents = MutableSharedFlow<AdminEvent>()
+            every { eventStreamRepo.adminEvents } returns adminEvents
+            return eventStreamRepo
         }
 
-    @Test
-    fun `loadData filters out claimed invites`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+        fun createUser(
+            id: String = "user-1",
+            email: String = "test@example.com",
+        ) = AdminUserInfo(
+            id = id,
+            email = email,
+            displayName = "Test User",
+            firstName = "Test",
+            lastName = "User",
+            isRoot = false,
+            role = "user",
+            status = "active",
+            createdAt = "2024-01-01T00:00:00Z",
+        )
 
-            val invites =
-                listOf(
-                    createInvite("pending", claimedAt = null),
-                    createInvite("claimed", claimedAt = "2024-01-15T00:00:00Z"),
-                )
-            everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns AppResult.Success(invites)
+        fun createInvite(
+            id: String = "invite-1",
+            claimedAt: String? = null,
+        ) = InviteInfo(
+            id = id,
+            code = "ABC123",
+            name = "Invited User",
+            email = "invited@example.com",
+            role = "user",
+            expiresAt = "2024-02-01T00:00:00Z",
+            claimedAt = claimedAt,
+            url = "https://example.com/invite/ABC123",
+            createdAt = "2024-01-01T00:00:00Z",
+        )
 
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-            advanceUntilIdle()
-
-            val ready = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.pendingInvites.size)
-            assertEquals("pending", ready.pendingInvites[0].id)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `loadData initial users failure transitions to Error`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
-
-            everySuspend { loadUsersUseCase() } returns Failure(RuntimeException("Network error"))
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
-
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-            advanceUntilIdle()
-
-            val error = assertIs<AdminUiState.Error>(viewModel.state.value)
-            assertTrue(error.message.contains("users"))
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `deleteUser removes user from list`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+        test("initial state is Loading") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
 
-            val users = listOf(createUser("user-1"), createUser("user-2"))
-            everySuspend { loadUsersUseCase() } returns AppResult.Success(users)
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { deleteUserUseCase("user-1") } returns AppResult.Success(Unit)
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
 
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-            advanceUntilIdle()
-            val afterLoad = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertEquals(2, afterLoad.users.size)
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
 
-            viewModel.deleteUser("user-1")
-            advanceUntilIdle()
-
-            val ready = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.users.size)
-            assertEquals("user-2", ready.users[0].id)
-        }
-
-    @Test
-    fun `revokeInvite removes invite from list`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
-
-            val invites = listOf(createInvite("invite-1"), createInvite("invite-2"))
-            everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns AppResult.Success(invites)
-            everySuspend { revokeInviteUseCase("invite-1") } returns AppResult.Success(Unit)
-
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-            advanceUntilIdle()
-
-            viewModel.revokeInvite("invite-1")
-            advanceUntilIdle()
-
-            val ready = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.pendingInvites.size)
-            assertEquals("invite-2", ready.pendingInvites[0].id)
-        }
-
-    @Test
-    fun `clearError clears error state`() =
-        runTest {
-            val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
-
-            // Users succeeds to land in Ready; invites fails to surface transient error on Ready.
-            everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
-            everySuspend { loadInvitesUseCase() } returns Failure(RuntimeException("Invites error"))
-
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-            advanceUntilIdle()
-            val beforeClear = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertTrue(beforeClear.error != null)
-
-            viewModel.clearError()
-
-            val afterClear = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertNull(afterClear.error)
-        }
-
-    @Test
-    fun `loadData fetches all data in parallel`() =
-        runTest {
-            val getRegistrationPolicyUseCase: GetRegistrationPolicyUseCase = mock()
-            everySuspend { getRegistrationPolicyUseCase() } calls {
-                delay(100)
-                AppResult.Success(false)
+                viewModel.state.value.shouldBeInstanceOf<AdminUiState.Loading>()
             }
-
-            val loadUsersUseCase: LoadUsersUseCase = mock()
-            val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
-            val loadInvitesUseCase: LoadInvitesUseCase = mock()
-            val deleteUserUseCase: DeleteUserUseCase = mock()
-            val revokeInviteUseCase: RevokeInviteUseCase = mock()
-            val approveUserUseCase: ApproveUserUseCase = mock()
-            val denyUserUseCase: DenyUserUseCase = mock()
-            val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
-
-            everySuspend { loadUsersUseCase() } calls {
-                delay(100)
-                AppResult.Success(listOf(createUser()))
-            }
-            everySuspend { loadPendingUsersUseCase() } calls {
-                delay(100)
-                AppResult.Success(emptyList())
-            }
-            everySuspend { loadInvitesUseCase() } calls {
-                delay(100)
-                AppResult.Success(listOf(createInvite()))
-            }
-
-            val viewModel =
-                AdminViewModel(
-                    getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
-                    loadUsersUseCase = loadUsersUseCase,
-                    loadPendingUsersUseCase = loadPendingUsersUseCase,
-                    loadInvitesUseCase = loadInvitesUseCase,
-                    deleteUserUseCase = deleteUserUseCase,
-                    revokeInviteUseCase = revokeInviteUseCase,
-                    approveUserUseCase = approveUserUseCase,
-                    denyUserUseCase = denyUserUseCase,
-                    setOpenRegistrationUseCase = setOpenRegistrationUseCase,
-                    eventStreamRepository = createMockEventStreamRepository(),
-                )
-
-            // If parallel, all 4 calls start at t=0 and complete at t=100ms.
-            // If sequential, they'd complete at t=400ms.
-            // Advance 150ms — enough for parallel, not enough for sequential.
-            advanceTimeBy(150)
-
-            val ready = assertIs<AdminUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.users.size)
-            assertEquals(1, ready.pendingInvites.size)
         }
-}
+
+        test("loadData transitions to Ready with users and invites") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                val users = listOf(createUser("user-1"), createUser("user-2"))
+                val invites = listOf(createInvite("invite-1"))
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(users)
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(invites)
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                ready.users.size shouldBe 2
+                ready.pendingInvites.size shouldBe 1
+            }
+        }
+
+        test("loadData filters out claimed invites") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                val invites =
+                    listOf(
+                        createInvite("pending", claimedAt = null),
+                        createInvite("claimed", claimedAt = "2024-01-15T00:00:00Z"),
+                    )
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(invites)
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                ready.pendingInvites.size shouldBe 1
+                ready.pendingInvites[0].id shouldBe "pending"
+            }
+        }
+
+        test("loadData initial users failure transitions to Error") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                everySuspend { loadUsersUseCase() } returns Failure(RuntimeException("Network error"))
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+                advanceUntilIdle()
+
+                val error = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Error>()
+                error.message shouldContain "users"
+            }
+        }
+
+        test("deleteUser removes user from list") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                val users = listOf(createUser("user-1"), createUser("user-2"))
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(users)
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { deleteUserUseCase("user-1") } returns AppResult.Success(Unit)
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+                advanceUntilIdle()
+                val afterLoad = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                afterLoad.users.size shouldBe 2
+
+                viewModel.deleteUser("user-1")
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                ready.users.size shouldBe 1
+                ready.users[0].id shouldBe "user-2"
+            }
+        }
+
+        test("revokeInvite removes invite from list") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                val invites = listOf(createInvite("invite-1"), createInvite("invite-2"))
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(invites)
+                everySuspend { revokeInviteUseCase("invite-1") } returns AppResult.Success(Unit)
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+                advanceUntilIdle()
+
+                viewModel.revokeInvite("invite-1")
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                ready.pendingInvites.size shouldBe 1
+                ready.pendingInvites[0].id shouldBe "invite-2"
+            }
+        }
+
+        test("clearError clears error state") {
+            runTest {
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                // Users succeeds to land in Ready; invites fails to surface transient error on Ready.
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { loadInvitesUseCase() } returns Failure(RuntimeException("Invites error"))
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+                advanceUntilIdle()
+                val beforeClear = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                (beforeClear.error != null) shouldBe true
+
+                viewModel.clearError()
+
+                val afterClear = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                afterClear.error shouldBe null
+            }
+        }
+
+        test("loadData fetches all data in parallel") {
+            runTest {
+                val getRegistrationPolicyUseCase: GetRegistrationPolicyUseCase = mock()
+                everySuspend { getRegistrationPolicyUseCase() } calls {
+                    delay(100)
+                    AppResult.Success(false)
+                }
+
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                val deleteUserUseCase: DeleteUserUseCase = mock()
+                val revokeInviteUseCase: RevokeInviteUseCase = mock()
+                val approveUserUseCase: ApproveUserUseCase = mock()
+                val denyUserUseCase: DenyUserUseCase = mock()
+                val setOpenRegistrationUseCase: SetOpenRegistrationUseCase = mock()
+
+                everySuspend { loadUsersUseCase() } calls {
+                    delay(100)
+                    AppResult.Success(listOf(createUser()))
+                }
+                everySuspend { loadPendingUsersUseCase() } calls {
+                    delay(100)
+                    AppResult.Success(emptyList())
+                }
+                everySuspend { loadInvitesUseCase() } calls {
+                    delay(100)
+                    AppResult.Success(listOf(createInvite()))
+                }
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase = getRegistrationPolicyUseCase,
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = deleteUserUseCase,
+                        revokeInviteUseCase = revokeInviteUseCase,
+                        approveUserUseCase = approveUserUseCase,
+                        denyUserUseCase = denyUserUseCase,
+                        setOpenRegistrationUseCase = setOpenRegistrationUseCase,
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+
+                // If parallel, all 4 calls start at t=0 and complete at t=100ms.
+                // If sequential, they'd complete at t=400ms.
+                // Advance 150ms — enough for parallel, not enough for sequential.
+                advanceTimeBy(150)
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                ready.users.size shouldBe 1
+                ready.pendingInvites.size shouldBe 1
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModelTest.kt
@@ -9,6 +9,9 @@ import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -16,187 +19,181 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CreateInviteViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class CreateInviteViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private fun createInviteInfo() =
-        InviteInfo(
-            id = "invite-1",
-            code = "XYZ789",
-            name = "New User",
-            email = "new@example.com",
-            role = "user",
-            expiresAt = "2024-02-01T00:00:00Z",
-            claimedAt = null,
-            url = "https://example.com/invite/XYZ789",
-            createdAt = "2024-01-01T00:00:00Z",
-        )
+        fun createInviteInfo() =
+            InviteInfo(
+                id = "invite-1",
+                code = "XYZ789",
+                name = "New User",
+                email = "new@example.com",
+                role = "user",
+                expiresAt = "2024-02-01T00:00:00Z",
+                claimedAt = null,
+                url = "https://example.com/invite/XYZ789",
+                createdAt = "2024-01-01T00:00:00Z",
+            )
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `initial state is Idle`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
-
-            val ready = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            checkIs<CreateInviteStatus.Idle>(ready.status)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `createInvite validates empty name`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            // Body-level message convention: ViewModel routes by string-matching
-            // failure.message, so pass a typed AppError whose body-level message
-            // matches the relevant branch ("Name is required").
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Name is required"),
-                )
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
-
-            viewModel.createInvite(name = "", email = "test@example.com", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
-
-            val ready = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            val status = assertIs<CreateInviteStatus.Error>(ready.status)
-            val errorType = assertIs<CreateInviteErrorType.ValidationError>(status.type)
-            assertEquals(CreateInviteField.NAME, errorType.field)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `createInvite validates invalid email`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            // Body-level message convention: see empty-name test for explanation.
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "Invalid email"),
-                )
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
+        test("initial state is Idle") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-            viewModel.createInvite(name = "Test User", email = "invalid-email", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
-
-            val ready = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            val status = assertIs<CreateInviteStatus.Error>(ready.status)
-            val errorType = assertIs<CreateInviteErrorType.ValidationError>(status.type)
-            assertEquals(CreateInviteField.EMAIL, errorType.field)
+                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                checkIs<CreateInviteStatus.Idle>(ready.status)
+            }
         }
 
-    @Test
-    fun `createInvite returns Success with invite on success`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            val invite = createInviteInfo()
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns AppResult.Success(invite)
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
+        test("createInvite validates empty name") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                // Body-level message convention: ViewModel routes by string-matching
+                // failure.message, so pass a typed AppError whose body-level message
+                // matches the relevant branch ("Name is required").
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Name is required"),
+                    )
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-            viewModel.createInvite(name = "New User", email = "new@example.com", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
+                viewModel.createInvite(name = "", email = "test@example.com", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
 
-            val ready = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            val status = assertIs<CreateInviteStatus.Success>(ready.status)
-            assertEquals(invite.id, status.invite.id)
+                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                val status = ready.status.shouldBeInstanceOf<CreateInviteStatus.Error>()
+                val errorType = status.type.shouldBeInstanceOf<CreateInviteErrorType.ValidationError>()
+                errorType.field shouldBe CreateInviteField.NAME
+            }
         }
 
-    @Test
-    fun `createInvite handles email already exists error`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            // Server returns 409 Conflict for duplicate email — ViewModel routes
-            // TransportError.Server4xx(409) → EmailInUse via type-pattern matching.
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error.TransportError
-                        .Server4xx(statusCode = 409),
-                )
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
+        test("createInvite validates invalid email") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                // Body-level message convention: see empty-name test for explanation.
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Invalid email"),
+                    )
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-            viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
+                viewModel.createInvite(name = "Test User", email = "invalid-email", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
 
-            val ready = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            val status = assertIs<CreateInviteStatus.Error>(ready.status)
-            checkIs<CreateInviteErrorType.EmailInUse>(status.type)
+                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                val status = ready.status.shouldBeInstanceOf<CreateInviteStatus.Error>()
+                val errorType = status.type.shouldBeInstanceOf<CreateInviteErrorType.ValidationError>()
+                errorType.field shouldBe CreateInviteField.EMAIL
+            }
         }
 
-    @Test
-    fun `createInvite handles network error`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            // Body-level message convention: TransportError.NetworkUnavailable's
-            // body-level message ("No internet connection. Check your network.")
-            // contains both "network" and "connection", which the VM's branch
-            // looks for.
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error.TransportError
-                        .NetworkUnavailable(),
-                )
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
+        test("createInvite returns Success with invite on success") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                val invite = createInviteInfo()
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns AppResult.Success(invite)
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-            viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
+                viewModel.createInvite(name = "New User", email = "new@example.com", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
 
-            val ready = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            val status = assertIs<CreateInviteStatus.Error>(ready.status)
-            checkIs<CreateInviteErrorType.NetworkError>(status.type)
+                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                val status = ready.status.shouldBeInstanceOf<CreateInviteStatus.Success>()
+                status.invite.id shouldBe invite.id
+            }
         }
 
-    @Test
-    fun `clearError resets to Idle`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
-                Failure(RuntimeException("Name is required"))
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
+        test("createInvite handles email already exists error") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                // Server returns 409 Conflict for duplicate email — ViewModel routes
+                // TransportError.Server4xx(409) → EmailInUse via type-pattern matching.
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error.TransportError
+                            .Server4xx(statusCode = 409),
+                    )
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-            viewModel.createInvite(name = "", email = "test@example.com", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
-            val readyAfterError = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            checkIs<CreateInviteStatus.Error>(readyAfterError.status)
+                viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
 
-            viewModel.clearError()
-
-            val readyAfterClear = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            checkIs<CreateInviteStatus.Idle>(readyAfterClear.status)
+                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                val status = ready.status.shouldBeInstanceOf<CreateInviteStatus.Error>()
+                checkIs<CreateInviteErrorType.EmailInUse>(status.type)
+            }
         }
 
-    @Test
-    fun `reset returns to initial state`() =
-        runTest {
-            val createInviteUseCase: CreateInviteUseCase = mock()
-            everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns AppResult.Success(createInviteInfo())
-            val viewModel = CreateInviteViewModel(createInviteUseCase)
+        test("createInvite handles network error") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                // Body-level message convention: TransportError.NetworkUnavailable's
+                // body-level message ("No internet connection. Check your network.")
+                // contains both "network" and "connection", which the VM's branch
+                // looks for.
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error.TransportError
+                            .NetworkUnavailable(),
+                    )
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-            viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
-            advanceUntilIdle()
-            val readyAfterSuccess = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            checkIs<CreateInviteStatus.Success>(readyAfterSuccess.status)
+                viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
 
-            viewModel.reset()
-
-            val readyAfterReset = assertIs<CreateInviteUiState.Ready>(viewModel.state.value)
-            checkIs<CreateInviteStatus.Idle>(readyAfterReset.status)
+                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                val status = ready.status.shouldBeInstanceOf<CreateInviteStatus.Error>()
+                checkIs<CreateInviteErrorType.NetworkError>(status.type)
+            }
         }
-}
+
+        test("clearError resets to Idle") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                    Failure(RuntimeException("Name is required"))
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
+
+                viewModel.createInvite(name = "", email = "test@example.com", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
+                val readyAfterError = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                checkIs<CreateInviteStatus.Error>(readyAfterError.status)
+
+                viewModel.clearError()
+
+                val readyAfterClear = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                checkIs<CreateInviteStatus.Idle>(readyAfterClear.status)
+            }
+        }
+
+        test("reset returns to initial state") {
+            runTest {
+                val createInviteUseCase: CreateInviteUseCase = mock()
+                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns AppResult.Success(createInviteInfo())
+                val viewModel = CreateInviteViewModel(createInviteUseCase)
+
+                viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
+                advanceUntilIdle()
+                val readyAfterSuccess = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                checkIs<CreateInviteStatus.Success>(readyAfterSuccess.status)
+
+                viewModel.reset()
+
+                val readyAfterReset = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
+                checkIs<CreateInviteStatus.Idle>(readyAfterReset.status)
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/UserDetailViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/UserDetailViewModelTest.kt
@@ -10,6 +10,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,200 +20,191 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import com.calypsan.listenup.core.error.ErrorBus
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class UserDetailViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class UserDetailViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private fun createUser(
-        id: String = "user-1",
-        email: String = "test@example.com",
-        canShare: Boolean = true,
-    ) = AdminUserInfo(
-        id = id,
-        email = email,
-        displayName = "Test User",
-        firstName = "Test",
-        lastName = "User",
-        isRoot = false,
-        role = "member",
-        status = "active",
-        permissions = UserPermissions(canShare = canShare),
-        createdAt = "2024-01-01T00:00:00Z",
-    )
+        fun createUser(
+            id: String = "user-1",
+            email: String = "test@example.com",
+            canShare: Boolean = true,
+        ) = AdminUserInfo(
+            id = id,
+            email = email,
+            displayName = "Test User",
+            firstName = "Test",
+            lastName = "User",
+            isRoot = false,
+            role = "member",
+            status = "active",
+            permissions = UserPermissions(canShare = canShare),
+            createdAt = "2024-01-01T00:00:00Z",
+        )
 
-    private fun networkFailure() = AppResult.Failure(TransportError.NetworkUnavailable())
+        fun networkFailure() = AppResult.Failure(TransportError.NetworkUnavailable())
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `initial state is Loading`() =
-        runTest {
-            val adminRepository: AdminRepository = mock()
-            everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(createUser())
-
-            val viewModel =
-                UserDetailViewModel(
-                    userId = "user-1",
-                    adminRepository = adminRepository,
-                    errorBus = ErrorBus(),
-                )
-
-            assertIs<UserDetailUiState.Loading>(viewModel.state.value)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `loadUser transitions to Ready with user details`() =
-        runTest {
-            val adminRepository: AdminRepository = mock()
-            val user = createUser(canShare = false)
-            everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(user)
-
-            val viewModel =
-                UserDetailViewModel(
-                    userId = "user-1",
-                    adminRepository = adminRepository,
-                    errorBus = ErrorBus(),
-                )
-            advanceUntilIdle()
-
-            val ready = assertIs<UserDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(user, ready.user)
-            assertFalse(ready.canShare)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `loadUser initial failure transitions to Error`() =
-        runTest {
-            val adminRepository: AdminRepository = mock()
-            everySuspend { adminRepository.getUser("user-1") } returns networkFailure()
+        test("initial state is Loading") {
+            runTest {
+                val adminRepository: AdminRepository = mock()
+                everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(createUser())
 
-            val viewModel =
-                UserDetailViewModel(
-                    userId = "user-1",
-                    adminRepository = adminRepository,
-                    errorBus = ErrorBus(),
-                )
-            advanceUntilIdle()
+                val viewModel =
+                    UserDetailViewModel(
+                        userId = "user-1",
+                        adminRepository = adminRepository,
+                        errorBus = ErrorBus(),
+                    )
 
-            assertIs<UserDetailUiState.Error>(viewModel.state.value)
-        }
-
-    @Test
-    fun `toggleCanShare updates state and saves`() =
-        runTest {
-            val adminRepository: AdminRepository = mock()
-            val user = createUser(canShare = true)
-            val updatedUser =
-                user.copy(
-                    permissions = UserPermissions(canShare = false),
-                )
-            everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(user)
-            everySuspend {
-                adminRepository.updateUser(
-                    userId = "user-1",
-                    canShare = false,
-                )
-            } returns AppResult.Success(updatedUser)
-
-            val viewModel =
-                UserDetailViewModel(
-                    userId = "user-1",
-                    adminRepository = adminRepository,
-                    errorBus = ErrorBus(),
-                )
-            advanceUntilIdle()
-
-            viewModel.toggleCanShare()
-            advanceUntilIdle()
-
-            val ready = assertIs<UserDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.canShare)
-            verifySuspend(VerifyMode.atLeast(1)) {
-                adminRepository.updateUser(userId = "user-1", canShare = false)
+                viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Loading>()
             }
         }
 
-    @Test
-    fun `clearError clears transient Ready error`() =
-        runTest {
-            // Load succeeds so VM reaches Ready; then a toggle failure surfaces a
-            // transient error on Ready that clearError resets.
-            val adminRepository: AdminRepository = mock()
-            val user = createUser(canShare = true)
-            everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(user)
-            everySuspend {
-                adminRepository.updateUser(
-                    userId = "user-1",
-                    canShare = false,
-                )
-            } returns networkFailure()
+        test("loadUser transitions to Ready with user details") {
+            runTest {
+                val adminRepository: AdminRepository = mock()
+                val user = createUser(canShare = false)
+                everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(user)
 
-            val viewModel =
-                UserDetailViewModel(
-                    userId = "user-1",
-                    adminRepository = adminRepository,
-                    errorBus = ErrorBus(),
-                )
-            advanceUntilIdle()
+                val viewModel =
+                    UserDetailViewModel(
+                        userId = "user-1",
+                        adminRepository = adminRepository,
+                        errorBus = ErrorBus(),
+                    )
+                advanceUntilIdle()
 
-            viewModel.toggleCanShare()
-            advanceUntilIdle()
-
-            val readyWithError = assertIs<UserDetailUiState.Ready>(viewModel.state.value)
-            assertTrue(readyWithError.error != null)
-
-            viewModel.clearError()
-
-            val readyCleared = assertIs<UserDetailUiState.Ready>(viewModel.state.value)
-            assertNull(readyCleared.error)
+                val ready = viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Ready>()
+                ready.user shouldBe user
+                ready.canShare shouldBe false
+            }
         }
 
-    @Test
-    fun `protected users cannot have permissions toggled`() =
-        runTest {
-            val adminRepository: AdminRepository = mock()
-            val rootUser =
-                AdminUserInfo(
-                    id = "root-1",
-                    email = "root@example.com",
-                    displayName = "Root User",
-                    firstName = "Root",
-                    lastName = "User",
-                    isRoot = true,
-                    role = "admin",
-                    status = "active",
-                    permissions = UserPermissions(canShare = true),
-                    createdAt = "2024-01-01T00:00:00Z",
-                )
-            everySuspend { adminRepository.getUser("root-1") } returns AppResult.Success(rootUser)
+        test("loadUser initial failure transitions to Error") {
+            runTest {
+                val adminRepository: AdminRepository = mock()
+                everySuspend { adminRepository.getUser("user-1") } returns networkFailure()
 
-            val viewModel =
-                UserDetailViewModel(
-                    userId = "root-1",
-                    adminRepository = adminRepository,
-                    errorBus = ErrorBus(),
-                )
-            advanceUntilIdle()
+                val viewModel =
+                    UserDetailViewModel(
+                        userId = "user-1",
+                        adminRepository = adminRepository,
+                        errorBus = ErrorBus(),
+                    )
+                advanceUntilIdle()
 
-            val ready = assertIs<UserDetailUiState.Ready>(viewModel.state.value)
-            assertTrue(ready.isProtected)
+                viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Error>()
+            }
         }
-}
+
+        test("toggleCanShare updates state and saves") {
+            runTest {
+                val adminRepository: AdminRepository = mock()
+                val user = createUser(canShare = true)
+                val updatedUser =
+                    user.copy(
+                        permissions = UserPermissions(canShare = false),
+                    )
+                everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(user)
+                everySuspend {
+                    adminRepository.updateUser(
+                        userId = "user-1",
+                        canShare = false,
+                    )
+                } returns AppResult.Success(updatedUser)
+
+                val viewModel =
+                    UserDetailViewModel(
+                        userId = "user-1",
+                        adminRepository = adminRepository,
+                        errorBus = ErrorBus(),
+                    )
+                advanceUntilIdle()
+
+                viewModel.toggleCanShare()
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Ready>()
+                ready.canShare shouldBe false
+                verifySuspend(VerifyMode.atLeast(1)) {
+                    adminRepository.updateUser(userId = "user-1", canShare = false)
+                }
+            }
+        }
+
+        test("clearError clears transient Ready error") {
+            runTest {
+                // Load succeeds so VM reaches Ready; then a toggle failure surfaces a
+                // transient error on Ready that clearError resets.
+                val adminRepository: AdminRepository = mock()
+                val user = createUser(canShare = true)
+                everySuspend { adminRepository.getUser("user-1") } returns AppResult.Success(user)
+                everySuspend {
+                    adminRepository.updateUser(
+                        userId = "user-1",
+                        canShare = false,
+                    )
+                } returns networkFailure()
+
+                val viewModel =
+                    UserDetailViewModel(
+                        userId = "user-1",
+                        adminRepository = adminRepository,
+                        errorBus = ErrorBus(),
+                    )
+                advanceUntilIdle()
+
+                viewModel.toggleCanShare()
+                advanceUntilIdle()
+
+                val readyWithError = viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Ready>()
+                (readyWithError.error != null) shouldBe true
+
+                viewModel.clearError()
+
+                val readyCleared = viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Ready>()
+                readyCleared.error shouldBe null
+            }
+        }
+
+        test("protected users cannot have permissions toggled") {
+            runTest {
+                val adminRepository: AdminRepository = mock()
+                val rootUser =
+                    AdminUserInfo(
+                        id = "root-1",
+                        email = "root@example.com",
+                        displayName = "Root User",
+                        firstName = "Root",
+                        lastName = "User",
+                        isRoot = true,
+                        role = "admin",
+                        status = "active",
+                        permissions = UserPermissions(canShare = true),
+                        createdAt = "2024-01-01T00:00:00Z",
+                    )
+                everySuspend { adminRepository.getUser("root-1") } returns AppResult.Success(rootUser)
+
+                val viewModel =
+                    UserDetailViewModel(
+                        userId = "root-1",
+                        adminRepository = adminRepository,
+                        errorBus = ErrorBus(),
+                    )
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<UserDetailUiState.Ready>()
+                ready.isProtected shouldBe true
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/connect/ServerConnectViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/connect/ServerConnectViewModelTest.kt
@@ -10,6 +10,9 @@ import com.calypsan.listenup.client.domain.repository.ServerConfig
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,11 +20,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 /**
  * Tests for ServerConnectViewModel.
@@ -32,196 +30,195 @@ import kotlin.test.assertIs
  * involves HttpClient internals that would require integration testing.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ServerConnectViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ServerConnectViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val serverConfig: ServerConfig = mock()
-        val instanceRepository: InstanceRepository = mock()
+        class TestFixture {
+            val serverConfig: ServerConfig = mock()
+            val instanceRepository: InstanceRepository = mock()
 
-        fun build(): ServerConnectViewModel =
-            ServerConnectViewModel(
-                serverConfig = serverConfig,
-                instanceRepository = instanceRepository,
-            )
-    }
-
-    private fun createFixture(): TestFixture = TestFixture()
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State ==========
-
-    @Test
-    fun `initial state is Idle`() =
-        runTest {
-            val viewModel = createFixture().build()
-
-            assertEquals(ServerConnectUiState.Idle, viewModel.state.value)
+            fun build(): ServerConnectViewModel =
+                ServerConnectViewModel(
+                    serverConfig = serverConfig,
+                    instanceRepository = instanceRepository,
+                )
         }
 
-    // ========== URL Validation ==========
+        fun createFixture(): TestFixture = TestFixture()
 
-    @Test
-    fun `submitUrl with blank URL produces InvalidUrl blank error`() =
-        runTest {
-            val viewModel = createFixture().build()
-
-            viewModel.submitUrl("")
-            advanceUntilIdle()
-
-            val error = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            val invalid = assertIs<ServerConnectError.InvalidUrl>(error.error)
-            assertEquals("blank", invalid.reason)
-            assertEquals("Please enter a server URL.", invalid.message)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `submitUrl with whitespace-only URL produces InvalidUrl blank error`() =
-        runTest {
-            val viewModel = createFixture().build()
-
-            viewModel.submitUrl("   ")
-            advanceUntilIdle()
-
-            val error = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            val invalid = assertIs<ServerConnectError.InvalidUrl>(error.error)
-            assertEquals("blank", invalid.reason)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    // Note: URL format validation is delegated to Ktor's URL parser.
-    // Ktor is lenient with URLs, so specific malformed patterns would test
-    // Ktor's behaviour rather than ours. Blank/whitespace covers our logic.
+        // ========== Initial State ==========
 
-    // ========== clearError ==========
+        test("initial state is Idle") {
+            runTest {
+                val viewModel = createFixture().build()
 
-    @Test
-    fun `clearError from Error returns to Idle`() =
-        runTest {
-            val viewModel = createFixture().build()
-            viewModel.submitUrl("")
-            advanceUntilIdle()
-            checkIs<ServerConnectUiState.Error>(viewModel.state.value)
-
-            viewModel.clearError()
-
-            assertEquals(ServerConnectUiState.Idle, viewModel.state.value)
+                viewModel.state.value shouldBe ServerConnectUiState.Idle
+            }
         }
 
-    @Test
-    fun `clearError from Idle is a no-op`() =
-        runTest {
-            val viewModel = createFixture().build()
-            assertEquals(ServerConnectUiState.Idle, viewModel.state.value)
+        // ========== URL Validation ==========
 
-            viewModel.clearError()
+        test("submitUrl with blank URL produces InvalidUrl blank error") {
+            runTest {
+                val viewModel = createFixture().build()
 
-            assertEquals(ServerConnectUiState.Idle, viewModel.state.value)
+                viewModel.submitUrl("")
+                advanceUntilIdle()
+
+                val error = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                val invalid = error.error.shouldBeInstanceOf<ServerConnectError.InvalidUrl>()
+                invalid.reason shouldBe "blank"
+                invalid.message shouldBe "Please enter a server URL."
+            }
         }
 
-    // ========== Failure Classification (mapFailure) ==========
-    //
-    // mapFailure pattern-matches on the unified TransportError subtypes to surface
-    // domain-specific user-facing messages rather than the generic VerificationFailed.
-    // These tests pin the classification — substring matching against message text was
-    // historically used here and silently broke under the body-level message convention
-    // (constants don't contain throwable text); the type-pattern shape replaces it.
+        test("submitUrl with whitespace-only URL produces InvalidUrl blank error") {
+            runTest {
+                val viewModel = createFixture().build()
 
-    @Test
-    fun `verifyServer NetworkUnavailable maps to ServerNotReachable`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
-                AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "connection refused"))
+                viewModel.submitUrl("   ")
+                advanceUntilIdle()
 
-            val viewModel = fixture.build()
-            viewModel.submitUrl("https://example.com")
-            advanceUntilIdle()
-
-            val errorState = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            assertIs<ServerConnectError.ServerNotReachable>(errorState.error)
+                val error = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                val invalid = error.error.shouldBeInstanceOf<ServerConnectError.InvalidUrl>()
+                invalid.reason shouldBe "blank"
+            }
         }
 
-    @Test
-    fun `verifyServer Timeout maps to ServerNotReachable`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
-                AppResult.Failure(TransportError.Timeout(debugInfo = "connect timed out"))
+        // Note: URL format validation is delegated to Ktor's URL parser.
+        // Ktor is lenient with URLs, so specific malformed patterns would test
+        // Ktor's behaviour rather than ours. Blank/whitespace covers our logic.
 
-            val viewModel = fixture.build()
-            viewModel.submitUrl("https://example.com")
-            advanceUntilIdle()
+        // ========== clearError ==========
 
-            val errorState = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            assertIs<ServerConnectError.ServerNotReachable>(errorState.error)
+        test("clearError from Error returns to Idle") {
+            runTest {
+                val viewModel = createFixture().build()
+                viewModel.submitUrl("")
+                advanceUntilIdle()
+                checkIs<ServerConnectUiState.Error>(viewModel.state.value)
+
+                viewModel.clearError()
+
+                viewModel.state.value shouldBe ServerConnectUiState.Idle
+            }
         }
 
-    @Test
-    fun `verifyServer DataMalformed maps to NotListenUpServer`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
-                AppResult.Failure(TransportError.DataMalformed(detail = "Unexpected token", debugInfo = "Unexpected token"))
+        test("clearError from Idle is a no-op") {
+            runTest {
+                val viewModel = createFixture().build()
+                viewModel.state.value shouldBe ServerConnectUiState.Idle
 
-            val viewModel = fixture.build()
-            viewModel.submitUrl("https://example.com")
-            advanceUntilIdle()
+                viewModel.clearError()
 
-            val errorState = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            assertIs<ServerConnectError.NotListenUpServer>(errorState.error)
+                viewModel.state.value shouldBe ServerConnectUiState.Idle
+            }
         }
 
-    @Test
-    fun `verifyServer Server4xx 404 maps to NotListenUpServer`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
-                AppResult.Failure(TransportError.Server4xx(statusCode = 404, debugInfo = "Not Found"))
+        // ========== Failure Classification (mapFailure) ==========
+        //
+        // mapFailure pattern-matches on the unified TransportError subtypes to surface
+        // domain-specific user-facing messages rather than the generic VerificationFailed.
+        // These tests pin the classification — substring matching against message text was
+        // historically used here and silently broke under the body-level message convention
+        // (constants don't contain throwable text); the type-pattern shape replaces it.
 
-            val viewModel = fixture.build()
-            viewModel.submitUrl("https://example.com")
-            advanceUntilIdle()
+        test("verifyServer NetworkUnavailable maps to ServerNotReachable") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable(debugInfo = "connection refused"))
 
-            val errorState = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            assertIs<ServerConnectError.NotListenUpServer>(errorState.error)
+                val viewModel = fixture.build()
+                viewModel.submitUrl("https://example.com")
+                advanceUntilIdle()
+
+                val errorState = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                errorState.error.shouldBeInstanceOf<ServerConnectError.ServerNotReachable>()
+            }
         }
 
-    @Test
-    fun `verifyServer Server4xx non-404 maps to VerificationFailed`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
-                AppResult.Failure(TransportError.Server4xx(statusCode = 401, debugInfo = "Unauthorized"))
+        test("verifyServer Timeout maps to ServerNotReachable") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
+                    AppResult.Failure(TransportError.Timeout(debugInfo = "connect timed out"))
 
-            val viewModel = fixture.build()
-            viewModel.submitUrl("https://example.com")
-            advanceUntilIdle()
+                val viewModel = fixture.build()
+                viewModel.submitUrl("https://example.com")
+                advanceUntilIdle()
 
-            val errorState = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            assertIs<ServerConnectError.VerificationFailed>(errorState.error)
+                val errorState = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                errorState.error.shouldBeInstanceOf<ServerConnectError.ServerNotReachable>()
+            }
         }
 
-    @Test
-    fun `verifyServer non-classifiable failure maps to VerificationFailed`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
-                AppResult.Failure(InternalError(debugInfo = "unexpected internal error"))
+        test("verifyServer DataMalformed maps to NotListenUpServer") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
+                    AppResult.Failure(TransportError.DataMalformed(detail = "Unexpected token", debugInfo = "Unexpected token"))
 
-            val viewModel = fixture.build()
-            viewModel.submitUrl("https://example.com")
-            advanceUntilIdle()
+                val viewModel = fixture.build()
+                viewModel.submitUrl("https://example.com")
+                advanceUntilIdle()
 
-            val errorState = assertIs<ServerConnectUiState.Error>(viewModel.state.value)
-            assertIs<ServerConnectError.VerificationFailed>(errorState.error)
+                val errorState = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                errorState.error.shouldBeInstanceOf<ServerConnectError.NotListenUpServer>()
+            }
         }
-}
+
+        test("verifyServer Server4xx 404 maps to NotListenUpServer") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
+                    AppResult.Failure(TransportError.Server4xx(statusCode = 404, debugInfo = "Not Found"))
+
+                val viewModel = fixture.build()
+                viewModel.submitUrl("https://example.com")
+                advanceUntilIdle()
+
+                val errorState = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                errorState.error.shouldBeInstanceOf<ServerConnectError.NotListenUpServer>()
+            }
+        }
+
+        test("verifyServer Server4xx non-404 maps to VerificationFailed") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
+                    AppResult.Failure(TransportError.Server4xx(statusCode = 401, debugInfo = "Unauthorized"))
+
+                val viewModel = fixture.build()
+                viewModel.submitUrl("https://example.com")
+                advanceUntilIdle()
+
+                val errorState = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                errorState.error.shouldBeInstanceOf<ServerConnectError.VerificationFailed>()
+            }
+        }
+
+        test("verifyServer non-classifiable failure maps to VerificationFailed") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.instanceRepository.verifyServer("https://example.com") } returns
+                    AppResult.Failure(InternalError(debugInfo = "unexpected internal error"))
+
+                val viewModel = fixture.build()
+                viewModel.submitUrl("https://example.com")
+                advanceUntilIdle()
+
+                val errorState = viewModel.state.value.shouldBeInstanceOf<ServerConnectUiState.Error>()
+                errorState.error.shouldBeInstanceOf<ServerConnectError.VerificationFailed>()
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/connect/ServerSelectViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/connect/ServerSelectViewModelTest.kt
@@ -18,6 +18,9 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,262 +31,256 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ServerSelectViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ServerSelectViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private fun createServer(
-        id: String = "server-1",
-        name: String = "Test Server",
-        localUrl: String = "http://192.168.1.100:8080",
-    ) = Server(
-        id = id,
-        name = name,
-        apiVersion = "v1",
-        serverVersion = "1.0.0",
-        localUrl = localUrl,
-        remoteUrl = null,
-        isActive = false,
-        lastSeenAt = 0,
-    )
+        fun createServer(
+            id: String = "server-1",
+            name: String = "Test Server",
+            localUrl: String = "http://192.168.1.100:8080",
+        ) = Server(
+            id = id,
+            name = name,
+            apiVersion = "v1",
+            serverVersion = "1.0.0",
+            localUrl = localUrl,
+            remoteUrl = null,
+            isActive = false,
+            lastSeenAt = 0,
+        )
 
-    private fun createServerWithStatus(
-        server: Server = createServer(),
-        isOnline: Boolean = true,
-    ) = ServerWithStatus(
-        server = server,
-        isOnline = isOnline,
-    )
+        fun createServerWithStatus(
+            server: Server = createServer(),
+            isOnline: Boolean = true,
+        ) = ServerWithStatus(
+            server = server,
+            isOnline = isOnline,
+        )
 
-    /** Keep the VM's WhileSubscribed state flow hot for the duration of the test. */
-    private fun TestScope.keepStateHot(viewModel: ServerSelectViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `initial state is Discovering with empty servers`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            every { serverRepository.observeServers() } returns
-                kotlinx.coroutines.flow.flow { /* never emits */ }
-
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            val state = viewModel.state.value
-            val discovering = assertIs<ServerSelectUiState.Discovering>(state)
-            assertEquals(emptyList(), discovering.servers)
+        // Keep the VM's WhileSubscribed state flow hot for the duration of the test.
+        fun TestScope.keepStateHot(viewModel: ServerSelectViewModel) {
+            backgroundScope.launch { viewModel.state.collect { } }
         }
 
-    @Test
-    fun `LocalNetworkPermissionGranted starts server discovery`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            every { serverRepository.startDiscovery() } returns Unit
-
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-
-            viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
-            advanceUntilIdle()
-
-            verify { serverRepository.startDiscovery() }
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `LocalNetworkPermissionGranted then observeServers emission transitions Discovering to Ready`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            val serversFlow = MutableStateFlow<List<ServerWithStatus>>(emptyList())
-            every { serverRepository.observeServers() } returns serversFlow
-            every { serverRepository.startDiscovery() } returns Unit
-
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-
-            viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
-            advanceUntilIdle()
-
-            // Initial emission (empty) flips to Ready
-            assertIs<ServerSelectUiState.Ready>(viewModel.state.value)
-
-            val servers = listOf(createServerWithStatus())
-            serversFlow.value = servers
-            advanceUntilIdle()
-
-            val ready = assertIs<ServerSelectUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.servers.size)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `LocalNetworkPermissionDenied emits error and navigates to manual entry`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            val errorBus = ErrorBus()
+        test("initial state is Discovering with empty servers") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                every { serverRepository.observeServers() } returns
+                    kotlinx.coroutines.flow.flow { /* never emits */ }
 
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = errorBus)
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            errorBus.errors.test {
-                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionDenied)
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
                 advanceUntilIdle()
-                assertIs<ServerConnectError.LocalNetworkPermissionDenied>(awaitItem())
-            }
 
-            viewModel.navigationEvents.test {
-                // Navigation event was already trySend'd synchronously, should be buffered
-                assertEquals(ServerSelectViewModel.NavigationEvent.GoToManualEntry, awaitItem())
+                val state = viewModel.state.value
+                val discovering = state.shouldBeInstanceOf<ServerSelectUiState.Discovering>()
+                discovering.servers shouldBe emptyList()
             }
-
-            // Discovery must never start on the denial path.
-            verify(VerifyMode.not) { serverRepository.startDiscovery() }
         }
 
-    @Test
-    fun `ManualEntryClicked emits GoToManualEntry navigation event`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            every { serverRepository.startDiscovery() } returns Unit
+        test("LocalNetworkPermissionGranted starts server discovery") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                every { serverRepository.startDiscovery() } returns Unit
 
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-            advanceUntilIdle()
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
 
-            viewModel.navigationEvents.test {
-                viewModel.onEvent(ServerSelectUiEvent.ManualEntryClicked)
+                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
                 advanceUntilIdle()
-                assertEquals(ServerSelectViewModel.NavigationEvent.GoToManualEntry, awaitItem())
+
+                verify { serverRepository.startDiscovery() }
             }
         }
 
-    @Test
-    fun `RefreshClicked stops and restarts discovery`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            every { serverRepository.startDiscovery() } returns Unit
-            every { serverRepository.stopDiscovery() } returns Unit
+        test("LocalNetworkPermissionGranted then observeServers emission transitions Discovering to Ready") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                val serversFlow = MutableStateFlow<List<ServerWithStatus>>(emptyList())
+                every { serverRepository.observeServers() } returns serversFlow
+                every { serverRepository.startDiscovery() } returns Unit
 
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-            viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
-            advanceUntilIdle()
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
 
-            viewModel.onEvent(ServerSelectUiEvent.RefreshClicked)
-            advanceUntilIdle()
+                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
+                advanceUntilIdle()
 
-            verify { serverRepository.stopDiscovery() }
+                // Initial emission (empty) flips to Ready
+                viewModel.state.value.shouldBeInstanceOf<ServerSelectUiState.Ready>()
+
+                val servers = listOf(createServerWithStatus())
+                serversFlow.value = servers
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<ServerSelectUiState.Ready>()
+                ready.servers.size shouldBe 1
+            }
         }
 
-    @Test
-    fun `ServerSelected activates server and emits navigation`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            val server = createServer()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            every { serverRepository.startDiscovery() } returns Unit
-            everySuspend { instanceRepository.findReachableUrl(any()) } returns server.localUrl
-            everySuspend { serverConfig.setServerUrl(any()) } returns Unit
-            everySuspend { serverConfig.setConnectedServerId(any()) } returns Unit
+        test("LocalNetworkPermissionDenied emits error and navigates to manual entry") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                val errorBus = ErrorBus()
 
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-            viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
-            advanceUntilIdle()
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = errorBus)
+                keepStateHot(viewModel)
+                advanceUntilIdle()
 
-            viewModel.navigationEvents.test {
+                errorBus.errors.test {
+                    viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionDenied)
+                    advanceUntilIdle()
+                    awaitItem().shouldBeInstanceOf<ServerConnectError.LocalNetworkPermissionDenied>()
+                }
+
+                viewModel.navigationEvents.test {
+                    // Navigation event was already trySend'd synchronously, should be buffered
+                    awaitItem() shouldBe ServerSelectViewModel.NavigationEvent.GoToManualEntry
+                }
+
+                // Discovery must never start on the denial path.
+                verify(VerifyMode.not) { serverRepository.startDiscovery() }
+            }
+        }
+
+        test("ManualEntryClicked emits GoToManualEntry navigation event") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                every { serverRepository.startDiscovery() } returns Unit
+
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.navigationEvents.test {
+                    viewModel.onEvent(ServerSelectUiEvent.ManualEntryClicked)
+                    advanceUntilIdle()
+                    awaitItem() shouldBe ServerSelectViewModel.NavigationEvent.GoToManualEntry
+                }
+            }
+        }
+
+        test("RefreshClicked stops and restarts discovery") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                every { serverRepository.startDiscovery() } returns Unit
+                every { serverRepository.stopDiscovery() } returns Unit
+
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
+                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
+                advanceUntilIdle()
+
+                viewModel.onEvent(ServerSelectUiEvent.RefreshClicked)
+                advanceUntilIdle()
+
+                verify { serverRepository.stopDiscovery() }
+            }
+        }
+
+        test("ServerSelected activates server and emits navigation") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                val server = createServer()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                every { serverRepository.startDiscovery() } returns Unit
+                everySuspend { instanceRepository.findReachableUrl(any()) } returns server.localUrl
+                everySuspend { serverConfig.setServerUrl(any()) } returns Unit
+                everySuspend { serverConfig.setConnectedServerId(any()) } returns Unit
+
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
+                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
+                advanceUntilIdle()
+
+                viewModel.navigationEvents.test {
+                    viewModel.onEvent(ServerSelectUiEvent.ServerSelected(createServerWithStatus(server)))
+                    advanceUntilIdle()
+
+                    verifySuspend { serverConfig.setServerUrl(ServerUrl(server.localUrl!!)) }
+                    verifySuspend { serverConfig.setConnectedServerId(server.id) }
+                    awaitItem() shouldBe ServerSelectViewModel.NavigationEvent.ServerActivated
+                }
+
+                // After success, overlay cleared → Ready
+                viewModel.state.value.shouldBeInstanceOf<ServerSelectUiState.Ready>()
+            }
+        }
+
+        test("ServerSelected failure transitions to Error state") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                val server = createServer()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                every { serverRepository.startDiscovery() } returns Unit
+                everySuspend { instanceRepository.findReachableUrl(any()) } throws RuntimeException("Failed")
+
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
+                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
+                advanceUntilIdle()
+
                 viewModel.onEvent(ServerSelectUiEvent.ServerSelected(createServerWithStatus(server)))
                 advanceUntilIdle()
 
-                verifySuspend { serverConfig.setServerUrl(ServerUrl(server.localUrl!!)) }
-                verifySuspend { serverConfig.setConnectedServerId(server.id) }
-                assertEquals(ServerSelectViewModel.NavigationEvent.ServerActivated, awaitItem())
+                val error = viewModel.state.value.shouldBeInstanceOf<ServerSelectUiState.Error>()
+                error.selectedServerId shouldBe server.id
             }
-
-            // After success, overlay cleared → Ready
-            assertIs<ServerSelectUiState.Ready>(viewModel.state.value)
         }
 
-    @Test
-    fun `ServerSelected failure transitions to Error state`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            val server = createServer()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            every { serverRepository.startDiscovery() } returns Unit
-            everySuspend { instanceRepository.findReachableUrl(any()) } throws RuntimeException("Failed")
+        test("ErrorDismissed transitions from Error back to Ready") {
+            runTest {
+                val serverRepository: ServerRepository = mock()
+                val serverConfig: ServerConfig = mock()
+                val instanceRepository: InstanceRepository = mock()
+                val server = createServer()
+                every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
+                every { serverRepository.startDiscovery() } returns Unit
+                everySuspend { instanceRepository.findReachableUrl(any()) } throws RuntimeException("Failed")
 
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-            viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
-            advanceUntilIdle()
+                val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
+                keepStateHot(viewModel)
+                viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
+                advanceUntilIdle()
+                viewModel.onEvent(ServerSelectUiEvent.ServerSelected(createServerWithStatus(server)))
+                advanceUntilIdle()
+                viewModel.state.value.shouldBeInstanceOf<ServerSelectUiState.Error>()
 
-            viewModel.onEvent(ServerSelectUiEvent.ServerSelected(createServerWithStatus(server)))
-            advanceUntilIdle()
+                viewModel.onEvent(ServerSelectUiEvent.ErrorDismissed)
+                advanceUntilIdle()
 
-            val error = assertIs<ServerSelectUiState.Error>(viewModel.state.value)
-            assertEquals(server.id, error.selectedServerId)
+                viewModel.state.value.shouldBeInstanceOf<ServerSelectUiState.Ready>()
+            }
         }
-
-    @Test
-    fun `ErrorDismissed transitions from Error back to Ready`() =
-        runTest {
-            val serverRepository: ServerRepository = mock()
-            val serverConfig: ServerConfig = mock()
-            val instanceRepository: InstanceRepository = mock()
-            val server = createServer()
-            every { serverRepository.observeServers() } returns MutableStateFlow(emptyList())
-            every { serverRepository.startDiscovery() } returns Unit
-            everySuspend { instanceRepository.findReachableUrl(any()) } throws RuntimeException("Failed")
-
-            val viewModel = ServerSelectViewModel(serverRepository, serverConfig, instanceRepository, errorBus = ErrorBus())
-            keepStateHot(viewModel)
-            viewModel.onEvent(ServerSelectUiEvent.LocalNetworkPermissionGranted)
-            advanceUntilIdle()
-            viewModel.onEvent(ServerSelectUiEvent.ServerSelected(createServerWithStatus(server)))
-            advanceUntilIdle()
-            assertIs<ServerSelectUiState.Error>(viewModel.state.value)
-
-            viewModel.onEvent(ServerSelectUiEvent.ErrorDismissed)
-            advanceUntilIdle()
-
-            assertIs<ServerSelectUiState.Ready>(viewModel.state.value)
-        }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModelTest.kt
@@ -12,6 +12,9 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,13 +26,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 /**
  * Tests for ActivityFeedViewModel.
@@ -44,43 +40,43 @@ import kotlin.test.assertTrue
  * Uses Mokkery for mocking `ActivityRepository` and `FetchActivitiesUseCase`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ActivityFeedViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class ActivityFeedViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    // ========== Test Fixtures ==========
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val activityRepository: ActivityRepository = mock()
-        val fetchActivitiesUseCase: FetchActivitiesUseCase = mock()
-        val refreshSignal = ActivityRefreshSignal()
-        val activitiesFlow = MutableStateFlow<List<Activity>>(emptyList())
+        class TestFixture {
+            val activityRepository: ActivityRepository = mock()
+            val fetchActivitiesUseCase: FetchActivitiesUseCase = mock()
+            val refreshSignal = ActivityRefreshSignal()
+            val activitiesFlow = MutableStateFlow<List<Activity>>(emptyList())
 
-        fun build(): ActivityFeedViewModel =
-            ActivityFeedViewModel(
-                activityRepository = activityRepository,
-                fetchActivitiesUseCase = fetchActivitiesUseCase,
-                refreshSignal = refreshSignal,
-            )
-    }
+            fun build(): ActivityFeedViewModel =
+                ActivityFeedViewModel(
+                    activityRepository = activityRepository,
+                    fetchActivitiesUseCase = fetchActivitiesUseCase,
+                    refreshSignal = refreshSignal,
+                )
+        }
 
-    private fun createFixture(existingCount: Int = 0): TestFixture {
-        val fixture = TestFixture()
+        fun createFixture(existingCount: Int = 0): TestFixture {
+            val fixture = TestFixture()
 
-        every { fixture.activityRepository.observeRecent(any()) } returns fixture.activitiesFlow
-        everySuspend { fixture.activityRepository.count() } returns existingCount
-        everySuspend { fixture.fetchActivitiesUseCase(any()) } returns AppResult.Success(0)
+            every { fixture.activityRepository.observeRecent(any()) } returns fixture.activitiesFlow
+            everySuspend { fixture.activityRepository.count() } returns existingCount
+            everySuspend { fixture.fetchActivitiesUseCase(any()) } returns AppResult.Success(0)
 
-        return fixture
-    }
+            return fixture
+        }
 
-    private fun TestScope.keepStateHot(viewModel: ActivityFeedViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
+        fun TestScope.keepStateHot(viewModel: ActivityFeedViewModel) {
+            backgroundScope.launch { viewModel.state.collect { } }
+        }
 
-    // ========== Test Data Factories ==========
+        // ========== Test Data Factories ==========
 
-    companion object {
-        private fun createActivity(
+        fun createActivity(
             id: String = "activity-1",
             type: String = "started_book",
             userId: String = "user-1",
@@ -105,162 +101,159 @@ class ActivityFeedViewModelTest {
                 shelfId = null,
                 shelfName = null,
             )
-    }
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State Tests ==========
-
-    @Test
-    fun `initial state is Loading before pipeline subscribes`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-
-            // When - viewModel created; `stateIn` initialValue is Loading
-            // Do NOT start collecting here — the stateIn initialValue is what we assert.
-            val viewModel = fixture.build()
-
-            // Then - initial value is Loading (asserted before pipeline runs)
-            assertIs<ActivityFeedUiState.Loading>(viewModel.state.value)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    // ========== Reactive Observation Tests ==========
-
-    @Test
-    fun `Ready state emitted when repository flow emits activities`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val activity = createActivity(id = "activity-1")
-            fixture.activitiesFlow.value = listOf(activity)
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            val ready = assertIs<ActivityFeedUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.activities.size)
-            assertEquals("activity-1", ready.activities.first().id)
-            assertTrue(ready.hasData)
-            assertFalse(ready.isEmpty)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `Ready state has isEmpty true when activities list is empty`() =
-        runTest {
-            // Given - repository emits an empty list (default fixture state)
-            val fixture = createFixture()
+        // ========== Initial State Tests ==========
 
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+        test("initial state is Loading before pipeline subscribes") {
+            runTest {
+                // Given
+                val fixture = createFixture()
 
-            // Then
-            val ready = assertIs<ActivityFeedUiState.Ready>(viewModel.state.value)
-            assertTrue(ready.isEmpty)
-            assertFalse(ready.hasData)
-            assertTrue(ready.activities.isEmpty())
+                // When - viewModel created; `stateIn` initialValue is Loading
+                // Do NOT start collecting here — the stateIn initialValue is what we assert.
+                val viewModel = fixture.build()
+
+                // Then - initial value is Loading (asserted before pipeline runs)
+                viewModel.state.value.shouldBeInstanceOf<ActivityFeedUiState.Loading>()
+            }
         }
 
-    // ========== Error Handling Tests ==========
+        // ========== Reactive Observation Tests ==========
 
-    @Test
-    fun `Error state emitted when repository flow throws`() =
-        runTest {
-            // Given - repository flow that throws
-            val fixture = TestFixture()
-            every { fixture.activityRepository.observeRecent(any()) } returns
-                flow {
-                    throw RuntimeException("boom")
-                }
-            everySuspend { fixture.activityRepository.count() } returns 0
-            everySuspend { fixture.fetchActivitiesUseCase(any()) } returns AppResult.Success(0)
+        test("Ready state emitted when repository flow emits activities") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val activity = createActivity(id = "activity-1")
+                fixture.activitiesFlow.value = listOf(activity)
 
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
 
-            // Then
-            val err = assertIs<ActivityFeedUiState.Error>(viewModel.state.value)
-            assertEquals("Failed to load activity feed", err.message)
+                // Then
+                val ready = viewModel.state.value.shouldBeInstanceOf<ActivityFeedUiState.Ready>()
+                ready.activities.size shouldBe 1
+                ready.activities.first().id shouldBe "activity-1"
+                ready.hasData shouldBe true
+                ready.isEmpty shouldBe false
+            }
         }
 
-    // ========== Initial Fetch Gate Tests ==========
+        test("Ready state has isEmpty true when activities list is empty") {
+            runTest {
+                // Given - repository emits an empty list (default fixture state)
+                val fixture = createFixture()
 
-    @Test
-    fun `fetchInitialActivitiesIfNeeded triggers fetch when count is zero`() =
-        runTest {
-            // Given - Room is empty
-            val fixture = createFixture(existingCount = 0)
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
 
-            // When - init runs
-            fixture.build()
-            advanceUntilIdle()
-
-            // Then - use case invoked with the initial fetch size
-            verifySuspend { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
+                // Then
+                val ready = viewModel.state.value.shouldBeInstanceOf<ActivityFeedUiState.Ready>()
+                ready.isEmpty shouldBe true
+                ready.hasData shouldBe false
+                ready.activities.isEmpty() shouldBe true
+            }
         }
 
-    @Test
-    fun `fetchInitialActivitiesIfNeeded skips when count is positive`() =
-        runTest {
-            // Given - Room already has activities
-            val fixture = createFixture(existingCount = 5)
+        // ========== Error Handling Tests ==========
 
-            // When - init runs
-            fixture.build()
-            advanceUntilIdle()
+        test("Error state emitted when repository flow throws") {
+            runTest {
+                // Given - repository flow that throws
+                val fixture = TestFixture()
+                every { fixture.activityRepository.observeRecent(any()) } returns
+                    flow {
+                        throw RuntimeException("boom")
+                    }
+                everySuspend { fixture.activityRepository.count() } returns 0
+                everySuspend { fixture.fetchActivitiesUseCase(any()) } returns AppResult.Success(0)
 
-            // Then - use case NOT invoked
-            verifySuspend(VerifyMode.not) { fixture.fetchActivitiesUseCase(any()) }
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                val err = viewModel.state.value.shouldBeInstanceOf<ActivityFeedUiState.Error>()
+                err.message shouldBe "Failed to load activity feed"
+            }
         }
 
-    // ========== Refresh Tests ==========
+        // ========== Initial Fetch Gate Tests ==========
 
-    @Test
-    fun `refresh calls fetchActivitiesUseCase with INITIAL_FETCH_SIZE`() =
-        runTest {
-            // Given - Room already populated (prevent init fetch from confusing the verification)
-            val fixture = createFixture(existingCount = 5)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("fetchInitialActivitiesIfNeeded triggers fetch when count is zero") {
+            runTest {
+                // Given - Room is empty
+                val fixture = createFixture(existingCount = 0)
 
-            // When
-            viewModel.refresh()
-            advanceUntilIdle()
+                // When - init runs
+                fixture.build()
+                advanceUntilIdle()
 
-            // Then - refresh invokes the use case exactly once with the expected limit
-            verifySuspend { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
+                // Then - use case invoked with the initial fetch size
+                verifySuspend { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
+            }
         }
 
-    // ========== Refresh-Signal Tests ==========
+        test("fetchInitialActivitiesIfNeeded skips when count is positive") {
+            runTest {
+                // Given - Room already has activities
+                val fixture = createFixture(existingCount = 5)
 
-    @Test
-    fun `refresh signal ping re-fetches the feed head`() =
-        runTest {
-            // Given - Room already populated (suppress the init fetch so the ping is isolated)
-            val fixture = createFixture(existingCount = 5)
-            fixture.build()
-            advanceUntilIdle()
+                // When - init runs
+                fixture.build()
+                advanceUntilIdle()
 
-            // When - the server signals the feed may have changed
-            fixture.refreshSignal.ping()
-            advanceUntilIdle()
-
-            // Then - the feed head is re-fetched into Room (Room observation repaints the UI)
-            verifySuspend(VerifyMode.exactly(1)) { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
+                // Then - use case NOT invoked
+                verifySuspend(VerifyMode.not) { fixture.fetchActivitiesUseCase(any()) }
+            }
         }
-}
+
+        // ========== Refresh Tests ==========
+
+        test("refresh calls fetchActivitiesUseCase with INITIAL_FETCH_SIZE") {
+            runTest {
+                // Given - Room already populated (prevent init fetch from confusing the verification)
+                val fixture = createFixture(existingCount = 5)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                // When
+                viewModel.refresh()
+                advanceUntilIdle()
+
+                // Then - refresh invokes the use case exactly once with the expected limit
+                verifySuspend { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
+            }
+        }
+
+        // ========== Refresh-Signal Tests ==========
+
+        test("refresh signal ping re-fetches the feed head") {
+            runTest {
+                // Given - Room already populated (suppress the init fetch so the ping is isolated)
+                val fixture = createFixture(existingCount = 5)
+                fixture.build()
+                advanceUntilIdle()
+
+                // When - the server signals the feed may have changed
+                fixture.refreshSignal.ping()
+                advanceUntilIdle()
+
+                // Then - the feed head is re-fetched into Room (Room observation repaints the UI)
+                verifySuspend(VerifyMode.exactly(1)) { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
+            }
+        }
+    })
 
 /** Mirror of the private constant in the VM for verify clarity. */
 private const val INITIAL_FETCH_SIZE = 50

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModelTest.kt
@@ -16,6 +16,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,12 +32,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.error.ErrorBus
 
@@ -55,60 +52,13 @@ import com.calypsan.listenup.core.error.ErrorBus
  * Uses Mokkery for mocking all four repositories plus `AuthSession`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class DiscoverViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class DiscoverViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    // ========== Test Fixture ==========
+        // ========== Test Data Factories ==========
 
-    private class TestFixture {
-        val bookRepository: BookRepository = mock()
-        val activeSessionRepository: ActiveSessionRepository = mock()
-        val authSession: AuthSession = mock()
-        val shelfRepository: ShelfRepository = mock()
-
-        val authStateFlow = MutableStateFlow<AuthState>(AuthState.Initializing)
-        val activeSessionsFlow = MutableStateFlow<List<ActiveSession>>(emptyList())
-        val recentlyAddedFlow = MutableStateFlow<List<DiscoveryBook>>(emptyList())
-
-        fun build(): DiscoverViewModel =
-            DiscoverViewModel(
-                bookRepository = bookRepository,
-                activeSessionRepository = activeSessionRepository,
-                authSession = authSession,
-                shelfRepository = shelfRepository,
-                errorBus = ErrorBus(),
-            )
-    }
-
-    private fun createFixture(
-        authState: AuthState = AuthState.Authenticated(userId = UserId(USER_ID), sessionId = SessionId(SESSION_ID)),
-        discoveredShelves: List<Shelf> = emptyList(),
-        randomBooks: List<DiscoveryBook> = emptyList(),
-    ): TestFixture {
-        val fixture = TestFixture()
-        fixture.authStateFlow.value = authState
-
-        every { fixture.authSession.authState } returns fixture.authStateFlow
-        every { fixture.activeSessionRepository.observeActiveSessions(any()) } returns fixture.activeSessionsFlow
-        every { fixture.bookRepository.observeRecentlyAddedBooks(any()) } returns fixture.recentlyAddedFlow
-        every { fixture.bookRepository.observeRandomUnstartedBooks(any()) } returns flowOf(randomBooks)
-        everySuspend { fixture.shelfRepository.discoverShelves() } returns AppResult.Success(discoveredShelves)
-
-        return fixture
-    }
-
-    private fun TestScope.keepStateHot(flow: StateFlow<*>) {
-        backgroundScope.launch { flow.collect { } }
-    }
-
-    // ========== Test Data Factories ==========
-
-    companion object {
-        private const val USER_ID = "user-1"
-        private const val SESSION_ID = "session-1"
-        private const val OTHER_USER_ID = "user-2"
-
-        private fun createActiveSession(
+        fun createActiveSession(
             sessionId: String = "active-1",
             userId: String = OTHER_USER_ID,
             bookId: String = "book-1",
@@ -136,7 +86,7 @@ class DiscoverViewModelTest {
                     ),
             )
 
-        private fun createDiscoveryBook(
+        fun createDiscoveryBook(
             id: String = "book-1",
             title: String = "A Book",
         ): DiscoveryBook =
@@ -149,7 +99,7 @@ class DiscoverViewModelTest {
                 createdAt = 0L,
             )
 
-        private fun createShelf(
+        fun createShelf(
             id: String = "shelf-1",
             ownerId: String = OTHER_USER_ID,
             ownerDisplayName: String = "Alice",
@@ -166,257 +116,301 @@ class DiscoverViewModelTest {
                 createdAtMs = 0L,
                 updatedAtMs = 0L,
             )
-    }
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
+        // ========== Test Fixture ==========
 
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+        class TestFixture {
+            val bookRepository: BookRepository = mock()
+            val activeSessionRepository: ActiveSessionRepository = mock()
+            val authSession: AuthSession = mock()
+            val shelfRepository: ShelfRepository = mock()
 
-    // ========== Currently Listening Tests ==========
+            val authStateFlow = MutableStateFlow<AuthState>(AuthState.Initializing)
+            val activeSessionsFlow = MutableStateFlow<List<ActiveSession>>(emptyList())
+            val recentlyAddedFlow = MutableStateFlow<List<DiscoveryBook>>(emptyList())
 
-    @Test
-    fun `currentlyListeningState initial value is Loading before subscription`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-
-            // When - viewModel created; `stateIn` initialValue is Loading.
-            // Do NOT start collecting — the stateIn initialValue is what we assert.
-            val viewModel = fixture.build()
-
-            // Then
-            assertIs<CurrentlyListeningUiState.Loading>(viewModel.currentlyListeningState.value)
-        }
-
-    @Test
-    fun `currentlyListeningState becomes Ready when authenticated and flow emits`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.activeSessionsFlow.value = listOf(createActiveSession(sessionId = "s-1"))
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.currentlyListeningState) }
-            advanceUntilIdle()
-
-            // Then
-            val ready = assertIs<CurrentlyListeningUiState.Ready>(viewModel.currentlyListeningState.value)
-            assertEquals(1, ready.sessions.size)
-            assertEquals("s-1", ready.sessions.first().sessionId)
-        }
-
-    @Test
-    fun `currentlyListeningState becomes Ready empty when unauthenticated`() =
-        runTest {
-            // Given - unauthenticated auth state steers flatMapLatest to flowOf(emptyList())
-            val fixture = createFixture(authState = AuthState.NeedsLogin())
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.currentlyListeningState) }
-            advanceUntilIdle()
-
-            // Then
-            val ready = assertIs<CurrentlyListeningUiState.Ready>(viewModel.currentlyListeningState.value)
-            assertTrue(ready.isEmpty)
-        }
-
-    @Test
-    fun `currentlyListeningState becomes Error when upstream throws`() =
-        runTest {
-            // Given - observeActiveSessions throws on collection
-            val fixture = createFixture()
-            every { fixture.activeSessionRepository.observeActiveSessions(any()) } returns
-                flow { throw RuntimeException("boom") }
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.currentlyListeningState) }
-            advanceUntilIdle()
-
-            // Then
-            val err = assertIs<CurrentlyListeningUiState.Error>(viewModel.currentlyListeningState.value)
-            assertEquals("Failed to load currently listening", err.message)
-        }
-
-    // ========== Recently Added Tests ==========
-
-    @Test
-    fun `recentlyAddedState becomes Ready when flow emits`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.recentlyAddedFlow.value = listOf(createDiscoveryBook(id = "new-1", title = "New"))
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.recentlyAddedState) }
-            advanceUntilIdle()
-
-            // Then
-            val ready = assertIs<RecentlyAddedUiState.Ready>(viewModel.recentlyAddedState.value)
-            assertEquals(1, ready.books.size)
-            assertEquals("new-1", ready.books.first().id)
-        }
-
-    @Test
-    fun `recentlyAddedState becomes Error when upstream throws`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            every { fixture.bookRepository.observeRecentlyAddedBooks(any()) } returns
-                flow { throw RuntimeException("boom") }
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.recentlyAddedState) }
-            advanceUntilIdle()
-
-            // Then
-            val err = assertIs<RecentlyAddedUiState.Error>(viewModel.recentlyAddedState.value)
-            assertEquals("Failed to load recently added", err.message)
-        }
-
-    // ========== Discover Shelves Tests ==========
-
-    @Test
-    fun `discoverShelvesState becomes Ready grouped by owner`() =
-        runTest {
-            // Given - two shelves from the same owner, one from another owner
-            val fixture =
-                createFixture(
-                    discoveredShelves =
-                        listOf(
-                            createShelf(id = "s1", ownerId = "alice", ownerDisplayName = "Alice"),
-                            createShelf(id = "s2", ownerId = "alice", ownerDisplayName = "Alice"),
-                            createShelf(id = "s3", ownerId = "bob", ownerDisplayName = "Bob"),
-                        ),
+            fun build(): DiscoverViewModel =
+                DiscoverViewModel(
+                    bookRepository = bookRepository,
+                    activeSessionRepository = activeSessionRepository,
+                    authSession = authSession,
+                    shelfRepository = shelfRepository,
+                    errorBus = ErrorBus(),
                 )
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.discoverShelvesState) }
-            advanceUntilIdle()
-
-            // Then
-            val ready = assertIs<DiscoverShelvesUiState.Ready>(viewModel.discoverShelvesState.value)
-            assertEquals(2, ready.users.size)
-            assertEquals(3, ready.totalShelfCount)
-            val alice = ready.users.single { it.user.id == "alice" }
-            assertEquals(2, alice.shelves.size)
         }
 
-    @Test
-    fun `discoverShelvesState becomes Error when the discover RPC fails`() =
-        runTest {
-            // Given - the discover RPC returns a failure
-            val fixture = createFixture()
-            everySuspend { fixture.shelfRepository.discoverShelves() } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error
-                        .ValidationError(message = "boom"),
-                )
+        fun createFixture(
+            authState: AuthState = AuthState.Authenticated(userId = UserId(USER_ID), sessionId = SessionId(SESSION_ID)),
+            discoveredShelves: List<Shelf> = emptyList(),
+            randomBooks: List<DiscoveryBook> = emptyList(),
+        ): TestFixture {
+            val fixture = TestFixture()
+            fixture.authStateFlow.value = authState
 
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.discoverShelvesState) }
-            advanceUntilIdle()
+            every { fixture.authSession.authState } returns fixture.authStateFlow
+            every { fixture.activeSessionRepository.observeActiveSessions(any()) } returns fixture.activeSessionsFlow
+            every { fixture.bookRepository.observeRecentlyAddedBooks(any()) } returns fixture.recentlyAddedFlow
+            every { fixture.bookRepository.observeRandomUnstartedBooks(any()) } returns flowOf(randomBooks)
+            everySuspend { fixture.shelfRepository.discoverShelves() } returns AppResult.Success(discoveredShelves)
 
-            // Then
-            val err = assertIs<DiscoverShelvesUiState.Error>(viewModel.discoverShelvesState.value)
-            assertEquals("Failed to load discover shelves", err.message)
+            return fixture
         }
 
-    // ========== Discover Books Tests ==========
-
-    @Test
-    fun `discoverBooksState becomes Ready with random books on initial load`() =
-        runTest {
-            // Given
-            val fixture = createFixture(randomBooks = listOf(createDiscoveryBook(id = "r-1")))
-
-            // When
-            val viewModel = fixture.build().also { keepStateHot(it.discoverBooksState) }
-            advanceUntilIdle()
-
-            // Then
-            val ready = assertIs<DiscoverBooksUiState.Ready>(viewModel.discoverBooksState.value)
-            assertEquals(1, ready.books.size)
-            assertEquals("r-1", ready.books.first().id)
+        fun TestScope.keepStateHot(flow: StateFlow<*>) {
+            backgroundScope.launch { flow.collect { } }
         }
 
-    @Test
-    fun `discoverBooksState reloads when refresh is called`() =
-        runTest {
-            // Given
-            val fixture = createFixture(randomBooks = listOf(createDiscoveryBook(id = "r-1")))
-            val viewModel = fixture.build().also { keepStateHot(it.discoverBooksState) }
-            advanceUntilIdle()
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
+        }
 
-            // When
-            viewModel.refresh()
-            advanceUntilIdle()
+        afterTest {
+            Dispatchers.resetMain()
+        }
 
-            // Then - random books query invoked twice: initial subscription + refresh trigger bump.
-            // Mokkery's default VerifyMode is `exactly(1)`, so assert `atLeast(2)` explicitly.
-            verifySuspend(
-                dev.mokkery.verify.VerifyMode
-                    .atLeast(2),
-            ) {
-                fixture.bookRepository.observeRandomUnstartedBooks(any())
+        // ========== Currently Listening Tests ==========
+
+        test("currentlyListeningState initial value is Loading before subscription") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+
+                // When - viewModel created; `stateIn` initialValue is Loading.
+                // Do NOT start collecting — the stateIn initialValue is what we assert.
+                val viewModel = fixture.build()
+
+                // Then
+                viewModel.currentlyListeningState.value.shouldBeInstanceOf<CurrentlyListeningUiState.Loading>()
             }
         }
 
-    // ========== Discover RPC Load Tests ==========
+        test("currentlyListeningState becomes Ready when authenticated and flow emits") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.activeSessionsFlow.value = listOf(createActiveSession(sessionId = "s-1"))
 
-    @Test
-    fun `discover shelves are loaded on init when authenticated`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.currentlyListeningState) }
+                advanceUntilIdle()
 
-            // When - init runs
-            fixture.build()
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend { fixture.shelfRepository.discoverShelves() }
-        }
-
-    @Test
-    fun `discover shelves are not loaded when unauthenticated`() =
-        runTest {
-            // Given - unauthenticated
-            val fixture = createFixture(authState = AuthState.NeedsLogin())
-
-            // When
-            fixture.build()
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend(dev.mokkery.verify.VerifyMode.not) {
-                fixture.shelfRepository.discoverShelves()
+                // Then
+                val ready = viewModel.currentlyListeningState.value.shouldBeInstanceOf<CurrentlyListeningUiState.Ready>()
+                ready.sessions.size shouldBe 1
+                ready.sessions.first().sessionId shouldBe "s-1"
             }
         }
 
-    @Test
-    fun `refresh re-fetches discover shelves`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("currentlyListeningState becomes Ready empty when unauthenticated") {
+            runTest {
+                // Given - unauthenticated auth state steers flatMapLatest to flowOf(emptyList())
+                val fixture = createFixture(authState = AuthState.NeedsLogin())
 
-            // When
-            viewModel.refresh()
-            advanceUntilIdle()
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.currentlyListeningState) }
+                advanceUntilIdle()
 
-            // Then - once on init, once on refresh
-            verifySuspend(
-                dev.mokkery.verify.VerifyMode
-                    .atLeast(2),
-            ) {
-                fixture.shelfRepository.discoverShelves()
+                // Then
+                val ready = viewModel.currentlyListeningState.value.shouldBeInstanceOf<CurrentlyListeningUiState.Ready>()
+                ready.isEmpty shouldBe true
             }
         }
-}
+
+        test("currentlyListeningState becomes Error when upstream throws") {
+            runTest {
+                // Given - observeActiveSessions throws on collection
+                val fixture = createFixture()
+                every { fixture.activeSessionRepository.observeActiveSessions(any()) } returns
+                    flow { throw RuntimeException("boom") }
+
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.currentlyListeningState) }
+                advanceUntilIdle()
+
+                // Then
+                val err = viewModel.currentlyListeningState.value.shouldBeInstanceOf<CurrentlyListeningUiState.Error>()
+                err.message shouldBe "Failed to load currently listening"
+            }
+        }
+
+        // ========== Recently Added Tests ==========
+
+        test("recentlyAddedState becomes Ready when flow emits") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.recentlyAddedFlow.value = listOf(createDiscoveryBook(id = "new-1", title = "New"))
+
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.recentlyAddedState) }
+                advanceUntilIdle()
+
+                // Then
+                val ready = viewModel.recentlyAddedState.value.shouldBeInstanceOf<RecentlyAddedUiState.Ready>()
+                ready.books.size shouldBe 1
+                ready.books.first().id shouldBe "new-1"
+            }
+        }
+
+        test("recentlyAddedState becomes Error when upstream throws") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeRecentlyAddedBooks(any()) } returns
+                    flow { throw RuntimeException("boom") }
+
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.recentlyAddedState) }
+                advanceUntilIdle()
+
+                // Then
+                val err = viewModel.recentlyAddedState.value.shouldBeInstanceOf<RecentlyAddedUiState.Error>()
+                err.message shouldBe "Failed to load recently added"
+            }
+        }
+
+        // ========== Discover Shelves Tests ==========
+
+        test("discoverShelvesState becomes Ready grouped by owner") {
+            runTest {
+                // Given - two shelves from the same owner, one from another owner
+                val fixture =
+                    createFixture(
+                        discoveredShelves =
+                            listOf(
+                                createShelf(id = "s1", ownerId = "alice", ownerDisplayName = "Alice"),
+                                createShelf(id = "s2", ownerId = "alice", ownerDisplayName = "Alice"),
+                                createShelf(id = "s3", ownerId = "bob", ownerDisplayName = "Bob"),
+                            ),
+                    )
+
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.discoverShelvesState) }
+                advanceUntilIdle()
+
+                // Then
+                val ready = viewModel.discoverShelvesState.value.shouldBeInstanceOf<DiscoverShelvesUiState.Ready>()
+                ready.users.size shouldBe 2
+                ready.totalShelfCount shouldBe 3
+                val alice = ready.users.single { it.user.id == "alice" }
+                alice.shelves.size shouldBe 2
+            }
+        }
+
+        test("discoverShelvesState becomes Error when the discover RPC fails") {
+            runTest {
+                // Given - the discover RPC returns a failure
+                val fixture = createFixture()
+                everySuspend { fixture.shelfRepository.discoverShelves() } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "boom"),
+                    )
+
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.discoverShelvesState) }
+                advanceUntilIdle()
+
+                // Then
+                val err = viewModel.discoverShelvesState.value.shouldBeInstanceOf<DiscoverShelvesUiState.Error>()
+                err.message shouldBe "Failed to load discover shelves"
+            }
+        }
+
+        // ========== Discover Books Tests ==========
+
+        test("discoverBooksState becomes Ready with random books on initial load") {
+            runTest {
+                // Given
+                val fixture = createFixture(randomBooks = listOf(createDiscoveryBook(id = "r-1")))
+
+                // When
+                val viewModel = fixture.build().also { keepStateHot(it.discoverBooksState) }
+                advanceUntilIdle()
+
+                // Then
+                val ready = viewModel.discoverBooksState.value.shouldBeInstanceOf<DiscoverBooksUiState.Ready>()
+                ready.books.size shouldBe 1
+                ready.books.first().id shouldBe "r-1"
+            }
+        }
+
+        test("discoverBooksState reloads when refresh is called") {
+            runTest {
+                // Given
+                val fixture = createFixture(randomBooks = listOf(createDiscoveryBook(id = "r-1")))
+                val viewModel = fixture.build().also { keepStateHot(it.discoverBooksState) }
+                advanceUntilIdle()
+
+                // When
+                viewModel.refresh()
+                advanceUntilIdle()
+
+                // Then - random books query invoked twice: initial subscription + refresh trigger bump.
+                // Mokkery's default VerifyMode is `exactly(1)`, so assert `atLeast(2)` explicitly.
+                verifySuspend(
+                    dev.mokkery.verify.VerifyMode
+                        .atLeast(2),
+                ) {
+                    fixture.bookRepository.observeRandomUnstartedBooks(any())
+                }
+            }
+        }
+
+        // ========== Discover RPC Load Tests ==========
+
+        test("discover shelves are loaded on init when authenticated") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+
+                // When - init runs
+                fixture.build()
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.shelfRepository.discoverShelves() }
+            }
+        }
+
+        test("discover shelves are not loaded when unauthenticated") {
+            runTest {
+                // Given - unauthenticated
+                val fixture = createFixture(authState = AuthState.NeedsLogin())
+
+                // When
+                fixture.build()
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend(dev.mokkery.verify.VerifyMode.not) {
+                    fixture.shelfRepository.discoverShelves()
+                }
+            }
+        }
+
+        test("refresh re-fetches discover shelves") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                // When
+                viewModel.refresh()
+                advanceUntilIdle()
+
+                // Then - once on init, once on refresh
+                verifySuspend(
+                    dev.mokkery.verify.VerifyMode
+                        .atLeast(2),
+                ) {
+                    fixture.shelfRepository.discoverShelves()
+                }
+            }
+        }
+    })
+
+private const val USER_ID = "user-1"
+private const val SESSION_ID = "session-1"
+private const val OTHER_USER_ID = "user-2"

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModelTest.kt
@@ -17,6 +17,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,13 +32,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 /**
  * Tests for HomeViewModel.
@@ -51,547 +47,567 @@ import kotlin.test.assertTrue
  * Uses Mokkery for mocking repositories.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class HomeViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class HomeViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    // ========== Test Fixtures ==========
+        // ========== Test Fixtures ==========
 
-    private class TestFixture {
-        val homeRepository: HomeRepository = mock()
-        val userRepository: UserRepository = mock()
-        val shelfRepository: ShelfRepository = mock()
-        val syncRepository: SyncRepository = mock()
-        val userFlow = MutableStateFlow<User?>(null)
-        val continueListeningFlow = MutableStateFlow<List<ContinueListeningItem>>(emptyList())
-        val scanProgressFlow =
-            MutableStateFlow<com.calypsan.listenup.client.domain.model.ScanProgressState?>(null)
-        val syncStateFlow = MutableStateFlow<SyncState>(SyncState.Idle)
-        var currentHour: Int = 10 // Default to morning
+        class TestFixture {
+            val homeRepository: HomeRepository = mock()
+            val userRepository: UserRepository = mock()
+            val shelfRepository: ShelfRepository = mock()
+            val syncRepository: SyncRepository = mock()
+            val userFlow = MutableStateFlow<User?>(null)
+            val continueListeningFlow = MutableStateFlow<List<ContinueListeningItem>>(emptyList())
+            val scanProgressFlow =
+                MutableStateFlow<com.calypsan.listenup.client.domain.model.ScanProgressState?>(null)
+            val syncStateFlow = MutableStateFlow<SyncState>(SyncState.Idle)
+            var currentHour: Int = 10 // Default to morning
 
-        fun build(): HomeViewModel {
-            every { syncRepository.scanProgress } returns scanProgressFlow
-            every { syncRepository.syncState } returns syncStateFlow
-            return HomeViewModel(
-                homeRepository = homeRepository,
-                userRepository = userRepository,
-                shelfRepository = shelfRepository,
-                syncRepository = syncRepository,
-                currentHour = { currentHour },
-            )
-        }
-    }
-
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Default stubs for reactive observation
-        every { fixture.userRepository.observeCurrentUser() } returns fixture.userFlow
-        every { fixture.homeRepository.observeContinueListening(any()) } returns
-            fixture.continueListeningFlow
-        every { fixture.shelfRepository.observeMyShelves(any()) } returns flowOf(emptyList())
-
-        return fixture
-    }
-
-    private fun TestScope.keepStateHot(viewModel: HomeViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
-
-    // ========== Test Data Factories ==========
-
-    private fun createUser(
-        id: String = "user-1",
-        email: String = "john@example.com",
-        displayName: String = "John Smith",
-        isAdmin: Boolean = false,
-    ): User =
-        User(
-            id =
-                UserId(id),
-            email = email,
-            displayName = displayName,
-            isAdmin = isAdmin,
-            createdAtMs = 1704067200000L,
-            updatedAtMs = 1704067200000L,
-        )
-
-    private fun createContinueListeningBook(
-        bookId: String = "book-1",
-        title: String = "Test Book",
-        authorNames: String = "Test Author",
-        progress: Float = 0.5f,
-        currentPositionMs: Long = 1_800_000L,
-        totalDurationMs: Long = 3_600_000L,
-    ): ContinueListeningBook =
-        ContinueListeningBook(
-            bookId = bookId,
-            title = title,
-            authorNames = authorNames,
-            coverPath = null,
-            progress = progress,
-            currentPositionMs = currentPositionMs,
-            totalDurationMs = totalDurationMs,
-            lastPlayedAt = "2024-01-01T00:00:00Z",
-        )
-
-    private fun createReadyItem(
-        bookId: String = "book-1",
-        title: String = "Test Book",
-        authorNames: String = "Test Author",
-        progress: Float = 0.5f,
-        currentPositionMs: Long = 1_800_000L,
-        totalDurationMs: Long = 3_600_000L,
-    ): ContinueListeningItem.Ready =
-        ContinueListeningItem.Ready(
-            bookId = bookId,
-            book =
-                createContinueListeningBook(
-                    bookId = bookId,
-                    title = title,
-                    authorNames = authorNames,
-                    progress = progress,
-                    currentPositionMs = currentPositionMs,
-                    totalDurationMs = totalDurationMs,
-                ),
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Initial State Tests ==========
-
-    @Test
-    fun `init starts observation and transitions to Ready after first emission`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-
-            // When - viewModel created, stateIn pipeline subscribes on first collect
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then - state should be Ready after combine emits
-            assertIs<HomeUiState.Ready>(viewModel.state.value)
-        }
-
-    // ========== Reactive Observation Tests ==========
-
-    @Test
-    fun `observeContinueListening updates state when flow emits`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            val initial = assertIs<HomeUiState.Ready>(viewModel.state.value)
-            assertTrue(initial.continueListening.isEmpty())
-
-            // When - flow emits new data
-            val items =
-                listOf(
-                    createReadyItem(bookId = "book-1", title = "Book 1"),
-                    createReadyItem(bookId = "book-2", title = "Book 2"),
+            fun build(): HomeViewModel {
+                every { syncRepository.scanProgress } returns scanProgressFlow
+                every { syncRepository.syncState } returns syncStateFlow
+                return HomeViewModel(
+                    homeRepository = homeRepository,
+                    userRepository = userRepository,
+                    shelfRepository = shelfRepository,
+                    syncRepository = syncRepository,
+                    currentHour = { currentHour },
                 )
-            fixture.continueListeningFlow.value = items
-            advanceUntilIdle()
-
-            // Then - state should update reactively
-            val ready = assertIs<HomeUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.isLoading)
-            assertEquals(2, ready.continueListening.size)
-            assertEquals("Book 1", (ready.continueListening[0] as ContinueListeningItem.Ready).book.title)
+            }
         }
 
-    @Test
-    fun `continueListening updates reactively when new book is played`() =
-        runTest {
-            // Given - start with one book
-            val fixture = createFixture()
-            fixture.continueListeningFlow.value =
-                listOf(
-                    createReadyItem(bookId = "book-1", title = "Original Book"),
-                )
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            assertEquals(
-                1,
-                assertIs<HomeUiState.Ready>(viewModel.state.value).continueListening.size,
-            )
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
 
-            // When - new book is played (Flow emits updated list)
-            fixture.continueListeningFlow.value =
-                listOf(
-                    createReadyItem(bookId = "book-new", title = "New Book"),
-                    createReadyItem(bookId = "book-1", title = "Original Book"),
-                )
-            advanceUntilIdle()
-
-            // Then - UI updates immediately without manual refresh
-            val ready = assertIs<HomeUiState.Ready>(viewModel.state.value)
-            assertEquals(2, ready.continueListening.size)
-            assertEquals("New Book", (ready.continueListening[0] as ContinueListeningItem.Ready).book.title)
-        }
-
-    // ========== User Observation Tests ==========
-
-    @Test
-    fun `observeUser updates userName from displayName`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            assertEquals("", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-
-            // When
-            fixture.userFlow.value = createUser(displayName = "John Smith")
-            advanceUntilIdle()
-
-            // Then - first name extracted
-            assertEquals("John", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-        }
-
-    @Test
-    fun `observeUser extracts first name only`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            fixture.userFlow.value = createUser(displayName = "Jane Doe Johnson")
-            advanceUntilIdle()
-
-            // Then
-            assertEquals("Jane", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-        }
-
-    @Test
-    fun `observeUser handles null user`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.userFlow.value = createUser(displayName = "John")
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            assertEquals("John", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-
-            // When
-            fixture.userFlow.value = null
-            advanceUntilIdle()
-
-            // Then
-            assertEquals("", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-        }
-
-    @Test
-    fun `observeUser handles blank displayName`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            fixture.userFlow.value = createUser(displayName = "   ")
-            advanceUntilIdle()
-
-            // Then
-            assertEquals("", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-        }
-
-    @Test
-    fun `observeUser handles single name`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            fixture.userFlow.value = createUser(displayName = "Madonna")
-            advanceUntilIdle()
-
-            // Then
-            assertEquals("Madonna", assertIs<HomeUiState.Ready>(viewModel.state.value).userName)
-        }
-
-    // ========== Refresh Tests ==========
-
-    @Test
-    fun `refresh triggers a full server sync`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.syncRepository.sync() } returns
-                AppResult.Success(Unit)
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend { fixture.syncRepository.sync() }
-        }
-
-    @Test
-    fun `refresh handles sync failure gracefully`() =
-        runTest {
-            // Given - sync returns a failure Result (not an exception)
-            val fixture = createFixture()
-            everySuspend { fixture.syncRepository.sync() } returns
-                Failure(RuntimeException("Network error"))
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // When
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            // Then - ViewModel is still functional, sync was attempted
-            verifySuspend { fixture.syncRepository.sync() }
-            val ready = assertIs<HomeUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.isLoading)
-        }
-
-    // ========== State Derived Properties Tests ==========
-
-    @Test
-    fun `hasContinueListening is true when list not empty`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.continueListeningFlow.value = listOf(createReadyItem())
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertTrue(assertIs<HomeUiState.Ready>(viewModel.state.value).hasContinueListening)
-        }
-
-    @Test
-    fun `hasContinueListening is false when list empty`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.continueListeningFlow.value = emptyList()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertFalse(assertIs<HomeUiState.Ready>(viewModel.state.value).hasContinueListening)
-        }
-
-    @Test
-    fun `greeting includes userName when available`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 10 // Morning
-            fixture.userFlow.value = createUser(displayName = "Alice")
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good morning, Alice",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    @Test
-    fun `greeting without userName is time-only`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 14 // Afternoon
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good afternoon",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    // ========== Sync State Tests ==========
-
-    @Test
-    fun `isSyncing reflects SyncState Syncing`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-            assertFalse(assertIs<HomeUiState.Ready>(viewModel.state.value).isSyncing)
-
-            // When
-            fixture.syncStateFlow.value = SyncState.Syncing
-            advanceUntilIdle()
-
-            // Then
-            assertTrue(assertIs<HomeUiState.Ready>(viewModel.state.value).isSyncing)
-        }
-
-    // ========== Time-Based Greeting Tests ==========
-
-    @Test
-    fun `greeting is morning between 5 and 11`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 8
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good morning",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    @Test
-    fun `greeting is afternoon between 12 and 16`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 14
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good afternoon",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    @Test
-    fun `greeting is evening between 17 and 20`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 19
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good evening",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    @Test
-    fun `greeting is night after 21`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 23
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good night",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    @Test
-    fun `greeting is night before 5`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            fixture.currentHour = 3
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // Then
-            assertEquals(
-                "Good night",
-                assertIs<HomeUiState.Ready>(viewModel.state.value).greeting,
-            )
-        }
-
-    // ========== Snackbar Tests ==========
-
-    @Test
-    fun `continue listening failure emits snackbar`() =
-        runTest {
-            val fixture = createFixture()
+            // Default stubs for reactive observation
+            every { fixture.userRepository.observeCurrentUser() } returns fixture.userFlow
             every { fixture.homeRepository.observeContinueListening(any()) } returns
-                flow { throw RuntimeException("boom") }
-            val viewModel = fixture.build()
+                fixture.continueListeningFlow
+            every { fixture.shelfRepository.observeMyShelves(any()) } returns flowOf(emptyList())
 
-            val emitted = mutableListOf<String>()
-            // Ordering matters: the snackbar collector must subscribe to the Channel-backed
-            // Flow before state subscription triggers the catch { trySend(...) } so the
-            // emission is routed to a live collector under runTest's virtual scheduler.
-            backgroundScope.launch { viewModel.snackbarMessages.collect { emitted += it } }
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            assertTrue(emitted.contains("Failed to load continue listening"))
+            return fixture
         }
 
-    @Test
-    fun `continue listening cancellation is not swallowed into a fallback emission`() =
-        runTest {
-            // Regression: the continueListening .catch used to omit the cancellation
-            // rethrow, swallowing CancellationException into an emit(emptyList()).
-            // fallbackTo restores the rethrow by construction, so a cancelling upstream
-            // must NOT collapse into a Ready/empty-list state — it must propagate.
-            val fixture = createFixture()
-            every { fixture.homeRepository.observeContinueListening(any()) } returns
-                flow { throw kotlin.coroutines.cancellation.CancellationException("cancelled") }
-            val viewModel = fixture.build().also { keepStateHot(it) }
-            advanceUntilIdle()
-
-            // State never advanced past the stateIn initial value — the cancelling
-            // upstream did not produce a Ready emission with an empty list.
-            assertIs<HomeUiState.Loading>(viewModel.state.value)
+        fun TestScope.keepStateHot(viewModel: HomeViewModel) {
+            backgroundScope.launch { viewModel.state.collect { } }
         }
 
-    @Test
-    fun `pipeline failure surfaces Error state`() =
-        runTest {
-            // Make the combine transform itself throw by failing the greeting
-            // computation. This isolates the failure to the outer pipeline (the
-            // `init` block does not call currentHour), so the terminal `.catch` is
-            // the only handler that sees it.
-            val fixture = createFixture()
-            // syncRepository stubs are installed by `build()`; install them here
-            // since we bypass build() to inject the failing currentHour.
-            every { fixture.syncRepository.scanProgress } returns fixture.scanProgressFlow
-            every { fixture.syncRepository.syncState } returns fixture.syncStateFlow
-            val viewModel =
-                HomeViewModel(
-                    homeRepository = fixture.homeRepository,
-                    userRepository = fixture.userRepository,
-                    shelfRepository = fixture.shelfRepository,
-                    syncRepository = fixture.syncRepository,
-                    currentHour = { throw RuntimeException("upstream boom") },
-                )
-            // Emit a non-null user so the combine pipeline's transform actually runs.
-            fixture.userFlow.value = createUser()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
+        // ========== Test Data Factories ==========
 
-            val state = viewModel.state.value
-            val error = assertIs<HomeUiState.Error>(state)
-            assertEquals("Failed to load home screen", error.message)
+        fun createUser(
+            id: String = "user-1",
+            email: String = "john@example.com",
+            displayName: String = "John Smith",
+            isAdmin: Boolean = false,
+        ): User =
+            User(
+                id =
+                    UserId(id),
+                email = email,
+                displayName = displayName,
+                isAdmin = isAdmin,
+                createdAtMs = 1704067200000L,
+                updatedAtMs = 1704067200000L,
+            )
+
+        fun createContinueListeningBook(
+            bookId: String = "book-1",
+            title: String = "Test Book",
+            authorNames: String = "Test Author",
+            progress: Float = 0.5f,
+            currentPositionMs: Long = 1_800_000L,
+            totalDurationMs: Long = 3_600_000L,
+        ): ContinueListeningBook =
+            ContinueListeningBook(
+                bookId = bookId,
+                title = title,
+                authorNames = authorNames,
+                coverPath = null,
+                progress = progress,
+                currentPositionMs = currentPositionMs,
+                totalDurationMs = totalDurationMs,
+                lastPlayedAt = "2024-01-01T00:00:00Z",
+            )
+
+        fun createReadyItem(
+            bookId: String = "book-1",
+            title: String = "Test Book",
+            authorNames: String = "Test Author",
+            progress: Float = 0.5f,
+            currentPositionMs: Long = 1_800_000L,
+            totalDurationMs: Long = 3_600_000L,
+        ): ContinueListeningItem.Ready =
+            ContinueListeningItem.Ready(
+                bookId = bookId,
+                book =
+                    createContinueListeningBook(
+                        bookId = bookId,
+                        title = title,
+                        authorNames = authorNames,
+                        progress = progress,
+                        currentPositionMs = currentPositionMs,
+                        totalDurationMs = totalDurationMs,
+                    ),
+            )
+
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
-}
+
+        afterTest {
+            Dispatchers.resetMain()
+        }
+
+        // ========== Initial State Tests ==========
+
+        test("init starts observation and transitions to Ready after first emission") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+
+                // When - viewModel created, stateIn pipeline subscribes on first collect
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then - state should be Ready after combine emits
+                viewModel.state.value.shouldBeInstanceOf<HomeUiState.Ready>()
+            }
+        }
+
+        // ========== Reactive Observation Tests ==========
+
+        test("observeContinueListening updates state when flow emits") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+                val initial = viewModel.state.value.shouldBeInstanceOf<HomeUiState.Ready>()
+                initial.continueListening.isEmpty() shouldBe true
+
+                // When - flow emits new data
+                val items =
+                    listOf(
+                        createReadyItem(bookId = "book-1", title = "Book 1"),
+                        createReadyItem(bookId = "book-2", title = "Book 2"),
+                    )
+                fixture.continueListeningFlow.value = items
+                advanceUntilIdle()
+
+                // Then - state should update reactively
+                val ready = viewModel.state.value.shouldBeInstanceOf<HomeUiState.Ready>()
+                ready.isLoading shouldBe false
+                ready.continueListening.size shouldBe 2
+                (ready.continueListening[0] as ContinueListeningItem.Ready).book.title shouldBe "Book 1"
+            }
+        }
+
+        test("continueListening updates reactively when new book is played") {
+            runTest {
+                // Given - start with one book
+                val fixture = createFixture()
+                fixture.continueListeningFlow.value =
+                    listOf(
+                        createReadyItem(bookId = "book-1", title = "Original Book"),
+                    )
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .continueListening.size shouldBe 1
+
+                // When - new book is played (Flow emits updated list)
+                fixture.continueListeningFlow.value =
+                    listOf(
+                        createReadyItem(bookId = "book-new", title = "New Book"),
+                        createReadyItem(bookId = "book-1", title = "Original Book"),
+                    )
+                advanceUntilIdle()
+
+                // Then - UI updates immediately without manual refresh
+                val ready = viewModel.state.value.shouldBeInstanceOf<HomeUiState.Ready>()
+                ready.continueListening.size shouldBe 2
+                (ready.continueListening[0] as ContinueListeningItem.Ready).book.title shouldBe "New Book"
+            }
+        }
+
+        // ========== User Observation Tests ==========
+
+        test("observeUser updates userName from displayName") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe ""
+
+                // When
+                fixture.userFlow.value = createUser(displayName = "John Smith")
+                advanceUntilIdle()
+
+                // Then - first name extracted
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe "John"
+            }
+        }
+
+        test("observeUser extracts first name only") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // When
+                fixture.userFlow.value = createUser(displayName = "Jane Doe Johnson")
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe "Jane"
+            }
+        }
+
+        test("observeUser handles null user") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.userFlow.value = createUser(displayName = "John")
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe "John"
+
+                // When
+                fixture.userFlow.value = null
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe ""
+            }
+        }
+
+        test("observeUser handles blank displayName") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // When
+                fixture.userFlow.value = createUser(displayName = "   ")
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe ""
+            }
+        }
+
+        test("observeUser handles single name") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // When
+                fixture.userFlow.value = createUser(displayName = "Madonna")
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .userName shouldBe "Madonna"
+            }
+        }
+
+        // ========== Refresh Tests ==========
+
+        test("refresh triggers a full server sync") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.syncRepository.sync() } returns
+                    AppResult.Success(Unit)
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // When
+                viewModel.refresh()
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.syncRepository.sync() }
+            }
+        }
+
+        test("refresh handles sync failure gracefully") {
+            runTest {
+                // Given - sync returns a failure Result (not an exception)
+                val fixture = createFixture()
+                everySuspend { fixture.syncRepository.sync() } returns
+                    Failure(RuntimeException("Network error"))
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // When
+                viewModel.refresh()
+                advanceUntilIdle()
+
+                // Then - ViewModel is still functional, sync was attempted
+                verifySuspend { fixture.syncRepository.sync() }
+                val ready = viewModel.state.value.shouldBeInstanceOf<HomeUiState.Ready>()
+                ready.isLoading shouldBe false
+            }
+        }
+
+        // ========== State Derived Properties Tests ==========
+
+        test("hasContinueListening is true when list not empty") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.continueListeningFlow.value = listOf(createReadyItem())
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .hasContinueListening shouldBe true
+            }
+        }
+
+        test("hasContinueListening is false when list empty") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.continueListeningFlow.value = emptyList()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .hasContinueListening shouldBe false
+            }
+        }
+
+        test("greeting includes userName when available") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 10 // Morning
+                fixture.userFlow.value = createUser(displayName = "Alice")
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good morning, Alice"
+            }
+        }
+
+        test("greeting without userName is time-only") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 14 // Afternoon
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good afternoon"
+            }
+        }
+
+        // ========== Sync State Tests ==========
+
+        test("isSyncing reflects SyncState Syncing") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .isSyncing shouldBe false
+
+                // When
+                fixture.syncStateFlow.value = SyncState.Syncing
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .isSyncing shouldBe true
+            }
+        }
+
+        // ========== Time-Based Greeting Tests ==========
+
+        test("greeting is morning between 5 and 11") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 8
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good morning"
+            }
+        }
+
+        test("greeting is afternoon between 12 and 16") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 14
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good afternoon"
+            }
+        }
+
+        test("greeting is evening between 17 and 20") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 19
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good evening"
+            }
+        }
+
+        test("greeting is night after 21") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 23
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good night"
+            }
+        }
+
+        test("greeting is night before 5") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                fixture.currentHour = 3
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value
+                    .shouldBeInstanceOf<HomeUiState.Ready>()
+                    .greeting shouldBe
+                    "Good night"
+            }
+        }
+
+        // ========== Snackbar Tests ==========
+
+        test("continue listening failure emits snackbar") {
+            runTest {
+                val fixture = createFixture()
+                every { fixture.homeRepository.observeContinueListening(any()) } returns
+                    flow { throw RuntimeException("boom") }
+                val viewModel = fixture.build()
+
+                val emitted = mutableListOf<String>()
+                // Ordering matters: the snackbar collector must subscribe to the Channel-backed
+                // Flow before state subscription triggers the catch { trySend(...) } so the
+                // emission is routed to a live collector under runTest's virtual scheduler.
+                backgroundScope.launch { viewModel.snackbarMessages.collect { emitted += it } }
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                emitted.contains("Failed to load continue listening") shouldBe true
+            }
+        }
+
+        test("continue listening cancellation is not swallowed into a fallback emission") {
+            runTest {
+                // Regression: the continueListening .catch used to omit the cancellation
+                // rethrow, swallowing CancellationException into an emit(emptyList()).
+                // fallbackTo restores the rethrow by construction, so a cancelling upstream
+                // must NOT collapse into a Ready/empty-list state — it must propagate.
+                val fixture = createFixture()
+                every { fixture.homeRepository.observeContinueListening(any()) } returns
+                    flow { throw kotlin.coroutines.cancellation.CancellationException("cancelled") }
+                val viewModel = fixture.build().also { keepStateHot(it) }
+                advanceUntilIdle()
+
+                // State never advanced past the stateIn initial value — the cancelling
+                // upstream did not produce a Ready emission with an empty list.
+                viewModel.state.value.shouldBeInstanceOf<HomeUiState.Loading>()
+            }
+        }
+
+        test("pipeline failure surfaces Error state") {
+            runTest {
+                // Make the combine transform itself throw by failing the greeting
+                // computation. This isolates the failure to the outer pipeline (the
+                // `init` block does not call currentHour), so the terminal `.catch` is
+                // the only handler that sees it.
+                val fixture = createFixture()
+                // syncRepository stubs are installed by `build()`; install them here
+                // since we bypass build() to inject the failing currentHour.
+                every { fixture.syncRepository.scanProgress } returns fixture.scanProgressFlow
+                every { fixture.syncRepository.syncState } returns fixture.syncStateFlow
+                val viewModel =
+                    HomeViewModel(
+                        homeRepository = fixture.homeRepository,
+                        userRepository = fixture.userRepository,
+                        shelfRepository = fixture.shelfRepository,
+                        syncRepository = fixture.syncRepository,
+                        currentHour = { throw RuntimeException("upstream boom") },
+                    )
+                // Emit a non-null user so the combine pipeline's transform actually runs.
+                fixture.userFlow.value = createUser()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value
+                val error = state.shouldBeInstanceOf<HomeUiState.Error>()
+                error.message shouldBe "Failed to load home screen"
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -25,6 +25,9 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,11 +39,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Integration tests for the consolidated [NowPlayingViewModel] (W7 Phase E2.2.3).
@@ -56,623 +54,622 @@ import kotlin.test.assertTrue
  * none of them invoke timer-launching methods).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class NowPlayingViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class NowPlayingViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val fakePm = FakePlaybackManager()
-        val bookRepository: BookRepository = mock()
-        val playbackController: PlaybackController = mock()
-        val playbackPreferences: PlaybackPreferences = mock()
-        val networkMonitor: NetworkMonitor = mock()
-        val sleepTimerManager: SleepTimerManager = SleepTimerManager(CoroutineScope(Job()))
+        class TestFixture {
+            val fakePm = FakePlaybackManager()
+            val bookRepository: BookRepository = mock()
+            val playbackController: PlaybackController = mock()
+            val playbackPreferences: PlaybackPreferences = mock()
+            val networkMonitor: NetworkMonitor = mock()
+            val sleepTimerManager: SleepTimerManager = SleepTimerManager(CoroutineScope(Job()))
 
-        init {
-            // Default: networkMonitor.isOnline() returns true. Tests override to false where needed.
-            every { networkMonitor.isOnline() } returns true
-            // Default: PlaybackPreferences.observeDefaultPlaybackSpeed() returns Flow of 1.0f.
-            // Required by NowPlayingViewModel's surfaceMetadataFlow combine pipeline.
-            every { playbackPreferences.observeDefaultPlaybackSpeed() } returns flowOf(1.0f)
-            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
-            // Default: bookRepository.getBookListItem returns null (no metadata).
-            // bookFlow tolerates null; pure mapToNowPlayingState handles it.
-            everySuspend { bookRepository.getBookListItem(any()) } returns null
-            // NowPlayingViewModel's init block calls playbackController.acquire() to
-            // establish the MediaController connection. Mokkery is strict by default
-            // and would raise CallNotMockedException without this stub.
-            every { playbackController.acquire() } returns Unit
-        }
-
-        fun newVm(): NowPlayingViewModel =
-            NowPlayingViewModel(
-                playbackManager = fakePm,
-                bookRepository = bookRepository,
-                sleepTimerManager = sleepTimerManager,
-                playbackController = playbackController,
-                playbackPreferences = playbackPreferences,
-                networkMonitor = networkMonitor,
-            )
-    }
-
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== lifecycle (W7 Phase E2.2.2 regression) ==========
-
-    @Test
-    fun `init acquires the PlaybackController so MediaController connects`() {
-        val fixture = TestFixture()
-
-        fixture.newVm()
-
-        // The W7 Phase E2.2.2 refactor mistakenly removed acquire/release from the
-        // VM under the assumption that Koin-singleton lifetime obviated the call.
-        // It does not — only acquire() triggers MediaControllerHolder.connect().
-        // Without this call, every in-app playback command is a silent no-op.
-        verify(VerifyMode.exactly(1)) { fixture.playbackController.acquire() }
-    }
-
-    // ========== playBook ==========
-
-    @Test
-    fun `playBook happy path activates book then invokes controller seam`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            val bookId = BookId("book-1")
-            val prepareResult = stubPrepareResult(bookId)
-            fixture.fakePm.stubbedPrepareResult = prepareResult
-            every { fixture.networkMonitor.isOnline() } returns true
-            everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
-
-            val vm = fixture.newVm()
-            vm.playBook(bookId)
-            advanceUntilIdle()
-
-            // activateBook must fire (records the bookId on the fake's recorder list).
-            // PlaybackController.startPlayback must fire afterwards.
-            // Strict ordering is asserted indirectly: activateBook is recorded, AND
-            // startPlayback was invoked exactly once with the prepared result. The
-            // production VM body in [NowPlayingViewModel.playBook] sequences them
-            // activate-then-seam; both having fired proves the bug-3 ordering closure.
-            assertEquals(listOf(bookId), fixture.fakePm.activatedBookIds)
-            verifySuspend(VerifyMode.exactly(1)) {
-                fixture.playbackController.startPlayback(prepareResult)
+            init {
+                // Default: networkMonitor.isOnline() returns true. Tests override to false where needed.
+                every { networkMonitor.isOnline() } returns true
+                // Default: PlaybackPreferences.observeDefaultPlaybackSpeed() returns Flow of 1.0f.
+                // Required by NowPlayingViewModel's surfaceMetadataFlow combine pipeline.
+                every { playbackPreferences.observeDefaultPlaybackSpeed() } returns flowOf(1.0f)
+                everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+                // Default: bookRepository.getBookListItem returns null (no metadata).
+                // bookFlow tolerates null; pure mapToNowPlayingState handles it.
+                everySuspend { bookRepository.getBookListItem(any()) } returns null
+                // NowPlayingViewModel's init block calls playbackController.acquire() to
+                // establish the MediaController connection. Mokkery is strict by default
+                // and would raise CallNotMockedException without this stub.
+                every { playbackController.acquire() } returns Unit
             }
-            // No error reported on the happy path.
-            assertTrue(
-                fixture.fakePm.reportedErrors.isEmpty(),
-                "happy path must not report any error; got: ${fixture.fakePm.reportedErrors}",
-            )
-        }
 
-    @Test
-    fun `playBook with offline + null prepare reports offline error`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            val bookId = BookId("book-1")
-            fixture.fakePm.stubbedPrepareResult = null
-            every { fixture.networkMonitor.isOnline() } returns false
-
-            val vm = fixture.newVm()
-            vm.playBook(bookId)
-            advanceUntilIdle()
-
-            assertEquals(1, fixture.fakePm.reportedErrors.size)
-            assertTrue(
-                fixture.fakePm.reportedErrors
-                    .first()
-                    .message
-                    .contains("offline", ignoreCase = true),
-                "expected offline error message; got: ${fixture.fakePm.reportedErrors.first().message}",
-            )
-            assertTrue(
-                fixture.fakePm.activatedBookIds.isEmpty(),
-                "must NOT activate when prepare fails",
-            )
-            verifySuspend(VerifyMode.exactly(0)) {
-                fixture.playbackController.startPlayback(any())
-            }
-        }
-
-    @Test
-    fun `playBook with online + null prepare reports generic error`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            val bookId = BookId("book-1")
-            fixture.fakePm.stubbedPrepareResult = null
-            every { fixture.networkMonitor.isOnline() } returns true
-
-            val vm = fixture.newVm()
-            vm.playBook(bookId)
-            advanceUntilIdle()
-
-            assertEquals(1, fixture.fakePm.reportedErrors.size)
-            assertTrue(
-                fixture.fakePm.reportedErrors
-                    .first()
-                    .message
-                    .contains("Failed to load", ignoreCase = true),
-                "expected generic load-failure message; got: ${fixture.fakePm.reportedErrors.first().message}",
-            )
-            assertTrue(
-                fixture.fakePm.activatedBookIds.isEmpty(),
-                "must NOT activate when prepare fails",
-            )
-            verifySuspend(VerifyMode.exactly(0)) {
-                fixture.playbackController.startPlayback(any())
-            }
-        }
-
-    // ========== playPause ==========
-
-    @Test
-    fun `playPause when playing calls controller pause`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.pause() } returns Unit
-            every { fixture.playbackController.play() } returns Unit
-            fixture.fakePm.isPlayingFlow.value = true
-
-            val vm = fixture.newVm()
-            vm.playPause()
-            advanceUntilIdle()
-
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.pause() }
-            verify(VerifyMode.not) { fixture.playbackController.play() }
-        }
-
-    @Test
-    fun `playPause when paused calls controller play`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.pause() } returns Unit
-            every { fixture.playbackController.play() } returns Unit
-            fixture.fakePm.isPlayingFlow.value = false
-
-            val vm = fixture.newVm()
-            vm.playPause()
-            advanceUntilIdle()
-
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.play() }
-            verify(VerifyMode.not) { fixture.playbackController.pause() }
-        }
-
-    // ========== Skip/seek ==========
-
-    @Test
-    fun `skipForward at speed 1_5 advances by speed-multiplied delta and clamps to total`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.seekTo(any()) } returns Unit
-            fixture.fakePm.currentTimelineFlow.value = stubTimeline()
-            fixture.fakePm.currentPositionMsFlow.value = 100_000L
-            fixture.fakePm.totalDurationMsFlow.value = 1_800_000L
-            fixture.fakePm.playbackSpeedFlow.value = 1.5f
-
-            val vm = fixture.newVm()
-            vm.skipForward(30)
-            advanceUntilIdle()
-
-            // 100_000 + (30 × 1.5 × 1000) = 145_000
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(145_000L) }
-            assertEquals(listOf(145_000L), fixture.fakePm.updatedPositions)
-
-            // Edge: at total - 5000, 30s skip clamps to total.
-            // updatePosition(145_000) above moved currentPositionMsFlow to 145_000;
-            // now reset to total - 5000 to exercise the clamp.
-            fixture.fakePm.currentPositionMsFlow.value = 1_800_000L - 5_000L
-            fixture.fakePm.updatedPositions.clear()
-            vm.skipForward(30)
-            advanceUntilIdle()
-            assertEquals(listOf(1_800_000L), fixture.fakePm.updatedPositions)
-        }
-
-    @Test
-    fun `skipBack at speed 1_5 retreats by speed-multiplied delta and clamps to zero`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.seekTo(any()) } returns Unit
-            fixture.fakePm.currentTimelineFlow.value = stubTimeline()
-            fixture.fakePm.currentPositionMsFlow.value = 100_000L
-            fixture.fakePm.playbackSpeedFlow.value = 1.5f
-
-            val vm = fixture.newVm()
-            vm.skipBack(10)
-            advanceUntilIdle()
-
-            // 100_000 - (10 × 1.5 × 1000) = 85_000
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(85_000L) }
-            assertEquals(listOf(85_000L), fixture.fakePm.updatedPositions)
-
-            // Edge: at 5000ms, 10s skip clamps to 0.
-            fixture.fakePm.currentPositionMsFlow.value = 5_000L
-            fixture.fakePm.updatedPositions.clear()
-            vm.skipBack(10)
-            advanceUntilIdle()
-            assertEquals(listOf(0L), fixture.fakePm.updatedPositions)
-        }
-
-    @Test
-    fun `seekToChapter seeks to chapter start and ignores out-of-range indices`() =
-        runTest(testDispatcher) {
-            // Production [NowPlayingViewModel.seekToChapter] uses chapters.getOrNull(index)
-            // and returns when null — so out-of-range indices are a no-op (NOT clamped).
-            // This deviates from the Task 3 skeleton's "clamp to last/first" expectation;
-            // the test asserts production behavior.
-            val fixture = TestFixture()
-            every { fixture.playbackController.seekTo(any()) } returns Unit
-            fixture.fakePm.chaptersFlow.value = stubChapters()
-
-            val vm = fixture.newVm()
-
-            vm.seekToChapter(1)
-            advanceUntilIdle()
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(600_000L) }
-            assertEquals(listOf(600_000L), fixture.fakePm.updatedPositions)
-
-            // Out-of-range high (chapters.size == 3) → no-op.
-            fixture.fakePm.updatedPositions.clear()
-            vm.seekToChapter(99)
-            advanceUntilIdle()
-            verify(VerifyMode.not) { fixture.playbackController.seekTo(any<Long>()) }
-            assertTrue(
-                fixture.fakePm.updatedPositions.isEmpty(),
-                "out-of-range high index must NOT update position; got: ${fixture.fakePm.updatedPositions}",
-            )
-
-            // Out-of-range low (negative) → no-op.
-            vm.seekToChapter(-1)
-            advanceUntilIdle()
-            verify(VerifyMode.not) { fixture.playbackController.seekTo(any<Long>()) }
-            assertTrue(
-                fixture.fakePm.updatedPositions.isEmpty(),
-                "out-of-range low index must NOT update position; got: ${fixture.fakePm.updatedPositions}",
-            )
-
-            // Index 0 → seeks to first chapter (startTime 0).
-            vm.seekToChapter(0)
-            advanceUntilIdle()
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(0L) }
-            assertEquals(listOf(0L), fixture.fakePm.updatedPositions)
-        }
-
-    // ========== Speed ==========
-
-    @Test
-    fun `setSpeed updates controller and marks book as having custom speed`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.setPlaybackSpeed(any()) } returns Unit
-
-            val vm = fixture.newVm()
-            vm.setSpeed(1.75f)
-            advanceUntilIdle()
-
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.setPlaybackSpeed(1.75f) }
-            assertEquals(listOf(1.75f), fixture.fakePm.speedChanges)
-        }
-
-    @Test
-    fun `resetSpeedToDefault uses preference value and marks book as default and cycleSpeed wraps`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            everySuspend { fixture.playbackPreferences.getDefaultPlaybackSpeed() } returns 1.25f
-            every { fixture.playbackController.setPlaybackSpeed(any()) } returns Unit
-
-            val vm = fixture.newVm()
-            vm.resetSpeedToDefault()
-            advanceUntilIdle()
-
-            verify(VerifyMode.atLeast(1)) { fixture.playbackController.setPlaybackSpeed(1.25f) }
-            assertEquals(listOf(1.25f), fixture.fakePm.speedResets)
-
-            // cycleSpeed wraps from the highest value (3.0f) back to the lowest (0.5f).
-            // The cycle list is [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0].
-            fixture.fakePm.playbackSpeedFlow.value = 3.0f
-            vm.cycleSpeed()
-            advanceUntilIdle()
-            // cycleSpeed routes through setSpeed → onSpeedChanged, so speedChanges grows.
-            assertEquals(0.5f, fixture.fakePm.speedChanges.last())
-        }
-
-    // ========== Sleep timer ==========
-
-    @Test
-    fun `setSleepTimer arms timer and cancelSleepTimer disarms it`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            // SleepTimerManager is a real instance (closed concrete class — cannot mock with
-            // Mokkery in this classpath; see fixture init). Both setTimer and cancelTimer
-            // update state.value synchronously before any background work, so we can
-            // observe state through the real instance without virtual-time juggling.
-
-            val vm = fixture.newVm()
-            vm.setSleepTimer(SleepTimerMode.Duration(minutes = 15))
-            advanceUntilIdle()
-
-            val activeState = fixture.sleepTimerManager.state.value
-            assertTrue(
-                activeState is SleepTimerState.Active && activeState.mode is SleepTimerMode.Duration,
-                "expected active Duration timer; got: $activeState",
-            )
-
-            vm.cancelSleepTimer()
-            advanceUntilIdle()
-            assertTrue(
-                fixture.sleepTimerManager.state.value is SleepTimerState.Inactive,
-                "expected inactive after cancel; got: ${fixture.sleepTimerManager.state.value}",
-            )
-        }
-
-    @Test
-    fun `init-block sleepEvent observer fades out and pauses on timer expiry`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.setVolume(any()) } returns Unit
-            every { fixture.playbackController.pause() } returns Unit
-
-            val vm = fixture.newVm()
-            advanceUntilIdle() // let init-block collectors start
-
-            // Use EndOfChapter mode + drive currentChapter to trigger the sleep event
-            // through public API. Duration mode's timer loop combines virtual-time delay
-            // with wall-clock math (Clock.System.now()), which doesn't progress under
-            // a TestDispatcher; EndOfChapter mode fires synchronously from
-            // SleepTimerManager.onChapterChanged when the chapter index advances.
-            vm.setSleepTimer(SleepTimerMode.EndOfChapter)
-            advanceUntilIdle()
-
-            // First chapter sets lastKnownChapterIndex; second (greater) triggers sleep.
-            fixture.fakePm.currentChapterFlow.value =
-                ChapterInfo(
-                    index = 0,
-                    title = "Chapter 1",
-                    startMs = 0L,
-                    endMs = 600_000L,
-                    remainingMs = 600_000L,
-                    totalChapters = 3,
-                    isGenericTitle = false,
+            fun newVm(): NowPlayingViewModel =
+                NowPlayingViewModel(
+                    playbackManager = fakePm,
+                    bookRepository = bookRepository,
+                    sleepTimerManager = sleepTimerManager,
+                    playbackController = playbackController,
+                    playbackPreferences = playbackPreferences,
+                    networkMonitor = networkMonitor,
                 )
-            advanceUntilIdle()
-            fixture.fakePm.currentChapterFlow.value =
-                ChapterInfo(
-                    index = 1,
-                    title = "Chapter 2",
-                    startMs = 600_000L,
-                    endMs = 1_200_000L,
-                    remainingMs = 600_000L,
-                    totalChapters = 3,
-                    isGenericTitle = false,
-                )
-            advanceUntilIdle() // drains fadeOutAndPause's 30 × delay + final 100ms delay
-
-            // fadeOutAndPause drives the controller through 30 setVolume steps, one pause,
-            // then a final setVolume(1f). At minimum: pause was invoked once.
-            verify(VerifyMode.atLeast(1)) { fixture.playbackController.pause() }
-            verify(VerifyMode.atLeast(1)) { fixture.playbackController.setVolume(any()) }
         }
 
-    // === Overlay + state machine ===
+        // ========== Helpers ==========
 
-    @Test
-    fun `showChapterPicker updates screenState overlay - hideChapterPicker restores None`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-
-            val vm = fixture.newVm()
-            // screenState uses WhileSubscribed — keep an active collector so the
-            // upstream pipeline runs and .value reflects mutations.
-            backgroundScope.launch { vm.screenState.collect {} }
-            advanceUntilIdle()
-
-            vm.showChapterPicker()
-            advanceUntilIdle()
-            assertTrue(
-                vm.screenState.value.overlay is NowPlayingOverlay.ChapterPicker,
-                "expected ChapterPicker overlay; got: ${vm.screenState.value.overlay}",
-            )
-
-            vm.hideChapterPicker()
-            advanceUntilIdle()
-            assertTrue(
-                vm.screenState.value.overlay is NowPlayingOverlay.None,
-                "expected None overlay; got: ${vm.screenState.value.overlay}",
-            )
-        }
-
-    @Test
-    fun `playbackError emission surfaces as NowPlayingState Error - recovery clears it`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            // Activate a book so the VM has state to display.
-            fixture.fakePm.activateBook(BookId("book-1"))
-
-            val vm = fixture.newVm()
-            // screenState uses WhileSubscribed — keep an active collector so the
-            // upstream pipeline runs and .value reflects mutations.
-            backgroundScope.launch { vm.screenState.collect {} }
-            advanceUntilIdle()
-
-            // Drive an error.
-            fixture.fakePm.playbackErrorFlow.value =
-                PlaybackErrorUiState(
-                    message = "Network unavailable",
-                    isRecoverable = true,
-                    timestampMs = 1_000L,
-                )
-            advanceUntilIdle()
-
-            // Per mapToNowPlayingState (NowPlayingStateMapper.kt:24-43), a non-null
-            // metadata.error produces NowPlayingState.Error. With activateBook driving
-            // currentBookIdFlow but bookRepository.getBookListItem stubbed to null,
-            // we hit the book-null + error branch.
-            val errored = vm.screenState.value
-            assertTrue(
-                errored.state is NowPlayingState.Error,
-                "expected state is NowPlayingState.Error; got: ${errored.state}",
-            )
-
-            // Recover.
-            fixture.fakePm.playbackErrorFlow.value = null
-            advanceUntilIdle()
-
-            val recovered = vm.screenState.value
-            assertTrue(
-                recovered.state !is NowPlayingState.Error,
-                "expected state recovered (not Error); got: ${recovered.state}",
-            )
-        }
-
-    // === closeBook ===
-
-    @Test
-    fun `closeBook stops controller, clears playback, cancels sleep timer, collapses overlay`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            every { fixture.playbackController.stop() } returns Unit
-            // Setup: book is playing and expanded.
-            fixture.fakePm.activateBook(BookId("book-1"))
-
-            val vm = fixture.newVm()
-            // screenState uses WhileSubscribed — keep an active collector so the
-            // upstream pipeline runs and .value reflects mutations.
-            backgroundScope.launch { vm.screenState.collect {} }
-            vm.expand()
-            advanceUntilIdle()
-            assertTrue(vm.screenState.value.isExpanded, "precondition: expanded")
-
-            vm.closeBook()
-            advanceUntilIdle()
-
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.stop() }
-            assertEquals(1, fixture.fakePm.clearPlaybackCalls)
-            // SleepTimerManager is real — state should be Inactive after cancel.
-            assertTrue(
-                fixture.sleepTimerManager.state.value is SleepTimerState.Inactive,
-                "expected sleep timer Inactive after closeBook; got: ${fixture.sleepTimerManager.state.value}",
-            )
-            assertTrue(!vm.screenState.value.isExpanded, "expected collapsed after closeBook")
-        }
-
-    // ========== Sleep timer resilience ==========
-
-    @Test
-    fun `sleepEvent observer resets timer to Inactive even when fadeOutAndPause throws`() =
-        runTest(testDispatcher) {
-            val fixture = TestFixture()
-            // Make setVolume (called in the fade loop) throw on first invocation.
-            // This exercises the bug: before the fix, the exception would escape
-            // the collector and onFadeCompleted() would never be called, leaving
-            // the timer stuck in FadingOut.
-            every { fixture.playbackController.setVolume(any()) } throws RuntimeException("simulated fade failure")
-            every { fixture.playbackController.pause() } returns Unit
-
-            val vm = fixture.newVm()
-            advanceUntilIdle() // let init-block collectors start
-
-            // Use EndOfChapter mode — fires synchronously from onChapterChanged without
-            // wall-clock math, so it works cleanly under a TestDispatcher.
-            vm.setSleepTimer(SleepTimerMode.EndOfChapter)
-            advanceUntilIdle()
-
-            // Drive first chapter (sets lastKnownChapterIndex).
-            fixture.fakePm.currentChapterFlow.value =
-                ChapterInfo(
-                    index = 0,
-                    title = "Chapter 1",
-                    startMs = 0L,
-                    endMs = 600_000L,
-                    remainingMs = 600_000L,
-                    totalChapters = 3,
-                    isGenericTitle = false,
-                )
-            advanceUntilIdle()
-
-            // Drive second chapter — this fires the sleep event, which calls
-            // fadeOutAndPause(), which calls setVolume() and throws immediately.
-            fixture.fakePm.currentChapterFlow.value =
-                ChapterInfo(
-                    index = 1,
-                    title = "Chapter 2",
-                    startMs = 600_000L,
-                    endMs = 1_200_000L,
-                    remainingMs = 600_000L,
-                    totalChapters = 3,
-                    isGenericTitle = false,
-                )
-            advanceUntilIdle()
-
-            // After the fix: the try/catch in the collector must call onFadeCompleted()
-            // even when fadeOutAndPause() throws, resetting state to Inactive.
-            assertTrue(
-                fixture.sleepTimerManager.state.value is SleepTimerState.Inactive,
-                "sleep timer must return to Inactive after fade failure; got: ${fixture.sleepTimerManager.state.value}",
-            )
-        }
-
-    // ========== Helpers ==========
-
-    private fun stubPrepareResult(bookId: BookId): PrepareResult =
-        PrepareResult(
-            timeline =
-                PlaybackTimeline(
-                    bookId = bookId,
-                    totalDurationMs = 1_800_000L,
-                    files =
-                        listOf(
-                            PlaybackTimeline.FileSegment(
-                                audioFileId = "af-stub",
-                                filename = "stub.m4b",
-                                format = "m4b",
-                                startOffsetMs = 0L,
-                                durationMs = 1_800_000L,
-                                size = 1_000_000L,
-                                streamingUrl = "https://example.test/stub.m4b",
-                                localPath = null,
-                                mediaItemIndex = 0,
+        fun stubPrepareResult(bookId: BookId): PrepareResult =
+            PrepareResult(
+                timeline =
+                    PlaybackTimeline(
+                        bookId = bookId,
+                        totalDurationMs = 1_800_000L,
+                        files =
+                            listOf(
+                                PlaybackTimeline.FileSegment(
+                                    audioFileId = "af-stub",
+                                    filename = "stub.m4b",
+                                    format = "m4b",
+                                    startOffsetMs = 0L,
+                                    durationMs = 1_800_000L,
+                                    size = 1_000_000L,
+                                    streamingUrl = "https://example.test/stub.m4b",
+                                    localPath = null,
+                                    mediaItemIndex = 0,
+                                ),
                             ),
-                        ),
-                ),
-            bookTitle = "Stub Book",
-            bookAuthor = "Stub Author",
-            seriesName = null,
-            coverPath = null,
-            totalChapters = 1,
-            resumePositionMs = 0L,
-            resumeSpeed = 1.0f,
-        )
-
-    private fun stubTimeline(): PlaybackTimeline =
-        PlaybackTimeline(
-            bookId = BookId("book-1"),
-            totalDurationMs = 1_800_000L,
-            files =
-                listOf(
-                    PlaybackTimeline.FileSegment(
-                        audioFileId = "af-stub",
-                        filename = "stub.m4b",
-                        format = "m4b",
-                        startOffsetMs = 0L,
-                        durationMs = 1_800_000L,
-                        size = 1_000_000L,
-                        streamingUrl = "https://example.test/stub.m4b",
-                        localPath = null,
-                        mediaItemIndex = 0,
                     ),
-                ),
-        )
+                bookTitle = "Stub Book",
+                bookAuthor = "Stub Author",
+                seriesName = null,
+                coverPath = null,
+                totalChapters = 1,
+                resumePositionMs = 0L,
+                resumeSpeed = 1.0f,
+            )
 
-    private fun stubChapters(): List<Chapter> =
-        listOf(
-            Chapter(id = "ch-0", title = "Chapter 1", duration = 600_000L, startTime = 0L),
-            Chapter(id = "ch-1", title = "Chapter 2", duration = 600_000L, startTime = 600_000L),
-            Chapter(id = "ch-2", title = "Chapter 3", duration = 600_000L, startTime = 1_200_000L),
-        )
-}
+        fun stubTimeline(): PlaybackTimeline =
+            PlaybackTimeline(
+                bookId = BookId("book-1"),
+                totalDurationMs = 1_800_000L,
+                files =
+                    listOf(
+                        PlaybackTimeline.FileSegment(
+                            audioFileId = "af-stub",
+                            filename = "stub.m4b",
+                            format = "m4b",
+                            startOffsetMs = 0L,
+                            durationMs = 1_800_000L,
+                            size = 1_000_000L,
+                            streamingUrl = "https://example.test/stub.m4b",
+                            localPath = null,
+                            mediaItemIndex = 0,
+                        ),
+                    ),
+            )
+
+        fun stubChapters(): List<Chapter> =
+            listOf(
+                Chapter(id = "ch-0", title = "Chapter 1", duration = 600_000L, startTime = 0L),
+                Chapter(id = "ch-1", title = "Chapter 2", duration = 600_000L, startTime = 600_000L),
+                Chapter(id = "ch-2", title = "Chapter 3", duration = 600_000L, startTime = 1_200_000L),
+            )
+
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
+        }
+
+        afterTest {
+            Dispatchers.resetMain()
+        }
+
+        // ========== lifecycle (W7 Phase E2.2.2 regression) ==========
+
+        test("init acquires the PlaybackController so MediaController connects") {
+            val fixture = TestFixture()
+
+            fixture.newVm()
+
+            // The W7 Phase E2.2.2 refactor mistakenly removed acquire/release from the
+            // VM under the assumption that Koin-singleton lifetime obviated the call.
+            // It does not — only acquire() triggers MediaControllerHolder.connect().
+            // Without this call, every in-app playback command is a silent no-op.
+            verify(VerifyMode.exactly(1)) { fixture.playbackController.acquire() }
+        }
+
+        // ========== playBook ==========
+
+        test("playBook happy path activates book then invokes controller seam") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                val prepareResult = stubPrepareResult(bookId)
+                fixture.fakePm.stubbedPrepareResult = prepareResult
+                every { fixture.networkMonitor.isOnline() } returns true
+                everySuspend { fixture.playbackController.startPlayback(any()) } returns Unit
+
+                val vm = fixture.newVm()
+                vm.playBook(bookId)
+                advanceUntilIdle()
+
+                // activateBook must fire (records the bookId on the fake's recorder list).
+                // PlaybackController.startPlayback must fire afterwards.
+                // Strict ordering is asserted indirectly: activateBook is recorded, AND
+                // startPlayback was invoked exactly once with the prepared result. The
+                // production VM body in [NowPlayingViewModel.playBook] sequences them
+                // activate-then-seam; both having fired proves the bug-3 ordering closure.
+                fixture.fakePm.activatedBookIds shouldBe listOf(bookId)
+                verifySuspend(VerifyMode.exactly(1)) {
+                    fixture.playbackController.startPlayback(prepareResult)
+                }
+                // No error reported on the happy path.
+                withClue("happy path must not report any error; got: ${fixture.fakePm.reportedErrors}") {
+                    fixture.fakePm.reportedErrors.isEmpty() shouldBe true
+                }
+            }
+        }
+
+        test("playBook with offline + null prepare reports offline error") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                fixture.fakePm.stubbedPrepareResult = null
+                every { fixture.networkMonitor.isOnline() } returns false
+
+                val vm = fixture.newVm()
+                vm.playBook(bookId)
+                advanceUntilIdle()
+
+                fixture.fakePm.reportedErrors.size shouldBe 1
+                withClue(
+                    "expected offline error message; got: ${fixture.fakePm.reportedErrors.first().message}",
+                ) {
+                    fixture.fakePm.reportedErrors
+                        .first()
+                        .message
+                        .contains("offline", ignoreCase = true) shouldBe true
+                }
+                withClue("must NOT activate when prepare fails") {
+                    fixture.fakePm.activatedBookIds.isEmpty() shouldBe true
+                }
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.playbackController.startPlayback(any())
+                }
+            }
+        }
+
+        test("playBook with online + null prepare reports generic error") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                fixture.fakePm.stubbedPrepareResult = null
+                every { fixture.networkMonitor.isOnline() } returns true
+
+                val vm = fixture.newVm()
+                vm.playBook(bookId)
+                advanceUntilIdle()
+
+                fixture.fakePm.reportedErrors.size shouldBe 1
+                withClue(
+                    "expected generic load-failure message; got: ${fixture.fakePm.reportedErrors.first().message}",
+                ) {
+                    fixture.fakePm.reportedErrors
+                        .first()
+                        .message
+                        .contains("Failed to load", ignoreCase = true) shouldBe true
+                }
+                withClue("must NOT activate when prepare fails") {
+                    fixture.fakePm.activatedBookIds.isEmpty() shouldBe true
+                }
+                verifySuspend(VerifyMode.exactly(0)) {
+                    fixture.playbackController.startPlayback(any())
+                }
+            }
+        }
+
+        // ========== playPause ==========
+
+        test("playPause when playing calls controller pause") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.pause() } returns Unit
+                every { fixture.playbackController.play() } returns Unit
+                fixture.fakePm.isPlayingFlow.value = true
+
+                val vm = fixture.newVm()
+                vm.playPause()
+                advanceUntilIdle()
+
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.pause() }
+                verify(VerifyMode.not) { fixture.playbackController.play() }
+            }
+        }
+
+        test("playPause when paused calls controller play") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.pause() } returns Unit
+                every { fixture.playbackController.play() } returns Unit
+                fixture.fakePm.isPlayingFlow.value = false
+
+                val vm = fixture.newVm()
+                vm.playPause()
+                advanceUntilIdle()
+
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.play() }
+                verify(VerifyMode.not) { fixture.playbackController.pause() }
+            }
+        }
+
+        // ========== Skip/seek ==========
+
+        test("skipForward at speed 1_5 advances by speed-multiplied delta and clamps to total") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.seekTo(any()) } returns Unit
+                fixture.fakePm.currentTimelineFlow.value = stubTimeline()
+                fixture.fakePm.currentPositionMsFlow.value = 100_000L
+                fixture.fakePm.totalDurationMsFlow.value = 1_800_000L
+                fixture.fakePm.playbackSpeedFlow.value = 1.5f
+
+                val vm = fixture.newVm()
+                vm.skipForward(30)
+                advanceUntilIdle()
+
+                // 100_000 + (30 × 1.5 × 1000) = 145_000
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(145_000L) }
+                fixture.fakePm.updatedPositions shouldBe listOf(145_000L)
+
+                // Edge: at total - 5000, 30s skip clamps to total.
+                // updatePosition(145_000) above moved currentPositionMsFlow to 145_000;
+                // now reset to total - 5000 to exercise the clamp.
+                fixture.fakePm.currentPositionMsFlow.value = 1_800_000L - 5_000L
+                fixture.fakePm.updatedPositions.clear()
+                vm.skipForward(30)
+                advanceUntilIdle()
+                fixture.fakePm.updatedPositions shouldBe listOf(1_800_000L)
+            }
+        }
+
+        test("skipBack at speed 1_5 retreats by speed-multiplied delta and clamps to zero") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.seekTo(any()) } returns Unit
+                fixture.fakePm.currentTimelineFlow.value = stubTimeline()
+                fixture.fakePm.currentPositionMsFlow.value = 100_000L
+                fixture.fakePm.playbackSpeedFlow.value = 1.5f
+
+                val vm = fixture.newVm()
+                vm.skipBack(10)
+                advanceUntilIdle()
+
+                // 100_000 - (10 × 1.5 × 1000) = 85_000
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(85_000L) }
+                fixture.fakePm.updatedPositions shouldBe listOf(85_000L)
+
+                // Edge: at 5000ms, 10s skip clamps to 0.
+                fixture.fakePm.currentPositionMsFlow.value = 5_000L
+                fixture.fakePm.updatedPositions.clear()
+                vm.skipBack(10)
+                advanceUntilIdle()
+                fixture.fakePm.updatedPositions shouldBe listOf(0L)
+            }
+        }
+
+        test("seekToChapter seeks to chapter start and ignores out-of-range indices") {
+            runTest(testDispatcher) {
+                // Production [NowPlayingViewModel.seekToChapter] uses chapters.getOrNull(index)
+                // and returns when null — so out-of-range indices are a no-op (NOT clamped).
+                // This deviates from the Task 3 skeleton's "clamp to last/first" expectation;
+                // the test asserts production behavior.
+                val fixture = TestFixture()
+                every { fixture.playbackController.seekTo(any()) } returns Unit
+                fixture.fakePm.chaptersFlow.value = stubChapters()
+
+                val vm = fixture.newVm()
+
+                vm.seekToChapter(1)
+                advanceUntilIdle()
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(600_000L) }
+                fixture.fakePm.updatedPositions shouldBe listOf(600_000L)
+
+                // Out-of-range high (chapters.size == 3) → no-op.
+                fixture.fakePm.updatedPositions.clear()
+                vm.seekToChapter(99)
+                advanceUntilIdle()
+                verify(VerifyMode.not) { fixture.playbackController.seekTo(any<Long>()) }
+                withClue(
+                    "out-of-range high index must NOT update position; got: ${fixture.fakePm.updatedPositions}",
+                ) {
+                    fixture.fakePm.updatedPositions.isEmpty() shouldBe true
+                }
+
+                // Out-of-range low (negative) → no-op.
+                vm.seekToChapter(-1)
+                advanceUntilIdle()
+                verify(VerifyMode.not) { fixture.playbackController.seekTo(any<Long>()) }
+                withClue(
+                    "out-of-range low index must NOT update position; got: ${fixture.fakePm.updatedPositions}",
+                ) {
+                    fixture.fakePm.updatedPositions.isEmpty() shouldBe true
+                }
+
+                // Index 0 → seeks to first chapter (startTime 0).
+                vm.seekToChapter(0)
+                advanceUntilIdle()
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.seekTo(0L) }
+                fixture.fakePm.updatedPositions shouldBe listOf(0L)
+            }
+        }
+
+        // ========== Speed ==========
+
+        test("setSpeed updates controller and marks book as having custom speed") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.setPlaybackSpeed(any()) } returns Unit
+
+                val vm = fixture.newVm()
+                vm.setSpeed(1.75f)
+                advanceUntilIdle()
+
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.setPlaybackSpeed(1.75f) }
+                fixture.fakePm.speedChanges shouldBe listOf(1.75f)
+            }
+        }
+
+        test("resetSpeedToDefault uses preference value and marks book as default and cycleSpeed wraps") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                everySuspend { fixture.playbackPreferences.getDefaultPlaybackSpeed() } returns 1.25f
+                every { fixture.playbackController.setPlaybackSpeed(any()) } returns Unit
+
+                val vm = fixture.newVm()
+                vm.resetSpeedToDefault()
+                advanceUntilIdle()
+
+                verify(VerifyMode.atLeast(1)) { fixture.playbackController.setPlaybackSpeed(1.25f) }
+                fixture.fakePm.speedResets shouldBe listOf(1.25f)
+
+                // cycleSpeed wraps from the highest value (3.0f) back to the lowest (0.5f).
+                // The cycle list is [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0].
+                fixture.fakePm.playbackSpeedFlow.value = 3.0f
+                vm.cycleSpeed()
+                advanceUntilIdle()
+                // cycleSpeed routes through setSpeed → onSpeedChanged, so speedChanges grows.
+                fixture.fakePm.speedChanges.last() shouldBe 0.5f
+            }
+        }
+
+        // ========== Sleep timer ==========
+
+        test("setSleepTimer arms timer and cancelSleepTimer disarms it") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                // SleepTimerManager is a real instance (closed concrete class — cannot mock with
+                // Mokkery in this classpath; see fixture init). Both setTimer and cancelTimer
+                // update state.value synchronously before any background work, so we can
+                // observe state through the real instance without virtual-time juggling.
+
+                val vm = fixture.newVm()
+                vm.setSleepTimer(SleepTimerMode.Duration(minutes = 15))
+                advanceUntilIdle()
+
+                val activeState = fixture.sleepTimerManager.state.value
+                withClue("expected active Duration timer; got: $activeState") {
+                    (activeState is SleepTimerState.Active && activeState.mode is SleepTimerMode.Duration) shouldBe true
+                }
+
+                vm.cancelSleepTimer()
+                advanceUntilIdle()
+                withClue("expected inactive after cancel; got: ${fixture.sleepTimerManager.state.value}") {
+                    (fixture.sleepTimerManager.state.value is SleepTimerState.Inactive) shouldBe true
+                }
+            }
+        }
+
+        test("init-block sleepEvent observer fades out and pauses on timer expiry") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.setVolume(any()) } returns Unit
+                every { fixture.playbackController.pause() } returns Unit
+
+                val vm = fixture.newVm()
+                advanceUntilIdle() // let init-block collectors start
+
+                // Use EndOfChapter mode + drive currentChapter to trigger the sleep event
+                // through public API. Duration mode's timer loop combines virtual-time delay
+                // with wall-clock math (Clock.System.now()), which doesn't progress under
+                // a TestDispatcher; EndOfChapter mode fires synchronously from
+                // SleepTimerManager.onChapterChanged when the chapter index advances.
+                vm.setSleepTimer(SleepTimerMode.EndOfChapter)
+                advanceUntilIdle()
+
+                // First chapter sets lastKnownChapterIndex; second (greater) triggers sleep.
+                fixture.fakePm.currentChapterFlow.value =
+                    ChapterInfo(
+                        index = 0,
+                        title = "Chapter 1",
+                        startMs = 0L,
+                        endMs = 600_000L,
+                        remainingMs = 600_000L,
+                        totalChapters = 3,
+                        isGenericTitle = false,
+                    )
+                advanceUntilIdle()
+                fixture.fakePm.currentChapterFlow.value =
+                    ChapterInfo(
+                        index = 1,
+                        title = "Chapter 2",
+                        startMs = 600_000L,
+                        endMs = 1_200_000L,
+                        remainingMs = 600_000L,
+                        totalChapters = 3,
+                        isGenericTitle = false,
+                    )
+                advanceUntilIdle() // drains fadeOutAndPause's 30 × delay + final 100ms delay
+
+                // fadeOutAndPause drives the controller through 30 setVolume steps, one pause,
+                // then a final setVolume(1f). At minimum: pause was invoked once.
+                verify(VerifyMode.atLeast(1)) { fixture.playbackController.pause() }
+                verify(VerifyMode.atLeast(1)) { fixture.playbackController.setVolume(any()) }
+            }
+        }
+
+        // === Overlay + state machine ===
+
+        test("showChapterPicker updates screenState overlay - hideChapterPicker restores None") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+
+                val vm = fixture.newVm()
+                // screenState uses WhileSubscribed — keep an active collector so the
+                // upstream pipeline runs and .value reflects mutations.
+                backgroundScope.launch { vm.screenState.collect {} }
+                advanceUntilIdle()
+
+                vm.showChapterPicker()
+                advanceUntilIdle()
+                withClue("expected ChapterPicker overlay; got: ${vm.screenState.value.overlay}") {
+                    (vm.screenState.value.overlay is NowPlayingOverlay.ChapterPicker) shouldBe true
+                }
+
+                vm.hideChapterPicker()
+                advanceUntilIdle()
+                withClue("expected None overlay; got: ${vm.screenState.value.overlay}") {
+                    (vm.screenState.value.overlay is NowPlayingOverlay.None) shouldBe true
+                }
+            }
+        }
+
+        test("playbackError emission surfaces as NowPlayingState Error - recovery clears it") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                // Activate a book so the VM has state to display.
+                fixture.fakePm.activateBook(BookId("book-1"))
+
+                val vm = fixture.newVm()
+                // screenState uses WhileSubscribed — keep an active collector so the
+                // upstream pipeline runs and .value reflects mutations.
+                backgroundScope.launch { vm.screenState.collect {} }
+                advanceUntilIdle()
+
+                // Drive an error.
+                fixture.fakePm.playbackErrorFlow.value =
+                    PlaybackErrorUiState(
+                        message = "Network unavailable",
+                        isRecoverable = true,
+                        timestampMs = 1_000L,
+                    )
+                advanceUntilIdle()
+
+                // Per mapToNowPlayingState (NowPlayingStateMapper.kt:24-43), a non-null
+                // metadata.error produces NowPlayingState.Error. With activateBook driving
+                // currentBookIdFlow but bookRepository.getBookListItem stubbed to null,
+                // we hit the book-null + error branch.
+                val errored = vm.screenState.value
+                withClue("expected state is NowPlayingState.Error; got: ${errored.state}") {
+                    (errored.state is NowPlayingState.Error) shouldBe true
+                }
+
+                // Recover.
+                fixture.fakePm.playbackErrorFlow.value = null
+                advanceUntilIdle()
+
+                val recovered = vm.screenState.value
+                withClue("expected state recovered (not Error); got: ${recovered.state}") {
+                    (recovered.state !is NowPlayingState.Error) shouldBe true
+                }
+            }
+        }
+
+        // === closeBook ===
+
+        test("closeBook stops controller, clears playback, cancels sleep timer, collapses overlay") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                every { fixture.playbackController.stop() } returns Unit
+                // Setup: book is playing and expanded.
+                fixture.fakePm.activateBook(BookId("book-1"))
+
+                val vm = fixture.newVm()
+                // screenState uses WhileSubscribed — keep an active collector so the
+                // upstream pipeline runs and .value reflects mutations.
+                backgroundScope.launch { vm.screenState.collect {} }
+                vm.expand()
+                advanceUntilIdle()
+                withClue("precondition: expanded") {
+                    vm.screenState.value.isExpanded shouldBe true
+                }
+
+                vm.closeBook()
+                advanceUntilIdle()
+
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.stop() }
+                fixture.fakePm.clearPlaybackCalls shouldBe 1
+                // SleepTimerManager is real — state should be Inactive after cancel.
+                withClue(
+                    "expected sleep timer Inactive after closeBook; got: ${fixture.sleepTimerManager.state.value}",
+                ) {
+                    (fixture.sleepTimerManager.state.value is SleepTimerState.Inactive) shouldBe true
+                }
+                withClue("expected collapsed after closeBook") {
+                    !vm.screenState.value.isExpanded shouldBe true
+                }
+            }
+        }
+
+        // ========== Sleep timer resilience ==========
+
+        test("sleepEvent observer resets timer to Inactive even when fadeOutAndPause throws") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                // Make setVolume (called in the fade loop) throw on first invocation.
+                // This exercises the bug: before the fix, the exception would escape
+                // the collector and onFadeCompleted() would never be called, leaving
+                // the timer stuck in FadingOut.
+                every { fixture.playbackController.setVolume(any()) } throws RuntimeException("simulated fade failure")
+                every { fixture.playbackController.pause() } returns Unit
+
+                val vm = fixture.newVm()
+                advanceUntilIdle() // let init-block collectors start
+
+                // Use EndOfChapter mode — fires synchronously from onChapterChanged without
+                // wall-clock math, so it works cleanly under a TestDispatcher.
+                vm.setSleepTimer(SleepTimerMode.EndOfChapter)
+                advanceUntilIdle()
+
+                // Drive first chapter (sets lastKnownChapterIndex).
+                fixture.fakePm.currentChapterFlow.value =
+                    ChapterInfo(
+                        index = 0,
+                        title = "Chapter 1",
+                        startMs = 0L,
+                        endMs = 600_000L,
+                        remainingMs = 600_000L,
+                        totalChapters = 3,
+                        isGenericTitle = false,
+                    )
+                advanceUntilIdle()
+
+                // Drive second chapter — this fires the sleep event, which calls
+                // fadeOutAndPause(), which calls setVolume() and throws immediately.
+                fixture.fakePm.currentChapterFlow.value =
+                    ChapterInfo(
+                        index = 1,
+                        title = "Chapter 2",
+                        startMs = 600_000L,
+                        endMs = 1_200_000L,
+                        remainingMs = 600_000L,
+                        totalChapters = 3,
+                        isGenericTitle = false,
+                    )
+                advanceUntilIdle()
+
+                // After the fix: the try/catch in the collector must call onFadeCompleted()
+                // even when fadeOutAndPause() throws, resetting state to Inactive.
+                withClue(
+                    "sleep timer must return to Inactive after fade failure; got: ${fixture.sleepTimerManager.state.value}",
+                ) {
+                    (fixture.sleepTimerManager.state.value is SleepTimerState.Inactive) shouldBe true
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
@@ -15,6 +15,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,338 +29,331 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class EditProfileViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class EditProfileViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val profileEditRepository: ProfileEditRepository = mock()
-        val userRepository: UserRepository = mock()
-        val imageRepository: ImageRepository = mock()
-        val currentUserFlow = MutableStateFlow<User?>(null)
+        class TestFixture {
+            val profileEditRepository: ProfileEditRepository = mock()
+            val userRepository: UserRepository = mock()
+            val imageRepository: ImageRepository = mock()
+            val currentUserFlow = MutableStateFlow<User?>(null)
 
-        fun configure(
-            currentUser: User?,
-            isAvatarCached: Boolean = false,
-            avatarPath: String = "/cache/avatars/avatar.jpg",
-        ) {
-            currentUserFlow.value = currentUser
-            every { userRepository.observeCurrentUser() } returns currentUserFlow
-            every { imageRepository.userAvatarExists(any()) } returns isAvatarCached
-            every { imageRepository.getUserAvatarPath(any()) } returns avatarPath
+            fun configure(
+                currentUser: User?,
+                isAvatarCached: Boolean = false,
+                avatarPath: String = "/cache/avatars/avatar.jpg",
+            ) {
+                currentUserFlow.value = currentUser
+                every { userRepository.observeCurrentUser() } returns currentUserFlow
+                every { imageRepository.userAvatarExists(any()) } returns isAvatarCached
+                every { imageRepository.getUserAvatarPath(any()) } returns avatarPath
+            }
+
+            fun build(): EditProfileViewModel =
+                EditProfileViewModel(
+                    profileEditRepository = profileEditRepository,
+                    userRepository = userRepository,
+                    imageRepository = imageRepository,
+                )
         }
 
-        fun build(): EditProfileViewModel =
-            EditProfileViewModel(
-                profileEditRepository = profileEditRepository,
-                userRepository = userRepository,
-                imageRepository = imageRepository,
+        fun TestScope.createFixture(): TestFixture = TestFixture()
+
+        fun TestScope.keepStateHot(viewModel: EditProfileViewModel) {
+            backgroundScope.launch { viewModel.state.collect { } }
+        }
+
+        fun createUser(
+            id: String = "user-1",
+            displayName: String = "Alice",
+            firstName: String? = "Alice",
+            lastName: String? = "Smith",
+            tagline: String? = "Hello world",
+            avatarType: String = "auto",
+            avatarValue: String? = null,
+            updatedAtMs: Long = 1000L,
+        ): User =
+            User(
+                id = UserId(id),
+                email = "$id@example.com",
+                displayName = displayName,
+                firstName = firstName,
+                lastName = lastName,
+                isAdmin = false,
+                avatarType = avatarType,
+                avatarValue = avatarValue,
+                avatarColor = "#6B7280",
+                tagline = tagline,
+                createdAtMs = 0L,
+                updatedAtMs = updatedAtMs,
             )
-    }
 
-    private fun TestScope.createFixture(): TestFixture = TestFixture()
-
-    private fun TestScope.keepStateHot(viewModel: EditProfileViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
-
-    private fun createUser(
-        id: String = "user-1",
-        displayName: String = "Alice",
-        firstName: String? = "Alice",
-        lastName: String? = "Smith",
-        tagline: String? = "Hello world",
-        avatarType: String = "auto",
-        avatarValue: String? = null,
-        updatedAtMs: Long = 1000L,
-    ): User =
-        User(
-            id = UserId(id),
-            email = "$id@example.com",
-            displayName = displayName,
-            firstName = firstName,
-            lastName = lastName,
-            isAdmin = false,
-            avatarType = avatarType,
-            avatarValue = avatarValue,
-            avatarColor = "#6B7280",
-            tagline = tagline,
-            createdAtMs = 0L,
-            updatedAtMs = updatedAtMs,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `initial state is Loading before pipeline emits`() =
-        runTest {
-            val fixture = createFixture().apply { configure(currentUser = null) }
-            val viewModel = fixture.build()
-            // No keepStateHot here — stateIn with no subscriber returns the initial value.
-
-            assertEquals(EditProfileUiState.Loading, viewModel.state.value)
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `state emits Error when no current user`() =
-        runTest {
-            val fixture = createFixture().apply { configure(currentUser = null) }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            val err = assertIs<EditProfileUiState.Error>(viewModel.state.value)
-            assertEquals("No user data available", err.message)
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `state emits Ready when user is present`() =
-        runTest {
-            val user = createUser()
-            val fixture = createFixture().apply { configure(currentUser = user) }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
+        test("initial state is Loading before pipeline emits") {
+            runTest {
+                val fixture = createFixture().apply { configure(currentUser = null) }
+                val viewModel = fixture.build()
+                // No keepStateHot here — stateIn with no subscriber returns the initial value.
 
-            val ready = assertIs<EditProfileUiState.Ready>(viewModel.state.value)
-            assertEquals(user, ready.user)
-            assertEquals(false, ready.isSaving)
+                viewModel.state.value shouldBe EditProfileUiState.Loading
+            }
         }
 
-    @Test
-    fun `Ready reflects cached avatar path when avatar is an image`() =
-        runTest {
-            val user = createUser(avatarType = "image", avatarValue = "avatar.jpg")
-            val fixture = createFixture().apply { configure(currentUser = user, isAvatarCached = true) }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            val ready = assertIs<EditProfileUiState.Ready>(viewModel.state.value)
-            assertEquals("/cache/avatars/avatar.jpg", ready.localAvatarPath)
-        }
-
-    @Test
-    fun `saveTagline success emits TaglineSaved and toggles isSaving`() =
-        runTest {
-            val user = createUser(tagline = null)
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.updateTagline(any()) } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.events.test {
-                viewModel.saveTagline("new tagline")
+        test("state emits Error when no current user") {
+            runTest {
+                val fixture = createFixture().apply { configure(currentUser = null) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
                 advanceUntilIdle()
-                assertEquals(EditProfileEvent.TaglineSaved, awaitItem())
-            }
-            verifySuspend { fixture.profileEditRepository.updateTagline("new tagline") }
-            assertEquals(false, (viewModel.state.value as EditProfileUiState.Ready).isSaving)
-        }
 
-    @Test
-    fun `saveTagline normalizes empty to null and truncates at max length`() =
-        runTest {
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.updateTagline(any()) } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.saveTagline("")
-            advanceUntilIdle()
-            verifySuspend { fixture.profileEditRepository.updateTagline(null) }
-
-            val longTagline = "x".repeat(EditProfileViewModel.MAX_TAGLINE_LENGTH + 10)
-            viewModel.saveTagline(longTagline)
-            advanceUntilIdle()
-            verifySuspend {
-                fixture.profileEditRepository.updateTagline("x".repeat(EditProfileViewModel.MAX_TAGLINE_LENGTH))
+                val err = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Error>()
+                err.message shouldBe "No user data available"
             }
         }
 
-    @Test
-    fun `saveTagline failure emits SaveFailed`() =
-        runTest {
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.updateTagline(any()) } returns
-                        AppResult.Failure(InternalError(debugInfo = "db error"))
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
+        test("state emits Ready when user is present") {
+            runTest {
+                val user = createUser()
+                val fixture = createFixture().apply { configure(currentUser = user) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
 
-            viewModel.events.test {
+                val ready = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Ready>()
+                ready.user shouldBe user
+                ready.isSaving shouldBe false
+            }
+        }
+
+        test("Ready reflects cached avatar path when avatar is an image") {
+            runTest {
+                val user = createUser(avatarType = "image", avatarValue = "avatar.jpg")
+                val fixture = createFixture().apply { configure(currentUser = user, isAvatarCached = true) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Ready>()
+                ready.localAvatarPath shouldBe "/cache/avatars/avatar.jpg"
+            }
+        }
+
+        test("saveTagline success emits TaglineSaved and toggles isSaving") {
+            runTest {
+                val user = createUser(tagline = null)
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.updateTagline(any()) } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.saveTagline("new tagline")
+                    advanceUntilIdle()
+                    awaitItem() shouldBe EditProfileEvent.TaglineSaved
+                }
+                verifySuspend { fixture.profileEditRepository.updateTagline("new tagline") }
+                (viewModel.state.value as EditProfileUiState.Ready).isSaving shouldBe false
+            }
+        }
+
+        test("saveTagline normalizes empty to null and truncates at max length") {
+            runTest {
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.updateTagline(any()) } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.saveTagline("")
+                advanceUntilIdle()
+                verifySuspend { fixture.profileEditRepository.updateTagline(null) }
+
+                val longTagline = "x".repeat(EditProfileViewModel.MAX_TAGLINE_LENGTH + 10)
+                viewModel.saveTagline(longTagline)
+                advanceUntilIdle()
+                verifySuspend {
+                    fixture.profileEditRepository.updateTagline("x".repeat(EditProfileViewModel.MAX_TAGLINE_LENGTH))
+                }
+            }
+        }
+
+        test("saveTagline failure emits SaveFailed") {
+            runTest {
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.updateTagline(any()) } returns
+                            AppResult.Failure(InternalError(debugInfo = "db error"))
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.saveTagline("new")
+                    advanceUntilIdle()
+                    val event = awaitItem().shouldBeInstanceOf<EditProfileEvent.SaveFailed>()
+                    event.message shouldBe "Failed to save tagline"
+                }
+            }
+        }
+
+        test("saveName success emits NameSaved") {
+            runTest {
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.updateName(any(), any()) } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.saveName("Bob", "Jones")
+                    advanceUntilIdle()
+                    awaitItem() shouldBe EditProfileEvent.NameSaved
+                }
+                verifySuspend { fixture.profileEditRepository.updateName("Bob", "Jones") }
+            }
+        }
+
+        test("uploadAvatar success emits AvatarUpdated") {
+            runTest {
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.uploadAvatar(any(), any()) } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.uploadAvatar(byteArrayOf(1, 2, 3), "image/jpeg")
+                    advanceUntilIdle()
+                    awaitItem() shouldBe EditProfileEvent.AvatarUpdated
+                }
+            }
+        }
+
+        test("revertToAutoAvatar success emits AvatarUpdated") {
+            runTest {
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.revertToAutoAvatar() } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.revertToAutoAvatar()
+                    advanceUntilIdle()
+                    awaitItem() shouldBe EditProfileEvent.AvatarUpdated
+                }
+            }
+        }
+
+        test("changePassword rejects passwords shorter than minimum") {
+            runTest {
+                val user = createUser()
+                val fixture = createFixture().apply { configure(currentUser = user) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.changePassword("currentpass1", "short")
+                    advanceUntilIdle()
+                    val event = awaitItem().shouldBeInstanceOf<EditProfileEvent.SaveFailed>()
+                    event.message shouldContain "$PASSWORD_MIN"
+                }
+            }
+        }
+
+        test("changePassword success emits PasswordChanged") {
+            runTest {
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.changePassword(any(), any()) } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.changePassword("currentpass1", "strongpass1")
+                    advanceUntilIdle()
+                    awaitItem() shouldBe EditProfileEvent.PasswordChanged
+                }
+                verifySuspend { fixture.profileEditRepository.changePassword("currentpass1", "strongpass1") }
+            }
+        }
+
+        test("isSaving returns to false after save completes") {
+            runTest {
+                // StateFlow conflates rapid true→false transitions, so we can't reliably
+                // observe the intermediate isSaving=true state with a non-suspending mock.
+                // Instead, verify the final state is unlocked for further edits.
+                val user = createUser()
+                val fixture =
+                    createFixture().apply {
+                        configure(currentUser = user)
+                        everySuspend { profileEditRepository.updateTagline(any()) } returns AppResult.Success(Unit)
+                    }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
                 viewModel.saveTagline("new")
                 advanceUntilIdle()
-                val event = assertIs<EditProfileEvent.SaveFailed>(awaitItem())
-                assertEquals("Failed to save tagline", event.message)
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Ready>()
+                ready.isSaving shouldBe false
             }
         }
 
-    @Test
-    fun `saveName success emits NameSaved`() =
-        runTest {
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.updateName(any(), any()) } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.events.test {
-                viewModel.saveName("Bob", "Jones")
+        test("state updates reactively when user changes") {
+            runTest {
+                val user1 = createUser(displayName = "Before")
+                val user2 = createUser(displayName = "After", updatedAtMs = 2000L)
+                val fixture = createFixture().apply { configure(currentUser = user1) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
                 advanceUntilIdle()
-                assertEquals(EditProfileEvent.NameSaved, awaitItem())
-            }
-            verifySuspend { fixture.profileEditRepository.updateName("Bob", "Jones") }
-        }
+                (viewModel.state.value as EditProfileUiState.Ready).user.displayName shouldBe "Before"
 
-    @Test
-    fun `uploadAvatar success emits AvatarUpdated`() =
-        runTest {
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.uploadAvatar(any(), any()) } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.events.test {
-                viewModel.uploadAvatar(byteArrayOf(1, 2, 3), "image/jpeg")
+                fixture.currentUserFlow.value = user2
                 advanceUntilIdle()
-                assertEquals(EditProfileEvent.AvatarUpdated, awaitItem())
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Ready>()
+                ready.user.displayName shouldBe "After"
             }
         }
-
-    @Test
-    fun `revertToAutoAvatar success emits AvatarUpdated`() =
-        runTest {
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.revertToAutoAvatar() } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.events.test {
-                viewModel.revertToAutoAvatar()
-                advanceUntilIdle()
-                assertEquals(EditProfileEvent.AvatarUpdated, awaitItem())
-            }
-        }
-
-    @Test
-    fun `changePassword rejects passwords shorter than minimum`() =
-        runTest {
-            val user = createUser()
-            val fixture = createFixture().apply { configure(currentUser = user) }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.events.test {
-                viewModel.changePassword("currentpass1", "short")
-                advanceUntilIdle()
-                val event = assertIs<EditProfileEvent.SaveFailed>(awaitItem())
-                assertTrue(event.message.contains("$PASSWORD_MIN"))
-            }
-        }
-
-    @Test
-    fun `changePassword success emits PasswordChanged`() =
-        runTest {
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.changePassword(any(), any()) } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.events.test {
-                viewModel.changePassword("currentpass1", "strongpass1")
-                advanceUntilIdle()
-                assertEquals(EditProfileEvent.PasswordChanged, awaitItem())
-            }
-            verifySuspend { fixture.profileEditRepository.changePassword("currentpass1", "strongpass1") }
-        }
-
-    @Test
-    fun `isSaving returns to false after save completes`() =
-        runTest {
-            // StateFlow conflates rapid true→false transitions, so we can't reliably
-            // observe the intermediate isSaving=true state with a non-suspending mock.
-            // Instead, verify the final state is unlocked for further edits.
-            val user = createUser()
-            val fixture =
-                createFixture().apply {
-                    configure(currentUser = user)
-                    everySuspend { profileEditRepository.updateTagline(any()) } returns AppResult.Success(Unit)
-                }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.saveTagline("new")
-            advanceUntilIdle()
-
-            val ready = assertIs<EditProfileUiState.Ready>(viewModel.state.value)
-            assertEquals(false, ready.isSaving)
-        }
-
-    @Test
-    fun `state updates reactively when user changes`() =
-        runTest {
-            val user1 = createUser(displayName = "Before")
-            val user2 = createUser(displayName = "After", updatedAtMs = 2000L)
-            val fixture = createFixture().apply { configure(currentUser = user1) }
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-            assertEquals("Before", (viewModel.state.value as EditProfileUiState.Ready).user.displayName)
-
-            fixture.currentUserFlow.value = user2
-            advanceUntilIdle()
-
-            val ready = assertIs<EditProfileUiState.Ready>(viewModel.state.value)
-            assertEquals("After", ready.user.displayName)
-        }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/search/SearchViewModelTest.kt
@@ -11,6 +11,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -21,12 +24,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import com.calypsan.listenup.core.error.ErrorBus
 
@@ -37,370 +34,365 @@ import com.calypsan.listenup.core.error.ErrorBus
  * without an active collector the upstream pipeline is torn down.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class SearchViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class SearchViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    private class TestFixture {
-        val searchRepository: SearchRepository = mock()
+        class TestFixture {
+            val searchRepository: SearchRepository = mock()
 
-        fun build(): SearchViewModel = SearchViewModel(searchRepository = searchRepository, errorBus = ErrorBus())
-    }
-
-    private fun TestScope.createFixture(): TestFixture = TestFixture()
-
-    private fun TestScope.keepStateHot(viewModel: SearchViewModel) {
-        backgroundScope.launch { viewModel.state.collect { } }
-    }
-
-    private fun createSearchResult(
-        query: String = "test",
-        hits: List<SearchHit> = emptyList(),
-        total: Int = hits.size,
-    ): SearchResult =
-        SearchResult(
-            query = query,
-            total = total,
-            tookMs = 10L,
-            hits = hits,
-        )
-
-    private fun createBookHit(
-        id: String = "book-1",
-        name: String = "Test Book",
-    ): SearchHit =
-        SearchHit(
-            id = id,
-            type = SearchHitType.BOOK,
-            name = name,
-        )
-
-    private fun createContributorHit(
-        id: String = "contributor-1",
-        name: String = "Test Author",
-    ): SearchHit =
-        SearchHit(
-            id = id,
-            type = SearchHitType.CONTRIBUTOR,
-            name = name,
-        )
-
-    private fun createSeriesHit(
-        id: String = "series-1",
-        name: String = "Test Series",
-    ): SearchHit =
-        SearchHit(
-            id = id,
-            type = SearchHitType.SERIES,
-            name = name,
-        )
-
-    private fun createTagHit(
-        id: String = "tag-1",
-        name: String = "Test Tag",
-    ): SearchHit =
-        SearchHit(
-            id = id,
-            type = SearchHitType.TAG,
-            name = name,
-        )
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `initial state is Idle with empty query and no type filters`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            val state = assertIs<SearchUiState.Idle>(viewModel.state.value)
-            assertEquals("", state.query)
-            assertTrue(state.selectedTypes.isEmpty())
+            fun build(): SearchViewModel = SearchViewModel(searchRepository = searchRepository, errorBus = ErrorBus())
         }
 
-    @Test
-    fun `onQueryChanged reflects new query in state immediately`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
+        fun TestScope.createFixture(): TestFixture = TestFixture()
 
-            viewModel.onQueryChanged("hello")
-            advanceUntilIdle()
-
-            assertEquals("hello", viewModel.state.value.query)
+        fun TestScope.keepStateHot(viewModel: SearchViewModel) {
+            backgroundScope.launch { viewModel.state.collect { } }
         }
 
-    @Test
-    fun `search triggers after debounce for query with min 2 chars`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
-                createSearchResult(
-                    query = "test",
-                    hits = listOf(createBookHit()),
-                )
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.onQueryChanged("te")
-
-            // Before debounce fires: phase still Idle (search hasn't started).
-            // Don't call advanceUntilIdle here — it would advance through the 300ms debounce.
-            advanceTimeBy(200.milliseconds)
-            assertIs<SearchUiState.Idle>(viewModel.state.value)
-
-            advanceTimeBy(150.milliseconds)
-            advanceUntilIdle()
-
-            val results = assertIs<SearchUiState.Results>(viewModel.state.value)
-            assertEquals(1, results.result.hits.size)
-            verifySuspend {
-                fixture.searchRepository.search(
-                    query = "te",
-                    types = null,
-                    genres = null,
-                    genrePath = null,
-                    limit = 30,
-                )
-            }
-        }
-
-    @Test
-    fun `search does not trigger for single character query`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.onQueryChanged("a")
-            advanceTimeBy(500.milliseconds)
-            advanceUntilIdle()
-
-            // Phase stays Idle; search never executes.
-            assertIs<SearchUiState.Idle>(viewModel.state.value)
-            assertEquals("a", viewModel.state.value.query)
-        }
-
-    @Test
-    fun `blank query returns phase to Idle after prior results`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
-                createSearchResult(hits = listOf(createBookHit()))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.onQueryChanged("test")
-            advanceTimeBy(400.milliseconds)
-            advanceUntilIdle()
-            assertIs<SearchUiState.Results>(viewModel.state.value)
-
-            viewModel.onQueryChanged("")
-            advanceTimeBy(100.milliseconds)
-            advanceUntilIdle()
-
-            assertIs<SearchUiState.Idle>(viewModel.state.value)
-        }
-
-    @Test
-    fun `search success emits Results carrying query and types`() =
-        runTest {
-            val fixture = createFixture()
-            val expectedHits = listOf(createBookHit(), createContributorHit())
-            everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
-                createSearchResult(hits = expectedHits)
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.onQueryChanged("test")
-            advanceTimeBy(400.milliseconds)
-            advanceUntilIdle()
-
-            val state = assertIs<SearchUiState.Results>(viewModel.state.value)
-            assertEquals("test", state.query)
-            assertEquals(2, state.result.hits.size)
-        }
-
-    @Test
-    fun `search failure emits Error with user-friendly message`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend {
-                fixture.searchRepository.search(any(), any(), any(), any(), any())
-            } throws Exception("Network error")
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.onQueryChanged("test")
-            advanceTimeBy(400.milliseconds)
-            advanceUntilIdle()
-
-            val state = assertIs<SearchUiState.Error>(viewModel.state.value)
-            assertEquals("test", state.query)
-            assertEquals("Search unavailable. Please try again.", state.message)
-        }
-
-    @Test
-    fun `toggleTypeFilter adds type to selectedTypes`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-            assertTrue(
-                viewModel.state.value.selectedTypes
-                    .isEmpty(),
+        fun createSearchResult(
+            query: String = "test",
+            hits: List<SearchHit> = emptyList(),
+            total: Int = hits.size,
+        ): SearchResult =
+            SearchResult(
+                query = query,
+                total = total,
+                tookMs = 10L,
+                hits = hits,
             )
 
-            viewModel.toggleTypeFilter(SearchHitType.BOOK)
-            advanceUntilIdle()
-
-            assertEquals(setOf(SearchHitType.BOOK), viewModel.state.value.selectedTypes)
-        }
-
-    @Test
-    fun `toggleTypeFilter removes type if already selected`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            viewModel.toggleTypeFilter(SearchHitType.BOOK)
-            advanceUntilIdle()
-            assertEquals(setOf(SearchHitType.BOOK), viewModel.state.value.selectedTypes)
-
-            viewModel.toggleTypeFilter(SearchHitType.BOOK)
-            advanceUntilIdle()
-
-            assertTrue(
-                viewModel.state.value.selectedTypes
-                    .isEmpty(),
+        fun createBookHit(
+            id: String = "book-1",
+            name: String = "Test Book",
+        ): SearchHit =
+            SearchHit(
+                id = id,
+                type = SearchHitType.BOOK,
+                name = name,
             )
+
+        fun createContributorHit(
+            id: String = "contributor-1",
+            name: String = "Test Author",
+        ): SearchHit =
+            SearchHit(
+                id = id,
+                type = SearchHitType.CONTRIBUTOR,
+                name = name,
+            )
+
+        fun createSeriesHit(
+            id: String = "series-1",
+            name: String = "Test Series",
+        ): SearchHit =
+            SearchHit(
+                id = id,
+                type = SearchHitType.SERIES,
+                name = name,
+            )
+
+        fun createTagHit(
+            id: String = "tag-1",
+            name: String = "Test Tag",
+        ): SearchHit =
+            SearchHit(
+                id = id,
+                type = SearchHitType.TAG,
+                name = name,
+            )
+
+        beforeTest {
+            Dispatchers.setMain(testDispatcher)
         }
 
-    @Test
-    fun `toggleTypeFilter triggers re-search immediately when query present`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns createSearchResult()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-
-            viewModel.onQueryChanged("test")
-            advanceTimeBy(400.milliseconds)
-            advanceUntilIdle()
-
-            viewModel.toggleTypeFilter(SearchHitType.BOOK)
-            advanceUntilIdle()
-
-            verifySuspend {
-                fixture.searchRepository.search(
-                    query = "test",
-                    types = listOf(SearchHitType.BOOK),
-                    genres = null,
-                    genrePath = null,
-                    limit = 30,
-                )
-            }
+        afterTest {
+            Dispatchers.resetMain()
         }
 
-    @Test
-    fun `onResultClicked on book emits NavigateToBook`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.navActions.test {
-                viewModel.onResultClicked(createBookHit(id = "book-123"))
+        test("initial state is Idle with empty query and no type filters") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
                 advanceUntilIdle()
-                val action = assertIs<SearchNavAction.NavigateToBook>(awaitItem())
-                assertEquals("book-123", action.bookId)
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SearchUiState.Idle>()
+                state.query shouldBe ""
+                state.selectedTypes.isEmpty() shouldBe true
             }
         }
 
-    @Test
-    fun `onResultClicked on contributor emits NavigateToContributor`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.navActions.test {
-                viewModel.onResultClicked(createContributorHit(id = "author-456"))
+        test("onQueryChanged reflects new query in state immediately") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
                 advanceUntilIdle()
-                val action = assertIs<SearchNavAction.NavigateToContributor>(awaitItem())
-                assertEquals("author-456", action.contributorId)
-            }
-        }
 
-    @Test
-    fun `onResultClicked on series emits NavigateToSeries`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.navActions.test {
-                viewModel.onResultClicked(createSeriesHit(id = "series-789"))
+                viewModel.onQueryChanged("hello")
                 advanceUntilIdle()
-                val action = assertIs<SearchNavAction.NavigateToSeries>(awaitItem())
-                assertEquals("series-789", action.seriesId)
+
+                viewModel.state.value.query shouldBe "hello"
             }
         }
 
-    @Test
-    fun `onResultClicked on tag emits NavigateToTag`() =
-        runTest {
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
-            advanceUntilIdle()
-
-            viewModel.navActions.test {
-                viewModel.onResultClicked(createTagHit(id = "tag-42"))
+        test("search triggers after debounce for query with min 2 chars") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
+                    createSearchResult(
+                        query = "test",
+                        hits = listOf(createBookHit()),
+                    )
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
                 advanceUntilIdle()
-                val action = assertIs<SearchNavAction.NavigateToTag>(awaitItem())
-                assertEquals("tag-42", action.tagId)
+
+                viewModel.onQueryChanged("te")
+
+                // Before debounce fires: phase still Idle (search hasn't started).
+                // Don't call advanceUntilIdle here — it would advance through the 300ms debounce.
+                advanceTimeBy(200.milliseconds)
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Idle>()
+
+                advanceTimeBy(150.milliseconds)
+                advanceUntilIdle()
+
+                val results = viewModel.state.value.shouldBeInstanceOf<SearchUiState.Results>()
+                results.result.hits.size shouldBe 1
+                verifySuspend {
+                    fixture.searchRepository.search(
+                        query = "te",
+                        types = null,
+                        genres = null,
+                        genrePath = null,
+                        limit = 30,
+                    )
+                }
             }
         }
 
-    @Test
-    fun `clearQuery returns state to Idle after Results`() =
-        runTest {
-            val fixture = createFixture()
-            everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
-                createSearchResult(hits = listOf(createBookHit()))
-            val viewModel = fixture.build()
-            keepStateHot(viewModel)
+        test("search does not trigger for single character query") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
 
-            viewModel.onQueryChanged("test")
-            advanceTimeBy(400.milliseconds)
-            advanceUntilIdle()
-            assertIs<SearchUiState.Results>(viewModel.state.value)
+                viewModel.onQueryChanged("a")
+                advanceTimeBy(500.milliseconds)
+                advanceUntilIdle()
 
-            viewModel.clearQuery()
-            advanceTimeBy(50.milliseconds)
-            advanceUntilIdle()
-
-            val state = assertIs<SearchUiState.Idle>(viewModel.state.value)
-            assertEquals("", state.query)
+                // Phase stays Idle; search never executes.
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Idle>()
+                viewModel.state.value.query shouldBe "a"
+            }
         }
-}
+
+        test("blank query returns phase to Idle after prior results") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
+                    createSearchResult(hits = listOf(createBookHit()))
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(400.milliseconds)
+                advanceUntilIdle()
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Results>()
+
+                viewModel.onQueryChanged("")
+                advanceTimeBy(100.milliseconds)
+                advanceUntilIdle()
+
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Idle>()
+            }
+        }
+
+        test("search success emits Results carrying query and types") {
+            runTest {
+                val fixture = createFixture()
+                val expectedHits = listOf(createBookHit(), createContributorHit())
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
+                    createSearchResult(hits = expectedHits)
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(400.milliseconds)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SearchUiState.Results>()
+                state.query shouldBe "test"
+                state.result.hits.size shouldBe 2
+            }
+        }
+
+        test("search failure emits Error with user-friendly message") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend {
+                    fixture.searchRepository.search(any(), any(), any(), any(), any())
+                } throws Exception("Network error")
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(400.milliseconds)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SearchUiState.Error>()
+                state.query shouldBe "test"
+                state.message shouldBe "Search unavailable. Please try again."
+            }
+        }
+
+        test("toggleTypeFilter adds type to selectedTypes") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+                viewModel.state.value.selectedTypes
+                    .isEmpty() shouldBe true
+
+                viewModel.toggleTypeFilter(SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                viewModel.state.value.selectedTypes shouldBe setOf(SearchHitType.BOOK)
+            }
+        }
+
+        test("toggleTypeFilter removes type if already selected") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                viewModel.toggleTypeFilter(SearchHitType.BOOK)
+                advanceUntilIdle()
+                viewModel.state.value.selectedTypes shouldBe setOf(SearchHitType.BOOK)
+
+                viewModel.toggleTypeFilter(SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                viewModel.state.value.selectedTypes
+                    .isEmpty() shouldBe true
+            }
+        }
+
+        test("toggleTypeFilter triggers re-search immediately when query present") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns createSearchResult()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(400.milliseconds)
+                advanceUntilIdle()
+
+                viewModel.toggleTypeFilter(SearchHitType.BOOK)
+                advanceUntilIdle()
+
+                verifySuspend {
+                    fixture.searchRepository.search(
+                        query = "test",
+                        types = listOf(SearchHitType.BOOK),
+                        genres = null,
+                        genrePath = null,
+                        limit = 30,
+                    )
+                }
+            }
+        }
+
+        test("onResultClicked on book emits NavigateToBook") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.navActions.test {
+                    viewModel.onResultClicked(createBookHit(id = "book-123"))
+                    advanceUntilIdle()
+                    val action = awaitItem().shouldBeInstanceOf<SearchNavAction.NavigateToBook>()
+                    action.bookId shouldBe "book-123"
+                }
+            }
+        }
+
+        test("onResultClicked on contributor emits NavigateToContributor") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.navActions.test {
+                    viewModel.onResultClicked(createContributorHit(id = "author-456"))
+                    advanceUntilIdle()
+                    val action = awaitItem().shouldBeInstanceOf<SearchNavAction.NavigateToContributor>()
+                    action.contributorId shouldBe "author-456"
+                }
+            }
+        }
+
+        test("onResultClicked on series emits NavigateToSeries") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.navActions.test {
+                    viewModel.onResultClicked(createSeriesHit(id = "series-789"))
+                    advanceUntilIdle()
+                    val action = awaitItem().shouldBeInstanceOf<SearchNavAction.NavigateToSeries>()
+                    action.seriesId shouldBe "series-789"
+                }
+            }
+        }
+
+        test("onResultClicked on tag emits NavigateToTag") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.navActions.test {
+                    viewModel.onResultClicked(createTagHit(id = "tag-42"))
+                    advanceUntilIdle()
+                    val action = awaitItem().shouldBeInstanceOf<SearchNavAction.NavigateToTag>()
+                    action.tagId shouldBe "tag-42"
+                }
+            }
+        }
+
+        test("clearQuery returns state to Idle after Results") {
+            runTest {
+                val fixture = createFixture()
+                everySuspend { fixture.searchRepository.search(any(), any(), any(), any(), any()) } returns
+                    createSearchResult(hits = listOf(createBookHit()))
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+
+                viewModel.onQueryChanged("test")
+                advanceTimeBy(400.milliseconds)
+                advanceUntilIdle()
+                viewModel.state.value.shouldBeInstanceOf<SearchUiState.Results>()
+
+                viewModel.clearQuery()
+                advanceTimeBy(50.milliseconds)
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<SearchUiState.Idle>()
+                state.query shouldBe ""
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/settings/SettingsViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/settings/SettingsViewModelTest.kt
@@ -17,6 +17,8 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,12 +27,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import com.calypsan.listenup.client.core.Failure
 
 /**
@@ -43,128 +39,72 @@ import com.calypsan.listenup.client.core.Failure
  * - Server sync for synced settings
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class SettingsViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class SettingsViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    // ========== Test Fixture Builder ==========
+        // ========== Test Fixture Builder ==========
 
-    private class TestFixture {
-        val libraryPreferences: LibraryPreferences = mock()
-        val playbackPreferences: PlaybackPreferences = mock()
-        val localPreferences: LocalPreferences = mock()
-        val userPreferencesRepository: UserPreferencesRepository = mock()
-        val instanceRepository: InstanceRepository = mock()
-        val serverConfig: ServerConfig = mock()
-        val authSession: AuthSession = mock()
-        val syncRepository: SyncRepository = mock()
-        val rpcCacheInvalidator: RpcCacheInvalidator = mock()
+        class TestFixture {
+            val libraryPreferences: LibraryPreferences = mock()
+            val playbackPreferences: PlaybackPreferences = mock()
+            val localPreferences: LocalPreferences = mock()
+            val userPreferencesRepository: UserPreferencesRepository = mock()
+            val instanceRepository: InstanceRepository = mock()
+            val serverConfig: ServerConfig = mock()
+            val authSession: AuthSession = mock()
+            val syncRepository: SyncRepository = mock()
+            val rpcCacheInvalidator: RpcCacheInvalidator = mock()
 
-        // StateFlows for local preferences (mocked as MutableStateFlow)
-        val themeModeFlow = MutableStateFlow(ThemeMode.SYSTEM)
-        val dynamicColorsFlow = MutableStateFlow(true)
-        val autoRewindFlow = MutableStateFlow(true)
-        val wifiOnlyFlow = MutableStateFlow(true)
-        val autoRemoveFlow = MutableStateFlow(false)
-        val hapticFeedbackFlow = MutableStateFlow(true)
+            // StateFlows for local preferences (mocked as MutableStateFlow)
+            val themeModeFlow = MutableStateFlow(ThemeMode.SYSTEM)
+            val dynamicColorsFlow = MutableStateFlow(true)
+            val autoRewindFlow = MutableStateFlow(true)
+            val wifiOnlyFlow = MutableStateFlow(true)
+            val autoRemoveFlow = MutableStateFlow(false)
+            val hapticFeedbackFlow = MutableStateFlow(true)
 
-        fun build(): SettingsViewModel =
-            SettingsViewModel(
-                libraryPreferences = libraryPreferences,
-                playbackPreferences = playbackPreferences,
-                localPreferences = localPreferences,
-                userPreferencesRepository = userPreferencesRepository,
-                instanceRepository = instanceRepository,
-                serverConfig = serverConfig,
-                authSession = authSession,
-                syncRepository = syncRepository,
-                rpcCacheInvalidator = rpcCacheInvalidator,
-            )
-    }
-
-    private fun createFixture(): TestFixture {
-        val fixture = TestFixture()
-
-        // Mock StateFlows for local preferences
-        every { fixture.localPreferences.themeMode } returns fixture.themeModeFlow
-        every { fixture.localPreferences.dynamicColorsEnabled } returns fixture.dynamicColorsFlow
-        every { fixture.localPreferences.autoRewindEnabled } returns fixture.autoRewindFlow
-        every { fixture.localPreferences.wifiOnlyDownloads } returns fixture.wifiOnlyFlow
-        every { fixture.localPreferences.autoRemoveFinished } returns fixture.autoRemoveFlow
-        every { fixture.localPreferences.hapticFeedbackEnabled } returns fixture.hapticFeedbackFlow
-
-        // Default stubs for playback preferences - getters
-        everySuspend { fixture.playbackPreferences.getDefaultPlaybackSpeed() } returns PlaybackPreferences.DEFAULT_PLAYBACK_SPEED
-        everySuspend { fixture.playbackPreferences.getSpatialPlayback() } returns true
-
-        // Default stubs for library preferences - getters
-        everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns true
-        everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns true
-
-        // Default stubs for playback preferences - setters (called when syncing from server)
-        everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(PlaybackPreferences.DEFAULT_PLAYBACK_SPEED) } returns Unit
-
-        // Default stub for API - return defaults
-        everySuspend { fixture.userPreferencesRepository.getPreferences() } returns
-            AppResult.Success(
-                UserPreferences(
-                    defaultPlaybackSpeed = PlaybackPreferences.DEFAULT_PLAYBACK_SPEED,
-                    defaultSkipForwardSec = 30,
-                    defaultSkipBackwardSec = 10,
-                    defaultSleepTimerMin = null,
-                    shakeToResetSleepTimer = false,
-                ),
-            )
-
-        // Default stubs for new dependencies
-        everySuspend { fixture.serverConfig.getServerUrl() } returns null
-        everySuspend { fixture.instanceRepository.getInstance() } returns
-            Failure(Exception("Not configured"))
-        everySuspend { fixture.authSession.clearAuthTokens() } returns Unit
-        everySuspend { fixture.syncRepository.disconnect() } returns Unit
-        everySuspend { fixture.rpcCacheInvalidator.invalidateAll() } returns Unit
-
-        return fixture
-    }
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    // ========== Init / Loading Tests ==========
-
-    @Test
-    fun `initial state is loading`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-
-            // When
-            val viewModel = fixture.build()
-
-            // Then - before advanceUntilIdle, should be loading
-            assertTrue(viewModel.state.value.isLoading)
+            fun build(): SettingsViewModel =
+                SettingsViewModel(
+                    libraryPreferences = libraryPreferences,
+                    playbackPreferences = playbackPreferences,
+                    localPreferences = localPreferences,
+                    userPreferencesRepository = userPreferencesRepository,
+                    instanceRepository = instanceRepository,
+                    serverConfig = serverConfig,
+                    authSession = authSession,
+                    syncRepository = syncRepository,
+                    rpcCacheInvalidator = rpcCacheInvalidator,
+                )
         }
 
-    @Test
-    fun `loads settings on init`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPreferences.getDefaultPlaybackSpeed() } returns 1.5f
-            everySuspend { fixture.playbackPreferences.getSpatialPlayback() } returns false
-            everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns false
-            everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns false
-            everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.5f) } returns Unit
+        fun createFixture(): TestFixture {
+            val fixture = TestFixture()
+
+            // Mock StateFlows for local preferences
+            every { fixture.localPreferences.themeMode } returns fixture.themeModeFlow
+            every { fixture.localPreferences.dynamicColorsEnabled } returns fixture.dynamicColorsFlow
+            every { fixture.localPreferences.autoRewindEnabled } returns fixture.autoRewindFlow
+            every { fixture.localPreferences.wifiOnlyDownloads } returns fixture.wifiOnlyFlow
+            every { fixture.localPreferences.autoRemoveFinished } returns fixture.autoRemoveFlow
+            every { fixture.localPreferences.hapticFeedbackEnabled } returns fixture.hapticFeedbackFlow
+
+            // Default stubs for playback preferences - getters
+            everySuspend { fixture.playbackPreferences.getDefaultPlaybackSpeed() } returns PlaybackPreferences.DEFAULT_PLAYBACK_SPEED
+            everySuspend { fixture.playbackPreferences.getSpatialPlayback() } returns true
+
+            // Default stubs for library preferences - getters
+            everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns true
+            everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns true
+
+            // Default stubs for playback preferences - setters (called when syncing from server)
+            everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(PlaybackPreferences.DEFAULT_PLAYBACK_SPEED) } returns Unit
+
+            // Default stub for API - return defaults
             everySuspend { fixture.userPreferencesRepository.getPreferences() } returns
                 AppResult.Success(
                     UserPreferences(
-                        defaultPlaybackSpeed = 1.5f,
+                        defaultPlaybackSpeed = PlaybackPreferences.DEFAULT_PLAYBACK_SPEED,
                         defaultSkipForwardSec = 30,
                         defaultSkipBackwardSec = 10,
                         defaultSleepTimerMin = null,
@@ -172,209 +112,259 @@ class SettingsViewModelTest {
                     ),
                 )
 
-            // When
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+            // Default stubs for new dependencies
+            everySuspend { fixture.serverConfig.getServerUrl() } returns null
+            everySuspend { fixture.instanceRepository.getInstance() } returns
+                Failure(Exception("Not configured"))
+            everySuspend { fixture.authSession.clearAuthTokens() } returns Unit
+            everySuspend { fixture.syncRepository.disconnect() } returns Unit
+            everySuspend { fixture.rpcCacheInvalidator.invalidateAll() } returns Unit
 
-            // Then
-            val state = viewModel.state.value
-            assertFalse(state.isLoading)
-            assertEquals(1.5f, state.defaultPlaybackSpeed)
-            assertFalse(state.spatialPlayback)
-            assertFalse(state.ignoreTitleArticles)
-            assertFalse(state.hideSingleBookSeries)
+            return fixture
         }
 
-    @Test
-    fun `uses default values when loading`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-            // When
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== Init / Loading Tests ==========
 
-            // Then - should use defaults
-            val state = viewModel.state.value
-            assertEquals(PlaybackPreferences.DEFAULT_PLAYBACK_SPEED, state.defaultPlaybackSpeed)
-            assertTrue(state.spatialPlayback)
-            assertTrue(state.ignoreTitleArticles)
-            assertTrue(state.hideSingleBookSeries)
+        test("initial state is loading") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+
+                // When
+                val viewModel = fixture.build()
+
+                // Then - before advanceUntilIdle, should be loading
+                viewModel.state.value.isLoading shouldBe true
+            }
         }
 
-    // ========== Playback Speed Tests ==========
+        test("loads settings on init") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPreferences.getDefaultPlaybackSpeed() } returns 1.5f
+                everySuspend { fixture.playbackPreferences.getSpatialPlayback() } returns false
+                everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns false
+                everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns false
+                everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.5f) } returns Unit
+                everySuspend { fixture.userPreferencesRepository.getPreferences() } returns
+                    AppResult.Success(
+                        UserPreferences(
+                            defaultPlaybackSpeed = 1.5f,
+                            defaultSkipForwardSec = 30,
+                            defaultSkipBackwardSec = 10,
+                            defaultSleepTimerMin = null,
+                            shakeToResetSleepTimer = false,
+                        ),
+                    )
 
-    @Test
-    fun `setDefaultPlaybackSpeed updates local cache and UI immediately`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.25f) } returns Unit
-            everySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(1.25f) } returns AppResult.Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+                // When
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.setDefaultPlaybackSpeed(1.25f)
-            advanceUntilIdle()
-
-            // Then - local cache updated
-            verifySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.25f) }
-            assertEquals(1.25f, viewModel.state.value.defaultPlaybackSpeed)
+                // Then
+                val state = viewModel.state.value
+                state.isLoading shouldBe false
+                state.defaultPlaybackSpeed shouldBe 1.5f
+                state.spatialPlayback shouldBe false
+                state.ignoreTitleArticles shouldBe false
+                state.hideSingleBookSeries shouldBe false
+            }
         }
 
-    @Test
-    fun `setDefaultPlaybackSpeed syncs to server`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.5f) } returns Unit
-            everySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(1.5f) } returns AppResult.Success(Unit)
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("uses default values when loading") {
+            runTest {
+                // Given
+                val fixture = createFixture()
 
-            // When
-            viewModel.setDefaultPlaybackSpeed(1.5f)
-            advanceUntilIdle()
+                // When
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then - server sync called
-            verifySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(1.5f) }
+                // Then - should use defaults
+                val state = viewModel.state.value
+                state.defaultPlaybackSpeed shouldBe PlaybackPreferences.DEFAULT_PLAYBACK_SPEED
+                state.spatialPlayback shouldBe true
+                state.ignoreTitleArticles shouldBe true
+                state.hideSingleBookSeries shouldBe true
+            }
         }
 
-    @Test
-    fun `setDefaultPlaybackSpeed continues on server sync failure`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(2.0f) } returns Unit
-            everySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(2.0f) } returns
-                Failure(Exception("Network error"))
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== Playback Speed Tests ==========
 
-            // When
-            viewModel.setDefaultPlaybackSpeed(2.0f)
-            advanceUntilIdle()
+        test("setDefaultPlaybackSpeed updates local cache and UI immediately") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.25f) } returns Unit
+                everySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(1.25f) } returns AppResult.Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then - UI still updated (optimistic), no error shown
-            assertEquals(2.0f, viewModel.state.value.defaultPlaybackSpeed)
+                // When
+                viewModel.setDefaultPlaybackSpeed(1.25f)
+                advanceUntilIdle()
+
+                // Then - local cache updated
+                verifySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.25f) }
+                viewModel.state.value.defaultPlaybackSpeed shouldBe 1.25f
+            }
         }
 
-    // ========== Spatial Playback Tests ==========
+        test("setDefaultPlaybackSpeed syncs to server") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(1.5f) } returns Unit
+                everySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(1.5f) } returns AppResult.Success(Unit)
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-    @Test
-    fun `setSpatialPlayback updates setting`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPreferences.setSpatialPlayback(false) } returns Unit
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+                // When
+                viewModel.setDefaultPlaybackSpeed(1.5f)
+                advanceUntilIdle()
 
-            // When
-            viewModel.setSpatialPlayback(false)
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend { fixture.playbackPreferences.setSpatialPlayback(false) }
-            assertFalse(viewModel.state.value.spatialPlayback)
+                // Then - server sync called
+                verifySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(1.5f) }
+            }
         }
 
-    @Test
-    fun `setSpatialPlayback toggles correctly`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.playbackPreferences.getSpatialPlayback() } returns true
-            everySuspend { fixture.playbackPreferences.setSpatialPlayback(false) } returns Unit
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-            assertTrue(viewModel.state.value.spatialPlayback)
+        test("setDefaultPlaybackSpeed continues on server sync failure") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPreferences.setDefaultPlaybackSpeed(2.0f) } returns Unit
+                everySuspend { fixture.userPreferencesRepository.setDefaultPlaybackSpeed(2.0f) } returns
+                    Failure(Exception("Network error"))
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.setSpatialPlayback(false)
-            advanceUntilIdle()
+                // When
+                viewModel.setDefaultPlaybackSpeed(2.0f)
+                advanceUntilIdle()
 
-            // Then
-            assertFalse(viewModel.state.value.spatialPlayback)
+                // Then - UI still updated (optimistic), no error shown
+                viewModel.state.value.defaultPlaybackSpeed shouldBe 2.0f
+            }
         }
 
-    // ========== Ignore Title Articles Tests ==========
+        // ========== Spatial Playback Tests ==========
 
-    @Test
-    fun `setIgnoreTitleArticles updates setting`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(false) } returns Unit
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        test("setSpatialPlayback updates setting") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPreferences.setSpatialPlayback(false) } returns Unit
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // When
-            viewModel.setIgnoreTitleArticles(false)
-            advanceUntilIdle()
+                // When
+                viewModel.setSpatialPlayback(false)
+                advanceUntilIdle()
 
-            // Then
-            verifySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(false) }
-            assertFalse(viewModel.state.value.ignoreTitleArticles)
+                // Then
+                verifySuspend { fixture.playbackPreferences.setSpatialPlayback(false) }
+                viewModel.state.value.spatialPlayback shouldBe false
+            }
         }
 
-    // ========== Hide Single Book Series Tests ==========
+        test("setSpatialPlayback toggles correctly") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.playbackPreferences.getSpatialPlayback() } returns true
+                everySuspend { fixture.playbackPreferences.setSpatialPlayback(false) } returns Unit
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+                viewModel.state.value.spatialPlayback shouldBe true
 
-    @Test
-    fun `setHideSingleBookSeries updates setting`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.setHideSingleBookSeries(false) } returns Unit
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+                // When
+                viewModel.setSpatialPlayback(false)
+                advanceUntilIdle()
 
-            // When
-            viewModel.setHideSingleBookSeries(false)
-            advanceUntilIdle()
-
-            // Then
-            verifySuspend { fixture.libraryPreferences.setHideSingleBookSeries(false) }
-            assertFalse(viewModel.state.value.hideSingleBookSeries)
+                // Then
+                viewModel.state.value.spatialPlayback shouldBe false
+            }
         }
 
-    @Test
-    fun `setHideSingleBookSeries can be enabled`() =
-        runTest {
-            // Given - start with false
-            val fixture = createFixture()
-            everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns false
-            everySuspend { fixture.libraryPreferences.setHideSingleBookSeries(true) } returns Unit
-            val viewModel = fixture.build()
-            advanceUntilIdle()
-            assertFalse(viewModel.state.value.hideSingleBookSeries)
+        // ========== Ignore Title Articles Tests ==========
 
-            // When
-            viewModel.setHideSingleBookSeries(true)
-            advanceUntilIdle()
+        test("setIgnoreTitleArticles updates setting") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(false) } returns Unit
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then
-            assertTrue(viewModel.state.value.hideSingleBookSeries)
+                // When
+                viewModel.setIgnoreTitleArticles(false)
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.libraryPreferences.setIgnoreTitleArticles(false) }
+                viewModel.state.value.ignoreTitleArticles shouldBe false
+            }
         }
 
-    @Test
-    fun `signOut stops the sync engine before clearing tokens`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            val viewModel = fixture.build()
-            advanceUntilIdle()
+        // ========== Hide Single Book Series Tests ==========
 
-            // When
-            viewModel.signOut()
-            advanceUntilIdle()
+        test("setHideSingleBookSeries updates setting") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.setHideSingleBookSeries(false) } returns Unit
+                val viewModel = fixture.build()
+                advanceUntilIdle()
 
-            // Then — the engine is stopped (no reconnect loop), cached RPC connections
-            // are dropped (no cross-user reuse), and tokens are cleared.
-            verifySuspend { fixture.syncRepository.disconnect() }
-            verifySuspend { fixture.rpcCacheInvalidator.invalidateAll() }
-            verifySuspend { fixture.authSession.clearAuthTokens() }
+                // When
+                viewModel.setHideSingleBookSeries(false)
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.libraryPreferences.setHideSingleBookSeries(false) }
+                viewModel.state.value.hideSingleBookSeries shouldBe false
+            }
         }
-}
+
+        test("setHideSingleBookSeries can be enabled") {
+            runTest {
+                // Given - start with false
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.getHideSingleBookSeries() } returns false
+                everySuspend { fixture.libraryPreferences.setHideSingleBookSeries(true) } returns Unit
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+                viewModel.state.value.hideSingleBookSeries shouldBe false
+
+                // When
+                viewModel.setHideSingleBookSeries(true)
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value.hideSingleBookSeries shouldBe true
+            }
+        }
+
+        test("signOut stops the sync engine before clearing tokens") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                // When
+                viewModel.signOut()
+                advanceUntilIdle()
+
+                // Then — the engine is stopped (no reconnect loop), cached RPC connections
+                // are dropped (no cross-user reuse), and tokens are cleared.
+                verifySuspend { fixture.syncRepository.disconnect() }
+                verifySuspend { fixture.rpcCacheInvalidator.invalidateAll() }
+                verifySuspend { fixture.authSession.clearAuthTokens() }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -18,6 +18,9 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,14 +29,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for AppStartupViewModel.
@@ -47,443 +42,437 @@ import kotlin.test.assertTrue
  * Uses Mokkery for mocking and follows Given-When-Then style.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class AppStartupViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class AppStartupViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+        // ========== Test Data Factories ==========
 
-    // ========== Test Data Factories ==========
+        fun createMockUserRepository(): UserRepository = mock<UserRepository>()
 
-    private fun createMockUserRepository(): UserRepository = mock<UserRepository>()
-
-    /** No-op [ProfileRepository] mock — profile refresh is fire-and-forget and not exercised here. */
-    private fun createNoOpProfileRepository(): ProfileRepository {
-        val repo = mock<ProfileRepository>()
-        everySuspend { repo.refreshMyProfile() } returns CoreAppResult.Success(Unit)
-        return repo
-    }
-
-    // readiness derives from the sync layer's scan signal; these tests don't drive a scan, so a
-    // not-scanning stub is all the aggregator needs. hasLocalLibrary() defaults to false so that
-    // existing failure tests still expect CheckFailed — only tests that explicitly opt in to
-    // hasLocalLibrary() = true will observe the offline-fallback path.
-    private fun createMockSyncRepository(hasLocalLibrary: Boolean = false): SyncRepository {
-        val sync = mock<SyncRepository>()
-        every { sync.isServerScanning } returns MutableStateFlow(false)
-        every { sync.scanProgress } returns MutableStateFlow(null)
-        everySuspend { sync.hasLocalLibrary() } returns hasLocalLibrary
-        return sync
-    }
-
-    private fun createMockLibraryAdminRpcFactory(service: LibraryAdminService = mock()): LibraryAdminRpcFactory {
-        val factory = mock<LibraryAdminRpcFactory>()
-        everySuspend { factory.get() } returns service
-        return factory
-    }
-
-    // The setup check now runs off authState transitions to Authenticated, so the VM needs an
-    // AuthSession. Default to already-Authenticated so existing tests exercise the check as before.
-    private fun createMockAuthSession(
-        authState: AuthState = AuthState.Authenticated(UserId("user-001"), SessionId("session-001")),
-    ): AuthSession {
-        val session = mock<AuthSession>()
-        every { session.authState } returns MutableStateFlow(authState)
-        return session
-    }
-
-    private fun createTestUser(
-        id: String = "user-001",
-        isAdmin: Boolean = false,
-    ): User =
-        User(
-            id =
-                UserId(id),
-            email = "test@example.com",
-            displayName = "Test User",
-            firstName = null,
-            lastName = null,
-            isAdmin = isAdmin,
-            avatarType = "auto",
-            avatarValue = null,
-            avatarColor = "#3B82F6",
-            tagline = null,
-            createdAtMs = 1704067200000L,
-            updatedAtMs = 1704153600000L,
-        )
-
-    // ========== Threshold Constant Tests ==========
-
-    @Test
-    fun `BACKGROUND_THRESHOLD_MS is 30 minutes`() {
-        // Given/When/Then
-        val expectedMs = 30 * 60 * 1000L
-        assertEquals(expectedMs, AppStartupViewModel.BACKGROUND_THRESHOLD_MS)
-    }
-
-    // ========== Initial State Tests ==========
-
-    @Test
-    fun `initial state has isChecking true`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val factory = createMockLibraryAdminRpcFactory()
-            everySuspend { userRepository.refreshCurrentUser() } returns null
-            everySuspend { userRepository.getCurrentUser() } returns null
-
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-
-            // Then - initial state before coroutine completes
-            assertTrue(viewModel.state.value.isChecking)
+        // No-op [ProfileRepository] mock — profile refresh is fire-and-forget and not exercised here.
+        fun createNoOpProfileRepository(): ProfileRepository {
+            val repo = mock<ProfileRepository>()
+            everySuspend { repo.refreshMyProfile() } returns CoreAppResult.Success(Unit)
+            return repo
         }
 
-    @Test
-    fun `initial check completes and sets isChecking false for non-admin user`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val factory = createMockLibraryAdminRpcFactory()
-            val regularUser = createTestUser(isAdmin = false)
-            everySuspend { userRepository.refreshCurrentUser() } returns regularUser
-            everySuspend { userRepository.getCurrentUser() } returns regularUser
-
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
-
-            // Then
-            assertFalse(viewModel.state.value.isChecking)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
+        // readiness derives from the sync layer's scan signal; these tests don't drive a scan, so a
+        // not-scanning stub is all the aggregator needs. hasLocalLibrary() defaults to false so that
+        // existing failure tests still expect CheckFailed — only tests that explicitly opt in to
+        // hasLocalLibrary() = true will observe the offline-fallback path.
+        fun createMockSyncRepository(hasLocalLibrary: Boolean = false): SyncRepository {
+            val sync = mock<SyncRepository>()
+            every { sync.isServerScanning } returns MutableStateFlow(false)
+            every { sync.scanProgress } returns MutableStateFlow(null)
+            everySuspend { sync.hasLocalLibrary() } returns hasLocalLibrary
+            return sync
         }
 
-    @Test
-    fun `initial check completes and sets needsLibrarySetup true for admin when library needs setup`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
-
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
-
-            // Then
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.needsLibrarySetup)
+        fun createMockLibraryAdminRpcFactory(service: LibraryAdminService = mock()): LibraryAdminRpcFactory {
+            val factory = mock<LibraryAdminRpcFactory>()
+            everySuspend { factory.get() } returns service
+            return factory
         }
 
-    // Regression: the VM is created eagerly at app launch (before login). The setup check
-    // must NOT run at construction against a null/unauthenticated user — it must run when
-    // authState becomes Authenticated, and re-run on that transition. Before the fix, the
-    // init-time check resolved a null user, cached "no setup needed", and never re-ran after
-    // the user registered, stranding the admin on the homepage instead of the wizard.
-    @Test
-    fun `setup check runs on transition to Authenticated, not at construction`() =
-        runTest {
-            // Given - admin + a library that needs setup, but NOT yet authenticated
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
-            val authState = MutableStateFlow<AuthState>(AuthState.NeedsLogin(openRegistration = false))
-            val authSession = mock<AuthSession>()
-            every { authSession.authState } returns authState
-
-            // When - constructed before login (as MainActivity does at app launch)
-            val viewModel = AppStartupViewModel(userRepository, factory, authSession, createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
-
-            // Then - no premature check; not dropped into the wizard
-            assertFalse(viewModel.state.value.isChecking)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
-
-            // When - the user authenticates (creates the account)
-            authState.value = AuthState.Authenticated(UserId("user-001"), SessionId("session-001"))
-            advanceUntilIdle()
-
-            // Then - the check runs against the authenticated admin → routes to the wizard
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.needsLibrarySetup)
+        // The setup check now runs off authState transitions to Authenticated, so the VM needs an
+        // AuthSession. Default to already-Authenticated so existing tests exercise the check as before.
+        fun createMockAuthSession(
+            authState: AuthState = AuthState.Authenticated(UserId("user-001"), SessionId("session-001")),
+        ): AuthSession {
+            val session = mock<AuthSession>()
+            every { session.authState } returns MutableStateFlow(authState)
+            return session
         }
 
-    // ========== onAppBackgrounded Tests ==========
+        fun createTestUser(
+            id: String = "user-001",
+            isAdmin: Boolean = false,
+        ): User =
+            User(
+                id =
+                    UserId(id),
+                email = "test@example.com",
+                displayName = "Test User",
+                firstName = null,
+                lastName = null,
+                isAdmin = isAdmin,
+                avatarType = "auto",
+                avatarValue = null,
+                avatarColor = "#3B82F6",
+                tagline = null,
+                createdAtMs = 1704067200000L,
+                updatedAtMs = 1704153600000L,
+            )
 
-    @Test
-    fun `onAppBackgrounded records timestamp`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val factory = createMockLibraryAdminRpcFactory()
-            everySuspend { userRepository.refreshCurrentUser() } returns null
-            everySuspend { userRepository.getCurrentUser() } returns null
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
+        // ========== Threshold Constant Tests ==========
 
-            // When
-            viewModel.onAppBackgrounded()
-
-            // Then
-            assertNotNull(viewModel.state.value.backgroundedAtMs)
+        test("BACKGROUND_THRESHOLD_MS is 30 minutes") {
+            // Given/When/Then
+            val expectedMs = 30 * 60 * 1000L
+            AppStartupViewModel.BACKGROUND_THRESHOLD_MS shouldBe expectedMs
         }
 
-    // ========== onAppForegrounded Tests ==========
+        // ========== Initial State Tests ==========
 
-    @Test
-    fun `onAppForegrounded does nothing when backgroundedAtMs is null`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val factory = createMockLibraryAdminRpcFactory()
-            everySuspend { userRepository.refreshCurrentUser() } returns null
-            everySuspend { userRepository.getCurrentUser() } returns null
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
+        test("initial state has isChecking true") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                everySuspend { userRepository.refreshCurrentUser() } returns null
+                everySuspend { userRepository.getCurrentUser() } returns null
 
-            // Verify backgroundedAtMs is null before the call
-            assertNull(viewModel.state.value.backgroundedAtMs)
-            val isCheckingBefore = viewModel.state.value.isChecking
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
 
-            // When
-            viewModel.onAppForegrounded()
-            advanceUntilIdle()
-
-            // Then - state unchanged
-            assertEquals(isCheckingBefore, viewModel.state.value.isChecking)
+                // Then - initial state before coroutine completes
+                viewModel.state.value.isChecking shouldBe true
+            }
         }
 
-    @Test
-    fun `onAppForegrounded does NOT reset isChecking for short background period`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val factory = createMockLibraryAdminRpcFactory()
-            everySuspend { userRepository.refreshCurrentUser() } returns null
-            everySuspend { userRepository.getCurrentUser() } returns null
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
+        test("initial check completes and sets isChecking false for non-admin user") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                val regularUser = createTestUser(isAdmin = false)
+                everySuspend { userRepository.refreshCurrentUser() } returns regularUser
+                everySuspend { userRepository.getCurrentUser() } returns regularUser
 
-            // Initial check is complete, isChecking should be false
-            assertFalse(viewModel.state.value.isChecking)
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // Simulate backgrounding and immediate foregrounding (short period)
-            viewModel.onAppBackgrounded()
-
-            // When - foreground immediately (elapsed time ~0ms, well under 30 min threshold)
-            viewModel.onAppForegrounded()
-            advanceUntilIdle()
-
-            // Then - isChecking should still be false (no re-check triggered)
-            assertFalse(viewModel.state.value.isChecking)
+                // Then
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe false
+            }
         }
 
-    // ========== Setup-status Failure Tests ==========
+        test("initial check completes and sets needsLibrarySetup true for admin when library needs setup") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
 
-    @Test
-    fun `admin getSetupStatus failure surfaces setupCheckFailed not silent Shell`() =
-        runTest {
-            // Given - admin user, setup-status check fails (e.g. transient network error)
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Failure(TransportError.NetworkUnavailable())
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
-
-            // Then - check is settled, failure surfaced, NOT forced into the wizard
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.setupCheckFailed)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
+                // Then
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe true
+            }
         }
 
-    @Test
-    fun `admin getSetupStatus success needsSetup true sets needsLibrarySetup not failed`() =
-        runTest {
-            // Given
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
+        // Regression: the VM is created eagerly at app launch (before login). The setup check
+        // must NOT run at construction against a null/unauthenticated user — it must run when
+        // authState becomes Authenticated, and re-run on that transition. Before the fix, the
+        // init-time check resolved a null user, cached "no setup needed", and never re-ran after
+        // the user registered, stranding the admin on the homepage instead of the wizard.
+        test("setup check runs on transition to Authenticated, not at construction") {
+            runTest {
+                // Given - admin + a library that needs setup, but NOT yet authenticated
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
+                val authState = MutableStateFlow<AuthState>(AuthState.NeedsLogin(openRegistration = false))
+                val authSession = mock<AuthSession>()
+                every { authSession.authState } returns authState
 
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
+                // When - constructed before login (as MainActivity does at app launch)
+                val viewModel = AppStartupViewModel(userRepository, factory, authSession, createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // Then
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.needsLibrarySetup)
-            assertFalse(viewModel.state.value.setupCheckFailed)
+                // Then - no premature check; not dropped into the wizard
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe false
+
+                // When - the user authenticates (creates the account)
+                authState.value = AuthState.Authenticated(UserId("user-001"), SessionId("session-001"))
+                advanceUntilIdle()
+
+                // Then - the check runs against the authenticated admin → routes to the wizard
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe true
+            }
         }
 
-    @Test
-    fun `non-admin is never blocked or failed by setup-status`() =
-        runTest {
-            // Given - non-admin user; getSetupStatus must never be consulted
-            val userRepository = createMockUserRepository()
-            val factory = createMockLibraryAdminRpcFactory()
-            val regularUser = createTestUser(isAdmin = false)
-            everySuspend { userRepository.refreshCurrentUser() } returns regularUser
-            everySuspend { userRepository.getCurrentUser() } returns regularUser
+        // ========== onAppBackgrounded Tests ==========
 
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
+        test("onAppBackgrounded records timestamp") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                everySuspend { userRepository.refreshCurrentUser() } returns null
+                everySuspend { userRepository.getCurrentUser() } returns null
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // Then
-            assertFalse(viewModel.state.value.isChecking)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
-            assertFalse(viewModel.state.value.setupCheckFailed)
+                // When
+                viewModel.onAppBackgrounded()
+
+                // Then
+                viewModel.state.value.backgroundedAtMs
+                    .shouldNotBeNull()
+            }
         }
 
-    @Test
-    fun `retryLibrarySetupCheck re-runs the check after a transient failure`() =
-        runTest {
-            // Given - admin user; first check fails, then the next check succeeds
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Failure(TransportError.NetworkUnavailable())
+        // ========== onAppForegrounded Tests ==========
 
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
-            assertTrue(viewModel.state.value.setupCheckFailed)
+        test("onAppForegrounded does nothing when backgroundedAtMs is null") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                everySuspend { userRepository.refreshCurrentUser() } returns null
+                everySuspend { userRepository.getCurrentUser() } returns null
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // Flip the stub to success and retry
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
+                // Verify backgroundedAtMs is null before the call
+                viewModel.state.value.backgroundedAtMs shouldBe null
+                val isCheckingBefore = viewModel.state.value.isChecking
 
-            // When
-            viewModel.retryLibrarySetupCheck()
-            advanceUntilIdle()
+                // When
+                viewModel.onAppForegrounded()
+                advanceUntilIdle()
 
-            // Then - failure cleared, check settled, no wizard
-            assertFalse(viewModel.state.value.isChecking)
-            assertFalse(viewModel.state.value.setupCheckFailed)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
+                // Then - state unchanged
+                viewModel.state.value.isChecking shouldBe isCheckingBefore
+            }
         }
 
-    @Test
-    fun `onAppForegrounded preserves needsLibrarySetup state for short background period`() =
-        runTest {
-            // Given - admin user with library needing setup
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
+        test("onAppForegrounded does NOT reset isChecking for short background period") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                everySuspend { userRepository.refreshCurrentUser() } returns null
+                everySuspend { userRepository.getCurrentUser() } returns null
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
-            advanceUntilIdle()
+                // Initial check is complete, isChecking should be false
+                viewModel.state.value.isChecking shouldBe false
 
-            // Verify initial state
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.needsLibrarySetup)
+                // Simulate backgrounding and immediate foregrounding (short period)
+                viewModel.onAppBackgrounded()
 
-            // Simulate short background period
-            viewModel.onAppBackgrounded()
+                // When - foreground immediately (elapsed time ~0ms, well under 30 min threshold)
+                viewModel.onAppForegrounded()
+                advanceUntilIdle()
 
-            // When - foreground after short period
-            viewModel.onAppForegrounded()
-            advanceUntilIdle()
-
-            // Then - state preserved, no re-check
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.needsLibrarySetup)
+                // Then - isChecking should still be false (no re-check triggered)
+                viewModel.state.value.isChecking shouldBe false
+            }
         }
 
-    // ========== Offline-first Fallback Tests ==========
+        // ========== Setup-status Failure Tests ==========
 
-    // Regression: a returning admin with a cached local library must NOT be stranded on a
-    // "Library Check Failed" wall when the server is unreachable at startup. The setup check
-    // only matters for a FRESH admin (no library yet). When books exist locally, the VM must
-    // resolve to Ready so the offline library is accessible.
-    @Test
-    fun `admin getSetupStatus failure resolves to Ready when a local library exists`() =
-        runTest {
-            // Given - admin user, setup-status check fails (server unreachable offline)
-            //         but a library is already cached in local Room
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Failure(TransportError.NetworkUnavailable())
-            // hasLocalLibrary = true: returning user with a cached library
-            val syncRepository = createMockSyncRepository(hasLocalLibrary = true)
+        test("admin getSetupStatus failure surfaces setupCheckFailed not silent Shell") {
+            runTest {
+                // Given - admin user, setup-status check fails (e.g. transient network error)
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
 
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), syncRepository)
-            advanceUntilIdle()
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // Then - opens offline, NOT stranded on the error wall
-            assertFalse(viewModel.state.value.isChecking)
-            assertFalse(viewModel.state.value.setupCheckFailed)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
-            assertEquals(LibraryReadiness.Ready, viewModel.readiness.value)
+                // Then - check is settled, failure surfaced, NOT forced into the wizard
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.setupCheckFailed shouldBe true
+                viewModel.state.value.needsLibrarySetup shouldBe false
+            }
         }
 
-    // Complement: when there is genuinely no local library (fresh admin, first startup offline),
-    // the retryable error wall is the correct and honest response.
-    @Test
-    fun `admin getSetupStatus failure surfaces CheckFailed when no local library exists`() =
-        runTest {
-            // Given - admin user, setup-status check fails and no local library
-            val userRepository = createMockUserRepository()
-            val service = mock<LibraryAdminService>()
-            val factory = createMockLibraryAdminRpcFactory(service)
-            val adminUser = createTestUser(isAdmin = true)
-            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
-            everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { service.getSetupStatus() } returns
-                AppResult.Failure(TransportError.NetworkUnavailable())
-            // hasLocalLibrary = false: fresh admin, no cache yet
-            val syncRepository = createMockSyncRepository(hasLocalLibrary = false)
+        test("admin getSetupStatus success needsSetup true sets needsLibrarySetup not failed") {
+            runTest {
+                // Given
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
 
-            // When
-            val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), syncRepository)
-            advanceUntilIdle()
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
 
-            // Then - retryable error surfaced (honest over silent for genuine no-library case)
-            assertFalse(viewModel.state.value.isChecking)
-            assertTrue(viewModel.state.value.setupCheckFailed)
-            assertFalse(viewModel.state.value.needsLibrarySetup)
-            assertEquals(LibraryReadiness.CheckFailed, viewModel.readiness.value)
+                // Then
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe true
+                viewModel.state.value.setupCheckFailed shouldBe false
+            }
         }
-}
+
+        test("non-admin is never blocked or failed by setup-status") {
+            runTest {
+                // Given - non-admin user; getSetupStatus must never be consulted
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                val regularUser = createTestUser(isAdmin = false)
+                everySuspend { userRepository.refreshCurrentUser() } returns regularUser
+                everySuspend { userRepository.getCurrentUser() } returns regularUser
+
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
+
+                // Then
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe false
+                viewModel.state.value.setupCheckFailed shouldBe false
+            }
+        }
+
+        test("retryLibrarySetupCheck re-runs the check after a transient failure") {
+            runTest {
+                // Given - admin user; first check fails, then the next check succeeds
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
+
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
+                viewModel.state.value.setupCheckFailed shouldBe true
+
+                // Flip the stub to success and retry
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = false, libraryCount = 1))
+
+                // When
+                viewModel.retryLibrarySetupCheck()
+                advanceUntilIdle()
+
+                // Then - failure cleared, check settled, no wizard
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.setupCheckFailed shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe false
+            }
+        }
+
+        test("onAppForegrounded preserves needsLibrarySetup state for short background period") {
+            runTest {
+                // Given - admin user with library needing setup
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Success(SetupStatus(needsSetup = true, libraryCount = 0))
+
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), createMockSyncRepository())
+                advanceUntilIdle()
+
+                // Verify initial state
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe true
+
+                // Simulate short background period
+                viewModel.onAppBackgrounded()
+
+                // When - foreground after short period
+                viewModel.onAppForegrounded()
+                advanceUntilIdle()
+
+                // Then - state preserved, no re-check
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe true
+            }
+        }
+
+        // ========== Offline-first Fallback Tests ==========
+
+        // Regression: a returning admin with a cached local library must NOT be stranded on a
+        // "Library Check Failed" wall when the server is unreachable at startup. The setup check
+        // only matters for a FRESH admin (no library yet). When books exist locally, the VM must
+        // resolve to Ready so the offline library is accessible.
+        test("admin getSetupStatus failure resolves to Ready when a local library exists") {
+            runTest {
+                // Given - admin user, setup-status check fails (server unreachable offline)
+                //         but a library is already cached in local Room
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
+                // hasLocalLibrary = true: returning user with a cached library
+                val syncRepository = createMockSyncRepository(hasLocalLibrary = true)
+
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), syncRepository)
+                advanceUntilIdle()
+
+                // Then - opens offline, NOT stranded on the error wall
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.setupCheckFailed shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe false
+                viewModel.readiness.value shouldBe LibraryReadiness.Ready
+            }
+        }
+
+        // Complement: when there is genuinely no local library (fresh admin, first startup offline),
+        // the retryable error wall is the correct and honest response.
+        test("admin getSetupStatus failure surfaces CheckFailed when no local library exists") {
+            runTest {
+                // Given - admin user, setup-status check fails and no local library
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
+                // hasLocalLibrary = false: fresh admin, no cache yet
+                val syncRepository = createMockSyncRepository(hasLocalLibrary = false)
+
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), syncRepository)
+                advanceUntilIdle()
+
+                // Then - retryable error surfaced (honest over silent for genuine no-library case)
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.setupCheckFailed shouldBe true
+                viewModel.state.value.needsLibrarySetup shouldBe false
+                viewModel.readiness.value shouldBe LibraryReadiness.CheckFailed
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
@@ -12,6 +12,8 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -21,137 +23,123 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import com.calypsan.listenup.core.error.ErrorBus
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class StorageViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+class StorageViewModelTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
 
-    /**
-     * Local fake that overrides [observeDownloadedBooks] with a controllable [MutableStateFlow].
-     * All other DownloadRepository methods are satisfied by [FakeDownloadRepository]'s defaults.
-     */
-    private class StorageViewModelFakeDownloadRepository(
-        initial: List<DownloadedBookSummary> = emptyList(),
-    ) : FakeDownloadRepository() {
-        val downloads = MutableStateFlow(initial)
+        // Local fake that overrides [observeDownloadedBooks] with a controllable [MutableStateFlow].
+        // All other DownloadRepository methods are satisfied by [FakeDownloadRepository]'s defaults.
+        class StorageViewModelFakeDownloadRepository(
+            initial: List<DownloadedBookSummary> = emptyList(),
+        ) : FakeDownloadRepository() {
+            val downloads = MutableStateFlow(initial)
 
-        override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> = downloads
-    }
+            override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> = downloads
+        }
 
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-    }
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
 
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+        class Fixture(
+            val downloadRepository: StorageViewModelFakeDownloadRepository,
+            val downloadService: DownloadService,
+            val storageSpaceProvider: StorageSpaceProvider,
+        )
 
-    private class Fixture(
-        val downloadRepository: StorageViewModelFakeDownloadRepository,
-        val downloadService: DownloadService,
-        val storageSpaceProvider: StorageSpaceProvider,
-    )
-
-    private fun buildVm(
-        downloads: List<DownloadedBookSummary> = emptyList(),
-        totalUsed: Long = 0L,
-        available: Long = 1_000_000L,
-    ): Pair<StorageViewModel, Fixture> {
-        val fixture =
-            Fixture(
-                downloadRepository = StorageViewModelFakeDownloadRepository(downloads),
-                downloadService = mock(),
-                storageSpaceProvider = mock(),
-            )
-        // StorageSpaceProvider is an interface — safely mockable
-        every { fixture.storageSpaceProvider.calculateStorageUsed() } returns totalUsed
-        every { fixture.storageSpaceProvider.getAvailableSpace() } returns available
-        val vm =
-            StorageViewModel(
-                downloadRepository = fixture.downloadRepository,
-                downloadService = fixture.downloadService,
-                storageSpaceProvider = fixture.storageSpaceProvider,
-                errorBus = ErrorBus(),
-            )
-        return vm to fixture
-    }
-
-    @Test
-    fun `state reflects downloaded books from repository`() =
-        runTest {
-            val summary =
-                DownloadedBookSummary(
-                    bookId = "b1",
-                    title = "Book One",
-                    authorNames = "Author A",
-                    coverBlurHash = null,
-                    sizeBytes = 1_000L,
-                    fileCount = 1,
+        fun buildVm(
+            downloads: List<DownloadedBookSummary> = emptyList(),
+            totalUsed: Long = 0L,
+            available: Long = 1_000_000L,
+        ): Pair<StorageViewModel, Fixture> {
+            val fixture =
+                Fixture(
+                    downloadRepository = StorageViewModelFakeDownloadRepository(downloads),
+                    downloadService = mock(),
+                    storageSpaceProvider = mock(),
                 )
-            val (vm, _) = buildVm(downloads = listOf(summary), totalUsed = 1_000L, available = 500L)
-
-            vm.state.test {
-                val first = awaitItem()
-                assertTrue(first.isLoading)
-                val second = awaitItem()
-                assertFalse(second.isLoading)
-                assertEquals(listOf(summary), second.downloadedBooks)
-                assertEquals(1_000L, second.totalStorageUsed)
-                assertEquals(500L, second.availableStorage)
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `confirmDeleteBook then executeDelete calls deleteDownload with matching bookId`() =
-        runTest {
-            val summary =
-                DownloadedBookSummary(
-                    bookId = "b1",
-                    title = "B",
-                    authorNames = "A",
-                    coverBlurHash = null,
-                    sizeBytes = 1L,
-                    fileCount = 1,
+            // StorageSpaceProvider is an interface — safely mockable
+            every { fixture.storageSpaceProvider.calculateStorageUsed() } returns totalUsed
+            every { fixture.storageSpaceProvider.getAvailableSpace() } returns available
+            val vm =
+                StorageViewModel(
+                    downloadRepository = fixture.downloadRepository,
+                    downloadService = fixture.downloadService,
+                    storageSpaceProvider = fixture.storageSpaceProvider,
+                    errorBus = ErrorBus(),
                 )
-            val (vm, fixture) = buildVm(downloads = listOf(summary))
-            everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
+            return vm to fixture
+        }
 
-            vm.state.test {
-                skipItems(2)
-                vm.confirmDeleteBook(summary)
-                vm.executeDelete()
-                advanceUntilIdle()
-                verifySuspend { fixture.downloadService.deleteDownload(BookId("b1")) }
-                cancelAndIgnoreRemainingEvents()
+        test("state reflects downloaded books from repository") {
+            runTest {
+                val summary =
+                    DownloadedBookSummary(
+                        bookId = "b1",
+                        title = "Book One",
+                        authorNames = "Author A",
+                        coverBlurHash = null,
+                        sizeBytes = 1_000L,
+                        fileCount = 1,
+                    )
+                val (vm, _) = buildVm(downloads = listOf(summary), totalUsed = 1_000L, available = 500L)
+
+                vm.state.test {
+                    val first = awaitItem()
+                    first.isLoading shouldBe true
+                    val second = awaitItem()
+                    second.isLoading shouldBe false
+                    second.downloadedBooks shouldBe listOf(summary)
+                    second.totalStorageUsed shouldBe 1_000L
+                    second.availableStorage shouldBe 500L
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
 
-    @Test
-    fun `confirmClearAll then executeDelete calls deleteDownload once per book`() =
-        runTest {
-            val s1 = DownloadedBookSummary("b1", "B1", "A", null, 10L, 1)
-            val s2 = DownloadedBookSummary("b2", "B2", "A", null, 20L, 1)
-            val (vm, fixture) = buildVm(downloads = listOf(s1, s2))
-            everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
+        test("confirmDeleteBook then executeDelete calls deleteDownload with matching bookId") {
+            runTest {
+                val summary =
+                    DownloadedBookSummary(
+                        bookId = "b1",
+                        title = "B",
+                        authorNames = "A",
+                        coverBlurHash = null,
+                        sizeBytes = 1L,
+                        fileCount = 1,
+                    )
+                val (vm, fixture) = buildVm(downloads = listOf(summary))
+                everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
 
-            vm.state.test {
-                skipItems(2)
-                vm.confirmClearAll()
-                vm.executeDelete()
-                advanceUntilIdle()
-                verifySuspend { fixture.downloadService.deleteDownload(BookId("b1")) }
-                verifySuspend { fixture.downloadService.deleteDownload(BookId("b2")) }
-                cancelAndIgnoreRemainingEvents()
+                vm.state.test {
+                    skipItems(2)
+                    vm.confirmDeleteBook(summary)
+                    vm.executeDelete()
+                    advanceUntilIdle()
+                    verifySuspend { fixture.downloadService.deleteDownload(BookId("b1")) }
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
-}
+
+        test("confirmClearAll then executeDelete calls deleteDownload once per book") {
+            runTest {
+                val s1 = DownloadedBookSummary("b1", "B1", "A", null, 10L, 1)
+                val s2 = DownloadedBookSummary("b2", "B2", "A", null, 20L, 1)
+                val (vm, fixture) = buildVm(downloads = listOf(s1, s2))
+                everySuspend { fixture.downloadService.deleteDownload(any()) } returns Unit
+
+                vm.state.test {
+                    skipItems(2)
+                    vm.confirmClearAll()
+                    vm.executeDelete()
+                    advanceUntilIdle()
+                    verifySuspend { fixture.downloadService.deleteDownload(BookId("b1")) }
+                    verifySuspend { fixture.downloadService.deleteDownload(BookId("b2")) }
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## What

Batch 4 of the `kotlin-test` → **Kotest FunSpec** migration (follows #514, #517, #520). All 18 presentation **ViewModel** `commonTest` specs:

admin (`ABSImportHub`, `ABSImportViewModelAnalysisCounts`, `AdminCategories`, `AdminSettings`, `Admin`, `CreateInvite`, `UserDetail`), `connect` (`ServerConnect`, `ServerSelect`), `discover` (`ActivityFeed`, `Discover`), `home`, `nowplaying`, `profile/EditProfile`, `search`, `settings`, `startup/AppStartup`, `storage`.

## How

Pure framework migration — no test logic/values/fixtures/mocks changed.

**Dispatcher lifecycle:** every VM test used `val testDispatcher = StandardTestDispatcher()` + `@BeforeTest { Dispatchers.setMain(testDispatcher) }` + `@AfterTest { Dispatchers.resetMain() }`. Mapped to a closure `val` + `beforeTest { setMain }` + `afterTest { resetMain }` — no `lateinit` (detekt-banned), `@OptIn(ExperimentalCoroutinesApi::class)` kept on each class. `TestFixture` holders and data factories moved into the `FunSpec` lambda; per-test fixture creation preserved. Assertions → Kotest matchers (`assertEquals(expected, actual)` → `actual shouldBe expected`). Turbine `.test { }`, mokkery `verifySuspend`, and `runTest(testDispatcher)` args preserved verbatim.

## Verification

`:sharedLogic:jvmTest` green (a missing `setMain` would make these tests fail loudly), spotless + detekt clean. No production code touched.

## Remaining

~22 `kotlin-test` files left: commonTest repository/infra/fakes/core (~14) and `androidHostTest` (~9, which run on Kotest via the JUnit-platform config). One more batch or two.
