### PR TITLE
🐛 fix: scan screen progress bar (#588) + carousel churn (#587)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/event/ScanEvent.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/event/ScanEvent.kt
@@ -48,6 +48,13 @@ sealed interface ScanEvent {
         val errors: Int,
         /** Total files discovered (known after WALKING; 0 before). */
         val totalFiles: Int = 0,
+        /**
+         * Total candidate books to analyze — known once ANALYZING starts (0 before, during
+         * WALKING/GROUPING). The denominator for the scan progress bar: real progress is
+         * `booksAnalyzed / booksTotal`, which advances through the long ANALYZING phase rather
+         * than pinning at 100% the instant file-walking ends.
+         */
+        val booksTotal: Int = 0,
         /** Running count of distinct author names matched so far. */
         val authorsMatched: Int = 0,
         /** Running sum of matched book durations, milliseconds → "Hours" stat. */

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -106,7 +106,15 @@ internal class Scanner(
         emitProgress(correlationId, ScanPhase.GROUPING, allFiles.size, 0, 0)
         val candidates = grouper.group(allFiles.asFlow()).toList()
 
-        emitProgress(correlationId, ScanPhase.ANALYZING, allFiles.size, 0, 0, totalFiles = allFiles.size)
+        emitProgress(
+            correlationId,
+            ScanPhase.ANALYZING,
+            allFiles.size,
+            0,
+            0,
+            totalFiles = allFiles.size,
+            booksTotal = candidates.size,
+        )
         // Analyzer uses the first folder root as the libraryRoot anchor for
         // computing rootRelPath and resolving error paths. When the library has
         // multiple folders, each folder's books will be at absolute paths inside
@@ -136,6 +144,7 @@ internal class Scanner(
             books.size,
             errors.size,
             totalFiles = allFiles.size,
+            booksTotal = candidates.size,
             authorsMatched = pass.authorsMatched,
             totalDurationMs = pass.totalDurationMs,
             currentFile = pass.currentFile,
@@ -300,6 +309,7 @@ internal class Scanner(
                     books.size,
                     errors.size,
                     totalFiles = fileCount,
+                    booksTotal = candidates.size,
                     authorsMatched = authorsSeen.size,
                     totalDurationMs = durationMsSum,
                     currentFile = currentFile,
@@ -316,6 +326,7 @@ internal class Scanner(
             books.size,
             errors.size,
             totalFiles = fileCount,
+            booksTotal = candidates.size,
             authorsMatched = authorsSeen.size,
             totalDurationMs = durationMsSum,
             currentFile = currentFile,
@@ -369,6 +380,7 @@ internal class Scanner(
         booksAnalyzed: Int,
         errors: Int,
         totalFiles: Int = 0,
+        booksTotal: Int = 0,
         authorsMatched: Int = 0,
         totalDurationMs: Long = 0,
         currentFile: String? = null,
@@ -383,6 +395,7 @@ internal class Scanner(
                 booksAnalyzed = booksAnalyzed,
                 errors = errors,
                 totalFiles = totalFiles,
+                booksTotal = booksTotal,
                 authorsMatched = authorsMatched,
                 totalDurationMs = totalDurationMs,
                 currentFile = currentFile,

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEmbeddedmetaIntegrationTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEmbeddedmetaIntegrationTest.kt
@@ -139,6 +139,28 @@ class ScannerEmbeddedmetaIntegrationTest :
                 }
             }
         }
+
+        test("scan progress carries booksTotal (candidate count) from ANALYZING onward") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    seedThreeBookLibrary(fixture)
+                    val (scanner, eventBus) = newScanner(fixture)
+
+                    scanner.runFullScan()
+
+                    // The fixture groups to exactly 3 candidate books, all of which
+                    // analyze successfully — so the final Progress tick must carry
+                    // booksTotal == 3 and, with every candidate analyzed, booksTotal
+                    // == booksAnalyzed.
+                    val last =
+                        eventBus.replayCache
+                            .filterIsInstance<ScanEvent.Progress>()
+                            .last { it.booksAnalyzed > 0 }
+                    last.booksTotal shouldBe 3
+                    last.booksTotal shouldBe last.booksAnalyzed
+                }
+            }
+        }
     })
 
 private fun seedThreeBookLibrary(fixture: AudioLibraryFixture) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -41,14 +41,6 @@ private val logger = KotlinLogging.logger {}
 private const val SCAN_STREAM_RESUBSCRIBE_DELAY_MS = 2_000L
 
 /**
- * Upper bound on the accumulated "recently matched" carousel. The server streams a small rolling
- * window per [ScanEvent.Progress]; the client accumulates across events (see [mergeRecentBooks]) so
- * the strip grows instead of looping the same few titles. This cap keeps that growth bounded on a
- * large library — the oldest matches scroll off and are dropped.
- */
-internal const val MAX_ACCUMULATED_RECENT_BOOKS = 60
-
-/**
  * Bridges the domain sync facade to the renovated client sync engine.
  *
  * Also hosts orphan-span recovery: on the first successful [startEngineForCurrentUser]
@@ -463,8 +455,12 @@ internal suspend fun applyScanEvent(
  * Merge a freshly-streamed [incoming] window of matched books into the already-accumulated
  * [existing] strip for the "recently matched" carousel. New titles append at the end; books already
  * present keep their position (dedupe by [ScanBookRef] value — title + author), so a tile never gets
- * its contents swapped for a different book just because that book was just scanned. The result is
- * trimmed to the newest [MAX_ACCUMULATED_RECENT_BOOKS], dropping the oldest off the front.
+ * its contents swapped for a different book just because that book was just scanned.
+ *
+ * Append-only with no cap: the marquee deliberately drifts slowly and shows the front (oldest) tiles,
+ * so trimming from the front would yank visible tiles out and make the strip blink/swap (#587).
+ * [ScanBookRef] is tiny (title + author) and a scan is bounded, so retaining all matched books is
+ * negligible and the rendering `LazyRow` stays lazy.
  */
 internal fun mergeRecentBooks(
     existing: List<ScanBookRef>,
@@ -474,11 +470,7 @@ internal fun mergeRecentBooks(
     val seen = existing.toHashSet()
     val merged = existing.toMutableList()
     for (book in incoming) if (seen.add(book)) merged += book
-    return if (merged.size > MAX_ACCUMULATED_RECENT_BOOKS) {
-        merged.subList(merged.size - MAX_ACCUMULATED_RECENT_BOOKS, merged.size).toList()
-    } else {
-        merged
-    }
+    return merged
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -422,6 +422,7 @@ internal suspend fun applyScanEvent(
                         removed = 0,
                         filesTotal = event.totalFiles,
                         books = event.booksAnalyzed,
+                        booksTotal = event.booksTotal,
                         authors = event.authorsMatched,
                         durationMs = event.totalDurationMs,
                         currentFile = event.currentFile,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressState.kt
@@ -16,6 +16,7 @@ data class ScanProgressState(
     val removed: Int,
     val filesTotal: Int = 0,
     val books: Int = 0,
+    val booksTotal: Int = 0,
     val authors: Int = 0,
     val durationMs: Long = 0,
     val currentFile: String? = null,
@@ -35,9 +36,13 @@ data class ScanProgressState(
                 else -> phase.replaceFirstChar { it.uppercase() }
             }
 
-    /** Progress fraction (0..1) over discovered files, or null if unknown. */
+    /**
+     * Progress fraction (0..1) over analyzed books, or null while the book total is unknown
+     * (WALKING/GROUPING → indeterminate bar). Driven by booksAnalyzed/booksTotal so it advances
+     * through the long ANALYZING phase instead of pinning at 100% the instant file-walking ends.
+     */
     val progressFraction: Float?
-        get() = if (filesTotal > 0) (current.toFloat() / filesTotal).coerceIn(0f, 1f) else null
+        get() = if (booksTotal > 0) (books.toFloat() / booksTotal).coerceIn(0f, 1f) else null
 
     /** Total matched audio rounded to whole hours, for the "Hours" stat. */
     val hours: Int

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/ScanEventContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/ScanEventContractTest.kt
@@ -22,6 +22,7 @@ class ScanEventContractTest :
                     booksAnalyzed = 174,
                     errors = 2,
                     totalFiles = 1647,
+                    booksTotal = 980,
                     authorsMatched = 21,
                     totalDurationMs = 252_000_000L,
                     currentFile = "Sanderson, Brandon/Mistborn/01.m4b",
@@ -29,5 +30,6 @@ class ScanEventContractTest :
                 )
             val decoded = json.decodeFromString(ScanEvent.serializer(), json.encodeToString(ScanEvent.serializer(), event))
             decoded shouldBe event
+            (decoded as ScanEvent.Progress).booksTotal shouldBe 980
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -260,6 +260,7 @@ class SyncRepositoryScanProgressTest :
                             booksAnalyzed = 28,
                             errors = 0,
                             totalFiles = 1647,
+                            booksTotal = 1600,
                             authorsMatched = 9,
                             totalDurationMs = 7_200_000L,
                             currentFile = "A/B.m4b",
@@ -275,6 +276,7 @@ class SyncRepositoryScanProgressTest :
                     setStartedAt = {},
                 )
                 progress!!.filesTotal shouldBe 1647
+                progress!!.booksTotal shouldBe 1600
                 progress!!.books shouldBe 28
                 progress!!.authors shouldBe 9
                 progress!!.hours shouldBe 2

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -221,7 +221,10 @@ class SyncRepositoryScanProgressTest :
             }
         }
 
