### PR TITLE
♻️ refactor(sharedUI): consistent form fields on the contributor edit page (#616, #617)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -320,5 +320,8 @@ private fun AudibleContributorProfile.toMetadataContributorProfile(): MetadataCo
         imageUrl = imageUrl.takeIf { it.isNotBlank() },
         birthDate = null,
         deathDate = null,
+        // Audible author pages expose no external website (the scrape yields only name, biography,
+        // and og:image), so there is nothing to populate here — website stays a manual-only field
+        // edited on the contributor page (#616).
         website = null,
     )

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpTextField.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpTextField.kt
@@ -5,13 +5,33 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
+import com.calypsan.listenup.client.design.theme.DisplayFontFamily
+
+/**
+ * Visual variant of [ListenUpTextField].
+ */
+enum class ListenUpTextFieldVariant {
+    /** Standard labeled form field — the default for every form row. */
+    Standard,
+
+    /**
+     * Large editorial inline editor: display type, bold, translucent tinted container, no floating
+     * label. For a hero/title field (e.g. the contributor name) that should still be *the* canonical
+     * text field, not a bespoke `OutlinedTextField`.
+     */
+    Hero,
+}
 
 /**
  * Material 3 text field using the theme's expressive shape system.
@@ -21,7 +41,7 @@ import androidx.compose.ui.text.input.VisualTransformation
  *
  * @param value Current text value
  * @param onValueChange Callback when text changes
- * @param label Floating label text
+ * @param label Floating label text. Null renders no label (the default for [ListenUpTextFieldVariant.Hero]).
  * @param modifier Optional modifier
  * @param placeholder Hint text shown when empty
  * @param enabled Whether the field is enabled for input
@@ -34,12 +54,15 @@ import androidx.compose.ui.text.input.VisualTransformation
  * @param trailingIcon Optional icon shown at the end of the field
  * @param onTrailingClick When non-null, the trailing icon becomes a clickable button
  *   (e.g. a password visibility toggle)
+ * @param variant [ListenUpTextFieldVariant.Standard] (default) or [ListenUpTextFieldVariant.Hero]
+ * @param heroContainerColor Tint for the [ListenUpTextFieldVariant.Hero] translucent container.
+ *   Ignored by [ListenUpTextFieldVariant.Standard]. Defaults to the theme surface.
  */
 @Composable
 fun ListenUpTextField(
     value: String,
     onValueChange: (String) -> Unit,
-    label: String,
+    label: String? = null,
     modifier: Modifier = Modifier,
     placeholder: String? = null,
     enabled: Boolean = true,
@@ -51,12 +74,34 @@ fun ListenUpTextField(
     leadingIcon: ImageVector? = null,
     trailingIcon: ImageVector? = null,
     onTrailingClick: (() -> Unit)? = null,
+    variant: ListenUpTextFieldVariant = ListenUpTextFieldVariant.Standard,
+    heroContainerColor: Color = MaterialTheme.colorScheme.surface,
 ) {
+    val isHero = variant == ListenUpTextFieldVariant.Hero
+    val heroTextStyle =
+        MaterialTheme.typography.headlineSmall.copy(
+            fontFamily = DisplayFontFamily,
+            fontWeight = FontWeight.Bold,
+        )
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        label = { Text(label) },
-        placeholder = placeholder?.let { { Text(it) } },
+        label = label?.let { { Text(it) } },
+        placeholder =
+            placeholder?.let {
+                {
+                    if (isHero) {
+                        Text(
+                            text = it,
+                            style = heroTextStyle,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    } else {
+                        Text(it)
+                    }
+                }
+            },
+        textStyle = if (isHero) heroTextStyle else LocalTextStyle.current,
         enabled = enabled,
         isError = isError,
         supportingText = supportingText?.let { { Text(it) } },
@@ -73,6 +118,17 @@ fun ListenUpTextField(
                         Icon(icon, contentDescription = null)
                     }
                 }
+            },
+        colors =
+            if (isHero) {
+                OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                    focusedContainerColor = heroContainerColor.copy(alpha = 0.4f),
+                    unfocusedContainerColor = heroContainerColor.copy(alpha = 0.2f),
+                )
+            } else {
+                OutlinedTextFieldDefaults.colors()
             },
         singleLine = true,
         shape = MaterialTheme.shapes.medium,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/ContributorIdentityHeader.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/ContributorIdentityHeader.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CameraAlt
