### PR TITLE
🐛 fix(server): detect Audible IP-geo redirect on /pd scrape so missing moods/tags aren't silently empty (#618)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -4,15 +4,19 @@ import com.calypsan.listenup.api.error.MetadataError
 import com.calypsan.listenup.api.metadata.AudibleRegion
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Ktor-backed HTTP adapter for the Audible catalog API.
@@ -180,9 +184,22 @@ class AudibleClient(
         asin: String,
     ): AppResult<List<ProductTag>> {
         rateLimiter.await(region)
-        return webGet(region, "/pd/$asin") { body ->
-            parseProductTags(body)
-        }.map { it ?: emptyList() }
+        val result =
+            webGet(region, "/pd/$asin", failOnGeoRedirect = true) { body ->
+                parseProductTags(body)
+            }.map { it ?: emptyList() }
+        if (result is AppResult.Failure) {
+            // Distinguish a geo-redirect / fetch failure from a genuine "title has no tags" empty:
+            // Audible IP-redirects the regional storefront when the server isn't located in that
+            // region (see [webGet]), so the /pd page — and its moods/tags — never loads. The caller
+            // flattens this to an empty list (best-effort), so without this log it would be silent.
+            logger.warn {
+                "Product-tag scrape for ASIN $asin in $region failed (${result.error.debugInfo}); " +
+                    "moods/tags will be empty. Audible geo-gates storefronts by IP — pick the Audible " +
+                    "region matching the server's country."
+            }
+        }
+        return result
     }
 
     // ─── Private infrastructure ───────────────────────────────────────────────
@@ -262,6 +279,7 @@ class AudibleClient(
         region: AudibleRegion,
         path: String,
         queryParams: Map<String, String> = emptyMap(),
+        failOnGeoRedirect: Boolean = false,
         decode: (String) -> T?,
     ): AppResult<T?> =
         try {
@@ -279,23 +297,32 @@ class AudibleClient(
                     header("Cookie", region.localeCookie())
                     queryParams.forEach { (k, v) -> parameter(k, v) }
                 }
-            when (response.status) {
-                HttpStatusCode.OK -> {
+            when {
+                failOnGeoRedirect && response.geoRedirectedAwayFrom(region) -> {
+                    AppResult.Failure(
+                        MetadataError.ExternalUnavailable(
+                            debugInfo =
+                                "Audible IP-redirected the $region storefront to " +
+                                    "${response.call.request.url.host} — region unavailable from this server's location",
+                        ),
+                    )
+                }
+
+                response.status == HttpStatusCode.OK -> {
                     AppResult.Success(decode(response.bodyAsText()))
                 }
 
-                HttpStatusCode.NotFound -> {
+                response.status == HttpStatusCode.NotFound -> {
                     AppResult.Success(null)
                 }
 
-                HttpStatusCode.TooManyRequests -> {
+                response.status == HttpStatusCode.TooManyRequests -> {
                     AppResult.Failure(MetadataError.ExternalRateLimited())
                 }
 
                 else -> {
-                    val status = response.status.value
                     AppResult.Failure(
-                        MetadataError.ExternalUnavailable(debugInfo = "HTTP $status"),
+                        MetadataError.ExternalUnavailable(debugInfo = "HTTP ${response.status.value}"),
                     )
                 }
             }
@@ -304,6 +331,20 @@ class AudibleClient(
         } catch (e: Exception) {
             AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = e.message))
         }
+
+    /**
+     * True when Audible redirected this web-host request off [region]'s storefront — i.e. the final
+     * URL is on a different host than [region]'s [webHost], or carries Audible's `ipRedirectFrom`
+     * IP-geo marker. Audible gates each regional storefront by request IP: a server outside the
+     * region is bounced to its own country's store (often the homepage), so the `/pd` product page
+     * never loads. A same-host canonical-slug redirect (e.g. `/pd/{asin}` → `/pd/Title/{asin}`) is
+     * NOT flagged.
+     */
+    private fun HttpResponse.geoRedirectedAwayFrom(region: AudibleRegion): Boolean {
+        val finalUrl = call.request.url
+        return !finalUrl.host.equals(region.webHost, ignoreCase = true) ||
+            finalUrl.parameters.contains("ipRedirectFrom")
+    }
 
     private companion object {
         /** Query parameter key for Audible response groups. */

--- a/server/src/test/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClientTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClientTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondRedirect
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -420,6 +421,31 @@ class AudibleClientTest :
                 client.getProductTags(AudibleRegion.UK, "B0CBP6NQVR")
 
                 sentCookie shouldBe "lc-acbuk=en_GB; i18n-prefs=GBP"
+            }
+        }
+
+        test("getProductTags surfaces ExternalUnavailable when Audible IP-redirects the storefront away") {
+            runTest {
+                // From an out-of-region IP, Audible redirects www.audible.ca off to the .com homepage
+                // (Adbl_ip_rdr_from_CA / ipRedirectFrom=CA) — the /pd page (and its topic tags) never
+                // loads. The scrape must surface this, not silently parse the wrong page and return empty.
+                val engine =
+                    MockEngine { request ->
+                        if (request.url.host == "www.audible.ca") {
+                            respondRedirect("https://www.audible.com/?ref=Adbl_ip_rdr_from_CA&ipRedirectFrom=CA")
+                        } else {
+                            respond(
+                                content = "<html><body>store homepage — no topic tags</body></html>",
+                                status = HttpStatusCode.OK,
+                                headers = headersOf("Content-Type", "text/html"),
+                            )
+                        }
+                    }
+                val client = makeClient(engine)
+                val result = client.getProductTags(AudibleRegion.CA, "B08G9PRS1K")
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                (result as AppResult.Failure).error.shouldBeInstanceOf<MetadataError.ExternalUnavailable>()
             }
         }
     })


