### PR TITLE
🐛 fix: registration-approval pull fallback — unstick iOS Awaiting screen + working Check Status

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutes.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutes.kt
@@ -4,7 +4,10 @@ import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.auth.RegistrationStatusEvent
 import com.calypsan.listenup.server.auth.RegistrationBroadcaster
 import com.calypsan.listenup.server.auth.RegistrationDecision
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
 import io.ktor.server.sse.ServerSSESession
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
@@ -29,10 +32,11 @@ private const val STATUS_RECHECK_INTERVAL_MILLIS = 3_000L
 private const val STATUS_PENDING = "pending"
 
 /**
- * Mounts the unauthenticated registration-status SSE stream:
- *  - `GET /api/v1/auth/registration-status/{userId}/stream`
+ * Mounts the unauthenticated registration-status surface:
+ *  - `GET /api/v1/auth/registration-status/{userId}` — one-shot status (the pull fallback)
+ *  - `GET /api/v1/auth/registration-status/{userId}/stream` — SSE push stream
  *
- * A registrant awaiting approval has no JWT yet, so this route lives OUTSIDE the auth wall.
+ * A registrant awaiting approval has no JWT yet, so these routes live OUTSIDE the auth wall.
  *
  * On connect it emits the registrant's **persisted** status via [currentStatus]: a registrant who
  * connects (or reconnects, or taps "check status") *after* the admin's decision learns it
@@ -52,6 +56,18 @@ fun Route.registrationStatusRoutes(
     broadcaster: RegistrationBroadcaster,
     currentStatus: suspend (userId: String) -> RegistrationStatusEvent,
 ) {
+    // Plain request/response status check — the "never stranded" pull fallback for clients where
+    // the SSE stream doesn't deliver (e.g. the iOS Darwin engine). "Check Status" / a poll / an
+    // on-launch check hit this and learn the persisted decision with no streaming or WebSocket.
+    get("/api/v1/auth/registration-status/{userId}") {
+        val userId = call.parameters["userId"]
+        if (userId.isNullOrBlank()) {
+            call.respond(HttpStatusCode.BadRequest)
+        } else {
+            call.respond(currentStatus(userId))
+        }
+    }
+
     sse("/api/v1/auth/registration-status/{userId}/stream") {
         val userId = call.parameters["userId"] ?: return@sse
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutesTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutesTest.kt
@@ -19,6 +19,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.plugins.sse.sse
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -69,6 +70,30 @@ class RegistrationStatusRoutesTest :
 
                     statuses shouldBe listOf("pending", "approved")
                 }
+            }
+        }
+
+        test("one-shot GET registration-status reports the persisted decision (pull fallback)") {
+            // The "never stranded" pull path: a client whose SSE stream never delivers (e.g. iOS
+            // Darwin) can still learn it was approved via a plain request/response GET.
+            testApplication {
+                useIsolatedTestConfig(registrationPolicy = "APPROVAL_QUEUE")
+                application { module() }
+                val rest = createClient { install(ContentNegotiation) { json(contractJson) } }
+                val rootToken = rest.setupRoot()
+                val pendingId = rest.registerPending("darlene")
+
+                rest
+                    .get("/api/v1/auth/registration-status/$pendingId")
+                    .body<RegistrationStatusEvent>()
+                    .status shouldBe "pending"
+
+                rest.approve(rootToken, pendingId)
+
+                rest
+                    .get("/api/v1/auth/registration-status/$pendingId")
+                    .body<RegistrationStatusEvent>()
+                    .status shouldBe "approved"
             }
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/RegistrationStatusStreamImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/RegistrationStatusStreamImpl.kt
@@ -7,9 +7,12 @@ import com.calypsan.listenup.client.domain.repository.RegistrationStatusStream
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.repository.StreamedRegistrationStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.request.get
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
 import io.ktor.utils.io.readLine
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -69,6 +72,28 @@ class RegistrationStatusStreamImpl(
                     }
                 }
             }
+        }
+
+    override suspend fun fetchStatus(userId: String): StreamedRegistrationStatus =
+        try {
+            val serverUrl =
+                serverConfig.getServerUrl()
+                    ?: return StreamedRegistrationStatus.Pending
+            val url = "$serverUrl/api/v1/auth/registration-status/$userId"
+            logger.debug { "Polling registration status (one-shot): $url" }
+            val body = apiClientFactory.getUnauthenticatedStreamingClient().get(url).bodyAsText()
+            val event = json.decodeFromString<RegistrationStatusEvent>(body)
+            when (event.status) {
+                "approved" -> StreamedRegistrationStatus.Approved
+                "denied" -> StreamedRegistrationStatus.Denied(event.message)
+                else -> StreamedRegistrationStatus.Pending
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Never-stranded: a failed poll must not crash the waiting screen — stay pending.
+            logger.warn(e) { "registration-status one-shot fetch failed; treating as pending" }
+            StreamedRegistrationStatus.Pending
         }
 
     private fun parseSSEEvent(eventJson: String): StreamedRegistrationStatus? =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/RegistrationStatusStream.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/RegistrationStatusStream.kt
@@ -39,4 +39,18 @@ interface RegistrationStatusStream {
      * @throws Exception if the connection fails
      */
     fun streamStatus(userId: String): Flow<StreamedRegistrationStatus>
