### PR TITLE
🐛 fix(server): persist edited added-date so Recently Added re-sorts

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/BookUpdate.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/BookUpdate.kt
@@ -26,6 +26,13 @@ data class BookUpdate(
     @SerialName("isbn") val isbn: String? = null,
     @SerialName("asin") val asin: String? = null,
     @SerialName("abridged") val abridged: Boolean? = null,
+    /**
+     * The book's effective "added date" as epoch milliseconds — the value the
+     * library's *Recently Added* ordering sorts on (persisted server-side as the
+     * book's `createdAt`). `null` means "don't touch"; a positive value re-stamps
+     * the added date so the book re-sorts.
+     */
+    @SerialName("addedAt") val addedAt: Long? = null,
 ) {
     init {
         title?.let { require(it.isNotBlank() && it.length <= MAX_TITLE) { "title must be 1..$MAX_TITLE chars" } }
@@ -37,6 +44,7 @@ data class BookUpdate(
         language?.let { require(it.length <= MAX_LANGUAGE) { "language must be <= $MAX_LANGUAGE chars" } }
         isbn?.let { require(it.length <= MAX_ISBN) { "isbn must be <= $MAX_ISBN chars" } }
         asin?.let { require(it.length <= MAX_ASIN) { "asin must be <= $MAX_ASIN chars" } }
+        addedAt?.let { require(it > 0) { "addedAt must be a positive epoch-millis value" } }
     }
 
     companion object {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
@@ -23,8 +23,10 @@ import com.calypsan.listenup.server.cover.CoverInfo
 import com.calypsan.listenup.server.cover.CoverStorage
 import com.calypsan.listenup.server.db.BookGenreTable
 import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.BookWriteExtras
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.SeriesRepository
+import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 
@@ -154,7 +156,16 @@ internal class BookServiceImpl(
             val current =
                 repo.findById(id)
                     ?: return@suspendTransaction bookNotFound(id)
-            when (val upsertResult = repo.upsert(current.applyPatch(patch))) {
+            val patched = current.applyPatch(patch)
+            // An added-date edit must re-stamp createdAt, which writePayload only writes when this
+            // override is present — keeping rescans (which carry a placeholder createdAt) from clobbering it.
+            val upsertResult =
+                if (patch.addedAt != null) {
+                    withContext(BookWriteExtras(createdAtOverride = patch.addedAt)) { repo.upsert(patched) }
+                } else {
+                    repo.upsert(patched)
+                }
+            when (upsertResult) {
                 is AppResult.Success -> AppResult.Success(Unit)
                 is AppResult.Failure -> AppResult.Failure(upsertResult.error)
             }
@@ -417,4 +428,7 @@ private fun BookSyncPayload.applyPatch(patch: BookUpdate): BookSyncPayload =
         isbn = patch.isbn ?: isbn,
         asin = patch.asin ?: asin,
         abridged = patch.abridged ?: abridged,
+        // The added date is stored as createdAt; null leaves it untouched. The DB write is gated by
+        // BookWriteExtras.createdAtOverride in writePayload so only this edit path can move it.
+        createdAt = patch.addedAt ?: createdAt,
     )

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -272,6 +272,10 @@ class BookRepository(
                 stmt[BookTable.updatedAt] = now
                 stmt[BookTable.deletedAt] = null
                 stmt[BookTable.clientOpId] = clientOpId
+                // Edit-path only: re-stamp the added date. `applyBookFields` never writes
+                // createdAt, so a rescan's placeholder value stays ignored — only an explicit
+                // metadata edit (which sets this override) can move it.
+                extras?.createdAtOverride?.let { stmt[BookTable.createdAt] = it }
             }
         } else {
             BookTable.insert { stmt ->

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookWriteExtras.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookWriteExtras.kt
@@ -12,6 +12,13 @@ import kotlin.coroutines.CoroutineContext
 class BookWriteExtras(
     val managedCover: StoredCoverInfo? = null,
     val inboxCollectionId: String? = null,
+    /**
+     * Edit-path override for the book's `createdAt` (the "added date"). Non-null
+     * only when an explicit metadata edit re-stamps the added date — [writePayload]'s
+     * UPDATE branch writes it through. The scanner never sets this, so a rescan's
+     * placeholder `createdAt` keeps being ignored on update.
+     */
+    val createdAtOverride: Long? = null,
 ) : AbstractCoroutineContextElement(Key) {
     companion object Key : CoroutineContext.Key<BookWriteExtras>
 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/BookServiceImplUpdateTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/BookServiceImplUpdateTest.kt
@@ -261,6 +261,63 @@ class BookServiceImplUpdateTest :
             }
         }
 
+        test("updateBook with addedAt re-stamps the book's createdAt") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                val (service, repo) = bookServiceFor(db, "admin", UserRole.ROOT)
+                runTest {
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings"))
+                    val newAddedAt = 1_500_000_000_000L
+
+                    service
+                        .updateBook(BookId("b1"), BookUpdate(addedAt = newAddedAt))
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    repo.findById(BookId("b1"))?.createdAt shouldBe newAddedAt
+                }
+            }
+        }
+
+        test("updateBook without addedAt leaves createdAt untouched") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                val (service, repo) = bookServiceFor(db, "admin", UserRole.ROOT)
+                runTest {
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings"))
+                    val original = repo.findById(BookId("b1"))?.createdAt
+
+                    service
+                        .updateBook(BookId("b1"), BookUpdate(title = "Words of Radiance"))
+                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    repo.findById(BookId("b1"))?.createdAt shouldBe original
+                }
+            }
+        }
+
+        test("a rescan after an added-date edit preserves the edited createdAt") {
+            // Regression guard: the scanner sends createdAt = 0L as a placeholder. writePayload must
+            // only move createdAt when the edit-path override is present, never on a plain rescan.
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                val (service, repo) = bookServiceFor(db, "admin", UserRole.ROOT)
+                runTest {
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings"))
+                    val editedAddedAt = 1_500_000_000_000L
+                    service.updateBook(BookId("b1"), BookUpdate(addedAt = editedAddedAt))
+                    repo.findById(BookId("b1"))?.createdAt shouldBe editedAddedAt
+
+                    // Simulate a rescan: an UPDATE upsert carrying the placeholder createdAt, no override.
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings: Rescanned"))
+
+                    repo.findById(BookId("b1"))?.createdAt shouldBe editedAddedAt
+                }
+            }
+        }
+
         test("updateBook returns BookError.NotFound when the book does not exist") {
             withInMemoryDatabase {
                 val db = this

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCase.kt
@@ -148,6 +148,7 @@ open class UpdateBookUseCase(
                 isbn = metadata.isbn.ifBlank { null },
                 asin = metadata.asin.ifBlank { null },
                 abridged = metadata.abridged,
+                addedAt = metadata.addedAt,
             )
         return bookEditRepository.updateBook(BookId(current.bookId), patch)
     }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/BookUpdateContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/BookUpdateContractTest.kt
@@ -33,6 +33,7 @@ class BookUpdateContractTest :
                     isbn = "978-0-7653-2635-5",
                     asin = "B0XXXXXXXX",
                     abridged = false,
+                    addedAt = 1_700_000_000_000L,
                 )
             roundTrip<BookUpdate>(original) shouldBe original
         }
