### PR TITLE
🐛 fix(server): set explicit multipart limit on backup restore upload

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/BackupRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/BackupRoutes.kt
@@ -33,6 +33,15 @@ import java.nio.file.StandardCopyOption
 import kotlinx.coroutines.CancellationException
 
 /**
+ * Max accepted size for an uploaded `.listenup.zip` backup. Legitimate backups for large libraries
+ * can exceed 50 MiB; this route streams the file straight to a temp file (never buffered in
+ * memory), so a generous cap is safe. Ktor's default [formFieldLimit] is 50 MiB (52_428_800 bytes),
+ * which would reject valid large restores before they could be staged. Mirrors [ImportRoutes]'
+ * cap for consistency — both upload endpoints accept the same ceiling.
+ */
+private const val MAX_BACKUP_RESTORE_BYTES: Long = 5L * 1024 * 1024 * 1024 // 5 GiB
+
+/**
  * REST routes for binary backup download and cross-machine upload (staging).
  *
  * These complement the RPC surface ([com.calypsan.listenup.api.BackupService]) — binary
@@ -105,7 +114,7 @@ private suspend fun ApplicationCall.handleUpload(
     val tmpFile = Files.createTempFile(paths.tmpDir, "upload-", ".listenup.zip")
     try {
         var received = false
-        receiveMultipart().forEachPart { part ->
+        receiveMultipart(formFieldLimit = MAX_BACKUP_RESTORE_BYTES).forEachPart { part ->
             if (part is PartData.FileItem && !received) {
                 received = true
                 Files.newOutputStream(tmpFile).use { out ->

--- a/server/src/test/kotlin/com/calypsan/listenup/server/routes/BackupRoutesTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/routes/BackupRoutesTest.kt
@@ -243,6 +243,58 @@ class BackupRoutesTest :
             }
         }
 
+        test("POST upload accepts a body larger than Ktor's default 50 MiB formFieldLimit") {
+            // Structural limit test: streams 51 MiB of zero bytes as a multipart part.
+            // If receiveMultipart() were called without an explicit formFieldLimit the default
+            // 50 MiB cap would reject this body before it reached the archive validator;
+            // the route would return 413 instead of 422 CorruptArchive.
+            // We assert 422 (CorruptArchive from the validator) rather than 413, which proves the
+            // configured MAX_BACKUP_RESTORE_BYTES limit (5 GiB) was passed to receiveMultipart().
+            val homeDir = Files.createTempDirectory("listenup-backup-routes-limit-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(homeDir = homeDir.toString())
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+                    val (token, _) = client.setupRoot()
+
+                    // 51 MiB of zeros — exceeds Ktor's default 50 MiB cap but well within
+                    // MAX_BACKUP_RESTORE_BYTES (5 GiB). Content is intentionally invalid (not a
+                    // zip) so the archive validator rejects it with CorruptArchive (422).
+                    val fiftyOneMib = ByteArray(51 * 1024 * 1024)
+                    val response =
+                        client.post("/api/v1/admin/backups/upload") {
+                            bearerAuth(token)
+                            setBody(
+                                MultiPartFormDataContent(
+                                    formData {
+                                        append(
+                                            "file",
+                                            fiftyOneMib,
+                                            Headers.build {
+                                                append(HttpHeaders.ContentType, "application/zip")
+                                                append(
+                                                    HttpHeaders.ContentDisposition,
+                                                    "filename=\"big.zip\"",
+                                                )
+                                            },
+                                        )
+                                    },
+                                ),
+                            )
+                        }
+                    // 422 = CorruptArchive from the validator — the upload was NOT rejected on
+                    // size (that would be 413 or a Ktor-internal failure).
+                    response.status shouldBe HttpStatusCode.UnprocessableEntity
+                    val error =
+                        contractJson.decodeFromString<AppError>(response.readRawBytes().decodeToString())
+                    error.shouldBeInstanceOf<BackupError.CorruptArchive>()
+                }
+            } finally {
+                homeDir.toFile().deleteRecursively()
+            }
+        }
+
         test("non-admin MEMBER gets 403 PermissionDenied on POST upload") {
             val homeDir = Files.createTempDirectory("listenup-backup-routes-403up-")
             try {


### PR DESCRIPTION
`BackupRoutes.handleUpload` called `receiveMultipart()` with no limit, inheriting Ktor's 50 MiB default and rejecting legitimate large restores. `ImportRoutes` already raises this to 5 GiB; this matches it. Upload streams to a temp file (never buffered), so the generous cap is safe.

- New `MAX_BACKUP_RESTORE_BYTES` (5 GiB) passed to `receiveMultipart`
- 51 MiB structural test asserts 422 CorruptArchive (not 413), proving the cap was raised
- Gates: `:server:test` + spotless/detekt green