### PR DESCRIPTION
Addresses #618 (Audible scraper returns only genres, no moods/tags — esp. non-local regions like CA).

## Root cause — Audible IP-geo gating (not a cookie/host/regex bug)
Genres come from the JSON API; moods/tags are HTML-scraped from `/pd/{asin}`. Audible gates each **regional storefront by request IP**. When the server's IP isn't in the requested region, Audible **redirects** the `/pd` request off the regional store (e.g. `www.audible.ca`) to the IP-home storefront — usually the **homepage**. The `lc-acb*` locale cookie sets currency/locale but does **not** override the IP redirect. Our HTTP client follows the redirect and runs `parseProductTags` on the homepage → 0 tags, indistinguishable from "this title has no tags."

Diagnostic (Project Hail Mary, `B08G9PRS1K`), browser UA + locale cookie, exactly like the server:
- **US** `www.audible.com/pd/B08G9PRS1K` → 200, stays on `/pd`, **28** `adbl_rec_tag` anchors.
- **CA** `www.audible.ca/pd/B08G9PRS1K` → final URL `www.audible.com/?...ipRedirectFrom=CA&ipRedirectOriginalURL=pd%2FB08G9PRS1K` → **0** tags.

Verified the CA host + locale cookie are byte-for-byte identical to the Go reference, so config isn't the issue. This is general — it hits **any** region the server isn't located in (matching a book's regional storefront), not just CA.

## Fix — detect + surface (we can't bypass Audible's gate)
A server outside the region fundamentally can't read that storefront, so this makes the failure **honest and diagnosable** instead of a silent empty:
- `webGet` gains `failOnGeoRedirect`; `getProductTags` opts in. When the `/pd` fetch's **final URL** lands on a different host than the region's web host, or carries Audible's `ipRedirectFrom` marker, it returns a typed `MetadataError.ExternalUnavailable` (with the redirect target) instead of parsing the wrong page. A same-host canonical-slug redirect (`/pd/{asin}` → `/pd/Title/{asin}`) is **not** flagged.
- `getProductTags` logs a clear WARN distinguishing a geo-redirect from a genuine empty.
- The DI boundary still flattens this to an empty list (`getProductTags(...).getOrElse { emptyList() }`), so moods/tags stay **best-effort** — nothing breaks — while #594/#611's *"try a different Audible region"* hint now has a real signal to fire on.
- Only the `/pd` scrape opts in; the contributor author scrape is untouched (it has the same latent issue — a reasonable follow-up).

## Tests (TDD)
- `getProductTags surfaces ExternalUnavailable when Audible IP-redirects the storefront away` — MockEngine 302 `www.audible.ca` → `www.audible.com/?ipRedirectFrom=CA`; asserts typed failure (red → green). Existing in-region success / 404-empty / locale-cookie tests unchanged.

## Local gates
`spotlessCheck` + `detekt` + `:server:test` — all green. (Server-only change; client modules don't depend on `:server`.)