### PR TITLE
🐛 fix(admin): searchUsers ACTIVE-only (#624) + never-strand admin page (#620)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
@@ -123,8 +123,10 @@ class AdminUserServiceImpl(
         val needle = query.trim()
         return suspendTransaction(db) {
             AppResult.Success(
+                // ACTIVE only: search is an active-roster operation; pending/denied registrations
+                // have their own surfaces and must not leak in (#624, sibling of listUsers).
                 UserEntity
-                    .find { UserTable.deletedAt eq null }
+                    .find { (UserTable.deletedAt eq null) and (UserTable.status eq UserStatusColumn.ACTIVE) }
                     .filter {
                         it.displayName.contains(needle, ignoreCase = true) ||
                             it.email.contains(needle, ignoreCase = true)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
@@ -328,6 +328,25 @@ class AdminUserServiceImplTest :
             }
         }
 
+        test("searchUsers returns only ACTIVE members, excluding pending and denied registrations") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestUser("root1", UserRoleColumn.ROOT)
+                seedUserWithStatus("activeAlice", userStatus = UserStatusColumn.ACTIVE)
+                seedUserWithStatus("pendingAlice", userStatus = UserStatusColumn.PENDING_APPROVAL)
+                seedUserWithStatus("deniedAlice", userStatus = UserStatusColumn.DENIED)
+                runTest {
+                    val svc = makeAdminUserService(db).actAs("root1", UserRole.ROOT)
+                    // Search is an active-roster operation — pending/denied have their own surfaces
+                    // and must not leak in (#624, sibling of the listUsers filter).
+                    val ids = svc.searchUsers("alice").shouldSucceed().map { it.id.value }
+                    ids shouldContain "activeAlice"
+                    ids shouldNotContain "pendingAlice"
+                    ids shouldNotContain "deniedAlice"
+                }
+            }
+        }
+
         test("listUsers returns only ACTIVE members, excluding pending and denied registrations") {
             withInMemoryDatabase {
                 val db = this

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
@@ -161,21 +161,20 @@ class AdminViewModel(
             val pendingResult = deferredPending.await()
             val invitesResult = deferredInvites.await()
 
-            // Users fetch is the primary load. If it fails on initial load, surface as Error.
-            // If already Ready (refresh), surface as transient error on Ready.
-            if (usersResult is AppResult.Failure) {
-                val message = "Failed to load users: ${usersResult.message}"
-                state.update { current ->
-                    if (current is AdminUiState.Ready) {
-                        current.copy(error = message)
-                    } else {
-                        AdminUiState.Error(message)
-                    }
+            // Every section degrades independently. A single failed fetch must never black out the
+            // whole page — that strands the admin without the (independent) registration-policy
+            // control and every other section (#620). Failures surface as a sectional error banner
+            // on Ready, never as a full Error screen.
+            val users =
+                when (usersResult) {
+                    is AppResult.Success -> usersResult.data
+                    is AppResult.Failure -> emptyList()
                 }
-                return@launch
-            }
-
-            val users = (usersResult as AppResult.Success).data
+            val usersError =
+                when (usersResult) {
+                    is AppResult.Success -> null
+                    is AppResult.Failure -> "Failed to load users: ${usersResult.message}"
+                }
             val pendingUsers =
                 when (pendingResult) {
                     is AppResult.Success -> pendingResult.data
@@ -191,6 +190,7 @@ class AdminViewModel(
                     is AppResult.Success -> null
                     is AppResult.Failure -> "Failed to load invites: ${invitesResult.message}"
                 }
+            val loadError = listOfNotNull(usersError, invitesError).joinToString("; ").ifEmpty { null }
 
             // Sort users: root user first, then by creation date (oldest first)
             val sortedUsers =
@@ -206,7 +206,7 @@ class AdminViewModel(
                         users = sortedUsers,
                         pendingUsers = pendingUsers,
                         pendingInvites = pendingInvites,
-                        error = invitesError,
+                        error = loadError,
                     )
                 } else {
                     // First emission (from Loading) or recovering from Error:
@@ -216,7 +216,7 @@ class AdminViewModel(
                         users = sortedUsers,
                         pendingUsers = pendingUsers,
                         pendingInvites = pendingInvites,
-                        error = invitesError,
+                        error = loadError,
                     )
                 }
             }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
@@ -296,9 +296,9 @@ class AdminViewModelTest :
             }
         }
 
-        test("loadData initial users failure transitions to Error") {
+        test("loadData users failure degrades to Ready and keeps the registration-policy control usable (#620)") {
             runTest {
-                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase()
+                val getRegistrationPolicyUseCase = createMockGetRegistrationPolicyUseCase(RegistrationPolicy.OPEN)
                 val loadUsersUseCase: LoadUsersUseCase = mock()
                 val loadPendingUsersUseCase: LoadPendingUsersUseCase = mock()
                 val loadInvitesUseCase: LoadInvitesUseCase = mock()
@@ -311,6 +311,7 @@ class AdminViewModelTest :
                 everySuspend { loadUsersUseCase() } returns Failure(RuntimeException("Network error"))
                 everySuspend { loadPendingUsersUseCase() } returns AppResult.Success(emptyList())
                 everySuspend { loadInvitesUseCase() } returns AppResult.Success(emptyList())
+                everySuspend { setRegistrationPolicyUseCase(any()) } returns AppResult.Success(Unit)
 
                 val viewModel =
                     AdminViewModel(
@@ -327,8 +328,20 @@ class AdminViewModelTest :
                     )
                 advanceUntilIdle()
 
-                val error = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Error>()
-                error.message shouldContain "users"
+                // #620: a users-load failure must NOT black out the page. It degrades to Ready —
+                // policy loaded, users empty, and the failure surfaced honestly — so the
+                // (independent) registration-policy control stays reachable.
+                val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()
+                ready.registrationPolicy shouldBe RegistrationPolicy.OPEN
+                ready.users.shouldBeEmpty()
+                ready.error.shouldBeInstanceOf<String>() shouldContain "users"
+
+                // The control now actually works: changing the policy takes effect.
+                viewModel.setRegistrationPolicy(RegistrationPolicy.CLOSED)
+                advanceUntilIdle()
+                viewModel.state.value
+                    .shouldBeInstanceOf<AdminUiState.Ready>()
+                    .registrationPolicy shouldBe RegistrationPolicy.CLOSED
             }
         }
 


### PR DESCRIPTION
Closes #624. Closes #620.

## Background
Investigation found the core defects behind #624/#620/#619 were already fixed in main by #626 (`listUsers()` now returns ACTIVE-only and serializes pending users correctly). This PR closes the **residual gaps** in the same family.

## #624 — `searchUsers()` leaked pending/denied users
`AdminUserServiceImpl.searchUsers()` filtered only on `deletedAt`, so PENDING_APPROVAL / DENIED users surfaced in admin user search — the same bug class as the `listUsers()` one fixed in #626, just on the search path.

**Fix:** filter `searchUsers()` to `status == ACTIVE`, matching `listUsers()`. (The activity-log half of #624 was verified already-correct: a pending registrant never gets `USER_JOINED`, and `createStarterShelf` records no activity.)

## #620 — can't change registration policy / page stranded
Root cause (the reporter's own hypothesis, confirmed): `AdminViewModel.loadData()` early-returned to a full-screen `Error` state whenever `listUsers()` failed. The registration-policy control lives only in `Ready`, and `setRegistrationPolicy()` no-ops outside `Ready` — so one failed section blacked out the page and made the independent policy control unreachable. A never-stranded violation.

**Fix:** every section now degrades independently. A `listUsers()` failure yields an empty users list + a sectional error banner, and the page still reaches `Ready` — keeping the registration-policy control (and every other section) usable. Mirrors how pending-users and invites already degrade.

## Tests (TDD)
- `AdminUserServiceImplTest`: `searchUsers returns only ACTIVE members, excluding pending and denied registrations` (red → green).
- `AdminViewModelTest`: rewrote the old `…transitions to Error` test into `…degrades to Ready and keeps the registration-policy control usable (#620)` — asserts the page reaches `Ready` with the policy loaded after a users-load failure, and that a subsequent `setRegistrationPolicy` actually takes effect.

## Follow-up
`AdminUiState.Error` is now unproduced. Removing it touches the iOS consumer (`AdminObserver.swift`), so it's deferred to a Mac in #649.

## Local gates
`spotlessCheck` + `detekt` · `:sharedLogic:jvmTest` · `:server:test` · `:androidApp:assembleDebug` — all green. iOS gates run on remote CI.

On-device verification (set APPROVAL_QUEUE, create a pending user, change policy) still recommended before relying on it.