### PR TITLE
🐛 fix(metadata): keep initForBook iOS bridge stable (fixes main's red iOS build)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
@@ -242,15 +242,15 @@ class MetadataViewModel(
      * route can then auto-search for a direct match). Otherwise the query is
      * `"$title $author"`.
      *
-     * [region] defaults to the current region but can be supplied explicitly so a freshly-scoped
-     * VM (e.g. the per-entry preview route) starts in the region carried across navigation.
+     * To start in a specific region (e.g. the per-entry preview route carrying the region across
+     * navigation), follow this with [changeRegion] before [selectMatch] — kept a separate call so
+     * the Swift/iOS bridge for this method stays stable (Kotlin default args don't cross to Swift).
      */
     fun initForBook(
         bookId: String,
         title: String,
         author: String,
         asin: String? = null,
-        region: AudibleRegion = _state.value.region,
     ) {
         val query =
             buildString {
@@ -262,7 +262,7 @@ class MetadataViewModel(
             }.trim()
         _state.value =
             MetadataUiState.Search(
-                region = region,
+                region = _state.value.region,
                 context =
                     BookContext(
                         bookId = bookId,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
@@ -741,16 +741,18 @@ class MetadataViewModelTest :
             }
         }
 
-        test("initForBook seeds an explicit region so the preview fetch uses it") {
+        test("region applied before selectMatch is used for the preview fetch") {
             runTest {
                 val book = makeBook(asin = "B007")
                 val repo = mock<MetadataRepository>()
                 everySuspend { repo.getBookMetadata(any(), any()) } returns AppResult.Success(book)
                 val vm = buildVm(repo)
 
-                // Mirrors MatchPreviewRoute initialising a fresh per-entry VM with the
-                // region carried across the navigation boundary from the search screen.
-                vm.initForBook(bookId = "b1", title = "", author = "", region = AudibleRegion.CA)
+                // Mirrors MatchPreviewRoute on a fresh per-entry VM: init, apply the region carried
+                // across navigation, then select the match. (changeRegion's search is a blank no-op.)
+                vm.initForBook(bookId = "b1", title = "", author = "")
+                vm.changeRegion(AudibleRegion.CA)
+                advanceUntilIdle()
                 vm.selectMatch(book)
                 advanceUntilIdle()
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewRoute.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewRoute.kt
@@ -73,9 +73,11 @@ fun MatchPreviewRoute(
         val alreadyOnThisMatch =
             current is MetadataUiState.Preview && current.match.asin == asin
         if (!alreadyOnThisMatch) {
-            // Seed the region carried over from the search screen so the first preview fetch hits the
-            // right Audible storefront instead of re-defaulting to US (which would show "not found").
-            metadataViewModel.initForBook(bookId = bookId, title = "", author = "", region = region)
+            // Apply the region carried over from the search screen BEFORE selecting the match, so the
+            // first preview fetch hits the right Audible storefront instead of re-defaulting to US
+            // (which would show "not found"). changeRegion is a no-op search here (query is blank).
+            metadataViewModel.initForBook(bookId = bookId, title = "", author = "")
+            metadataViewModel.changeRegion(region)
             metadataViewModel.selectMatch(
                 MetadataBook(
                     asin = asin,


### PR DESCRIPTION
## Why

#564 merged with the `Test (iOS)` job red. It added a `region` parameter to `MetadataViewModel.initForBook(...)`. Kotlin/Native does **not** bridge default arguments to Swift, so the existing Swift caller `MetadataMatchObserver.swift` (`viewModel.doInitForBook(bookId:title:author:asin:)`) no longer compiled — it was suddenly missing the required `region:` argument. (The classic [iOS Swift breaks on a Kotlin signature change] gotcha, for a function param.) Main's iOS build is currently broken.

## Fix

Revert `initForBook`'s signature to its original 4 params (no `region`) so the Swift bridge is unchanged. Instead, set the region the Android-only way it's needed: `MatchPreviewRoute` now calls `changeRegion(region)` between `initForBook()` and `selectMatch()`. `changeRegion` in the Search phase re-runs the search, which is a no-op here because the query is blank — it just stamps the region so the first preview fetch hits the right storefront.

**iOS never had the region-loss bug** anyway: its metadata flow uses a single persistent `MetadataViewModel` (the observer), so region already survives `selectMatch`. This keeps the whole region-carry-through fix Android-only, where the per-nav-entry VM made it necessary.

The user-facing behaviour from #564 is unchanged: pick region pill → results refresh → tap result → preview opens in that region.

## Tests

Updated the VM test to drive region via `changeRegion` before `selectMatch` (was asserting the removed param). All green: `:sharedLogic:jvmTest`, `:androidApp:assembleDebug`, `spotlessCheck`, `detekt`. iOS bridge is now back to the signature it compiled against before #564.