### PR TITLE
🐛 fix(sharedLogic): redirect to login on stale-session 401 (#640)

### DIFF
--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
@@ -5,7 +5,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.error.DownloadError
 import com.calypsan.listenup.core.error.ErrorBus
@@ -45,7 +45,6 @@ class DownloadWorker(
         const val KEY_FILE_SIZE = "file_size"
 
         private const val MAX_RETRIES = 3
-        private const val HTTP_UNAUTHORIZED = 401
     }
 
     override suspend fun doWork(): Result {
@@ -83,9 +82,10 @@ class DownloadWorker(
     ): Result {
         // 401 → markPaused (don't burn the 3-attempt retry budget on unrecoverable auth).
         // installListenUpErrorHandling() routes Ktor ResponseException through ErrorMapper, which
-        // maps 401 → TransportError.Server4xx(statusCode=401). Auth-specific upgrade to AuthError
-        // happens at the repository layer; the worker only sees the boundary classification.
-        if (error is TransportError.Server4xx && error.statusCode == HTTP_UNAUTHORIZED) {
+        // types a 401 as AuthError.SessionExpired at the boundary. The global AuthFailureObserver
+        // reacts to that on the foreground error bus by driving the app to login; here in the
+        // background worker we simply pause so the download resumes after re-auth.
+        if (error is AuthError.SessionExpired) {
             logger.warn { "Download paused due to auth failure: $audioFileId" }
             downloadRepository.markPaused(audioFileId)
             return Result.failure()

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.core.error
 
 import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
@@ -8,6 +9,7 @@ import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
 import kotlinx.io.IOException
 import kotlinx.serialization.SerializationException
 
@@ -31,10 +33,22 @@ object ErrorMapper {
 
             is ResponseException -> {
                 val status = exception.response.status.value
-                if (status in 500..599) {
-                    TransportError.Server5xx(statusCode = status, debugInfo = exception.message)
-                } else {
-                    TransportError.Server4xx(statusCode = status, debugInfo = exception.message)
+                when {
+                    // 401 means the session is stale/invalid — type it as an auth error at the
+                    // boundary so the global auth-failure observer drives the app back to login
+                    // instead of looping a generic "server error" snackbar (issue #640). 403
+                    // (authenticated-but-forbidden) stays a plain 4xx — it is not a session failure.
+                    status == HttpStatusCode.Unauthorized.value -> {
+                        AuthError.SessionExpired(debugInfo = exception.message)
+                    }
+
+                    status in 500..599 -> {
+                        TransportError.Server5xx(statusCode = status, debugInfo = exception.message)
+                    }
+
+                    else -> {
+                        TransportError.Server4xx(statusCode = status, debugInfo = exception.message)
+                    }
                 }
             }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserver.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserver.kt
@@ -1,0 +1,60 @@
+package com.calypsan.listenup.client.data.auth
+
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.client.domain.model.AuthState
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.core.error.ErrorBus
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Watches the app-wide [ErrorBus] and turns a session-invalidating [AuthError]
+ * into a soft logout, so a stale/invalid session lands the user on the login
+ * screen instead of looping a generic error snackbar (issue #640).
+ *
+ * This is the single, transport-agnostic place that reacts to auth failure:
+ * a 401 from any surface (REST, RPC, SSE) is typed as an [AuthError] at the
+ * `ErrorMapper` boundary, emitted to the bus by its consumer, and resolved here.
+ * The token-refresh flow remains the first line of defence; this catches the
+ * 401s that survive a failed (or absent) refresh.
+ *
+ * Only fires while currently [AuthState.Authenticated] — the pre-auth connect
+ * and login flows produce their own auth errors that must not be misread as a
+ * logout.
+ */
+class AuthFailureObserver(
+    errorBus: ErrorBus,
+    private val authSession: AuthSession,
+    scope: CoroutineScope,
+) {
+    init {
+        scope.launch {
+            errorBus.errors.collect { error ->
+                if (error.invalidatesSession() && authSession.authState.value is AuthState.Authenticated) {
+                    logger.info { "Session-invalidating auth error (${error.code}); soft-logout → login" }
+                    authSession.clearAuthTokens()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * True for auth errors that mean the current session can no longer be used and
+ * the user must sign in again. Permission-style auth errors (e.g. [AuthError.PermissionDenied])
+ * are deliberately excluded — they mean "not allowed", not "logged out".
+ */
+private fun AppError.invalidatesSession(): Boolean =
+    when (this) {
+        is AuthError.SessionExpired,
+        is AuthError.SessionNotFound,
+        is AuthError.InvalidRefreshToken,
+        is AuthError.ServerInstanceChanged,
+        -> true
+
+        else -> false
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AppCoreModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AppCoreModule.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.client.data.auth.AuthFailureObserver
 import com.calypsan.listenup.client.data.repository.DeepLinkManager
 import com.calypsan.listenup.client.data.repository.ShortcutActionManager
 import kotlinx.coroutines.CoroutineScope
@@ -43,6 +44,17 @@ val appCoreModule: Module =
         ) {
             CoroutineScope(
                 SupervisorJob() + Dispatchers.Default,
+            )
+        }
+
+        // Global auth-failure watcher: a session-invalidating AuthError on the bus
+        // soft-logs-out → login (issue #640). createdAtStart so it subscribes before
+        // any auth error can be emitted.
+        single(createdAtStart = true) {
+            AuthFailureObserver(
+                errorBus = get(),
+                authSession = get(),
+                scope = get(qualifier = named(APP_SCOPE)),
             )
         }
     }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserverTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserverTest.kt
@@ -1,0 +1,100 @@
+package com.calypsan.listenup.client.data.auth
+
+import com.calypsan.listenup.api.dto.auth.AccessToken
+import com.calypsan.listenup.api.dto.auth.RefreshToken
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.client.data.repository.AuthSessionStore
+import com.calypsan.listenup.client.domain.model.AuthState
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.SecureStorage
+import com.calypsan.listenup.core.error.ErrorBus
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [AuthFailureObserver] — the single place that converts a
+ * session-invalidating [AuthError] surfaced on the [ErrorBus] into a soft logout,
+ * driving navigation back to the login screen (issue #640).
+ *
+ * The observer collects a hot [kotlinx.coroutines.flow.SharedFlow], so the collector
+ * is launched on an [UnconfinedTestDispatcher] — it subscribes eagerly, before the
+ * test emits, and processes each emission synchronously.
+ */
+class AuthFailureObserverTest :
+    FunSpec({
+        fun authenticatedStore(): AuthSessionStore {
+            val storage = mock<SecureStorage>()
+            everySuspend { storage.save(any(), any()) } returns Unit
+            everySuspend { storage.delete(any()) } returns Unit
+            // clearAuthTokens reads KEY_OPEN_REGISTRATION when routing to NeedsLogin.
+            everySuspend { storage.read(any()) } returns null
+            return AuthSessionStore(storage, mock<ServerConfig>(), mock<InstanceRepository>())
+        }
+
+        test("session-invalidating error while Authenticated drives state to NeedsLogin") {
+            runTest {
+                val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+                try {
+                    val errorBus = ErrorBus()
+                    val store = authenticatedStore()
+                    store.saveAuthTokens(AccessToken("a"), RefreshToken("r"), "session", "user")
+                    store.authState.value.shouldBeInstanceOf<AuthState.Authenticated>()
+
+                    AuthFailureObserver(errorBus, store, scope)
+                    errorBus.emit(AuthError.SessionExpired())
+
+                    store.authState.value.shouldBeInstanceOf<AuthState.NeedsLogin>()
+                } finally {
+                    scope.cancel()
+                }
+            }
+        }
+
+        test("non-auth error while Authenticated does not log the user out") {
+            runTest {
+                val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+                try {
+                    val errorBus = ErrorBus()
+                    val store = authenticatedStore()
+                    store.saveAuthTokens(AccessToken("a"), RefreshToken("r"), "session", "user")
+
+                    AuthFailureObserver(errorBus, store, scope)
+                    errorBus.emit(TransportError.Server5xx(statusCode = 500))
+
+                    store.authState.value.shouldBeInstanceOf<AuthState.Authenticated>()
+                } finally {
+                    scope.cancel()
+                }
+            }
+        }
+
+        test("session-invalidating error while not Authenticated is ignored") {
+            runTest {
+                val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+                try {
+                    val errorBus = ErrorBus()
+                    val store = authenticatedStore()
+                    // Never authenticated — store stays in its initial state.
+                    val before = store.authState.value
+
+                    AuthFailureObserver(errorBus, store, scope)
+                    errorBus.emit(AuthError.SessionExpired())
+
+                    store.authState.value shouldBe before
+                } finally {
+                    scope.cancel()
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpClientErrorHandlingTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpClientErrorHandlingTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.remote
 
+import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.test.http.testMockEngine
@@ -87,6 +88,23 @@ class HttpClientErrorHandlingTest :
                 val error = result.error
                 error.shouldBeInstanceOf<TransportError.Server5xx>()
                 error.statusCode shouldBe 500
+            }
+        }
+
+        test("apiCallCatchesUnauthorizedAndProducesTypedSessionExpiredFailure") {
+            runTest {
+                // 401 Unauthorized → ErrorMapper upgrades to AuthError.SessionExpired at the
+                // boundary (a stale/invalid session). This is the typed signal that the global
+                // auth-failure observer reacts to by driving the app back to the login screen.
+                val c = client { respondStatus("/secret", HttpStatusCode.Unauthorized) }
+
+                val result =
+                    apiCall<String>(errorMessage = "Failed to fetch") {
+                        c.get("http://unit.test/secret").body()
+                    }
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                result.error.shouldBeInstanceOf<AuthError.SessionExpired>()
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/AppCoreModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/AppCoreModuleVerifyTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import io.kotest.core.spec.style.FunSpec
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.verify
@@ -8,9 +9,10 @@ import org.koin.test.verify.verify
  * Leaf verify for [appCoreModule]. Per the architecture rubric every leaf
  * Koin module is covered by a `module.verify()` test in commonTest.
  *
- * [appCoreModule] has no external dependencies — [ErrorBus], [DeepLinkManager],
- * [ShortcutActionManager], and the app-scoped [kotlinx.coroutines.CoroutineScope]
- * are all self-contained. The extra-types whitelist is therefore empty.
+ * [ErrorBus], [DeepLinkManager], [ShortcutActionManager], and the app-scoped
+ * [kotlinx.coroutines.CoroutineScope] are self-contained. [AuthSession] is the one
+ * external dependency — the [com.calypsan.listenup.client.data.auth.AuthFailureObserver]
+ * consumes it — so it is whitelisted as externally provided.
  */
 @OptIn(KoinExperimentalAPI::class)
 class AppCoreModuleVerifyTest :
@@ -18,7 +20,7 @@ class AppCoreModuleVerifyTest :
 
         test("appCoreModule wires up against its declared external dependencies") {
             appCoreModule.verify(
-                extraTypes = emptyList(),
+                extraTypes = listOf(AuthSession::class),
             )
         }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.api.sync.PlaybackPositionSyncPayload
 import com.calypsan.listenup.api.sync.UserStatsSyncPayload
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.appJson
+import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.DownloadError
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
@@ -106,7 +107,7 @@ class DownloadWorkerLogicTest :
         // Mirrors the production ApiClientFactory client: installs [installListenUpErrorHandling] so
         // non-2xx responses raise [io.ktor.client.plugins.ResponseException] (via
         // `expectSuccess = true`); the surrounding `apiCall { ... }` boundary catches it and routes
-        // through `ErrorMapper` to produce an `AppResult.Failure(TransportError.Server4xx(401))`
+        // through `ErrorMapper` to produce an `AppResult.Failure(AuthError.SessionExpired)`
         // after a failed refresh. Without this, the 401 leaks through the success-decoder path.
         fun authProductionLikeClient(
             engine: HttpClientEngine,
@@ -318,12 +319,12 @@ class DownloadWorkerLogicTest :
 
         // ---- Scenario 4 ----
 
-        // 401 persistent → refresh returns null → returns AppResult.Failure(TransportError.Server4xx(401)).
+        // 401 persistent → refresh returns null → returns AppResult.Failure(AuthError.SessionExpired).
         //
         // Production path: installListenUpErrorHandling raises ResponseException on the non-2xx
         // response; the surrounding apiCall boundary catches it and produces
-        // AppResult.Failure(TransportError.Server4xx(statusCode=401)). The worker inspects the
-        // AppResult and on a 401 calls markPaused. This test asserts the typed-failure contract —
+        // AppResult.Failure(AuthError.SessionExpired). The worker inspects the AppResult and on a
+        // session-invalid auth error calls markPaused. This test asserts the typed-failure contract —
         // catching a bug where the old dead-code ResponseException catch caused FAILED instead.
         test("401 persistent with null refresh — returns AppResult Failure and worker would markPaused") {
             runTest {
@@ -354,11 +355,9 @@ class DownloadWorkerLogicTest :
                         )
 
                     val failure = result.shouldBeInstanceOf<AppResult.Failure>()
-                    val server4xx = failure.error as? TransportError.Server4xx
-                    withClue("Expected TransportError.Server4xx but got ${failure.error::class.simpleName}") {
-                        failure.error.shouldBeInstanceOf<TransportError.Server4xx>()
+                    withClue("Expected AuthError.SessionExpired but got ${failure.error::class.simpleName}") {
+                        failure.error.shouldBeInstanceOf<AuthError.SessionExpired>()
                     }
-                    server4xx?.statusCode shouldBe HttpStatusCode.Unauthorized.value
                     // Replicate worker's auth-failure path: markPaused (not markFailed).
                     fakeRepo.markPaused("file-1")
 


### PR DESCRIPTION
Closes #640.

## Problem
A stale/invalid session (401) left the app looping "server connection error" snackbars on the current screen instead of redirecting to login — unusable until restart.

## Root cause
Two broken links:
1. `ErrorMapper` flattened **every** 4xx — including 401 — into `TransportError.Server4xx`. Code comments claimed an "auth-specific upgrade to AuthError happens at the repository layer", but that upgrade was never implemented, so a 401 surfaced as a generic transport error → the looping snackbar.
2. The only path that reset `authState` → `NeedsLogin` was the REST token-refresh flow. Nothing caught 401s arriving over RPC/SSE or surviving a failed refresh, so auth state stayed `Authenticated` and navigation never moved.

## Fix (401-only; 403 stays an honest "not allowed")
- **`ErrorMapper`**: 401 → `AuthError.SessionExpired` at the boundary (translate-once, per the rubric). 403 and other 4xx unchanged.
- **New `AuthFailureObserver`** (`data/auth/`, wired in `appCoreModule` as a `createdAtStart` single): watches the `ErrorBus` and, on a session-invalidating `AuthError` (`SessionExpired`, `SessionNotFound`, `InvalidRefreshToken`, `ServerInstanceChanged`) **while currently `Authenticated`**, calls `clearAuthTokens()` → `NeedsLogin` → `ListenUpNavigation` redirects. Transport-agnostic — REST, RPC, and SSE all converge here. The `Authenticated` guard avoids disturbing the pre-auth connect/login flows.
- Ripple (compiler-guided): `DownloadWorker` now matches `AuthError.SessionExpired`; updated `DownloadWorkerLogicTest`, `AppCoreModuleVerifyTest` (AuthSession is now an external dep), and `HttpClientErrorHandlingTest` (added the 401 case).

## Tests (TDD)
- `HttpClientErrorHandlingTest`: 401 → `SessionExpired` through the real apiCall boundary.
- `AuthFailureObserverTest`: logs out on a session-class error while Authenticated; ignores non-auth errors and the not-authenticated case.

## Local gates
`:sharedLogic:jvmTest` (2619) · `spotlessCheck` + `detekt` · `:androidApp:assembleDebug` · `:server:test` — all green. iOS gates run on remote CI.

On-device verification of the live redirect is still pending.