### PR TITLE
♻️ refactor: purge stale multi-library references → single-library reality

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/event/ScanEvent.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/event/ScanEvent.kt
@@ -11,9 +11,8 @@ import kotlinx.serialization.Serializable
  * Server-to-client streaming events emitted during and after a scan. Every
  * event carries `correlationId` so a client can disambiguate concurrent
  * server-side scans (a watcher-driven incremental can run after a manual
- * full scan ends — the IDs differentiate the streams), and `libraryId` so a
- * multi-library client can route events to the correct library's view without
- * parsing the correlationId.
+ * full scan ends — the IDs differentiate the streams), and `libraryId` so the
+ * client can route events to the library's view without parsing the correlationId.
  *
  * Throughput: `Progress` is throttled at the scanner to at most one emit
  * per ~200ms; `Change` and `Started`/`Completed` are emitted at their

--- a/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/Application.kt
@@ -683,7 +683,7 @@ private fun Application.startBackgroundTasks(
     RescanScheduler(
         scope = scope,
         interval = environment.config.periodicRescanInterval(),
-        libraryIds = { orchestrator.registeredLibraryIds() },
+        libraryId = { orchestrator.registeredLibraryId() },
         rescan = { orchestrator.scanLibraryAsync(it) },
     ).start()
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
@@ -144,9 +144,8 @@ fun scannerModule(
             }.asPort()
         }
 
