### PR TITLE
🐛 fix(server): contributor search — match Audible author hrefs with tracking query params (closes #551)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -403,22 +403,25 @@ private fun stripHtml(html: String): String =
  * Ported from Go's `parseContributorSearch` in `contributor.go`.
  */
 internal fun parseContributorSearch(html: String): List<AudibleContributorProfile> {
-    // Pattern: href="/author/{slug}/{ASIN}" — ASIN is all-caps alphanumeric.
-    val linkPattern = Regex("""href="/author/[^/]+/([A-Z0-9]+)"""")
-    // Within an <a href="/author/..."> ... </a> block, extract the name from
-    // the first non-blank text. The block may contain nested tags (span, img).
-    val nameInLinkPattern = Regex("""href="/author/[^/]+/[A-Z0-9]+"[^>]*>(.*?)</a>""", RegexOption.DOT_MATCHES_ALL)
+    // Author links are `href="/author/{slug}/{ASIN}?{tracking}"` — Audible always appends tracking
+    // query params (ref, pf_rd_*, plink, …) after the ASIN. The pattern must therefore tolerate
+    // anything up to the closing quote after the ASIN; requiring a quote *immediately* after it
+    // (the previous behaviour) matched nothing, so every contributor search returned empty (#551).
+    // The anchor's inner text is the contributor name. Mirrors Go's `parseContributorSearch`.
+    val anchorPattern =
+        Regex(
+            """href="/author/[^/]+/([A-Z0-9]+)[^"]*"[^>]*>(.*?)</a>""",
+            RegexOption.DOT_MATCHES_ALL,
+        )
 
     val seen = mutableSetOf<String>()
     val results = mutableListOf<AudibleContributorProfile>()
 
-    nameInLinkPattern.findAll(html).forEach { match ->
-        val rawInner = match.groupValues[1]
-        // Extract ASIN from the href — re-match the anchor opening tag portion.
-        val asin = linkPattern.find(match.value)?.groupValues?.get(1) ?: return@forEach
-        if (!seen.add(asin)) return@forEach // deduplicate
+    anchorPattern.findAll(html).forEach { match ->
+        val asin = match.groupValues[1]
+        if (!seen.add(asin)) return@forEach // an author repeats across product listings — dedupe
 
-        val name = stripHtml(rawInner).trim().takeIf { it.isNotBlank() } ?: return@forEach
+        val name = stripHtml(match.groupValues[2]).trim().takeIf { it.isNotBlank() } ?: return@forEach
         results += AudibleContributorProfile(asin = asin, name = name, biography = "", imageUrl = "")
     }
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/metadata/audible/ParseContributorSearchTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/metadata/audible/ParseContributorSearchTest.kt
@@ -1,0 +1,54 @@
+package com.calypsan.listenup.server.metadata.audible
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [parseContributorSearch] — extracts the contributor hits from an Audible
+ * search-by-author page (`/search?searchAuthor=...`).
+ *
+ * Fixtures mirror the real anchor shape rather than full page snapshots. The key case is #551:
+ * Audible appends tracking query params (`?ref=…`, `pf_rd_*`, …) after the ASIN, which the previous
+ * regex (requiring a quote immediately after the ASIN) failed to match, making every search empty.
+ */
+class ParseContributorSearchTest :
+    FunSpec({
+        test("extracts ASIN and name when the href carries tracking query params (#551)") {
+            val html =
+                """
+                <li><a href="/author/Brandon-Sanderson/B001IGFHW6?ref_pageloadid=not_applicable&pf_rd_p=83218cca&ref=a_search_c3_lAuthor_1_2_1">Brandon Sanderson</a></li>
+                """.trimIndent()
+
+            val results = parseContributorSearch(html)
+
+            results.size shouldBe 1
+            results.single().asin shouldBe "B001IGFHW6"
+            results.single().name shouldBe "Brandon Sanderson"
+        }
+
+        test("still parses a plain href with no query params") {
+            val html = """<a href="/author/Frank-Herbert/B000APZOQA">Frank Herbert</a>"""
+
+            val results = parseContributorSearch(html)
+
+            results.single().asin shouldBe "B000APZOQA"
+            results.single().name shouldBe "Frank Herbert"
+        }
+
+        test("deduplicates an author that repeats across product listings, preserving order") {
+            val html =
+                """
+                <a href="/author/Tim-Ferriss/B001ILKBW2?ref=a">Tim Ferriss</a>
+                <a href="/author/James-Clear/B07D23CFGR?ref=b">James Clear</a>
+                <a href="/author/Tim-Ferriss/B001ILKBW2?ref=c">Tim Ferriss</a>
+                """.trimIndent()
+
+            parseContributorSearch(html).map { it.asin } shouldContainExactly
+                listOf("B001ILKBW2", "B07D23CFGR")
+        }
+
+        test("returns an empty list when no author links are present") {
+            parseContributorSearch("<html><body><p>No results</p></body></html>") shouldBe emptyList()
+        }
+    })


### PR DESCRIPTION
## Symptom (#551)

Contributor (author/narrator) metadata download fails — contributor **search** returns nothing. (Book metadata + covers work; they use the JSON API, not HTML scraping.)

## Root cause (reproduced against live Audible)

I reproduced the exact Ktor CIO request the server makes and ran the real parsers on the live HTML:

- Fetch is fine: `/search?searchAuthor=…` and `/author/x/{asin}` both return **HTTP 200** with valid HTML (no bot-block, no geo-redirect from this host).
- `parseContributorProfile` works (extracts name/bio/image).
- **`parseContributorSearch` returned 0 results** despite 19+ author links on the page.

The author links now look like:
```
href="/author/Brandon-Sanderson/B001IGFHW6?ref_pageloadid=…&pf_rd_p=…&ref=a_search_c3_lAuthor_1_2_1"
```
The Kotlin regex required a quote **immediately** after the ASIN (`/([A-Z0-9]+)"`). Audible always appends tracking query params after the ASIN now, so the pattern matched nothing → every search came back empty. (Go's reference parser uses `/author/[^/]+/([A-Z0-9]+)` with no trailing-quote requirement, which is why Go was unaffected.)

## Fix

Tolerate anything up to the closing quote after the ASIN, and capture the anchor's inner text as the name — one anchor regex instead of two coupled ones. Verified against the live search page: now returns **18 results** (Brandon Sanderson B001IGFHW6, …).

## Tests

New `ParseContributorSearchTest` with the #551 regression fixture (href + tracking params), plus plain-href, dedupe-preserves-order, and empty cases. Fails on the old regex, passes on the new. `:server:test` + `spotlessCheck` + `detekt` green.

## Honest scope note

I could **not** reproduce the literal "Couldn't reach the external metadata service" (`ExternalUnavailable`) for a US-region search — an empty search surfaces client-side as "no results", not that error. This PR fixes the confirmed broken-search root cause (issue suspect #1: "HTML parser path failing"). If the `ExternalUnavailable` message persists after this, it's likely a **non-US region** path (e.g. `www.audible.ca` geo-redirecting from a US host → non-200 → `ExternalUnavailable`); the Go reference handles that with locale cookies + `ipRedirectOriginalURL` retry that the Kotlin `webGet` doesn't yet port. Happy to follow up on that once we capture a dev-server log line confirming it — but it's a separate fix from this confirmed one.