### PR TITLE
🐛 fix(sharedUI): status-bar inset on ColorBlockHero + stop cards clipping

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ActionTile.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ActionTile.kt
@@ -26,7 +26,7 @@ private const val CHEVRON_ALPHA = 0.7f
 private val BADGE_SIZE = 50.dp
 
 /**
- * A color-blocked navigation tile: a rounded ([MaterialTheme.shapes.extraLarge]) [Surface] filled
+ * A color-blocked navigation tile: a rounded ([MaterialTheme.shapes.large]) [Surface] filled
  * with [containerColor], leading with a [ScallopBadge] holding [icon], a [title] + muted [subtitle]
  * text column, and a trailing chevron. The canonical "big nav tile" for management/landing actions —
  * the Admin Management section composes one per destination, and any screen needing a vivid,
@@ -58,7 +58,7 @@ fun ActionTile(
     Surface(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = containerColor,
         contentColor = contentColor,
     ) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ColorBlockHero.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ColorBlockHero.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
@@ -67,6 +70,9 @@ fun ColorBlockHero(
             modifier =
                 Modifier
                     .fillMaxWidth()
+                    // The primaryContainer Surface bleeds edge-to-edge behind the status bar; inset
+                    // only the content so the back button clears the system clock and stays tappable.
+                    .windowInsetsPadding(WindowInsets.statusBars)
                     .padding(start = 8.dp, end = 20.dp, top = 8.dp, bottom = 24.dp),
         ) {
             Row(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SectionGroup.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SectionGroup.kt
@@ -23,7 +23,7 @@ private val HEADER_TILE_SIZE = 30.dp
 /**
  * The canonical accent-headed grouped-section container: an accent-tinted [TonalIconTile] paired
  * with an UPPERCASE overline [label] in [accent], floating above a [surfaceContainerLow] card
- * ([MaterialTheme.shapes.extraLarge]) whose body is the [content] [Column]. Used wherever the app
+ * ([MaterialTheme.shapes.large]) whose body is the [content] [Column]. Used wherever the app
  * groups related rows under a coloured heading — Settings sections (Appearance, Playback, …) and
  * Admin sections (Server, Users, Management) all compose this with their own accent and rows.
  *
@@ -65,7 +65,7 @@ fun SectionGroup(
         }
         Surface(
             modifier = Modifier.fillMaxWidth(),
-            shape = MaterialTheme.shapes.extraLarge,
+            shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceContainerLow,
         ) {
             Column(content = content)

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/CreateInviteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/CreateInviteScreen.kt
@@ -508,7 +508,7 @@ private fun LinkPreviewCard(
     val colors = MaterialTheme.colorScheme
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = colors.primaryContainer,
         contentColor = colors.onPrimaryContainer,
     ) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/ChapterNameReviewSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/ChapterNameReviewSheet.kt
@@ -104,7 +104,7 @@ fun ChapterNameReviewSheet(
 
             Surface(
                 modifier = Modifier.fillMaxWidth().weight(1f, fill = false),
-                shape = MaterialTheme.shapes.extraLarge,
+                shape = MaterialTheme.shapes.large,
                 color = MaterialTheme.colorScheme.surfaceContainerLow,
             ) {
                 LazyColumn {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewScreen.kt
@@ -282,7 +282,7 @@ private fun MatchedEditionHero(
     val colors = MaterialTheme.colorScheme
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = colors.primaryContainer,
         contentColor = colors.onPrimaryContainer,
     ) {
@@ -665,7 +665,7 @@ private fun FieldGroup(
         }
         Surface(
             modifier = Modifier.fillMaxWidth(),
-            shape = MaterialTheme.shapes.extraLarge,
+            shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceContainerLow,
             content = { Column(content = content) },
         )
@@ -707,7 +707,7 @@ private fun ChapterNamesItem(
         is ChapterSuggestion.CountMismatch -> {
             Surface(
                 modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.extraLarge,
+                shape = MaterialTheme.shapes.large,
                 color = MaterialTheme.colorScheme.surfaceContainerLow,
             ) {
                 Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
@@ -732,7 +732,7 @@ private fun ChapterNamesItem(
             Surface(
                 onClick = onReview,
                 modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.extraLarge,
+                shape = MaterialTheme.shapes.large,
                 color = MaterialTheme.colorScheme.secondaryContainer,
                 contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
             ) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchScreen.kt
@@ -318,7 +318,7 @@ private fun MetadataSearchResultItem(
 ) {
     Surface(
         onClick = onClick,
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         Row(


### PR DESCRIPTION
## What

The recent Material 3 Expressive reskins (#556 metadata, #533 admin/invite, #530 settings) introduced two recurring visual regressions. This fixes both at their shared source.

### 1. Header bars jammed under the status bar
`ColorBlockHero` (the shared color-blocked screen header) had no top inset, so its back button sat under the system clock — unreachable without dropping the notification shade. Added `windowInsetsPadding(WindowInsets.statusBars)` to its inner content column: the colored block still bleeds edge-to-edge behind the status bar, but the back button/title now clear the clock. One fix covers Admin, Create Invite, Metadata Search, and Match Preview.

### 2. Cards clipped by a giant rounded arc
The theme defines `extraLarge = CircleShape` (reserved for fully-round elements — FABs, avatars), while `large` (28dp) is the documented card shape. The reskin gave tall content cards `shape = MaterialTheme.shapes.extraLarge`, so `CircleShape` set their corner radius to 50% of the width — a huge arc that clipped the content (e.g. the cover tiles in the metadata IDENTITY card).

Swapped `extraLarge → large` on the card-shaped surfaces:
- **Shared**: `SectionGroup` (every Settings/Admin section) and `ActionTile` (nav tiles) — fixes those app-wide.
- **Metadata**: `MatchPreviewScreen` (matched-edition hero, field-group card, two chapter cards), `MetadataSearchScreen` (result card), `ChapterNameReviewSheet` (list container).
- **Admin**: `CreateInviteScreen` (hero card).

Genuinely round elements are left as `extraLarge` on purpose: `MatchingContextPill`, `SearchPillBar`, `SeeAllAction`, the 52dp circular icon, `TagFlow` pills, and `SignOutTile`. The theme's `extraLarge` is **not** changed.

## Verification

- compile (`:sharedUI:compileAndroidMain`), `spotlessCheck`, `detekt`, `:androidApp:assembleDebug` — all green.
- On-device (emulator): confirmed both fixes on **Settings** (SectionGroup cards cleanly rounded), **Admin** (ColorBlockHero back button clears the clock; section cards + ActionTile no longer clipped), and **Create Invite** (ColorBlockHero inset + access-level cards rounded).

## Notes

- **ABS import** screens (suspected to have the same bugs) live on the unmerged `feat/abs-import-rpc-rebuild` branch, not `main` — they'll need the same treatment when that lands; they use `TopAppBar` + shared components so most will be covered automatically.
- No automated test: these are Compose shape/inset properties with no practical unit seam (the regressions shipped without one). Verified visually instead.