-        test("recentBooks accumulation caps at MAX_ACCUMULATED_RECENT_BOOKS, dropping the oldest") {
+        // #587: the marquee shows the front (oldest) tiles and deliberately falls behind; dropping
+        // from the front to honour a cap yanked visible tiles out, causing the blink/swap. Accumulation
+        // is now pure append-only — every matched book is retained, in order.
+        test("recentBooks accumulation is append-only — nothing is dropped from the front") {
             runTest {
                 var progress: ScanProgressState? = null
                 val apply: suspend (ScanBookRef) -> Unit = { book ->
@@ -236,13 +239,12 @@ class SyncRepositoryScanProgressTest :
                     )
                 }
 
-                val total = MAX_ACCUMULATED_RECENT_BOOKS + 5
+                val total = 250
                 repeat(total) { i -> apply(ScanBookRef("Book $i", "Author")) }
 
                 val recent = progress!!.recentBooks
-                recent.size shouldBe MAX_ACCUMULATED_RECENT_BOOKS
-                // Oldest five dropped; the newest is last.
-                recent.first() shouldBe ScanBookRef("Book 5", "Author")
+                recent.size shouldBe total
+                recent.first() shouldBe ScanBookRef("Book 0", "Author")
                 recent.last() shouldBe ScanBookRef("Book ${total - 1}", "Author")
             }
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressStateTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressStateTest.kt
@@ -1,0 +1,51 @@
+package com.calypsan.listenup.client.domain.model
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Covers [ScanProgressState.progressFraction] — the scan progress bar's value. It must advance
+ * through ANALYZING (driven by booksAnalyzed/booksTotal) and stay null (indeterminate) while the
+ * book total is unknown, rather than pinning at 100% the instant file-walking ends.
+ */
+class ScanProgressStateTest :
+    FunSpec({
+
+        fun state(
+            books: Int = 0,
+            booksTotal: Int = 0,
+            current: Int = 0,
+            filesTotal: Int = 0,
+        ) = ScanProgressState(
+            phase = "analyzing",
+            current = current,
+            total = current,
+            added = 0,
+            updated = 0,
+            removed = 0,
+            filesTotal = filesTotal,
+            books = books,
+            booksTotal = booksTotal,
+        )
+
+        test("progressFraction is null while the book total is unknown (WALKING/GROUPING)") {
+            state(books = 0, booksTotal = 0, current = 1200, filesTotal = 0).progressFraction shouldBe null
+        }
+
+        test("progressFraction advances as books are analyzed") {
+            state(books = 250, booksTotal = 1000).progressFraction shouldBe 0.25f
+        }
+
+        test("progressFraction reaches 1.0 when all candidates are analyzed") {
+            state(books = 1000, booksTotal = 1000).progressFraction shouldBe 1.0f
+        }
+
+        test("progressFraction is coerced into 0..1 if books overshoots the total") {
+            state(books = 1010, booksTotal = 1000).progressFraction shouldBe 1.0f
+        }
+
+        test("progressFraction does NOT pin at 100% just because files are fully walked") {
+            // filesTotal == current (all files walked) but only 30% of books analyzed → 0.3, not 1.0.
+            state(books = 30, booksTotal = 100, current = 1647, filesTotal = 1647).progressFraction shouldBe 0.3f
+        }
+    })

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/LibraryScanScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/LibraryScanScreen.kt
@@ -224,10 +224,15 @@ private fun ScanProgressBlock(progress: ScanProgressState) {
         )
     }
     Spacer(Modifier.height(14.dp))
