### PR TITLE
🐛 fix(sharedUI): wrap SettingRow subtitle instead of truncating on phones

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SettingRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/SettingRow.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 /** Leading-icon column width: tile (44) + row gap (14) ≈ the divider's inset start. */
@@ -38,7 +37,8 @@ private val DIVIDER_INSET = 70.dp
  *
  * @param title Primary label, [MaterialTheme.typography.titleMedium].
  * @param modifier Modifier for the row.
- * @param subtitle Optional secondary line, single-line ellipsised [onSurfaceVariant] body text.
+ * @param subtitle Optional secondary description in [onSurfaceVariant] body text; wraps to as many
+ *   lines as it needs so it never truncates on narrow (phone) widths.
  * @param icon Optional leading glyph; when null (and [leading] is null) the row has no leading tile.
  * @param accent Accent colour for the leading tile.
  * @param danger When true, uses the error-tinted tile and an error-coloured title.
@@ -97,8 +97,6 @@ fun SettingRow(
                         text = it,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }


### PR DESCRIPTION
## Problem

On the Settings screen on phones, row description text truncated mid-word — "Choose light, dark, or follo…", "Use colors from your wallpaper (…", "Duration when pressing skip fo…". The trailing control (pill/switch) ate the width and the subtitle was pinned to a single ellipsised line.

## Fix

`SettingRow` (`design/components/SettingRow.kt`) — the canonical row for every grouped section (Settings, Admin) — pinned its subtitle to `maxLines = 1` + `TextOverflow.Ellipsis`. Removed that cap so the subtitle wraps to as many lines as it needs. The title already wrapped (no cap); only the subtitle was constrained. No behavioural change on wide screens where the text already fits on one line — wrapping only engages when space is tight.

Also removed the now-unused `TextOverflow` import and updated the KDoc.

## Verification

- `:sharedUI:compileAndroidMain`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug` — green.
- On-device (emulator): Settings descriptions now wrap in full ("…follow system", "…wallpaper (Material You)", "…skip forward", etc.) instead of truncating.

## Note

This branch is off `main`, which doesn't yet have #563 — so the Settings section cards still show the `extraLarge`/`CircleShape` clipping arc in screenshots. That's fixed by #563; once it merges and this rebases, the cards render cleanly *and* the text wraps.