### PR TITLE
✨ feat: moods & tags in the metadata downloader (#594)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/MetadataDtos.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/MetadataDtos.kt
@@ -40,6 +40,10 @@ data class MetadataBook(
     val series: List<MetadataSeriesRef>,
     /** Genre labels as returned by Audible (may be empty). */
     val genres: List<String>,
+    /** Mood labels scraped from Audible's product topic-tags (may be empty). */
+    val moods: List<String> = emptyList(),
+    /** Trope/theme tag labels scraped from Audible's product topic-tags (may be empty). */
+    val tags: List<String> = emptyList(),
     /** Audible cover thumbnail URL (typically 500×500). */
     val coverUrl: String?,
     /** High-resolution cover URL from iTunes (up to 7000×7000), or `null` if unavailable. */
@@ -217,6 +221,10 @@ data class CoverSearchResults(
  * [genres] carries the raw Audible genre labels selected by the user; the server resolves
  * them through the same 3-step cascade used by the scanner (alias → [GenreNormalizer] →
  * pending). An empty set leaves the book's genres untouched.
+ *
+ * [moods] and [tags] carry the raw Audible mood / trope labels selected by the user; the
+ * server writes the selected values additively through the add-only mood/tag junction writers.
+ * An empty set writes nothing for that dimension.
  */
 @Serializable
 @SerialName("MetadataApplySelection")
@@ -235,4 +243,8 @@ data class MetadataApplySelection(
     @SerialName("coverUrl") val coverUrl: String? = null,
     /** Selected raw genre labels from the match; resolved server-side through the genre cascade. Empty = leave genres untouched. */
     @SerialName("genres") val genres: Set<String> = emptySet(),
+    /** Selected raw mood labels from the match; written additively server-side. Empty = write no moods. */
+    @SerialName("moods") val moods: Set<String> = emptySet(),
+    /** Selected raw trope/tag labels from the match; written additively server-side. Empty = write no tags. */
+    @SerialName("tags") val tags: Set<String> = emptySet(),
 )

--- a/iosApp/ListenUp/Features/Metadata/MetadataMatchMapping.swift
+++ b/iosApp/ListenUp/Features/Metadata/MetadataMatchMapping.swift
@@ -55,13 +55,16 @@ enum MetadataMatchMapping {
         let narrators = contributors(book.narrators, selected: sel.selectedNarrators)
         let seriesItems = series(book.series, selected: sel.selectedSeries)
         let genres = genreSelections(book.genres, selected: sel.selectedGenres)
+        let moods = genreSelections(book.moods, selected: sel.selectedMoods)
+        let tags = genreSelections(book.tags, selected: sel.selectedTags)
         let description = descriptionField(book: book, selections: sel)
 
         let scalarFields = identity + details + (description.map { [$0] } ?? [])
         let counts = selectionCounts(
             scalarFields: scalarFields,
             groups: [authors.map(\.isSelected), narrators.map(\.isSelected),
-                     seriesItems.map(\.isSelected), genres.map(\.isSelected)],
+                     seriesItems.map(\.isSelected), genres.map(\.isSelected),
+                     moods.map(\.isSelected), tags.map(\.isSelected)],
             coverEnabled: sel.cover
         )
 
@@ -78,6 +81,8 @@ enum MetadataMatchMapping {
             narrators: narrators,
             seriesItems: seriesItems,
             genres: genres,
+            moods: moods,
+            tags: tags,
             descriptionField: description,
             coverEnabled: sel.cover,
             coverValueText: String(localized: "metadata.field_cover_value"),

--- a/iosApp/ListenUp/Features/Metadata/MetadataMatchModels.swift
+++ b/iosApp/ListenUp/Features/Metadata/MetadataMatchModels.swift
@@ -54,6 +54,8 @@ struct MetadataPreview: Equatable {
     let narrators: [MetadataContributorSelection]
     let seriesItems: [MetadataSeriesSelection]
     let genres: [MetadataGenreSelection]
+    let moods: [MetadataGenreSelection]
+    let tags: [MetadataGenreSelection]
 
     let descriptionField: MetadataFieldSelection?
 

--- a/iosApp/ListenUp/Features/Metadata/MetadataMatchObserver.swift
+++ b/iosApp/ListenUp/Features/Metadata/MetadataMatchObserver.swift
@@ -86,6 +86,8 @@ final class MetadataMatchObserver {
     func toggleNarrator(_ asin: String) { viewModel.toggleNarrator(asin: asin) }
     func toggleSeries(_ asin: String) { viewModel.toggleSeries(asin: asin) }
     func toggleGenre(_ genre: String) { viewModel.toggleGenre(genre: genre) }
+    func toggleMood(_ mood: String) { viewModel.toggleMood(mood: mood) }
+    func toggleTag(_ tag: String) { viewModel.toggleTag(tag: tag) }
     func selectCover(_ url: String?) { viewModel.selectCover(coverUrl: url) }
 
     func applyMatch() { viewModel.applyMatch() }

--- a/iosApp/ListenUp/Features/Metadata/MetadataSelectView.swift
+++ b/iosApp/ListenUp/Features/Metadata/MetadataSelectView.swift
@@ -106,9 +106,11 @@ struct MetadataSelectBody: View {
                 ForEach(preview.seriesItems) { seriesRow($0) }
             }
 
-            if !preview.genres.isEmpty {
+            if !preview.genres.isEmpty || !preview.moods.isEmpty || !preview.tags.isEmpty {
                 section(String(localized: "metadata.section_classification")) {
-                    genresRow
+                    if !preview.genres.isEmpty { genresRow }
+                    if !preview.moods.isEmpty { moodsRow }
+                    if !preview.tags.isEmpty { tagsRow }
                 }
             }
 
@@ -213,6 +215,42 @@ struct MetadataSelectBody: View {
         }
     }
 
+    private var moodsRow: some View {
+        MetadataFieldRow(
+            systemImage: "theatermasks",
+            label: String(localized: "metadata.field_moods"),
+            isOn: preview.moods.contains { $0.isSelected },
+            onToggle: { toggleAllMoods() }
+        ) {
+            FlowLayout(spacing: 8) {
+                ForEach(preview.moods) { mood in
+                    MetadataGenreChip(label: mood.label, isOn: mood.isSelected) {
+                        observer.toggleMood(mood.id)
+                    }
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private var tagsRow: some View {
+        MetadataFieldRow(
+            systemImage: "number",
+            label: String(localized: "metadata.field_tags"),
+            isOn: preview.tags.contains { $0.isSelected },
+            onToggle: { toggleAllTags() }
+        ) {
+            FlowLayout(spacing: 8) {
+                ForEach(preview.tags) { tag in
+                    MetadataGenreChip(label: tag.label, isOn: tag.isSelected) {
+                        observer.toggleTag(tag.id)
+                    }
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+
     private var chaptersSection: some View {
         section(String(localized: "metadata.section_chapters")) {
             Button(action: onReviewChapters) {
@@ -258,6 +296,20 @@ struct MetadataSelectBody: View {
         let anySelected = preview.genres.contains { $0.isSelected }
         for genre in preview.genres where genre.isSelected == anySelected {
             observer.toggleGenre(genre.id)
+        }
+    }
+
+    private func toggleAllMoods() {
+        let anySelected = preview.moods.contains { $0.isSelected }
+        for mood in preview.moods where mood.isSelected == anySelected {
+            observer.toggleMood(mood.id)
+        }
+    }
+
+    private func toggleAllTags() {
+        let anySelected = preview.tags.contains { $0.isSelected }
+        for tag in preview.tags where tag.isSelected == anySelected {
+            observer.toggleTag(tag.id)
         }
     }
 

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -9181,6 +9181,16 @@
         }
       }
     },
+    "metadata.field_moods": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moods"
+          }
+        }
+      }
+    },
     "metadata.field_narrators": {
       "localizations": {
         "en": {
@@ -9227,6 +9237,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Subtitle"
+          }
+        }
+      }
+    },
+    "metadata.field_tags": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tags"
           }
         }
       }

--- a/iosApp/ListenUpTests/MetadataMatchMappingTests.swift
+++ b/iosApp/ListenUpTests/MetadataMatchMappingTests.swift
@@ -158,6 +158,8 @@ struct MetadataMatchMappingTests {
         narrators: [MetadataContributorRef] = [],
         series: [MetadataSeriesRef] = [],
         genres: [String] = [],
+        moods: [String] = [],
+        tags: [String] = [],
         coverUrl: String? = nil
     ) -> MetadataBook {
         MetadataBook(
@@ -173,6 +175,8 @@ struct MetadataMatchMappingTests {
             narrators: narrators,
             series: series,
             genres: genres,
+            moods: moods,
+            tags: tags,
             coverUrl: coverUrl,
             coverUrlMaxSize: nil
         )
@@ -184,7 +188,9 @@ struct MetadataMatchMappingTests {
         authors: Set<String> = [],
         narrators: Set<String> = [],
         series: Set<String> = [],
-        genres: Set<String> = []
+        genres: Set<String> = [],
+        moods: Set<String> = [],
+        tags: Set<String> = []
     ) -> MetadataSelections {
         MetadataSelections(
             cover: cover,
@@ -197,7 +203,9 @@ struct MetadataMatchMappingTests {
             selectedAuthors: authors,
             selectedNarrators: narrators,
             selectedSeries: series,
-            selectedGenres: genres
+            selectedGenres: genres,
+            selectedMoods: moods,
+            selectedTags: tags
         )
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
@@ -15,9 +15,7 @@ import com.calypsan.listenup.api.sync.CoverSource
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.cover.CoverImageStore
 import com.calypsan.listenup.server.db.BookGenreTable
-import com.calypsan.listenup.server.db.GenreTable
 import com.calypsan.listenup.server.metadata.ImageStorage
-import com.calypsan.listenup.server.metadata.audible.ProductTagClassifier
 import com.calypsan.listenup.server.metadata.provider.MetadataProvider
 import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.ContributorRepository
@@ -25,9 +23,7 @@ import com.calypsan.listenup.server.services.GenreHierarchyFromLadder
 import com.calypsan.listenup.server.services.SeriesRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
-import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 
 private val log = KotlinLogging.logger {}
@@ -51,9 +47,9 @@ private val log = KotlinLogging.logger {}
  *    3-step cascade as the scanner (alias → [GenreNormalizer] → pending), written BEFORE the
  *    text `upsert` so the upsert's `readPayload` re-reads the junction and the genres ride the
  *    same SSE event + revision bump. An empty set leaves existing genres untouched.
- *  - **Enrichment** (always, best-effort) scrapes the matched ASIN's Audible product
- *    topic-tags, classifies them against the book's just-applied genre slugs, and writes the
- *    resulting moods + tropes additively. Never fails the match (see [applyEnrichmentBestEffort]).
+ *  - **Enrichment** (best-effort) writes the user's selected moods + tropes from the apply
+ *    [selection] additively (the values were scraped + classified at lookup time and chosen by the
+ *    user as chips). Never fails the match (see [applyEnrichmentBestEffort]).
  *  - **Cover** (when selected) downloads the wizard's chosen cover URL and stores it as
  *    [CoverSource.UPLOADED] — an explicit user choice that wins over any existing cover.
  *
@@ -94,11 +90,7 @@ internal class BookMetadataApplier(
 
             applyGenresBestEffort(bookId, asin, selection)
             applyGenreHierarchyBestEffort(bookId, asin, region, selection)
-
-            // Computed AFTER the genre apply so it reflects the user's actual selection
-            // (the just-linked junction rows), not the raw match. Read once, reused per tag.
-            val appliedGenreSlugs = appliedGenreSlugs(bookId)
-            applyEnrichmentBestEffort(bookId, asin, region, appliedGenreSlugs)
+            applyEnrichmentBestEffort(bookId, asin, selection)
 
             val updated =
                 existing.copy(
@@ -254,61 +246,40 @@ internal class BookMetadataApplier(
     }
 
     /**
-     * The canonical genre slugs currently linked to [bookId]. Joins the book's
-     * applied-genre ids ([BookGenreTable.genresForBook]) to their [GenreTable.slug]
-     * values in a single transaction, so the classifier's genre-exclusion check
-     * reflects the user's actual selection (the rows just linked by
-     * [applyGenresBestEffort] / [applyGenreHierarchyBestEffort]) rather than the raw
-     * match. Returns an empty set when the book has no linked genres.
-     */
-    private suspend fun appliedGenreSlugs(bookId: BookId): Set<String> =
-        suspendTransaction(db) {
-            val ids = BookGenreTable.genresForBook(bookId.value)
-            if (ids.isEmpty()) {
-                emptySet()
-            } else {
-                GenreTable
-                    .selectAll()
-                    .where { GenreTable.id inList ids }
-                    .mapTo(mutableSetOf()) { it[GenreTable.slug] }
-            }
-        }
-
-    /**
-     * Enriches [bookId] with the matched ASIN's Audible product topic-tags: scrapes the
-     * tags via [MetadataEnrichmentDeps.productTagSource] (matched [region] + [asin]),
-     * classifies them against [appliedGenreSlugs] via [ProductTagClassifier] (mood → moods,
-     * theme → tropes minus already-applied genres), then writes the classified moods and
-     * tropes additively through [BookMoodWriter][com.calypsan.listenup.server.services.BookMoodWriter]
-     * and [BookTagWriter][com.calypsan.listenup.server.services.BookTagWriter]. Both writers
-     * are add-only — existing moods/tags are never wiped.
+     * Writes the user's selected moods and tropes from [selection] additively through
+     * [BookMoodWriter][com.calypsan.listenup.server.services.BookMoodWriter] and
+     * [BookTagWriter][com.calypsan.listenup.server.services.BookTagWriter]. Both writers are
+     * add-only — existing moods/tags are never wiped.
      *
-     * Runs AFTER the genre apply so [appliedGenreSlugs] reflects the user's selection.
-     * Best-effort: a failure (scrape error, classify error, write error) is logged and
-     * skipped so the already-committed match is never rolled back. [CancellationException]
-     * is always re-raised. No-ops when the scrape yields no tags.
+     * The moods/tags were scraped + classified at lookup time (see
+     * `MetadataLookupServiceImpl.enrichWithMoodsAndTags`) and presented to the user as toggleable
+     * chips; the apply path honors that selection rather than re-scraping, so a deselected mood/tag
+     * is never written. An empty set for a dimension writes nothing for it.
      *
-     * Limitation (#573): re-matching a book ACCUMULATES moods/tropes — the writers are
-     * add-only, so a second apply adds the new match's tags on top of the first's. A future
+     * Best-effort: a write error is logged and skipped so the already-committed match is never
+     * rolled back. [CancellationException] is always re-raised. No-ops when both sets are empty.
+     *
+     * Limitation (#573): re-matching a book ACCUMULATES moods/tropes — the writers are add-only,
+     * so a second apply adds the new selection's tags on top of the first's. A future
      * selective-apply surface (#573) is the fix; for now accumulation is the accepted shape.
      */
     private suspend fun applyEnrichmentBestEffort(
         bookId: BookId,
         asin: String,
-        region: AudibleRegion,
-        appliedGenreSlugs: Set<String>,
+        selection: MetadataApplySelection,
     ) {
+        if (selection.moods.isEmpty() && selection.tags.isEmpty()) return
         try {
-            val productTags = enrichmentDeps.productTagSource(region, asin)
-            if (productTags.isEmpty()) return
-
-            val classified = ProductTagClassifier.classify(productTags, appliedGenreSlugs)
-            enrichmentDeps.bookMoodWriter.writeMoods(bookId, classified.moods)
-            enrichmentDeps.bookTagWriter.writeScanTags(bookId, classified.tags)
+            if (selection.moods.isNotEmpty()) {
+                enrichmentDeps.bookMoodWriter.writeMoods(bookId, selection.moods.toList())
+            }
+            if (selection.tags.isNotEmpty()) {
+                enrichmentDeps.bookTagWriter.writeScanTags(bookId, selection.tags.toList())
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            log.warn(e) { "Audible enrichment failed for ${bookId.value} (ASIN $asin) — skipping" }
+            log.warn(e) { "Audible enrichment write failed for ${bookId.value} (ASIN $asin) — skipping" }
         }
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPermissionPolicy
 import com.calypsan.listenup.server.metadata.audible.AudibleContributorProfile
 import com.calypsan.listenup.server.media.ImageStore
+import com.calypsan.listenup.server.metadata.audible.ProductTagClassifier
 import com.calypsan.listenup.server.metadata.provider.MetadataProvider
 import com.calypsan.listenup.server.metadata.provider.MetadataSource
 import com.calypsan.listenup.server.services.BookRepository
@@ -28,11 +29,15 @@ import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.CoverSearchService
 import com.calypsan.listenup.server.services.GenreAutoCreator
 import com.calypsan.listenup.server.services.GenreHierarchyFromLadder
+import com.calypsan.listenup.server.services.GenreNormalizer
 import com.calypsan.listenup.server.services.GenreRepository
 import com.calypsan.listenup.server.services.MetadataService
 import com.calypsan.listenup.server.services.SeriesRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import org.jetbrains.exposed.v1.jdbc.Database
+
+private val log = KotlinLogging.logger {}
 
 /**
  * Server-side implementation of [MetadataLookupService].
@@ -123,7 +128,7 @@ internal class MetadataLookupServiceImpl(
     override suspend fun getBookMetadata(
         asin: String,
         region: AudibleRegion,
-    ): AppResult<MetadataBook?> = audible.getBook(asin, region).enrichWithItunesCover()
+    ): AppResult<MetadataBook?> = audible.getBook(asin, region).enrichWithItunesCover().enrichWithMoodsAndTags(region)
 
     override suspend fun getBookChapters(
         asin: String,
@@ -154,7 +159,7 @@ internal class MetadataLookupServiceImpl(
         region: AudibleRegion,
     ): AppResult<MetadataBook?> {
         requireCanEdit()?.let { return AppResult.Failure(it) }
-        return audible.getBook(asin, region, refresh = true).enrichWithItunesCover()
+        return audible.getBook(asin, region, refresh = true).enrichWithItunesCover().enrichWithMoodsAndTags(region)
     }
 
     /**
@@ -179,6 +184,39 @@ internal class MetadataLookupServiceImpl(
         val hit = (metadataService.findCover(book.title, author) as? AppResult.Success)?.data ?: return this
         val maxUrl = hit.maxSizeUrl.takeIf { it.isNotBlank() } ?: return this
         return AppResult.Success(book.copy(coverUrlMaxSize = maxUrl))
+    }
+
+    /**
+     * Grafts the matched book's Audible moods and tropes onto a single-book metadata result so
+     * the metadata wizard's preview can show them as toggleable chips alongside genres.
+     *
+     * Scrapes the matched ASIN's Audible product topic-tags via the same
+     * [MetadataEnrichmentDeps.productTagSource] the apply path uses, then classifies them via
+     * [ProductTagClassifier] — `mood` tags become [MetadataBook.moods], `theme` tags become
+     * [MetadataBook.tags] minus any theme that canonicalizes to a genre already on the match (the
+     * exclusion set is derived from the match's own [MetadataBook.genres] through
+     * [GenreNormalizer.normalizeToSlugs], mirroring the apply path's slug-based exclusion).
+     *
+     * Best-effort: a missing book, an empty scrape, or any classifier error leaves moods/tags
+     * empty so the rest of the metadata still flows. One product-page request per preview load —
+     * behind the existing loading state. [CancellationException] is always re-raised.
+     */
+    private suspend fun AppResult<MetadataBook?>.enrichWithMoodsAndTags(
+        region: AudibleRegion,
+    ): AppResult<MetadataBook?> {
+        val book = (this as? AppResult.Success)?.data ?: return this
+        return try {
+            val productTags = enrichmentDeps.productTagSource(region, book.asin)
+            if (productTags.isEmpty()) return this
+            val appliedGenreSlugs = book.genres.flatMap { GenreNormalizer.normalizeToSlugs(it) }.toSet()
+            val classified = ProductTagClassifier.classify(productTags, appliedGenreSlugs)
+            AppResult.Success(book.copy(moods = classified.moods, tags = classified.tags))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Mood/tag enrichment failed for ASIN ${book.asin} in region $region — leaving empty" }
+            this
+        }
     }
 
     override suspend fun applyBookMetadata(

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/MetadataApplyEnrichmentTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/MetadataApplyEnrichmentTest.kt
@@ -78,8 +78,7 @@ private val TINY_JPEG =
         0x00,
     )
 
-// Genres are NOT selected here, so the applied-genre slug set is empty and the classifier's
-// genre-exclusion never fires — the test focuses purely on the mood/trope enrichment seam.
+// Base selection with no moods/tags chosen — used as the starting point each test copies from.
 private val ENRICH_SELECTION =
     MetadataApplySelection(
         title = true,
@@ -95,61 +94,61 @@ private val ENRICH_SELECTION =
     )
 
 /**
- * Task 7 — verifies the best-effort Audible mood/trope enrichment wired into the
- * metadata-apply path:
+ * Verifies the user-selected Audible mood/trope enrichment wired into the metadata-apply path.
  *
- *  - **Happy path:** a stubbed `productTagSource` returning known `mood` + `theme` tags
- *    persists the expected moods (`book_moods`) and tropes (`book_tags`); non-mood/theme
- *    types (`genre`) are dropped by the classifier.
- *  - **Best-effort boundary:** a `productTagSource` that THROWS leaves the match successful
- *    with no moods/tropes — enrichment never fails the apply.
- *  - **Additive re-match (#573):** re-applying with a second product-tag set accumulates the
+ * The applier no longer re-scrapes Audible at apply time: moods + tropes are scraped and
+ * classified at lookup time (see `MetadataLookupServiceImpl.enrichWithMoodsAndTags`) and
+ * presented to the user as toggleable chips. The apply path honors that selection —
+ * [MetadataApplySelection.moods] / [MetadataApplySelection.tags] — writing the chosen values
+ * additively. This test covers:
+ *
+ *  - **Happy path:** a selection carrying moods + tags persists them to `book_moods` /
+ *    `book_tags`; a value the user deselected is never written.
+ *  - **Empty selection:** a selection with no moods/tags writes nothing, but the match still
+ *    succeeds (the text metadata commits regardless).
+ *  - **Additive re-match (#573):** re-applying with a second selection accumulates the
  *    moods/tropes (the writers are add-only). Selective apply is the future #573 fix.
  *
- * Drives [BookMetadataApplier] directly (rather than through [MetadataLookupServiceImpl]) so
- * the stub `productTagSource` and the same mood/tag repositories used for assertion are
- * injected without round-tripping the DI module.
+ * Drives [BookMetadataApplier] directly (rather than through [MetadataLookupServiceImpl]) so the
+ * same mood/tag repositories used for assertion are injected without round-tripping the DI module.
+ * The `productTagSource` is no longer consulted by the apply path; the stub asserts that.
  */
 class MetadataApplyEnrichmentTest :
     FunSpec({
 
-        test("enrichment persists classified moods + tropes; non-mood/theme types dropped") {
+        test("apply persists the user-selected moods + tags") {
             withInMemoryDatabase {
                 val ctx = enrichmentCtx(this)
-                val productTags =
-                    listOf(
-                        ProductTag(type = "mood", name = "Feel-Good"),
-                        ProductTag(type = "mood", name = "Tense"),
-                        ProductTag(type = "theme", name = "Found Family"),
-                        ProductTag(type = "genre", name = "Fantasy"), // dropped by the classifier
+                // The apply path must NOT scrape — a throwing source proves moods/tags come from the selection.
+                val applier = ctx.applier { _, _ -> error("apply must not scrape product tags") }
+                val selection =
+                    ENRICH_SELECTION.copy(
+                        moods = setOf("Feel-Good", "Tense"),
+                        tags = setOf("Found Family"),
                     )
-                val applier = ctx.applier { _, _ -> productTags }
 
                 runTest {
                     ctx.bookRepo.upsert(minimalEnrichBook(BOOK_ID), clientOpId = null)
 
-                    val result = applier.apply(BookId(BOOK_ID), ENRICH_ASIN, AudibleRegion.US, ENRICH_SELECTION)
+                    val result = applier.apply(BookId(BOOK_ID), ENRICH_ASIN, AudibleRegion.US, selection)
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                     ctx.moodNamesForBook(BOOK_ID) shouldContainExactlyInAnyOrder listOf("Feel-Good", "Tense")
                     ctx.tagNamesForBook(BOOK_ID) shouldContainExactlyInAnyOrder listOf("Found Family")
-                    // "Fantasy" (a genre-typed product tag) was never persisted as a trope.
-                    ctx.tagNamesForBook(BOOK_ID).none { it == "Fantasy" } shouldBe true
                 }
             }
         }
 
-        test("a throwing productTagSource still succeeds with no moods/tropes (best-effort)") {
+        test("an empty mood/tag selection writes nothing but still succeeds") {
             withInMemoryDatabase {
                 val ctx = enrichmentCtx(this)
-                val applier = ctx.applier { _, _ -> error("simulated scrape failure") }
+                val applier = ctx.applier { _, _ -> error("apply must not scrape product tags") }
 
                 runTest {
                     ctx.bookRepo.upsert(minimalEnrichBook(BOOK_ID), clientOpId = null)
 
                     val result = applier.apply(BookId(BOOK_ID), ENRICH_ASIN, AudibleRegion.US, ENRICH_SELECTION)
 
-                    // Best-effort: the match still committed despite the scrape throwing.
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
                     ctx.bookRepo.findById(BookId(BOOK_ID))?.description shouldBe "An enriched description."
 
@@ -159,66 +158,31 @@ class MetadataApplyEnrichmentTest :
             }
         }
 
-        // C3 integration seam: a theme product-tag whose CANONICAL slug matches an applied genre
-        // is dropped from tropes (it would otherwise leak the genre back in as a tag), while a
-        // non-colliding theme survives. Exercises the full
-        // applyGenresBestEffort → appliedGenreSlugs(read, post-apply) → classify(slugs) chain,
-        // not just ProductTagClassifier in isolation. Collision pair mirrors the classifier's own
-        // C3 case: applied genre "Science Fiction" + theme "Sci-Fi" both canonicalize to
-        // `science-fiction` via GenreNormalizer, so the alias-aware (not naive-slugify) exclusion fires.
-        test("a theme product-tag matching an applied genre is excluded from tropes") {
-            withInMemoryDatabase {
-                val ctx = enrichmentCtx(this)
-                val selectionWithGenre = ENRICH_SELECTION.copy(genres = setOf("Science Fiction"))
-                val productTags =
-                    listOf(
-                        ProductTag(type = "theme", name = "Sci-Fi"), // collides with applied genre → dropped
-                        ProductTag(type = "theme", name = "Survival"), // no collision → survives as a trope
-                        ProductTag(type = "mood", name = "Tense"), // a mood regardless of genres
-                    )
-                val applier = ctx.applier { _, _ -> productTags }
-
-                runTest {
-                    ctx.bookRepo.upsert(minimalEnrichBook(BOOK_ID), clientOpId = null)
-
-                    val result = applier.apply(BookId(BOOK_ID), ENRICH_ASIN, AudibleRegion.US, selectionWithGenre)
-                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
-
-                    // The applied genre is linked (so appliedGenreSlugs is non-empty and the exclusion can fire).
-                    ctx.bookRepo
-                        .findById(BookId(BOOK_ID))!!
-                        .genres
-                        .map { it.name } shouldContainExactlyInAnyOrder
-                        listOf("Science Fiction")
-
-                    // The colliding theme is gone; the non-colliding theme survives.
-                    ctx.tagNamesForBook(BOOK_ID) shouldContainExactlyInAnyOrder listOf("Survival")
-                    ctx.tagNamesForBook(BOOK_ID).none { it == "Sci-Fi" } shouldBe true
-
-                    // Moods are unaffected by the genre-exclusion filter.
-                    ctx.moodNamesForBook(BOOK_ID) shouldContainExactlyInAnyOrder listOf("Tense")
-                }
-            }
-        }
-
         // #573: re-matching ACCUMULATES moods/tropes because the writers are add-only.
         // A future selective-apply surface (#573) is the fix; for now accumulation is expected.
         test("re-match accumulates moods + tropes (additive, #573)") {
             withInMemoryDatabase {
                 val ctx = enrichmentCtx(this)
+                val applier = ctx.applier { _, _ -> error("apply must not scrape product tags") }
 
                 runTest {
                     ctx.bookRepo.upsert(minimalEnrichBook(BOOK_ID), clientOpId = null)
 
-                    ctx
-                        .applier { _, _ -> listOf(ProductTag("mood", "Tense"), ProductTag("theme", "Heist")) }
-                        .apply(BookId(BOOK_ID), ENRICH_ASIN, AudibleRegion.US, ENRICH_SELECTION)
-                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    applier
+                        .apply(
+                            BookId(BOOK_ID),
+                            ENRICH_ASIN,
+                            AudibleRegion.US,
+                            ENRICH_SELECTION.copy(moods = setOf("Tense"), tags = setOf("Heist")),
+                        ).shouldBeInstanceOf<AppResult.Success<Unit>>()
 
-                    ctx
-                        .applier { _, _ -> listOf(ProductTag("mood", "Hopeful"), ProductTag("theme", "Revenge")) }
-                        .apply(BookId(BOOK_ID), ENRICH_ASIN, AudibleRegion.US, ENRICH_SELECTION)
-                        .shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    applier
+                        .apply(
+                            BookId(BOOK_ID),
+                            ENRICH_ASIN,
+                            AudibleRegion.US,
+                            ENRICH_SELECTION.copy(moods = setOf("Hopeful"), tags = setOf("Revenge")),
+                        ).shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                     ctx.moodNamesForBook(BOOK_ID) shouldContainExactlyInAnyOrder listOf("Tense", "Hopeful")
                     ctx.tagNamesForBook(BOOK_ID) shouldContainExactlyInAnyOrder listOf("Heist", "Revenge")

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
@@ -45,6 +45,7 @@ import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.testEnrichmentDeps
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -173,6 +174,68 @@ class MetadataLookupServiceImplTest :
                     book.shouldNotBeNull()
                     book.coverUrl shouldBe "https://audible.test/cover.jpg"
                     book.coverUrlMaxSize shouldBe null
+                }
+            }
+        }
+
+        // ── getBookMetadata mood/tag enrichment ───────────────────────────────
+
+        test("getBookMetadata populates moods + tags from the classified product tags") {
+            withInMemoryDatabase {
+                val audible = BookStubAudibleApi(bookWithCover("https://audible.test/cover.jpg"))
+                val productTags =
+                    listOf(
+                        ProductTag(type = "mood", name = "Feel-Good"),
+                        ProductTag(type = "mood", name = "Tense"),
+                        ProductTag(type = "theme", name = "Found Family"),
+                        ProductTag(type = "genre", name = "Fantasy"), // dropped by the classifier
+                    )
+                val service = makeService(audible = audible, db = this, productTagSource = { _, _ -> productTags })
+
+                runTest {
+                    val result = service.getBookMetadata("B0TESTASIN", AudibleRegion.US)
+                    val book = result.shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataBook?>>().data
+                    book.shouldNotBeNull()
+                    book.moods shouldContainExactlyInAnyOrder listOf("Feel-Good", "Tense")
+                    book.tags shouldContainExactlyInAnyOrder listOf("Found Family")
+                }
+            }
+        }
+
+        test("getBookMetadata excludes a theme whose canonical slug matches one of the book's genres") {
+            withInMemoryDatabase {
+                // The book carries genre "Science Fiction"; a "Sci-Fi" theme canonicalizes to the same slug.
+                val audible = BookStubAudibleApi(bookWithGenres(listOf("Science Fiction")))
+                val productTags =
+                    listOf(
+                        ProductTag(type = "theme", name = "Sci-Fi"), // collides with the book genre → dropped
+                        ProductTag(type = "theme", name = "Survival"), // no collision → survives
+                        ProductTag(type = "mood", name = "Tense"),
+                    )
+                val service = makeService(audible = audible, db = this, productTagSource = { _, _ -> productTags })
+
+                runTest {
+                    val result = service.getBookMetadata("B0TESTASIN", AudibleRegion.US)
+                    val book = result.shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataBook?>>().data
+                    book.shouldNotBeNull()
+                    book.tags shouldContainExactlyInAnyOrder listOf("Survival")
+                    book.moods shouldContainExactlyInAnyOrder listOf("Tense")
+                }
+            }
+        }
+
+        test("getBookMetadata leaves moods + tags empty when the product-tag scrape throws") {
+            withInMemoryDatabase {
+                val audible = BookStubAudibleApi(bookWithCover("https://audible.test/cover.jpg"))
+                val service =
+                    makeService(audible = audible, db = this, productTagSource = { _, _ -> error("scrape failed") })
+
+                runTest {
+                    val result = service.getBookMetadata("B0TESTASIN", AudibleRegion.US)
+                    val book = result.shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataBook?>>().data
+                    book.shouldNotBeNull()
+                    book.moods shouldHaveSize 0
+                    book.tags shouldHaveSize 0
                 }
             }
         }
@@ -316,6 +379,25 @@ private fun bookWithCover(coverUrl: String): AudibleBook =
         ratingCount = 0,
     )
 
+private fun bookWithGenres(genres: List<String>): AudibleBook =
+    AudibleBook(
+        asin = "B0TESTASIN",
+        title = "The Way of Kings",
+        subtitle = "",
+        authors = emptyList(),
+        narrators = emptyList(),
+        publisher = "",
+        releaseDate = "",
+        runtimeMinutes = 0,
+        description = "",
+        coverUrl = "",
+        series = emptyList(),
+        genres = genres,
+        language = "",
+        rating = 0f,
+        ratingCount = 0,
+    )
+
 private fun bookFixture(bookId: String): BookSyncPayload =
     BookSyncPayload(
         id = bookId,
@@ -367,6 +449,7 @@ private fun makeService(
     audible: AudibleApi,
     db: Database,
     itunes: ITunesApi = NoOpITunesApi(),
+    productTagSource: suspend (AudibleRegion, String) -> List<ProductTag> = { _, _ -> emptyList() },
 ): MetadataLookupServiceImpl {
     val tempDir = Files.createTempDirectory("metadata-test-").toAbsolutePath()
     val metadataService =
@@ -407,7 +490,7 @@ private fun makeService(
                 coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), maxBytes = 10L * 1024 * 1024)),
                 imageHome = Path(tempDir.toString()),
             ),
-        enrichmentDeps = testEnrichmentDeps(db, bus, syncRegistry),
+        enrichmentDeps = testEnrichmentDeps(db, bus, syncRegistry, productTagSource = productTagSource),
         permissionPolicy = UserPermissionPolicy(db),
         db = db,
         genreRepository = genreRepo,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
@@ -38,6 +38,8 @@ data class MetadataSelections(
     val selectedNarrators: Set<String> = emptySet(),
     val selectedSeries: Set<String> = emptySet(),
     val selectedGenres: Set<String> = emptySet(),
+    val selectedMoods: Set<String> = emptySet(),
+    val selectedTags: Set<String> = emptySet(),
 )
 
 /** Simple metadata fields that can be toggled as a unit. */
@@ -424,6 +426,10 @@ class MetadataViewModel(
 
     fun toggleGenre(genre: String) = updateReadySelections { it.copy(selectedGenres = it.selectedGenres.toggle(genre)) }
 
+    fun toggleMood(mood: String) = updateReadySelections { it.copy(selectedMoods = it.selectedMoods.toggle(mood)) }
+
+    fun toggleTag(tag: String) = updateReadySelections { it.copy(selectedTags = it.selectedTags.toggle(tag)) }
+
     /** Pick a cover URL (null = use the Audible default from the preview). */
     fun selectCover(coverUrl: String?) {
         updateReady { it.copy(selectedCoverUrl = coverUrl) }
@@ -725,6 +731,8 @@ class MetadataViewModel(
             seriesAsins = selectedSeries,
             coverUrl = coverUrl,
             genres = selectedGenres,
+            moods = selectedMoods,
+            tags = selectedTags,
         )
 
     private fun initializeSelections(preview: MetadataBook): MetadataSelections =
@@ -740,6 +748,8 @@ class MetadataViewModel(
             selectedNarrators = preview.narrators.mapNotNull { it.asin }.toSet(),
             selectedSeries = preview.series.mapNotNull { it.asin }.toSet(),
             selectedGenres = preview.genres.toSet(),
+            selectedMoods = preview.moods.toSet(),
+            selectedTags = preview.tags.toSet(),
         )
 
     /**

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -526,6 +526,8 @@
     "field_authors": "Authors",
     "field_narrators": "Narrators",
     "field_genres": "Genres",
+    "field_moods": "Moods",
+    "field_tags": "Tags",
     "field_description": "Description",
     "field_publisher": "Publisher",
     "field_language": "Language",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/MetadataLookupContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/MetadataLookupContractTest.kt
@@ -82,6 +82,8 @@ class MetadataLookupContractTest :
                         ),
                     series = listOf(MetadataSeriesRef(asin = "B001S1", title = "Stormlight Archive", sequence = "1")),
                     genres = listOf("Fantasy", "Epic Fantasy"),
+                    moods = listOf("Adventurous", "Epic"),
+                    tags = listOf("Chosen One", "Magic System"),
                     coverUrl = "https://m.media-amazon.com/images/I/example.jpg",
                     coverUrlMaxSize = "https://is1-ssl.mzstatic.com/image/thumb/example/7000x7000bb.jpg",
                 )
@@ -116,8 +118,8 @@ class MetadataLookupContractTest :
                 MetadataSearchResults(
                     hits =
                         listOf(
-                            MetadataBook("B001", "Book A", null, null, null, null, 600, null, emptyList(), emptyList(), emptyList(), emptyList(), null, null),
-                            MetadataBook("B002", "Book B", "Sub B", null, "Pub B", "2020-01-01", 720, "en-US", emptyList(), emptyList(), emptyList(), emptyList(), "http://cover.jpg", null),
+                            MetadataBook("B001", "Book A", null, null, null, null, 600, null, emptyList(), emptyList(), emptyList(), emptyList(), coverUrl = null, coverUrlMaxSize = null),
+                            MetadataBook("B002", "Book B", "Sub B", null, "Pub B", "2020-01-01", 720, "en-US", emptyList(), emptyList(), emptyList(), emptyList(), coverUrl = "http://cover.jpg", coverUrlMaxSize = null),
                         ),
                 )
             roundTrip<MetadataSearchResults>(results) shouldBe results

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/dto/MetadataApplySelectionContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/dto/MetadataApplySelectionContractTest.kt
@@ -45,6 +45,27 @@ class MetadataApplySelectionContractTest :
             json.decodeFromString(MetadataApplySelection.serializer(), json.encodeToString(MetadataApplySelection.serializer(), selection)) shouldBe selection
         }
 
+        test("MetadataApplySelection round-trips with selected moods and tags") {
+            val selection =
+                MetadataApplySelection(
+                    title = true,
+                    subtitle = false,
+                    description = true,
+                    publisher = false,
+                    releaseDate = true,
+                    language = false,
+                    cover = true,
+                    authorAsins = setOf("B01AUTHOR"),
+                    narratorAsins = emptySet(),
+                    seriesAsins = emptySet(),
+                    coverUrl = null,
+                    genres = setOf("Fantasy"),
+                    moods = setOf("Dark", "Tense"),
+                    tags = setOf("Found Family", "Slow Burn"),
+                )
+            json.decodeFromString(MetadataApplySelection.serializer(), json.encodeToString(MetadataApplySelection.serializer(), selection)) shouldBe selection
+        }
+
         test("MetadataApplySelection survives a JSON round-trip") {
             val selection =
                 MetadataApplySelection(

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
@@ -59,6 +59,8 @@ class MetadataViewModelTest :
                 narrators = listOf(MetadataContributorRef(asin = "N1", name = "Narrator One")),
                 series = emptyList(),
                 genres = listOf("Fantasy", "Sci-Fi"),
+                moods = listOf("Dark", "Hopeful"),
+                tags = listOf("Found Family", "Slow Burn"),
                 coverUrl = "https://example.com/cover.jpg",
                 coverUrlMaxSize = "https://example.com/cover-max.jpg",
             )
@@ -387,6 +389,8 @@ class MetadataViewModelTest :
                             narratorAsins = setOf("N1"),
                             seriesAsins = emptySet(),
                             genres = setOf("Fantasy", "Sci-Fi"),
+                            moods = setOf("Dark", "Hopeful"),
+                            tags = setOf("Found Family", "Slow Burn"),
                         ),
                     )
                 }
@@ -427,6 +431,8 @@ class MetadataViewModelTest :
                             seriesAsins = emptySet(),
                             coverUrl = "https://itunes/hd.jpg",
                             genres = setOf("Fantasy", "Sci-Fi"),
+                            moods = setOf("Dark", "Hopeful"),
+                            tags = setOf("Found Family", "Slow Burn"),
                         ),
                     )
                 }
@@ -467,6 +473,51 @@ class MetadataViewModelTest :
                             seriesAsins = emptySet(),
                             coverUrl = null,
                             genres = setOf("Fantasy"),
+                            moods = setOf("Dark", "Hopeful"),
+                            tags = setOf("Found Family", "Slow Burn"),
+                        ),
+                    )
+                }
+            }
+        }
+
+        test("applyMatch forwards selected moods + tags; initializeSelections seeds them from the preview") {
+            runTest {
+                val book = makeBook()
+                val repo = mock<MetadataRepository>()
+                everySuspend { repo.getBookMetadata(any(), any()) } returns AppResult.Success(book)
+                everySuspend { repo.applyBookMetadata(any(), any(), any(), any()) } returns AppResult.Success(Unit)
+                val vm = buildVm(repo)
+
+                vm.initForBook("b1", "Dune", "FH")
+                vm.selectMatch(book)
+                advanceUntilIdle()
+
+                vm.toggleMood("Hopeful") // turn one mood off
+                vm.toggleTag("Slow Burn") // turn one tag off
+                vm.applyMatch()
+                advanceUntilIdle()
+
+                verifySuspend {
+                    repo.applyBookMetadata(
+                        BookId("b1"),
+                        "B001",
+                        AudibleRegion.US,
+                        MetadataApplySelection(
+                            title = true,
+                            subtitle = true,
+                            description = true,
+                            publisher = true,
+                            releaseDate = true,
+                            language = true,
+                            cover = true,
+                            authorAsins = setOf("A1"),
+                            narratorAsins = setOf("N1"),
+                            seriesAsins = emptySet(),
+                            coverUrl = null,
+                            genres = setOf("Fantasy", "Sci-Fi"),
+                            moods = setOf("Dark"),
+                            tags = setOf("Found Family"),
                         ),
                     )
                 }

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -919,11 +919,13 @@ One beautiful library.</string>
     <string name="metadata_field_description">Description</string>
     <string name="metadata_field_genres">Genres</string>
     <string name="metadata_field_language">Language</string>
+    <string name="metadata_field_moods">Moods</string>
     <string name="metadata_field_narrators">Narrators</string>
     <string name="metadata_field_publisher">Publisher</string>
     <string name="metadata_field_release_date">Release date</string>
     <string name="metadata_field_series">Series</string>
     <string name="metadata_field_subtitle">Subtitle</string>
+    <string name="metadata_field_tags">Tags</string>
     <string name="metadata_field_title">Title</string>
     <string name="metadata_fields_selected">%1$d of %2$d selected</string>
     <string name="metadata_find_on_audible">Find on Audible</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewRoute.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewRoute.kt
@@ -150,6 +150,8 @@ fun MatchPreviewRoute(
                 onToggleNarrator = metadataViewModel::toggleNarrator,
                 onToggleSeries = metadataViewModel::toggleSeries,
                 onToggleGenre = metadataViewModel::toggleGenre,
+                onToggleMood = metadataViewModel::toggleMood,
+                onToggleTag = metadataViewModel::toggleTag,
                 onApply = metadataViewModel::applyMatch,
                 onBack = onBack,
             )

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewScreen.kt
@@ -87,8 +87,10 @@ import listenup.composeapp.generated.resources.metadata_field_authors
 import listenup.composeapp.generated.resources.metadata_field_description
 import listenup.composeapp.generated.resources.metadata_field_genres
 import listenup.composeapp.generated.resources.metadata_field_language
+import listenup.composeapp.generated.resources.metadata_field_moods
 import listenup.composeapp.generated.resources.metadata_field_narrators
 import listenup.composeapp.generated.resources.metadata_field_publisher
+import listenup.composeapp.generated.resources.metadata_field_tags
 import listenup.composeapp.generated.resources.metadata_field_subtitle
 import listenup.composeapp.generated.resources.metadata_field_title
 import listenup.composeapp.generated.resources.metadata_metadata_is_up_to_date
@@ -142,22 +144,12 @@ fun MatchPreviewScreen(
     onToggleNarrator: (String) -> Unit,
     onToggleSeries: (String) -> Unit,
     onToggleGenre: (String) -> Unit,
+    onToggleMood: (String) -> Unit,
+    onToggleTag: (String) -> Unit,
     onApply: () -> Unit,
     onBack: () -> Unit,
 ) {
-    // Check if any field is selected
-    val hasAnySelected =
-        selections.cover ||
-            selections.title ||
-            selections.subtitle ||
-            selections.description ||
-            selections.publisher ||
-            selections.releaseDate ||
-            selections.language ||
-            selections.selectedAuthors.isNotEmpty() ||
-            selections.selectedNarrators.isNotEmpty() ||
-            selections.selectedSeries.isNotEmpty() ||
-            selections.selectedGenres.isNotEmpty()
+    val hasAnySelected = selections.hasAnySelected()
 
     Scaffold(
         topBar = {
@@ -212,21 +204,7 @@ fun MatchPreviewScreen(
                     }
                 }
 
-                // Check if there's any metadata available
-                val hasAnyData =
-                    newMetadata.coverUrl != null ||
-                        newMetadata.title.isNotBlank() ||
-                        !newMetadata.subtitle.isNullOrBlank() ||
-                        newMetadata.authors.isNotEmpty() ||
-                        newMetadata.narrators.isNotEmpty() ||
-                        newMetadata.series.isNotEmpty() ||
-                        newMetadata.genres.isNotEmpty() ||
-                        !newMetadata.description.isNullOrBlank() ||
-                        !newMetadata.publisher.isNullOrBlank() ||
-                        !newMetadata.language.isNullOrBlank() ||
-                        !newMetadata.releaseDate.isNullOrBlank()
-
-                if (!hasAnyData) {
+                if (!newMetadata.hasAnyData()) {
                     item {
                         if (previewNotFound) {
                             NoMetadataAvailableMessage(selectedRegion = selectedRegion)
@@ -250,12 +228,46 @@ fun MatchPreviewScreen(
                         onToggleNarrator = onToggleNarrator,
                         onToggleSeries = onToggleSeries,
                         onToggleGenre = onToggleGenre,
+                        onToggleMood = onToggleMood,
+                        onToggleTag = onToggleTag,
                     )
                 }
             }
         }
     }
 }
+
+/** True when at least one metadata field is selected for apply — gates the Apply button. */
+private fun MetadataSelections.hasAnySelected(): Boolean =
+    cover ||
+        title ||
+        subtitle ||
+        description ||
+        publisher ||
+        releaseDate ||
+        language ||
+        selectedAuthors.isNotEmpty() ||
+        selectedNarrators.isNotEmpty() ||
+        selectedSeries.isNotEmpty() ||
+        selectedGenres.isNotEmpty() ||
+        selectedMoods.isNotEmpty() ||
+        selectedTags.isNotEmpty()
+
+/** True when the match carries any displayable metadata — gates the "no metadata" placeholder. */
+private fun MetadataBook.hasAnyData(): Boolean =
+    coverUrl != null ||
+        title.isNotBlank() ||
+        !subtitle.isNullOrBlank() ||
+        authors.isNotEmpty() ||
+        narrators.isNotEmpty() ||
+        series.isNotEmpty() ||
+        genres.isNotEmpty() ||
+        moods.isNotEmpty() ||
+        tags.isNotEmpty() ||
+        !description.isNullOrBlank() ||
+        !publisher.isNullOrBlank() ||
+        !language.isNullOrBlank() ||
+        !releaseDate.isNullOrBlank()
 
 /** UPPERCASE muted overline label, matching the grouped-section heading idiom. */
 @Composable
@@ -428,6 +440,8 @@ private fun LazyListScope.metadataFieldsSection(
     onToggleNarrator: (String) -> Unit,
     onToggleSeries: (String) -> Unit,
     onToggleGenre: (String) -> Unit,
+    onToggleMood: (String) -> Unit,
+    onToggleTag: (String) -> Unit,
 ) {
     // ── IDENTITY ──
     item {
@@ -452,18 +466,38 @@ private fun LazyListScope.metadataFieldsSection(
     }
 
     // ── CLASSIFICATION ──
-    if (newMetadata.genres.isNotEmpty()) {
+    val hasClassification =
+        newMetadata.genres.isNotEmpty() ||
+            newMetadata.moods.isNotEmpty() ||
+            newMetadata.tags.isNotEmpty()
+    if (hasClassification) {
         item {
             FieldGroup(
                 label = stringResource(Res.string.metadata_section_classification),
                 icon = Icons.Outlined.Category,
                 accent = MaterialTheme.colorScheme.tertiary,
             ) {
-                GenreFieldRow(
-                    genres = newMetadata.genres,
-                    selectedGenres = selections.selectedGenres,
-                    onToggle = onToggleGenre,
-                )
+                if (newMetadata.genres.isNotEmpty()) {
+                    GenreFieldRow(
+                        genres = newMetadata.genres,
+                        selectedGenres = selections.selectedGenres,
+                        onToggle = onToggleGenre,
+                    )
+                }
+                if (newMetadata.moods.isNotEmpty()) {
+                    MoodFieldRow(
+                        moods = newMetadata.moods,
+                        selectedMoods = selections.selectedMoods,
+                        onToggle = onToggleMood,
+                    )
+                }
+                if (newMetadata.tags.isNotEmpty()) {
+                    TagFieldRow(
+                        tags = newMetadata.tags,
+                        selectedTags = selections.selectedTags,
+                        onToggle = onToggleTag,
+                    )
+                }
             }
         }
     }
@@ -1162,6 +1196,66 @@ private fun GenreFieldRow(
                     label = genre,
                     selected = genre in selectedGenres,
                     onClick = { onToggle(genre) },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MoodFieldRow(
+    moods: List<String>,
+    selectedMoods: Set<String>,
+    onToggle: (String) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Text(
+            text = stringResource(Res.string.metadata_field_moods),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.tertiary,
+            modifier = Modifier.padding(bottom = 10.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            moods.forEach { mood ->
+                GenreToggleChip(
+                    label = mood,
+                    selected = mood in selectedMoods,
+                    onClick = { onToggle(mood) },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagFieldRow(
+    tags: List<String>,
+    selectedTags: Set<String>,
+    onToggle: (String) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Text(
+            text = stringResource(Res.string.metadata_field_tags),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.tertiary,
+            modifier = Modifier.padding(bottom = 10.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            tags.forEach { tag ->
+                GenreToggleChip(
+                    label = tag,
+                    selected = tag in selectedTags,
+                    onClick = { onToggle(tag) },
                 )
             }
         }


### PR DESCRIPTION
## Why
In the metadata downloader, only **genres** flowed through — you couldn't see or pick the **moods/tags** Audible exposes. The server already scraped & classified Audible product tags (`ProductTagClassifier`), but only **post-confirm** (best-effort, no user control); the lookup contract carried genres only.

Closes #594. (The companion #609 added the manual moods editor on the Book Edit screen.)

## What — mirror the genres flow for moods AND tags, end-to-end
- **Contract** (`MetadataDtos.kt`): `MetadataBook` gains `moods`/`tags`; `MetadataApplySelection` gains `moods`/`tags` (defaulted).
- **Server lookup** (`MetadataLookupServiceImpl.getBookMetadata`/`refreshBookMetadata`): after the match is built, scrape product tags and `ProductTagClassifier.classify(...)` them — at **lookup** time, behind the existing loading state — so the preview can show toggleable chips. The genre-exclusion set is derived from the match's own genres. Best-effort: a failed scrape leaves them empty, never failing the lookup.
- **Server apply** (`BookMetadataApplier`): now writes the **user-selected** moods/tags from the selection (no re-scrape), still best-effort/additive.
- **Client** (`MetadataViewModel`): `selectedMoods`/`selectedTags`, `toggleMood`/`toggleTag`, threaded into `toApplySelection`, default-select-all on load — exactly like genres.
- **Preview UI**: `MoodFieldRow`/`TagFieldRow` in `MatchPreviewScreen` (Compose) + mood/tag toggle rows in `MetadataSelectView` (iOS) — both gated on availability, reusing the genre chip + select-all behaviour.

## Notes
- Scraping at lookup adds one product-page fetch to the preview (already shows a spinner) — the deliberate trade for letting the user *see and choose* moods/tags.
- The Audible scrape is **locale-cookie-gated per region** (`AudibleRegionConfig`); a mismatched region returns empty moods/tags. Worth confirming the server's region if a title shows none.

## Tests
Kotest: contract round-trips with moods/tags; server `getBookMetadata` populates them (incl. theme-vs-genre exclusion + scrape-failure-empty); apply writes the *selected* moods/tags (proven the apply path no longer scrapes); client toggle + `toApplySelection` + default-select-all.

## Verification
Local green: `:contract:jvmTest`, `:sharedLogic:jvmTest`, `:server:test`, `:androidApp:assembleDebug`, `spotlessCheck`, `detekt`. iOS via CI.
