### PR TITLE
✅ test(shared): migrate repository/infra/fake specs to Kotest (batch 5/N)

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/SharedCommonTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/SharedCommonTest.kt
@@ -1,11 +1,11 @@
 package com.calypsan.listenup.client
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class SharedCommonTest {
-    @Test
-    fun example() {
-        assertEquals(3, 1 + 2)
-    }
-}
+class SharedCommonTest :
+    FunSpec({
+        test("example") {
+            (1 + 2) shouldBe 3
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/TestAssertions.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/TestAssertions.kt
@@ -1,11 +1,12 @@
 package com.calypsan.listenup.client
 
-import kotlin.test.assertIs
+import io.kotest.assertions.withClue
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Type assertion that doesn't return a value.
  *
- * Use this instead of [assertIs] when you only need to verify the type
+ * Use this instead of [shouldBeInstanceOf] when you only need to verify the type
  * without using the returned cast value. This avoids "Unused return value"
  * compiler warnings.
  *
@@ -13,10 +14,13 @@ import kotlin.test.assertIs
  * @param value The value to check
  * @param message Optional assertion message
  */
-inline fun <reified T> checkIs(
+inline fun <reified T : Any> checkIs(
     value: Any?,
     message: String? = null,
 ) {
-    @Suppress("UNUSED_VARIABLE")
-    val result = assertIs<T>(value, message)
+    if (message != null) {
+        withClue(message) { value.shouldBeInstanceOf<T>() }
+    } else {
+        value.shouldBeInstanceOf<T>()
+    }
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImplTest.kt
@@ -7,10 +7,10 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
 
 /**
  * Tests for AvatarDownloadRepositoryImpl.
@@ -19,42 +19,43 @@ import kotlin.test.Test
  * correct arguments and that async work fires on the provided scope.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class AvatarDownloadRepositoryImplTest {
-    @Test
-    fun `queueAvatarDownload triggers download with forceRefresh=false`() =
-        runTest {
-            val imageDownloader: ImageDownloaderContract = mock()
-            everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns AppResult.Success(false)
-            val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
+class AvatarDownloadRepositoryImplTest :
+    FunSpec({
+        test("queueAvatarDownload triggers download with forceRefresh=false") {
+            runTest {
+                val imageDownloader: ImageDownloaderContract = mock()
+                everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns AppResult.Success(false)
+                val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
 
-            repo.queueAvatarDownload("user-1")
-            advanceUntilIdle()
+                repo.queueAvatarDownload("user-1")
+                advanceUntilIdle()
 
-            verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = false) }
+                verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = false) }
+            }
         }
 
-    @Test
-    fun `queueAvatarForceRefresh triggers download with forceRefresh=true`() =
-        runTest {
-            val imageDownloader: ImageDownloaderContract = mock()
-            everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns AppResult.Success(true)
-            val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
+        test("queueAvatarForceRefresh triggers download with forceRefresh=true") {
+            runTest {
+                val imageDownloader: ImageDownloaderContract = mock()
+                everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns AppResult.Success(true)
+                val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
 
-            repo.queueAvatarForceRefresh("user-1")
-            advanceUntilIdle()
+                repo.queueAvatarForceRefresh("user-1")
+                advanceUntilIdle()
 
-            verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = true) }
+                verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = true) }
+            }
         }
 
-    @Test
-    fun `deleteAvatar delegates to imageDownloader deleteUserAvatar`() =
-        runTest {
-            val imageDownloader: ImageDownloaderContract = mock()
-            everySuspend { imageDownloader.deleteUserAvatar(any()) } returns AppResult.Success(Unit)
-            val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
+        test("deleteAvatar delegates to imageDownloader deleteUserAvatar") {
+            runTest {
+                val imageDownloader: ImageDownloaderContract = mock()
+                everySuspend { imageDownloader.deleteUserAvatar(any()) } returns AppResult.Success(Unit)
+                val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
 
-            repo.deleteAvatar("user-1")
+                repo.deleteAvatar("user-1")
 
-            verifySuspend { imageDownloader.deleteUserAvatar("user-1") }
+                verifySuspend { imageDownloader.deleteUserAvatar("user-1") }
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepositoryTest.kt
@@ -8,234 +8,231 @@ import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
-class FakeDownloadRepositoryTest {
-    private fun entity(
-        audioFileId: String,
-        bookId: String = "book-1",
-        state: DownloadState = DownloadState.QUEUED,
-        totalBytes: Long = 1000L,
-        downloadedBytes: Long = 0L,
-    ) = DownloadEntity(
-        audioFileId = audioFileId,
-        bookId = bookId,
-        filename = "$audioFileId.mp3",
-        fileIndex = 0,
-        state = state,
-        localPath = null,
-        totalBytes = totalBytes,
-        downloadedBytes = downloadedBytes,
-        queuedAt = 0L,
-        startedAt = null,
-        completedAt = null,
-        errorMessage = null,
-        retryCount = 0,
-    )
+class FakeDownloadRepositoryTest :
+    FunSpec({
+        fun entity(
+            audioFileId: String,
+            bookId: String = "book-1",
+            state: DownloadState = DownloadState.QUEUED,
+            totalBytes: Long = 1000L,
+            downloadedBytes: Long = 0L,
+        ) = DownloadEntity(
+            audioFileId = audioFileId,
+            bookId = bookId,
+            filename = "$audioFileId.mp3",
+            fileIndex = 0,
+            state = state,
+            localPath = null,
+            totalBytes = totalBytes,
+            downloadedBytes = downloadedBytes,
+            queuedAt = 0L,
+            startedAt = null,
+            completedAt = null,
+            errorMessage = null,
+            retryCount = 0,
+        )
 
-    @Test
-    fun `markDownloading transitions state and emits update`() =
-        runTest {
-            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
-            fake.observeForBook(BookId("book-1")).test {
-                assertEquals(DownloadState.QUEUED, awaitItem().single().state)
-                fake.markDownloading("file-1", startedAt = 100L)
-                val downloading = awaitItem().single()
-                assertEquals(DownloadState.DOWNLOADING, downloading.state)
-                assertEquals(100L, downloading.startedAt)
-                cancelAndIgnoreRemainingEvents()
+        test("markDownloading transitions state and emits update") {
+            runTest {
+                val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                fake.observeForBook(BookId("book-1")).test {
+                    awaitItem().single().state shouldBe DownloadState.QUEUED
+                    fake.markDownloading("file-1", startedAt = 100L)
+                    val downloading = awaitItem().single()
+                    downloading.state shouldBe DownloadState.DOWNLOADING
+                    downloading.startedAt shouldBe 100L
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
 
-    @Test
-    fun `updateProgress updates byte counts`() =
-        runTest {
-            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
-            val result = fake.updateProgress("file-1", downloadedBytes = 250L, totalBytes = 1000L)
-            assertIs<AppResult.Success<Unit>>(result)
-            assertEquals(250L, fake.entities.single().downloadedBytes)
-        }
-
-    @Test
-    fun `markCompleted sets state and downloadedBytes equals totalBytes`() =
-        runTest {
-            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
-            fake.markCompleted("file-1", localPath = "/tmp/file-1.mp3", completedAt = 500L)
-            val completed = fake.entities.single()
-            assertEquals(DownloadState.COMPLETED, completed.state)
-            assertEquals("/tmp/file-1.mp3", completed.localPath)
-            assertEquals(500L, completed.completedAt)
-            assertEquals(completed.totalBytes, completed.downloadedBytes)
-        }
-
-    @Test
-    fun `markCancelled writes CANCELLED state`() =
-        runTest {
-            val fake = FakeDownloadRepository(initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)))
-            fake.markCancelled("file-1")
-            assertEquals(DownloadState.CANCELLED, fake.entities.single().state)
-        }
-
-    @Test
-    fun `markFailed sets state and error message`() =
-        runTest {
-            val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
-            fake.markFailed("file-1", DownloadError.DownloadFailed(debugInfo = "test failure"))
-            val failed = fake.entities.single()
-            assertEquals(DownloadState.FAILED, failed.state)
-            assertTrue(failed.errorMessage?.contains("Download") == true)
-        }
-
-    @Test
-    fun `enqueueForBook returns Started by default`() =
-        runTest {
-            val fake = FakeDownloadRepository()
-            val result = fake.enqueueForBook(BookId("book-1"))
-            assertIs<AppResult.Success<DownloadOutcome>>(result)
-            assertEquals(DownloadOutcome.Started, result.data)
-        }
-
-    @Test
-    fun `enqueueForBook respects injected failure`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    enqueueFailure = { _ ->
-                        AppResult.Success(DownloadOutcome.InsufficientStorage(requiredBytes = 1000, availableBytes = 500))
-                    },
-                )
-            val result = fake.enqueueForBook(BookId("book-1"))
-            assertIs<AppResult.Success<DownloadOutcome>>(result)
-            assertIs<DownloadOutcome.InsufficientStorage>(result.data)
-        }
-
-    @Test
-    fun `aggregator returns NotDownloaded for empty book`() =
-        runTest {
-            val fake = FakeDownloadRepository()
-            fake.observeBookStatus(BookId("book-1")).test {
-                assertIs<BookDownloadStatus.NotDownloaded>(awaitItem())
-                cancelAndIgnoreRemainingEvents()
+        test("updateProgress updates byte counts") {
+            runTest {
+                val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                val result = fake.updateProgress("file-1", downloadedBytes = 250L, totalBytes = 1000L)
+                result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                fake.entities.single().downloadedBytes shouldBe 250L
             }
         }
 
-    @Test
-    fun `aggregator returns Completed when all files complete`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", state = DownloadState.COMPLETED, downloadedBytes = 1000L),
-                            entity("file-2", state = DownloadState.COMPLETED, downloadedBytes = 1000L),
-                        ),
-                )
-            fake.observeBookStatus(BookId("book-1")).test {
-                val status = awaitItem()
-                assertIs<BookDownloadStatus.Completed>(status)
-                assertEquals(2000L, status.totalBytes)
-                cancelAndIgnoreRemainingEvents()
+        test("markCompleted sets state and downloadedBytes equals totalBytes") {
+            runTest {
+                val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                fake.markCompleted("file-1", localPath = "/tmp/file-1.mp3", completedAt = 500L)
+                val completed = fake.entities.single()
+                completed.state shouldBe DownloadState.COMPLETED
+                completed.localPath shouldBe "/tmp/file-1.mp3"
+                completed.completedAt shouldBe 500L
+                completed.downloadedBytes shouldBe completed.totalBytes
             }
         }
 
-    @Test
-    fun `aggregator returns Failed when any file failed`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", state = DownloadState.COMPLETED),
-                            entity("file-2", state = DownloadState.FAILED),
-                        ),
-                )
-            fake.observeBookStatus(BookId("book-1")).test {
-                val status = awaitItem()
-                assertIs<BookDownloadStatus.Failed>(status)
-                assertEquals(1, status.partiallyDownloadedFiles)
-                cancelAndIgnoreRemainingEvents()
+        test("markCancelled writes CANCELLED state") {
+            runTest {
+                val fake = FakeDownloadRepository(initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)))
+                fake.markCancelled("file-1")
+                fake.entities.single().state shouldBe DownloadState.CANCELLED
             }
         }
 
-    @Test
-    fun `aggregator returns InProgress for mixed downloading and queued`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", state = DownloadState.DOWNLOADING, downloadedBytes = 500L),
-                            entity("file-2", state = DownloadState.QUEUED),
-                        ),
-                )
-            fake.observeBookStatus(BookId("book-1")).test {
-                val status = awaitItem()
-                assertIs<BookDownloadStatus.InProgress>(status)
-                assertEquals(1, status.downloadingFiles)
-                assertEquals(2, status.totalFiles)
-                assertEquals(500L, status.downloadedBytes)
-                cancelAndIgnoreRemainingEvents()
+        test("markFailed sets state and error message") {
+            runTest {
+                val fake = FakeDownloadRepository(initial = listOf(entity("file-1")))
+                fake.markFailed("file-1", DownloadError.DownloadFailed(debugInfo = "test failure"))
+                val failed = fake.entities.single()
+                failed.state shouldBe DownloadState.FAILED
+                (failed.errorMessage?.contains("Download") == true) shouldBe true
             }
         }
 
-    @Test
-    fun `aggregator returns Paused when all files paused`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", state = DownloadState.PAUSED, downloadedBytes = 100L),
-                            entity("file-2", state = DownloadState.PAUSED, downloadedBytes = 200L),
-                        ),
-                )
-            fake.observeBookStatus(BookId("book-1")).test {
-                val status = awaitItem()
-                assertIs<BookDownloadStatus.Paused>(status)
-                assertEquals(2, status.pausedFiles)
-                assertEquals(300L, status.downloadedBytes)
-                cancelAndIgnoreRemainingEvents()
+        test("enqueueForBook returns Started by default") {
+            runTest {
+                val fake = FakeDownloadRepository()
+                val result = fake.enqueueForBook(BookId("book-1"))
+                result.shouldBeInstanceOf<AppResult.Success<DownloadOutcome>>()
+                result.data shouldBe DownloadOutcome.Started
             }
         }
 
-    @Test
-    fun `getLocalPath returns null for non-completed file`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)),
-                )
-            assertNull(fake.getLocalPath("file-1"))
+        test("enqueueForBook respects injected failure") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        enqueueFailure = { _ ->
+                            AppResult.Success(
+                                DownloadOutcome.InsufficientStorage(requiredBytes = 1000, availableBytes = 500),
+                            )
+                        },
+                    )
+                val result = fake.enqueueForBook(BookId("book-1"))
+                result.shouldBeInstanceOf<AppResult.Success<DownloadOutcome>>()
+                result.data.shouldBeInstanceOf<DownloadOutcome.InsufficientStorage>()
+            }
         }
 
-    @Test
-    fun `getLocalPath returns path for completed file`() =
-        runTest {
-            val fake = FakeDownloadRepository()
-            fake.seed(
-                entity("file-1", state = DownloadState.COMPLETED).copy(localPath = "/tmp/file-1.mp3"),
-            )
-            assertEquals("/tmp/file-1.mp3", fake.getLocalPath("file-1"))
+        test("aggregator returns NotDownloaded for empty book") {
+            runTest {
+                val fake = FakeDownloadRepository()
+                fake.observeBookStatus(BookId("book-1")).test {
+                    awaitItem().shouldBeInstanceOf<BookDownloadStatus.NotDownloaded>()
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
         }
 
-    @Test
-    fun `deleteForBook removes all entities for that book`() =
-        runTest {
-            val fake =
-                FakeDownloadRepository(
-                    initial =
-                        listOf(
-                            entity("file-1", bookId = "book-1"),
-                            entity("file-2", bookId = "book-2"),
-                        ),
-                )
-            fake.deleteForBook("book-1")
-            assertEquals(1, fake.entities.size)
-            assertEquals("book-2", fake.entities.single().bookId)
+        test("aggregator returns Completed when all files complete") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", state = DownloadState.COMPLETED, downloadedBytes = 1000L),
+                                entity("file-2", state = DownloadState.COMPLETED, downloadedBytes = 1000L),
+                            ),
+                    )
+                fake.observeBookStatus(BookId("book-1")).test {
+                    val status = awaitItem().shouldBeInstanceOf<BookDownloadStatus.Completed>()
+                    status.totalBytes shouldBe 2000L
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
         }
-}
+
+        test("aggregator returns Failed when any file failed") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", state = DownloadState.COMPLETED),
+                                entity("file-2", state = DownloadState.FAILED),
+                            ),
+                    )
+                fake.observeBookStatus(BookId("book-1")).test {
+                    val status = awaitItem().shouldBeInstanceOf<BookDownloadStatus.Failed>()
+                    status.partiallyDownloadedFiles shouldBe 1
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("aggregator returns InProgress for mixed downloading and queued") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", state = DownloadState.DOWNLOADING, downloadedBytes = 500L),
+                                entity("file-2", state = DownloadState.QUEUED),
+                            ),
+                    )
+                fake.observeBookStatus(BookId("book-1")).test {
+                    val status = awaitItem().shouldBeInstanceOf<BookDownloadStatus.InProgress>()
+                    status.downloadingFiles shouldBe 1
+                    status.totalFiles shouldBe 2
+                    status.downloadedBytes shouldBe 500L
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("aggregator returns Paused when all files paused") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", state = DownloadState.PAUSED, downloadedBytes = 100L),
+                                entity("file-2", state = DownloadState.PAUSED, downloadedBytes = 200L),
+                            ),
+                    )
+                fake.observeBookStatus(BookId("book-1")).test {
+                    val status = awaitItem().shouldBeInstanceOf<BookDownloadStatus.Paused>()
+                    status.pausedFiles shouldBe 2
+                    status.downloadedBytes shouldBe 300L
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("getLocalPath returns null for non-completed file") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)),
+                    )
+                fake.getLocalPath("file-1") shouldBe null
+            }
+        }
+
+        test("getLocalPath returns path for completed file") {
+            runTest {
+                val fake = FakeDownloadRepository()
+                fake.seed(
+                    entity("file-1", state = DownloadState.COMPLETED).copy(localPath = "/tmp/file-1.mp3"),
+                )
+                fake.getLocalPath("file-1") shouldBe "/tmp/file-1.mp3"
+            }
+        }
+
+        test("deleteForBook removes all entities for that book") {
+            runTest {
+                val fake =
+                    FakeDownloadRepository(
+                        initial =
+                            listOf(
+                                entity("file-1", bookId = "book-1"),
+                                entity("file-2", bookId = "book-2"),
+                            ),
+                    )
+                fake.deleteForBook("book-1")
+                fake.entities.size shouldBe 1
+                fake.entities.single().bookId shouldBe "book-2"
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/MetadataRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/MetadataRepositoryImplTest.kt
@@ -19,11 +19,11 @@ import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CancellationException
-import kotlin.test.assertFailsWith
 
 /**
  * Unit tests for [MetadataRepositoryImpl].
@@ -67,7 +67,7 @@ class MetadataRepositoryImplTest :
             val service = mock<MetadataLookupService>()
             everySuspend { service.searchBooks(any(), any()) } throws CancellationException("cancelled")
 
-            assertFailsWith<CancellationException> {
+            shouldThrow<CancellationException> {
                 buildRepo(service).searchBooks("q", AudibleRegion.US)
             }
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserRepositoryImplTest.kt
@@ -15,6 +15,9 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -22,12 +25,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Tests for UserRepositoryImpl.
@@ -41,848 +38,836 @@ import kotlin.test.assertTrue
  * Uses Mokkery for mocking UserDao and follows Given-When-Then style.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class UserRepositoryImplTest {
-    // ========== Test Data Factories ==========
+class UserRepositoryImplTest :
+    FunSpec({
+        // ========== Test Data Factories ==========
 
-    /**
-     * Creates a test UserEntity with all fields populated.
-     * Provides sensible defaults while allowing field overrides for specific test scenarios.
-     */
-    private fun createTestUserEntity(
-        id: String = "user-001",
-        email: String = "test@example.com",
-        displayName: String = "Test User",
-        firstName: String? = "Test",
-        lastName: String? = "User",
-        isRoot: Boolean = false,
-        avatarType: String = "auto",
-        avatarValue: String? = null,
-        avatarColor: String = "#3B82F6",
-        tagline: String? = "Audiobook enthusiast",
-        createdAt: Long = 1704067200000L, // 2024-01-01 00:00:00 UTC
-        updatedAt: Long = 1704153600000L, // 2024-01-02 00:00:00 UTC
-    ): UserEntity =
-        UserEntity(
-            id =
-                UserId(id),
-            email = email,
-            displayName = displayName,
-            firstName = firstName,
-            lastName = lastName,
-            isRoot = isRoot,
-            avatarType = avatarType,
-            avatarValue = avatarValue,
-            avatarColor = avatarColor,
-            tagline = tagline,
-            createdAt =
-                com.calypsan.listenup.core
-                    .Timestamp(createdAt),
-            updatedAt =
-                com.calypsan.listenup.core
-                    .Timestamp(updatedAt),
-        )
+        // Creates a test UserEntity with all fields populated.
+        // Provides sensible defaults while allowing field overrides for specific test scenarios.
+        fun createTestUserEntity(
+            id: String = "user-001",
+            email: String = "test@example.com",
+            displayName: String = "Test User",
+            firstName: String? = "Test",
+            lastName: String? = "User",
+            isRoot: Boolean = false,
+            avatarType: String = "auto",
+            avatarValue: String? = null,
+            avatarColor: String = "#3B82F6",
+            tagline: String? = "Audiobook enthusiast",
+            createdAt: Long = 1704067200000L, // 2024-01-01 00:00:00 UTC
+            updatedAt: Long = 1704153600000L, // 2024-01-02 00:00:00 UTC
+        ): UserEntity =
+            UserEntity(
+                id =
+                    UserId(id),
+                email = email,
+                displayName = displayName,
+                firstName = firstName,
+                lastName = lastName,
+                isRoot = isRoot,
+                avatarType = avatarType,
+                avatarValue = avatarValue,
+                avatarColor = avatarColor,
+                tagline = tagline,
+                createdAt =
+                    com.calypsan.listenup.core
+                        .Timestamp(createdAt),
+                updatedAt =
+                    com.calypsan.listenup.core
+                        .Timestamp(updatedAt),
+            )
 
-    private fun createMockUserDao(): UserDao = mock<UserDao>()
+        fun createMockUserDao(): UserDao = mock<UserDao>()
 
-    private fun createMockAuthRpcFactory(): AuthRpcFactory = mock<AuthRpcFactory>()
+        fun createMockAuthRpcFactory(): AuthRpcFactory = mock<AuthRpcFactory>()
 
-    // ========== observeCurrentUser Tests ==========
+        // ========== observeCurrentUser Tests ==========
 
-    @Test
-    fun `observeCurrentUser emits User when user exists`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity()
-            every { userDao.observeCurrentUser() } returns flowOf(entity)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeCurrentUser emits User when user exists") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity()
+                every { userDao.observeCurrentUser() } returns flowOf(entity)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.observeCurrentUser().first()
+                // When
+                val user = repository.observeCurrentUser().first().shouldNotBeNull()
 
-            // Then
-            assertNotNull(user)
-            assertEquals("user-001", user.id.value)
-            assertEquals("test@example.com", user.email)
-            assertEquals("Test User", user.displayName)
+                // Then
+                user.id.value shouldBe "user-001"
+                user.email shouldBe "test@example.com"
+                user.displayName shouldBe "Test User"
+            }
         }
 
-    @Test
-    fun `observeCurrentUser emits null when no user exists`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            every { userDao.observeCurrentUser() } returns flowOf(null)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeCurrentUser emits null when no user exists") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                every { userDao.observeCurrentUser() } returns flowOf(null)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.observeCurrentUser().first()
+                // When
+                val user = repository.observeCurrentUser().first()
 
-            // Then
-            assertNull(user)
+                // Then
+                user shouldBe null
+            }
         }
 
-    @Test
-    fun `observeCurrentUser emits changes when user updates`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val initialUser = createTestUserEntity(displayName = "Initial Name")
-            val updatedUser = createTestUserEntity(displayName = "Updated Name")
-            // Flow emits null -> user1 -> user2 -> null
-            every { userDao.observeCurrentUser() } returns flowOf(null, initialUser, updatedUser, null)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeCurrentUser emits changes when user updates") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val initialUser = createTestUserEntity(displayName = "Initial Name")
+                val updatedUser = createTestUserEntity(displayName = "Updated Name")
+                // Flow emits null -> user1 -> user2 -> null
+                every { userDao.observeCurrentUser() } returns flowOf(null, initialUser, updatedUser, null)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val emissions = repository.observeCurrentUser().take(4).toList()
+                // When
+                val emissions = repository.observeCurrentUser().take(4).toList()
 
-            // Then
-            assertNull(emissions[0])
-            assertEquals("Initial Name", emissions[1]?.displayName)
-            assertEquals("Updated Name", emissions[2]?.displayName)
-            assertNull(emissions[3])
+                // Then
+                emissions[0] shouldBe null
+                emissions[1]?.displayName shouldBe "Initial Name"
+                emissions[2]?.displayName shouldBe "Updated Name"
+                emissions[3] shouldBe null
+            }
         }
 
