### PR TITLE
🐛 fix(sharedLogic): recover RPC connection without an app relaunch (#619)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinator.kt
@@ -2,6 +2,8 @@ package com.calypsan.listenup.client.data.connection
 
 import com.calypsan.listenup.client.data.discovery.ServerDiscoveryService
 import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
+import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -36,6 +38,9 @@ private val logger = KotlinLogging.logger {}
  * @param networkMonitor drives the network-regain trigger
  * @param invalidator drops all cached remote connections
  * @param scope app-lifetime scope the observers run on
+ * @param engineState firehose connection state; a reconnect to the same server invalidates the
+ *   stale RPC proxy caches (see [start]). Defaults to an idle holder so existing call sites that
+ *   don't drive reconnects (tests) need no change; production wires the live engine state.
  */
 class ConnectionCoordinator(
     private val serverConfig: ServerConfig,
@@ -44,6 +49,7 @@ class ConnectionCoordinator(
     private val networkMonitor: NetworkMonitor,
     private val invalidator: RpcCacheInvalidator,
     private val scope: CoroutineScope,
+    private val engineState: SyncEngineState = SyncEngineState(),
 ) {
     private val relocationMutex = Mutex()
 
@@ -72,6 +78,26 @@ class ConnectionCoordinator(
                     reevaluate()
                 }
                 wasOnline = online
+            }
+        }
+        scope.launch {
+            // A firehose reconnect to the SAME server (host:port unchanged, so the URL observer
+            // above never fires) leaves every cached kotlinx.rpc proxy bound to the prior, now-dead
+            // RpcClient — so every RPC call throws "RpcClient was cancelled" until the app restarts.
+            // Sweep the caches on each reconnect (not the initial connect) so the next RPC call
+            // rebinds to the live connection. Never-stranded: recovery without a relaunch.
+            var wasConnected = false
+            var hasConnectedOnce = false
+            engineState.observe().collect { snapshot ->
+                val connected = snapshot.connection is ConnectionState.Connected
+                if (connected && !wasConnected) {
+                    if (hasConnectedOnce) {
+                        logger.info { "Firehose reconnected; invalidating stale RPC proxy caches" }
+                        invalidator.invalidateAll()
+                    }
+                    hasConnectedOnce = true
+                }
+                wasConnected = connected
             }
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCacheInvalidator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCacheInvalidator.kt
@@ -15,7 +15,7 @@ private val logger = KotlinLogging.logger {}
  * source of truth for a server-URL change, replacing the hand-maintained two-cache
  * list that silently missed every other authed proxy.
  */
-interface RpcCacheInvalidator {
+fun interface RpcCacheInvalidator {
     /** Invalidate every registered [RemoteCache]. */
     suspend fun invalidateAll()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.data.remote.BrowseFilesystemResponse
 import com.calypsan.listenup.client.data.remote.DirectoryEntryResponse
 import com.calypsan.listenup.client.data.remote.InviteRpcFactory
 import com.calypsan.listenup.client.data.remote.LibraryAdminRpcFactory
+import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
 import com.calypsan.listenup.client.domain.model.AccessMode
 import com.calypsan.listenup.client.domain.model.AdminUserInfo
 import com.calypsan.listenup.client.domain.model.InviteInfo
@@ -54,6 +55,7 @@ class AdminRepositoryImpl(
     private val inviteRpc: InviteRpcFactory,
     private val libraryAdminRpc: LibraryAdminRpcFactory,
     private val serverConfig: ServerConfig,
+    private val rpcCacheInvalidator: RpcCacheInvalidator = RpcCacheInvalidator {},
 ) : AdminRepository {
     // ═══════════════════════════════════════════════════════════════════════
     // USER MANAGEMENT
@@ -147,7 +149,14 @@ class AdminRepositoryImpl(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            logger.warn(e) { "admin user RPC $op failed at the transport boundary" }
+            // An exception reaching this catch is a transport-level failure (the data layer returns
+            // typed failures rather than raising them). The cached kotlinx.rpc proxy is likely bound
+            // to a dead/cancelled RpcClient after a reconnect to the same server — so drop the caches
+            // now and the next call (or a screen re-entry) rebinds to the live connection instead of
+            // stranding the user until app restart (#619). No auto-retry: this path also wraps
+            // non-idempotent writes, so re-firing the same call could double-apply.
+            logger.warn(e) { "admin RPC $op failed at the transport boundary; invalidating RPC caches" }
+            rpcCacheInvalidator.invalidateAll()
             AppResult.Failure(InternalError())
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AdminModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AdminModule.kt
@@ -119,6 +119,7 @@ val adminModule: Module =
                 inviteRpc = get(),
                 libraryAdminRpc = get(),
                 serverConfig = get(),
+                rpcCacheInvalidator = get(),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ConnectionModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ConnectionModule.kt
@@ -78,6 +78,7 @@ val connectionModule: Module =
                             qualifier =
                                 named(APP_SCOPE),
                         ),
+                    engineState = get(),
                 )
             coordinator.start()
             coordinator

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinatorTest.kt
@@ -3,6 +3,8 @@ package com.calypsan.listenup.client.data.connection
 import com.calypsan.listenup.client.data.discovery.DiscoveredServer
 import com.calypsan.listenup.client.data.discovery.ServerDiscoveryService
 import com.calypsan.listenup.client.data.remote.RpcCacheInvalidator
+import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -250,6 +252,56 @@ class ConnectionCoordinatorTest :
             scope.testScheduler.advanceUntilIdle()
 
             verifySuspend { instance.findReachableUrl(any()) }
+        }
+
+        test("a firehose reconnect invalidates stale RPC proxy caches, but the initial connect does not") {
+            val scope = TestScope(StandardTestDispatcher())
+            val online = MutableStateFlow(true)
+            val invalidator = FakeInvalidator()
+            val engineState = SyncEngineState()
+            val serverConfig =
+                mock<ServerConfig> {
+                    // Host:port never changes — so the URL observer must not be what invalidates here.
+                    every { activeUrl } returns MutableStateFlow<ServerUrl?>(ServerUrl(local))
+                    everySuspend { getActiveUrl() } returns ServerUrl(local)
+                    everySuspend { getServerUrl() } returns ServerUrl(local)
+                    everySuspend { getRemoteUrl() } returns ServerUrl(remote)
+                    everySuspend { setActiveUrl(any()) } returns Unit
+                }
+            val instance =
+                mock<InstanceRepository> {
+                    everySuspend { findReachableUrl(any()) } returns local
+                }
+            val networkMonitor =
+                mock<NetworkMonitor> {
+                    every { isOnlineFlow } returns online
+                    every { isOnline() } returns online.value
+                }
+            ConnectionCoordinator(
+                serverConfig,
+                instance,
+                idleDiscovery(),
+                networkMonitor,
+                invalidator,
+                scope,
+                engineState,
+            ).start()
+            scope.testScheduler.advanceUntilIdle()
+
+            // Initial connect: no stale proxies yet → no sweep.
+            engineState.setConnection(ConnectionState.Connected(lastEventId = null))
+            scope.testScheduler.advanceUntilIdle()
+            invalidator.count shouldBe 0
+
+            // Drop, then reconnect to the same server: the cached proxies are now bound to a dead
+            // RpcClient and must be swept so the next RPC call rebinds.
+            engineState.setConnection(ConnectionState.Disconnected(reason = "network blip"))
+            scope.testScheduler.advanceUntilIdle()
+            invalidator.count shouldBe 0
+
+            engineState.setConnection(ConnectionState.Connected(lastEventId = 7L))
+            scope.testScheduler.advanceUntilIdle()
+            invalidator.count shouldBe 1
         }
 
         test("invalidates when the active URL host changes") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -251,13 +251,14 @@ class AdminRepositoryImplUserTest :
             result shouldBe AppResult.Success(RegistrationPolicy.OPEN)
         }
 
-        test("a transport exception from the RPC factory becomes AppResult.Failure, not a throw") {
+        test("a transport exception becomes AppResult.Failure and invalidates the RPC caches (self-heal #619)") {
             val throwingFactory =
                 object : AdminUserRpcFactory {
                     override suspend fun get(): AdminUserService = throw IllegalStateException("simulated WS 401")
 
                     override suspend fun invalidate() = Unit
                 }
+            var invalidations = 0
             val repo =
                 AdminRepositoryImpl(
                     adminUserRpc = throwingFactory,
@@ -265,9 +266,12 @@ class AdminRepositoryImplUserTest :
                     inviteRpc = mock<com.calypsan.listenup.client.data.remote.InviteRpcFactory>(),
                     libraryAdminRpc = mock(),
                     serverConfig = mock<com.calypsan.listenup.client.domain.repository.ServerConfig>(),
+                    rpcCacheInvalidator = { invalidations++ },
                 )
 
             (repo.getUsers() is AppResult.Failure) shouldBe true
+            // The dead cached proxy is dropped so the next call rebinds to a live connection.
+            invalidations shouldBe 1
         }
 
         test("setRegistrationPolicy(OPEN) sets policy OPEN") {


### PR DESCRIPTION
Fixes #619 (and likely #620, which was entangled with it): the admin page — and in fact every RPC-backed surface — would show "Something Went Wrong on the Server" after a connection blip and **only recover on a full app relaunch**.

## Root cause
Every kotlinx.rpc factory caches its service proxy for the process lifetime (`cachedService ?: connect()`) and only `invalidate()`s on logout or a server **host:port change** (`ConnectionCoordinator`). When the RPC WebSocket to the *same* server drops and reconnects — a network blip, the server restarting on the same address, the app backgrounding — the cached proxy stays bound to the dead/cancelled `RpcClient`, so **every** RPC call (`listUsers`, scanner `observeProgress`, …) throws "RpcClient was cancelled" until the process restarts. Confirmed against every observed symptom: only-relaunch-recovers, re-entering the screen doesn't help, the scan-progress loop spins (its gate watches the SSE firehose, which reconnects independently), and the server logs nothing (the throw is client-side).

## Fix — two layers ("both", staged)
**Stage 1 — sweep on reconnect (global).** `ConnectionCoordinator` now observes the firehose connection state and, on a reconnect (a `Disconnected→Connected` transition — not the initial connect), calls `RpcCacheInvalidator.invalidateAll()`. The network event that kills the RPC WebSocket also drops the SSE firehose, so when the firehose reconnects we drop the stale proxies and the next RPC call rebinds to the live connection. This covers **all** RPC surfaces at once.

**Stage 2 — self-heal on transport failure (admin surface).** `AdminRepositoryImpl.catching` now invalidates the RPC caches when a call throws a transport-level exception, so the next call (or a screen re-entry) reconnects — converting "only relaunch helps" into "re-entry helps" even for an RPC-only drop the firehose never sees. **No auto-retry**: this path also wraps non-idempotent writes (approve/deny/delete/createInvite), and re-firing could double-apply. `RpcCacheInvalidator` became a `fun interface` to keep the wiring light. This pattern extends to other repos as a fast-follow if RPC-only drops surface elsewhere; Stage 1 already protects them on reconnect.

## Tests
- `ConnectionCoordinatorTest`: a drop-then-reconnect sweeps the caches; the initial connect does not.
- `AdminRepositoryImplUserTest`: a transport exception returns `Failure` **and** invalidates the caches.
- All `:sharedLogic:jvmTest` (incl. Konsist + Koin `module.verify()`), `spotlessCheck`, `detekt`, `:androidApp:assembleDebug` green locally.
