### PR TITLE
🐛 fix(server): parse Xing/VBRI headers for correct VBR MP3 duration

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
@@ -25,9 +25,11 @@ import java.io.IOException
  * - **Artwork.** `APIC` frames are scanned in tag order; the highest-priority
  *   match wins (picture type 3 "Cover (front)" beats every other type;
  *   otherwise first APIC wins).
- * - **Duration.** CBR-only — read bitrate and sample rate from the first
- *   MPEG frame header found within a 64 KB sniff window past the tag,
- *   then derive duration from the audio-region size.
+ * - **Duration.** Reads bitrate, sample rate, MPEG version, and channel mode
+ *   from the first MPEG frame header found within a 64 KB sniff window past
+ *   the tag. If the frame is followed by a Xing/Info or VBRI VBR header,
+ *   exact duration is derived from the declared frame count. Otherwise falls
+ *   back to the CBR approximation (audio-region size ÷ bitrate).
  *
  * Streaming contract: the parser only reads bounded regions out of [source]
  * — the ID3v2 tag (capped at [ID3V2_SOFT_LIMIT_BYTES]), the trailing 128-byte
@@ -36,11 +38,6 @@ import java.io.IOException
  *
  * Failure mapping:
  * - File-level read errors → [AudioMetadataError.IoError].
- *
- * TODO(VBR): Xing/VBRI VBR-header parsing is deferred. Real-world audiobook
- * MP3s are overwhelmingly CBR; the duration approximation is good enough for
- * the scan summary. When a VBR file surfaces, port the `parseVBRHeader` block
- * from `/home/simonh/Code/audiometa/internal/mp3/technical.go`.
  */
 internal class Mp3Parser : AudioFormatParser {
     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp3)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/MpegDurationCalculator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/MpegDurationCalculator.kt
@@ -12,21 +12,32 @@ import java.io.IOException
  * 1. Seek to [audioStart] (just past the ID3v2 tag, or 0 if no tag).
  * 2. Read a small sniff window and locate the first MPEG sync (`0xFFE` top
  *    11 bits) within it.
- * 3. Decode bitrate and sample rate from the 4-byte frame header.
- * 4. Compute audio-region size = `source.length - syncFileOffset - footerSize`.
- * 5. Duration = audioBytes * 8 / bitrate (CBR approximation).
+ * 3. Decode bitrate, sample rate, MPEG version, and channel mode from the
+ *    4-byte frame header.
+ * 4. Check for a Xing/Info VBR header at the version/channel-mode-dependent
+ *    offset past the frame sync, or a VBRI header at the fixed +32 offset.
+ *    If a frame-count field is present, derive duration from frame count ×
+ *    1152 samples/frame ÷ sample-rate (exact for VBR).
+ * 5. Fall back to CBR approximation when no VBR header is found:
+ *    duration = audioBytes × 8 × 1000 / bitrate.
  *
  * Returns `0` if no MPEG frame can be located in the sniff window or the
  * frame header is invalid — the parser still surfaces tags successfully;
  * only duration is unknown.
  *
- * TODO(VBR): Xing/VBRI VBR-header parsing is deferred. CBR is the common case
- * for audiobook MP3s; revisit when a VBR file surfaces in the live validation
- * harness. Reference: `/home/simonh/Code/audiometa/internal/mp3/technical.go`.
+ * VBR header offsets (byte offset from start of frame header):
+ * - Xing/Info: 4 + sideInfoSize, where sideInfoSize depends on MPEG version
+ *   and channel mode:
+ *     MPEG-1 Stereo/JS/Dual → 32  → Xing at offset 36
+ *     MPEG-1 Mono           → 17  → Xing at offset 21
+ *     MPEG-2/2.5 Stereo/JS/Dual → 17 → Xing at offset 21
+ *     MPEG-2/2.5 Mono       → 9   → Xing at offset 13
+ * - VBRI: fixed offset 32 (produced by Fraunhofer encoder).
  *