-    // ========== observeIsAdmin Tests ==========
+        // ========== observeIsAdmin Tests ==========
 
-    @Test
-    fun `observeIsAdmin emits true when user isRoot is true`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(isRoot = true)
-            every { userDao.observeCurrentUser() } returns flowOf(entity)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeIsAdmin emits true when user isRoot is true") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(isRoot = true)
+                every { userDao.observeCurrentUser() } returns flowOf(entity)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val isAdmin = repository.observeIsAdmin().first()
+                // When
+                val isAdmin = repository.observeIsAdmin().first()
 
-            // Then
-            assertTrue(isAdmin)
+                // Then
+                isAdmin shouldBe true
+            }
         }
 
-    @Test
-    fun `observeIsAdmin emits false when user isRoot is false`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(isRoot = false)
-            every { userDao.observeCurrentUser() } returns flowOf(entity)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeIsAdmin emits false when user isRoot is false") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(isRoot = false)
+                every { userDao.observeCurrentUser() } returns flowOf(entity)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val isAdmin = repository.observeIsAdmin().first()
+                // When
+                val isAdmin = repository.observeIsAdmin().first()
 
-            // Then
-            assertFalse(isAdmin)
+                // Then
+                isAdmin shouldBe false
+            }
         }
 
-    @Test
-    fun `observeIsAdmin emits false when user is null`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            every { userDao.observeCurrentUser() } returns flowOf(null)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeIsAdmin emits false when user is null") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                every { userDao.observeCurrentUser() } returns flowOf(null)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val isAdmin = repository.observeIsAdmin().first()
+                // When
+                val isAdmin = repository.observeIsAdmin().first()
 
