### PR TITLE
🐛 fix(sharedUI): version server-fallback cover request on coverHash

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
@@ -171,7 +171,7 @@ private fun rememberCoverRequest(
                             .diskCacheKey(cacheKey)
                             .build()
                     } else {
-                        serverCoverRequest(context, bookId, serverConfig, authSession, localPath)
+                        serverCoverRequest(context, bookId, serverConfig, authSession, localPath, cacheKey)
                     }
                 }
         }
@@ -182,6 +182,11 @@ private fun rememberCoverRequest(
 /**
  * Builds the authenticated server cover request, falling back to the local path when no server URL is
  * configured (offline before any onboarding).
+ *
+ * [cacheKey] folds the book's coverHash into Coil's memory/disk key so a re-covered book (new hash)
+ * busts the cached image instead of serving the stale one. Without it Coil keys on the cover URL —
+ * which never changes for a given book — so a replaced cover (e.g. a wizard-applied Audible cover)
+ * keeps rendering the old image, and the disk cache survives even an app restart.
  */
 private suspend fun serverCoverRequest(
     context: coil3.PlatformContext,
@@ -189,6 +194,7 @@ private suspend fun serverCoverRequest(
     serverConfig: ServerConfig,
     authSession: AuthSession,
     localPath: String,
+    cacheKey: String,
 ): ImageRequest {
     val baseUrl = serverConfig.getActiveUrl()?.value
     val token = authSession.getAccessToken()?.value
@@ -197,12 +203,19 @@ private suspend fun serverCoverRequest(
         ImageRequest
             .Builder(context)
             .data("$baseUrl/api/v1/covers/$bookId")
+            .memoryCacheKey(cacheKey)
+            .diskCacheKey(cacheKey)
             .apply {
                 if (token != null) {
                     httpHeaders(NetworkHeaders.Builder().set("Authorization", "Bearer $token").build())
                 }
             }.build()
     } else {
-        ImageRequest.Builder(context).data(localPath).build()
+        ImageRequest
+            .Builder(context)
+            .data(localPath)
+            .memoryCacheKey(cacheKey)
+            .diskCacheKey(cacheKey)
+            .build()
     }
 }


### PR DESCRIPTION
## The bug

A wizard-applied cover (e.g. an Audible cover) wouldn't appear — the book kept rendering its old image, and **an app restart didn't fix it either**.

## Root cause

The cover-busting fix (#504) folds a book's `coverHash` into Coil's memory/disk cache key (`bookCoverCacheKey`) so that replacing a cover changes the key and forces a re-fetch. But `BookCoverImage.serverCoverRequest` — the slow path that hits `GET /api/v1/covers/{bookId}` when no local file exists — built its `ImageRequest` **without that key**.

So Coil keyed the server request on the cover URL, which never changes for a given book. After a cover change, the sync handler deletes the stale local file (`BookSyncDomainHandler`, #504), the next render falls through to `serverCoverRequest`, and Coil serves the **old** image from its URL-keyed cache. Because the disk cache is URL-keyed too, it survived an app restart — exactly the reported symptom.

The fast path and the local-file branch already applied the versioned key; only the server-URL fallback was missing it.

## The fix

Thread the already-computed `cacheKey` into `serverCoverRequest` and apply `.memoryCacheKey(cacheKey).diskCacheKey(cacheKey)` to **both** branches (server URL and the offline local-path fallback). One key, every cover request.

## Testing

`bookCoverCacheKey` key-derivation is already covered by `CoverCacheKeyTest` (sharedLogic, runs in CI). A request-level guard would naturally live in `sharedUI`, but desktopTest can't run (pre-existing `androidx.room.RoomDatabase` classpath break in `desktopMain`) and androidHostTest doesn't execute Kotest — so this is verified by the android build gate plus on-device retest of the Audible-cover-apply flow.