- * MagicNumber suppressed: MPEG-1 Layer III frame-header field widths, the 11-bit
- * `0xFFE` sync mask, and the bytes→bits×milliseconds duration arithmetic are fixed
- * by ISO/IEC 11172-3.
+ * MagicNumber suppressed: MPEG-1 Layer III frame-header field widths, the
+ * 11-bit `0xFFE` sync mask, side-information sizes, the Xing/VBRI field
+ * offsets, and the samples-per-frame constant (1152) are fixed by
+ * ISO/IEC 11172-3 and the Fraunhofer/Xing VBR specifications.
  */
 @Suppress("MagicNumber")
 internal object MpegDurationCalculator {
@@ -48,6 +59,10 @@ internal object MpegDurationCalculator {
         val syncInPrefix = locateMpegSync(prefix) ?: return 0
         val frame = decodeFrameHeader(prefix, syncInPrefix) ?: return 0
 
+        // VBR path: check for Xing/Info or VBRI header in the sniff window.
+        vbrDurationMs(prefix, syncInPrefix, frame)?.let { return it }
+
+        // CBR fallback: estimate from audio-region byte count.
         val syncFileOffset = audioStart + syncInPrefix
         val footer = if (hasV1Footer) ID3V1_LEN.toLong() else 0L
         val audioBytes = source.length - syncFileOffset - footer
@@ -55,9 +70,70 @@ internal object MpegDurationCalculator {
         return audioBytes * 8 * 1000 / frame.bitrate
     }
 
+    /**
+     * Returns the exact VBR duration in milliseconds if a Xing/Info or VBRI
+     * header is present in [prefix] at [syncOffset], or `null` if neither
+     * header is found and the caller should fall back to CBR estimation.
+     */
+    private fun vbrDurationMs(
+        prefix: ByteArray,
+        syncOffset: Int,
+        frame: FrameHeader,
+    ): Long? = xingDurationMs(prefix, syncOffset, frame) ?: vbriDurationMs(prefix, syncOffset, frame)
+
+    /**
+     * Parses a Xing or Info VBR header at the version/channel-mode-dependent
+     * offset past [syncOffset] in [prefix]. Returns the frame-count-derived
+     * duration in milliseconds, or `null` if no valid Xing/Info header is found.
+     *
+     * Xing offset = 4 (frame header) + sideInfoSize (17 or 32 bytes depending
+     * on MPEG version and channel mode).
+     */
+    private fun xingDurationMs(
+        prefix: ByteArray,
+        syncOffset: Int,
+        frame: FrameHeader,
+    ): Long? {
+        val xingOffset = syncOffset + 4 + frame.sideInfoSize
+        if (xingOffset + 12 > prefix.size) return null
+        val tag = String(prefix, xingOffset, 4, Charsets.ISO_8859_1)
+        if (tag != "Xing" && tag != "Info") return null
+        val flags = readInt32BE(prefix, xingOffset + 4)
+        // Bit 0: frames field is present.
+        if (flags and 0x0001 == 0) return null
+        val frameCount = readInt32BE(prefix, xingOffset + 8).toLong()
+        if (frameCount <= 0) return null
+        return frameCount * SAMPLES_PER_FRAME * 1000L / frame.sampleRate
+    }
+
+    /**
+     * Parses a VBRI header (Fraunhofer encoder) at the fixed offset of 32 bytes
+     * past [syncOffset] in [prefix]. Returns the frame-count-derived duration in
+     * milliseconds, or `null` if no valid VBRI header is found.
+     *
+     * VBRI layout: tag(4) + version(2) + delay(2) + quality(2) + bytes(4) + frames(4).
+     * Frame count is at byte offset 14 within the VBRI block.
+     */
+    private fun vbriDurationMs(
+        prefix: ByteArray,
+        syncOffset: Int,
+        frame: FrameHeader,
+    ): Long? {
+        val vbriOffset = syncOffset + 32
+        if (vbriOffset + 18 > prefix.size) return null
+        val tag = String(prefix, vbriOffset, 4, Charsets.ISO_8859_1)
+        if (tag != "VBRI") return null
+        val frameCount = readInt32BE(prefix, vbriOffset + 14).toLong()
+        if (frameCount <= 0) return null
+        return frameCount * SAMPLES_PER_FRAME * 1000L / frame.sampleRate
+    }
+
     private data class FrameHeader(
         val bitrate: Int,
         val sampleRate: Int,
+        /** Size of the MPEG side-information region in bytes. Used to locate
+         *  the Xing/Info VBR header, which immediately follows the side info. */
+        val sideInfoSize: Int,
     )
 
     private fun decodeFrameHeader(
@@ -77,7 +153,29 @@ internal object MpegDurationCalculator {
         val bitrate = BITRATE_TABLE[bitrateIdx] * 1000
         val sampleRate = SAMPLE_RATE_TABLE[sampleRateIdx]
         if (bitrate == 0 || sampleRate == 0) return null
-        return FrameHeader(bitrate = bitrate, sampleRate = sampleRate)
+
+        // MPEG version: bits 20..19. 0b11=MPEG-1, 0b10=MPEG-2, 0b00=MPEG-2.5.
+        val mpegVersion = (header ushr 19) and 0x3
+        // Channel mode: bits 7..6. 0b11=Mono, else stereo-family.
+        val channelMode = (header ushr 6) and 0x3
+        val isMono = channelMode == 3
+        // Side-information size per ISO 11172-3 §2.4.3.1:
+        //   MPEG-1 stereo=32, mono=17; MPEG-2/2.5 stereo=17, mono=9.
+        val sideInfoSize =
+            when {
+                mpegVersion == 3 && !isMono -> 32
+
+                // MPEG-1 stereo/JS/dual
+                mpegVersion == 3 && isMono -> 17
+
+                // MPEG-1 mono
+                !isMono -> 17
+
+                // MPEG-2/2.5 stereo/JS/dual
+                else -> 9 // MPEG-2/2.5 mono
+            }
+
+        return FrameHeader(bitrate = bitrate, sampleRate = sampleRate, sideInfoSize = sideInfoSize)
     }
 
     private fun locateMpegSync(bytes: ByteArray): Int? {
@@ -91,18 +189,33 @@ internal object MpegDurationCalculator {
         return null
     }
 
+    /** Read a big-endian 32-bit unsigned integer from [buf] at [offset]. */
+    private fun readInt32BE(
+        buf: ByteArray,
+        offset: Int,
+    ): Int =
+        ((buf[offset].toInt() and 0xFF) shl 24) or
+            ((buf[offset + 1].toInt() and 0xFF) shl 16) or
+            ((buf[offset + 2].toInt() and 0xFF) shl 8) or
+            (buf[offset + 3].toInt() and 0xFF)
+
     /** MPEG-1 Layer III bitrate table in kbps. */
     private val BITRATE_TABLE = intArrayOf(0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0)
 
     /** MPEG-1 sample-rate table in Hz. */
     private val SAMPLE_RATE_TABLE = intArrayOf(44_100, 48_000, 32_000, 0)
 
+    /** MPEG-1 Layer III: 1152 PCM samples per encoded audio frame. */
+    private const val SAMPLES_PER_FRAME = 1152
+
     /**
      * 64 KB sniff window for the first MPEG sync byte. Real-world ID3v2 tags
      * declare their own size — there is no padding between tag and audio in
      * standard files. 64 KB leaves generous headroom for files with a short
      * non-standard gap; sync byte not found within this window → duration
-     * reported as 0 (best-effort, parser still returns tags).
+     * reported as 0 (best-effort, parser still returns tags). Also large
+     * enough to contain the VBR header that immediately follows the first
+     * frame's side-information region.
      */
     private const val SNIFF_WINDOW_BYTES = 64 * 1024
     private const val ID3V1_LEN = 128

--- a/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/fixtures/BuildMp3File.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/fixtures/BuildMp3File.kt
@@ -14,10 +14,9 @@ import kotlinx.io.readByteArray
  * - [Mp3Builder.id3v2] — emit an ID3v2.3 or 2.4 tag with a configurable frame set
  * - [Mp3Builder.id3v1] — emit a 128-byte ID3v1 footer (used for fallback tests)
  * - [Mp3Builder.mpegFrames] — emit N MPEG audio frames computed from a target duration
- *
- * NOT covered (out-of-scope for tests): true audio data, lyrics frames,
- * encrypted frames, VBR (Xing/VBRI) headers. Add as needed when a parser
- * test demands them.
+ * - [Mp3Builder.xingVbrFrames] — emit a single MPEG frame with a Xing/Info VBR header
+ *   declaring a known frame count (all remaining bytes zeroed so VBR path is exercised)
+ * - [Mp3Builder.vbriVbrFrames] — emit a single MPEG frame with a VBRI header
  */
 internal fun buildMp3File(block: Mp3Builder.() -> Unit): ByteArray = Mp3Builder().apply(block).build()
 
@@ -90,6 +89,110 @@ internal class Mp3Builder internal constructor() {
             out.write(header)
             out.write(padding)
         }
+    }
+
+    /**
+     * Emit a single MPEG-1 Layer III stereo frame containing a Xing (VBR) or
+     * Info (CBR-with-TOC) header that declares [frameCount] frames. The
+     * remainder of the file is zeroed byte padding so the CBR formula on the
+     * same bytes would produce a different (wrong) answer — thereby proving
+     * that the VBR path engaged.
+     *
+     * The Xing/Info tag sits at byte offset 36 within the frame
+     * (4-byte frame header + 32-byte MPEG-1 stereo side information).
+     *
+     * @param tag       "Xing" for a true VBR file, "Info" for CBR-but-has-header.
+     * @param frameCount declared frame count embedded in the Xing/Info header.
+     * @param sampleRate sample rate to encode in the frame header.
+     * @param bitrate    nominal bitrate to encode in the frame header (only
+     *                   used to size the frame; the VBR path ignores it for
+     *                   duration).
+     * @param extraPaddingBytes extra zero bytes appended after the frame so
+     *                   the CBR formula (file size / bitrate) produces a
+     *                   measurably different duration from the VBR formula.
+     */
+    @Suppress("MagicNumber")
+    fun xingVbrFrames(
+        frameCount: Int,
+        tag: String = "Xing",
+        sampleRate: Int = 44_100,
+        bitrate: Int = 128_000,
+        extraPaddingBytes: Int = 0,
+    ) {
+        require(tag == "Xing" || tag == "Info") { "tag must be 'Xing' or 'Info'" }
+        require(frameCount > 0) { "frameCount must be positive" }
+        val frameHeader = mpegFrameHeader(bitrate = bitrate, sampleRate = sampleRate)
+        val frameSize = (144 * bitrate) / sampleRate
+        require(frameSize >= 4 + 32 + 12) { "frame too small to hold Xing header" }
+
+        // Build the frame: 4-byte header + 32-byte side info (zeroed) + Xing header + padding.
+        val frame = ByteArray(frameSize)
+        frameHeader.copyInto(frame)
+        // Xing/Info tag at offset 36 = 4 (frame header) + 32 (MPEG-1 stereo side info).
+        val xingOffset = 36
+        tag.toByteArray(Charsets.ISO_8859_1).copyInto(frame, xingOffset)
+        // Flags = 0x0001: frames field present.
+        frame[xingOffset + 4] = 0x00
+        frame[xingOffset + 5] = 0x00
+        frame[xingOffset + 6] = 0x00
+        frame[xingOffset + 7] = 0x01
+        // Frame count (big-endian 32-bit).
+        frame[xingOffset + 8] = ((frameCount ushr 24) and 0xFF).toByte()
+        frame[xingOffset + 9] = ((frameCount ushr 16) and 0xFF).toByte()
+        frame[xingOffset + 10] = ((frameCount ushr 8) and 0xFF).toByte()
+        frame[xingOffset + 11] = (frameCount and 0xFF).toByte()
+        out.write(frame)
+        if (extraPaddingBytes > 0) out.write(ByteArray(extraPaddingBytes))
+    }
+
+    /**
+     * Emit a single MPEG-1 Layer III stereo frame containing a VBRI header
+     * (produced by the Fraunhofer encoder) that declares [frameCount] frames.
+     *
+     * The VBRI tag sits at fixed byte offset 32 from the start of the frame
+     * (4-byte frame header + 28 bytes). VBRI layout within its block:
+     * tag(4) + version(2) + delay(2) + quality(2) + bytes(4) + frames(4).
+     *
+     * @param frameCount declared frame count.
+     * @param sampleRate sample rate to encode in the frame header.
+     * @param bitrate    nominal bitrate for the frame header.
+     */
+    @Suppress("MagicNumber")
+    fun vbriVbrFrames(
+        frameCount: Int,
+        sampleRate: Int = 44_100,
+        bitrate: Int = 128_000,
+    ) {
+        require(frameCount > 0) { "frameCount must be positive" }
+        val frameHeader = mpegFrameHeader(bitrate = bitrate, sampleRate = sampleRate)
+        val frameSize = (144 * bitrate) / sampleRate
+        require(frameSize >= 32 + 18) { "frame too small to hold VBRI header" }
+
+        val frame = ByteArray(frameSize)
+        frameHeader.copyInto(frame)
+        // VBRI tag at fixed offset 32 from the frame start.
+        val vbriOffset = 32
+        "VBRI".toByteArray(Charsets.ISO_8859_1).copyInto(frame, vbriOffset)
+        // version (2 bytes, big-endian): 1
+        frame[vbriOffset + 4] = 0x00
+        frame[vbriOffset + 5] = 0x01
+        // delay (2 bytes): 0
+        frame[vbriOffset + 6] = 0x00
+        frame[vbriOffset + 7] = 0x00
+        // quality (2 bytes): 0
+        frame[vbriOffset + 8] = 0x00
+        frame[vbriOffset + 9] = 0x00
+        // bytes (4 bytes): 0 (not needed for duration)
+        frame[vbriOffset + 10] = 0x00
+        frame[vbriOffset + 11] = 0x00
+        frame[vbriOffset + 12] = 0x00
+        frame[vbriOffset + 13] = 0x00
+        // frames (4 bytes, big-endian): frameCount
+        frame[vbriOffset + 14] = ((frameCount ushr 24) and 0xFF).toByte()
+        frame[vbriOffset + 15] = ((frameCount ushr 16) and 0xFF).toByte()
+        frame[vbriOffset + 16] = ((frameCount ushr 8) and 0xFF).toByte()
+        frame[vbriOffset + 17] = (frameCount and 0xFF).toByte()
+        out.write(frame)
     }
 
     fun build(): ByteArray = out.readByteArray()

--- a/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/VbrDurationTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/VbrDurationTest.kt
@@ -1,0 +1,131 @@
+package com.calypsan.listenup.server.embeddedmeta.format.mp3
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Verifies that [MpegDurationCalculator] (via [Mp3Parser]) correctly computes
+ * duration from Xing/Info and VBRI VBR headers, and that the CBR fallback is
+ * preserved when no VBR header is present.
+ *
+ * Duration formula for VBR: frameCount × 1152 samples/frame × 1000 ms/s ÷ sampleRate Hz.
+ *
+ * Example at 44 100 Hz with 1 000 declared frames:
+ *   1 000 × 1 152 × 1 000 / 44 100 ≈ 26 122 ms  (≈ 26.1 s)
+ */
+class VbrDurationTest :
+    FunSpec({
+        val parser = Mp3Parser()
+
+        /**
+         * Compute the exact VBR duration in milliseconds that the parser should
+         * return for [frameCount] frames at [sampleRate] Hz.
+         */
+        fun expectedVbrMs(
+            frameCount: Int,
+            sampleRate: Int = 44_100,
+        ): Long = frameCount.toLong() * 1_152L * 1_000L / sampleRate
+
+        test("Xing VBR header: parser returns frame-count-derived duration, not CBR estimate") {
+            // 1 000 frames at 44 100 Hz → VBR duration ≈ 26 122 ms.
+            // Extra 500 KB of padding inflates the CBR estimate to ≈ 31 276 ms,
+            // so the two formulas produce measurably different answers — proving
+            // that the parser took the VBR path when it returns the exact value.
+            val frameCount = 1_000
+            val extraPadding = 500_000
+            val bytes =
+                buildMp3File {
+                    xingVbrFrames(
+                        frameCount = frameCount,
+                        tag = "Xing",
+                        sampleRate = 44_100,
+                        bitrate = 128_000,
+                        extraPaddingBytes = extraPadding,
+                    )
+                }
+
+            val result = parser.parse(byteSource(bytes))
+            require(result is AppResult.Success<EmbeddedAudioMetadata>)
+
+            val vbrExpected = expectedVbrMs(frameCount, 44_100)
+            val cbrEstimate = bytes.size.toLong() * 8L * 1_000L / 128_000L
+
+            // CBR formula yields a larger number due to extra padding bytes.
+            (cbrEstimate > vbrExpected) shouldBe true
+
+            // Parser must have taken the VBR path — returns the exact frame-count value.
+            result.data.durationMs shouldBe vbrExpected
+        }
+
+        test("Info VBR header (CBR-with-header): parser returns frame-count-derived duration") {
+            val frameCount = 500
+            val bytes =
+                buildMp3File {
+                    xingVbrFrames(
+                        frameCount = frameCount,
+                        tag = "Info",
+                        sampleRate = 44_100,
+                        bitrate = 64_000,
+                    )
+                }
+
+            val result = parser.parse(byteSource(bytes))
+            require(result is AppResult.Success<EmbeddedAudioMetadata>)
+
+            result.data.durationMs shouldBe expectedVbrMs(frameCount, 44_100)
+        }
+
+        test("VBRI header: parser returns frame-count-derived duration") {
+            val frameCount = 2_000
+            val bytes =
+                buildMp3File {
+                    vbriVbrFrames(
+                        frameCount = frameCount,
+                        sampleRate = 44_100,
+                        bitrate = 128_000,
+                    )
+                }
+
+            val result = parser.parse(byteSource(bytes))
+            require(result is AppResult.Success<EmbeddedAudioMetadata>)
+
+            result.data.durationMs shouldBe expectedVbrMs(frameCount, 44_100)
+        }
+
+        test("CBR file without VBR header: CBR formula is used, not VBR") {
+            // A genuine CBR file produced by mpegFrames() has no Xing/VBRI header.
+            // The parser must fall back to the byte-count estimate.
+            val bytes =
+                buildMp3File {
+                    mpegFrames(durationSeconds = 10, bitrate = 64_000, sampleRate = 44_100)
+                }
+
+            val result = parser.parse(byteSource(bytes))
+            require(result is AppResult.Success<EmbeddedAudioMetadata>)
+
+            // Duration should be in the right ballpark (within ±2 s of 10 s).
+            result.data.durationMs shouldNotBe 0L
+            result.data.durationMs shouldBeGreaterThan 0L
+            (result.data.durationMs in 8_000L..12_000L) shouldBe true
+        }
+
+        test("file with no valid MPEG frame returns durationMs = 0 (failure path intact)") {
+            // A file that is just an ID3v2 tag with no MPEG audio frames.
+            val bytes =
+                buildMp3File {
+                    id3v2(version = 4) {
+                        textFrame("TIT2", "No Audio")
+                    }
+                    // No mpegFrames/xingVbrFrames call — no audio body.
+                }
+
+            val result = parser.parse(byteSource(bytes))
+            require(result is AppResult.Success<EmbeddedAudioMetadata>)
+            result.data.durationMs shouldBe 0L
+        }
+    })


### PR DESCRIPTION
MP3 duration used a CBR approximation (first-frame bitrate × byte count), giving wrong durations for VBR files — corrupting progress bars, chapter offsets, and position sync. Now reads the Xing/Info or VBRI VBR header's declared frame count for an exact duration, falling back to CBR when no header is present.

- Version/channel-mode-dependent Xing offset (MPEG-1/2 × stereo/mono); VBRI at fixed +32
- 5 Kotest cases (Xing/Info/VBRI/CBR-regression/no-frame); fixtures extended
- Resolves the `TODO(VBR)` in the mp3 parser
- Gates: `:server:test` (mp3) + spotless/detekt green