-            // Then
-            assertFalse(isAdmin)
+                // Then
+                isAdmin shouldBe false
+            }
         }
 
-    @Test
-    fun `observeIsAdmin emits changes when admin status changes`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val regularUser = createTestUserEntity(isRoot = false)
-            val adminUser = createTestUserEntity(isRoot = true)
-            // Flow: null -> regular -> admin -> regular
-            every { userDao.observeCurrentUser() } returns flowOf(null, regularUser, adminUser, regularUser)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeIsAdmin emits changes when admin status changes") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val regularUser = createTestUserEntity(isRoot = false)
+                val adminUser = createTestUserEntity(isRoot = true)
+                // Flow: null -> regular -> admin -> regular
+                every { userDao.observeCurrentUser() } returns flowOf(null, regularUser, adminUser, regularUser)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val emissions = repository.observeIsAdmin().take(4).toList()
+                // When
+                val emissions = repository.observeIsAdmin().take(4).toList()
 
-            // Then
-            assertFalse(emissions[0]) // null user -> not admin
-            assertFalse(emissions[1]) // regular user -> not admin
-            assertTrue(emissions[2]) // admin user -> admin
-            assertFalse(emissions[3]) // demoted -> not admin
+                // Then
+                emissions[0] shouldBe false // null user -> not admin
+                emissions[1] shouldBe false // regular user -> not admin
+                emissions[2] shouldBe true // admin user -> admin
+                emissions[3] shouldBe false // demoted -> not admin
+            }
         }
 
-    @Test
-    fun `observeIsAdmin reacts to MutableStateFlow changes`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val userFlow = MutableStateFlow<UserEntity?>(null)
-            every { userDao.observeCurrentUser() } returns userFlow
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeIsAdmin reacts to MutableStateFlow changes") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val userFlow = MutableStateFlow<UserEntity?>(null)
+                every { userDao.observeCurrentUser() } returns userFlow
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When/Then - initial state
-            assertFalse(repository.observeIsAdmin().first())
+                // When/Then - initial state
+                repository.observeIsAdmin().first() shouldBe false
 
-            // When/Then - user becomes admin
-            userFlow.value = createTestUserEntity(isRoot = true)
-            assertTrue(repository.observeIsAdmin().first())
+                // When/Then - user becomes admin
+                userFlow.value = createTestUserEntity(isRoot = true)
+                repository.observeIsAdmin().first() shouldBe true
 
-            // When/Then - user demoted
-            userFlow.value = createTestUserEntity(isRoot = false)
-            assertFalse(repository.observeIsAdmin().first())
+                // When/Then - user demoted
+                userFlow.value = createTestUserEntity(isRoot = false)
+                repository.observeIsAdmin().first() shouldBe false
 
-            // When/Then - user logs out
-            userFlow.value = null
-            assertFalse(repository.observeIsAdmin().first())
+                // When/Then - user logs out
+                userFlow.value = null
+                repository.observeIsAdmin().first() shouldBe false
+            }
         }
 
-    // ========== getCurrentUser Tests ==========
+        // ========== getCurrentUser Tests ==========
 
-    @Test
-    fun `getCurrentUser returns User when user exists`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity()
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("getCurrentUser returns User when user exists") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity()
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser().shouldNotBeNull()
 
-            // Then
-            assertNotNull(user)
-            assertEquals("user-001", user.id.value)
-            assertEquals("test@example.com", user.email)
+                // Then
+                user.id.value shouldBe "user-001"
+                user.email shouldBe "test@example.com"
+            }
         }
 
-    @Test
-    fun `getCurrentUser returns null when no user exists`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            everySuspend { userDao.getCurrentUser() } returns null
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("getCurrentUser returns null when no user exists") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                everySuspend { userDao.getCurrentUser() } returns null
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertNull(user)
+                // Then
+                user shouldBe null
+            }
         }
 
-    // ========== refreshCurrentUser (RPC) Tests ==========
+        // ========== refreshCurrentUser (RPC) Tests ==========
 
-    @Test
-    fun `refreshCurrentUser fetches the user via RPC AuthServiceAuthed and persists it`() =
-        runTest {
-            // Given - the authed RPC proxy returns a ROOT user
-            val userDao = createMockUserDao()
-            everySuspend { userDao.upsert(any()) } returns Unit
-            val authed = mock<AuthServiceAuthed>()
-            everySuspend { authed.currentUser() } returns
-                AppResult.Success(
-                    ContractUser(
-                        id = UserId("root-1"),
-                        email = "root@example.com",
-                        displayName = "Root Admin",
-                        role = UserRole.ROOT,
-                        status = UserStatus.ACTIVE,
-                        createdAt = 1_700_000_000_000L,
-                    ),
-                )
-            val authRpcFactory = createMockAuthRpcFactory()
-            everySuspend { authRpcFactory.authedService() } returns authed
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("refreshCurrentUser fetches the user via RPC AuthServiceAuthed and persists it") {
+            runTest {
+                // Given - the authed RPC proxy returns a ROOT user
+                val userDao = createMockUserDao()
+                everySuspend { userDao.upsert(any()) } returns Unit
+                val authed = mock<AuthServiceAuthed>()
+                everySuspend { authed.currentUser() } returns
+                    AppResult.Success(
+                        ContractUser(
+                            id = UserId("root-1"),
+                            email = "root@example.com",
+                            displayName = "Root Admin",
+                            role = UserRole.ROOT,
+                            status = UserStatus.ACTIVE,
+                            createdAt = 1_700_000_000_000L,
+                        ),
+                    )
+                val authRpcFactory = createMockAuthRpcFactory()
+                everySuspend { authRpcFactory.authedService() } returns authed
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.refreshCurrentUser()
+                // When
+                val user = repository.refreshCurrentUser().shouldNotBeNull()
 
-            // Then - ROOT maps to admin and the user is persisted to Room
-            assertNotNull(user)
-            assertEquals("root@example.com", user.email)
-            assertTrue(user.isAdmin)
-            verifySuspend { userDao.upsert(any()) }
+                // Then - ROOT maps to admin and the user is persisted to Room
+                user.email shouldBe "root@example.com"
+                user.isAdmin shouldBe true
+                verifySuspend { userDao.upsert(any()) }
+            }
         }
 
-    @Test
-    fun `refreshCurrentUser returns null when the RPC call fails`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val authed = mock<AuthServiceAuthed>()
-            everySuspend { authed.currentUser() } returns
-                AppResult.Failure(
-                    com.calypsan.listenup.api.error.TransportError
-                        .NetworkUnavailable(),
-                )
-            val authRpcFactory = createMockAuthRpcFactory()
-            everySuspend { authRpcFactory.authedService() } returns authed
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("refreshCurrentUser returns null when the RPC call fails") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val authed = mock<AuthServiceAuthed>()
+                everySuspend { authed.currentUser() } returns
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error.TransportError
+                            .NetworkUnavailable(),
+                    )
+                val authRpcFactory = createMockAuthRpcFactory()
+                everySuspend { authRpcFactory.authedService() } returns authed
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.refreshCurrentUser()
+                // When
+                val user = repository.refreshCurrentUser()
 
-            // Then
-            assertNull(user)
+                // Then
+                user shouldBe null
+            }
         }
 
-    // ========== Entity to Domain Conversion Tests ==========
+        // ========== Entity to Domain Conversion Tests ==========
 
-    @Test
-    fun `toDomain converts id correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(id = "unique-user-id-123")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts id correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(id = "unique-user-id-123")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("unique-user-id-123", user?.id?.value)
+                // Then
+                user?.id?.value shouldBe "unique-user-id-123"
+            }
         }
 
-    @Test
-    fun `toDomain converts email correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(email = "user@listenup.app")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts email correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(email = "user@listenup.app")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("user@listenup.app", user?.email)
+                // Then
+                user?.email shouldBe "user@listenup.app"
+            }
         }
 
-    @Test
-    fun `toDomain converts displayName correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(displayName = "Bookworm Betty")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts displayName correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(displayName = "Bookworm Betty")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("Bookworm Betty", user?.displayName)
+                // Then
+                user?.displayName shouldBe "Bookworm Betty"
+            }
         }
 
-    @Test
-    fun `toDomain converts firstName correctly when present`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(firstName = "Elizabeth")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts firstName correctly when present") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(firstName = "Elizabeth")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("Elizabeth", user?.firstName)
+                // Then
+                user?.firstName shouldBe "Elizabeth"
+            }
         }
 
-    @Test
-    fun `toDomain converts firstName correctly when null`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(firstName = null)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts firstName correctly when null") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(firstName = null)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertNull(user?.firstName)
+                // Then
+                user?.firstName shouldBe null
+            }
         }
 
-    @Test
-    fun `toDomain converts lastName correctly when present`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(lastName = "Bennet")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts lastName correctly when present") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(lastName = "Bennet")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("Bennet", user?.lastName)
+                // Then
+                user?.lastName shouldBe "Bennet"
+            }
         }
 
-    @Test
-    fun `toDomain converts lastName correctly when null`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(lastName = null)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts lastName correctly when null") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(lastName = null)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertNull(user?.lastName)
+                // Then
+                user?.lastName shouldBe null
+            }
         }
 
-    @Test
-    fun `toDomain converts isRoot to isAdmin correctly when true`() =
-        runTest {
-            // Given - entity uses isRoot, domain uses isAdmin
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(isRoot = true)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts isRoot to isAdmin correctly when true") {
+            runTest {
+                // Given - entity uses isRoot, domain uses isAdmin
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(isRoot = true)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertTrue(user?.isAdmin == true)
+                // Then
+                (user?.isAdmin == true) shouldBe true
+            }
         }
 
-    @Test
-    fun `toDomain converts isRoot to isAdmin correctly when false`() =
-        runTest {
-            // Given - entity uses isRoot, domain uses isAdmin
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(isRoot = false)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts isRoot to isAdmin correctly when false") {
+            runTest {
+                // Given - entity uses isRoot, domain uses isAdmin
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(isRoot = false)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertFalse(user?.isAdmin == true)
+                // Then
+                (user?.isAdmin == true) shouldBe false
+            }
         }
 
-    @Test
-    fun `toDomain converts avatarType correctly for auto avatar`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(avatarType = "auto")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts avatarType correctly for auto avatar") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(avatarType = "auto")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("auto", user?.avatarType)
+                // Then
+                user?.avatarType shouldBe "auto"
+            }
         }
 
-    @Test
-    fun `toDomain converts avatarType correctly for image avatar`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(avatarType = "image")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts avatarType correctly for image avatar") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(avatarType = "image")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("image", user?.avatarType)
+                // Then
+                user?.avatarType shouldBe "image"
+            }
         }
 
-    @Test
-    fun `toDomain converts avatarValue correctly when present`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity =
-                createTestUserEntity(
-                    avatarType = "image",
-                    avatarValue = "/avatars/user-001.jpg",
-                )
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts avatarValue correctly when present") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity =
+                    createTestUserEntity(
+                        avatarType = "image",
+                        avatarValue = "/avatars/user-001.jpg",
+                    )
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("/avatars/user-001.jpg", user?.avatarValue)
+                // Then
+                user?.avatarValue shouldBe "/avatars/user-001.jpg"
+            }
         }
 
-    @Test
-    fun `toDomain converts avatarValue correctly when null`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(avatarValue = null)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts avatarValue correctly when null") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(avatarValue = null)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertNull(user?.avatarValue)
+                // Then
+                user?.avatarValue shouldBe null
+            }
         }
 
-    @Test
-    fun `toDomain converts avatarColor correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(avatarColor = "#EF4444")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts avatarColor correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(avatarColor = "#EF4444")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("#EF4444", user?.avatarColor)
+                // Then
+                user?.avatarColor shouldBe "#EF4444"
+            }
         }
 
-    @Test
-    fun `toDomain converts tagline correctly when present`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(tagline = "Fantasy is my escape")
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts tagline correctly when present") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(tagline = "Fantasy is my escape")
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals("Fantasy is my escape", user?.tagline)
+                // Then
+                user?.tagline shouldBe "Fantasy is my escape"
+            }
         }
 
