### PR TITLE
🐛 fix(server): parse ABS offset timestamps (fixes Continue Listening order + Home stats)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/absimport/AbsBackupReader.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/absimport/AbsBackupReader.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.calypsan.listenup.server.absimport
 
 import java.nio.file.Path
@@ -5,8 +7,7 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.ResultSet
 import java.sql.SQLException
-import java.time.Instant
-import java.time.format.DateTimeParseException
+import kotlin.time.Instant
 
 /**
  * Reads an extracted Audiobookshelf `absdatabase.sqlite` on a throwaway **read-only** JDBC
@@ -110,7 +111,7 @@ internal class AbsBackupReader {
                     currentTimeSeconds = currentTime,
                     isFinished = rs.getBoolean("isFinished"),
                     progress = if (duration > 0.0) (currentTime / duration).coerceIn(0.0, 1.0) else 0.0,
-                    lastUpdateMs = parseTimestampMs(rs.getString("updatedAt")),
+                    lastUpdateMs = parseAbsTimestampMs(rs.getString("updatedAt")),
                 )
             }
         }
@@ -141,7 +142,7 @@ internal class AbsBackupReader {
                     startPositionSeconds = rs.getDouble("startTime"),
                     endPositionSeconds = rs.getDouble("currentTime"),
                     timeListeningSeconds = rs.getDouble("timeListening"),
-                    startedAtMs = parseTimestampMs(rs.getString("startedAt")),
+                    startedAtMs = parseAbsTimestampMs(rs.getString("startedAt")),
                     playbackSpeed = DEFAULT_PLAYBACK_SPEED,
                     deviceLabel = rs.getString("deviceLabel")?.ifBlank { null },
                 )
@@ -178,36 +179,46 @@ internal class AbsBackupReader {
     }
 
     private companion object {
-        /**
-         * Parses an ABS `updatedAt` value to epoch millis. Sequelize stores `DataTypes.DATE` in
-         * SQLite as ISO-8601 text (e.g. `2022-01-17T04:33:12.000Z`), but tolerates a bare numeric
-         * epoch (ms or seconds) for robustness across ABS versions. Unparseable → 0L.
-         */
-        fun parseTimestampMs(raw: String?): Long {
-            if (raw.isNullOrBlank()) return 0L
-            raw.toLongOrNull()?.let { numeric ->
-                // Heuristic: a 10-digit value is seconds, larger is already millis.
-                return if (numeric < SECONDS_THRESHOLD) numeric * MILLIS_PER_SECOND else numeric
-            }
-            return try {
-                Instant.parse(raw).toEpochMilli()
-            } catch (_: DateTimeParseException) {
-                // SQLite's space-separated form ("2022-01-17 04:33:12") isn't ISO-T; normalize it.
-                try {
-                    Instant.parse(raw.replaceFirst(' ', 'T').let { if (it.endsWith("Z")) it else "${it}Z" })
-                        .toEpochMilli()
-                } catch (_: DateTimeParseException) {
-                    0L
-                }
-            }
-        }
-
-        private const val MILLIS_PER_SECOND = 1_000L
-
         /** ABS stores no per-session playback rate; sessions default to normal speed. */
         private const val DEFAULT_PLAYBACK_SPEED = 1.0f
+    }
+}
 