-        // ScanOrchestrator — one Scanner + ScanCoordinator bundle per library.
-        // Currently the server runs with a single library (multi-library support
-        // lands in Task 18). The factory lambda is called once per onLibraryAdded().
+        // ScanOrchestrator — the Scanner + ScanCoordinator bundle for the library.
+        // The factory lambda is called once, when the library is registered (onLibraryAdded).
         single {
             val scope: CoroutineScope = get()
             val eventBus: MutableSharedFlow<ScanEvent> = get(EventBusQualifiers.ScanEvents)

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/RescanScheduler.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/RescanScheduler.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration
 private val logger = KotlinLogging.logger {}
 
 /**
- * Never-Stranded backstop: periodically full-rescans every registered library so
+ * Never-Stranded backstop: periodically full-rescans the registered library so
  * anything the live watcher missed (kernel OVERFLOW, a dropped mount, downtime)
  * is reconciled. Reuses the single-flight scan trigger, so a periodic pass that
  * collides with an in-flight scan is simply skipped.
@@ -23,7 +23,7 @@ private val logger = KotlinLogging.logger {}
 internal class RescanScheduler(
     private val scope: CoroutineScope,
     private val interval: Duration,
-    private val libraryIds: suspend () -> List<LibraryId>,
+    private val libraryId: suspend () -> LibraryId?,
     private val rescan: suspend (LibraryId) -> Unit,
 ) {
     fun start(): Job? {
@@ -35,14 +35,13 @@ internal class RescanScheduler(
         return scope.launch {
             while (isActive) {
                 delay(interval)
-                for (id in libraryIds()) {
-                    try {
-                        rescan(id)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Throwable) {
-                        logger.warn(e) { "periodic rescan failed for library ${id.value} — continuing" }
-                    }
+                val id = libraryId() ?: continue
+                try {
+                    rescan(id)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.warn(e) { "periodic rescan failed for library ${id.value} — continuing" }
                 }
             }
         }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
@@ -17,12 +17,10 @@ import java.util.concurrent.ConcurrentHashMap
 private val logger = KotlinLogging.logger {}
 
 /**
- * Per-library single-flight coordinator for full scans and incremental re-analysis.
+ * Single-flight coordinator for the library's full scans and incremental re-analysis.
  *
- * Each [ScanCoordinator] instance owns exactly one library (identified by
- * [libraryId]). The [ScanOrchestrator] manages one coordinator per library,
- * allowing concurrent scans of different libraries while serialising concurrent
- * scans of the same library.
+ * The [ScanOrchestrator] owns one [ScanCoordinator], bound to the library
+ * (identified by [libraryId]), which serialises that library's scans.
  *
  * One [Mutex] serialises every scan operation — a full scan and an
  * incremental re-analysis cannot overlap, because both mutate the

--- a/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
@@ -214,8 +214,8 @@ internal class ScanOrchestrator(
     fun lastResult(libraryId: LibraryId): ScanResult? =
         bundle?.takeIf { it.library.id == libraryId }?.scanner?.lastResult()
 
-    /** The single registered library id, as a 0-or-1 element list (kept list-shaped for the caller). */
-    fun registeredLibraryIds(): List<LibraryId> = bundle?.let { listOf(it.library.id) } ?: emptyList()
+    /** The registered library id, or null before the library is configured. */
+    fun registeredLibraryId(): LibraryId? = bundle?.library?.id
 
     private fun onFileChanged(
         libraryId: LibraryId,

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/RescanSchedulerTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/RescanSchedulerTest.kt
@@ -12,20 +12,20 @@ import kotlin.time.Duration.Companion.minutes
 class RescanSchedulerTest :
     FunSpec({
 
-        test("rescans every registered library once per interval") {
+        test("rescans the registered library once per interval") {
             runTest {
                 val calls = AtomicInteger(0)
                 val scheduler =
                     RescanScheduler(
                         scope = backgroundScope,
                         interval = 1.hours,
-                        libraryIds = { listOf(LibraryId("lib-a"), LibraryId("lib-b")) },
+                        libraryId = { LibraryId("lib-a") },
                         rescan = { calls.incrementAndGet() },
                     )
                 val job = scheduler.start()
                 testScheduler.advanceTimeBy(1.hours + 1.minutes)
                 testScheduler.runCurrent()
-                calls.get() shouldBe 2 // two libraries, one interval elapsed
+                calls.get() shouldBe 1 // one library, one interval elapsed
                 job!!.cancelAndJoin()
             }
         }
@@ -37,7 +37,7 @@ class RescanSchedulerTest :
                     RescanScheduler(
                         scope = backgroundScope,
                         interval = 1.hours,
-                        libraryIds = { listOf(LibraryId("lib-a")) },
+                        libraryId = { LibraryId("lib-a") },
                         rescan = {
                             calls.incrementAndGet()
                             error("boom")
@@ -57,7 +57,7 @@ class RescanSchedulerTest :
                     RescanScheduler(
                         scope = backgroundScope,
                         interval = kotlin.time.Duration.ZERO,
-                        libraryIds = { listOf(LibraryId("lib-a")) },
+                        libraryId = { LibraryId("lib-a") },
                         rescan = { error("should never run") },
                     )
                 scheduler.start() shouldBe null

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestratorTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestratorTest.kt
@@ -119,7 +119,7 @@ class ScanOrchestratorTest :
                 orchestrator.onLibraryAdded(libraryA)
                 orchestrator.onLibraryAdded(libraryB)
 
-                orchestrator.registeredLibraryIds() shouldBe listOf(libraryB.id)
+                orchestrator.registeredLibraryId() shouldBe libraryB.id
                 (orchestrator.scanLibrary(libraryA.id) as AppResult.Failure).error.shouldBeInstanceOf<LibraryError.NotFound>()
                 orchestrator.scanLibrary(libraryB.id).shouldBeInstanceOf<AppResult.Success<ScanResult>>()
             }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndTest.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.delay
  *    folder fields are overridden, wire round-trips correctly)
  *  - POST /api/v1/scan returns Success after the library is registered
  *
- * No auto-scan on boot (Task 18): the server does NOT scan at startup. Tests
+ * No auto-scan on boot: the server does NOT scan at startup. Tests
  * trigger a scan explicitly via POST /api/v1/scan and then poll for the
  * result. This removes the race between the bootstrap scan and test assertions.
  *
@@ -112,7 +112,7 @@ class ScannerEndToEndTest :
  * registered with the orchestrator, then polls GET /api/v1/scan/last until
  * a result is available.
  *
- * No auto-scan on boot (Task 18): `bootstrapLibraries` registers the library
+ * No auto-scan on boot: `bootstrapLibraries` registers the library
  * with the orchestrator but does not scan. This helper bridges the gap for
  * tests that need a populated scan result.
  *

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerSseRouteTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerSseRouteTest.kt
@@ -108,7 +108,7 @@ class ScannerSseRouteTest :
  * Triggers a scan and waits for it to complete so the orchestrator is warm
  * and no scan is in progress. This replaces the old `waitForBootstrap` which
  * polled `GET /scan/last` waiting for an auto-scan that no longer happens
- * (Task 18: no auto-scan on boot).
+ * (no auto-scan on boot).
  *
  * On return: library is registered with the orchestrator, no scan in flight.
  */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/setup/LibrarySetupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/setup/LibrarySetupViewModel.kt
@@ -38,8 +38,7 @@ sealed interface LibrarySetupNavAction {
  * - Selecting one or more folders to add to THE library
  * - Registering each folder via [addFolder] and kicking off the initial scan
  *
- * Replaces the legacy multi-library loop. There is one library; the wizard selects
- * how many folders it watches.
+ * There is one library; the wizard selects which folders it watches.
  */
 class LibrarySetupViewModel(
     private val libraryAdminRpcFactory: LibraryAdminRpcFactory,


### PR DESCRIPTION
ListenUp is single-library by design — exactly one Library per app (multiple folders + collections live under it). This removes references that imply otherwise.

**Part A — comments/KDoc:** reworded 6 dishonest comments so they describe reality (one library, many folders): `ScannerModule` ("multi-library support lands in Task 18"), `ScanEvent` KDoc, `ScanCoordinator` KDoc, `LibrarySetupViewModel`, and two scanner-test "(Task 18)" tags.

**Part B — code shape:** collapsed the rescan-scheduler's multi-library surface — `ScanOrchestrator.registeredLibraryIds(): List<LibraryId>` + `RescanScheduler(libraryIds: () -> List<LibraryId>)` → a single `registeredLibraryId(): LibraryId?` / `libraryId: () -> LibraryId?`. No behavior change; scheduler tests updated.

The `observeAll(): Flow<List<Library>>` → `observeSingle()` collapse was deliberately left out (it touches the sync handlers) — separate follow-up if wanted.

Gates: spotlessCheck, detekt, `:sharedLogic:jvmTest`, `:contract:jvmTest`, `:server:test`, `:androidApp:assembleDebug` all green. Zero residual multi-library references.