-    @Test
-    fun `toDomain converts tagline correctly when null`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity = createTestUserEntity(tagline = null)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts tagline correctly when null") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity = createTestUserEntity(tagline = null)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertNull(user?.tagline)
+                // Then
+                user?.tagline shouldBe null
+            }
         }
 
-    @Test
-    fun `toDomain converts createdAt to createdAtMs correctly`() =
-        runTest {
-            // Given - entity uses createdAt, domain uses createdAtMs
-            val userDao = createMockUserDao()
-            val timestamp = 1704067200000L // 2024-01-01 00:00:00 UTC
-            val entity = createTestUserEntity(createdAt = timestamp)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts createdAt to createdAtMs correctly") {
+            runTest {
+                // Given - entity uses createdAt, domain uses createdAtMs
+                val userDao = createMockUserDao()
+                val timestamp = 1704067200000L // 2024-01-01 00:00:00 UTC
+                val entity = createTestUserEntity(createdAt = timestamp)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals(timestamp, user?.createdAtMs)
+                // Then
+                user?.createdAtMs shouldBe timestamp
+            }
         }
 
-    @Test
-    fun `toDomain converts updatedAt to updatedAtMs correctly`() =
-        runTest {
-            // Given - entity uses updatedAt, domain uses updatedAtMs
-            val userDao = createMockUserDao()
-            val timestamp = 1704153600000L // 2024-01-02 00:00:00 UTC
-            val entity = createTestUserEntity(updatedAt = timestamp)
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts updatedAt to updatedAtMs correctly") {
+            runTest {
+                // Given - entity uses updatedAt, domain uses updatedAtMs
+                val userDao = createMockUserDao()
+                val timestamp = 1704153600000L // 2024-01-02 00:00:00 UTC
+                val entity = createTestUserEntity(updatedAt = timestamp)
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser()
 
-            // Then
-            assertEquals(timestamp, user?.updatedAtMs)
+                // Then
+                user?.updatedAtMs shouldBe timestamp
+            }
         }
 
-    @Test
-    fun `toDomain converts all fields correctly in comprehensive test`() =
-        runTest {
-            // Given - test all fields together to ensure complete conversion
-            val userDao = createMockUserDao()
-            val entity =
-                UserEntity(
-                    id =
-                        UserId("admin-user-42"),
-                    email = "admin@listenup.app",
-                    displayName = "Admin Alice",
-                    firstName = "Alice",
-                    lastName = "Administrator",
-                    isRoot = true,
-                    avatarType = "image",
-                    avatarValue = "/avatars/admin.png",
-                    avatarColor = "#10B981",
-                    tagline = "Keeping things running smoothly",
-                    createdAt =
-                        com.calypsan.listenup.core
-                            .Timestamp(1700000000000L),
-                    updatedAt =
-                        com.calypsan.listenup.core
-                            .Timestamp(1705000000000L),
-                )
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain converts all fields correctly in comprehensive test") {
+            runTest {
+                // Given - test all fields together to ensure complete conversion
+                val userDao = createMockUserDao()
+                val entity =
+                    UserEntity(
+                        id =
+                            UserId("admin-user-42"),
+                        email = "admin@listenup.app",
+                        displayName = "Admin Alice",
+                        firstName = "Alice",
+                        lastName = "Administrator",
+                        isRoot = true,
+                        avatarType = "image",
+                        avatarValue = "/avatars/admin.png",
+                        avatarColor = "#10B981",
+                        tagline = "Keeping things running smoothly",
+                        createdAt =
+                            com.calypsan.listenup.core
+                                .Timestamp(1700000000000L),
+                        updatedAt =
+                            com.calypsan.listenup.core
+                                .Timestamp(1705000000000L),
+                    )
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser().shouldNotBeNull()
 
-            // Then - verify every field is correctly mapped
-            assertNotNull(user)
-            assertEquals("admin-user-42", user.id.value)
-            assertEquals("admin@listenup.app", user.email)
-            assertEquals("Admin Alice", user.displayName)
-            assertEquals("Alice", user.firstName)
-            assertEquals("Administrator", user.lastName)
-            assertTrue(user.isAdmin)
-            assertEquals("image", user.avatarType)
-            assertEquals("/avatars/admin.png", user.avatarValue)
-            assertEquals("#10B981", user.avatarColor)
-            assertEquals("Keeping things running smoothly", user.tagline)
-            assertEquals(1700000000000L, user.createdAtMs)
-            assertEquals(1705000000000L, user.updatedAtMs)
+                // Then - verify every field is correctly mapped
+                user.id.value shouldBe "admin-user-42"
+                user.email shouldBe "admin@listenup.app"
+                user.displayName shouldBe "Admin Alice"
+                user.firstName shouldBe "Alice"
+                user.lastName shouldBe "Administrator"
+                user.isAdmin shouldBe true
+                user.avatarType shouldBe "image"
+                user.avatarValue shouldBe "/avatars/admin.png"
+                user.avatarColor shouldBe "#10B981"
+                user.tagline shouldBe "Keeping things running smoothly"
+                user.createdAtMs shouldBe 1700000000000L
+                user.updatedAtMs shouldBe 1705000000000L
+            }
         }
 
-    // ========== Edge Cases ==========
+        // ========== Edge Cases ==========
 
-    @Test
-    fun `toDomain handles empty strings correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity =
-                createTestUserEntity(
-                    displayName = "",
-                    email = "",
-                    avatarColor = "",
-                )
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain handles empty strings correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity =
+                    createTestUserEntity(
+                        displayName = "",
+                        email = "",
+                        avatarColor = "",
+                    )
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser().shouldNotBeNull()
 
-            // Then
-            assertNotNull(user)
-            assertEquals("", user.displayName)
-            assertEquals("", user.email)
-            assertEquals("", user.avatarColor)
+                // Then
+                user.displayName shouldBe ""
+                user.email shouldBe ""
+                user.avatarColor shouldBe ""
+            }
         }
 
-    @Test
-    fun `toDomain handles zero timestamps correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val entity =
-                createTestUserEntity(
-                    createdAt = 0L,
-                    updatedAt = 0L,
-                )
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain handles zero timestamps correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val entity =
+                    createTestUserEntity(
+                        createdAt = 0L,
+                        updatedAt = 0L,
+                    )
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser().shouldNotBeNull()
 
-            // Then
-            assertNotNull(user)
-            assertEquals(0L, user.createdAtMs)
-            assertEquals(0L, user.updatedAtMs)
+                // Then
+                user.createdAtMs shouldBe 0L
+                user.updatedAtMs shouldBe 0L
+            }
         }
 
-    @Test
-    fun `toDomain handles maximum timestamp values correctly`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val maxTimestamp = Long.MAX_VALUE
-            val entity =
-                createTestUserEntity(
-                    createdAt = maxTimestamp,
-                    updatedAt = maxTimestamp,
-                )
-            everySuspend { userDao.getCurrentUser() } returns entity
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("toDomain handles maximum timestamp values correctly") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val maxTimestamp = Long.MAX_VALUE
+                val entity =
+                    createTestUserEntity(
+                        createdAt = maxTimestamp,
+                        updatedAt = maxTimestamp,
+                    )
+                everySuspend { userDao.getCurrentUser() } returns entity
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val user = repository.getCurrentUser()
+                // When
+                val user = repository.getCurrentUser().shouldNotBeNull()
 
-            // Then
-            assertNotNull(user)
-            assertEquals(maxTimestamp, user.createdAtMs)
-            assertEquals(maxTimestamp, user.updatedAtMs)
+                // Then
+                user.createdAtMs shouldBe maxTimestamp
+                user.updatedAtMs shouldBe maxTimestamp
+            }
         }
 
-    @Test
-    fun `observeCurrentUser correctly transforms entity stream to domain stream`() =
-        runTest {
-            // Given - multiple different users emitted
-            val userDao = createMockUserDao()
-            val user1Entity =
-                createTestUserEntity(
-                    id = "user-1",
-                    isRoot = false,
-                    avatarType = "auto",
-                )
-            val user2Entity =
-                createTestUserEntity(
-                    id = "user-2",
-                    isRoot = true,
-                    avatarType = "image",
-                    avatarValue = "/path/to/avatar.jpg",
-                )
-            every { userDao.observeCurrentUser() } returns flowOf(user1Entity, user2Entity)
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeCurrentUser correctly transforms entity stream to domain stream") {
+            runTest {
+                // Given - multiple different users emitted
+                val userDao = createMockUserDao()
+                val user1Entity =
+                    createTestUserEntity(
+                        id = "user-1",
+                        isRoot = false,
+                        avatarType = "auto",
+                    )
+                val user2Entity =
+                    createTestUserEntity(
+                        id = "user-2",
+                        isRoot = true,
+                        avatarType = "image",
+                        avatarValue = "/path/to/avatar.jpg",
+                    )
+                every { userDao.observeCurrentUser() } returns flowOf(user1Entity, user2Entity)
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When
-            val emissions = repository.observeCurrentUser().take(2).toList()
+                // When
+                val emissions = repository.observeCurrentUser().take(2).toList()
 
-            // Then
-            val user1 = emissions[0]
-            assertNotNull(user1)
-            assertEquals("user-1", user1.id.value)
-            assertFalse(user1.isAdmin)
-            assertEquals("auto", user1.avatarType)
+                // Then
+                val user1 = emissions[0].shouldNotBeNull()
+                user1.id.value shouldBe "user-1"
+                user1.isAdmin shouldBe false
+                user1.avatarType shouldBe "auto"
 
-            val user2 = emissions[1]
-            assertNotNull(user2)
-            assertEquals("user-2", user2.id.value)
-            assertTrue(user2.isAdmin)
-            assertEquals("image", user2.avatarType)
-            assertEquals("/path/to/avatar.jpg", user2.avatarValue)
+                val user2 = emissions[1].shouldNotBeNull()
+                user2.id.value shouldBe "user-2"
+                user2.isAdmin shouldBe true
+                user2.avatarType shouldBe "image"
+                user2.avatarValue shouldBe "/path/to/avatar.jpg"
+            }
         }
 
-    @Test
-    fun `observeCurrentUser handles user with MutableStateFlow updates`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val userFlow = MutableStateFlow<UserEntity?>(null)
-            every { userDao.observeCurrentUser() } returns userFlow
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeCurrentUser handles user with MutableStateFlow updates") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val userFlow = MutableStateFlow<UserEntity?>(null)
+                every { userDao.observeCurrentUser() } returns userFlow
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When/Then - initial null
-            assertNull(repository.observeCurrentUser().first())
+                // When/Then - initial null
+                repository.observeCurrentUser().first() shouldBe null
 
-            // When/Then - user logs in
-            userFlow.value = createTestUserEntity(id = "logged-in-user")
-            val loggedIn = repository.observeCurrentUser().first()
-            assertNotNull(loggedIn)
-            assertEquals("logged-in-user", loggedIn.id.value)
+                // When/Then - user logs in
+                userFlow.value = createTestUserEntity(id = "logged-in-user")
+                val loggedIn = repository.observeCurrentUser().first().shouldNotBeNull()
+                loggedIn.id.value shouldBe "logged-in-user"
 
-            // When/Then - user updates profile
-            userFlow.value = createTestUserEntity(id = "logged-in-user", displayName = "New Name")
-            val updated = repository.observeCurrentUser().first()
-            assertNotNull(updated)
-            assertEquals("New Name", updated.displayName)
+                // When/Then - user updates profile
+                userFlow.value = createTestUserEntity(id = "logged-in-user", displayName = "New Name")
+                val updated = repository.observeCurrentUser().first().shouldNotBeNull()
+                updated.displayName shouldBe "New Name"
 
-            // When/Then - user logs out
-            userFlow.value = null
-            assertNull(repository.observeCurrentUser().first())
+                // When/Then - user logs out
+                userFlow.value = null
+                repository.observeCurrentUser().first() shouldBe null
+            }
         }
 
