### PR TITLE
🔥 chore(quality): drop kotlin-test from the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,6 @@ kotlincrypto-hash = "0.8.0"
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 android-kmpLibrary-gradlePlugin = { module = "com.android.kotlin.multiplatform.library:com.android.kotlin.multiplatform.library.gradle.plugin", version.ref = "agp" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidx-core-splashscreen" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }

--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -146,7 +146,6 @@ kotlin {
         }
 
         commonTest.dependencies {
-            implementation(libs.kotlin.test)
             implementation(libs.mokkery.runtime)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.koin.test)

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -169,7 +169,6 @@ kotlin {
         }
         val androidHostTest by getting {
             dependencies {
-                implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.coroutines.test)
 
                 // Kotest — canonical FunSpec framework for new androidHostTest tests.
@@ -194,7 +193,6 @@ kotlin {
         }
         val desktopTest by getting {
             dependencies {
-                implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.mokkery.runtime)
 


### PR DESCRIPTION
## What

Removes `kotlin-test` from the version catalog now that the Kotest migration is complete (#514, #517, #520, #523, #524, #526 all merged — zero `import kotlin.test` left in any app-module source set).

- Drops `kotlin-test = { … }` from `gradle/libs.versions.toml`.
- Drops `implementation(libs.kotlin.test)` from the three test source sets that declared it: `sharedLogic` commonTest, `sharedUI` androidHostTest, `sharedUI` desktopTest.

## Why it's safe

- **commonTest / jvmTest**: now Kotest FunSpec — no `kotlin.test`.
- **androidHostTest**: Kotest FunSpec for pure tests; the Robolectric/Compose tests stay JUnit4 but use `org.junit.Test` (provided transitively by `robolectric` + `androidx.compose.ui.test.junit4` + `junit-vintage-engine`), not `kotlin.test`.
- **desktopTest**: no `kotlin.test` usages.
- **build-logic** is unaffected — it uses the `kotlin("test")` plugin helper, not this catalog entry.

## Verification

`:sharedLogic:jvmTest`, `:sharedUI:testAndroidHostTest` (Robolectric — confirms `org.junit.Test` still resolves without `kotlin.test`), `:androidApp:assembleDebug`, spotless, and detekt all green.

Note: `:sharedUI:compileKotlinDesktop` has a **pre-existing** failure (`androidx.room.RoomDatabase` classpath in `desktopMain/PlatformModule.kt`) unrelated to this change — it's the desktop *main* source set (not touched here), and desktop isn't a CI gate.