-        /** Epoch values below this are treated as seconds (≈ year 33658 in ms). */
-        private const val SECONDS_THRESHOLD = 1_000_000_000_000L
+private const val MILLIS_PER_SECOND = 1_000L
+
+/** Epoch values below this are treated as seconds (≈ year 33658 in ms). */
+private const val SECONDS_THRESHOLD = 1_000_000_000_000L
+
+/**
+ * Parses an ABS timestamp to epoch millis.
+ *
+ * ABS (Sequelize on SQLite) stores `DataTypes.DATE` columns as space-separated text with a
+ * millisecond fraction and an explicit offset, e.g. `2024-06-12 02:48:10.063 +00:00`. The cleaner
+ * ISO-8601 form (`2022-01-17T04:33:12.000Z`), the offsetless SQLite form (`2022-01-16 04:33:12`),
+ * and a bare numeric epoch (ms or seconds) are also accepted. Anything unparseable → 0L.
+ *
+ * `internal` so it can be unit-tested directly against the real-world formats — the offset form
+ * silently parsing to 0L is exactly what mis-ordered Continue Listening after an ABS import.
+ */
+internal fun parseAbsTimestampMs(raw: String?): Long {
+    if (raw.isNullOrBlank()) return 0L
+    val trimmed = raw.trim()
+    trimmed.toLongOrNull()?.let { numeric ->
+        // Heuristic: a 10-digit value is seconds, larger is already millis.
+        return if (numeric < SECONDS_THRESHOLD) numeric * MILLIS_PER_SECOND else numeric
+    }
+    // Normalize the SQLite text form to ISO-8601: swap the date/time space for 'T' and drop the
+    // space before the offset ("2024-06-12 02:48:10.063 +00:00" → "2024-06-12T02:48:10.063+00:00").
+    val isoLike = trimmed.replaceFirst(' ', 'T').replace(" ", "")
+    return try {
+        // Instant.parse handles an explicit offset (e.g. "+00:00") and the trailing 'Z' (UTC) form.
+        Instant.parse(isoLike).toEpochMilliseconds()
+    } catch (_: IllegalArgumentException) {
+        // Offsetless form ("2022-01-16T04:33:12") — treat as UTC.
+        try {
+            Instant.parse(if (isoLike.endsWith("Z")) isoLike else "${isoLike}Z").toEpochMilliseconds()
+        } catch (_: IllegalArgumentException) {
+            0L
+        }
     }
 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/absimport/AbsBackupReaderTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/absimport/AbsBackupReaderTest.kt
@@ -43,7 +43,7 @@ class AbsBackupReaderTest :
                 inProgress.currentTimeSeconds shouldBe 1234.0
                 // duration 5000s → progress ≈ 0.2468
                 inProgress.progress shouldBe 1234.0 / 5000.0
-                // 2022-01-17T04:33:12.000Z → epoch millis
+                // Real ABS offset form "2022-01-17 04:33:12.000 +00:00" → epoch millis (#537/#532).
                 inProgress.lastUpdateMs shouldBe 1_642_393_992_000L
             }
         }
@@ -76,8 +76,24 @@ class AbsBackupReaderTest :
                 // ABS stores no per-session playback rate → default 1.0.
                 session.playbackSpeed shouldBe 1.0f
                 session.deviceLabel shouldBe "Pixel 8"
-                // createdAt 2022-01-17T04:33:12.000Z → epoch millis.
+                // createdAt is the real ABS offset form "2022-01-17 04:33:12.000 +00:00" → epoch millis.
                 session.startedAtMs shouldBe 1_642_393_992_000L
