### PR TITLE
♻️ refactor(sharedLogic): replace commonMain !! with null-safe handling (fix import NPE edge)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImpl.kt
@@ -178,9 +178,7 @@ class InstanceRepositoryImpl(
     private var cachedInstance: Instance? = null
 
     override suspend fun getInstance(forceRefresh: Boolean): AppResult<Instance> {
-        if (!forceRefresh && cachedInstance != null) {
-            return AppResult.Success(cachedInstance!!)
-        }
+        cachedInstance?.takeIf { !forceRefresh }?.let { return AppResult.Success(it) }
 
         val serverUrl = getServerUrl()
         if (serverUrl == null) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/absimport/AnalysisDelegate.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/absimport/AnalysisDelegate.kt
@@ -113,32 +113,37 @@ internal class AnalysisDelegate(
                 statusResponse = pollStatus(analysisId) ?: return@launch
             }
 
-            if (statusResponse.status == "failed") {
-                val failureDetail = statusResponse.error ?: "Analysis failed"
-                logger.error { "Analysis reported failed status: $failureDetail" }
-                state.updateReady {
-                    it.copy(
-                        isAnalyzing = false,
-                        step = ABSImportStep.SOURCE_SELECTION,
-                        error = ImportError.AnalysisFailed(debugInfo = failureDetail),
-                    )
-                }
-                return@launch
-            }
+            // Resolve result: failed status or missing result both route to AnalysisFailed.
+            val result =
+                statusResponse.result?.takeIf { statusResponse.status != "failed" }
+                    ?: run {
+                        val detail =
+                            if (statusResponse.status == "failed") {
+                                statusResponse.error ?: "Analysis failed"
+                            } else {
+                                "Analysis returned no result"
+                            }
+                        logger.error { "Analysis did not complete successfully: $detail" }
+                        state.updateReady {
+                            it.copy(
+                                isAnalyzing = false,
+                                step = ABSImportStep.SOURCE_SELECTION,
+                                error = ImportError.AnalysisFailed(debugInfo = detail),
+                            )
+                        }
+                        return@launch
+                    }
 
-            val result = statusResponse.result!!
-
-            // Build initial mappings from server-matched items
-            // All items with listenupId are auto-matched; users can review and change
+            // Items with listenupId are auto-matched; users can review and change
             val initialUserMappings =
                 result.userMatches
-                    .filter { it.listenupId != null }
-                    .associate { it.absUserId to it.listenupId!! }
+                    .mapNotNull { m -> m.listenupId?.let { m.absUserId to it } }
+                    .toMap()
 
             val initialBookMappings =
                 result.bookMatches
-                    .filter { it.listenupId != null }
-                    .associate { it.absItemId to it.listenupId!! }
+                    .mapNotNull { m -> m.listenupId?.let { m.absItemId to it } }
+                    .toMap()
 
             // Pre-populate display info for auto-matched books
             val initialBookDisplays = buildInitialBookDisplays(result)
@@ -181,9 +186,8 @@ internal class AnalysisDelegate(
 
     private fun buildInitialBookDisplays(result: AnalyzeABSResponse): Map<String, SelectedBookDisplay> =
         result.bookMatches
-            .filter { it.listenupId != null }
-            .associate { match ->
-                val listenupId = match.listenupId!!
+            .mapNotNull { match -> match.listenupId?.let { match to it } }
+            .associate { (match, listenupId) ->
                 // Try to find the matched book in suggestions for full details
                 val matchedSuggestion = match.suggestions.firstOrNull { it.bookId == listenupId }
                 // Fallback to first suggestion if matched book not in list

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorBooksViewModel.kt
@@ -91,8 +91,8 @@ class ContributorBooksViewModel(
 
         val seriesGroups =
             books
-                .filter { it.seriesName != null }
-                .groupBy { it.seriesName!! }
+                .mapNotNull { b -> b.seriesName?.let { b to it } }
+                .groupBy({ it.second }) { it.first }
                 .map { (seriesName, seriesBooks) ->
                     SeriesGroup(
                         seriesName = seriesName,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/admin/absimport/AnalysisNullResultTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/admin/absimport/AnalysisNullResultTest.kt
@@ -1,0 +1,118 @@
+package com.calypsan.listenup.client.presentation.admin.absimport
+
+import com.calypsan.listenup.api.error.ImportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.BackupApiContract
+import com.calypsan.listenup.client.data.remote.SearchApiContract
+import com.calypsan.listenup.client.data.remote.ABSImportApiContract
+import com.calypsan.listenup.client.data.remote.model.AnalysisStatusResponse
+import com.calypsan.listenup.client.data.remote.model.AsyncAnalyzeResponse
+import com.calypsan.listenup.client.domain.repository.SyncRepository
+import com.calypsan.listenup.client.presentation.admin.ABSImportStep
+import com.calypsan.listenup.client.presentation.admin.ABSImportUiState
+import com.calypsan.listenup.client.presentation.admin.ABSImportViewModel
+import com.calypsan.listenup.core.error.ErrorBus
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+/**
+ * Regression test for the genuine null-crash risk in [AnalysisDelegate]:
+ * when the server returns a non-"failed" status with a null result, the
+ * delegate must route to [ABSImportStep.SOURCE_SELECTION] with an
+ * [ImportError.AnalysisFailed] error rather than throwing NPE.
+ *
+ * Before the fix, `statusResponse.result!!` threw on this path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AnalysisNullResultTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
+
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
+
+        fun createViewModel(
+            backupApi: BackupApiContract,
+        ): ABSImportViewModel {
+            val searchApi: SearchApiContract = mock()
+            val absImportApi: ABSImportApiContract = mock()
+            val syncRepository: SyncRepository = mock()
+            return ABSImportViewModel(
+                backupApi = backupApi,
+                searchApi = searchApi,
+                absImportApi = absImportApi,
+                syncRepository = syncRepository,
+                errorBus = ErrorBus(),
+            )
+        }
+
+        test("non-failed status with null result routes to AnalysisFailed, not NPE") {
+            runTest {
+                val backupApi: BackupApiContract = mock()
+
+                everySuspend { backupApi.analyzeABSBackupAsync(any()) } returns
+                    AppResult.Success(AsyncAnalyzeResponse(analysisId = "id1"))
+
+                // Server says "completed" but provides no result — the edge case
+                everySuspend { backupApi.getAnalysisStatus("id1") } returns
+                    AppResult.Success(
+                        AnalysisStatusResponse(
+                            status = "completed",
+                            phase = "done",
+                            result = null,
+                        ),
+                    )
+
+                val viewModel = createViewModel(backupApi)
+                viewModel.setFullRemotePath("/tmp/backup.abs")
+
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                state.step shouldBe ABSImportStep.SOURCE_SELECTION
+                state.isAnalyzing shouldBe false
+                state.error.shouldBeInstanceOf<ImportError.AnalysisFailed>()
+            }
+        }
+
+        test("failed status with null result routes to AnalysisFailed via the explicit failed branch") {
+            runTest {
+                val backupApi: BackupApiContract = mock()
+
+                everySuspend { backupApi.analyzeABSBackupAsync(any()) } returns
+                    AppResult.Success(AsyncAnalyzeResponse(analysisId = "id2"))
+
+                // Server says "failed" with no detail — the pre-existing path
+                everySuspend { backupApi.getAnalysisStatus("id2") } returns
+                    AppResult.Success(
+                        AnalysisStatusResponse(
+                            status = "failed",
+                            phase = "done",
+                            result = null,
+                        ),
+                    )
+
+                val viewModel = createViewModel(backupApi)
+                viewModel.setFullRemotePath("/tmp/backup.abs")
+
+                advanceUntilIdle()
+
+                val state = viewModel.state.value.shouldBeInstanceOf<ABSImportUiState.Ready>()
+                state.step shouldBe ABSImportStep.SOURCE_SELECTION
+                state.isAnalyzing shouldBe false
+                state.error.shouldBeInstanceOf<ImportError.AnalysisFailed>()
+            }
+        }
+    })


### PR DESCRIPTION
Six `!!` assertions in commonMain. Five were filter-guarded (safe-but-smelly); one — `statusResponse.result!!` in the ABS-import analysis path — was a genuine NPE when the server returns a non-failed status with a null result.

- AnalysisDelegate: result-null now routes to the existing AnalysisFailed state (the failed-status and null-result paths are unified; distinct debugInfo preserved — server error vs "Analysis returned no result")
- Five guarded sites rewritten to mapNotNull / null-binding (behavior-identical)
- New AnalysisNullResultTest covers the null-result edge (both completed+null and failed+null)
- Gates: :sharedLogic:jvmTest + :androidApp:assembleDebug + spotless/detekt all green