### PR TITLE
✨ feat: persistent per-book readership (Readers section — current + dated finishes)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/SocialService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/SocialService.kt
@@ -1,17 +1,17 @@
 package com.calypsan.listenup.api
 
-import com.calypsan.listenup.api.dto.social.BookReader
+import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.dto.social.CurrentlyListeningSession
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import kotlinx.rpc.annotations.Rpc
 
 /**
- * Read-only social presence: who is listening right now, and who is reading a given book.
+ * Read-only social presence: who is listening right now, and the full readership of a given book.
  *
  * Every result is filtered through the server's `BookAccessPolicy` for the calling viewer —
  * a session for a book the caller cannot access is never returned, and an inaccessible book's
- * reader list returns [com.calypsan.listenup.api.error.SocialError.NotFound] (never revealing
+ * readership returns [com.calypsan.listenup.api.error.SocialError.NotFound] (never revealing
  * the book exists).
  */
 @Rpc
@@ -19,6 +19,10 @@ interface SocialService {
     /** Other users' live sessions on books the caller can access (caller excluded). */
     suspend fun currentlyListening(): AppResult<List<CurrentlyListeningSession>>
 
-    /** Other users currently reading [bookId]; `NotFound` if the caller cannot access it. */
-    suspend fun bookReaders(bookId: BookId): AppResult<List<BookReader>>
+    /**
+     * The full readership of [bookId] for the caller: each user (including the caller) with their
+     * current progress% (if reading) and their newest-first list of finish dates. `NotFound` if the
+     * caller cannot access the book.
+     */
+    suspend fun bookReadership(bookId: BookId): AppResult<BookReadership>
 }

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/social/SocialDtos.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/social/SocialDtos.kt
@@ -26,19 +26,22 @@ data class CurrentlyListeningSession(
     val startedAtMs: Long,
 )
 
-/**
- * One other user currently reading a given book, as seen by a viewer who can access that book.
- *
- * @property userId The reading user.
- * @property displayName The reading user's public display name.
- * @property avatarType `"auto"` or `"image"`.
- * @property startedAtMs Epoch-ms the session began.
- */
+/** One reader of a book: their live progress (if reading) plus their dated finish history. */
 @Serializable
-@SerialName("BookReader")
-data class BookReader(
+@SerialName("BookReaderEntry")
+data class BookReaderEntry(
     val userId: String,
     val displayName: String,
     val avatarType: String,
-    val startedAtMs: Long,
+    /** 0..100 when the user has an in-progress (unfinished) position; null otherwise. */
+    val currentProgressPct: Int?,
+    /** finished_at epoch ms, newest-first; empty when the user is only currently reading. */
+    val finishes: List<Long>,
+)
+
+/** The full readership of a book: everyone (incl. the caller) who is reading or has finished it. */
+@Serializable
+@SerialName("BookReadership")
+data class BookReadership(
+    val readers: List<BookReaderEntry>,
 )

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/dto/social/SocialDtosTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/dto/social/SocialDtosTest.kt
@@ -10,8 +10,21 @@ class SocialDtosTest :
             val v = CurrentlyListeningSession(userId = "u1", displayName = "Alice", avatarType = "auto", bookId = "b1", startedAtMs = 123L)
             contractJson.decodeFromString(CurrentlyListeningSession.serializer(), contractJson.encodeToString(CurrentlyListeningSession.serializer(), v)) shouldBe v
         }
-        test("BookReader survives a contractJson round-trip") {
-            val v = BookReader(userId = "u2", displayName = "Bob", avatarType = "image", startedAtMs = 9L)
-            contractJson.decodeFromString(BookReader.serializer(), contractJson.encodeToString(BookReader.serializer(), v)) shouldBe v
+        test("BookReadership round-trips") {
+            val original =
+                BookReadership(
+                    readers =
+                        listOf(
+                            BookReaderEntry("u1", "Jake", "auto", currentProgressPct = 43, finishes = emptyList()),
+                            BookReaderEntry(
+                                "u2",
+                                "You",
+                                "image",
+                                currentProgressPct = null,
+                                finishes = listOf(1_777_000_000_000L, 1_610_000_000_000L),
+                            ),
+                        ),
+                )
+            contractJson.decodeFromString<BookReadership>(contractJson.encodeToString(original)) shouldBe original
         }
     })

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -2251,6 +2251,16 @@
         }
       }
     },