@@ -24,8 +23,6 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,11 +34,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.calypsan.listenup.client.design.components.ContributorCoverImage
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicatorSmall
+import com.calypsan.listenup.client.design.components.ListenUpTextField
+import com.calypsan.listenup.client.design.components.ListenUpTextFieldVariant
 
 import com.calypsan.listenup.client.design.theme.DisplayFontFamily
 import org.jetbrains.compose.resources.stringResource
@@ -192,37 +190,13 @@ fun ContributorIdentityHeader(
                 }
             }
 
-            // Name field - Large editorial style
-            OutlinedTextField(
+            // Name field — large editorial hero variant of the canonical text field.
+            ListenUpTextField(
                 value = name,
                 onValueChange = onNameChange,
-                textStyle =
-                    TextStyle(
-                        fontFamily = DisplayFontFamily,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = MaterialTheme.typography.headlineSmall.fontSize,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    ),
-                placeholder = {
-                    Text(
-                        stringResource(Res.string.common_name),
-                        style =
-                            MaterialTheme.typography.headlineSmall.copy(
-                                fontFamily = DisplayFontFamily,
-                                fontWeight = FontWeight.Bold,
-                            ),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                    )
-                },
-                colors =
-                    OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
-                        unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                        focusedContainerColor = surfaceColor.copy(alpha = 0.4f),
-                        unfocusedContainerColor = surfaceColor.copy(alpha = 0.2f),
-                    ),
-                shape = RoundedCornerShape(16.dp),
-                singleLine = true,
+                placeholder = stringResource(Res.string.common_name),
+                variant = ListenUpTextFieldVariant.Hero,
+                heroContainerColor = surfaceColor,
                 modifier = Modifier.weight(1f),
             )
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/ContributorMergeDialog.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/ContributorMergeDialog.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.ListenUpTextField
 import com.calypsan.listenup.client.presentation.contributoredit.ContributorCandidate
 import com.calypsan.listenup.core.ContributorId
 import listenup.composeapp.generated.resources.Res
@@ -77,15 +77,11 @@ fun ContributorMergeDialog(
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
-                OutlinedTextField(
+                ListenUpTextField(
                     value = query,
                     onValueChange = onQueryChange,
-                    label = { Text(stringResource(Res.string.common_search)) },
-                    placeholder = {
-                        Text(stringResource(Res.string.contributor_merge_search_placeholder))
-                    },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    label = stringResource(Res.string.common_search),
+                    placeholder = stringResource(Res.string.contributor_merge_search_placeholder),
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 LazyColumn(


### PR DESCRIPTION
Makes every form field on the contributor edit page use our canonical `ListenUpTextField`, and folds in the #616/#617 findings.

## Form-field consistency (the main change)
The page's standard rows (bio, website, dates) already used `ListenUp*` components. Two hold-outs used raw Material `OutlinedTextField`:
- **Name field** (`ContributorIdentityHeader`) — an intentional hero/editorial inline editor. Rather than flatten it, added a **`Hero` variant to `ListenUpTextField`** (display type, bold, translucent tinted container via `heroContainerColor`, no floating label) and routed the name field through it. One canonical component, hero look preserved.
- **Merge dialog** input (`ContributorMergeDialog`) — converted to plain `ListenUpTextField`.

`ListenUpTextField` now takes an optional `variant: ListenUpTextFieldVariant` (`Standard` default / `Hero`) and a `heroContainerColor`; `label` is now nullable (Hero omits the floating label). `Standard` rendering is unchanged.

## #617 — already fixed
The Website field's `autoCorrectEnabled = false` + `capitalization = None` already landed in **PR #627**. No code change needed; safe to close. It now also flows through the consistent field.

## #616 — not scrapeable; documented
The Audible author-page scrape only yields name, biography, and `og:image` — **Audible exposes no author website**, so the `website = null` in `toMetadataContributorProfile` isn't an oversight; there's nothing to read. The website is a manual-only field (and already persists via the contributor edit → patch path). Added a clarifying comment at the mapper so this isn't re-filed. Recommend closing #616 as *manual-only by design*.

## Tests / verification
No unit test — this is a visual component variant (not unit-testable). Verified by compile + `spotlessCheck`/`detekt` + `:androidApp:assembleDebug` + `:server:test` + `:sharedLogic:jvmTest`, all green. **On-device/screenshot check of the hero name field is recommended** before merge, since the styling can only be eyeballed at runtime. No iOS impact (Compose UI is Android/Desktop only).