+
+    /**
+     * One-shot pull of the registrant's current status via a plain request/response GET.
+     *
+     * The "never stranded" fallback for clients where the SSE [streamStatus] doesn't deliver
+     * (notably the iOS Darwin engine's handling of the hand-rolled stream): "Check Status", an
+     * on-screen poll, and the on-entry check all use this so an approved registrant always learns
+     * it. Never throws — any transport/parse failure resolves to [StreamedRegistrationStatus.Pending]
+     * so the screen safely stays in its waiting state.
+     *
+     * @param userId The user ID to check
+     * @return the current status; [StreamedRegistrationStatus.Pending] on any failure
+     */
+    suspend fun fetchStatus(userId: String): StreamedRegistrationStatus
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/auth/PendingApprovalViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/auth/PendingApprovalViewModel.kt
@@ -7,12 +7,16 @@ import com.calypsan.listenup.client.domain.repository.RegistrationStatusStream
 import com.calypsan.listenup.client.domain.repository.StreamedRegistrationStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
+
+/** Cadence for the automatic status re-check while awaiting approval. */
+private const val POLL_INTERVAL_MS = 5_000L
 
 /**
  * ViewModel for the pending-approval screen.
@@ -36,14 +40,43 @@ class PendingApprovalViewModel(
     val state: StateFlow<PendingApprovalUiState> = _state.asStateFlow()
 
     private var sseJob: Job? = null
+    private var pollJob: Job? = null
 
     init {
         connectToSSE()
+        startStatusPolling()
     }
 
     override fun onCleared() {
         super.onCleared()
         sseJob?.cancel()
+        pollJob?.cancel()
+    }
+
+    /**
+     * Automatic pull fallback: re-checks the persisted status on a fixed cadence while waiting, so
+     * an approved registrant advances even when the SSE stream never delivers (e.g. iOS Darwin).
+     * An immediate check on entry catches an already-decided registration; the loop then stops the
+     * moment a terminal decision lands. Mirrors the server-side never-stranded poll.
+     */
+    private fun startStatusPolling() {
+        pollJob?.cancel()
+        pollJob =
+            viewModelScope.launch {
+                checkOnce()
+                while (state.value is PendingApprovalUiState.Waiting) {
+                    delay(POLL_INTERVAL_MS)
+                    checkOnce()
+                }
+            }
+    }
+
+    /** One reliable pull of the persisted status; advances the screen on a terminal decision. */
+    private suspend fun checkOnce() {
+        val status = registrationStatusStream.fetchStatus(userId)
+        if (status !is StreamedRegistrationStatus.Pending) {
+            handleStatusUpdate(status)
+        }
     }
 
     private fun connectToSSE() {
@@ -94,12 +127,17 @@ class PendingApprovalViewModel(
     }
 
     /**
-     * Manually re-check approval status by re-opening the SSE stream — the server answers a fresh
-     * subscription with the current status. The "never stranded" manual fallback to the always-on
-     * stream; safe to tap repeatedly (each call cancels and replaces the previous subscription).
+     * Manually re-check approval status. Uses the reliable one-shot pull first (works where the SSE
+     * stream doesn't, e.g. iOS), then re-opens the stream for instant future pushes if still
+     * waiting. The "never stranded" manual fallback; safe to tap repeatedly.
      */
     fun checkStatus() {
-        connectToSSE()
+        viewModelScope.launch {
+            checkOnce()
+            if (state.value is PendingApprovalUiState.Waiting) {
+                connectToSSE()
+            }
+        }
     }
 
     /** Cancel the pending registration and return to login. */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/auth/PendingApprovalViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/auth/PendingApprovalViewModelTest.kt
@@ -3,56 +3,95 @@ package com.calypsan.listenup.client.presentation.auth
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.RegistrationStatusStream
 import com.calypsan.listenup.client.domain.repository.StreamedRegistrationStatus
-import dev.mokkery.answering.returns
-import dev.mokkery.answering.sequentially
-import dev.mokkery.every
-import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+
+/**
+ * A controllable [RegistrationStatusStream] fake. [pullStatus] backs the one-shot `fetchStatus`
+ * pull (mutate it to simulate the admin's decision); [stream] backs the SSE push path.
+ */
+private class FakeRegistrationStatusStream(
+    var pullStatus: StreamedRegistrationStatus = StreamedRegistrationStatus.Pending,
+    private val stream: Flow<StreamedRegistrationStatus> = emptyFlow(),
+) : RegistrationStatusStream {
+    override fun streamStatus(userId: String): Flow<StreamedRegistrationStatus> = stream
+
+    override suspend fun fetchStatus(userId: String): StreamedRegistrationStatus = pullStatus
+}
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PendingApprovalViewModelTest :
     FunSpec({
         afterTest { Dispatchers.resetMain() }
 
-        test("checkStatus re-opens a dropped stream and recovers the approval transition") {
+        fun viewModel(stream: RegistrationStatusStream) =
+            PendingApprovalViewModel(
+                authSession = mock<AuthSession>(),
+                registrationStatusStream = stream,
+                userId = "user-1",
+                email = "reader@example.com",
+            )
+
+        test("the automatic poll advances to Approved when the registration is approved (no SSE)") {
             runTest {
                 Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-                val authSession: AuthSession = mock()
-                val stream: RegistrationStatusStream = mock()
-                // First subscription drops immediately (empty); the manual re-check gets a live
-                // stream that reports approval.
-                every { stream.streamStatus(any()) } sequentially {
-                    returns(emptyFlow())
-                    returns(flowOf(StreamedRegistrationStatus.Approved))
-                }
+                // SSE never delivers (empty) — exactly the iOS-Darwin case the pull fallback exists for.
+                val stream = FakeRegistrationStatusStream(pullStatus = StreamedRegistrationStatus.Pending)
+                val vm = viewModel(stream)
 
-                val viewModel =
-                    PendingApprovalViewModel(
-                        authSession = authSession,
-                        registrationStatusStream = stream,
-                        userId = "user-1",
-                        email = "reader@example.com",
+                runCurrent() // immediate on-entry check resolves pending
+                vm.state.value shouldBe PendingApprovalUiState.Waiting
+
+                stream.pullStatus = StreamedRegistrationStatus.Approved
+                advanceTimeBy(6_000) // next poll tick fires
+                advanceUntilIdle()
+
+                vm.state.value shouldBe PendingApprovalUiState.Approved
+            }
+        }
+
+        test("checkStatus pulls the approval immediately, even without the SSE stream") {
+            runTest {
+                Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+                val stream = FakeRegistrationStatusStream(pullStatus = StreamedRegistrationStatus.Pending)
+                val vm = viewModel(stream)
+                runCurrent()
+                vm.state.value shouldBe PendingApprovalUiState.Waiting
+
+                stream.pullStatus = StreamedRegistrationStatus.Approved
+                vm.checkStatus()
+                advanceUntilIdle()
+
+                vm.state.value shouldBe PendingApprovalUiState.Approved
+            }
+        }
+
+        test("an SSE push of Approved still advances the screen") {
+            runTest {
+                Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+                val stream =
+                    FakeRegistrationStatusStream(
+                        pullStatus = StreamedRegistrationStatus.Pending,
+                        stream = flowOf(StreamedRegistrationStatus.Approved),
                     )
-                advanceUntilIdle()
-                // The first stream ended without a verdict — still waiting.
-                viewModel.state.value shouldBe PendingApprovalUiState.Waiting
+                val vm = viewModel(stream)
 
-                viewModel.checkStatus()
                 advanceUntilIdle()
 
-                // Re-subscribing surfaced the approval.
-                viewModel.state.value shouldBe PendingApprovalUiState.Approved
+                vm.state.value shouldBe PendingApprovalUiState.Approved
             }
         }
     })


### PR DESCRIPTION
Fixes the iOS registrant softlock: after an admin approves, the Awaiting Approval screen never advanced and **"Check Status" did nothing** — a "never stranded" violation. The registration approval commits server-side correctly (the running server returns `{"status":"approved"}` instantly), but the client never learned it.

## Root cause
The approval signal depended **solely** on the SSE stream (`RegistrationStatusStreamImpl` hand-rolls `bodyAsChannel().readLine()`), which doesn't reliably deliver on the iOS Darwin engine. The REST polling fallback (`checkRegistrationStatus`) had been deliberately removed in favor of SSE-only, and the "just retry login" fallback isn't reachable from the Awaiting screen (only "Check Status" → re-subscribe SSE, and "Cancel"). So a registrant whose SSE didn't deliver had **no path** to learn they were approved — stuck even across reboots.

## Fix — restore the pull path (plain REST, no RPC/WS/SSE)
- **Server**: new one-shot `GET /api/v1/auth/registration-status/{userId}` (unauthenticated, beside the existing `/stream`) returning the persisted status. A plain request/response has the fewest moving parts — no WebSocket handshake, no cached-proxy lifecycle, no Darwin SSE quirks — which is exactly what a never-stranded fallback should be.
- **Client (shared → iOS + Android both inherit it)**:
  - `RegistrationStatusStream.fetchStatus()` — the restored pull, never-throwing (any failure → `Pending` so the screen stays safe).
  - **Auto-poll** every 5s while waiting (+ an immediate check on entry), so an approved registrant advances on its own even if SSE never delivers.
  - **"Check Status" now works**: `checkStatus()` does the reliable pull first, then re-opens SSE if still pending. The button was already wired on both the Compose and iOS screens — it just needed `checkStatus()` to actually do something.

No iOS Swift change needed (the shared VM constructor is unchanged; the wrapper already binds `state` and calls `viewModel.checkStatus()`).

## Tests
- `RegistrationStatusRoutesTest`: one-shot GET reports `pending`, then `approved` after admin approval.
- `PendingApprovalViewModelTest`: auto-poll advances to Approved with no SSE; `checkStatus` pulls the approval immediately; an SSE push still advances.
- `spotlessCheck`, `detekt`, `:server:test`, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` green locally.

Follow-up (separate PR): the admin's pending list not updating live (needs a server-side broadcast on pending registration).
