### PR TITLE
🐛 fix(sharedUI): initials avatar for pending registrants (#625) + verify #624 activity guard

### DIFF
--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarUiStateTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarUiStateTest.kt
@@ -1,0 +1,58 @@
+package com.calypsan.listenup.client.design.components
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * Pins the profile-less avatar fallback (#625): a pending registrant has no server-side public
+ * profile, so without a fallback name the avatar is stuck on the loading circle. With a name we
+ * render initials; without one we keep the original loading behaviour for a profile still in flight.
+ *
+ * Plain JUnit4 (no Robolectric): [userAvatarUiState] is pure Kotlin with no Android framework deps.
+ */
+class UserAvatarUiStateTest {
+    private val userId = "0c3dc41c-1361-4c6e-8638-3fe7671b6b22"
+
+    @Test
+    fun `no cached profile but a fallback name renders initials from that name`() {
+        val state =
+            userAvatarUiState(
+                profile = null,
+                hasLocalAvatar = false,
+                localPath = "",
+                userId = userId,
+                fallbackName = "Darlene Hull",
+            )
+
+        state.shouldBeInstanceOf<UserAvatarUiState.Initials>().initials shouldBe "DH"
+    }
+
+    @Test
+    fun `no cached profile and no fallback name stays on the loading placeholder`() {
+        val state =
+            userAvatarUiState(
+                profile = null,
+                hasLocalAvatar = false,
+                localPath = "",
+                userId = userId,
+                fallbackName = null,
+            )
+
+        state shouldBe UserAvatarUiState.Loading
+    }
+
+    @Test
+    fun `a blank fallback name does not mask the loading placeholder`() {
+        val state =
+            userAvatarUiState(
+                profile = null,
+                hasLocalAvatar = false,
+                localPath = "",
+                userId = "u1",
+                fallbackName = "   ",
+            )
+
+        state shouldBe UserAvatarUiState.Loading
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
@@ -83,6 +83,7 @@ fun UserAvatar(
     size: AvatarSize = AvatarSize.Medium,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
+    fallbackName: String? = null,
 ) {
     val baseModifier =
         modifier
@@ -90,7 +91,7 @@ fun UserAvatar(
             .clip(CircleShape)
             .let { if (onClick != null) it.clickable(onClick = onClick) else it }
 
-    when (val state = rememberUserAvatarState(userId)) {
+    when (val state = rememberUserAvatarState(userId, fallbackName)) {
         UserAvatarUiState.Loading -> {
             LoadingPlaceholder(modifier = baseModifier)
         }
@@ -116,17 +117,21 @@ fun UserAvatar(
 }
 
 @Composable
-internal fun rememberUserAvatarState(userId: String): UserAvatarUiState {
+internal fun rememberUserAvatarState(
+    userId: String,
+    fallbackName: String? = null,
+): UserAvatarUiState {
     val repo: UserProfileRepository = koinInject()
     val imageStorage: ImageStorage = koinInject()
     val profile by repo.observeProfile(userId).collectAsStateWithLifecycle(initialValue = null)
 
-    return remember(userId, profile) {
+    return remember(userId, profile, fallbackName) {
         userAvatarUiState(
             profile = profile,
             hasLocalAvatar = imageStorage.userAvatarExists(userId),
             localPath = imageStorage.getUserAvatarPath(userId),
             userId = userId,
+            fallbackName = fallbackName,
         )
     }
 }
@@ -274,14 +279,28 @@ internal fun avatarInitials(displayName: String): String =
         .joinToString("") { it.first().uppercase() }
         .ifBlank { "?" }
 
-/** Pure mapping from a profile + local-avatar presence to the render state. No Compose/IO. */
+/**
+ * Pure mapping from a profile + local-avatar presence to the render state. No Compose/IO.
+ *
+ * [fallbackName] lets a caller render initials for a user that has no cached public profile —
+ * a pending registrant never gets a server-side profile row, so without this the avatar would be
+ * stuck on the indefinite loading circle (#625). Active users (profile present) ignore it.
+ */
 internal fun userAvatarUiState(
     profile: CachedUserProfile?,
     hasLocalAvatar: Boolean,
     localPath: String,
     userId: String,
+    fallbackName: String? = null,
 ): UserAvatarUiState =
     when {
+        profile == null && !fallbackName.isNullOrBlank() -> {
+            UserAvatarUiState.Initials(
+                initials = avatarInitials(fallbackName),
+                color = stableColorForUserId(userId),
+            )
+        }
+
         profile == null -> {
             UserAvatarUiState.Loading
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
@@ -774,7 +774,6 @@ private fun PendingRegistrationsGroup(
             state.pendingUsers.forEachIndexed { index, user ->
                 PendingUserRow(
                     user = user,
-                    accent = accent,
                     isApproving = state.approvingUserId == user.id,
                     isDenying = state.denyingUserId == user.id,
                     showDivider = index > 0,
@@ -789,7 +788,6 @@ private fun PendingRegistrationsGroup(
 @Composable
 private fun PendingUserRow(
     user: AdminUserInfo,
-    accent: Color,
     isApproving: Boolean,
     isDenying: Boolean,
     showDivider: Boolean,
@@ -800,11 +798,12 @@ private fun PendingUserRow(
         user.displayName
             ?: "${user.firstName ?: ""} ${user.lastName ?: ""}".trim().ifEmpty { user.email }
     SettingRow(
-        icon = Icons.Outlined.PersonAdd,
-        accent = accent,
         title = name,
         subtitle = user.email,
         showDivider = showDivider,
+        // A pending registrant has no server-side public profile yet, so drive initials from their
+        // name (#625) rather than the generic add-person glyph / an indefinite loading circle.
+        leading = { UserAvatar(userId = user.id, size = AvatarSize.Medium, fallbackName = name) },
     ) {
         if (isApproving || isDenying) {
             ListenUpLoadingIndicatorSmall()


### PR DESCRIPTION
Combines the two remaining pending-user representation issues from the registration-approval testing pass.

## #625 — pending registration avatar doesn't render
A pending registrant has **no server-side public profile** (the server only creates one at approval). `UserAvatar` maps a missing profile to `UserAvatarUiState.Loading` — an indefinite neutral grey circle — so the admin "Pending registrations" row showed no avatar.

**Fix:** `UserAvatar`/`userAvatarUiState` gain an optional `fallbackName`. When there's no cached profile but a name is supplied, the avatar renders **initials** (colored by the stable per-user palette) instead of the loading placeholder. The admin `PendingUserRow` now passes the applicant's name, replacing the generic add-person glyph with their real initials. Active users (profile present) are unaffected.

## #624 — activity-log sighting: investigated, no fix needed
The other half of #624 was "the pending user appears in the activity log." Traced it: registration on an APPROVAL_QUEUE instance records **no** `user_joined` activity and creates **no** public profile for the applicant — both are guarded to the ACTIVE branch in `AuthServiceImpl`, and this is already pinned by `AuthServiceImplTest` ("register on an APPROVAL_QUEUE instance records no user_joined for the pending applicant"). With the merged `listUsers`-active-only fix (#624), a pending user no longer appears in any roster or feed. So the original sighting was the roster leak, now resolved — no further server change required.

## Tests
- `UserAvatarUiStateTest` (androidHostTest, executes): no-profile + fallback name → initials `"DH"`; no-profile + null/blank fallback → `Loading` (active-user behaviour preserved).
- `spotlessCheck`, `detekt`, `:sharedUI:testAndroidHostTest`, `:androidApp:assembleDebug` green locally.

Closes #625.