-    @Test
-    fun `repository correctly implements UserRepository interface`() =
-        runTest {
-            // Given
-            val userDao = createMockUserDao()
-            val authRpcFactory = createMockAuthRpcFactory()
-            every { userDao.observeCurrentUser() } returns flowOf(null)
-            everySuspend { userDao.getCurrentUser() } returns null
+        test("repository correctly implements UserRepository interface") {
+            runTest {
+                // Given
+                val userDao = createMockUserDao()
+                val authRpcFactory = createMockAuthRpcFactory()
+                every { userDao.observeCurrentUser() } returns flowOf(null)
+                everySuspend { userDao.getCurrentUser() } returns null
 
-            // When
-            val repository: com.calypsan.listenup.client.domain.repository.UserRepository =
-                UserRepositoryImpl(userDao, authRpcFactory)
+                // When
+                val repository: com.calypsan.listenup.client.domain.repository.UserRepository =
+                    UserRepositoryImpl(userDao, authRpcFactory)
 
-            // Then - all methods are accessible via interface
-            assertNull(repository.observeCurrentUser().first())
-            assertFalse(repository.observeIsAdmin().first())
-            assertNull(repository.getCurrentUser())
+                // Then - all methods are accessible via interface
+                repository.observeCurrentUser().first() shouldBe null
+                repository.observeIsAdmin().first() shouldBe false
+                repository.getCurrentUser() shouldBe null
+            }
         }
 
-    @Test
-    fun `observeIsAdmin correctly maps isRoot field from multiple emissions`() =
-        runTest {
-            // Given - test the specific mapping of isRoot -> isAdmin through flow
-            val userDao = createMockUserDao()
-            val userFlow = MutableStateFlow<UserEntity?>(null)
-            every { userDao.observeCurrentUser() } returns userFlow
-            val authRpcFactory = createMockAuthRpcFactory()
-            val repository = UserRepositoryImpl(userDao, authRpcFactory)
+        test("observeIsAdmin correctly maps isRoot field from multiple emissions") {
+            runTest {
+                // Given - test the specific mapping of isRoot -> isAdmin through flow
+                val userDao = createMockUserDao()
+                val userFlow = MutableStateFlow<UserEntity?>(null)
+                every { userDao.observeCurrentUser() } returns userFlow
+                val authRpcFactory = createMockAuthRpcFactory()
+                val repository = UserRepositoryImpl(userDao, authRpcFactory)
 
-            // When/Then - null user
-            assertFalse(repository.observeIsAdmin().first())
+                // When/Then - null user
+                repository.observeIsAdmin().first() shouldBe false
 
-            // When/Then - user with isRoot = false
-            userFlow.value = createTestUserEntity(isRoot = false)
-            assertFalse(repository.observeIsAdmin().first())
+                // When/Then - user with isRoot = false
+                userFlow.value = createTestUserEntity(isRoot = false)
+                repository.observeIsAdmin().first() shouldBe false
 
-            // When/Then - user with isRoot = true
-            userFlow.value = createTestUserEntity(isRoot = true)
-            assertTrue(repository.observeIsAdmin().first())
+                // When/Then - user with isRoot = true
+                userFlow.value = createTestUserEntity(isRoot = true)
+                repository.observeIsAdmin().first() shouldBe true
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/MainDispatcherRuleTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/MainDispatcherRuleTest.kt
@@ -1,13 +1,12 @@
 package com.calypsan.listenup.client.test
 
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertTrue
 
 /**
  * Verifies [MainDispatcherRule] installs its [TestDispatcher] as [Dispatchers.Main] during a test,
@@ -17,20 +16,21 @@ import kotlin.test.assertTrue
  * because no Main dispatcher is installed on any non-Android target.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class MainDispatcherRuleTest {
-    private val mainRule = MainDispatcherRule()
+class MainDispatcherRuleTest :
+    FunSpec({
+        val mainRule = MainDispatcherRule()
 
-    @BeforeTest
-    fun beforeTest() = mainRule.setUp()
+        beforeTest { mainRule.setUp() }
 
-    @AfterTest
-    fun afterTest() = mainRule.tearDown()
+        afterTest { mainRule.tearDown() }
 
-    @Test
-    fun mainDispatcherIsUsableAfterSetUp() =
-        runTest(mainRule.testDispatcher) {
-            var ran = false
-            withContext(Dispatchers.Main) { ran = true }
-            assertTrue(ran, "withContext(Dispatchers.Main) must execute under MainDispatcherRule")
+        test("mainDispatcherIsUsableAfterSetUp") {
+            runTest(mainRule.testDispatcher) {
+                var ran = false
+                withContext(Dispatchers.Main) { ran = true }
+                withClue("withContext(Dispatchers.Main) must execute under MainDispatcherRule") {
+                    ran shouldBe true
+                }
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/di/KoinTestRuleTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/di/KoinTestRuleTest.kt
@@ -1,53 +1,48 @@
 package com.calypsan.listenup.client.test.di
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
 
 /**
  * Verifies [KoinTestRule] starts Koin with the supplied modules and stops it on tearDown,
  * establishing the KMP-compat alternative to JVM-only `org.koin.test.KoinTestRule`.
  */
-class KoinTestRuleTest {
-    private val fakeModule =
-        module {
-            single<Greeter> { HelloGreeter() }
+class KoinTestRuleTest :
+    FunSpec({
+        val fakeModule =
+            module {
+                single<Greeter> { HelloGreeter() }
+            }
+
+        val koinRule = KoinTestRule(listOf(fakeModule))
+
+        beforeTest { koinRule.setUp() }
+
+        afterTest { koinRule.tearDown() }
+
+        test("startsKoinWithProvidedModules") {
+            val greeter = KoinPlatform.getKoin().get<Greeter>()
+            greeter.shouldNotBeNull()
+            greeter.greet() shouldBe "hello"
         }
 
-    private val koinRule = KoinTestRule(listOf(fakeModule))
+        test("stopsKoinAfterTeardown") {
+            // Simulate a completed test lifecycle: tearDown then attempt a resolve.
+            koinRule.tearDown()
+            shouldThrow<IllegalStateException> { KoinPlatform.getKoin() }
+            // Restart so afterTest tearDown doesn't explode on an already-stopped Koin.
+            koinRule.setUp()
+        }
+    })
 
-    @BeforeTest
-    fun beforeTest() = koinRule.setUp()
+private interface Greeter {
+    fun greet(): String
+}
 
-    @AfterTest
-    fun afterTest() = koinRule.tearDown()
-
-    @Test
-    fun startsKoinWithProvidedModules() {
-        val greeter = KoinPlatform.getKoin().get<Greeter>()
-        assertNotNull(greeter)
-        assertEquals("hello", greeter.greet())
-    }
-
-    @Test
-    fun stopsKoinAfterTeardown() {
-        // Simulate a completed test lifecycle: tearDown then attempt a resolve.
-        koinRule.tearDown()
-        assertFailsWith<IllegalStateException> { KoinPlatform.getKoin() }
-        // Restart so @AfterTest tearDown doesn't explode on an already-stopped Koin.
-        koinRule.setUp()
-    }
-
-    private interface Greeter {
-        fun greet(): String
-    }
-
-    private class HelloGreeter : Greeter {
-        override fun greet(): String = "hello"
-    }
+private class HelloGreeter : Greeter {
+    override fun greet(): String = "hello"
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeBookRepositoryTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeBookRepositoryTest.kt
@@ -5,105 +5,104 @@ import app.cash.turbine.test
 import com.calypsan.listenup.client.TestData
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.Chapter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
-class FakeBookRepositoryTest {
-    @Test
-    fun observeBookListItemsEmitsSeededThenUpdated() =
-        runTest {
-            val first = TestData.bookListItem(id = "book-1", title = "Dune")
-            val repo = FakeBookRepository(initialBooks = listOf(first))
+class FakeBookRepositoryTest :
+    FunSpec({
+        test("observeBookListItemsEmitsSeededThenUpdated") {
+            runTest {
+                val first = TestData.bookListItem(id = "book-1", title = "Dune")
+                val repo = FakeBookRepository(initialBooks = listOf(first))
 
-            repo.observeBookListItems().test {
-                assertEquals(listOf(first), awaitItem())
+                repo.observeBookListItems().test {
+                    awaitItem() shouldBe listOf(first)
 
-                val second = TestData.bookListItem(id = "book-2", title = "Neuromancer")
-                repo.setBooks(listOf(first, second))
+                    val second = TestData.bookListItem(id = "book-2", title = "Neuromancer")
+                    repo.setBooks(listOf(first, second))
 
-                assertEquals(2, awaitItem().size)
-                cancelAndIgnoreRemainingEvents()
+                    awaitItem().size shouldBe 2
+                    cancelAndIgnoreRemainingEvents()
+                }
             }
         }
 
-    @Test
-    fun getBookListItemLooksUpById() =
-        runTest {
-            val book = TestData.bookListItem(id = "book-1", title = "Dune")
-            val repo = FakeBookRepository(initialBooks = listOf(book))
+        test("getBookListItemLooksUpById") {
+            runTest {
+                val book = TestData.bookListItem(id = "book-1", title = "Dune")
+                val repo = FakeBookRepository(initialBooks = listOf(book))
 
-            val fetched = repo.getBookListItem("book-1")
-            val missing = repo.getBookListItem("nope")
+                val fetched = repo.getBookListItem("book-1")
+                val missing = repo.getBookListItem("nope")
 
-            assertNotNull(fetched)
-            assertEquals("Dune", fetched.title)
-            assertNull(missing)
-        }
-
-    @Test
-    fun getBookListItemsReturnsOnlyMatchingIds() =
-        runTest {
-            val a = TestData.bookListItem(id = "a", title = "A")
-            val b = TestData.bookListItem(id = "b", title = "B")
-            val c = TestData.bookListItem(id = "c", title = "C")
-            val repo = FakeBookRepository(initialBooks = listOf(a, b, c))
-
-            val found = repo.getBookListItems(listOf("a", "c", "missing"))
-
-            assertEquals(2, found.size)
-            assertTrue(found.any { it.id == BookId("a") })
-            assertTrue(found.any { it.id == BookId("c") })
-        }
-
-    @Test
-    fun refreshBooksSucceedsAndCountsCalls() =
-        runTest {
-            val repo = FakeBookRepository()
-
-            val result = repo.refreshBooks()
-
-            assertTrue(result is AppResult.Success)
-            assertEquals(1, repo.refreshCount)
-        }
-
-    @Test
-    fun chaptersRoundTripThroughSetChapters() =
-        runTest {
-            val repo = FakeBookRepository()
-            val chapters = listOf(Chapter(id = "c1", title = "Ch 1", duration = 1_000L, startTime = 0L))
-
-            repo.setChapters("book-1", chapters)
-
-            assertEquals(chapters, repo.getChapters("book-1"))
-        }
-
-    @Test
-    fun observeRecentlyAddedBooksOrdersByAddedAtDescending() =
-        runTest {
-            val older =
-                TestData.bookListItem(id = "older").copy(
-                    addedAt =
-                        com.calypsan.listenup.core
-                            .Timestamp(epochMillis = 1_000L),
-                )
-            val newer =
-                TestData.bookListItem(id = "newer").copy(
-                    addedAt =
-                        com.calypsan.listenup.core
-                            .Timestamp(epochMillis = 2_000L),
-                )
-            val repo = FakeBookRepository(initialBooks = listOf(older, newer))
-
-            repo.observeRecentlyAddedBooks(limit = 10).test {
-                val first = awaitItem()
-                assertEquals(2, first.size)
-                assertEquals("newer", first[0].id)
-                assertEquals("older", first[1].id)
-                cancelAndIgnoreRemainingEvents()
+                fetched.shouldNotBeNull()
+                fetched.title shouldBe "Dune"
+                missing shouldBe null
             }
         }
-}
+
+        test("getBookListItemsReturnsOnlyMatchingIds") {
+            runTest {
+                val a = TestData.bookListItem(id = "a", title = "A")
+                val b = TestData.bookListItem(id = "b", title = "B")
+                val c = TestData.bookListItem(id = "c", title = "C")
+                val repo = FakeBookRepository(initialBooks = listOf(a, b, c))
+
+                val found = repo.getBookListItems(listOf("a", "c", "missing"))
+
+                found.size shouldBe 2
+                found.any { it.id == BookId("a") } shouldBe true
+                found.any { it.id == BookId("c") } shouldBe true
+            }
+        }
+
+        test("refreshBooksSucceedsAndCountsCalls") {
+            runTest {
+                val repo = FakeBookRepository()
+
+                val result = repo.refreshBooks()
+
+                (result is AppResult.Success) shouldBe true
+                repo.refreshCount shouldBe 1
+            }
+        }
+
+        test("chaptersRoundTripThroughSetChapters") {
+            runTest {
+                val repo = FakeBookRepository()
+                val chapters = listOf(Chapter(id = "c1", title = "Ch 1", duration = 1_000L, startTime = 0L))
+
+                repo.setChapters("book-1", chapters)
+
+                repo.getChapters("book-1") shouldBe chapters
+            }
+        }
+
+        test("observeRecentlyAddedBooksOrdersByAddedAtDescending") {
+            runTest {
+                val older =
+                    TestData.bookListItem(id = "older").copy(
+                        addedAt =
+                            com.calypsan.listenup.core
+                                .Timestamp(epochMillis = 1_000L),
+                    )
+                val newer =
+                    TestData.bookListItem(id = "newer").copy(
+                        addedAt =
+                            com.calypsan.listenup.core
+                                .Timestamp(epochMillis = 2_000L),
+                    )
+                val repo = FakeBookRepository(initialBooks = listOf(older, newer))
+
+                repo.observeRecentlyAddedBooks(limit = 10).test {
+                    val first = awaitItem()
+                    first.size shouldBe 2
+                    first[0].id shouldBe "newer"
+                    first[1].id shouldBe "older"
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepositoryTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepositoryTest.kt
@@ -3,155 +3,154 @@ package com.calypsan.listenup.client.test.fake
 import app.cash.turbine.test
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.client.domain.repository.LastPlayedInfo
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Smoke tests for [FakePlaybackPositionRepository]. Proves the fake's write-then-read
  * semantics hold — this is the core distinction from a Mokkery mock, which has no state
  * to read back from.
  */
-class FakePlaybackPositionRepositoryTest {
-    @Test
-    fun savePlaybackStateAndGet() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
+class FakePlaybackPositionRepositoryTest :
+    FunSpec({
+        test("savePlaybackStateAndGet") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
 
-            repo.savePlaybackState(
-                BookId("book-1"),
-                PlaybackUpdate.Position(positionMs = 5_000L, speed = 1.0f),
-            )
-
-            val result =
-                assertIs<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>(
-                    repo.get(BookId("book-1")),
+                repo.savePlaybackState(
+                    BookId("book-1"),
+                    PlaybackUpdate.Position(positionMs = 5_000L, speed = 1.0f),
                 )
-            val saved = assertNotNull(result.data)
-            assertEquals(5_000L, saved.positionMs)
+
+                val result =
+                    repo
+                        .get(BookId("book-1"))
+                        .shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>()
+                val saved = result.data.shouldNotBeNull()
+                saved.positionMs shouldBe 5_000L
+            }
         }
 
-    @Test
-    fun observeAllEmitsOnWrite() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
+        test("observeAllEmitsOnWrite") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
 
-            repo.observeAll().test {
-                val initial = awaitItem()
-                assertTrue(initial.isEmpty(), "initial emission must be empty (nothing saved)")
+                repo.observeAll().test {
+                    val initial = awaitItem()
+                    withClue("initial emission must be empty (nothing saved)") { initial.isEmpty() shouldBe true }
 
+                    repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
+
+                    val after = awaitItem()
+                    after.size shouldBe 1
+                    after[BookId("book-1")]?.positionMs shouldBe 1_000L
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("observeAllReflectsAllBooks") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
+                repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 100L, speed = 1.0f))
+                repo.savePlaybackState(BookId("book-2"), PlaybackUpdate.Position(positionMs = 200L, speed = 1.0f))
+
+                repo.observeAll().test {
+                    val all = awaitItem()
+                    all.size shouldBe 2
+                    all.keys shouldBe setOf(BookId("book-1"), BookId("book-2"))
+                    all[BookId("book-1")]?.positionMs shouldBe 100L
+                    all[BookId("book-2")]?.positionMs shouldBe 200L
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("markCompleteSetsIsFinishedAndFinishedAt") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
                 repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
 
-                val after = awaitItem()
-                assertEquals(1, after.size)
-                assertEquals(1_000L, after[BookId("book-1")]?.positionMs)
-                cancelAndIgnoreRemainingEvents()
+                val result = repo.markComplete(BookId("book-1"), startedAt = 100L, finishedAt = 999L)
+
+                (result is AppResult.Success) shouldBe true
+                val after =
+                    repo
+                        .get(BookId("book-1"))
+                        .shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>()
+                        .data
+                        .shouldNotBeNull()
+                after.isFinished shouldBe true
+                after.finishedAtMs shouldBe 999L
+                after.startedAtMs shouldBe 100L
             }
         }
 
-    @Test
-    fun observeAllReflectsAllBooks() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
-            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 100L, speed = 1.0f))
-            repo.savePlaybackState(BookId("book-2"), PlaybackUpdate.Position(positionMs = 200L, speed = 1.0f))
+        test("discardProgressRemovesEntry") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
+                repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
 
-            repo.observeAll().test {
-                val all = awaitItem()
-                assertEquals(2, all.size)
-                assertEquals(setOf(BookId("book-1"), BookId("book-2")), all.keys)
-                assertEquals(100L, all[BookId("book-1")]?.positionMs)
-                assertEquals(200L, all[BookId("book-2")]?.positionMs)
-                cancelAndIgnoreRemainingEvents()
+                val result = repo.discardProgress(BookId("book-1"))
+
+                (result is AppResult.Success) shouldBe true
+                val afterDiscard = repo.get(BookId("book-1")).shouldBeInstanceOf<AppResult.Success<*>>()
+                afterDiscard.data shouldBe null
             }
         }
 
-    @Test
-    fun markCompleteSetsIsFinishedAndFinishedAt() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
-            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
+        test("restartBookResetsPositionAndClearsFinished") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
+                repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 10_000L, speed = 1.0f))
+                repo.markComplete(BookId("book-1"))
 
-            val result = repo.markComplete(BookId("book-1"), startedAt = 100L, finishedAt = 999L)
+                val result = repo.restartBook(BookId("book-1"))
 
-            assertTrue(result is AppResult.Success)
-            val after =
-                assertNotNull(
-                    assertIs<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>(
-                        repo.get(BookId("book-1")),
-                    ).data,
-                )
-            assertTrue(after.isFinished)
-            assertEquals(999L, after.finishedAtMs)
-            assertEquals(100L, after.startedAtMs)
+                (result is AppResult.Success) shouldBe true
+                val after =
+                    repo
+                        .get(BookId("book-1"))
+                        .shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>()
+                        .data
+                        .shouldNotBeNull()
+                after.positionMs shouldBe 0L
+                after.isFinished shouldBe false
+                after.finishedAtMs shouldBe null
+            }
         }
 
-    @Test
-    fun discardProgressRemovesEntry() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
-            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 1_000L, speed = 1.0f))
+        test("getLastPlayedBookReturnsMostRecentlyPlayed") {
+            runTest {
+                var clock = 1_000L
+                val repo = FakePlaybackPositionRepository(nowMs = { clock })
+                repo.savePlaybackState(BookId("oldest"), PlaybackUpdate.Position(positionMs = 100L, speed = 1.0f))
+                clock = 2_000L
+                repo.savePlaybackState(BookId("newest"), PlaybackUpdate.Speed(positionMs = 5_000L, speed = 1.5f, custom = true))
 
-            val result = repo.discardProgress(BookId("book-1"))
+                val result = repo.getLastPlayedBook()
 
-            assertTrue(result is AppResult.Success)
-            val afterDiscard = assertIs<AppResult.Success<*>>(repo.get(BookId("book-1")))
-            assertNull(afterDiscard.data)
+                val info = result.shouldBeInstanceOf<AppResult.Success<LastPlayedInfo?>>().data
+                info.shouldNotBeNull()
+                info.bookId.value shouldBe "newest"
+                info.positionMs shouldBe 5_000L
+                info.playbackSpeed shouldBe 1.5f
+            }
         }
 
-    @Test
-    fun restartBookResetsPositionAndClearsFinished() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
-            repo.savePlaybackState(BookId("book-1"), PlaybackUpdate.Position(positionMs = 10_000L, speed = 1.0f))
-            repo.markComplete(BookId("book-1"))
+        test("getLastPlayedBookReturnsNullWhenEmpty") {
+            runTest {
+                val repo = FakePlaybackPositionRepository()
 
-            val result = repo.restartBook(BookId("book-1"))
+                val result = repo.getLastPlayedBook()
 
-            assertTrue(result is AppResult.Success)
-            val after =
-                assertNotNull(
-                    assertIs<AppResult.Success<com.calypsan.listenup.client.domain.model.PlaybackPosition?>>(
-                        repo.get(BookId("book-1")),
-                    ).data,
-                )
-            assertEquals(0L, after.positionMs)
-            assertEquals(false, after.isFinished)
-            assertNull(after.finishedAtMs)
+                result.shouldBeInstanceOf<AppResult.Success<LastPlayedInfo?>>().data shouldBe null
+            }
         }
-
-    @Test
-    fun getLastPlayedBookReturnsMostRecentlyPlayed() =
-        runTest {
-            var clock = 1_000L
-            val repo = FakePlaybackPositionRepository(nowMs = { clock })
-            repo.savePlaybackState(BookId("oldest"), PlaybackUpdate.Position(positionMs = 100L, speed = 1.0f))
-            clock = 2_000L
-            repo.savePlaybackState(BookId("newest"), PlaybackUpdate.Speed(positionMs = 5_000L, speed = 1.5f, custom = true))
-
-            val result = repo.getLastPlayedBook()
-
-            assertTrue(result is AppResult.Success)
-            val info = result.data
-            assertNotNull(info)
-            assertEquals("newest", info.bookId.value)
-            assertEquals(5_000L, info.positionMs)
-            assertEquals(1.5f, info.playbackSpeed)
-        }
-
-    @Test
-    fun getLastPlayedBookReturnsNullWhenEmpty() =
-        runTest {
-            val repo = FakePlaybackPositionRepository()
-
-            val result = repo.getLastPlayedBook()
-
-            assertTrue(result is AppResult.Success)
-            assertNull(result.data)
-        }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlayerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlayerTest.kt
@@ -2,81 +2,82 @@ package com.calypsan.listenup.client.test.fake
 
 import com.calypsan.listenup.client.playback.AudioSegment
 import com.calypsan.listenup.client.playback.PlaybackState
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-class FakePlayerTest {
-    @Test
-    fun loadRecordsCallAndDuration() =
-        runTest {
-            val player = FakePlayer()
-            val segments =
-                listOf(
-                    AudioSegment(url = "s1", localPath = null, durationMs = 1_000L, offsetMs = 0L),
-                    AudioSegment(url = "s2", localPath = null, durationMs = 2_000L, offsetMs = 1_000L),
-                )
+class FakePlayerTest :
+    FunSpec({
+        test("loadRecordsCallAndDuration") {
+            runTest {
+                val player = FakePlayer()
+                val segments =
+                    listOf(
+                        AudioSegment(url = "s1", localPath = null, durationMs = 1_000L, offsetMs = 0L),
+                        AudioSegment(url = "s2", localPath = null, durationMs = 2_000L, offsetMs = 1_000L),
+                    )
 
-            player.load(segments)
+                player.load(segments)
 
-            assertEquals(listOf(FakePlayer.Call.Load(segments)), player.calls)
-            assertEquals(3_000L, player.durationMs.value, "durationMs must sum segment durations")
+                player.calls shouldBe listOf(FakePlayer.Call.Load(segments))
+                withClue("durationMs must sum segment durations") { player.durationMs.value shouldBe 3_000L }
+            }
         }
 
-    @Test
-    fun playSetsStateAndRecordsCall() =
-        runTest {
-            val player = FakePlayer()
+        test("playSetsStateAndRecordsCall") {
+            runTest {
+                val player = FakePlayer()
 
-            player.play()
+                player.play()
 
-            assertEquals(PlaybackState.Playing, player.state.value)
-            assertTrue(player.calls.contains(FakePlayer.Call.Play))
+                player.state.value shouldBe PlaybackState.Playing
+                player.calls.contains(FakePlayer.Call.Play) shouldBe true
+            }
         }
 
-    @Test
-    fun pauseSetsState() =
-        runTest {
-            val player = FakePlayer()
-            player.play()
+        test("pauseSetsState") {
+            runTest {
+                val player = FakePlayer()
+                player.play()
 
-            player.pause()
+                player.pause()
 
-            assertEquals(PlaybackState.Paused, player.state.value)
-            assertTrue(player.calls.contains(FakePlayer.Call.Pause))
+                player.state.value shouldBe PlaybackState.Paused
+                player.calls.contains(FakePlayer.Call.Pause) shouldBe true
+            }
         }
 
-    @Test
-    fun seekToUpdatesPositionAndRecordsCall() =
-        runTest {
-            val player = FakePlayer()
+        test("seekToUpdatesPositionAndRecordsCall") {
+            runTest {
+                val player = FakePlayer()
 
-            player.seekTo(5_000L)
+                player.seekTo(5_000L)
 
-            assertEquals(5_000L, player.positionMs.value)
-            assertTrue(player.calls.contains(FakePlayer.Call.SeekTo(5_000L)))
+                player.positionMs.value shouldBe 5_000L
+                player.calls.contains(FakePlayer.Call.SeekTo(5_000L)) shouldBe true
+            }
         }
 
-    @Test
-    fun setSpeedRecordsCall() =
-        runTest {
-            val player = FakePlayer()
+        test("setSpeedRecordsCall") {
+            runTest {
+                val player = FakePlayer()
 
-            player.setSpeed(1.5f)
+                player.setSpeed(1.5f)
 
-            assertTrue(player.calls.contains(FakePlayer.Call.SetSpeed(1.5f)))
+                player.calls.contains(FakePlayer.Call.SetSpeed(1.5f)) shouldBe true
+            }
         }
 
-    @Test
-    fun releaseResetsStateAndRecordsCall() =
-        runTest {
-            val player = FakePlayer()
-            player.play()
+        test("releaseResetsStateAndRecordsCall") {
+            runTest {
+                val player = FakePlayer()
+                player.play()
 
-            player.release()
+                player.release()
 
-            assertEquals(PlaybackState.Idle, player.state.value)
-            assertTrue(player.calls.contains(FakePlayer.Call.Release))
+                player.state.value shouldBe PlaybackState.Idle
+                player.calls.contains(FakePlayer.Call.Release) shouldBe true
+            }
         }
-}
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/http/TestMockEngineTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/http/TestMockEngineTest.kt
@@ -1,5 +1,9 @@
 package com.calypsan.listenup.client.test.http
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
@@ -7,75 +11,71 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
 /**
  * Verifies [testMockEngine] dispatches requests to path handlers, falls back with 404 for
  * unmatched paths, and exposes the resulting [HttpClient] for use in seam tests.
  */
-class TestMockEngineTest {
-    @Test
-    fun dispatchesJsonResponseForRegisteredPath() =
-        runTest {
-            val client =
-                HttpClient(
-                    testMockEngine {
-                        respondJson("/api/v1/books") { """{"id":"book-1","title":"Dune"}""" }
-                    },
-                )
+class TestMockEngineTest :
+    FunSpec({
+        test("dispatchesJsonResponseForRegisteredPath") {
+            runTest {
+                val client =
+                    HttpClient(
+                        testMockEngine {
+                            respondJson("/api/v1/books") { """{"id":"book-1","title":"Dune"}""" }
+                        },
+                    )
 
-            val response: HttpResponse = client.get("http://unit.test/api/v1/books")
-            assertTrue(response.status.isSuccess(), "matched path must resolve to 2xx")
-            assertEquals("""{"id":"book-1","title":"Dune"}""", response.bodyAsText())
-        }
-
-    @Test
-    fun returns404ForUnregisteredPath() =
-        runTest {
-            val client =
-                HttpClient(
-                    testMockEngine {
-                        respondJson("/api/v1/books") { "{}" }
-                    },
-                )
-
-            assertFailsWith<AssertionError> {
-                client.get("http://unit.test/api/v1/nonexistent")
+                val response: HttpResponse = client.get("http://unit.test/api/v1/books")
+                withClue("matched path must resolve to 2xx") { response.status.isSuccess() shouldBe true }
+                response.bodyAsText() shouldBe """{"id":"book-1","title":"Dune"}"""
             }
         }
 
-    @Test
-    fun respondJsonIncludesContentTypeHeader() =
-        runTest {
-            val client =
-                HttpClient(
-                    testMockEngine {
-                        respondJson("/whoami") { """{"user":"alice"}""" }
-                    },
-                )
+        test("returns404ForUnregisteredPath") {
+            runTest {
+                val client =
+                    HttpClient(
+                        testMockEngine {
+                            respondJson("/api/v1/books") { "{}" }
+                        },
+                    )
 
-            val response: HttpResponse = client.get("http://unit.test/whoami")
-            val contentType = response.headers["Content-Type"]
-            assertTrue(
-                contentType?.startsWith("application/json") == true,
-                "respondJson must set Content-Type: application/json (was $contentType)",
-            )
+                shouldThrow<AssertionError> {
+                    client.get("http://unit.test/api/v1/nonexistent")
+                }
+            }
         }
 
-    @Test
-    fun respondStatusEmitsRequestedStatusCode() =
-        runTest {
-            val client =
-                HttpClient(
-                    testMockEngine {
-                        respondStatus("/missing", HttpStatusCode.NotFound)
-                    },
-                )
+        test("respondJsonIncludesContentTypeHeader") {
+            runTest {
+                val client =
+                    HttpClient(
+                        testMockEngine {
+                            respondJson("/whoami") { """{"user":"alice"}""" }
+                        },
+                    )
 
-            val response: HttpResponse = client.get("http://unit.test/missing")
-            assertEquals(HttpStatusCode.NotFound, response.status)
+                val response: HttpResponse = client.get("http://unit.test/whoami")
+                val contentType = response.headers["Content-Type"]
+                withClue("respondJson must set Content-Type: application/json (was $contentType)") {
+                    (contentType?.startsWith("application/json") == true) shouldBe true
+                }
+            }
         }
-}
+
+        test("respondStatusEmitsRequestedStatusCode") {
+            runTest {
+                val client =
+                    HttpClient(
+                        testMockEngine {
+                            respondStatus("/missing", HttpStatusCode.NotFound)
+                        },
+                    )
+
+                val response: HttpResponse = client.get("http://unit.test/missing")
+                response.status shouldBe HttpStatusCode.NotFound
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/core/SecureStorageTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/core/SecureStorageTest.kt
@@ -4,178 +4,178 @@ import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 /**
  * Tests for SecureStorage interface contract.
  * Uses Mokkery for mocking the platform-specific implementations.
  */
-class SecureStorageTest {
-    @Test
-    fun `save stores key-value pair`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.save("key", "value") } returns Unit
+class SecureStorageTest :
+    FunSpec({
+        test("save stores key-value pair") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.save("key", "value") } returns Unit
 
-            // When
-            storage.save("key", "value")
+                // When
+                storage.save("key", "value")
 
-            // Then
-            verifySuspend { storage.save("key", "value") }
+                // Then
+                verifySuspend { storage.save("key", "value") }
+            }
         }
 
-    @Test
-    fun `read returns stored value`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.read("key") } returns "value"
+        test("read returns stored value") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.read("key") } returns "value"
 
-            // When
-            val result = storage.read("key")
+                // When
+                val result = storage.read("key")
 
-            // Then
-            assertEquals("value", result)
-            verifySuspend { storage.read("key") }
+                // Then
+                result shouldBe "value"
+                verifySuspend { storage.read("key") }
+            }
         }
 
-    @Test
-    fun `read returns null for non-existent key`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.read("nonexistent") } returns null
+        test("read returns null for non-existent key") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.read("nonexistent") } returns null
 
-            // When
-            val result = storage.read("nonexistent")
+                // When
+                val result = storage.read("nonexistent")
 
-            // Then
-            assertNull(result)
-            verifySuspend { storage.read("nonexistent") }
+                // Then
+                result shouldBe null
+                verifySuspend { storage.read("nonexistent") }
+            }
         }
 
-    @Test
-    fun `delete removes key`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.delete("key") } returns Unit
+        test("delete removes key") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.delete("key") } returns Unit
 
-            // When
-            storage.delete("key")
+                // When
+                storage.delete("key")
 
-            // Then
-            verifySuspend { storage.delete("key") }
+                // Then
+                verifySuspend { storage.delete("key") }
+            }
         }
 
-    @Test
-    fun `clear removes all keys`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.clear() } returns Unit
+        test("clear removes all keys") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.clear() } returns Unit
 
-            // When
-            storage.clear()
+                // When
+                storage.clear()
 
-            // Then
-            verifySuspend { storage.clear() }
+                // Then
+                verifySuspend { storage.clear() }
+            }
         }
 
-    @Test
-    fun `save overwrites existing value`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.save("key", "value1") } returns Unit
-            everySuspend { storage.save("key", "value2") } returns Unit
-            everySuspend { storage.read("key") } returns "value2"
+        test("save overwrites existing value") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.save("key", "value1") } returns Unit
+                everySuspend { storage.save("key", "value2") } returns Unit
+                everySuspend { storage.read("key") } returns "value2"
 
-            // When
-            storage.save("key", "value1")
-            storage.save("key", "value2")
-            val result = storage.read("key")
+                // When
+                storage.save("key", "value1")
+                storage.save("key", "value2")
+                val result = storage.read("key")
 
-            // Then
-            assertEquals("value2", result)
-            // Verify save was called at least once (removing exact count for Mokkery compatibility)
-            verifySuspend { storage.save("key", "value2") }
+                // Then
+                result shouldBe "value2"
+                // Verify save was called at least once (removing exact count for Mokkery compatibility)
+                verifySuspend { storage.save("key", "value2") }
+            }
         }
 
-    @Test
-    fun `multiple keys can be stored independently`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.save("key1", "value1") } returns Unit
-            everySuspend { storage.save("key2", "value2") } returns Unit
-            everySuspend { storage.read("key1") } returns "value1"
-            everySuspend { storage.read("key2") } returns "value2"
+        test("multiple keys can be stored independently") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.save("key1", "value1") } returns Unit
+                everySuspend { storage.save("key2", "value2") } returns Unit
+                everySuspend { storage.read("key1") } returns "value1"
+                everySuspend { storage.read("key2") } returns "value2"
 
-            // When
-            storage.save("key1", "value1")
-            storage.save("key2", "value2")
-            val result1 = storage.read("key1")
-            val result2 = storage.read("key2")
+                // When
+                storage.save("key1", "value1")
+                storage.save("key2", "value2")
+                val result1 = storage.read("key1")
+                val result2 = storage.read("key2")
 
-            // Then
-            assertEquals("value1", result1)
-            assertEquals("value2", result2)
+                // Then
+                result1 shouldBe "value1"
+                result2 shouldBe "value2"
+            }
         }
 
