### PR TITLE
🐛 fix(sharedLogic): admin pending registrations appear live (poll) without an app restart

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
@@ -20,12 +20,25 @@ import com.calypsan.listenup.client.domain.usecase.admin.RevokeInviteUseCase
 import com.calypsan.listenup.client.domain.usecase.admin.SetRegistrationPolicyUseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
+
+/**
+ * Cadence for refreshing the pending-registrations list while the admin screen is open.
+ *
+ * The live admin-event firehose isn't wired yet ([com.calypsan.listenup.client.data.repository.EventStreamRepositoryImpl]
+ * stubs `adminEvents` to `emptyFlow()`), so without this a newly-registered pending user only
+ * appears after an app restart. This poll is the never-stranded refresh until that migration lands.
+ */
+private const val PENDING_POLL_INTERVAL_MS = 10_000L
 
 /**
  * ViewModel for the combined admin screen.
@@ -51,6 +64,34 @@ class AdminViewModel(
     init {
         loadData()
         observeSSEEvents()
+        pollPendingUsers()
+    }
+
+    /**
+     * Periodically re-fetch the pending-registrations list so a newly-registered applicant appears
+     * without an app restart. Updates only the `pendingUsers` of an existing [AdminUiState.Ready]
+     * (no-op while Loading/Error, and per-action overlays are preserved); a transient failure keeps
+     * the current list.
+     *
+     * Gated on [state] having subscribers, so it only runs while the admin screen is actually on
+     * screen — no wasted polling in the background. Stops automatically when the scope is cancelled.
+     */
+    private fun pollPendingUsers() {
+        viewModelScope.launch {
+            state.subscriptionCount
+                .map { it > 0 }
+                .distinctUntilChanged()
+                .collectLatest { isObserved ->
+                    if (!isObserved) return@collectLatest
+                    while (true) {
+                        delay(PENDING_POLL_INTERVAL_MS)
+                        when (val result = loadPendingUsersUseCase()) {
+                            is AppResult.Success -> updateReady { it.copy(pendingUsers = result.data) }
+                            is AppResult.Failure -> Unit
+                        }
+                    }
+                }
+        }
     }
 
     /**

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
@@ -23,12 +23,14 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -509,6 +511,50 @@ class AdminViewModelTest :
                 val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
                 ready.users.size shouldBe 1
                 ready.pendingInvites.size shouldBe 1
+            }
+        }
+
+        test("the pending list refreshes on a poll tick while the screen is observed") {
+            runTest {
+                // Server-side pending list, flipped mid-test to simulate a new registration arriving.
+                var pending: List<AdminUserInfo> = emptyList()
+                val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
+                everySuspend { loadPendingUsersUseCase() } calls { AppResult.Success(pending) }
+                val loadUsersUseCase: LoadUsersUseCase = mock()
+                everySuspend { loadUsersUseCase() } returns AppResult.Success(emptyList())
+                val loadInvitesUseCase: LoadInvitesUseCase = mock()
+                everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
+
+                val viewModel =
+                    AdminViewModel(
+                        getRegistrationPolicyUseCase =
+                            createMockGetRegistrationPolicyUseCase(RegistrationPolicy.APPROVAL_QUEUE),
+                        loadUsersUseCase = loadUsersUseCase,
+                        loadPendingUsersUseCase = loadPendingUsersUseCase,
+                        loadInvitesUseCase = loadInvitesUseCase,
+                        deleteUserUseCase = mock(),
+                        revokeInviteUseCase = mock(),
+                        approveUserUseCase = mock(),
+                        denyUserUseCase = mock(),
+                        setRegistrationPolicyUseCase = mock(),
+                        eventStreamRepository = createMockEventStreamRepository(),
+                    )
+
+                // Observe state so the subscription-gated poll runs (auto-cancelled at test end).
+                backgroundScope.launch { viewModel.state.collect {} }
+                advanceTimeBy(200) // initial load settles → Ready, empty pending
+                viewModel.state.value
+                    .shouldBeInstanceOf<AdminUiState.Ready>()
+                    .pendingUsers
+                    .shouldBeEmpty()
+
+                pending = listOf(createUser(id = "p1"))
+                advanceTimeBy(11_000) // crosses the 10s poll cadence
+
+                viewModel.state.value
+                    .shouldBeInstanceOf<AdminUiState.Ready>()
+                    .pendingUsers
+                    .map { it.id } shouldBe listOf("p1")
             }
         }
     })


### PR DESCRIPTION
Fixes the admin-side real-time gap found in the registration-approval test pass: **a newly-registered pending user didn't appear on the admin's "Pending registrations" list until the app was restarted.**

## Root cause
`AdminViewModel` subscribes to `EventStreamRepository.adminEvents` for live `UserPending`/`UserApproved` updates — but `EventStreamRepositoryImpl.adminEvents` is a hardcoded `emptyFlow()` ("until non-sync admin/book SSE domains migrate to the renovated firehose"). That firehose migration was never done, so the live handlers never receive anything and the pending list only refreshes on a full reload (app restart).

## Fix — never-stranded poll
`AdminViewModel` now re-fetches the pending-registrations list on a 10s cadence and updates only the `pendingUsers` of an existing `Ready` state (per-action overlays preserved; transient failures keep the current list). The poll is **gated on `state` having subscribers**, so it only runs while the admin screen is actually on-screen — no background polling.

This is the pragmatic, reliable fallback consistent with the registrant-side poll (PR #632) until the admin-event firehose migration lands (which would restore instant push). The existing SSE handlers remain, so they light up for free once `adminEvents` is wired.

## Tests
- New `AdminViewModelTest` case: with the screen observed, a pending user that appears server-side surfaces on the next poll tick — no reload.
- The 13 existing `advanceUntilIdle`-based tests still pass: the subscription gate means the poll doesn't run for `.value`-only tests (which never subscribe), so it can't hang them.
- `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` green locally.
