### PR TITLE
🐛 fix(server): enrich metadata covers with iTunes high-res variant

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -120,7 +120,7 @@ internal class MetadataLookupServiceImpl(
     override suspend fun getBookMetadata(
         asin: String,
         region: AudibleRegion,
-    ): AppResult<MetadataBook?> = audible.getBook(asin, region)
+    ): AppResult<MetadataBook?> = audible.getBook(asin, region).enrichWithItunesCover()
 
     override suspend fun getBookChapters(
         asin: String,
@@ -151,7 +151,31 @@ internal class MetadataLookupServiceImpl(
         region: AudibleRegion,
     ): AppResult<MetadataBook?> {
         requireCanEdit()?.let { return AppResult.Failure(it) }
-        return audible.getBook(asin, region, refresh = true)
+        return audible.getBook(asin, region, refresh = true).enrichWithItunesCover()
+    }
+
+    /**
+     * Grafts iTunes' high-resolution cover onto a single-book metadata result.
+     *
+     * The metadata wizard's cover picker sources its "iTunes HD" option from
+     * [MetadataBook.coverUrlMaxSize] — but the Audible mappers never populate it.
+     * When the lookup succeeded with a book whose max-size cover is still empty,
+     * fetch the best iTunes cover by title + primary author and copy its
+     * max-resolution URL in. Failure-contained: a missing book, a blank title, a
+     * null hit, a blank URL, or any iTunes error leaves the result untouched so
+     * the Audible metadata still flows. One iTunes request per preview load.
+     */
+    private suspend fun AppResult<MetadataBook?>.enrichWithItunesCover(): AppResult<MetadataBook?> {
+        val book = (this as? AppResult.Success)?.data ?: return this
+        if (book.coverUrlMaxSize != null || book.title.isBlank()) return this
+        val author =
+            book.authors
+                .firstOrNull()
+                ?.name
+                .orEmpty()
+        val hit = (metadataService.findCover(book.title, author) as? AppResult.Success)?.data ?: return this
+        val maxUrl = hit.maxSizeUrl.takeIf { it.isNotBlank() } ?: return this
+        return AppResult.Success(book.copy(coverUrlMaxSize = maxUrl))
     }
 
     override suspend fun applyBookMetadata(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
@@ -41,6 +41,7 @@ import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
@@ -109,6 +110,64 @@ class MetadataLookupServiceImplTest :
                     result
                         .shouldBeInstanceOf<AppResult.Success<List<MetadataContributorHit>>>()
                         .data shouldHaveSize 0
+                }
+            }
+        }
+
+        // ── getBookMetadata iTunes cover enrichment ───────────────────────────
+
+        test("getBookMetadata enriches coverUrlMaxSize from iTunes findCover") {
+            withInMemoryDatabase {
+                val audible = BookStubAudibleApi(bookWithCover("https://audible.test/cover.jpg"))
+                val itunes =
+                    StubITunesApi(
+                        AppResult.Success(
+                            ITunesCoverHit(
+                                coverUrl = "https://itunes.test/100x100bb.jpg",
+                                maxSizeUrl = "https://itunes.test/7000x7000bb.jpg",
+                                sourceId = "12345",
+                            ),
+                        ),
+                    )
+                val service = makeService(audible = audible, db = this, itunes = itunes)
+
+                runTest {
+                    val result = service.getBookMetadata("B0TESTASIN", AudibleRegion.US)
+
+                    val book = result.shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataBook?>>().data
+                    book.shouldNotBeNull()
+                    book.coverUrl shouldBe "https://audible.test/cover.jpg"
+                    book.coverUrlMaxSize shouldBe "https://itunes.test/7000x7000bb.jpg"
+                }
+            }
+        }
+
+        test("getBookMetadata leaves coverUrlMaxSize null when iTunes finds nothing") {
+            withInMemoryDatabase {
+                val audible = BookStubAudibleApi(bookWithCover("https://audible.test/cover.jpg"))
+                val service = makeService(audible = audible, db = this, itunes = StubITunesApi(AppResult.Success(null)))
+
+                runTest {
+                    val result = service.getBookMetadata("B0TESTASIN", AudibleRegion.US)
+                    val book = result.shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataBook?>>().data
+                    book.shouldNotBeNull()
+                    book.coverUrlMaxSize shouldBe null
+                }
+            }
+        }
+
+        test("getBookMetadata still returns the Audible book when the iTunes lookup fails") {
+            withInMemoryDatabase {
+                val audible = BookStubAudibleApi(bookWithCover("https://audible.test/cover.jpg"))
+                val itunes = StubITunesApi(AppResult.Failure(MetadataError.ExternalUnavailable()))
+                val service = makeService(audible = audible, db = this, itunes = itunes)
+
+                runTest {
+                    val result = service.getBookMetadata("B0TESTASIN", AudibleRegion.US)
+                    val book = result.shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataBook?>>().data
+                    book.shouldNotBeNull()
+                    book.coverUrl shouldBe "https://audible.test/cover.jpg"
+                    book.coverUrlMaxSize shouldBe null
                 }
             }
         }