-    @Test
-    fun `delete does not affect other keys`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.delete("key1") } returns Unit
-            everySuspend { storage.read("key1") } returns null
-            everySuspend { storage.read("key2") } returns "value2"
+        test("delete does not affect other keys") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.delete("key1") } returns Unit
+                everySuspend { storage.read("key1") } returns null
+                everySuspend { storage.read("key2") } returns "value2"
 
-            // When
-            storage.delete("key1")
-            val result1 = storage.read("key1")
-            val result2 = storage.read("key2")
+                // When
+                storage.delete("key1")
+                val result1 = storage.read("key1")
+                val result2 = storage.read("key2")
 
-            // Then
-            assertNull(result1)
-            assertEquals("value2", result2)
+                // Then
+                result1 shouldBe null
+                result2 shouldBe "value2"
+            }
         }
 
-    @Test
-    fun `empty string can be stored as value`() =
-        runTest {
-            // Given
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.save("key", "") } returns Unit
-            everySuspend { storage.read("key") } returns ""
+        test("empty string can be stored as value") {
+            runTest {
+                // Given
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.save("key", "") } returns Unit
+                everySuspend { storage.read("key") } returns ""
 
-            // When
-            storage.save("key", "")
-            val result = storage.read("key")
+                // When
+                storage.save("key", "")
+                val result = storage.read("key")
 
-            // Then
-            assertEquals("", result)
+                // Then
+                result shouldBe ""
+            }
         }
 
