### PR TITLE
🔒️ fix(server): refuse to boot with the committed default JWT secret/pepper

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -42,8 +42,9 @@ import kotlin.time.ExperimentalTime
  * it); primitives (`Clock`, generators, hashers); then services that compose
  * primitives; then the top-level `AuthServiceImpl`.
  */
-fun authModule(config: ApplicationConfig): Module =
-    module {
+fun authModule(config: ApplicationConfig): Module {
+    config.rejectInsecureSecrets()
+    return module {
         single<Clock> { Clock.System }
 
         single<DatabaseHandle> {
@@ -150,6 +151,7 @@ fun authModule(config: ApplicationConfig): Module =
 
         single { RegistrationBroadcaster() }
     }
+}
 
 private const val REFRESH_TOKEN_TTL_DAYS = 30L
 
@@ -175,3 +177,40 @@ private fun ApplicationConfig.resolveJdbcUrl(): String {
     val home = resolveListenupHome(System.getenv("LISTENUP_HOME"), System.getProperty("user.home"))
     return resolveDatabaseUrl(configuredUrl = configured, listenupHome = home)
 }
+
+/**
+ * Fails fast if either the JWT signing secret or the refresh-token pepper equals
+ * the committed test default shipped in `application.conf`. Booting with either
+ * default in production allows token forgery (shared secret) or session hijacking
+ * (shared pepper).
+ *
+ * Override is possible only via `auth.allowInsecureSecrets = true` (mapped from
+ * `LISTENUP_ALLOW_INSECURE_SECRETS`). Set that flag ONLY in local development or
+ * test environments — never in any production or staging deployment.
+ */
+internal fun ApplicationConfig.rejectInsecureSecrets() {
+    val allow = propertyOrNull("auth.allowInsecureSecrets")?.getString() == "true"
+    if (allow) return
+
+    val secret = propertyOrNull("jwt.secret")?.getString()
+    check(secret != INSECURE_DEFAULT_JWT_SECRET) {
+        "JWT secret equals the committed test default. " +
+            "Set LISTENUP_JWT_SECRET to a 32+ byte random value before starting the server. " +
+            "For local development only, set LISTENUP_ALLOW_INSECURE_SECRETS=true to suppress this check."
+    }
+
+    val pepper = propertyOrNull("auth.refreshPepper")?.getString()
+    check(pepper != INSECURE_DEFAULT_REFRESH_PEPPER) {
+        "Refresh-token pepper equals the committed test default. " +
+            "Set LISTENUP_REFRESH_PEPPER to a 32+ byte random value before starting the server. " +
+            "For local development only, set LISTENUP_ALLOW_INSECURE_SECRETS=true to suppress this check."
+    }
+}
+
+/** Committed test default for the JWT signing secret — used only for the boot-time guard comparison. */
+internal const val INSECURE_DEFAULT_JWT_SECRET =
+    "test-jwt-secret-change-in-production-at-least-32-bytes-please"
+
+/** Committed test default for the refresh-token pepper — used only for the boot-time guard comparison. */
+internal const val INSECURE_DEFAULT_REFRESH_PEPPER =
+    "test-pepper-change-in-production-this-must-be-32-bytes-or-more"

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -30,6 +30,11 @@ auth {
     # every stored hash and forces all sessions to re-authenticate.
     refreshPepper = "test-pepper-change-in-production-this-must-be-32-bytes-or-more"
     refreshPepper = ${?LISTENUP_REFRESH_PEPPER}
+
+    # Set LISTENUP_ALLOW_INSECURE_SECRETS=true ONLY for local development when
+    # running with the committed test defaults above. NEVER set this in production.
+    allowInsecureSecrets = false
+    allowInsecureSecrets = ${?LISTENUP_ALLOW_INSECURE_SECRETS}
 }
 
 jwt {

--- a/server/src/test/kotlin/com/calypsan/listenup/server/auth/InsecureSecretGuardTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/auth/InsecureSecretGuardTest.kt
@@ -1,0 +1,66 @@
+package com.calypsan.listenup.server.auth
+
+import com.calypsan.listenup.server.di.INSECURE_DEFAULT_JWT_SECRET
+import com.calypsan.listenup.server.di.INSECURE_DEFAULT_REFRESH_PEPPER
+import com.calypsan.listenup.server.di.rejectInsecureSecrets
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.ktor.server.config.MapApplicationConfig
+
+/**
+ * Verifies that [rejectInsecureSecrets] refuses to proceed when either the JWT
+ * signing secret or the refresh-token pepper equals the committed test default
+ * in `application.conf`, and that the opt-in and custom values are accepted.
+ */
+class InsecureSecretGuardTest :
+    FunSpec({
+
+        fun config(
+            jwtSecret: String = "x".repeat(32),
+            refreshPepper: String = "x".repeat(32),
+            allowInsecureSecrets: String? = null,
+        ): MapApplicationConfig =
+            MapApplicationConfig(
+                "jwt.secret" to jwtSecret,
+                "auth.refreshPepper" to refreshPepper,
+            ).apply {
+                if (allowInsecureSecrets != null) put("auth.allowInsecureSecrets", allowInsecureSecrets)
+            }
+
+        test("default JWT secret without opt-in throws and names LISTENUP_JWT_SECRET") {
+            val ex =
+                shouldThrow<IllegalStateException> {
+                    config(jwtSecret = INSECURE_DEFAULT_JWT_SECRET).rejectInsecureSecrets()
+                }
+            ex.message shouldContain "LISTENUP_JWT_SECRET"
+        }
+
+        test("default refresh pepper without opt-in throws and names LISTENUP_REFRESH_PEPPER") {
+            val ex =
+                shouldThrow<IllegalStateException> {
+                    config(refreshPepper = INSECURE_DEFAULT_REFRESH_PEPPER).rejectInsecureSecrets()
+                }
+            ex.message shouldContain "LISTENUP_REFRESH_PEPPER"
+        }
+
+        test("default secret and pepper are permitted when allowInsecureSecrets = true") {
+            shouldNotThrowAny {
+                config(
+                    jwtSecret = INSECURE_DEFAULT_JWT_SECRET,
+                    refreshPepper = INSECURE_DEFAULT_REFRESH_PEPPER,
+                    allowInsecureSecrets = "true",
+                ).rejectInsecureSecrets()
+            }
+        }
+
+        test("non-default secret and pepper are permitted regardless of opt-in") {
+            shouldNotThrowAny {
+                config(
+                    jwtSecret = "a-genuinely-unique-production-secret-value",
+                    refreshPepper = "a-genuinely-unique-production-pepper-value",
+                ).rejectInsecureSecrets()
+            }
+        }
+    })


### PR DESCRIPTION
Fail-fast at boot if `jwt.secret` or `auth.refreshPepper` resolves to the committed test default, unless `LISTENUP_ALLOW_INSECURE_SECRETS=true` (local-dev opt-in). Prevents a misconfigured self-hosted deploy silently signing tokens with a publicly-committed secret (token forgery / session hijacking).

- Guard in `authModule(config)` (the production wiring chokepoint)
- `allowInsecureSecrets` defaults to false (secure by default); only set in dev/test
- 4 Kotest cases in `InsecureSecretGuardTest`
- Gates: `:server:test` + spotless/detekt green