@@ -296,12 +355,13 @@ private fun bookFixture(bookId: String): BookSyncPayload =
 private fun makeService(
     audible: AudibleApi,
     db: Database,
+    itunes: ITunesApi = NoOpITunesApi(),
 ): MetadataLookupServiceImpl {
     val tempDir = Files.createTempDirectory("metadata-test-").toAbsolutePath()
     val metadataService =
         MetadataService(
             audible = audible,
-            itunes = NoOpITunesApi(),
+            itunes = itunes,
             cache = MetadataCacheRepository(db, clock = FixedClock(NOW)),
         )
     val bus = ChangeBus()
@@ -398,6 +458,20 @@ private class NoOpITunesApi : ITunesApi {
         title: String,
         author: String,
     ): AppResult<ITunesCoverHit?> = AppResult.Success(null)
+
+    override suspend fun searchCovers(
+        title: String,
+        author: String,
+    ): AppResult<List<ITunesCoverHit>> = AppResult.Success(emptyList())
+}
+
+private class StubITunesApi(
+    private val findCoverResult: AppResult<ITunesCoverHit?>,
+) : ITunesApi {
+    override suspend fun findCover(
+        title: String,
+        author: String,
+    ): AppResult<ITunesCoverHit?> = findCoverResult
 
     override suspend fun searchCovers(
         title: String,


### PR DESCRIPTION
## Problem

iTunes covers never appeared in the find-metadata wizard. The client builds the "iTunes HD" cover option *only* from `MetadataBook.coverUrlMaxSize`, but the server hardcoded that field to `null` in **both** Audible→DTO mappers (`AudibleMetadataProvider.toMetadataBook`). The iTunes enrichment the DTO's KDoc promises was never wired up — lost in the Go→Kotlin migration. (A working `searchCovers()` RPC exists, but the client deliberately stopped calling it; the two halves never met.)

## Fix

`MetadataLookupServiceImpl.enrichWithItunesCover()` — after the Audible fetch in `getBookMetadata`/`refreshBookMetadata`, call the already-injected `MetadataService.findCover(title, primaryAuthor)` and graft `coverUrlMaxSize = hit.maxSizeUrl`. Failure-contained: a null hit, blank URL, blank title, or any iTunes error leaves the Audible result untouched. One iTunes request per preview load.

Zero client changes needed — the existing UI lights up the "iTunes HD" option, and applying it already flows the selected URL through `selection.coverUrl` → `BookMetadataApplier` downloads & stores it. Both showing and downloading iTunes covers now work end-to-end.

## Tests

3 new Kotest tests in `MetadataLookupServiceImplTest` (red→green):
- enriches `coverUrlMaxSize` from iTunes `findCover`
- leaves it null when iTunes finds nothing
- still returns the Audible book when the iTunes lookup fails

Full Linux gate green: `spotlessCheck detekt :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`.