@@ -54,6 +55,12 @@ class BookUpdateContractTest :
         test("should throw when BookUpdate publishYear is out of range") {
             shouldThrow<IllegalArgumentException> {
                 BookUpdate(publishYear = 99_999)
+            }
+        }
+
+        test("should throw when BookUpdate addedAt is not positive") {
+            shouldThrow<IllegalArgumentException> {
+                BookUpdate(addedAt = 0L)
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCaseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCaseTest.kt
@@ -295,6 +295,31 @@ class UpdateBookUseCaseTest :
             }
         }
 
+        test("includes edited addedAt in the metadata patch") {
+            runTest {
+                // Given — only the added date changes
+                val originalMetadata = createMetadata(addedAt = 1_700_000_000_000L)
+                val currentMetadata = createMetadata(addedAt = 1_500_000_000_000L)
+                val original = createOriginalState(metadata = originalMetadata)
+                val current = createUpdateRequest(metadata = currentMetadata)
+
+                val fixture = createFixture()
+                val useCase = fixture.build()
+
+                // When
+                val result = useCase(current, original)
+
+                // Then
+                checkIs<AppResult.Success<Unit>>(result)
+                verifySuspend {
+                    fixture.bookEditRepository.updateBook(
+                        BookId("book-1"),
+                        matches { patch: BookUpdate -> patch.addedAt == 1_500_000_000_000L },
+                    )
+                }
+            }
+        }
+
         // ========== Contributor Change Tests ==========
 
         test("updates contributors when list changes") {


### PR DESCRIPTION
Closes #538.

## Problem

Editing a book's **Added Date** did nothing — Recently Added kept the old ordering. The editable `addedAt` field maps to the book's `createdAt` column (the exact key `observeRecentlyAdded` sorts on: `ORDER BY b.createdAt DESC`), but the edit was silently dropped at **three** layers:

1. **Contract** — `BookUpdate` had no added-date field.
2. **Client** — `UpdateBookUseCase.updateMetadata` built the patch without it, so the edit never left the device.
3. **Server** — `applyPatch` didn't set `createdAt`, and the upsert's UPDATE branch never writes `createdAt` at all (only INSERT does).

## The regression trap

`AnalyzedBookMapper` sends `createdAt = 0L` as a **placeholder** in every rescan payload. Today the UPDATE branch ignoring `createdAt` is what keeps that harmless — so a naïve "just write createdAt on update" would reset every book's added-date to 1970 on each rescan. The fix therefore writes `createdAt` **only on the explicit edit path**.

## Fix

- **contract** — `BookUpdate.addedAt: Long?` (epoch millis, `require(addedAt == null || addedAt > 0)`).
- **client** — `UpdateBookUseCase` serializes `metadata.addedAt` into the patch.
- **server** — `applyPatch` sets `createdAt = patch.addedAt ?: createdAt`; the edit-path upsert carries a `createdAtOverride` through the existing `BookWriteExtras` per-call mechanism (same one used for `managedCover`). `writePayload`'s UPDATE branch writes `createdAt` only when that override is present — scanner rescans (no override) keep ignoring the `0L` placeholder. One upsert, one sync emission → clients re-sync the new `createdAt` and Recently Added re-sorts.

## Tests (Kotest)

- **Server:** added-date edit re-stamps `createdAt`; edit without `addedAt` leaves it untouched; **a rescan after an added-date edit preserves the edited date** (regression guard for the `0L` trap).
- **Contract:** `BookUpdate` round-trips `addedAt` + rejects `addedAt <= 0`.
- **Client:** `UpdateBookUseCase` serializes an edited `addedAt` into the patch.

Full Linux gate green: `spotlessCheck detekt :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`.