-    @Test
-    fun `long values can be stored`() =
-        runTest {
-            // Given
-            val longValue = "x".repeat(10000)
-            val storage = mock<SecureStorage>()
-            everySuspend { storage.save("key", longValue) } returns Unit
-            everySuspend { storage.read("key") } returns longValue
+        test("long values can be stored") {
+            runTest {
+                // Given
+                val longValue = "x".repeat(10000)
+                val storage = mock<SecureStorage>()
+                everySuspend { storage.save("key", longValue) } returns Unit
+                everySuspend { storage.read("key") } returns longValue
 
-            // When
-            storage.save("key", longValue)
-            val result = storage.read("key")
+                // When
+                storage.save("key", longValue)
+                val result = storage.read("key")
 
-            // Then
-            assertEquals(longValue, result)
+                // Then
+                result shouldBe longValue
+            }
         }
-}
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/core/JvmSecureStorageTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/core/JvmSecureStorageTest.kt
@@ -1,16 +1,10 @@
 package com.calypsan.listenup.core
 
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import java.io.File
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Integration tests for JvmSecureStorage.
@@ -18,259 +12,212 @@ import kotlin.test.assertTrue
  * Tests the actual encryption/decryption logic, persistence,
  * and edge cases using real file I/O with temporary directories.
  */