-    LinearWavyProgressIndicator(
-        progress = { progress.progressFraction ?: 0f },
-        modifier = Modifier.fillMaxWidth(),
-    )
+    val fraction = progress.progressFraction
+    if (fraction != null) {
+        LinearWavyProgressIndicator(
+            progress = { fraction },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    } else {
+        LinearWavyProgressIndicator(modifier = Modifier.fillMaxWidth())
+    }
     Spacer(Modifier.height(12.dp))
     ScanProgressLabel(progress = progress)
 }
@@ -245,8 +250,18 @@ private fun ScanProgressLabel(progress: ScanProgressState) {
             delay(ETA_TICK_MS)
         }
     }
-    val pct = ((progress.progressFraction ?: 0f) * 100).roundToInt()
-    val eta = etaMinutes(nowMs - progress.startedAtMs, progress.progressFraction ?: 0f)
+    val fraction = progress.progressFraction
+    if (fraction == null) {
+        Text(
+            text = progress.phaseDisplayName,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+    val pct = (fraction * 100).roundToInt()
+    val eta = etaMinutes(nowMs - progress.startedAtMs, fraction)
     Text(
         text = if (eta != null) "$pct% complete  ·  about $eta min left" else "$pct% complete",
         style = MaterialTheme.typography.labelLarge,


### PR DESCRIPTION
Fixes two "Building your library" scan-screen bugs.

## #588 — progress bar pinned at 100% for the whole scan

`progressFraction` was `filesWalked / totalFiles`, and the server pins `filesWalked` at the full file count the instant WALKING ends (with `totalFiles` set to that same number) — so the bar read `N/N = 100%` through the entire long ANALYZING/DIFFING phase.

The only counter that actually advances during analysis is `booksAnalyzed`. Fix drives progress from the analyze pipeline:
- **contract:** add `booksTotal` (candidate-book count) to `ScanEvent.Progress`.
- **server:** emit `booksTotal = candidates.size` from ANALYZING onward (WALKING/GROUPING stay 0).
- **client:** `progressFraction = booksAnalyzed / booksTotal`, coerced to 0..1, and **null while `booksTotal == 0`** (WALKING/GROUPING).
- **UI:** an indeterminate wavy bar + the phase name while the fraction is null; the determinate bar + percent/ETA once analysis starts.

Net: the bar advances smoothly 0→~100% through analyzing instead of snapping to 100% the moment file-walking ends.

## #587 — recently-matched carousel blinks/swaps covers instead of growing

Accumulation and keying were already correct. The churn was `mergeRecentBooks` capping the accumulated strip at 60 and **dropping from the front** — while the marquee deliberately drifts slowly and shows the front (oldest) tiles, so the cap yanked visible tiles out from under the viewport, making it jump.

Fix makes accumulation **pure append-only** (no cap, no front-drop). `ScanBookRef` is tiny (title+author) and a scan is bounded, so retaining every matched book is negligible and the rendering `LazyRow` stays lazy.

## Test plan

- [x] `ScanEventContractTest` round-trips `booksTotal`.
- [x] `ScannerEmbeddedmetaIntegrationTest` asserts a post-ANALYZING Progress event carries `booksTotal` == candidate count (== booksAnalyzed on the all-analyzable fixture).
- [x] New `ScanProgressStateTest`: `progressFraction` null while book total unknown, advances with booksAnalyzed, coerces to 0..1, and does NOT pin at 100% just because files are fully walked.
- [x] `SyncRepositoryScanProgressTest`: maps `booksTotal`; carousel accumulation is append-only (250 books retained in order, nothing dropped).
- [x] Full local gate green: `spotlessCheck` + `detekt`, `:sharedLogic:jvmTest` (incl. Konsist), `:server:test`, `:androidApp:assembleDebug`.
- [ ] On-device: initial scan of a large library → bar advances smoothly (indeterminate briefly during discovery); recently-matched strip only grows, no blink/swap.
- [ ] iOS lanes via remote CI (no Swift fixture constructs `ScanEvent.Progress`, so the new defaulted field is safe).

Closes #588
Closes #587