+            }
+        }
+
+        test("real ABS offset timestamps survive to true epochs, not 1970 (the #532 stats path)") {
+            // Bug #532: imported listening stats stayed empty because session/progress timestamps in
+            // ABS's "2024-06-12 02:48:10.063 +00:00" form parsed to 0L → every listening_event landed
+            // in 1970, outside the weekly window, with all streak dates collapsed onto one day. Guard
+            // both the session (startedAt → stats minutes/streaks) and progress (sort key) paths.
+            val absDb = Files.createTempDirectory("abs-offset-").resolve(AbsSchema.DB_FILENAME)
+            buildSyntheticAbsDb(absDb)
+            AbsBackupReader().open(absDb).use { handle ->
+                val sessionStartedAt = handle.playbackSessions().single { it.itemId == "book-1" }.startedAtMs
+                val progressUpdatedAt = handle.progress().first { it.itemId == "book-2" }.lastUpdateMs
+                // Both sit well after the epoch — the offset form no longer collapses to 1970.
+                (sessionStartedAt > 1_600_000_000_000L).shouldBeTrue()
+                (progressUpdatedAt > 1_600_000_000_000L).shouldBeTrue()
             }
         }
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/absimport/AbsTestFixtures.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/absimport/AbsTestFixtures.kt
@@ -170,7 +170,8 @@ private fun java.sql.Connection.insertAbsRows() {
                     1234.0,
                     5000.0,
                     finished = false,
-                    "2022-01-17T04:33:12.000Z",
+                    // Real Sequelize-SQLite offset form (#537/#532) — same instant as the clean ISO-Z form.
+                    "2022-01-17 04:33:12.000 +00:00",
                 ),
                 ProgressRow(
                     "mp-3",
@@ -214,7 +215,9 @@ private fun java.sql.Connection.insertAbsSessions() {
                 startTime = 100.0,
                 currentTime = 3700.0,
                 timeListening = 3600,
-                startedAt = "2022-01-17T04:33:12.000Z",
+                // The real Sequelize-on-SQLite DATE form ABS writes (#537/#532): same instant as
+                // 2022-01-17T04:33:12.000Z, but the offset spelling collapsed to 1970 in the old parser.
+                startedAt = "2022-01-17 04:33:12.000 +00:00",
                 device = "Pixel 8",
             ),
             SessionRow(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/absimport/AbsTimestampParseTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/absimport/AbsTimestampParseTest.kt
@@ -1,0 +1,46 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.absimport
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+
+/**
+ * Unit coverage for [parseAbsTimestampMs] across every timestamp form an ABS backup can carry.
+ *
+ * The regression that motivated this: Sequelize-on-SQLite writes `DataTypes.DATE` columns as
+ * `2024-06-12 02:48:10.063 +00:00` — space-separated, with a millisecond fraction and an explicit
+ * ` +00:00` offset. The old parser fell through every branch on that form and returned 0L, so every
+ * imported listening position got `lastPlayedAt = 0` and Continue Listening lost its ordering (#537).
+ */
+class AbsTimestampParseTest :
+    FunSpec({
+
+        test("parses the real Sequelize-SQLite offset form (the #537 regression)") {
+            val expected = Instant.parse("2024-06-12T02:48:10.063Z").toEpochMilliseconds()
+            parseAbsTimestampMs("2024-06-12 02:48:10.063 +00:00") shouldBe expected
+        }
+
+        test("parses the clean ISO-8601 Z form") {
+            parseAbsTimestampMs("2022-01-17T04:33:12.000Z") shouldBe 1_642_393_992_000L
+        }
+
+        test("parses the offsetless space-separated SQLite form as UTC") {
+            parseAbsTimestampMs("2022-01-16 04:33:12") shouldBe 1_642_307_592_000L
+        }
+
+        test("parses a bare numeric epoch-millis value") {
+            parseAbsTimestampMs("1642393992000") shouldBe 1_642_393_992_000L
+        }
+
+        test("parses a bare numeric epoch-seconds value") {
+            parseAbsTimestampMs("1642393992") shouldBe 1_642_393_992_000L
+        }
+
+        test("returns 0L for null, blank, and unparseable input") {
+            parseAbsTimestampMs(null) shouldBe 0L
+            parseAbsTimestampMs("   ") shouldBe 0L
+            parseAbsTimestampMs("not a date") shouldBe 0L
+        }
+    })


### PR DESCRIPTION
Closes #537 and #532 — one root cause, two symptoms.

## Root cause (confirmed against a real ABS backup)

ABS (Sequelize on SQLite) writes `DataTypes.DATE` columns as:

```
2024-06-12 02:48:10.063 +00:00     ← space-separated, .SSS millis, " +00:00" offset
```

`parseAbsTimestampMs` handled only `2022-01-17T04:33:12.000Z` and the offsetless `2022-01-16 04:33:12`. On the real offset form it fell through every branch and returned **`0L`**.

Verified on the user's actual `absdatabase.sqlite`:
- `mediaProgresses`: 194 book rows, all distinct/ordered `updatedAt`, **every one** parsing to 0 before this fix.
- `playbackSessions`: 2,751 book rows (range 2024-05 → 2026-06, incl. the last few days), same offset format, all parsing to 0.

## Two symptoms, same bug

**#537 — Continue Listening wrong order.** Positions sort by `lastPlayedAt`, copied from `mediaProgresses.updatedAt`. All zeroed → identical sort keys → insertion order.

**#532 — Home stats empty after import.** Listening events are built from sessions: `startedAt = parse(session.createdAt)`, `endedAt = startedAt + listenMs`. Zeroed `startedAt` → every event lands in **January 1970** → outside the weekly window (no minutes / empty 7-day chart) and all streak dates collapse onto ~one day. The userId-stamping and `UserStatsBackfillService` paths were already correct; only the timestamps were broken.

## Fix

Normalize the offset form to ISO-8601 (swap the date/time space for `T`, drop the space before the offset) and parse with **`kotlin.time.Instant`**, which accepts an explicit offset or `Z`. Offsetless values still fall back to UTC; numeric epochs and null/blank are unchanged. Dropped `java.time` from the file per the server's minimize-Java-libraries rule. Extracted the parser to an `internal` top-level `parseAbsTimestampMs` so it's directly unit-testable.

## Tests (Kotest, red→green)

- `AbsTimestampParseTest` — the real offset form (the regression), ISO-Z, offsetless, numeric ms/seconds, null/garbage→0.
- `AbsBackupReaderTest` + `AbsTestFixtures` — the session + progress fixtures now use the real ` +00:00` offset form (same instants), and an explicit guard asserts session/progress timestamps survive to true epochs, not 1970 (the #532 stats path).

Full Linux gate green: `spotlessCheck detekt :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`.

## Note on already-imported data

`listening_events` are append-only and keyed on `abs:<sessionId>`, so events imported *before* this fix keep their 1970 timestamps on re-import (the row already exists). Existing broken imports need a clean re-import to benefit; deferred a one-time repair for now.
