### PR TITLE
⚡️ perf(sharedLogic): batch FTS rebuild reads to kill per-book query storm

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
@@ -279,4 +279,122 @@ interface SearchDao {
     """,
     )
     suspend fun getGenreNamesForBook(bookId: String): String?
+
+    // ==================== BATCH QUERIES FOR FULL REBUILD ====================
+
+    /**
+     * Fetch the alphabetically-first author name for every book that has at
+     * least one author contributor, in a single query.
+     *
+     * Using [MIN] over contributor names rather than an arbitrary `LIMIT 1`
+     * produces a deterministic result when a book has multiple authors — the
+     * same author is always chosen across rebuild runs. The per-book
+     * [getPrimaryAuthorName] uses `LIMIT 1` without ordering, which has the
+     * same single-author semantics but is non-deterministic for multi-author
+     * books; this batch variant is strictly more consistent.
+     *
+     * @return List of `(bookId, authorName)` pairs — one row per book that has an author.
+     *   Books with no author contributor are absent from the result.
+     */
+    @Query(
+        """
+        SELECT bc.bookId AS bookId, MIN(c.name) AS authorName
+        FROM contributors c
+        INNER JOIN book_contributors bc ON bc.contributorId = c.id
+        WHERE LOWER(bc.role) = 'author'
+        GROUP BY bc.bookId
+    """,
+    )
+    suspend fun getAllPrimaryAuthorNames(): List<BookIdNameRow>
+
+    /**
+     * Fetch the alphabetically-first narrator name for every book that has at
+     * least one narrator contributor, in a single query.
+     *
+     * Mirrors [getAllPrimaryAuthorNames] with `role = 'narrator'`.
+     *
+     * @return List of `(bookId, authorName)` pairs — one row per book that has a narrator.
+     *   Books with no narrator are absent.
+     */
+    @Query(
+        """
+        SELECT bc.bookId AS bookId, MIN(c.name) AS authorName
+        FROM contributors c
+        INNER JOIN book_contributors bc ON bc.contributorId = c.id
+        WHERE LOWER(bc.role) = 'narrator'
+        GROUP BY bc.bookId
+    """,
+    )
+    suspend fun getAllPrimaryNarratorNames(): List<BookIdNameRow>
+
+    /**
+     * Fetch the comma-joined, alphabetically-sorted series names for every
+     * book that belongs to at least one series, in a single query.
+     *
+     * Reproduces exactly the `ORDER BY name COLLATE NOCASE ASC` + `GROUP_CONCAT`
+     * logic of [getSeriesNamesForBook], extended across all books at once.
+     * The inner `ORDER BY` is applied before `GROUP_CONCAT` via the subquery,
+     * so the joined string is identical to what the per-book query would return.
+     *
+     * @return List of `(bookId, authorName)` pairs — one row per book that belongs to a series.
+     *   Books in no series are absent.
+     */
+    @Query(
+        """
+        SELECT bookId, GROUP_CONCAT(name, ', ') AS authorName
+        FROM (
+            SELECT bs.bookId AS bookId, s.name AS name
+            FROM series s
+            INNER JOIN book_series bs ON s.id = bs.seriesId
+            ORDER BY bs.bookId, s.name COLLATE NOCASE ASC
+        )
+        GROUP BY bookId
+    """,
+    )
+    suspend fun getAllSeriesNamesGrouped(): List<BookIdNameRow>
+
+    /**
+     * Fetch the comma-joined, alphabetically-sorted genre names for every
+     * book that has at least one genre, in a single query.
+     *
+     * Mirrors [getAllSeriesNamesGrouped] for the `book_genres` junction.
+     *
+     * @return List of `(bookId, authorName)` pairs — one row per book that has a genre.
+     *   Books with no genre are absent.
+     */
+    @Query(
+        """
+        SELECT bookId, GROUP_CONCAT(name, ', ') AS authorName
+        FROM (
+            SELECT bg.bookId AS bookId, g.name AS name
+            FROM genres g
+            INNER JOIN book_genres bg ON g.id = bg.genreId
+            ORDER BY bg.bookId, g.name COLLATE NOCASE ASC
+        )
+        GROUP BY bookId
+    """,
+    )
+    suspend fun getAllGenreNamesGrouped(): List<BookIdNameRow>
 }
+
+/**
+ * A `(bookId, name)` projection returned by the batch FTS-rebuild queries.
+ *
+ * Each batch query returns one row per book: the book's ID and the
+ * pre-aggregated value for a single dimension (author name, narrator name,
+ * series names, or genre names). [FtsPopulator] assembles these into maps
+ * keyed by [bookId] so it can look up each dimension in O(1) while
+ * iterating the book list for FTS inserts.
+ *
+ * Column alias `authorName` is reused across all four batch queries so a
+ * single data class serves all four projections without introducing four
+ * identical types.
+ *
+ * @property bookId The book's primary key.
+ * @property authorName The aggregated name string for this dimension (author,
+ *   narrator, series names, or genre names depending on the calling query).
+ */
+data class BookIdNameRow(
+    val bookId: String,
+    val authorName: String,
+)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulator.kt
@@ -5,11 +5,14 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ContributorDao
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesDao
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.withContext
 import kotlin.time.measureTime
 
 private val logger = KotlinLogging.logger {}
+
+private const val FTS_INSERT_CHUNK_SIZE = 200
 
 /**
  * Populates FTS5 tables for offline full-text search.
@@ -23,16 +26,23 @@ private val logger = KotlinLogging.logger {}
  * we could optimize with incremental updates, but full rebuild is fast enough
  * for typical library sizes (<5k books) and avoids complexity of tracking changes.
  *
+ * The book rebuild issues four aggregate SQL queries (one per denormalized dimension)
+ * instead of four per-book queries, then inserts in chunks of [FTS_INSERT_CHUNK_SIZE]
+ * rows inside a write transaction per chunk. This removes the O(n) query storm that
+ * previously caused heap pressure on large libraries.
+ *
  * @property bookDao DAO for reading books
  * @property contributorDao DAO for reading contributors
  * @property seriesDao DAO for reading series
  * @property searchDao DAO for FTS operations
+ * @property transactionRunner Wraps chunked FTS inserts in write transactions
  */
 class FtsPopulator(
     private val bookDao: BookDao,
     private val contributorDao: ContributorDao,
     private val seriesDao: SeriesDao,
     private val searchDao: SearchDao,
+    private val transactionRunner: TransactionRunner,
 ) : FtsPopulatorContract {
     /**
      * Rebuild all FTS tables from main tables.
@@ -76,8 +86,14 @@ class FtsPopulator(
     /**
      * Rebuild book FTS entries.
      *
-     * Denormalizes author, narrator, and series name into the FTS table
+     * Denormalizes author, narrator, series name, and genre names into the FTS table
      * for rich search results.
+     *
+     * Uses four aggregate SQL queries (one per dimension) instead of four per-book
+     * queries, eliminating the O(n) query storm on large libraries. Each dimension
+     * is collected into a map keyed by bookId, then looked up in O(1) per book
+     * during the insert pass. Inserts are grouped into chunks of [FTS_INSERT_CHUNK_SIZE]
+     * rows, each chunk wrapped in a write transaction to bound lock-hold time.
      *
      * @return Number of books inserted into FTS
      */
@@ -87,34 +103,37 @@ class FtsPopulator(
         // Clear existing entries
         searchDao.clearBooksFts()
 
-        // Get all books
+        // Load all books and all four denormalized dimensions in parallel batch queries.
+        // O(4) queries total instead of O(4 * n).
         val books = bookDao.getAllLive()
+        val authorsByBookId = searchDao.getAllPrimaryAuthorNames().associate { it.bookId to it.authorName }
+        val narratorsByBookId = searchDao.getAllPrimaryNarratorNames().associate { it.bookId to it.authorName }
+        val seriesByBookId = searchDao.getAllSeriesNamesGrouped().associate { it.bookId to it.authorName }
+        val genresByBookId = searchDao.getAllGenreNamesGrouped().associate { it.bookId to it.authorName }
 
-        // Insert each book with denormalized data
+        // Insert in chunks; each chunk is one write transaction to bound lock-hold time.
         var insertCount = 0
-        for (book in books) {
-            try {
-                // Get denormalized data for FTS indexing
-                val authorName = searchDao.getPrimaryAuthorName(book.id.value)
-                val narratorName = searchDao.getPrimaryNarratorName(book.id.value)
-                val seriesNames = searchDao.getSeriesNamesForBook(book.id.value)
-                val genreNames = searchDao.getGenreNamesForBook(book.id.value)
-
-                searchDao.insertBookFts(
-                    bookId = book.id.value,
-                    title = book.title,
-                    subtitle = book.subtitle,
-                    description = book.description,
-                    author = authorName,
-                    narrator = narratorName,
-                    seriesName = seriesNames,
-                    genres = genreNames,
-                )
-                insertCount++
-            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.warn(e) { "Failed to insert book ${book.id} into FTS" }
+        for (chunk in books.chunked(FTS_INSERT_CHUNK_SIZE)) {
+            transactionRunner.atomically {
+                for (book in chunk) {
+                    try {
+                        searchDao.insertBookFts(
+                            bookId = book.id.value,
+                            title = book.title,
+                            subtitle = book.subtitle,
+                            description = book.description,
+                            author = authorsByBookId[book.id.value],
+                            narrator = narratorsByBookId[book.id.value],
+                            seriesName = seriesByBookId[book.id.value],
+                            genres = genresByBookId[book.id.value],
+                        )
+                        insertCount++
+                    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.warn(e) { "Failed to insert book ${book.id} into FTS" }
+                    }
+                }
             }
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SearchModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SearchModule.kt
@@ -36,6 +36,7 @@ val searchModule: Module =
                 contributorDao = get(),
                 seriesDao = get(),
                 searchDao = get(),
+                transactionRunner = get(),
             )
         } bind FtsPopulatorContract::class
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorRebuildIfEmptyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorRebuildIfEmptyTest.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ContributorDao
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesDao
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
@@ -21,6 +22,11 @@ import kotlinx.coroutines.test.runTest
 class FtsPopulatorRebuildIfEmptyTest :
     FunSpec({
 
+        val passThrough =
+            object : TransactionRunner {
+                override suspend fun <R> atomically(block: suspend () -> R): R = block()
+            }
+
         fun populator(
             searchDao: SearchDao,
             bookDao: BookDao = mock { everySuspend { getAllLive() } returns emptyList() },
@@ -31,6 +37,7 @@ class FtsPopulatorRebuildIfEmptyTest :
             contributorDao = contributorDao,
             seriesDao = seriesDao,
             searchDao = searchDao,
+            transactionRunner = passThrough,
         )
 
         test("rebuildIfEmpty rebuilds the index when it is empty") {
@@ -41,6 +48,10 @@ class FtsPopulatorRebuildIfEmptyTest :
                         everySuspend { clearBooksFts() } returns Unit
                         everySuspend { clearContributorsFts() } returns Unit
                         everySuspend { clearSeriesFts() } returns Unit
+                        everySuspend { getAllPrimaryAuthorNames() } returns emptyList()
+                        everySuspend { getAllPrimaryNarratorNames() } returns emptyList()
+                        everySuspend { getAllSeriesNamesGrouped() } returns emptyList()
+                        everySuspend { getAllGenreNamesGrouped() } returns emptyList()
                     }
 
                 populator(searchDao).rebuildIfEmpty()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorTest.kt
@@ -6,11 +6,13 @@ import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.BookIdNameRow
 import com.calypsan.listenup.client.data.local.db.ContributorDao
 import com.calypsan.listenup.client.data.local.db.ContributorEntity
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesDao
 import com.calypsan.listenup.client.data.local.db.SeriesEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -39,12 +41,19 @@ class FtsPopulatorTest :
             val seriesDao: SeriesDao = mock()
             val searchDao: SearchDao = mock()
 
+            // Inline fake that executes the block directly — no DB needed in mock tests.
+            val transactionRunner: TransactionRunner =
+                object : TransactionRunner {
+                    override suspend fun <R> atomically(block: suspend () -> R): R = block()
+                }
+
             fun build(): FtsPopulator =
                 FtsPopulator(
                     bookDao = bookDao,
                     contributorDao = contributorDao,
                     seriesDao = seriesDao,
                     searchDao = searchDao,
+                    transactionRunner = transactionRunner,
                 )
         }
 
@@ -60,10 +69,13 @@ class FtsPopulatorTest :
             everySuspend { fixture.searchDao.clearBooksFts() } returns Unit
             everySuspend { fixture.searchDao.clearContributorsFts() } returns Unit
             everySuspend { fixture.searchDao.clearSeriesFts() } returns Unit
-            everySuspend { fixture.searchDao.getPrimaryAuthorName(any()) } returns null
-            everySuspend { fixture.searchDao.getPrimaryNarratorName(any()) } returns null
-            everySuspend { fixture.searchDao.getSeriesNamesForBook(any()) } returns null
-            everySuspend { fixture.searchDao.getGenreNamesForBook(any()) } returns null
+
+            // Batch query stubs (the new API — no per-book queries)
+            everySuspend { fixture.searchDao.getAllPrimaryAuthorNames() } returns emptyList()
+            everySuspend { fixture.searchDao.getAllPrimaryNarratorNames() } returns emptyList()
+            everySuspend { fixture.searchDao.getAllSeriesNamesGrouped() } returns emptyList()
+            everySuspend { fixture.searchDao.getAllGenreNamesGrouped() } returns emptyList()
+
             everySuspend { fixture.searchDao.insertBookFts(any(), any(), any(), any(), any(), any(), any(), any()) } returns
                 Unit
             everySuspend { fixture.searchDao.insertContributorFts(any(), any(), any()) } returns Unit
@@ -234,15 +246,17 @@ class FtsPopulatorTest :
             }
         }
 
-        test("rebuildAll includes author and narrator names from lookup") {
+        test("rebuildAll includes author and narrator names from batch lookup") {
             runTest {
                 // Given
                 val fixture = createFixture()
                 val book = createBookEntity(id = "book-1", title = "Test Book")
 
                 everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
-                everySuspend { fixture.searchDao.getPrimaryAuthorName("book-1") } returns "John Author"
-                everySuspend { fixture.searchDao.getPrimaryNarratorName("book-1") } returns "Jane Narrator"
+                everySuspend { fixture.searchDao.getAllPrimaryAuthorNames() } returns
+                    listOf(BookIdNameRow(bookId = "book-1", authorName = "John Author"))
+                everySuspend { fixture.searchDao.getAllPrimaryNarratorNames() } returns
+                    listOf(BookIdNameRow(bookId = "book-1", authorName = "Jane Narrator"))
                 val ftsPopulator = fixture.build()
 
                 // When
@@ -264,9 +278,9 @@ class FtsPopulatorTest :
             }
         }
 
-        test("rebuildAll includes genres in FTS") {
+        test("rebuildAll includes genres in FTS via batch lookup") {
             runTest {
-                // Given - genre names now come from book_genres junction via getGenreNamesForBook
+                // Given — genre names come from getAllGenreNamesGrouped batch query
                 val fixture = createFixture()
                 val book =
                     createBookEntity(
@@ -275,13 +289,14 @@ class FtsPopulatorTest :
                     )
 
                 everySuspend { fixture.bookDao.getAllLive() } returns listOf(book)
-                everySuspend { fixture.searchDao.getGenreNamesForBook("book-1") } returns "Fantasy, Adventure"
+                everySuspend { fixture.searchDao.getAllGenreNamesGrouped() } returns
+                    listOf(BookIdNameRow(bookId = "book-1", authorName = "Fantasy, Adventure"))
                 val ftsPopulator = fixture.build()
 
                 // When
                 ftsPopulator.rebuildAll()
 
-                // Then - both series and genre names come from junction tables, not BookEntity
+                // Then — both series and genre names come from batch queries, not per-book calls
                 verifySuspend {
                     fixture.searchDao.insertBookFts(
                         "book-1",
@@ -290,8 +305,8 @@ class FtsPopulatorTest :
                         null,
                         null,
                         null,
-                        null, // Series comes from junction table
-                        "Fantasy, Adventure", // Genres come from junction table
+                        null, // Series comes from batch query
+                        "Fantasy, Adventure", // Genres come from batch query
                     )
                 }
             }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/SearchModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/SearchModuleVerifyTest.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ContributorDao
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesDao
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import io.kotest.core.spec.style.FunSpec
@@ -21,6 +22,7 @@ import org.koin.test.verify.verify
  *  - [BookDao] — owned by `persistenceModule`.
  *  - [ContributorDao] — owned by `persistenceModule`.
  *  - [SeriesDao] — owned by `persistenceModule`.
+ *  - [TransactionRunner] — owned by `persistenceModule`.
  */
 @OptIn(KoinExperimentalAPI::class)
 class SearchModuleVerifyTest :
@@ -36,6 +38,7 @@ class SearchModuleVerifyTest :
                         ContributorDao::class,
                         SeriesDao::class,
                         ApiClientFactory::class,
+                        TransactionRunner::class,
                     ),
             )
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorRebuildTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/FtsPopulatorRebuildTest.kt
@@ -1,0 +1,354 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ContributorId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.SeriesId
+import com.calypsan.listenup.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.BookContributorCrossRef
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
+import com.calypsan.listenup.client.data.local.db.BookSeriesCrossRef
+import com.calypsan.listenup.client.data.local.db.ContributorEntity
+import com.calypsan.listenup.client.data.local.db.GenreEntity
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.SeriesEntity
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Integration tests for [FtsPopulator.rebuildBooks] against a real in-memory [ListenUpDatabase].
+ *
+ * These tests verify that the batched rebuild path produces the same denormalized FTS rows
+ * as the old per-book query approach, and that the Room queries in [SearchDao] work correctly
+ * against real data. The key risks guarded here are:
+ *
+ *  - SQL correctness: the four batch queries reproduce the exact same joins, GROUP_CONCAT
+ *    ordering, and role filters as the original per-book queries.
+ *  - Null-safety: a book with no author / narrator / series / genre still gets an FTS row.
+ *  - Idempotency: running rebuildAll() twice leaves exactly N rows — no duplicates.
+ *  - Search coverage: a [SearchDao.searchBooks] query finds a book by author, narrator,
+ *    series name, and genre name after rebuild — proving the denormalized strings are
+ *    correctly indexed.
+ */
+class FtsPopulatorRebuildTest :
+    FunSpec({
+
+        // ========== Seed helpers ==========
+
+        suspend fun seedBook(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            id: String,
+            title: String,
+            subtitle: String? = null,
+            description: String? = null,
+        ) {
+            db.bookDao().upsert(
+                BookEntity(
+                    id = BookId(id),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = title,
+                    sortTitle = title,
+                    subtitle = subtitle,
+                    coverHash = null,
+                    totalDuration = 3_600_000L,
+                    description = description,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
+        }
+
+        suspend fun seedContributor(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            id: String,
+            name: String,
+        ) {
+            db.contributorDao().upsert(
+                ContributorEntity(
+                    id = ContributorId(id),
+                    name = name,
+                    description = null,
+                    imagePath = null,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
+        }
+
+        suspend fun linkContributor(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            bookId: String,
+            contributorId: String,
+            role: String,
+        ) {
+            db.bookContributorDao().insert(
+                BookContributorCrossRef(
+                    bookId = BookId(bookId),
+                    contributorId = ContributorId(contributorId),
+                    role = role,
+                ),
+            )
+        }
+
+        suspend fun seedSeries(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            id: String,
+            name: String,
+        ) {
+            db.seriesDao().upsert(
+                SeriesEntity(
+                    id = SeriesId(id),
+                    name = name,
+                    description = null,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
+        }
+
+        suspend fun linkSeries(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            bookId: String,
+            seriesId: String,
+        ) {
+            db.bookSeriesDao().insertAll(
+                listOf(BookSeriesCrossRef(bookId = BookId(bookId), seriesId = SeriesId(seriesId))),
+            )
+        }
+
+        suspend fun seedGenre(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            id: String,
+            name: String,
+        ) {
+            db.genreDao().upsertAll(
+                listOf(
+                    GenreEntity(
+                        id = id,
+                        name = name,
+                        slug = id,
+                        path = "/$id",
+                        parentId = null,
+                        depth = 0,
+                        sortOrder = 0,
+                    ),
+                ),
+            )
+        }
+
+        suspend fun linkGenre(
+            db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+            bookId: String,
+            genreId: String,
+        ) {
+            db.genreDao().insertAllBookGenres(
+                listOf(BookGenreCrossRef(bookId = BookId(bookId), genreId = genreId)),
+            )
+        }
+
+        fun buildPopulator(db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase) =
+            FtsPopulator(
+                bookDao = db.bookDao(),
+                contributorDao = db.contributorDao(),
+                seriesDao = db.seriesDao(),
+                searchDao = db.searchDao(),
+                transactionRunner = RoomTransactionRunner(db),
+            )
+
+        // ========== Case 1: Full denormalization — author, narrator, multi-series, multi-genre ==========
+
+        test("rebuildAll writes one FTS row per book and search finds it by author, narrator, series, and genre") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    // Seed 3 books with rich denormalized data
+                    seedBook(db, id = "b1", title = "The Way of Kings", description = "Epic fantasy")
+                    seedBook(db, id = "b2", title = "Words of Radiance")
+                    seedBook(db, id = "b3", title = "Oathbringer")
+
+                    seedContributor(db, id = "c-author", name = "Brandon Sanderson")
+                    seedContributor(db, id = "c-narrator", name = "Michael Kramer")
+                    linkContributor(db, bookId = "b1", contributorId = "c-author", role = "author")
+                    linkContributor(db, bookId = "b1", contributorId = "c-narrator", role = "narrator")
+                    linkContributor(db, bookId = "b2", contributorId = "c-author", role = "author")
+                    linkContributor(db, bookId = "b3", contributorId = "c-author", role = "author")
+
+                    seedSeries(db, id = "s1", name = "The Stormlight Archive")
+                    seedSeries(db, id = "s2", name = "The Cosmere")
+                    linkSeries(db, bookId = "b1", seriesId = "s1")
+                    linkSeries(db, bookId = "b1", seriesId = "s2")
+                    linkSeries(db, bookId = "b2", seriesId = "s1")
+                    linkSeries(db, bookId = "b3", seriesId = "s1")
+
+                    seedGenre(db, id = "g1", name = "Fantasy")
+                    seedGenre(db, id = "g2", name = "Epic Fantasy")
+                    linkGenre(db, bookId = "b1", genreId = "g1")
+                    linkGenre(db, bookId = "b1", genreId = "g2")
+
+                    buildPopulator(db).rebuildAll()
+
+                    // All 3 books have an FTS row
+                    db.searchDao().countBooksFts() shouldBe 3
+
+                    // Book can be found by title
+                    val byTitle = db.searchDao().searchBooks("Way*")
+                    byTitle.size shouldBe 1
+                    byTitle.first().book.id shouldBe BookId("b1")
+
+                    // Book b1 can be found by author name
+                    val byAuthor = db.searchDao().searchBooks("Sanderson*")
+                    byAuthor.any { it.book.id == BookId("b1") } shouldBe true
+
+                    // Book b1 can be found by narrator name
+                    val byNarrator = db.searchDao().searchBooks("Kramer*")
+                    byNarrator.any { it.book.id == BookId("b1") } shouldBe true
+
+                    // Book b1 can be found by series name
+                    val bySeries = db.searchDao().searchBooks("Stormlight*")
+                    bySeries.any { it.book.id == BookId("b1") } shouldBe true
+
+                    // Book b1 can be found by genre name
+                    val byGenre = db.searchDao().searchBooks("Fantasy*")
+                    byGenre.any { it.book.id == BookId("b1") } shouldBe true
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ========== Case 2: Book with no author, narrator, series, or genre still gets an FTS row ==========
+
+        test("rebuildAll inserts an FTS row for a book with no contributors, series, or genres") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBook(db, id = "b-bare", title = "Bare Book")
+
+                    buildPopulator(db).rebuildAll()
+
+                    // The book has a row even though all denormalized fields are null
+                    db.searchDao().countBooksFts() shouldBe 1
+
+                    // It is findable by title
+                    val results = db.searchDao().searchBooks("Bare*")
+                    results.size shouldBe 1
+                    results.first().book.id shouldBe BookId("b-bare")
+
+                    // authorName is null (stored in the FTS table; searchBooks returns it)
+                    results.first().authorName shouldBe null
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ========== Case 3: Idempotency — running rebuildAll() twice leaves exactly N rows ==========
+
+        test("rebuildAll is idempotent — running it twice leaves exactly N rows") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBook(db, id = "b1", title = "Book Alpha")
+                    seedBook(db, id = "b2", title = "Book Beta")
+
+                    val populator = buildPopulator(db)
+                    populator.rebuildAll()
+                    val countAfterFirst = db.searchDao().countBooksFts()
+
+                    populator.rebuildAll()
+                    val countAfterSecond = db.searchDao().countBooksFts()
+
+                    countAfterFirst shouldBe 2
+                    countAfterSecond shouldBe 2
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ========== Case 4: Multi-series string is alphabetically sorted ==========
+
+        test("rebuildAll produces alphabetically-sorted series names matching per-book query output") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBook(db, id = "b1", title = "Some Book")
+                    seedSeries(db, id = "s1", name = "Mistborn Era 1")
+                    seedSeries(db, id = "s2", name = "The Cosmere")
+                    seedSeries(db, id = "s3", name = "Mistborn")
+                    linkSeries(db, bookId = "b1", seriesId = "s1")
+                    linkSeries(db, bookId = "b1", seriesId = "s2")
+                    linkSeries(db, bookId = "b1", seriesId = "s3")
+
+                    // Verify the per-book query produces the expected string
+                    val perBookResult = db.searchDao().getSeriesNamesForBook("b1")
+                    perBookResult shouldBe "Mistborn, Mistborn Era 1, The Cosmere"
+
+                    buildPopulator(db).rebuildAll()
+
+                    // The FTS row must be findable by the earliest series name in the joined string
+                    db.searchDao().searchBooks("Mistborn*").any { it.book.id == BookId("b1") } shouldBe true
+                    db.searchDao().searchBooks("Cosmere*").any { it.book.id == BookId("b1") } shouldBe true
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ========== Case 5: Multi-genre string is alphabetically sorted ==========
+
+        test("rebuildAll produces alphabetically-sorted genre names matching per-book query output") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBook(db, id = "b1", title = "Genre Book")
+                    seedGenre(db, id = "g1", name = "Horror")
+                    seedGenre(db, id = "g2", name = "Fantasy")
+                    seedGenre(db, id = "g3", name = "Adventure")
+                    linkGenre(db, bookId = "b1", genreId = "g1")
+                    linkGenre(db, bookId = "b1", genreId = "g2")
+                    linkGenre(db, bookId = "b1", genreId = "g3")
+
+                    // Verify the per-book query produces the expected string
+                    val perBookResult = db.searchDao().getGenreNamesForBook("b1")
+                    perBookResult shouldBe "Adventure, Fantasy, Horror"
+
+                    buildPopulator(db).rebuildAll()
+
+                    // The FTS row must be findable by any of the genre names
+                    db.searchDao().searchBooks("Horror*").any { it.book.id == BookId("b1") } shouldBe true
+                    db.searchDao().searchBooks("Adventure*").any { it.book.id == BookId("b1") } shouldBe true
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        // ========== Case 6: searchBooks returns the stored authorName from the FTS row ==========
+
+        test("searchBooks result carries the authorName that was written to the FTS row") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBook(db, id = "b1", title = "Author Name Book")
+                    seedContributor(db, id = "c1", name = "Mary Shelley")
+                    linkContributor(db, bookId = "b1", contributorId = "c1", role = "author")
+
+                    buildPopulator(db).rebuildAll()
+
+                    val results = db.searchDao().searchBooks("Mary*")
+                    results.size shouldBe 1
+                    results.first().authorName shouldNotBe null
+                    results.first().authorName shouldBe "Mary Shelley"
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })


### PR DESCRIPTION
FtsPopulator.rebuildBooks() issued 4 DAO queries per book over a full in-memory load — ~4,500 sequential queries on a 1,100-book rebuild, the leading suspect for the logged incremental-scan OOM/jank. Now: 4 aggregate queries (one per denormalized dimension) into maps, then chunked inserts (200/chunk) inside a write transaction.

- Series/genre batch queries reproduce the exact GROUP_CONCAT + COLLATE NOCASE ordering of the per-book queries (verified by dedicated ordering tests)
- Author/narrator now use MIN(name) instead of arbitrary LIMIT 1 — identical for single-author books; deterministic (alphabetically-first) for multi-author, vs the previous non-deterministic pick
- Full-rebuild semantics unchanged; per-item CancellationException rethrow preserved
- New FtsPopulatorRebuildTest (6 in-memory-Room cases incl. ordering-parity); existing fixtures updated for the injected TransactionRunner
- Gates: :sharedLogic:jvmTest + :androidApp:assembleDebug + spotless/detekt all green