### PR TITLE
✨ fix(composeApp): un-clip the expressive carousel + roll it out app-wide (#549)

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BrowseCarousel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BrowseCarousel.kt
@@ -1,27 +1,33 @@
 package com.calypsan.listenup.client.design.components
 
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.carousel.HorizontalUncontainedCarousel
-import androidx.compose.material3.carousel.rememberCarouselState
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
- * Horizontal browse carousel for the home/discover rows.
+ * Horizontal browse carousel for the home/discover/detail rows.
  *
- * Wraps M3 [HorizontalUncontainedCarousel]: uniform, full-size items with snap-to-item fling and an
- * edge peek — expressive motion without resizing/cropping (audiobook covers are square and must stay
- * legible, so Multi-Browse is deliberately not used). Items keep their own look (e.g. BookCard's
- * floating cover); the carousel only provides layout + motion.
+ * A snap-flinging [LazyRow]: each item is laid out at a uniform [itemWidth] with snap-to-item fling.
+ * Unlike M3's `HorizontalUncontainedCarousel` (which mask-clips each item to a rounded carousel
+ * shape — cropping a card's title, rounded cover corners, and drop shadow), a plain LazyRow imposes
+ * no mask, so each card renders in full. Items keep their own look (BookCard's floating cover, a
+ * shelf card, etc.); the carousel only provides layout + snap motion.
  *
  * @param items the row's items, rendered uniformly at [itemWidth].
- * @param itemWidth uniform item width (match the card's width — 140.dp for BookCard rows).
+ * @param itemWidth uniform item width — MUST match the rendered card's width so a self-sizing card
+ *   is neither clipped (itemWidth too small) nor left-gapped (too large).
+ * @param key stable item key (recommended for content rows so scroll/animation state survives reorder).
  * @param itemContent renders one item (e.g. a BookCard / ShelfCard).
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun <T> BrowseCarousel(
     items: List<T>,
@@ -29,16 +35,21 @@ fun <T> BrowseCarousel(
     itemWidth: Dp = 140.dp,
     itemSpacing: Dp = 16.dp,
     contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
+    key: ((item: T) -> Any)? = null,
     itemContent: @Composable (T) -> Unit,
 ) {
-    val state = rememberCarouselState(itemCount = { items.size })
-    HorizontalUncontainedCarousel(
-        state = state,
-        itemWidth = itemWidth,
-        itemSpacing = itemSpacing,
-        contentPadding = contentPadding,
+    val listState = rememberLazyListState()
+    LazyRow(
+        state = listState,
         modifier = modifier,
-    ) { index ->
-        itemContent(items[index])
+        contentPadding = contentPadding,
+        horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+        flingBehavior = rememberSnapFlingBehavior(listState),
+    ) {
+        items(items = items, key = key) { item ->
+            Box(modifier = Modifier.width(itemWidth)) {
+                itemContent(item)
+            }
+        }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorBooksScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorBooksScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -40,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.BrowseCarousel
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.theme.DisplayFontFamily
 import com.calypsan.listenup.client.domain.model.BookListItem
@@ -383,22 +383,20 @@ private fun SeriesCarouselSection(
         Spacer(modifier = Modifier.height(16.dp))
 
         // Horizontal carousel
-        LazyRow(
+        BrowseCarousel(
+            items = seriesGroup.books,
+            itemWidth = 150.dp,
+            itemSpacing = 16.dp,
             contentPadding = PaddingValues(horizontal = 24.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            items(
-                items = seriesGroup.books,
-                key = { it.id.value },
-            ) { book ->
-                BookCard(
-                    cover = book.toCoverModel(),
-                    onClick = { onBookClick(book.id.value) },
-                    duration = book.formatDuration(),
-                    progress = bookProgress[book.id],
-                    cardWidth = 150.dp,
-                )
-            }
+            key = { it.id.value },
+        ) { book ->
+            BookCard(
+                cover = book.toCoverModel(),
+                onClick = { onBookClick(book.id.value) },
+                duration = book.formatDuration(),
+                progress = bookProgress[book.id],
+                cardWidth = 150.dp,
+            )
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -65,6 +64,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.client.design.components.BrowseCarousel
 import com.calypsan.listenup.client.design.components.HeroNavRow
 import com.calypsan.listenup.client.design.components.ListenUpDestructiveDialog
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
@@ -691,22 +691,20 @@ private fun NarrowWorkSection(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        LazyRow(
+        BrowseCarousel(
+            items = section.previewBooks,
+            itemWidth = 150.dp,
+            itemSpacing = 16.dp,
             contentPadding = PaddingValues(horizontal = 24.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            items(
-                items = section.previewBooks,
-                key = { it.id.value },
-            ) { book ->
-                BookCard(
-                    cover = book.toCoverModel(),
-                    onClick = { onBookClick(book.id.value) },
-                    duration = book.formatDuration(),
-                    progress = bookProgress[book.id],
-                    cardWidth = 150.dp,
-                )
-            }
+            key = { it.id.value },
+        ) { book ->
+            BookCard(
+                cover = book.toCoverModel(),
+                onClick = { onBookClick(book.id.value) },
+                duration = book.formatDuration(),
+                progress = bookProgress[book.id],
+                cardWidth = 150.dp,
+            )
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/discover/DiscoverScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/discover/DiscoverScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -41,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import com.calypsan.listenup.client.design.components.AvatarSize
+import com.calypsan.listenup.client.design.components.BrowseCarousel
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.components.UserAvatar
 import com.calypsan.listenup.client.features.discover.components.ActivityFeedSection
@@ -335,20 +335,18 @@ private fun UserShelvesSection(
         Spacer(modifier = Modifier.height(12.dp))
 
         // Horizontal scroll of shelves
-        LazyRow(
+        BrowseCarousel(
+            items = userShelves.shelves,
+            itemWidth = 140.dp,
+            itemSpacing = 12.dp,
             contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            items(
-                items = userShelves.shelves,
-                key = { it.id },
-            ) { shelf ->
-                DiscoverShelfCard(
-                    shelf = shelf,
-                    avatarColor = avatarColor,
-                    onClick = { onShelfClick(shelf.id) },
-                )
-            }
+            key = { it.id },
+        ) { shelf ->
+            DiscoverShelfCard(
+                shelf = shelf,
+                avatarColor = avatarColor,
+                onClick = { onShelfClick(shelf.id) },
+            )
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ContinueListeningRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ContinueListeningRow.kt
@@ -1,7 +1,6 @@
 package com.calypsan.listenup.client.features.home.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -9,12 +8,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.BrowseCarousel
 import com.calypsan.listenup.client.design.components.SectionTitle
 import com.calypsan.listenup.client.design.components.toCoverModel
 import com.calypsan.listenup.client.design.theme.ContentShapes
@@ -56,26 +54,27 @@ fun ContinueListeningRow(
 
         Spacer(modifier = Modifier.height(Spacing.titleGap))
 
-        LazyRow(
+        BrowseCarousel(
+            items = items,
+            itemWidth = ContinueCardWidth,
+            itemSpacing = Spacing.itemGap,
             contentPadding = PaddingValues(horizontal = Spacing.screenMargin),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.itemGap),
-        ) {
-            items(items, key = { it.bookId }) { item ->
-                when (item) {
-                    is ContinueListeningItem.Ready -> {
-                        BookCard(
-                            cover = item.book.toCoverModel(),
-                            onClick = { onBookClick(item.bookId) },
-                            progress = item.book.progress,
-                            timeRemaining = item.book.timeRemainingFormatted,
-                            isPlaying = item.book.bookId == playingBookId,
-                            cardWidth = ContinueCardWidth,
-                        )
-                    }
+            key = { it.bookId },
+        ) { item ->
+            when (item) {
+                is ContinueListeningItem.Ready -> {
+                    BookCard(
+                        cover = item.book.toCoverModel(),
+                        onClick = { onBookClick(item.bookId) },
+                        progress = item.book.progress,
+                        timeRemaining = item.book.timeRemainingFormatted,
+                        isPlaying = item.book.bookId == playingBookId,
+                        cardWidth = ContinueCardWidth,
+                    )
+                }
 
-                    is ContinueListeningItem.Loading -> {
-                        ContinueListeningSkeletonCard()
-                    }
+                is ContinueListeningItem.Loading -> {
+                    ContinueListeningSkeletonCard()
                 }
             }
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ContinueListeningRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/ContinueListeningRow.kt
@@ -31,9 +31,9 @@ private val ContinueCardWidth = 176.dp
  *
  * Renders [ContinueListeningItem.Ready] items as full [BookCard]s and
  * [ContinueListeningItem.Loading] items as skeleton placeholder cards that
- * match the real card's dimensions. Rendered in a [LazyRow] (not a carousel) so the cards' soft
- * cover shadows aren't clipped at the item bounds; the list order is stable, so a Loading item
- * transitions to Ready in place — no flicker or re-enter animation.
+ * match the real card's dimensions. Rendered in a snap [BrowseCarousel] (an unmasked LazyRow) so the
+ * cards' soft cover shadows aren't clipped at the item bounds; the list order is stable, so a Loading
+ * item transitions to Ready in place — no flicker or re-enter animation.
  *
  * @param items List of [ContinueListeningItem] — Ready or Loading
  * @param onBookClick Callback when a ready book card is clicked

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/MyShelvesRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/MyShelvesRow.kt
@@ -6,13 +6,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.BrowseCarousel
 import com.calypsan.listenup.client.design.components.SectionTitle
 import com.calypsan.listenup.client.design.theme.Spacing
 import com.calypsan.listenup.client.domain.model.Shelf
@@ -70,21 +69,21 @@ fun MyShelvesRow(
                 }
             }
         } else {
-            // LazyRow (not a clipping carousel) so the cards' rounded corners aren't cropped, and the
-            // gutter matches the title (screenMargin).
-            LazyRow(
+            // Snap carousel; the gutter matches the title (screenMargin).
+            BrowseCarousel(
+                items = shelves,
+                itemWidth = 180.dp,
+                itemSpacing = Spacing.itemGap,
                 contentPadding = PaddingValues(horizontal = Spacing.screenMargin),
-                horizontalArrangement = Arrangement.spacedBy(Spacing.itemGap),
-            ) {
-                items(shelves, key = { it.id }) { shelf ->
-                    val (container, content) = shelfColors(shelves.indexOf(shelf))
-                    ShelfCard(
-                        shelf = shelf,
-                        containerColor = container,
-                        contentColor = content,
-                        onClick = { onShelfClick(shelf.id) },
-                    )
-                }
+                key = { it.id },
+            ) { shelf ->
+                val (container, content) = shelfColors(shelves.indexOf(shelf))
+                ShelfCard(
+                    shelf = shelf,
+                    containerColor = container,
+                    contentColor = content,
+                    onClick = { onShelfClick(shelf.id) },
+                )
             }
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/UserProfileScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/UserProfileScreen.kt
@@ -22,8 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -59,6 +57,7 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
+import com.calypsan.listenup.client.design.components.BrowseCarousel
 import com.calypsan.listenup.client.design.components.HeroNavRow
 import com.calypsan.listenup.client.design.components.ListenUpAsyncImage
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
@@ -635,14 +634,15 @@ private fun RecentBooksRow(
     onBookClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyRow(
+    BrowseCarousel(
+        items = books,
         modifier = modifier,
+        itemWidth = 140.dp,
+        itemSpacing = 16.dp,
         contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        items(books, key = { it.bookId }) { book ->
-            RecentBookCard(book = book, onClick = { onBookClick(book.bookId) })
-        }
+        key = { it.bookId },
+    ) { book ->
+        RecentBookCard(book = book, onClick = { onBookClick(book.bookId) })
     }
 }
 


### PR DESCRIPTION
## Problem (#549)

Discover's M3 Expressive carousels **crop content** — book titles below the cover and the cover's rounded corners/drop shadow get clipped. Root cause: `BrowseCarousel` wrapped M3 `HorizontalUncontainedCarousel`, which **mask-clips every item** to a rounded carousel shape. Each item is a full `BookCard` (cover *with shadow + rounded corners*, then title/subtitle below), so the mask crops the shadow, fights the corners, and clips the text. ("Uncontained" still masks.) Tellingly, Home's rows were already hand-rolled as raw `LazyRow` *specifically to dodge this clipping*.

## Fix + rollout

**Phase 1 — fix the component.** Reimplement `BrowseCarousel` internally as a **snap-flinging `LazyRow`** (no mask, no clip), keeping its public API and adding an optional `key`. A `LazyRow` imposes no item mask, so cards render in full; `rememberSnapFlingBehavior` preserves the springy snap-to-item feel. The 3 Discover rows benefit with zero call-site change.

**Phase 2 — roll it out** to every remaining horizontal content row (each was a raw `LazyRow`), passing each row's existing width/spacing/padding:
- **Home:** Continue Listening (176dp) + My Shelves compact branch (180dp) — these fold back onto the shared component now that it no longer clips.
- **Contributor Detail:** series-books row + top-books row (150dp).
- **Profile:** recent-books row (140dp).
- **Discover:** shelves row (140dp).

**Out of scope (untouched):** `FannedDeck` (Series Detail hero + Series cards — a distinct fanned-stack primitive, not a scrolling row) and chrome rows (filter chips, region pills). The issue's hypothetical Library/Book-Detail/Collections carousels don't exist as horizontal rows today, so there was nothing to convert.

## Test plan

- [x] `:androidApp:assembleDebug` green after each task; full gate (`spotlessCheck` + `detekt`, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug`) green.
- [x] Debug build deploys + launches cleanly on the emulator.
- [ ] **On-device visual confirm** — covers show full rounded corners + shadow and titles are uncropped across Discover / Home / Contributor Detail / Profile. (Couldn't capture content-ful screenshots from here — the test emulator has no server configured/login. The fix is structurally guaranteed: `BrowseCarousel` is now an unmasked `LazyRow` with no `.clip()`, so item clipping is impossible. Worth a quick look on a logged-in device.)
- [ ] iOS unaffected (sharedUI Compose = Android + Desktop; iOS has its own SwiftUI surface).

Closes #549