### PR TITLE
🐛 fix(metadata): auto-search on region change + carry region into match preview

### DIFF
--- a/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
+++ b/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
@@ -53,6 +53,7 @@ import com.calypsan.listenup.client.features.contributoredit.ContributorEditScre
 import com.calypsan.listenup.client.features.contributormetadata.ContributorMetadataPreviewRoute
 import com.calypsan.listenup.client.features.contributormetadata.ContributorMetadataSearchRoute
 import com.calypsan.listenup.client.features.shelf.CreateEditShelfScreen
+import com.calypsan.listenup.api.metadata.AudibleRegion
 import com.calypsan.listenup.client.features.metadata.MatchPreviewRoute
 import com.calypsan.listenup.client.features.metadata.MetadataSearchRoute
 import com.calypsan.listenup.client.features.shelf.ShelfDetailScreen
@@ -126,6 +127,7 @@ sealed interface DetailDestination {
     data class MatchPreview(
         val bookId: String,
         val asin: String,
+        val region: AudibleRegion,
     ) : DetailDestination
 
     data class ContributorMetadataSearch(
@@ -438,8 +440,8 @@ private fun DetailScreen(
         is DetailDestination.MetadataSearch -> {
             MetadataSearchRoute(
                 bookId = destination.bookId,
-                onResultSelected = { asin ->
-                    navigateTo(DetailDestination.MatchPreview(destination.bookId, asin))
+                onResultSelected = { asin, region ->
+                    navigateTo(DetailDestination.MatchPreview(destination.bookId, asin, region))
                 },
                 onBack = navigateBack,
             )
@@ -449,6 +451,7 @@ private fun DetailScreen(
             MatchPreviewRoute(
                 bookId = destination.bookId,
                 asin = destination.asin,
+                region = destination.region,
                 onBack = navigateBack,
                 onApplySuccess = {
                     // Pop both MatchPreview and MetadataSearch to go back to BookDetail

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
@@ -241,12 +241,16 @@ class MetadataViewModel(
      * If the book has an existing ASIN, we seed the search query with it (the
      * route can then auto-search for a direct match). Otherwise the query is
      * `"$title $author"`.
+     *
+     * [region] defaults to the current region but can be supplied explicitly so a freshly-scoped
+     * VM (e.g. the per-entry preview route) starts in the region carried across navigation.
      */
     fun initForBook(
         bookId: String,
         title: String,
         author: String,
         asin: String? = null,
+        region: AudibleRegion = _state.value.region,
     ) {
         val query =
             buildString {
@@ -258,7 +262,7 @@ class MetadataViewModel(
             }.trim()
         _state.value =
             MetadataUiState.Search(
-                region = _state.value.region,
+                region = region,
                 context =
                     BookContext(
                         bookId = bookId,
@@ -278,7 +282,10 @@ class MetadataViewModel(
         }
     }
 
-    /** Change the Audible region. If in preview, re-fetch with the new region. */
+    /**
+     * Change the Audible region and immediately reflect it: in preview, re-fetch the open match in
+     * the new region; in search, re-run the query so results update without a manual re-submit.
+     */
     fun changeRegion(region: AudibleRegion) {
         _state.update { current ->
             when (current) {
@@ -287,9 +294,13 @@ class MetadataViewModel(
                 is MetadataUiState.Preview -> current.copy(region = region)
             }
         }
-        val current = _state.value
-        if (current is MetadataUiState.Preview) {
-            selectMatch(current.match)
+        when (val current = _state.value) {
+            is MetadataUiState.Preview -> selectMatch(current.match)
+
+            is MetadataUiState.Search -> search()
+
+            // no-op when the query is blank
+            is MetadataUiState.Idle -> Unit
         }
     }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
@@ -714,13 +714,67 @@ class MetadataViewModelTest :
             }
         }
 
+        test("changeRegion in Search phase re-runs the search with the new region") {
+            runTest {
+                val repo = mock<MetadataRepository>()
+                everySuspend { repo.searchBooks(any(), AudibleRegion.US) } returns
+                    AppResult.Success(MetadataSearchResults(listOf(makeBook(title = "US Edition"))))
+                everySuspend { repo.searchBooks(any(), AudibleRegion.CA) } returns
+                    AppResult.Success(MetadataSearchResults(listOf(makeBook(title = "CA Edition"))))
+                val vm = buildVm(repo)
+
+                vm.initForBook("b1", "Dune", "FH")
+                vm.search()
+                advanceUntilIdle()
+
+                vm.changeRegion(AudibleRegion.CA)
+                advanceUntilIdle()
+
+                val state = vm.state.value.shouldBeInstanceOf<MetadataUiState.Search>()
+                state.region shouldBe AudibleRegion.CA
+                state.loadState
+                    .shouldBeInstanceOf<SearchLoadState.Loaded>()
+                    .results
+                    .single()
+                    .title shouldBe "CA Edition"
+                verifySuspend { repo.searchBooks(any(), AudibleRegion.CA) }
+            }
+        }
+
+        test("initForBook seeds an explicit region so the preview fetch uses it") {
+            runTest {
+                val book = makeBook(asin = "B007")
+                val repo = mock<MetadataRepository>()
+                everySuspend { repo.getBookMetadata(any(), any()) } returns AppResult.Success(book)
+                val vm = buildVm(repo)
+
+                // Mirrors MatchPreviewRoute initialising a fresh per-entry VM with the
+                // region carried across the navigation boundary from the search screen.
+                vm.initForBook(bookId = "b1", title = "", author = "", region = AudibleRegion.CA)
+                vm.selectMatch(book)
+                advanceUntilIdle()
+
+                vm.state.value
+                    .shouldBeInstanceOf<MetadataUiState.Preview>()
+                    .region shouldBe AudibleRegion.CA
+                verifySuspend { repo.getBookMetadata("B007", AudibleRegion.CA) }
+            }
+        }
+
         // ── reset() ───────────────────────────────────────────────────────────
 
         test("reset returns to Idle preserving region") {
             runTest {
-                val vm = buildVm(mock())
+                // changeRegion in Search now re-runs the search, so the repo must stub searchBooks.
+                val repo =
+                    mock<MetadataRepository> {
+                        everySuspend { searchBooks(any(), any()) } returns
+                            AppResult.Success(MetadataSearchResults(emptyList()))
+                    }
+                val vm = buildVm(repo)
                 vm.initForBook("b1", "Dune", "FH")
                 vm.changeRegion(AudibleRegion.DE)
+                advanceUntilIdle()
                 vm.reset()
 
                 val state = vm.state.value.shouldBeInstanceOf<MetadataUiState.Idle>()

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/RouteSerializationTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/RouteSerializationTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.navigation
 
+import com.calypsan.listenup.api.metadata.AudibleRegion
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
@@ -47,7 +48,7 @@ private fun sampleRoutes(): List<Route> =
         add(BookDetail(bookId = "test-book-id"))
         add(BookReaders(bookId = "test-book-id"))
         add(BookEdit(bookId = "test-book-id"))
-        add(MatchPreview(bookId = "test-book-id", asin = "test-asin"))
+        add(MatchPreview(bookId = "test-book-id", asin = "test-asin", region = AudibleRegion.US))
         add(MetadataSearch(bookId = "test-book-id"))
         add(SeriesDetail(seriesId = "test-series-id"))
         add(TagDetail(tagId = "test-tag-id"))

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/Routes.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/Routes.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.navigation
 
 import androidx.navigation3.runtime.NavKey
+import com.calypsan.listenup.api.metadata.AudibleRegion
 import kotlinx.serialization.Serializable
 
 /**
@@ -71,11 +72,14 @@ data class BookEdit(
  *
  * @property bookId The unique ID of the book to update.
  * @property asin The Audible ASIN of the matched book.
+ * @property region The Audible region the match was found in, carried over from the search screen so
+ *   the preview fetches in the same storefront instead of re-defaulting to US.
  */
 @Serializable
 data class MatchPreview(
     val bookId: String,
     val asin: String,
+    val region: AudibleRegion,
 ) : Route
 
 /**

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/BookEntries.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/BookEntries.kt
@@ -70,8 +70,8 @@ internal fun EntryProviderScope<NavKey>.bookEntries(backStack: NavBackStack<NavK
     entry<MetadataSearch> { args ->
         com.calypsan.listenup.client.features.metadata.MetadataSearchRoute(
             bookId = args.bookId,
-            onResultSelected = { asin ->
-                backStack.add(MatchPreview(args.bookId, asin))
+            onResultSelected = { asin, region ->
+                backStack.add(MatchPreview(args.bookId, asin, region))
             },
             onBack = {
                 backStack.removeAt(backStack.lastIndex)
@@ -82,6 +82,7 @@ internal fun EntryProviderScope<NavKey>.bookEntries(backStack: NavBackStack<NavK
         com.calypsan.listenup.client.features.metadata.MatchPreviewRoute(
             bookId = args.bookId,
             asin = args.asin,
+            region = args.region,
             onBack = {
                 backStack.removeAt(backStack.lastIndex)
             },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewRoute.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewRoute.kt
@@ -59,6 +59,7 @@ import listenup.composeapp.generated.resources.common_back
 fun MatchPreviewRoute(
     bookId: String,
     asin: String,
+    region: AudibleRegion,
     onBack: () -> Unit,
     onApplySuccess: () -> Unit,
     metadataViewModel: MetadataViewModel = koinViewModel(),
@@ -67,12 +68,14 @@ fun MatchPreviewRoute(
     val state by metadataViewModel.state.collectAsStateWithLifecycle()
     var showChapterReview by remember { mutableStateOf(false) }
 
-    LaunchedEffect(bookId, asin) {
+    LaunchedEffect(bookId, asin, region) {
         val current = state
         val alreadyOnThisMatch =
             current is MetadataUiState.Preview && current.match.asin == asin
         if (!alreadyOnThisMatch) {
-            metadataViewModel.initForBook(bookId = bookId, title = "", author = "")
+            // Seed the region carried over from the search screen so the first preview fetch hits the
+            // right Audible storefront instead of re-defaulting to US (which would show "not found").
+            metadataViewModel.initForBook(bookId = bookId, title = "", author = "", region = region)
             metadataViewModel.selectMatch(
                 MetadataBook(
                     asin = asin,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchRoute.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchRoute.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.calypsan.listenup.api.metadata.AudibleRegion
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.presentation.metadata.MetadataUiState
@@ -23,13 +24,13 @@ import org.koin.compose.viewmodel.koinViewModel
  * Route for the book metadata search screen.
  *
  * Loads the book, initializes the wizard, and auto-searches. When a result is
- * clicked, forwards the ASIN to [onResultSelected] so the host can navigate to
- * the match preview.
+ * clicked, forwards the ASIN and the selected region to [onResultSelected] so the
+ * host can navigate to the match preview in the same Audible storefront.
  */
 @Composable
 fun MetadataSearchRoute(
     bookId: String,
-    onResultSelected: (asin: String) -> Unit,
+    onResultSelected: (asin: String, region: AudibleRegion) -> Unit,
     onBack: () -> Unit,
     viewModel: MetadataViewModel = koinViewModel(),
 ) {
@@ -59,7 +60,7 @@ fun MetadataSearchRoute(
                 onRegionSelected = viewModel::changeRegion,
                 onResultClick = { result ->
                     viewModel.selectMatch(result)
-                    onResultSelected(result.asin)
+                    onResultSelected(result.asin, current.region)
                 },
                 onBack = onBack,
             )


### PR DESCRIPTION
## Problem

Matching a book whose ASIN is in a non-US Audible storefront (e.g. Canada) was a 3-step chore instead of 1:

1. Tapping the **Canada** region pill on the search screen didn't re-run the search — you had to manually click the field and search again.
2. Tapping a result then landed on a "book not found on Audible" page with *another* region selector, because the preview re-defaulted to US.
3. Only after picking Canada *again* there did the metadata screen appear.

## Root cause

Two independent defects, both verified by reading the flow:

**BUG 1 — `MetadataViewModel.changeRegion()`** only re-fetched when already in the *Preview* phase. In the *Search* phase it updated the region but never called `search()`, so results stayed stale until a manual re-submit.

**BUG 2 — region lost across the navigation boundary.** Each route gets its own per-entry `MetadataViewModel` (Navigation 3 entry scoping). The `MatchPreview` route carried only `bookId` + `asin`, so the preview's fresh VM started at the default `AudibleRegion.US`. For a Canadian ASIN, `getBookMetadata(asin, US)` fails → the "not found" fallback screen → selecting Canada there finally re-fetched correctly.

## Fix

- **`changeRegion()`**: in the Search phase, re-run `search()` with the new region (guarded for blank query). Preview behaviour unchanged.
- **Thread the region through navigation**: `MatchPreview` route gains a `region: AudibleRegion` arg; `MetadataSearchRoute`'s result callback now forwards `(asin, region)`; `MatchPreviewRoute` seeds it via a new optional `region` param on `initForBook(...)` so the first preview fetch hits the right storefront. Wired through both the Android nav graph and the desktop nav.

Net result: pick the region pill once → results refresh → tap a result → metadata screen. One step. The "not found" page is no longer hit in the happy path (it remains as the genuine-failure fallback — see note).

## Tests (TDD)

Two new `MetadataViewModelTest` cases (both fail on `main`):
- `changeRegion in Search phase re-runs the search with the new region`
- `initForBook seeds an explicit region so the preview fetch uses it`

Updated `reset returns to Idle preserving region` (its `changeRegion` call now triggers a search, so it stubs `searchBooks`). `RouteSerializationTest` updated for the new `MatchPreview` arg.

## Verification

`spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug`, and androidHostTest compile — all green. APK installed for live confirmation of the Canadian-ASIN repro.

## Notes

- I kept the full-screen `NotFoundErrorScreen` as the genuine-failure fallback (network error / truly-not-in-region) — removing it entirely would strand users on real failures. It just no longer appears spuriously. Happy to remove or consolidate it with the in-screen region selector if you'd prefer one unified not-found UI — say the word.
- The **contributor**-metadata match flow (`ContributorMetadataSearchRoute`/`...PreviewRoute`) likely has the same region-carry-through gap; out of scope here, flagged for a follow-up.
- Desktop module has a pre-existing `androidx.room` classpath break on `main` (unrelated); the desktop edits here mirror the Android ones.