+    "book.detail_readers_empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No one is reading this book yet."
+          }
+        }
+      }
+    },
     "book.detail_readers_finished": {
       "localizations": {
         "en": {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/SocialServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/SocialServiceImpl.kt
@@ -85,7 +85,7 @@ internal class SocialServiceImpl(
                 val positionMs = inProgress.firstOrNull { it.first == uid }?.second
                 val pct =
                     positionMs?.let {
-                        if (totalDuration > 0) ((it * 100) / totalDuration).toInt().coerceIn(0, 100) else null
+                        if (totalDuration > 0) (it * 100 / totalDuration).toInt().coerceIn(0, 100) else null
                     }
                 BookReaderEntry(
                     userId = uid,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/SocialServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/SocialServiceImpl.kt
@@ -2,13 +2,17 @@ package com.calypsan.listenup.server.api
 
 import com.calypsan.listenup.api.SocialService
 import com.calypsan.listenup.api.dto.auth.UserRole
-import com.calypsan.listenup.api.dto.social.BookReader
+import com.calypsan.listenup.api.dto.social.BookReaderEntry
+import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.dto.social.CurrentlyListeningSession
 import com.calypsan.listenup.api.error.SocialError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.services.ActiveSessionRepository
+import com.calypsan.listenup.server.services.BookReadsRepository
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.PlaybackPositionRepository
 import com.calypsan.listenup.server.sync.PublicProfileRepository
 
 /**
@@ -23,8 +27,9 @@ import com.calypsan.listenup.server.sync.PublicProfileRepository
  *   the caller can access. ROOT/ADMIN (unconstrained access set) see every session.
  *   Sessions whose user has no live `public_profiles` identity are dropped — there is no
  *   one to display.
- * - [bookReaders] returns `NotFound` when the caller cannot access the book — never
- *   revealing the book exists — and otherwise lists its other readers.
+ * - [bookReadership] returns `NotFound` when the caller cannot access the book — never
+ *   revealing the book exists — and otherwise lists its full readership (including the
+ *   caller): each reader's current progress (if reading) and their dated finish history.
  *
  * Route handlers call [copyWith] to bind each request to the authenticated principal;
  * the Koin singleton carries an unscoped placeholder [PrincipalProvider] that throws
@@ -35,6 +40,9 @@ internal class SocialServiceImpl(
     private val activeSessions: ActiveSessionRepository,
     private val bookAccessPolicy: BookAccessPolicy,
     private val publicProfiles: PublicProfileRepository,
+    private val playbackPositions: PlaybackPositionRepository,
+    private val bookReads: BookReadsRepository,
+    private val books: BookRepository,
     private val principal: PrincipalProvider,
 ) : SocialService {
     override suspend fun currentlyListening(): AppResult<List<CurrentlyListeningSession>> {
@@ -58,25 +66,42 @@ internal class SocialServiceImpl(
         )
     }
 
-    override suspend fun bookReaders(bookId: BookId): AppResult<List<BookReader>> {
+    override suspend fun bookReadership(bookId: BookId): AppResult<BookReadership> {
         val caller = resolveCaller() ?: return noPrincipal()
-        // Inaccessible book → NotFound, never revealing the book exists.
+        // Inaccessible book → NotFound, never revealing the book exists (unchanged ACL).
         if (!bookAccessPolicy.canAccess(caller.userId, caller.role, bookId.value)) {
             return AppResult.Failure(SocialError.NotFound())
         }
-        val rows = activeSessions.listReadersForBook(bookId.value, excludeUserId = caller.userId)
-        val identities = publicProfiles.identities(rows.map { it.userId }.toSet())
-        return AppResult.Success(
-            rows.mapNotNull { row ->
-                val identity = identities[row.userId] ?: return@mapNotNull null
-                BookReader(
-                    userId = row.userId,
+        val totalDuration = books.findById(bookId)?.totalDuration ?: 0L
+        val inProgress = playbackPositions.listInProgressForBook(bookId.value) // List<userId, positionMs>
+        val finishesByUser = bookReads.finishesForBook(bookId.value).groupBy { it.userId } // newest-first per user
+
+        val userIds = (inProgress.map { it.first } + finishesByUser.keys).toSet()
+        val identities = publicProfiles.identities(userIds)
+
+        val entries =
+            userIds.mapNotNull { uid ->
+                val identity = identities[uid] ?: return@mapNotNull null
+                val positionMs = inProgress.firstOrNull { it.first == uid }?.second
+                val pct =
+                    positionMs?.let {
+                        if (totalDuration > 0) ((it * 100) / totalDuration).toInt().coerceIn(0, 100) else null
+                    }
+                BookReaderEntry(
+                    userId = uid,
                     displayName = identity.displayName,
                     avatarType = identity.avatarType,
-                    startedAtMs = row.startedAt,
+                    currentProgressPct = pct,
+                    finishes = finishesByUser[uid]?.map { it.finishedAt } ?: emptyList(),
                 )
-            },
-        )
+            }
+        // Reading-first, then most-recent finish desc.
+        val ordered =
+            entries.sortedWith(
+                compareByDescending<BookReaderEntry> { it.currentProgressPct != null }
+                    .thenByDescending { it.finishes.firstOrNull() ?: Long.MIN_VALUE },
+            )
+        return AppResult.Success(BookReadership(readers = ordered))
     }
 
     /** Returns a copy scoped to the given [principal]. Route handlers call this per-request. */
@@ -85,6 +110,9 @@ internal class SocialServiceImpl(
             activeSessions = activeSessions,
             bookAccessPolicy = bookAccessPolicy,
             publicProfiles = publicProfiles,
+            playbackPositions = playbackPositions,
+            bookReads = bookReads,
+            books = books,
             principal = principal,
         )
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/db/BookReadsTable.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/db/BookReadsTable.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.server.db
+
+import org.jetbrains.exposed.v1.core.Table
+
+/**
+ * Append-only completion log: one row per time a user finishes a book. Re-reads stack as distinct
+ * rows. Server-only persistence — read by the readership RPC, never streamed over sync.
+ */
+internal object BookReadsTable : Table("book_reads") {
+    val id = varchar("id", 80)
+    val userId = varchar("user_id", 36)
+    val bookId = varchar("book_id", 36)
+    val finishedAt = long("finished_at")
+    val readSource = varchar("source", 16) // "playback" | "import"
+    val createdAt = long("created_at")
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        index("idx_book_reads_book", false, bookId)
+        index("idx_book_reads_user_book", false, userId, bookId)
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.server.scheduler.ActiveSessionCleanupTask
 import com.calypsan.listenup.server.services.ActiveSessionRepository
 import com.calypsan.listenup.server.services.ActivityRecorder
 import com.calypsan.listenup.server.services.ActivityRepository
+import com.calypsan.listenup.server.services.BookReadsRepository
 import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.ListeningEventRepository
 import com.calypsan.listenup.server.services.PlaybackPositionRepository
@@ -74,6 +75,7 @@ fun playbackModule(): Module =
         single(createdAtStart = true) { ActiveSessionRepository(db = get(), bus = get()) }
         single { ActivityRepository(db = get()) }
         single { ActivityRecorder(repo = get(), bus = get()) }
+        single { BookReadsRepository(db = get(), clock = get()) }
         single(createdAtStart = true) {
             PlaybackPositionRepository(
                 db = get(),
@@ -82,6 +84,7 @@ fun playbackModule(): Module =
                 userStatsUpdater = get(),
                 activeSessionRepo = get(),
                 activityRecorder = get(),
+                bookReadsRepository = get(),
             )
         }
         // UserStatsRepository references UserStatsUpdater (for lazy window decay), while
@@ -149,6 +152,9 @@ fun playbackModule(): Module =
                 activeSessions = get(),
                 bookAccessPolicy = get(),
                 publicProfiles = get(),
+                playbackPositions = get(),
+                bookReads = get(),
+                books = get(),
                 principal = unscopedSocialPlaceholder(),
             )
         }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
@@ -27,7 +27,7 @@ data class BookReadRow(
  * as distinct rows (naturally deduplicated by [finishedAt]). Used by the readership
  * RPC surface to show persistent readers on the Book Detail screen.
  */
-internal class BookReadsRepository(
+class BookReadsRepository(
     private val db: Database,
     private val clock: Clock = Clock.System,
 ) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
@@ -45,29 +45,6 @@ class BookReadsRepository(
         source: String,
     ) = suspendTransaction(db) { insertRow(id, userId, bookId, finishedAt, source) }
 
-    /**
-     * Append only if [id] doesn't already exist.
-     *
-     * ABS import seeds use a stable deterministic id (`abs-read:<userId>:<bookId>`)
-     * so that re-importing the same backup is a no-op. A second call with the same
-     * [id] leaves the original [finishedAt] untouched.
-     */
-    suspend fun recordReadIfAbsent(
-        id: String,
-        userId: String,
-        bookId: String,
-        finishedAt: Long,
-        source: String,
-    ) = suspendTransaction(db) {
-        val exists =
-            BookReadsTable
-                .selectAll()
-                .where { BookReadsTable.id eq id }
-                .limit(1)
-                .any()
-        if (!exists) insertRow(id, userId, bookId, finishedAt, source)
-    }
-
     /** All completions of [bookId] across all users, newest-first. */
     suspend fun finishesForBook(bookId: String): List<BookReadRow> =
         suspendTransaction(db) {

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
@@ -1,0 +1,117 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.server.db.BookReadsTable
+import kotlin.time.Clock
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+
+/** A single completion event: who finished what, when, and how. */
+data class BookReadRow(
+    val userId: String,
+    val bookId: String,
+    val finishedAt: Long,
+    val source: String,
+)
+
+/**
+ * Server-only persistence for per-completion read history.
+ *
+ * Append-only: rows are never updated or deleted. Re-reads of the same book stack
+ * as distinct rows (naturally deduplicated by [finishedAt]). Used by the readership
+ * RPC surface to show persistent readers on the Book Detail screen.
+ */
+internal class BookReadsRepository(
+    private val db: Database,
+    private val clock: Clock = Clock.System,
+) {
+    /**
+     * Append a completion row unconditionally.
+     *
+     * Live finishes use a fresh UUID for [id], so multiple completions by the same
+     * user stack as distinct rows.
+     */
+    suspend fun recordRead(
+        id: String,
+        userId: String,
+        bookId: String,
+        finishedAt: Long,
+        source: String,
+    ) = suspendTransaction(db) { insertRow(id, userId, bookId, finishedAt, source) }
+
+    /**
+     * Append only if [id] doesn't already exist.
+     *
+     * ABS import seeds use a stable deterministic id (`abs-read:<userId>:<bookId>`)
+     * so that re-importing the same backup is a no-op. A second call with the same
+     * [id] leaves the original [finishedAt] untouched.
+     */
+    suspend fun recordReadIfAbsent(
+        id: String,
+        userId: String,
+        bookId: String,
+        finishedAt: Long,
+        source: String,
+    ) = suspendTransaction(db) {
+        val exists =
+            BookReadsTable
+                .selectAll()
+                .where { BookReadsTable.id eq id }
+                .limit(1)
+                .any()
+        if (!exists) insertRow(id, userId, bookId, finishedAt, source)
+    }
+
+    /** All completions of [bookId] across all users, newest-first. */
+    suspend fun finishesForBook(bookId: String): List<BookReadRow> =
+        suspendTransaction(db) {
+            BookReadsTable
+                .selectAll()
+                .where { BookReadsTable.bookId eq bookId }
+                .orderBy(BookReadsTable.finishedAt, SortOrder.DESC)
+                .map {
+                    BookReadRow(
+                        userId = it[BookReadsTable.userId],
+                        bookId = it[BookReadsTable.bookId],
+                        finishedAt = it[BookReadsTable.finishedAt],
+                        source = it[BookReadsTable.readSource],
+                    )
+                }
+        }
+
+    /** All completion timestamps for a single user+book pair, newest-first. */
+    suspend fun finishesForUserBook(
+        userId: String,
+        bookId: String,
+    ): List<Long> =
+        suspendTransaction(db) {
+            BookReadsTable
+                .selectAll()
+                .where { (BookReadsTable.userId eq userId) and (BookReadsTable.bookId eq bookId) }
+                .orderBy(BookReadsTable.finishedAt, SortOrder.DESC)
+                .map { it[BookReadsTable.finishedAt] }
+        }
+
+    private fun insertRow(
+        id: String,
+        userId: String,
+        bookId: String,
+        finishedAt: Long,
+        source: String,
+    ) {
+        BookReadsTable.insert {
+            it[BookReadsTable.id] = id
+            it[BookReadsTable.userId] = userId
+            it[BookReadsTable.bookId] = bookId
+            it[BookReadsTable.finishedAt] = finishedAt
+            it[BookReadsTable.readSource] = source
+            it[BookReadsTable.createdAt] = clock.now().toEpochMilliseconds()
+        }
+    }
+}

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepository.kt
@@ -50,6 +50,7 @@ class PlaybackPositionRepository(
     private val userStatsUpdater: UserStatsUpdater? = null,
     private val activeSessionRepo: ActiveSessionRepository? = null,
     private val activityRecorder: ActivityRecorder? = null,
+    private val bookReadsRepository: BookReadsRepository? = null,
 ) : SyncableRepository<PlaybackPositionSyncPayload, PlaybackPositionId>(
         db = db,
         table = PlaybackPositionTable,
@@ -175,6 +176,13 @@ class PlaybackPositionRepository(
                 userStatsUpdater?.onPositionFinishedFlip(userId)
                 activeSessionRepo?.deleteForUserBook(userId, bookId)
                 activityRecorder?.record(userId, ActivityType.FINISHED_BOOK, bookId = bookId)
+                bookReadsRepository?.recordRead(
+                    id = Uuid.random().toString(),
+                    userId = userId,
+                    bookId = bookId,
+                    finishedAt = lastPlayedAt,
+                    source = "playback",
+                )
             } else if (result is AppResult.Success && !finished) {
                 activeSessionRepo?.startOrRefresh(userId, bookId)
                 if (existing == null) {
@@ -304,6 +312,18 @@ class PlaybackPositionRepository(
                 }.orderBy(PlaybackPositionTable.lastPlayedAt, SortOrder.DESC)
                 .limit(limit)
                 .map { row -> row.toSyncPayload() }
+        }
+
+    /** (userId, positionMs) for every user with an in-progress (unfinished, positionMs>0) position on [bookId]. */
+    suspend fun listInProgressForBook(bookId: String): List<Pair<String, Long>> =
+        suspendTransaction(db) {
+            PlaybackPositionTable
+                .selectAll()
+                .where {
+                    (PlaybackPositionTable.bookId eq bookId) and
+                        (PlaybackPositionTable.finished eq false) and
+                        (PlaybackPositionTable.positionMs greater 0L)
+                }.map { it[PlaybackPositionTable.userId] to it[PlaybackPositionTable.positionMs] }
         }
 
     private fun org.jetbrains.exposed.v1.core.ResultRow.toSyncPayload(): PlaybackPositionSyncPayload =

--- a/server/src/main/resources/db/migration/V34__book_reads.sql
+++ b/server/src/main/resources/db/migration/V34__book_reads.sql
@@ -1,0 +1,10 @@
+CREATE TABLE book_reads (
+    id          TEXT    NOT NULL PRIMARY KEY,
+    user_id     TEXT    NOT NULL,
+    book_id     TEXT    NOT NULL,
+    finished_at INTEGER NOT NULL,
+    source      TEXT    NOT NULL,
+    created_at  INTEGER NOT NULL
+);
+CREATE INDEX idx_book_reads_book ON book_reads (book_id);
+CREATE INDEX idx_book_reads_user_book ON book_reads (user_id, book_id);

--- a/server/src/test/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.server.db.ListeningEventTable
 import com.calypsan.listenup.server.db.UserEntity
 import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.db.UserStatusColumn
+import com.calypsan.listenup.server.services.BookReadsRepository
 import com.calypsan.listenup.server.services.LibraryRegistry
 import com.calypsan.listenup.server.services.PlaybackPositionRepository
 import com.calypsan.listenup.server.services.ListeningEventRepository
@@ -244,6 +245,41 @@ class ImportApplierTest :
             }
         }
 
+        test("ABS import records a book_reads row for the finished book (via the finish-flip)") {
+            withInMemoryDatabase {
+                val db = this
+                runTest {
+                    val staged = stageAnalyzedImport(db)
+                    val applier = applierFor(staged)
+                    confirmSimonMapping(staged.paths, staged.importId)
+
+                    applier.apply(staged.importId) {}
+
+                    // mp-1 (book-1, "2022-01-16 04:33:12" UTC) triggers the false→true flip;
+                    // the finish-flip dates the read by lastPlayedAt = that instant in epoch ms.
+                    staged.bookReads.finishesForUserBook(LU_USER, LU_KINGS) shouldBe listOf(1_642_307_592_000L)
+                }
+            }
+        }
+
+        test("re-applying the import does not duplicate the book_reads row") {
+            withInMemoryDatabase {
+                val db = this
+                runTest {
+                    val staged = stageAnalyzedImport(db)
+                    val applier = applierFor(staged)
+                    confirmSimonMapping(staged.paths, staged.importId)
+
+                    applier.apply(staged.importId) {}
+                    // Second apply: position already finished → lastPlayedAt-wins guard short-circuits
+                    // recordPosition before reaching the flip → no second book_reads row.
+                    applier.apply(staged.importId) {}
+
+                    staged.bookReads.finishesForUserBook(LU_USER, LU_KINGS).size shouldBe 1
+                }
+            }
+        }
+
         test("apply without a confirmed mapping returns ApplyFailed") {
             withInMemoryDatabase {
                 val db = this
@@ -358,6 +394,7 @@ private data class StagedImport(
     val statsRepo: UserStatsRepository,
     val listeningEventRepo: ListeningEventRepository,
     val statsBackfill: UserStatsBackfillService,
+    val bookReads: BookReadsRepository,
 )
 
 /**
@@ -382,7 +419,8 @@ private suspend fun stageAnalyzedImport(
 
     val bus = ChangeBus()
     val registry = SyncRegistry()
-    val repo = PlaybackPositionRepository(db = db, bus = bus, registry = registry)
+    val bookReads = BookReadsRepository(db = db)
+    val repo = PlaybackPositionRepository(db = db, bus = bus, registry = registry, bookReadsRepository = bookReads)
     val statsRepo = UserStatsRepository(db = db, bus = bus, registry = registry)
     val statsUpdater =
         UserStatsUpdater(
@@ -405,7 +443,7 @@ private suspend fun stageAnalyzedImport(
             db = db,
         )
     analyzer.analyze(importId) {}
-    return StagedImport(paths, importId, repo, statsRepo, listeningEventRepo, statsBackfill)
+    return StagedImport(paths, importId, repo, statsRepo, listeningEventRepo, statsBackfill, bookReads)
 }
 
 private fun applierFor(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/SocialAclE2ETest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/SocialAclE2ETest.kt
@@ -6,7 +6,7 @@ import com.calypsan.listenup.api.dto.auth.AuthSession
 import com.calypsan.listenup.api.dto.auth.LoginRequest
 import com.calypsan.listenup.api.dto.auth.RegisterRequest
 import com.calypsan.listenup.api.dto.auth.RegisterResult
-import com.calypsan.listenup.api.dto.social.BookReader
+import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.dto.social.CurrentlyListeningSession
 import com.calypsan.listenup.api.error.SocialError
 import com.calypsan.listenup.api.result.AppResult
@@ -15,6 +15,7 @@ import com.calypsan.listenup.api.sync.CollectionSyncPayload
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.module
 import com.calypsan.listenup.server.services.ActiveSessionRepository
+import com.calypsan.listenup.server.services.BookReadsRepository
 import com.calypsan.listenup.server.services.PublicProfileMaintainer
 import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
@@ -66,8 +67,8 @@ import java.nio.file.Files
  * Driving the reads as B over RPC, the test asserts:
  *  - `currentlyListening()` returns the accessible-book session and **omits** the
  *    private-book one (both present-and-absent asserted).
- *  - `bookReaders(accessibleBook)` lists A.
- *  - `bookReaders(privateBook)` returns `AppResult.Failure(SocialError.NotFound)` —
+ *  - `bookReadership(accessibleBook)` lists A (seeded a finish row).
+ *  - `bookReadership(privateBook)` returns `AppResult.Failure(SocialError.NotFound)` —
  *    never revealing the book exists.
  *
  * Presence is server-derived and never synced, so A's sessions are seeded through the
@@ -190,6 +191,17 @@ class SocialAclE2ETest :
                     sessions.startOrRefresh(userId = alice.userId, bookId = "public-book")
                     sessions.startOrRefresh(userId = alice.userId, bookId = "private-book")
 
+                    // ── A also has a persistent completion of the public book, so she appears in
+                    //    its readership (which reads book_reads + in-progress positions, not presence). ──
+                    val reads by application.inject<BookReadsRepository>()
+                    reads.recordRead(
+                        id = "alice-public-finish",
+                        userId = alice.userId,
+                        bookId = "public-book",
+                        finishedAt = 1_000L,
+                        source = "playback",
+                    )
+
                     // ── Drive the reads as B over the real authed RPC surface. ────────────────
                     val rpcClient =
                         createClient {
@@ -209,17 +221,19 @@ class SocialAclE2ETest :
                     listening.single().userId shouldBe alice.userId
                     listening.none { it.bookId == "private-book" } shouldBe true
 
-                    // bookReaders on the accessible book: A is listed.
+                    // bookReadership on the accessible book: A is listed (via her finish row).
                     val readers =
                         social
-                            .bookReaders(BookId("public-book"))
-                            .shouldBeInstanceOf<AppResult.Success<List<BookReader>>>()
+                            .bookReadership(BookId("public-book"))
+                            .shouldBeInstanceOf<AppResult.Success<BookReadership>>()
                             .data
+                            .readers
                     readers shouldHaveSize 1
                     readers.single().userId shouldBe alice.userId
+                    readers.single().finishes shouldBe listOf(1_000L)
 
-                    // bookReaders on the private book: NotFound — never revealing it exists.
-                    val denied = social.bookReaders(BookId("private-book"))
+                    // bookReadership on the private book: NotFound — never revealing it exists.
+                    val denied = social.bookReadership(BookId("private-book"))
                     denied.shouldBeInstanceOf<AppResult.Failure>()
                     denied.error.shouldBeInstanceOf<SocialError.NotFound>()
                 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
@@ -5,7 +5,6 @@ package com.calypsan.listenup.server.api
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
-import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.error.SocialError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.CollectionBookSyncPayload

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/SocialServiceTest.kt
@@ -5,6 +5,7 @@ package com.calypsan.listenup.server.api
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.error.SocialError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
@@ -12,8 +13,16 @@ import com.calypsan.listenup.api.sync.CollectionSyncPayload
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.db.BookReadsTable
+import com.calypsan.listenup.server.db.BookTable
+import com.calypsan.listenup.server.db.PlaybackPositionTable
 import com.calypsan.listenup.server.db.PublicProfilesTable
 import com.calypsan.listenup.server.services.ActiveSessionRepository
+import com.calypsan.listenup.server.services.BookReadsRepository
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.services.PlaybackPositionRepository
+import com.calypsan.listenup.server.services.SeriesRepository
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
@@ -28,9 +37,11 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 
 /**
  * Contract and ACL tests for [SocialServiceImpl] — the crown-jewel ACL surface.
@@ -40,8 +51,9 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
  *    `public_profiles`.
  * 2. (CROWN JEWEL) A viewer never learns that someone is listening to a book they cannot
  *    access: only the accessible-book session is returned; the private-book one is omitted.
- * 3. `bookReaders(accessibleBook)` lists other readers; `bookReaders(inaccessibleBook)`
- *    returns `SocialError.NotFound` (never revealing the book exists).
+ * 3. `bookReadership(accessibleBook)` lists every reader (including the caller) with their
+ *    current progress% and dated finish history; `bookReadership(inaccessibleBook)` returns
+ *    `SocialError.NotFound` (never revealing the book exists).
  * 4. An unauthenticated caller receives `AppResult.Failure(SocialError.NotFound)`.
  *
  * Uses a real in-memory Flyway-migrated SQLite database + real repositories; no mocks.
@@ -62,12 +74,78 @@ class SocialServiceTest :
         ): SocialServiceImpl {
             val bus = ChangeBus()
             val registry = SyncRegistry()
+            // BookRepository registers global domains; give it its own registry to avoid
+            // duplicate-domain registration against the per-test [registry] above.
+            val bookRegistry = SyncRegistry()
+            val books =
+                BookRepository(
+                    db = db,
+                    bus = bus,
+                    registry = bookRegistry,
+                    contributorRepository = ContributorRepository(db = db, bus = bus, registry = bookRegistry),
+                    seriesRepository = SeriesRepository(db = db, bus = bus, registry = bookRegistry),
+                )
             return SocialServiceImpl(
                 activeSessions = ActiveSessionRepository(db = db, bus = bus),
                 bookAccessPolicy = BookAccessPolicy(db),
                 publicProfiles = PublicProfileRepository(db = db, bus = bus, registry = registry),
+                playbackPositions = PlaybackPositionRepository(db = db, bus = bus, registry = registry),
+                bookReads = BookReadsRepository(db = db),
+                books = books,
                 principal = principal,
             )
+        }
+
+        /** Sets a book's `total_duration` (ms); [seedTestBook] inserts 0L by default. */
+        fun Database.setBookDuration(
+            bookId: String,
+            totalDuration: Long,
+        ) {
+            transaction(this) {
+                BookTable.update({ BookTable.id eq bookId }) { it[BookTable.totalDuration] = totalDuration }
+            }
+        }
+
+        /** Inserts an in-progress (unfinished) playback position row directly. */
+        fun Database.seedInProgressPosition(
+            userId: String,
+            bookId: String,
+            positionMs: Long,
+        ) {
+            transaction(this) {
+                PlaybackPositionTable.insert {
+                    it[id] = "$userId-$bookId"
+                    it[PlaybackPositionTable.userId] = userId
+                    it[PlaybackPositionTable.bookId] = bookId
+                    it[PlaybackPositionTable.positionMs] = positionMs
+                    it[lastPlayedAt] = 1L
+                    it[finished] = false
+                    it[revision] = 0L
+                    it[createdAt] = 1L
+                    it[updatedAt] = 1L
+                    it[deletedAt] = null
+                }
+            }
+        }
+
+        /** Appends a `book_reads` completion row directly (newest-first ordering is by [finishedAt]). */
+        fun Database.seedFinish(
+            id: String,
+            userId: String,
+            bookId: String,
+            finishedAt: Long,
+            source: String = "playback",
+        ) {
+            transaction(this) {
+                BookReadsTable.insert {
+                    it[BookReadsTable.id] = id
+                    it[BookReadsTable.userId] = userId
+                    it[BookReadsTable.bookId] = bookId
+                    it[BookReadsTable.finishedAt] = finishedAt
+                    it[BookReadsTable.readSource] = source
+                    it[BookReadsTable.createdAt] = finishedAt
+                }
+            }
         }
 
         fun <T> AppResult<T>.value(): T {
@@ -192,9 +270,9 @@ class SocialServiceTest :
             }
         }
 
-        // ── 3: bookReaders on accessible / inaccessible books ────────────────────────
+        // ── 3: bookReadership on accessible / inaccessible books ─────────────────────
 
-        test("bookReaders lists other readers of an accessible book") {
+        test("bookReadership lists every reader of an accessible book, including the caller") {
             withInMemoryDatabase {
                 val db = this
                 seedTestLibraryAndFolder()
@@ -204,23 +282,26 @@ class SocialServiceTest :
                 seedPublicProfile("alice", displayName = "Alice")
                 seedPublicProfile("viewer", displayName = "Viewer")
                 runTest {
-                    val sessions = ActiveSessionRepository(db = db, bus = ChangeBus())
-                    sessions.startOrRefresh(userId = "alice", bookId = "book-a")
-                    sessions.startOrRefresh(userId = "viewer", bookId = "book-a")
+                    db.setBookDuration("book-a", totalDuration = 10_000L)
+                    db.seedFinish("alice-1", userId = "alice", bookId = "book-a", finishedAt = 500L)
+                    db.seedInProgressPosition(userId = "viewer", bookId = "book-a", positionMs = 2_000L)
 
-                    val result =
+                    val readers =
                         makeService(db, principalFor("viewer"))
-                            .bookReaders(BookId("book-a"))
+                            .bookReadership(BookId("book-a"))
                             .value()
+                            .readers
 
-                    result shouldHaveSize 1
-                    result.first().userId shouldBe "alice"
-                    result.first().displayName shouldBe "Alice"
+                    // The caller (viewer) is now included alongside alice.
+                    readers shouldHaveSize 2
+                    readers.map { it.userId }.toSet() shouldBe setOf("alice", "viewer")
+                    readers.first { it.userId == "viewer" }.currentProgressPct shouldBe 20
+                    readers.first { it.userId == "alice" }.finishes shouldBe listOf(500L)
                 }
             }
         }
 
-        test("bookReaders returns Failure(SocialError.NotFound) for an inaccessible book") {
+        test("bookReadership returns Failure(SocialError.NotFound) for an inaccessible book") {
             withInMemoryDatabase {
                 val db = this
                 seedTestLibraryAndFolder()
@@ -229,15 +310,42 @@ class SocialServiceTest :
                 seedTestBook("private-book")
                 runTest {
                     makeBookInaccessible(db, bookId = "private-book", collectionId = "priv-col", collectionOwner = "alice")
-                    val sessions = ActiveSessionRepository(db = db, bus = ChangeBus())
-                    sessions.startOrRefresh(userId = "alice", bookId = "private-book")
+                    db.seedFinish("alice-1", userId = "alice", bookId = "private-book", finishedAt = 500L)
 
                     val result =
                         makeService(db, principalFor("viewer"))
-                            .bookReaders(BookId("private-book"))
+                            .bookReadership(BookId("private-book"))
 
                     result.shouldBeInstanceOf<AppResult.Failure>()
                     result.error.shouldBeInstanceOf<SocialError.NotFound>()
+                }
+            }
+        }
+
+        test("bookReadership returns current progress + finish history, including the caller") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("u1")
+                seedTestUser("u2")
+                seedTestBook("b1")
+                seedPublicProfile("u1", displayName = "User One")
+                seedPublicProfile("u2", displayName = "User Two")
+                runTest {
+                    db.setBookDuration("b1", totalDuration = 10_000L)
+                    // Caller u1 finished b1 twice (100L, 300L); u2 is in progress at 4_300/10_000.
+                    db.seedFinish("u1-a", userId = "u1", bookId = "b1", finishedAt = 100L)
+                    db.seedFinish("u1-b", userId = "u1", bookId = "b1", finishedAt = 300L)
+                    db.seedInProgressPosition(userId = "u2", bookId = "b1", positionMs = 4_300L)
+
+                    val readers =
+                        makeService(db, principalFor("u1"))
+                            .bookReadership(BookId("b1"))
+                            .value()
+                            .readers
+
+                    readers.first { it.userId == "u2" }.currentProgressPct shouldBe 43
+                    readers.first { it.userId == "u1" }.finishes shouldBe listOf(300L, 100L) // newest-first
                 }
             }
         }
@@ -256,13 +364,13 @@ class SocialServiceTest :
             }
         }
 
-        test("bookReaders returns Failure(SocialError.NotFound) when caller is unauthenticated") {
+        test("bookReadership returns Failure(SocialError.NotFound) when caller is unauthenticated") {
             withInMemoryDatabase {
                 val db = this
                 seedTestLibraryAndFolder()
                 seedTestBook("book-a")
                 runTest {
-                    val result = makeService(db, noPrincipal()).bookReaders(BookId("book-a"))
+                    val result = makeService(db, noPrincipal()).bookReadership(BookId("book-a"))
                     result.shouldBeInstanceOf<AppResult.Failure>()
                     result.error.shouldBeInstanceOf<SocialError.NotFound>()
                 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/services/BookReadsRepositoryTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/services/BookReadsRepositoryTest.kt
@@ -1,0 +1,49 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+private val NOW = Instant.parse("2026-06-14T00:00:00Z")
+
+class BookReadsRepositoryTest :
+    FunSpec({
+        test("recordRead appends a row and finishesForBook returns it") {
+            withInMemoryDatabase {
+                val repo = BookReadsRepository(this, FixedClock(NOW))
+                runTest {
+                    repo.recordRead(id = "r1", userId = "u1", bookId = "b1", finishedAt = 100L, source = "playback")
+                    repo.finishesForBook("b1") shouldContainExactly
+                        listOf(BookReadRow("u1", "b1", 100L, "playback"))
+                }
+            }
+        }
+
+        test("re-reads stack: two rows for the same user+book, newest-first per user") {
+            withInMemoryDatabase {
+                val repo = BookReadsRepository(this, FixedClock(NOW))
+                runTest {
+                    repo.recordRead("r1", "u1", "b1", finishedAt = 100L, source = "playback")
+                    repo.recordRead("r2", "u1", "b1", finishedAt = 300L, source = "playback")
+                    repo.finishesForUserBook("u1", "b1") shouldBe listOf(300L, 100L)
+                }
+            }
+        }
+
+        test("recordReadIfAbsent is idempotent on id (ABS re-import safety)") {
+            withInMemoryDatabase {
+                val repo = BookReadsRepository(this, FixedClock(NOW))
+                runTest {
+                    repo.recordReadIfAbsent("abs-read:u1:b1", "u1", "b1", finishedAt = 100L, source = "import")
+                    repo.recordReadIfAbsent("abs-read:u1:b1", "u1", "b1", finishedAt = 999L, source = "import")
+                    repo.finishesForUserBook("u1", "b1") shouldBe listOf(100L) // not duplicated, not overwritten
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/services/BookReadsRepositoryTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/services/BookReadsRepositoryTest.kt
@@ -35,15 +35,4 @@ class BookReadsRepositoryTest :
                 }
             }
         }
-
-        test("recordReadIfAbsent is idempotent on id (ABS re-import safety)") {
-            withInMemoryDatabase {
-                val repo = BookReadsRepository(this, FixedClock(NOW))
-                runTest {
-                    repo.recordReadIfAbsent("abs-read:u1:b1", "u1", "b1", finishedAt = 100L, source = "import")
-                    repo.recordReadIfAbsent("abs-read:u1:b1", "u1", "b1", finishedAt = 999L, source = "import")
-                    repo.finishesForUserBook("u1", "b1") shouldBe listOf(100L) // not duplicated, not overwritten
-                }
-            }
-        }
     })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepositoryTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/services/PlaybackPositionRepositoryTest.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlin.time.ExperimentalTime::class)
 
 package com.calypsan.listenup.server.services
 
@@ -8,6 +8,7 @@ import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.core.PlaybackPositionId
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.noOpPublicProfileMaintainer
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
@@ -17,6 +18,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Instant
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -537,6 +539,31 @@ class PlaybackPositionRepositoryTest :
                             currentChapterId = null,
                         )
                     result.shouldBeInstanceOf<AppResult.Success<*>>()
+                }
+            }
+        }
+
+        test("finishing a book appends a book_reads row dated lastPlayedAt") {
+            withInMemoryDatabase {
+                val reads = BookReadsRepository(db = this, clock = FixedClock(Instant.fromEpochMilliseconds(1_700_000_000_000L)))
+                val repo =
+                    PlaybackPositionRepository(
+                        db = this,
+                        bus = ChangeBus(),
+                        registry = SyncRegistry(),
+                        bookReadsRepository = reads,
+                    )
+                runTest {
+                    repo.recordPosition(
+                        userId = "u1",
+                        bookId = "b1",
+                        positionMs = 5_000L,
+                        lastPlayedAt = 1_700_000_000_000L,
+                        finished = true,
+                        playbackSpeed = 1f,
+                        currentChapterId = null,
+                    )
+                    reads.finishesForUserBook("u1", "b1") shouldBe listOf(1_700_000_000_000L)
                 }
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImpl.kt
@@ -2,17 +2,14 @@
 
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.api.dto.social.BookReaderEntry
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.core.error.ErrorMapper
 import com.calypsan.listenup.client.data.remote.SocialRpcFactory
 import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
-import com.calypsan.listenup.client.domain.model.PlaybackPosition
-import com.calypsan.listenup.client.domain.model.User
 import com.calypsan.listenup.client.domain.readers.BookReaders
 import com.calypsan.listenup.client.domain.readers.Reader
-import com.calypsan.listenup.client.domain.readers.ReaderState
 import com.calypsan.listenup.client.domain.repository.BookReadersRepository
-import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.core.BookId
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -27,83 +24,55 @@ import kotlinx.coroutines.flow.onStart
 private val logger = KotlinLogging.logger {}
 
 /**
- * Book-readers repository combining the current user's own reading state with other live listeners.
+ * Book-readers repository over the [com.calypsan.listenup.api.SocialService] `bookReadership` RPC.
  *
- * The current user's row comes from the local playback position ([PlaybackPositionRepository]) and
- * profile ([UserRepository]) — so it shows whether *you* are reading or have finished the book even
- * when the server is unreachable. Other listeners come from the [com.calypsan.listenup.api.SocialService]
- * `bookReadership` RPC, which is ACL-filtered; that list is fetched on first subscribe and re-fetched
- * on every [PresenceRefreshSignal] ping. The readership now *includes* the caller server-side, so the
- * caller's own entry is dropped here in favour of the locally-derived self row, which is listed first.
+ * The RPC is ACL-filtered and now *includes* the caller, so each [BookReaderEntry] maps straight to a
+ * domain [Reader] — the current user flagged via [Reader.isYou] from [UserRepository]. The readership
+ * is fetched on first subscribe and re-fetched on every [PresenceRefreshSignal] ping.
  *
- * On any RPC failure the *other-listeners* list is empty — Never-Stranded: the section still shows
- * the current user's own row, and the next ping recovers the others.
+ * On any RPC failure the list is empty — Never-Stranded: the section renders empty rather than
+ * hanging, and the next ping recovers.
  *
  * @property socialRpc Supplies the [com.calypsan.listenup.api.SocialService] RPC proxy.
- * @property presence Pings whenever presence may have changed, driving a re-fetch of other listeners.
- * @property playbackPositionRepository Source of the current user's local reading state per book.
- * @property userRepository Source of the current user's identity (id + display name).
+ * @property presence Pings whenever presence may have changed, driving a re-fetch of the readership.
+ * @property userRepository Source of the current user's identity, used to flag [Reader.isYou].
  */
 class BookReadersRepositoryImpl(
     private val socialRpc: SocialRpcFactory,
     private val presence: PresenceRefreshSignal,
-    private val playbackPositionRepository: PlaybackPositionRepository,
     private val userRepository: UserRepository,
 ) : BookReadersRepository {
     override fun observeReadersFor(bookId: String): Flow<BookReaders> =
         combine(
-            readership(bookId),
-            playbackPositionRepository.observeAll(),
+            readershipFlow(bookId),
             userRepository.observeCurrentUser(),
-        ) { readers, positions, currentUser ->
-            val self = currentUser?.let { user -> selfReader(user, positions[BookId(bookId)]) }
-            // The server-side readership now includes the caller; drop their entry in favour of the
-            // locally-derived self row (authoritative and offline-resilient), listed first.
-            val others = readers.filterNot { it.userId == currentUser?.id?.value }
-            BookReaders(readers = listOfNotNull(self) + others)
+        ) { entries, currentUser ->
+            val myId = currentUser?.id?.value
+            BookReaders(
+                readers =
+                    entries.map { entry ->
+                        Reader(
+                            userId = entry.userId,
+                            displayName = entry.displayName,
+                            isYou = entry.userId == myId,
+                            currentProgressPct = entry.currentProgressPct,
+                            finishes = entry.finishes,
+                        )
+                    },
+            )
         }
 
     /** The full readership of the book — ACL-filtered server-side; empty on any RPC failure. */
-    private fun readership(bookId: String): Flow<List<Reader>> =
+    private fun readershipFlow(bookId: String): Flow<List<BookReaderEntry>> =
         presence.signal
             .onStart { emit(Unit) }
             .flatMapLatest { flow { emit(fetchReadership(bookId)) } }
 
-    private suspend fun fetchReadership(bookId: String): List<Reader> =
+    private suspend fun fetchReadership(bookId: String): List<BookReaderEntry> =
         when (val result = bookReadership(bookId)) {
-            is AppResult.Success -> {
-                result.data.readers.map { entry ->
-                    val state =
-                        when {
-                            entry.currentProgressPct != null -> ReaderState.Listening
-                            else -> ReaderState.Finished(entry.finishes.firstOrNull())
-                        }
-                    Reader(userId = entry.userId, displayName = entry.displayName, state = state)
-                }
-            }
-
-            is AppResult.Failure -> {
-                emptyList()
-            }
+            is AppResult.Success -> result.data.readers
+            is AppResult.Failure -> emptyList()
         }
-
-    /**
-     * The current user as a reader of this book, derived from their local [position] — or null when
-     * they haven't started it (no position, or a zeroed position that isn't finished).
-     */
-    private fun selfReader(
-        user: User,
-        position: PlaybackPosition?,
-    ): Reader? {
-        if (position == null) return null
-        val state =
-            when {
-                position.isFinished -> ReaderState.Finished(position.finishedAtMs)
-                position.positionMs > 0 -> ReaderState.Listening
-                else -> return null
-            }
-        return Reader(userId = user.id.value, displayName = user.displayName, state = state)
-    }
 
     private suspend fun bookReadership(bookId: String) =
         try {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImpl.kt
@@ -32,9 +32,9 @@ private val logger = KotlinLogging.logger {}
  * The current user's row comes from the local playback position ([PlaybackPositionRepository]) and
  * profile ([UserRepository]) — so it shows whether *you* are reading or have finished the book even
  * when the server is unreachable. Other listeners come from the [com.calypsan.listenup.api.SocialService]
- * `bookReaders` RPC, which is ACL-filtered and excludes the caller server-side; that list is fetched
- * on first subscribe and re-fetched on every [PresenceRefreshSignal] ping. The current user, when
- * applicable, is listed first.
+ * `bookReadership` RPC, which is ACL-filtered; that list is fetched on first subscribe and re-fetched
+ * on every [PresenceRefreshSignal] ping. The readership now *includes* the caller server-side, so the
+ * caller's own entry is dropped here in favour of the locally-derived self row, which is listed first.
  *
  * On any RPC failure the *other-listeners* list is empty — Never-Stranded: the section still shows
  * the current user's own row, and the next ping recovers the others.
@@ -52,25 +52,33 @@ class BookReadersRepositoryImpl(
 ) : BookReadersRepository {
     override fun observeReadersFor(bookId: String): Flow<BookReaders> =
         combine(
-            otherListeners(bookId),
+            readership(bookId),
             playbackPositionRepository.observeAll(),
             userRepository.observeCurrentUser(),
-        ) { others, positions, currentUser ->
+        ) { readers, positions, currentUser ->
             val self = currentUser?.let { user -> selfReader(user, positions[BookId(bookId)]) }
+            // The server-side readership now includes the caller; drop their entry in favour of the
+            // locally-derived self row (authoritative and offline-resilient), listed first.
+            val others = readers.filterNot { it.userId == currentUser?.id?.value }
             BookReaders(readers = listOfNotNull(self) + others)
         }
 
-    /** Other users currently listening — ACL-filtered and caller-excluded server-side. */
-    private fun otherListeners(bookId: String): Flow<List<Reader>> =
+    /** The full readership of the book — ACL-filtered server-side; empty on any RPC failure. */
+    private fun readership(bookId: String): Flow<List<Reader>> =
         presence.signal
             .onStart { emit(Unit) }
-            .flatMapLatest { flow { emit(fetchOthers(bookId)) } }
+            .flatMapLatest { flow { emit(fetchReadership(bookId)) } }
 
-    private suspend fun fetchOthers(bookId: String): List<Reader> =
-        when (val result = bookReaders(bookId)) {
+    private suspend fun fetchReadership(bookId: String): List<Reader> =
+        when (val result = bookReadership(bookId)) {
             is AppResult.Success -> {
-                result.data.map {
-                    Reader(userId = it.userId, displayName = it.displayName, state = ReaderState.Listening)
+                result.data.readers.map { entry ->
+                    val state =
+                        when {
+                            entry.currentProgressPct != null -> ReaderState.Listening
+                            else -> ReaderState.Finished(entry.finishes.firstOrNull())
+                        }
+                    Reader(userId = entry.userId, displayName = entry.displayName, state = state)
                 }
             }
 
@@ -97,13 +105,13 @@ class BookReadersRepositoryImpl(
         return Reader(userId = user.id.value, displayName = user.displayName, state = state)
     }
 
-    private suspend fun bookReaders(bookId: String) =
+    private suspend fun bookReadership(bookId: String) =
         try {
-            socialRpc.get().bookReaders(BookId(bookId))
+            socialRpc.get().bookReadership(BookId(bookId))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            logger.warn(e) { "bookReaders RPC failed" }
+            logger.warn(e) { "bookReadership RPC failed" }
             AppResult.Failure(ErrorMapper.map(e))
         }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SocialModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SocialModule.kt
@@ -128,14 +128,13 @@ val socialModule: Module =
             )
         }
 
-        // BookReadersRepository for Book Detail Readers section — combines the current user's local
-        // reading state with other live listeners (SocialService RPC, ACL-filtered, caller-excluded,
-        // re-fetched on every PresenceRefreshSignal ping).
+        // BookReadersRepository for Book Detail Readers section — maps the ACL-filtered SocialService
+        // bookReadership RPC (which includes the caller) to domain readers, flagging the current user,
+        // re-fetched on every PresenceRefreshSignal ping.
         single<BookReadersRepository> {
             BookReadersRepositoryImpl(
                 socialRpc = get(),
                 presence = get(),
-                playbackPositionRepository = get(),
                 userRepository = get(),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/readers/BookReaders.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/readers/BookReaders.kt
@@ -3,46 +3,34 @@ package com.calypsan.listenup.client.domain.readers
 /**
  * Readers state for one book.
  *
- * Assembled by [com.calypsan.listenup.client.data.repository.BookReadersRepositoryImpl] from two
- * sources: the current user's own reading state (from the local playback position — works offline)
- * and the other users currently listening (from the ACL-filtered, caller-excluded
- * `SocialService.bookReaders` RPC, refreshed on every presence ping). The current user, when they
- * are reading or have finished the book, is listed first.
+ * Assembled by [com.calypsan.listenup.client.data.repository.BookReadersRepositoryImpl] from the
+ * ACL-filtered `SocialService.bookReadership` RPC — which now *includes* the caller — refreshed on
+ * every presence ping. Each entry carries both states at once: live progress and finish history.
  *
- * @property readers Everyone reading or who has finished this book that we can show — the current
- *   user (when applicable) followed by other live listeners.
+ * @property readers Everyone reading or who has finished this book that we can show, including the
+ *   current user when applicable.
  */
 data class BookReaders(
     val readers: List<Reader>,
 )
 
 /**
- * A reader of a book, for display in the Readers section.
+ * A reader of a book, for the Readers section. Carries both states at once: [currentProgressPct]
+ * (non-null ⇒ reading now) and [finishes] (dated completions, newest-first; may be empty).
  *
- * Avatar resolution is intentionally omitted — the [UserAvatar] composable resolves avatars
- * internally from [userId], keeping this type dependency-free.
+ * Avatar resolution is omitted — the UI's UserAvatar resolves avatars from [userId].
  *
- * @property userId Server-issued user identifier (used by [UserAvatar] for avatar lookup).
+ * @property userId Server-issued user identifier (used by the UI for avatar lookup).
  * @property displayName Human-readable name shown beside the avatar.
- * @property state Whether the reader is actively listening or has finished the book.
+ * @property isYou Whether this reader is the current user.
+ * @property currentProgressPct 0..100 when the user has an in-progress (unfinished) position; null
+ *   otherwise. Non-null ⇒ reading now.
+ * @property finishes Dated completions (epoch ms), newest-first; may be empty.
  */
 data class Reader(
     val userId: String,
     val displayName: String,
-    val state: ReaderState,
+    val isYou: Boolean,
+    val currentProgressPct: Int?,
+    val finishes: List<Long>,
 )
-
-/** A reader's relationship to the book — actively listening, or finished. */
-sealed interface ReaderState {
-    /** Actively listening to the book. */
-    data object Listening : ReaderState
-
-    /**
-     * Finished the book.
-     *
-     * @property finishedAtMs When the book was finished (epoch ms), or null if unknown.
-     */
-    data class Finished(
-        val finishedAtMs: Long?,
-    ) : ReaderState
-}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/readers/ReaderLine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/readers/ReaderLine.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.client.domain.readers
+
+/** One display line in the Readers list — a person in one state. */
+data class ReaderLine(
+    val userId: String,
+    val name: String,
+    val isYou: Boolean,
+    val kind: ReaderLineKind,
+)
+
+sealed interface ReaderLineKind {
+    /** The person is currently reading; [progressPct] is known when non-null. */
+    data class Reading(
+        val progressPct: Int?,
+    ) : ReaderLineKind
+
+    /** The person finished the book at the instant recorded in [finishedAtMs] (epoch ms). */
+    data class Finished(
+        val finishedAtMs: Long,
+    ) : ReaderLineKind
+}
+
+/**
+ * Flattens readers into display lines: each reader yields a [ReaderLineKind.Reading] line when they
+ * are currently reading, plus one [ReaderLineKind.Finished] line per finish. Ordering: all reading
+ * lines first, then all finished lines newest-first across readers.
+ */
+fun flattenToLines(readers: List<Reader>): List<ReaderLine> {
+    val reading =
+        readers
+            .filter { it.currentProgressPct != null }
+            .map { ReaderLine(it.userId, it.displayName, it.isYou, ReaderLineKind.Reading(it.currentProgressPct)) }
+    val finished =
+        readers
+            .flatMap { r -> r.finishes.map { r to it } }
+            .sortedByDescending { it.second }
+            .map { (r, ts) -> ReaderLine(r.userId, r.displayName, r.isYou, ReaderLineKind.Finished(ts)) }
+    return reading + finished
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookReadersRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookReadersRepository.kt
@@ -1,23 +1,23 @@
 package com.calypsan.listenup.client.domain.repository
 
 import com.calypsan.listenup.client.domain.readers.BookReaders
+import com.calypsan.listenup.client.domain.readers.Reader
 import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository contract for the Book Detail Readers section.
  *
- * Backed by the `SocialService.bookReaders` RPC, which is ACL-filtered and caller-excluded
- * server-side. The repository fetches on first subscribe and re-fetches on every presence
- * ping (the server's `ActiveSessionsChanged` nudge or a firehose reconnect). On RPC failure
- * it emits empty readers — Never-Stranded: the section renders empty rather than hanging, and
- * the next ping recovers.
+ * Backed by the `SocialService.bookReadership` RPC, which is ACL-filtered and *includes* the caller
+ * server-side. The repository fetches on first subscribe and re-fetches on every presence ping (the
+ * server's `ActiveSessionsChanged` nudge or a firehose reconnect). On RPC failure it emits empty
+ * readers — Never-Stranded: the section renders empty rather than hanging, and the next ping recovers.
  */
 interface BookReadersRepository {
     /**
      * Observe the readers state for a specific book.
      *
      * The returned [Flow] emits the current reader list on subscribe and re-emits on every
-     * presence ping. The current user is already excluded server-side.
+     * presence ping. The current user is included and flagged via [Reader.isYou].
      *
      * @param bookId The book to observe readers for.
      * @return Flow emitting [BookReaders] on subscribe and on every presence refresh.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
@@ -41,11 +41,12 @@ sealed interface BookReadersUiState {
  * Backs the Book Detail "Readers" section.
  *
  * Observes [BookReadersRepository.observeReadersFor] for the given [bookId] and maps each
- * emission to a sealed [BookReadersUiState]. The repository combines the current user's own reading
- * state (local, offline-capable) with other live listeners from the server, so the section shows
- * whenever the current user — or anyone else — is reading or has finished the book.
+ * emission to a sealed [BookReadersUiState]. The repository observes the server's `bookReadership`
+ * RPC, which returns every reader of this book — including the current user — each with their
+ * current progress and dated finish history. On RPC failure the list is empty, so the Readers
+ * section shows nothing when the server is unreachable.
  *
- * @param repo The readers repository (current user + live others), refreshed on presence pings.
+ * @param repo The readers repository, backed by the server's bookReadership RPC.
  * @param bookId The book whose readers this ViewModel tracks.
  */
 class BookReadersViewModel(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DateFormatting.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DateFormatting.kt
@@ -38,12 +38,16 @@ fun relativeOrMonthYear(
     nowMs: Long,
 ): String {
     val deltaMs = nowMs - finishedAtMs
-    val deltaDays = (deltaMs / (24L * 60 * 60 * 1000)).toInt()
+    val deltaDays = (deltaMs / MILLIS_PER_DAY).toInt()
     return when {
         deltaDays < 1 -> "today"
         deltaDays < 2 -> "yesterday"
-        deltaDays < 7 -> "$deltaDays days ago"
-        deltaDays < 30 -> "${deltaDays / 7} weeks ago"
+        deltaDays < DAYS_PER_WEEK -> "$deltaDays days ago"
+        deltaDays < MONTH_YEAR_THRESHOLD_DAYS -> "${deltaDays / DAYS_PER_WEEK} weeks ago"
         else -> formatDate(finishedAtMs, "MMMM yyyy")
     }
 }
+
+private const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000
+private const val DAYS_PER_WEEK = 7
+private const val MONTH_YEAR_THRESHOLD_DAYS = 30

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DateFormatting.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DateFormatting.kt
@@ -40,11 +40,26 @@ fun relativeOrMonthYear(
     val deltaMs = nowMs - finishedAtMs
     val deltaDays = (deltaMs / MILLIS_PER_DAY).toInt()
     return when {
-        deltaDays < 1 -> "today"
-        deltaDays < 2 -> "yesterday"
-        deltaDays < DAYS_PER_WEEK -> "$deltaDays days ago"
-        deltaDays < MONTH_YEAR_THRESHOLD_DAYS -> "${deltaDays / DAYS_PER_WEEK} weeks ago"
-        else -> formatDate(finishedAtMs, "MMMM yyyy")
+        deltaDays < 1 -> {
+            "today"
+        }
+
+        deltaDays < 2 -> {
+            "yesterday"
+        }
+
+        deltaDays < DAYS_PER_WEEK -> {
+            "$deltaDays days ago"
+        }
+
+        deltaDays < MONTH_YEAR_THRESHOLD_DAYS -> {
+            val weeks = deltaDays / DAYS_PER_WEEK
+            if (weeks == 1) "1 week ago" else "$weeks weeks ago"
+        }
+
+        else -> {
+            formatDate(finishedAtMs, "MMMM yyyy")
+        }
     }
 }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DateFormatting.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/util/DateFormatting.kt
@@ -23,3 +23,27 @@ fun formatDateShort(epochMillis: Long): String = formatDate(epochMillis, "MMM d,
  * Format epoch milliseconds to a long date (e.g., "January 15, 2024").
  */
 fun formatDateLong(epochMillis: Long): String = formatDate(epochMillis, "MMMM d, yyyy")
+
+/**
+ * A human display of a finish time relative to [nowMs]:
+ * - under 1 day → "today"
+ * - 1–6 days → "yesterday" or "N days ago"
+ * - 7–29 days → "N weeks ago" (rounded down to nearest week)
+ * - 30+ days → "Month Year" (e.g. "April 2026")
+ *
+ * Pure (takes [nowMs]) so it is unit-testable without time injection.
+ */
+fun relativeOrMonthYear(
+    finishedAtMs: Long,
+    nowMs: Long,
+): String {
+    val deltaMs = nowMs - finishedAtMs
+    val deltaDays = (deltaMs / (24L * 60 * 60 * 1000)).toInt()
+    return when {
+        deltaDays < 1 -> "today"
+        deltaDays < 2 -> "yesterday"
+        deltaDays < 7 -> "$deltaDays days ago"
+        deltaDays < 30 -> "${deltaDays / 7} weeks ago"
+        else -> formatDate(finishedAtMs, "MMMM yyyy")
+    }
+}

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -278,6 +278,7 @@
     "detail_readers": "Readers",
     "detail_readers_finished": "Finished %1$s",
     "detail_readers_listening_now": "%1$d listening now",
+    "detail_readers_empty": "No one is reading this book yet.",
     "detail_remove_the_downloaded_files_for": "Remove the downloaded files for “%1$s”? ",
     "detail_retry_download": "Retry download",
     "detail_scan_warning": "This book had a scanning error — double-check the files aren’t corrupted.",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ActiveSessionRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ActiveSessionRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.data.repository
 
 import app.cash.turbine.test
 import com.calypsan.listenup.api.SocialService
+import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.dto.social.CurrentlyListeningSession
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
@@ -101,7 +102,7 @@ class ActiveSessionRepositoryImplTest :
                     mock<SocialService> {
                         everySuspend { currentlyListening() } returns
                             AppResult.Success(listOf(session(userId = "u2", bookId = "bookA", displayName = "Bob")))
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
+                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 val bookDao =
                     bookDaoReturning(
@@ -137,7 +138,7 @@ class ActiveSessionRepositoryImplTest :
                                     session(userId = "u3", bookId = "missing"),
                                 ),
                             )
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
+                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 val bookDao =
                     bookDaoReturning(
@@ -169,7 +170,7 @@ class ActiveSessionRepositoryImplTest :
                                     ),
                                 ),
                             )
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
+                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 val bookDao =
                     bookDaoReturning(
@@ -194,7 +195,7 @@ class ActiveSessionRepositoryImplTest :
                     mock<SocialService> {
                         everySuspend { currentlyListening() } returns
                             AppResult.Failure(TransportError.NetworkUnavailable())
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
+                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
 
                 repo(fakeRpc(service), bookDaoReturning(), PresenceRefreshSignal())
@@ -242,7 +243,7 @@ class ActiveSessionRepositoryImplTest :
                     mock<SocialService> {
                         everySuspend { currentlyListening() } returns
                             AppResult.Success(listOf(session(userId = "u2", bookId = "bookA")))
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
+                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 // First lookup throws (transient SQLite/disk error); second lookup succeeds.
                 var lookups = 0

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImplTest.kt
@@ -3,16 +3,14 @@ package com.calypsan.listenup.client.data.repository
 import app.cash.turbine.test
 import com.calypsan.listenup.api.SocialService
 import com.calypsan.listenup.api.dto.auth.UserId
-import com.calypsan.listenup.api.dto.social.BookReader
+import com.calypsan.listenup.api.dto.social.BookReaderEntry
+import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.SocialRpcFactory
 import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
-import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.domain.model.User
-import com.calypsan.listenup.client.domain.readers.ReaderState
 import com.calypsan.listenup.client.domain.repository.UserRepository
-import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
 import com.calypsan.listenup.core.BookId
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.sequentiallyReturns
@@ -24,7 +22,6 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -35,19 +32,27 @@ import kotlinx.coroutines.withTimeoutOrNull
 /**
  * Tests for [BookReadersRepositoryImpl].
  *
- * The repository combines the current user's own reading state (from the local playback position +
- * profile) with other live listeners from the [SocialService] RPC (ACL-filtered, caller-excluded),
- * re-fetching the others on every [PresenceRefreshSignal] ping. The current user, when reading or
- * finished, is listed first and survives an RPC failure (Never-Stranded); a cancelled fetch always
- * propagates rather than collapsing into an empty emission.
+ * The repository maps the ACL-filtered [SocialService] `bookReadership` RPC — which includes the
+ * caller — straight to domain [com.calypsan.listenup.client.domain.readers.Reader]s, flagging the
+ * current user via `isYou`, re-fetching on every [PresenceRefreshSignal] ping. On RPC failure it
+ * yields an empty list (Never-Stranded); a cancelled fetch always propagates rather than collapsing
+ * into an empty emission.
  */
 class BookReadersRepositoryImplTest :
     FunSpec({
 
-        fun reader(
+        fun entry(
             userId: String,
             displayName: String,
-        ) = BookReader(userId = userId, displayName = displayName, avatarType = "auto", startedAtMs = 1_000L)
+            currentProgressPct: Int? = null,
+            finishes: List<Long> = emptyList(),
+        ) = BookReaderEntry(
+            userId = userId,
+            displayName = displayName,
+            avatarType = "auto",
+            currentProgressPct = currentProgressPct,
+            finishes = finishes,
+        )
 
         fun user(
             id: String = "me",
@@ -59,23 +64,6 @@ class BookReadersRepositoryImplTest :
             isAdmin = false,
             createdAtMs = 0L,
             updatedAtMs = 0L,
-        )
-
-        fun position(
-            bookId: String = "bookA",
-            positionMs: Long = 0L,
-            isFinished: Boolean = false,
-            finishedAtMs: Long? = null,
-        ) = PlaybackPosition(
-            bookId = bookId,
-            positionMs = positionMs,
-            playbackSpeed = 1.0f,
-            hasCustomSpeed = false,
-            updatedAtMs = 0L,
-            syncedAtMs = null,
-            lastPlayedAtMs = 0L,
-            isFinished = isFinished,
-            finishedAtMs = finishedAtMs,
         )
 
         fun fakeRpc(service: SocialService): SocialRpcFactory =
@@ -110,90 +98,61 @@ class BookReadersRepositoryImplTest :
         fun repo(
             rpc: SocialRpcFactory,
             presence: PresenceRefreshSignal = PresenceRefreshSignal(),
-            positions: Map<String, PlaybackPosition> = emptyMap(),
             currentUser: User? = user(),
         ) = BookReadersRepositoryImpl(
             socialRpc = rpc,
             presence = presence,
-            playbackPositionRepository = FakePlaybackPositionRepository(initialPositions = positions),
             userRepository = fakeUsers(currentUser),
         )
 
-        // ── Other listeners (server) ──────────────────────────────────────────
+        // ── Mapping ───────────────────────────────────────────────────────────
 
-        test("maps other live listeners to readers when the current user has not started") {
+        test("maps bookReadership entries to domain readers and flags the current user") {
             runTest {
                 val service =
                     mock<SocialService> {
-                        everySuspend { bookReaders(BookId("bookA")) } returns
-                            AppResult.Success(listOf(reader("u2", "Bob"), reader("u3", "Carol")))
+                        everySuspend { bookReadership(BookId("b1")) } returns
+                            AppResult.Success(
+                                BookReadership(
+                                    listOf(
+                                        entry("me", "You", currentProgressPct = null, finishes = listOf(300L, 100L)),
+                                        entry("u2", "Jake", currentProgressPct = 43, finishes = emptyList()),
+                                    ),
+                                ),
+                            )
                     }
 
-                repo(fakeRpc(service)).observeReadersFor("bookA").test {
+                repo(fakeRpc(service), currentUser = user(id = "me")).observeReadersFor("b1").test {
+                    val readers = awaitItem().readers
+                    readers.first { it.userId == "me" }.let {
+                        it.isYou shouldBe true
+                        it.finishes shouldBe listOf(300L, 100L)
+                        it.currentProgressPct shouldBe null
+                    }
+                    readers.first { it.userId == "u2" }.let {
+                        it.isYou shouldBe false
+                        it.currentProgressPct shouldBe 43
+                        it.finishes.shouldBeEmpty()
+                    }
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("maps readers in server order, preserving entries with no current user") {
+            runTest {
+                val service =
+                    mock<SocialService> {
+                        everySuspend { bookReadership(BookId("b1")) } returns
+                            AppResult.Success(
+                                BookReadership(listOf(entry("u2", "Bob"), entry("u3", "Carol"))),
+                            )
+                    }
+
+                repo(fakeRpc(service), currentUser = null).observeReadersFor("b1").test {
                     val readers = awaitItem().readers
                     readers.map { it.userId } shouldContainExactly listOf("u2", "u3")
-                    readers.all { it.state is ReaderState.Listening } shouldBe true
-                    cancelAndIgnoreRemainingEvents()
-                }
-            }
-        }
-
-        // ── Current user inclusion ────────────────────────────────────────────
-
-        test("current user reading is listed first, ahead of other listeners") {
-            runTest {
-                val service =
-                    mock<SocialService> {
-                        everySuspend { bookReaders(BookId("bookA")) } returns
-                            AppResult.Success(listOf(reader("u2", "Bob")))
-                    }
-
-                repo(
-                    fakeRpc(service),
-                    positions = mapOf("bookA" to position(positionMs = 5_000L)),
-                    currentUser = user(id = "me", displayName = "Me"),
-                ).observeReadersFor("bookA").test {
-                    val readers = awaitItem().readers
-                    readers.map { it.userId } shouldContainExactly listOf("me", "u2")
-                    readers.first().state.shouldBeInstanceOf<ReaderState.Listening>()
-                    cancelAndIgnoreRemainingEvents()
-                }
-            }
-        }
-
-        test("current user who finished the book shows a Finished reader with the finish date") {
-            runTest {
-                val service =
-                    mock<SocialService> {
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
-                    }
-
-                repo(
-                    fakeRpc(service),
-                    positions = mapOf("bookA" to position(isFinished = true, finishedAtMs = 1_700_000_000_000L)),
-                ).observeReadersFor("bookA").test {
-                    val readers = awaitItem().readers
-                    readers shouldHaveSize 1
-                    val state = readers.single().state
-                    state.shouldBeInstanceOf<ReaderState.Finished>()
-                    state.finishedAtMs shouldBe 1_700_000_000_000L
-                    cancelAndIgnoreRemainingEvents()
-                }
-            }
-        }
-
-        test("current user with a zeroed, unfinished position is not a reader") {
-            runTest {
-                val service =
-                    mock<SocialService> {
-                        everySuspend { bookReaders(any()) } returns AppResult.Success(emptyList())
-                    }
-
-                repo(
-                    fakeRpc(service),
-                    positions = mapOf("bookA" to position(positionMs = 0L)),
-                ).observeReadersFor("bookA").test {
-                    awaitItem().readers.shouldBeEmpty()
+                    readers.all { !it.isYou } shouldBe true
                     cancelAndIgnoreRemainingEvents()
                 }
             }
@@ -201,20 +160,20 @@ class BookReadersRepositoryImplTest :
 
         // ── Re-fetches on presence ping ───────────────────────────────────────
 
-        test("re-fetches other listeners when the presence signal pings") {
+        test("re-fetches readership when the presence signal pings") {
             runTest {
                 val service =
                     mock<SocialService> {
-                        everySuspend { bookReaders(BookId("bookA")) } sequentiallyReturns
+                        everySuspend { bookReadership(BookId("b1")) } sequentiallyReturns
                             listOf(
-                                AppResult.Success(listOf(reader("u2", "Bob"))),
-                                AppResult.Success(listOf(reader("u2", "Bob"), reader("u3", "Carol"))),
+                                AppResult.Success(BookReadership(listOf(entry("u2", "Bob")))),
+                                AppResult.Success(BookReadership(listOf(entry("u2", "Bob"), entry("u3", "Carol")))),
                             )
                     }
                 val presence = PresenceRefreshSignal()
 
                 repo(fakeRpc(service), presence = presence, currentUser = null)
-                    .observeReadersFor("bookA")
+                    .observeReadersFor("b1")
                     .test {
                         awaitItem().readers shouldHaveSize 1
                         presence.ping()
@@ -224,45 +183,27 @@ class BookReadersRepositoryImplTest :
             }
         }
 
-        // ── RPC failure → only the current user's own row survives ─────────────
+        // ── RPC failure → empty (Never-Stranded) ──────────────────────────────
 
-        test("RPC failure still shows the current user's own row") {
+        test("RPC failure yields empty readers") {
             runTest {
                 val service =
                     mock<SocialService> {
-                        everySuspend { bookReaders(any()) } returns
+                        everySuspend { bookReadership(any()) } returns
                             AppResult.Failure(TransportError.NetworkUnavailable())
                     }
 
-                repo(
-                    fakeRpc(service),
-                    positions = mapOf("bookA" to position(positionMs = 5_000L)),
-                ).observeReadersFor("bookA").test {
-                    awaitItem().readers.map { it.userId } shouldContainExactly listOf("me")
-                    cancelAndIgnoreRemainingEvents()
-                }
-            }
-        }
-
-        test("RPC failure with no current-user reading yields empty readers") {
-            runTest {
-                val service =
-                    mock<SocialService> {
-                        everySuspend { bookReaders(any()) } returns
-                            AppResult.Failure(TransportError.NetworkUnavailable())
-                    }
-
-                repo(fakeRpc(service), currentUser = null).observeReadersFor("bookA").test {
+                repo(fakeRpc(service)).observeReadersFor("b1").test {
                     awaitItem().readers.shouldBeEmpty()
                     cancelAndIgnoreRemainingEvents()
                 }
             }
         }
 
-        test("thrown RPC error with no current-user reading yields empty readers") {
+        test("thrown RPC error yields empty readers") {
             runTest {
-                repo(throwingRpc(RuntimeException("boom")), currentUser = null)
-                    .observeReadersFor("bookA")
+                repo(throwingRpc(RuntimeException("boom")))
+                    .observeReadersFor("b1")
                     .test {
                         awaitItem().readers.shouldBeEmpty()
                         cancelAndIgnoreRemainingEvents()
@@ -275,8 +216,8 @@ class BookReadersRepositoryImplTest :
         test("CancellationException from the RPC is not swallowed into an emission") {
             runTest {
                 val flow =
-                    repo(throwingRpc(CancellationException("cancel")), currentUser = null)
-                        .observeReadersFor("bookA")
+                    repo(throwingRpc(CancellationException("cancel")))
+                        .observeReadersFor("b1")
 
                 val emitted = withTimeoutOrNull(100) { flow.first() }
                 emitted shouldBe null

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/readers/ReaderLineTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/readers/ReaderLineTest.kt
@@ -1,0 +1,50 @@
+package com.calypsan.listenup.client.domain.readers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ReaderLineTest :
+    FunSpec({
+
+        test("flattenToLines: reading lines first, then finishes newest-first across readers") {
+            val readers =
+                listOf(
+                    Reader("u2", "Jake", isYou = false, currentProgressPct = 43, finishes = emptyList()),
+                    Reader("me", "You", isYou = true, currentProgressPct = null, finishes = listOf(1_777_000_000_000L, 1_610_000_000_000L)),
+                    Reader("u3", "Mary", isYou = false, currentProgressPct = null, finishes = listOf(1_600_000_000_000L)),
+                )
+            flattenToLines(readers).map { it.kind } shouldBe
+                listOf(
+                    ReaderLineKind.Reading(43),
+                    ReaderLineKind.Finished(1_777_000_000_000L),
+                    ReaderLineKind.Finished(1_610_000_000_000L),
+                    ReaderLineKind.Finished(1_600_000_000_000L),
+                )
+        }
+
+        test("a reader who is both reading now and has past finishes yields a reading line AND finished lines") {
+            val readers = listOf(Reader("me", "You", true, currentProgressPct = 10, finishes = listOf(500L, 200L)))
+            flattenToLines(readers).map { it.kind } shouldBe
+                listOf(
+                    ReaderLineKind.Reading(10),
+                    ReaderLineKind.Finished(500L),
+                    ReaderLineKind.Finished(200L),
+                )
+        }
+
+        test("flattenToLines: empty readers yields empty lines") {
+            flattenToLines(emptyList()) shouldBe emptyList()
+        }
+
+        test("flattenToLines: reader ids and names are preserved in lines") {
+            val readers =
+                listOf(
+                    Reader("u1", "Alice", isYou = false, currentProgressPct = 75, finishes = emptyList()),
+                )
+            val lines = flattenToLines(readers)
+            lines.size shouldBe 1
+            lines[0].userId shouldBe "u1"
+            lines[0].name shouldBe "Alice"
+            lines[0].isYou shouldBe false
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/RelativeOrMonthYearTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/RelativeOrMonthYearTest.kt
@@ -1,0 +1,40 @@
+package com.calypsan.listenup.client.util
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [relativeOrMonthYear].
+ *
+ * Fixed reference: nowMs = 2026-06-01T12:00:00 UTC = 1780315200000L.
+ *
+ * Cases:
+ * - same instant → "today"
+ * - ~26h ago (1780221600000L) → "yesterday"
+ * - 21 days ago (1778500800000L) → "3 weeks ago"
+ * - 60 days ago (1775131200000L, landing in April 2026) → "April 2026"
+ */
+class RelativeOrMonthYearTest :
+    FunSpec({
+
+        val nowMs = 1780315200000L // 2026-06-01T12:00:00 UTC
+
+        test("same instant returns today") {
+            relativeOrMonthYear(finishedAtMs = nowMs, nowMs = nowMs) shouldBe "today"
+        }
+
+        test("~26 hours ago returns yesterday") {
+            val yesterdayMs = 1780221600000L // 2026-05-31T10:00:00 UTC, 26h before nowMs
+            relativeOrMonthYear(finishedAtMs = yesterdayMs, nowMs = nowMs) shouldBe "yesterday"
+        }
+
+        test("21 days ago returns 3 weeks ago") {
+            val threeWeeksMs = 1778500800000L // 2026-05-11T12:00:00 UTC, exactly 21 days before nowMs
+            relativeOrMonthYear(finishedAtMs = threeWeeksMs, nowMs = nowMs) shouldBe "3 weeks ago"
+        }
+
+        test("60 days ago returns Month Year") {
+            val sixtyDaysMs = 1775131200000L // 2026-04-02T12:00:00 UTC, 60 days before nowMs
+            relativeOrMonthYear(finishedAtMs = sixtyDaysMs, nowMs = nowMs) shouldBe "April 2026"
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/RelativeOrMonthYearTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/util/RelativeOrMonthYearTest.kt
@@ -28,6 +28,11 @@ class RelativeOrMonthYearTest :
             relativeOrMonthYear(finishedAtMs = yesterdayMs, nowMs = nowMs) shouldBe "yesterday"
         }
 
+        test("7 days ago returns 1 week ago") {
+            val oneWeekMs = 1779710400000L // 2026-05-25T12:00:00 UTC, exactly 7 days before nowMs
+            relativeOrMonthYear(finishedAtMs = oneWeekMs, nowMs = nowMs) shouldBe "1 week ago"
+        }
+
         test("21 days ago returns 3 weeks ago") {
             val threeWeeksMs = 1778500800000L // 2026-05-11T12:00:00 UTC, exactly 21 days before nowMs
             relativeOrMonthYear(finishedAtMs = threeWeeksMs, nowMs = nowMs) shouldBe "3 weeks ago"

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/RouteSerializationTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/RouteSerializationTest.kt
@@ -45,6 +45,7 @@ private fun sampleRoutes(): List<Route> =
         // Core
         add(Shell)
         add(BookDetail(bookId = "test-book-id"))
+        add(BookReaders(bookId = "test-book-id"))
         add(BookEdit(bookId = "test-book-id"))
         add(MatchPreview(bookId = "test-book-id", asin = "test-asin"))
         add(MetadataSearch(bookId = "test-book-id"))

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/Routes.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/Routes.kt
@@ -38,6 +38,19 @@ data class BookDetail(
 ) : Route
 
 /**
+ * Book readers screen - the full "See all" list of everyone reading or who has finished a book.
+ *
+ * Reached from the Readers section's "See all" affordance on [BookDetail]. Renders the uncapped
+ * flattened reader list (the section caps at five).
+ *
+ * @property bookId The unique ID of the book whose readers to display.
+ */
+@Serializable
+data class BookReaders(
+    val bookId: String,
+) : Route
+
+/**
  * Book edit screen - edit book metadata and contributors.
  *
  * Allows editing title, subtitle, description, series info, publish year,

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/BookEntries.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/BookEntries.kt
@@ -5,6 +5,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.calypsan.listenup.client.navigation.BookDetail
 import com.calypsan.listenup.client.navigation.BookEdit
+import com.calypsan.listenup.client.navigation.BookReaders
 import com.calypsan.listenup.client.navigation.ContributorDetail
 import com.calypsan.listenup.client.navigation.MatchPreview
 import com.calypsan.listenup.client.navigation.MetadataSearch
@@ -36,6 +37,20 @@ internal fun EntryProviderScope<NavKey>.bookEntries(backStack: NavBackStack<NavK
                 backStack.add(TagDetail(tagId))
             },
             onUserProfileClick = { userId ->
+                backStack.add(UserProfile(userId))
+            },
+            onSeeAllReaders = { id ->
+                backStack.add(BookReaders(id))
+            },
+        )
+    }
+    entry<BookReaders> { args ->
+        com.calypsan.listenup.client.features.bookreaders.BookReadersScreen(
+            bookId = args.bookId,
+            onBack = {
+                backStack.removeAt(backStack.lastIndex)
+            },
+            onUserClick = { userId ->
                 backStack.add(UserProfile(userId))
             },
         )

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -226,6 +226,7 @@ One beautiful library.</string>
     <string name="book_detail_read_less">Read less</string>
     <string name="book_detail_read_more">Read more</string>
     <string name="book_detail_readers">Readers</string>
+    <string name="book_detail_readers_empty">No one is reading this book yet.</string>
     <string name="book_detail_readers_finished">Finished %1$s</string>
     <string name="book_detail_readers_listening_now">%1$d listening now</string>
     <string name="book_detail_released">Released</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -98,6 +98,7 @@ fun BookDetailScreen(
     onContributorClick: (contributorId: String) -> Unit,
     onTagClick: (tagId: String) -> Unit,
     onUserProfileClick: (userId: String) -> Unit,
+    onSeeAllReaders: (bookId: String) -> Unit = {},
     viewModel: BookDetailViewModel = koinViewModel(),
 ) {
     LaunchedEffect(bookId) {
@@ -143,6 +144,7 @@ fun BookDetailScreen(
                     onContributorClick = onContributorClick,
                     onTagClick = onTagClick,
                     onUserProfileClick = onUserProfileClick,
+                    onSeeAllReaders = onSeeAllReaders,
                 )
             }
         }
@@ -169,6 +171,7 @@ private fun BookDetailReadyContent(
     onContributorClick: (contributorId: String) -> Unit,
     onTagClick: (tagId: String) -> Unit,
     onUserProfileClick: (userId: String) -> Unit,
+    onSeeAllReaders: (bookId: String) -> Unit,
 ) {
     val platformActions: BookDetailPlatformActions = koinInject()
     val instanceRepository: InstanceRepository = koinInject()
@@ -249,6 +252,7 @@ private fun BookDetailReadyContent(
         onSeriesClick = onSeriesClick,
         onContributorClick = onContributorClick,
         onTagClick = onTagClick,
+        onSeeAllReaders = onSeeAllReaders,
     )
 
     if (showDeleteDialog) {
@@ -334,6 +338,7 @@ fun BookDetailContent(
     onContributorClick: (contributorId: String) -> Unit,
     onTagClick: (tagId: String) -> Unit,
     onUserProfileClick: (userId: String) -> Unit,
+    onSeeAllReaders: (bookId: String) -> Unit = {},
 ) {
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
 
@@ -377,6 +382,7 @@ fun BookDetailContent(
             onContributorClick = onContributorClick,
             onTagClick = onTagClick,
             onUserProfileClick = onUserProfileClick,
+            onSeeAllReaders = onSeeAllReaders,
         )
     } else {
         ImmersiveBookDetail(
@@ -410,6 +416,7 @@ fun BookDetailContent(
             onContributorClick = onContributorClick,
             onTagClick = onTagClick,
             onUserProfileClick = onUserProfileClick,
+            onSeeAllReaders = onSeeAllReaders,
         )
     }
 }
@@ -459,6 +466,7 @@ private fun ImmersiveBookDetail(
     onContributorClick: (contributorId: String) -> Unit,
     onTagClick: (tagId: String) -> Unit,
     onUserProfileClick: (userId: String) -> Unit,
+    onSeeAllReaders: (bookId: String) -> Unit,
 ) {
     var isDescriptionExpanded by rememberSaveable { mutableStateOf(false) }
     var isChaptersExpanded by rememberSaveable { mutableStateOf(false) }
@@ -585,6 +593,7 @@ private fun ImmersiveBookDetail(
                 BookReadersSection(
                     bookId = bookId,
                     onUserClick = onUserProfileClick,
+                    onSeeAllClick = onSeeAllReaders,
                     modifier = screenPadding.padding(vertical = 8.dp),
                 )
             }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.calypsan.listenup.client.features.bookdetail.components
 
 import androidx.compose.foundation.background
@@ -38,10 +40,11 @@ import com.calypsan.listenup.client.design.components.UserAvatar
 import com.calypsan.listenup.client.design.theme.ContentShapes
 import com.calypsan.listenup.client.design.theme.DisplayFontFamily
 import com.calypsan.listenup.client.design.theme.Spacing
-import com.calypsan.listenup.client.domain.readers.ReaderState
+import com.calypsan.listenup.client.domain.readers.ReaderLineKind
+import com.calypsan.listenup.client.domain.readers.flattenToLines
 import com.calypsan.listenup.client.presentation.bookdetail.BookReadersUiState
 import com.calypsan.listenup.client.presentation.bookdetail.BookReadersViewModel
-import com.calypsan.listenup.client.util.formatDate
+import com.calypsan.listenup.client.util.relativeOrMonthYear
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.book_detail_readers
 import listenup.composeapp.generated.resources.book_detail_readers_finished
@@ -51,6 +54,9 @@ import listenup.composeapp.generated.resources.common_see_all
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
+import kotlin.time.Clock
+
+private const val MAX_COLLAPSED_READERS = 5
 
 /**
  * Presentation-only model for a single reader row in [BookReadersContent].
@@ -101,6 +107,7 @@ fun BookReadersSection(
     onUserClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     isCard: Boolean = false,
+    onSeeAllClick: (String) -> Unit = {},
     viewModel: BookReadersViewModel = koinViewModel(parameters = { parametersOf(bookId) }),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -108,37 +115,41 @@ fun BookReadersSection(
     // Loading and Error render nothing — the Readers section is non-critical.
     val data = state as? BookReadersUiState.Data ?: return
 
-    val readers =
-        data.readers.readers.map { reader ->
-            when (val readerState = reader.state) {
-                is ReaderState.Listening -> {
+    val lines = flattenToLines(data.readers.readers)
+    val nowMs = Clock.System.now().toEpochMilliseconds()
+    val rows =
+        lines.take(MAX_COLLAPSED_READERS).map { line ->
+            val name = if (line.isYou) "You" else line.name
+            when (val k = line.kind) {
+                is ReaderLineKind.Reading -> {
                     ReaderRowUi(
-                        userId = reader.userId,
-                        name = reader.displayName,
+                        userId = line.userId,
+                        name = name,
                         isReading = true,
-                        progressPct = null,
+                        progressPct = k.progressPct,
                         finishedWhen = null,
                     )
                 }
 
-                is ReaderState.Finished -> {
+                is ReaderLineKind.Finished -> {
                     ReaderRowUi(
-                        userId = reader.userId,
-                        name = reader.displayName,
+                        userId = line.userId,
+                        name = name,
                         isReading = false,
                         progressPct = null,
-                        finishedWhen = readerState.finishedAtMs?.let { formatDate(it, "MMM d") },
+                        finishedWhen = relativeOrMonthYear(k.finishedAtMs, nowMs),
                     )
                 }
             }
         }
 
     BookReadersContent(
-        readers = readers,
-        listeningNowCount = readers.count { it.isReading },
-        totalCount = readers.size,
+        readers = rows,
+        listeningNowCount = rows.count { it.isReading },
+        totalCount = lines.size,
         isCard = isCard,
         onUserClick = onUserClick,
+        onSeeAllClick = { onSeeAllClick(bookId) },
         modifier = modifier,
     )
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
@@ -40,6 +40,7 @@ import com.calypsan.listenup.client.design.components.UserAvatar
 import com.calypsan.listenup.client.design.theme.ContentShapes
 import com.calypsan.listenup.client.design.theme.DisplayFontFamily
 import com.calypsan.listenup.client.design.theme.Spacing
+import com.calypsan.listenup.client.domain.readers.Reader
 import com.calypsan.listenup.client.domain.readers.ReaderLineKind
 import com.calypsan.listenup.client.domain.readers.flattenToLines
 import com.calypsan.listenup.client.presentation.bookdetail.BookReadersUiState
@@ -83,6 +84,39 @@ data class ReaderRowUi(
 )
 
 /**
+ * Flattens readers into [ReaderRowUi] rows for both the capped Book Detail section and the full
+ * [com.calypsan.listenup.client.features.bookreaders.BookReadersScreen]. Reading lines come first,
+ * then finished lines newest-first (see [flattenToLines]); the caller's own row is labelled "You".
+ *
+ * @param nowMs Current epoch-ms reference, passed to [relativeOrMonthYear] for finished dates.
+ */
+internal fun List<Reader>.toReaderRows(nowMs: Long): List<ReaderRowUi> =
+    flattenToLines(this).map { line ->
+        val name = if (line.isYou) "You" else line.name
+        when (val k = line.kind) {
+            is ReaderLineKind.Reading -> {
+                ReaderRowUi(
+                    userId = line.userId,
+                    name = name,
+                    isReading = true,
+                    progressPct = k.progressPct,
+                    finishedWhen = null,
+                )
+            }
+
+            is ReaderLineKind.Finished -> {
+                ReaderRowUi(
+                    userId = line.userId,
+                    name = name,
+                    isReading = false,
+                    progressPct = null,
+                    finishedWhen = relativeOrMonthYear(k.finishedAtMs, nowMs),
+                )
+            }
+        }
+    }
+
+/**
  * VM-bound entry point for the Readers section on the Book Detail screen.
  *
  * Collects [BookReadersViewModel] state and, on [BookReadersUiState.Data], maps each reader's
@@ -115,38 +149,14 @@ fun BookReadersSection(
     // Loading and Error render nothing — the Readers section is non-critical.
     val data = state as? BookReadersUiState.Data ?: return
 
-    val lines = flattenToLines(data.readers.readers)
     val nowMs = Clock.System.now().toEpochMilliseconds()
-    val rows =
-        lines.take(MAX_COLLAPSED_READERS).map { line ->
-            val name = if (line.isYou) "You" else line.name
-            when (val k = line.kind) {
-                is ReaderLineKind.Reading -> {
-                    ReaderRowUi(
-                        userId = line.userId,
-                        name = name,
-                        isReading = true,
-                        progressPct = k.progressPct,
-                        finishedWhen = null,
-                    )
-                }
-
-                is ReaderLineKind.Finished -> {
-                    ReaderRowUi(
-                        userId = line.userId,
-                        name = name,
-                        isReading = false,
-                        progressPct = null,
-                        finishedWhen = relativeOrMonthYear(k.finishedAtMs, nowMs),
-                    )
-                }
-            }
-        }
+    val allRows = data.readers.readers.toReaderRows(nowMs)
+    val rows = allRows.take(MAX_COLLAPSED_READERS)
 
     BookReadersContent(
         readers = rows,
         listeningNowCount = rows.count { it.isReading },
-        totalCount = lines.size,
+        totalCount = allRows.size,
         isCard = isCard,
         onUserClick = onUserClick,
         onSeeAllClick = { onSeeAllClick(bookId) },
@@ -271,7 +281,7 @@ fun BookReadersContent(
  * @param modifier Optional modifier.
  */
 @Composable
-private fun ReaderRow(
+internal fun ReaderRow(
     reader: ReaderRowUi,
     onUserClick: (String) -> Unit,
     modifier: Modifier = Modifier,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
@@ -155,7 +155,7 @@ fun BookReadersSection(
 
     BookReadersContent(
         readers = rows,
-        listeningNowCount = rows.count { it.isReading },
+        listeningNowCount = allRows.count { it.isReading },
         totalCount = allRows.size,
         isCard = isCard,
         onUserClick = onUserClick,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -87,6 +87,7 @@ fun WideBookDetail(
     onContributorClick: (contributorId: String) -> Unit,
     onTagClick: (tagId: String) -> Unit,
     onUserProfileClick: (userId: String) -> Unit,
+    onSeeAllReaders: (bookId: String) -> Unit = {},
 ) {
     var isDescriptionExpanded by rememberSaveable { mutableStateOf(false) }
     var isChaptersExpanded by rememberSaveable { mutableStateOf(false) }
@@ -204,6 +205,7 @@ fun WideBookDetail(
                     isChaptersExpanded = isChaptersExpanded,
                     onExpandChapters = { isChaptersExpanded = true },
                     onUserProfileClick = onUserProfileClick,
+                    onSeeAllReaders = onSeeAllReaders,
                     modifier = Modifier.widthIn(max = RIGHT_COLUMN_MAX_WIDTH),
                 )
             }
@@ -301,6 +303,7 @@ private fun WideRightColumn(
     isChaptersExpanded: Boolean,
     onExpandChapters: () -> Unit,
     onUserProfileClick: (userId: String) -> Unit,
+    onSeeAllReaders: (bookId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -313,6 +316,7 @@ private fun WideRightColumn(
             bookId = bookId,
             onUserClick = onUserProfileClick,
             isCard = true,
+            onSeeAllClick = onSeeAllReaders,
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookreaders/BookReadersScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookreaders/BookReadersScreen.kt
@@ -1,0 +1,147 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.calypsan.listenup.client.features.bookreaders
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
+import com.calypsan.listenup.client.design.theme.Spacing
+import com.calypsan.listenup.client.features.bookdetail.components.ReaderRow
+import com.calypsan.listenup.client.features.bookdetail.components.toReaderRows
+import com.calypsan.listenup.client.presentation.bookdetail.BookReadersUiState
+import com.calypsan.listenup.client.presentation.bookdetail.BookReadersViewModel
+import listenup.composeapp.generated.resources.Res
+import listenup.composeapp.generated.resources.book_detail_readers
+import listenup.composeapp.generated.resources.book_detail_readers_empty
+import listenup.composeapp.generated.resources.common_back
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+import kotlin.time.Clock
+
+/** Caps the readable column width so the list stays comfortable on tablets and desktop. */
+private val ReadableWidth = 560.dp
+
+/**
+ * Full "See all" Readers screen — the uncapped list behind the Book Detail Readers section's
+ * "See all" affordance.
+ *
+ * Mirrors [com.calypsan.listenup.client.features.bookdetail.components.BookReadersSection]'s
+ * flatten → [com.calypsan.listenup.client.features.bookdetail.components.ReaderRowUi] mapping via
+ * the shared `toReaderRows` helper, but renders *every* row instead of the section's five. Each row
+ * is the same [ReaderRow] composable, so the two surfaces never drift.
+ *
+ * @param bookId The book whose readers to list; scopes the [BookReadersViewModel].
+ * @param onBack Pops back to the originating Book Detail screen.
+ * @param onUserClick Navigates to a reader's profile (same target as the section's row click).
+ * @param viewModel The readers ViewModel, scoped to [bookId].
+ */
+@Composable
+fun BookReadersScreen(
+    bookId: String,
+    onBack: () -> Unit,
+    onUserClick: (String) -> Unit,
+    viewModel: BookReadersViewModel = koinViewModel(parameters = { parametersOf(bookId) }),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.book_detail_readers)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = stringResource(Res.string.common_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        BookReadersBody(
+            state = state,
+            innerPadding = innerPadding,
+            onUserClick = onUserClick,
+        )
+    }
+}
+
+/**
+ * Stateless body for [BookReadersScreen]. Renders the full reader list on
+ * [BookReadersUiState.Data], a centered loading indicator while the first emission is in flight, and
+ * a centered empty message for [BookReadersUiState.NoReaders] / [BookReadersUiState.Error] (the
+ * Readers list is non-critical, so an error reads the same as "nobody yet").
+ */
+@Composable
+private fun BookReadersBody(
+    state: BookReadersUiState,
+    innerPadding: PaddingValues,
+    onUserClick: (String) -> Unit,
+) {
+    when (state) {
+        is BookReadersUiState.Loading -> {
+            Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                ListenUpLoadingIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+        }
+
+        is BookReadersUiState.NoReaders, is BookReadersUiState.Error -> {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(innerPadding).padding(horizontal = 24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(Res.string.book_detail_readers_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+
+        is BookReadersUiState.Data -> {
+            val nowMs = Clock.System.now().toEpochMilliseconds()
+            val rows = state.readers.readers.toReaderRows(nowMs)
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentPadding = PaddingValues(horizontal = Spacing.screenMargin, vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                items(
+                    items = rows,
+                    key = { row -> "${row.userId}:${row.isReading}:${row.finishedWhen}" },
+                ) { row ->
+                    ReaderRow(
+                        reader = row,
+                        onUserClick = onUserClick,
+                        modifier = Modifier.fillMaxWidth().widthIn(max = ReadableWidth),
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #476.

Makes a book's **Readers** section a persistent, dated readership — current readers (with % progress) and finishers (with dates, including re-reads), **including the current user** — for both normal playback and ABS-imported history.

## Backend
- **New `book_reads` table** (server-only, append-only completion log; one row per finish, re-reads stack) + `V34` Flyway migration + `BookReadsRepository`.
- **Live finish-flip** (`PlaybackPositionRepository`, finished false→true) appends a `book_reads` row dated by `lastPlayedAt`. ABS imports flow through that same path, so imported finishes seed automatically (dated by the progress `updatedAt`) and re-import is idempotent (the position is already finished → the flip doesn't re-fire). DI wired so this fires in production (`BookReadsRepository` had no binding before).
- **New RPC** `SocialService.bookReadership(bookId): BookReadership` replaces the live-presence-only, caller-excluded `bookReaders`. Returns every user (incl. the caller) with `currentProgressPct: Int?` + `finishes: List<Long>` (newest-first). The crown-jewel ACL is preserved: `NotFound` for inaccessible books, never leaking existence.

## Client
- New flat `Reader(userId, displayName, isYou, currentProgressPct, finishes)` domain model; `BookReadersRepositoryImpl` maps the RPC (RPC failure → empty list, Never-Stranded).
- `flattenToLines` turns readers into display lines (reading lines first, then finishes newest-first); `relativeOrMonthYear` formats finish dates (relative under ~30 days, else "Month Year").
- **Book Detail Readers section** flattens to lines, caps at **5**, shows **"See All (N)"**; new **`BookReadersScreen`** (full list) + Navigation 3 route mirroring the `BookDetail` entry pattern.

Renders e.g. `Jake — reading 43%` · `You — read April 2026` · `You — read January 2021` · `Mary — read October 2020`.

## Scope
- iOS SwiftUI Readers rendering is a follow-up (no iOS consumer of this RPC). ABS `tz="UTC"` (#476 note 4) out of scope. No retro-backfill of finishes recorded before this feature (live finishes accrue going forward; ABS history seeds on next import).

## Tests & review
- Server (Kotest + in-memory SQLite): finish-flip append, ABS import seeding + idempotency, `bookReadership` (progress + finishes + caller inclusion), ACL `NotFound`. Contract round-trip. Client: repo mapping + `isYou`, flatten ordering, date-formatter boundaries.
- Whole-branch code review completed; findings addressed (removed dead `recordReadIfAbsent`, fixed "1 week ago" pluralization, `listeningNowCount` over the full list, ViewModel KDoc).
- Full Linux gate green: `spotlessCheck detekt :sharedLogic:jvmTest :server:test :androidApp:assembleDebug`.
