### PR TITLE
🐛 fix: registration approval flow — iOS stuck on Awaiting (#623) + pending users in active roster (#624)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/AdminUserService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/AdminUserService.kt
@@ -24,7 +24,11 @@ import kotlinx.rpc.annotations.Rpc
  */
 @Rpc
 interface AdminUserService {
-    /** Returns every user on the instance, regardless of status. */
+    /**
+     * Returns the instance's **active** members. Pending and denied registrations are excluded —
+     * they have their own surfaces ([listPendingUsers] / the approval flow) and must not appear in
+     * the active user roster. Soft-deleted users are always excluded.
+     */
     suspend fun listUsers(): AppResult<List<User>>
 
     /** Returns only users awaiting an approval decision (PENDING_APPROVAL). */

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -140,6 +140,9 @@ import kotlinx.coroutines.runBlocking
 import kotlin.time.Duration
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+import com.calypsan.listenup.api.dto.auth.RegistrationStatusEvent
+import com.calypsan.listenup.server.db.UserEntity
+import com.calypsan.listenup.server.db.UserStatusColumn
 import kotlinx.rpc.krpc.ktor.server.Krpc
 import org.koin.ktor.ext.get as koinGet
 import org.koin.ktor.ext.inject
@@ -433,7 +436,17 @@ private fun Application.installAppRoutes(homeDir: Path) {
         sseRoutes()
         authRoutes(authService)
         publicInviteRoutes(inviteService)
-        registrationStatusRoutes(registrationBroadcaster)
+        registrationStatusRoutes(registrationBroadcaster) { userId ->
+            // Persisted status is the source of truth: a registrant reconnecting after the
+            // admin's decision must learn it even though the live broadcast was a no-op drop.
+            suspendTransaction(db) {
+                when (UserEntity.findById(userId)?.status) {
+                    UserStatusColumn.ACTIVE -> RegistrationStatusEvent(status = "approved")
+                    UserStatusColumn.DENIED -> RegistrationStatusEvent(status = "denied")
+                    else -> RegistrationStatusEvent(status = "pending")
+                }
+            }
+        }
         rpcRoutes(
             authService,
             instanceService,

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
@@ -86,7 +86,11 @@ class AdminUserServiceImpl(
         requireAdmin()?.let { return it }
         return suspendTransaction(db) {
             AppResult.Success(
-                UserEntity.find { UserTable.deletedAt eq null }.map { it.toContract() },
+                // ACTIVE only: pending/denied registrations have their own surfaces and must not
+                // appear in the active roster (#624). Soft-deleted users are excluded as always.
+                UserEntity
+                    .find { (UserTable.deletedAt eq null) and (UserTable.status eq UserStatusColumn.ACTIVE) }
+                    .map { it.toContract() },
             )
         }
     }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutes.kt
@@ -9,8 +9,11 @@ import io.ktor.server.sse.ServerSSESession
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
@@ -18,22 +21,37 @@ import kotlinx.coroutines.launch
 // idle pre-approval connection alive across NATs/load balancers that drop silent streams.
 private const val HEARTBEAT_INTERVAL_MILLIS = 25_000L
 
+// Fallback re-check cadence for the persisted status. The live broadcast delivers a decision
+// instantly when the registrant is subscribed at that instant; this poll is the "never stranded"
+// safety net that advances the stream even if that live push was missed (replay=0 broadcaster).
+private const val STATUS_RECHECK_INTERVAL_MILLIS = 3_000L
+
+private const val STATUS_PENDING = "pending"
+
 /**
  * Mounts the unauthenticated registration-status SSE stream:
  *  - `GET /api/v1/auth/registration-status/{userId}/stream`
  *
  * A registrant awaiting approval has no JWT yet, so this route lives OUTSIDE the auth wall.
- * On connect it emits a `RegistrationStatusEvent(status = "pending")`, then suspends until the
- * admin's decision arrives via [broadcaster], emits the terminal `"approved"`/`"denied"` event,
- * and closes. A comment-line keepalive runs in the background to hold the idle connection open.
  *
- * The pending event is sent from inside [onSubscription], which fires only after this collector
- * is registered as a live subscriber but before any upstream decision is processed.
- * [RegistrationBroadcaster] is `replay = 0`, so any other ordering — subscribe, then send pending,
- * then start collecting — would drop a decision fired in that window. [onSubscription] closes the
- * window entirely; the client's reconnect/retry-login path is the fallback for a true disconnect.
+ * On connect it emits the registrant's **persisted** status via [currentStatus]: a registrant who
+ * connects (or reconnects, or taps "check status") *after* the admin's decision learns it
+ * immediately rather than waiting forever on `"pending"`. This is the fix for the iOS Awaiting
+ * screen never advancing — [RegistrationBroadcaster] is `replay = 0`, so a decision pushed while
+ * the registrant wasn't subscribed is otherwise lost.
+ *
+ * While still pending it awaits a terminal decision from **either** an instant live broadcast
+ * ([broadcaster]) **or** a periodic re-check of the persisted status — whichever fires first —
+ * then emits the terminal `"approved"`/`"denied"` event and closes. A comment-line keepalive
+ * holds the idle connection open across proxies.
+ *
+ * @param currentStatus reads the registrant's persisted status as a wire event; an unknown user
+ *   id maps to `"pending"` (the stream simply waits).
  */
-fun Route.registrationStatusRoutes(broadcaster: RegistrationBroadcaster) {
+fun Route.registrationStatusRoutes(
+    broadcaster: RegistrationBroadcaster,
+    currentStatus: suspend (userId: String) -> RegistrationStatusEvent,
+) {
     sse("/api/v1/auth/registration-status/{userId}/stream") {
         val userId = call.parameters["userId"] ?: return@sse
 
@@ -45,21 +63,38 @@ fun Route.registrationStatusRoutes(broadcaster: RegistrationBroadcaster) {
                 }
             }
         try {
-            // first() suspends until the first approve/deny decision; onSubscription emits the
-            // pending event the instant this collector is live, so no decision can slip the gap.
-            // When first() returns the block ends and the SSE session closes — matching the
-            // client, which closes on a terminal status.
-            val decision =
-                broadcaster
-                    .subscribe(userId)
-                    .onSubscription { sendStatus(RegistrationStatusEvent(status = "pending")) }
-                    .first()
-            sendStatus(decision.toEvent())
+            val initial = currentStatus(userId)
+            sendStatus(initial)
+            if (initial.status == STATUS_PENDING) {
+                // Still pending: resolve a terminal status from whichever source fires first.
+                val terminal =
+                    merge(
+                        broadcaster.subscribe(userId).map { it.toEvent() },
+                        pollUntilTerminal(userId, currentStatus),
+                    ).first()
+                sendStatus(terminal)
+            }
         } finally {
             heartbeat.cancel()
         }
     }
 }
+
+/** Re-reads the persisted status on a fixed cadence, emitting once it leaves `"pending"`. */
+private fun pollUntilTerminal(
+    userId: String,
+    currentStatus: suspend (userId: String) -> RegistrationStatusEvent,
+): Flow<RegistrationStatusEvent> =
+    flow {
+        while (true) {
+            delay(STATUS_RECHECK_INTERVAL_MILLIS)
+            val status = currentStatus(userId)
+            if (status.status != STATUS_PENDING) {
+                emit(status)
+                break
+            }
+        }
+    }
 
 /** Emits a [RegistrationStatusEvent] as a data-only SSE frame; the client decodes `data:` regardless of `event:`. */
 private suspend fun ServerSSESession.sendStatus(event: RegistrationStatusEvent) {

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
@@ -328,6 +328,24 @@ class AdminUserServiceImplTest :
             }
         }
 
+        test("listUsers returns only ACTIVE members, excluding pending and denied registrations") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestUser("root1", UserRoleColumn.ROOT)
+                seedTestUser("m1", UserRoleColumn.MEMBER)
+                seedUserWithStatus("p1", userStatus = UserStatusColumn.PENDING_APPROVAL)
+                seedUserWithStatus("d1", userStatus = UserStatusColumn.DENIED)
+                runTest {
+                    val svc = makeAdminUserService(db).actAs("root1", UserRole.ROOT)
+                    val ids = svc.listUsers().shouldSucceed().map { it.id.value }
+                    ids shouldContain "root1"
+                    ids shouldContain "m1"
+                    ids shouldNotContain "p1"
+                    ids shouldNotContain "d1"
+                }
+            }
+        }
+
         // ── listPendingUsers ──────────────────────────────────────────────────────
 
         test("listPendingUsers returns only PENDING_APPROVAL users") {

--- a/server/src/test/kotlin/com/calypsan/listenup/server/routes/AdminUserServiceRpcTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/routes/AdminUserServiceRpcTest.kt
@@ -1,0 +1,128 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.AdminUserService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.LoginRequest
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.dto.auth.RegisterResult
+import com.calypsan.listenup.api.dto.auth.User
+import com.calypsan.listenup.api.dto.auth.UserStatus
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.client.rpcConfig
+import kotlinx.rpc.krpc.serialization.json.json
+import kotlinx.rpc.withService
+
+/**
+ * End-to-end reachability test for [AdminUserService.listUsers] over the authed kotlinx.rpc
+ * surface — the exact path the Android admin screen drives (`AdminRepositoryImpl` → RPC proxy).
+ *
+ * Regression for #619: with a PENDING_APPROVAL applicant present, the admin page showed
+ * "Something Went Wrong on the Server" and the pending list never appeared. The REST surface
+ * serializes a pending [User] fine; this test exercises the RPC transport specifically.
+ */
+class AdminUserServiceRpcTest :
+    FunSpec({
+
+        suspend fun HttpClient.mintRootToken(): String {
+            post("/api/v1/auth/setup") {
+                contentType(ContentType.Application.Json)
+                setBody(RegisterRequest("root@rpc-admin.example", "x".repeat(8), "Root"))
+            }
+            return post("/api/v1/auth/login") {
+                contentType(ContentType.Application.Json)
+                setBody(LoginRequest("root@rpc-admin.example", "x".repeat(8)))
+            }.body<AppResult<AuthSession>>()
+                .shouldBeInstanceOf<AppResult.Success<AuthSession>>()
+                .data
+                .accessToken
+                .value
+        }
+
+        suspend fun HttpClient.registerPending(name: String): String =
+            post("/api/v1/auth/register") {
+                contentType(ContentType.Application.Json)
+                setBody(RegisterRequest("$name@rpc-admin.example", "y".repeat(8), name))
+            }.body<AppResult<RegisterResult>>()
+                .shouldBeInstanceOf<AppResult.Success<RegisterResult>>()
+                .data
+                .shouldBeInstanceOf<RegisterResult.PendingApproval>()
+                .userId
+                .value
+
+        test("AdminUserService.listUsers over RPC excludes a PENDING_APPROVAL applicant (active roster only)") {
+            testApplication {
+                useIsolatedTestConfig(registrationPolicy = "APPROVAL_QUEUE")
+                application { module() }
+
+                val restClient = createClient { install(ContentNegotiation) { json(contractJson) } }
+                val token = restClient.mintRootToken()
+                val pendingId = restClient.registerPending("pending")
+
+                val rpcClient =
+                    createClient {
+                        install(WebSockets)
+                        installKrpc()
+                    }
+
+                val service =
+                    rpcClient
+                        .rpc("ws://localhost/api/rpc/authed") {
+                            rpcConfig { serialization { json(contractJson) } }
+                            bearerAuth(token)
+                        }.withService<AdminUserService>()
+
+                val users = service.listUsers().shouldBeInstanceOf<AppResult.Success<List<User>>>().data
+                // #624: the active roster excludes a pending applicant (it belongs only in the
+                // pending section); the root admin (ACTIVE) is present. Serialization round-trips
+                // cleanly over RPC either way.
+                users.any { it.id.value == pendingId } shouldBe false
+                users.all { it.status == UserStatus.ACTIVE } shouldBe true
+            }
+        }
+
+        test("AdminUserService.listPendingUsers over RPC returns the pending applicant") {
+            testApplication {
+                useIsolatedTestConfig(registrationPolicy = "APPROVAL_QUEUE")
+                application { module() }
+
+                val restClient = createClient { install(ContentNegotiation) { json(contractJson) } }
+                val token = restClient.mintRootToken()
+                val pendingId = restClient.registerPending("pending")
+
+                val rpcClient =
+                    createClient {
+                        install(WebSockets)
+                        installKrpc()
+                    }
+
+                val service =
+                    rpcClient
+                        .rpc("ws://localhost/api/rpc/authed") {
+                            rpcConfig { serialization { json(contractJson) } }
+                            bearerAuth(token)
+                        }.withService<AdminUserService>()
+
+                val pending = service.listPendingUsers().shouldBeInstanceOf<AppResult.Success<List<User>>>().data
+                pending.map { it.id.value } shouldBe listOf(pendingId)
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutesTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutesTest.kt
@@ -1,17 +1,32 @@
 package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.dto.auth.RegisterResult
 import com.calypsan.listenup.api.dto.auth.RegistrationStatusEvent
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.auth.RegistrationBroadcaster
 import com.calypsan.listenup.server.auth.RegistrationDecision
 import com.calypsan.listenup.server.module
 import com.calypsan.listenup.server.testing.useIsolatedTestConfig
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -21,8 +36,8 @@ import org.koin.ktor.ext.inject
 /**
  * Pins the multi-user MC §Task-3 contract: the registration-status SSE stream is mounted
  * OUTSIDE the JWT wall (a registrant awaiting approval has no token yet) and emits the exact
- * client wire shape — a data-only `RegistrationStatusEvent` JSON frame whose `status` is
- * `"pending"` on connect, then the broadcaster-driven terminal decision (`"approved"`/`"denied"`).
+ * client wire shape — a data-only `RegistrationStatusEvent` JSON frame whose `status` reflects
+ * the registrant's persisted state, then the broadcaster-driven terminal decision.
  *
  * The connection is established with NO `bearerAuth`; a 401 here would mean the route was
  * accidentally placed inside `authenticate(JWT_PROVIDER)` and is a regression.
@@ -30,7 +45,7 @@ import org.koin.ktor.ext.inject
 class RegistrationStatusRoutesTest :
     FunSpec({
 
-        test("registration-status stream emits pending then the decision, unauthenticated") {
+        test("registration-status stream emits pending then the live decision, unauthenticated") {
             testApplication {
                 useIsolatedTestConfig()
                 application { module() }
@@ -41,8 +56,8 @@ class RegistrationStatusRoutesTest :
                     }
                 client.sse("/api/v1/auth/registration-status/u1/stream") {
                     // Heartbeat comment-events carry null data; filter to the real status frames.
-                    // The first data frame is "pending"; firing the decision then yields the
-                    // terminal "approved" frame, after which the server closes the stream.
+                    // The first data frame is "pending" (u1 has no persisted row); firing the
+                    // decision then yields the terminal "approved" frame and the server closes.
                     val statuses =
                         incoming
                             .filter { it.data != null }
@@ -56,4 +71,65 @@ class RegistrationStatusRoutesTest :
                 }
             }
         }
+
+        test("registration-status stream reports approved on connect when the decision was already made") {
+            // Regression for #623: the registrant's SSE wasn't live at the instant the admin
+            // approved (replay=0 broadcaster → the live push was dropped). On a fresh connect
+            // / reconnect / "check status", the stream must report the PERSISTED status, not an
+            // eternal "pending". Otherwise the iOS Awaiting screen never advances.
+            testApplication {
+                useIsolatedTestConfig(registrationPolicy = "APPROVAL_QUEUE")
+                application { module() }
+                val rest = createClient { install(ContentNegotiation) { json(contractJson) } }
+                val rootToken = rest.setupRoot()
+                val pendingId = rest.registerPending("darlene")
+                // Approve while NO SSE is connected — the live broadcast is dropped.
+                rest.approve(rootToken, pendingId)
+
+                val sse = createClient { install(SSE) }
+                sse.sse("/api/v1/auth/registration-status/$pendingId/stream") {
+                    val firstStatus =
+                        incoming
+                            .filter { it.data != null }
+                            .map { contractJson.decodeFromString<RegistrationStatusEvent>(it.data!!).status }
+                            .first()
+                    firstStatus shouldBe "approved"
+                }
+            }
+        }
     })
+
+/** Runs first-user setup; returns the ROOT (admin) access token. */
+private suspend fun HttpClient.setupRoot(): String =
+    post("/api/v1/auth/setup") {
+        contentType(ContentType.Application.Json)
+        setBody(RegisterRequest("root@x", "x".repeat(8), "Root"))
+    }.body<AppResult<AuthSession>>()
+        .shouldBeInstanceOf<AppResult.Success<AuthSession>>()
+        .data
+        .accessToken
+        .value
+
+/** Registers under APPROVAL_QUEUE; returns the server-issued PENDING_APPROVAL user id. */
+private suspend fun HttpClient.registerPending(name: String): String =
+    post("/api/v1/auth/register") {
+        contentType(ContentType.Application.Json)
+        setBody(RegisterRequest("$name@x", "y".repeat(8), name))
+    }.body<AppResult<RegisterResult>>()
+        .shouldBeInstanceOf<AppResult.Success<RegisterResult>>()
+        .data
+        .shouldBeInstanceOf<RegisterResult.PendingApproval>()
+        .userId
+        .value
+
+/** Admin-approves the pending registration [userId]. */
+private suspend fun HttpClient.approve(
+    rootToken: String,
+    userId: String,
+) {
+    post("/api/v1/admin/users/pending-decision") {
+        bearerAuth(rootToken)
+        contentType(ContentType.Application.Json)
+        setBody("""{"userId":"$userId","approved":true}""")
+    }
+}


### PR DESCRIPTION
Fixes the two root-caused defects blocking multi-user / cross-device testing in the registration-approval flow. Server-side only (+ one contract KDoc); iOS/Android Swift/Compose code unchanged.

## #623 — iOS Awaiting Registration never advances after approval
The registration-status SSE stream was **broadcast-only**: on connect it emitted `"pending"`, then waited for a *live* approve/deny push from `RegistrationBroadcaster` (`replay = 0`, `tryEmit` → dropped if no subscriber is live at that instant). It never read the registrant's **persisted** status. So if the registrant wasn't subscribed at the exact moment the admin approved (flaky connection, app backgrounded, or it subscribed/reconnected *after* approval), the decision was lost and the stream emitted `"pending"` forever — the iOS Awaiting screen could never advance.

**Fix:** the stream now emits the registrant's persisted status on connect (ACTIVE→`approved`, DENIED→`denied`, else `pending`); while still pending it awaits a terminal decision from **either** the instant live broadcast **or** a periodic re-check of the persisted status — whichever fires first. A registrant that connects, reconnects, or taps "Check Status" after the decision now learns it immediately, and a live stream auto-advances even if the broadcast was missed. The existing iOS view already reacts correctly to the `Approved` state, so no client change is needed.

## #624 — Pending users appear in the active Users list
`AdminUserService.listUsers()` returned all non-deleted users regardless of status, so a `PENDING_APPROVAL` applicant showed in both the active Users roster and the Pending section.

**Fix:** `listUsers()` now returns `ACTIVE` members only. Pending/denied registrations have their own surfaces (the pending section / approval flow) and no longer pollute the roster. Contract KDoc updated to match.

## Tests
- New `RegistrationStatusRoutesTest` case: connect after the decision was already made → reports `approved` (was: hung on `pending`).
- New `AdminUserServiceImplTest` case: `listUsers` excludes pending + denied.
- New `AdminUserServiceRpcTest`: pins both behaviors over the real kotlinx.rpc WebSocket transport (the exact Android admin path).
- All `:server:test`, `:contract:jvmTest`, `:sharedLogic:jvmTest`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug` green locally.

## Follow-ups (still open)
- The activity-log sighting of pending users (part of #624) — to re-verify on device after this lands; register() already guards `USER_JOINED` to ACTIVE only, so the Users-list leak was the primary cause.
- #619 (admin transient "Something Went Wrong" on first load) and #625 (pending avatar) remain open.