-class JvmSecureStorageTest {
-    @get:Rule
-    val tempFolder = TemporaryFolder()
+class JvmSecureStorageTest :
+    FunSpec({
+        // A fresh, empty storage file inside a per-test temp directory ([tempdir] is cleaned up
+        // by Kotest after the spec). Starting fresh mirrors the original @BeforeTest setup.
+        fun newStorageFile(): File = File(tempdir(), "test-auth.enc").apply { delete() }
 
-    private lateinit var storageFile: File
-    private lateinit var storage: JvmSecureStorage
+        test("save and read round-trip works") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
 
-    @BeforeTest
-    fun setup() {
-        tempFolder.create()
-        storageFile = tempFolder.newFile("test-auth.enc")
-        storageFile.delete() // Start fresh
-        storage = JvmSecureStorage(storageFile)
-    }
+                storage.save("access_token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
 
-    @AfterTest
-    fun teardown() {
-        tempFolder.delete()
-    }
-
-    @Test
-    fun `save and read round-trip works`() =
-        runTest {
-            // When
-            storage.save("access_token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
-
-            // Then
-            val result = storage.read("access_token")
-            assertEquals("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", result)
+                val result = storage.read("access_token")
+                result shouldBe "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            }
         }
 
-    @Test
-    fun `read returns null for non-existent key`() =
-        runTest {
-            // When
-            val result = storage.read("nonexistent")
+        test("read returns null for non-existent key") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
 
-            // Then
-            assertNull(result)
+                storage.read("nonexistent") shouldBe null
+            }
         }
 
-    @Test
-    fun `data persists across storage instances`() =
-        runTest {
-            // Given
-            storage.save("refresh_token", "secret-refresh-token")
+        test("data persists across storage instances") {
+            runTest {
+                val storageFile = newStorageFile()
+                val storage = JvmSecureStorage(storageFile)
+                storage.save("refresh_token", "secret-refresh-token")
 
-            // When - create new instance pointing to same file
-            val newStorage = JvmSecureStorage(storageFile)
-            val result = newStorage.read("refresh_token")
-
-            // Then
-            assertEquals("secret-refresh-token", result)
+                // Create a new instance pointing to the same file.
+                val newStorage = JvmSecureStorage(storageFile)
+                newStorage.read("refresh_token") shouldBe "secret-refresh-token"
+            }
         }
 
-    @Test
-    fun `save overwrites existing value`() =
-        runTest {
-            // Given
-            storage.save("key", "value1")
+        test("save overwrites existing value") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                storage.save("key", "value1")
 
-            // When
-            storage.save("key", "value2")
-            val result = storage.read("key")
-
-            // Then
-            assertEquals("value2", result)
+                storage.save("key", "value2")
+                storage.read("key") shouldBe "value2"
+            }
         }
 
-    @Test
-    fun `multiple keys stored independently`() =
-        runTest {
-            // When
-            storage.save("access_token", "access123")
-            storage.save("refresh_token", "refresh456")
-            storage.save("server_url", "https://example.com")
+        test("multiple keys stored independently") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
 
-            // Then
-            assertEquals("access123", storage.read("access_token"))
-            assertEquals("refresh456", storage.read("refresh_token"))
-            assertEquals("https://example.com", storage.read("server_url"))
+                storage.save("access_token", "access123")
+                storage.save("refresh_token", "refresh456")
+                storage.save("server_url", "https://example.com")
+
+                storage.read("access_token") shouldBe "access123"
+                storage.read("refresh_token") shouldBe "refresh456"
+                storage.read("server_url") shouldBe "https://example.com"
+            }
         }
 
-    @Test
-    fun `delete removes specific key`() =
-        runTest {
-            // Given
-            storage.save("key1", "value1")
-            storage.save("key2", "value2")
+        test("delete removes specific key") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                storage.save("key1", "value1")
+                storage.save("key2", "value2")
 
-            // When
-            storage.delete("key1")
+                storage.delete("key1")
 
-            // Then
-            assertNull(storage.read("key1"))
-            assertEquals("value2", storage.read("key2"))
+                storage.read("key1") shouldBe null
+                storage.read("key2") shouldBe "value2"
+            }
         }
 
-    @Test
-    fun `clear removes all data`() =
-        runTest {
-            // Given
-            storage.save("key1", "value1")
-            storage.save("key2", "value2")
+        test("clear removes all data") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                storage.save("key1", "value1")
+                storage.save("key2", "value2")
 
-            // When
-            storage.clear()
+                storage.clear()
 
-            // Then
-            assertNull(storage.read("key1"))
-            assertNull(storage.read("key2"))
+                storage.read("key1") shouldBe null
+                storage.read("key2") shouldBe null
+            }
         }
 
-    @Test
-    fun `clear deletes storage file`() =
-        runTest {
-            // Given
-            storage.save("key", "value")
-            assertTrue(storageFile.exists())
+        test("clear deletes storage file") {
+            runTest {
+                val storageFile = newStorageFile()
+                val storage = JvmSecureStorage(storageFile)
+                storage.save("key", "value")
+                storageFile.exists() shouldBe true
 
-            // When
-            storage.clear()
+                storage.clear()
 
-            // Then
-            assertTrue(!storageFile.exists())
+                storageFile.exists() shouldBe false
+            }
         }
 
-    @Test
-    fun `handles empty string value`() =
-        runTest {
-            // When
-            storage.save("empty", "")
-            val result = storage.read("empty")
+        test("handles empty string value") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
 
-            // Then
-            assertEquals("", result)
+                storage.save("empty", "")
+                storage.read("empty") shouldBe ""
+            }
         }
 
-    @Test
-    fun `handles unicode characters`() =
-        runTest {
-            // Given
-            val unicodeValue = "用户名：测试 🎧📚"
+        test("handles unicode characters") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                val unicodeValue = "用户名：测试 🎧📚"
 
-            // When
-            storage.save("unicode_key", unicodeValue)
-            val result = storage.read("unicode_key")
-
-            // Then
-            assertEquals(unicodeValue, result)
+                storage.save("unicode_key", unicodeValue)
+                storage.read("unicode_key") shouldBe unicodeValue
+            }
         }
 
-    @Test
-    fun `handles long values`() =
-        runTest {
-            // Given - simulate a large JWT or certificate
-            val longValue = "x".repeat(10_000)
+        test("handles long values") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                // Simulate a large JWT or certificate.
+                val longValue = "x".repeat(10_000)
 
-            // When
-            storage.save("long_key", longValue)
-            val result = storage.read("long_key")
-
-            // Then
-            assertEquals(longValue, result)
+                storage.save("long_key", longValue)
+                storage.read("long_key") shouldBe longValue
+            }
         }
 
-    @Test
-    fun `handles special JSON characters in values`() =
-        runTest {
-            // Given - JSON with quotes, backslashes, newlines
-            val jsonValue = """{"key": "value with \"quotes\" and \\ backslash\nand newline"}"""
+        test("handles special JSON characters in values") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+                // JSON with quotes, backslashes, newlines.
+                val jsonValue = """{"key": "value with \"quotes\" and \\ backslash\nand newline"}"""
 
-            // When
-            storage.save("json_data", jsonValue)
-            val result = storage.read("json_data")
-
-            // Then
-            assertEquals(jsonValue, result)
+                storage.save("json_data", jsonValue)
+                storage.read("json_data") shouldBe jsonValue
+            }
         }
 
-    @Test
-    fun `file content is encrypted not plaintext`() =
-        runTest {
-            // Given
-            val secretValue = "super-secret-token-12345"
+        test("file content is encrypted not plaintext") {
+            runTest {
+                val storageFile = newStorageFile()
+                val storage = JvmSecureStorage(storageFile)
+                val secretValue = "super-secret-token-12345"
 
-            // When
-            storage.save("secret", secretValue)
+                storage.save("secret", secretValue)
 
-            // Then - file should exist but not contain plaintext
-            assertTrue(storageFile.exists())
-            val fileContent = storageFile.readText()
-            assertTrue(!fileContent.contains(secretValue), "Plaintext found in encrypted file!")
-            assertTrue(fileContent.isNotEmpty(), "Encrypted file should not be empty")
+                // The file should exist but not contain plaintext.
+                storageFile.exists() shouldBe true
+                val fileContent = storageFile.readText()
+                fileContent.contains(secretValue) shouldBe false
+                fileContent.isNotEmpty() shouldBe true
+            }
         }
 
-    @Test
-    fun `handles corrupted file gracefully`() =
-        runTest {
-            // Given - write garbage to the file
-            storageFile.writeText("not-valid-encrypted-data")
+        test("handles corrupted file gracefully") {
+            runTest {
+                val storageFile = newStorageFile()
+                val storage = JvmSecureStorage(storageFile)
+                // Write garbage to the file.
+                storageFile.writeText("not-valid-encrypted-data")
 
-            // When
-            val result = storage.read("any_key")
-
-            // Then - should return null, not crash
-            assertNull(result)
+                // Should return null, not crash.
+                storage.read("any_key") shouldBe null
+            }
         }
 
-    @Test
-    fun `delete on non-existent key does not crash`() =
-        runTest {
-            // When/Then - should not throw
-            storage.delete("nonexistent_key")
+        test("delete on non-existent key does not crash") {
+            runTest {
+                val storage = JvmSecureStorage(newStorageFile())
+
+                // Should not throw.
+                storage.delete("nonexistent_key")
+            }
         }
 
-    @Test
-    fun `new storage on non-existent file works`() =
-        runTest {
-            // Given
-            val newFile = File(tempFolder.root, "brand-new.enc")
-            val newStorage = JvmSecureStorage(newFile)
+        test("new storage on non-existent file works") {
+            runTest {
+                val newFile = File(tempdir(), "brand-new.enc")
+                val newStorage = JvmSecureStorage(newFile)
 
-            // When
-            newStorage.save("key", "value")
+                newStorage.save("key", "value")
 
-            // Then
-            assertEquals("value", newStorage.read("key"))
-            assertTrue(newFile.exists())
+                newStorage.read("key") shouldBe "value"
+                newFile.exists() shouldBe true
+            }
         }
 
-    @Test
-    fun `encryption produces different ciphertext for same plaintext`() =
-        runTest {
-            // This tests that we're using random IVs (not deterministic encryption)
+        test("encryption produces different ciphertext for same plaintext") {
+            runTest {
+                // This tests that we're using random IVs (not deterministic encryption).
+                val dir = tempdir()
+                val file1 = File(dir, "enc1.enc")
+                val file2 = File(dir, "enc2.enc")
+                val storage1 = JvmSecureStorage(file1)
+                val storage2 = JvmSecureStorage(file2)
 
-            // Given
-            val file1 = File(tempFolder.root, "enc1.enc")
-            val file2 = File(tempFolder.root, "enc2.enc")
-            val storage1 = JvmSecureStorage(file1)
-            val storage2 = JvmSecureStorage(file2)
+                storage1.save("key", "same-value")
+                storage2.save("key", "same-value")
 
-            // When
-            storage1.save("key", "same-value")
-            storage2.save("key", "same-value")
-
-            // Then - ciphertext should differ due to random IV
-            val content1 = file1.readText()
-            val content2 = file2.readText()
-
-            // Note: They might still be equal by chance (very unlikely with 96-bit IV)
-            // but the values should decrypt to the same thing
-            assertEquals("same-value", storage1.read("key"))
-            assertEquals("same-value", storage2.read("key"))
+                // Ciphertext might still be equal by chance (very unlikely with a 96-bit IV),
+                // but the values must decrypt to the same thing.
+                storage1.read("key") shouldBe "same-value"
+                storage2.read("key") shouldBe "same-value"
+            }
         }
-}
+    })


### PR DESCRIPTION
## What

Batch 5 of the `kotlin-test` → **Kotest FunSpec** migration (follows #514, #517, #520, #523). The remaining `commonTest` repository / infra / fake specs + the last `jvmTest` holdout:

- repository: `AvatarDownloadRepositoryImpl`, `FakeDownloadRepository`, `MetadataRepositoryImpl`, `UserRepositoryImpl`
- fakes: `FakeBookRepository`, `FakePlaybackPositionRepository`, `FakePlayer`
- infra: `SharedCommon`, `core/SecureStorage`, `test/http/TestMockEngine`, `test/di/KoinTestRule`, `test/MainDispatcherRule`, `TestAssertions` (the `checkIs` helper)
- jvmTest: `core/JvmSecureStorage`

## How

Pure framework migration — no test logic/values/fixtures changed.

- `TestAssertions.checkIs` reimplemented on Kotest (`shouldBeInstanceOf` + `withClue`) so it no longer depends on `kotlin.test.assertIs`; its callers are unchanged.
- `JvmSecureStorageTest` used a JUnit `@get:Rule TemporaryFolder` — replaced with Kotest's `tempdir()` (a fresh temp dir per test, auto-cleaned), fixtures created per-test.
- `MainDispatcherRule`/`KoinTestRule` are plain helper classes (not JUnit rules); their `setUp`/`tearDown` move to `beforeTest`/`afterTest`.
- Assertions → Kotest matchers (`assertEquals(expected, actual)` → `actual shouldBe expected`); `assertIs` that smart-casts → `shouldBeInstanceOf` (keeps the contract).

## Verification

`:sharedLogic:jvmTest` green, spotless + detekt clean. No production code touched.

## Remaining

After this + the in-flight #520/#523 merge, the only `kotlin-test` left is the `androidHostTest` source sets (sharedUI + sharedLogic) — those run on Kotest via the JUnit-platform config, but I'll convert them as a final batch with explicit run-verification (the harness mixes Kotest + JUnit4/Robolectric there). Then `kotlin-test` can leave the version catalog.
