### PR TITLE
✨ feat: surface the admin Inbox — add the entry-point tile (Android + Desktop)

### DIFF
--- a/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
+++ b/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
@@ -537,6 +537,7 @@ private fun DetailScreen(
                 onInviteClick = { navigateTo(DetailDestination.CreateInvite) },
                 onCollectionsClick = { navigateTo(DetailDestination.AdminCollections) },
                 onCategoriesClick = { navigateTo(DetailDestination.AdminCategories) },
+                onInboxClick = { navigateTo(DetailDestination.AdminInbox) },
                 onUserClick = { navigateTo(DetailDestination.UserDetail(it)) },
                 serverName = readySettings?.serverName ?: "",
                 onServerNameChange = { settingsViewModel.setServerName(it) },

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -671,6 +671,16 @@
         }
       }
     },
+    "admin.inbox": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inbox"
+          }
+        }
+      }
+    },
     "admin.inbox_empty": {
       "localizations": {
         "en": {
@@ -697,6 +707,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hold new books for review"
+          }
+        }
+      }
+    },
+    "admin.inbox_subtitle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review and release new books waiting for approval."
           }
         }
       }

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -974,6 +974,8 @@
     "view_the_genre_hierarchy_tree": "View the genre hierarchy tree",
     "what_to_include": "What to include",
     "whos_joining": "Who's joining",
+    "inbox": "Inbox",
+    "inbox_subtitle": "Review and release new books waiting for approval.",
     "inbox_setting_title": "Hold new books for review",
     "inbox_setting_subtitle": "New books wait in the inbox until an admin releases them."
   },

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/AdminEntries.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/AdminEntries.kt
@@ -67,6 +67,9 @@ internal fun EntryProviderScope<NavKey>.adminEntries(backStack: NavBackStack<Nav
             onBackupClick = {
                 backStack.add(AdminBackups)
             },
+            onInboxClick = {
+                backStack.add(AdminInbox)
+            },
             onUserClick = { userId ->
                 backStack.add(AdminUserDetail(userId))
             },

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -67,9 +67,11 @@
     <string name="admin_import_sessions_progress">Sessions: %1$d/%2$d</string>
     <string name="admin_import_users_progress">Users: %1$d/%2$d</string>
     <string name="admin_in_this_collection">in this collection</string>
+    <string name="admin_inbox">Inbox</string>
     <string name="admin_inbox_empty">Inbox Empty</string>
     <string name="admin_inbox_setting_subtitle">New books wait in the inbox until an admin releases them.</string>
     <string name="admin_inbox_setting_title">Hold new books for review</string>
+    <string name="admin_inbox_subtitle">Review and release new books waiting for approval.</string>
     <string name="admin_inbox_workflow">Inbox Workflow</string>
     <string name="admin_info_emoji">ℹ️</string>
     <string name="admin_invite_created">Invite Created!</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
@@ -82,6 +82,8 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
+import listenup.composeapp.generated.resources.admin_inbox
+import listenup.composeapp.generated.resources.admin_inbox_subtitle
 import listenup.composeapp.generated.resources.admin_inbox_setting_subtitle
 import listenup.composeapp.generated.resources.admin_inbox_setting_title
 import listenup.composeapp.generated.resources.admin_backup_restore
@@ -139,6 +141,7 @@ fun AdminScreen(
     onCollectionsClick: () -> Unit = {},
     onCategoriesClick: () -> Unit = {},
     onBackupClick: () -> Unit = {},
+    onInboxClick: () -> Unit = {},
     onUserClick: (String) -> Unit = {},
     serverName: String = "",
     onServerNameChange: (String) -> Unit = {},
@@ -222,6 +225,7 @@ fun AdminScreen(
                     onCollectionsClick = onCollectionsClick,
                     onCategoriesClick = onCategoriesClick,
                     onBackupClick = onBackupClick,
+                    onInboxClick = onInboxClick,
                     serverName = serverName,
                     onServerNameChange = onServerNameChange,
                     remoteUrl = remoteUrl,
@@ -320,6 +324,7 @@ private fun AdminContent(
     onCollectionsClick: () -> Unit,
     onCategoriesClick: () -> Unit,
     onBackupClick: () -> Unit,
+    onInboxClick: () -> Unit,
     serverName: String,
     onServerNameChange: (String) -> Unit,
     remoteUrl: String,
@@ -347,6 +352,7 @@ private fun AdminContent(
             onCollectionsClick = onCollectionsClick,
             onCategoriesClick = onCategoriesClick,
             onBackupClick = onBackupClick,
+            onInboxClick = onInboxClick,
             serverName = serverName,
             onServerNameChange = onServerNameChange,
             remoteUrl = remoteUrl,
@@ -394,6 +400,8 @@ private fun AdminContent(
                     onCollectionsClick = onCollectionsClick,
                     onCategoriesClick = onCategoriesClick,
                     onBackupClick = onBackupClick,
+                    onInboxClick = onInboxClick,
+                    inboxEnabled = inboxEnabled,
                 )
             }
         }
@@ -416,6 +424,7 @@ private fun AdminTwoPaneContent(
     onCollectionsClick: () -> Unit,
     onCategoriesClick: () -> Unit,
     onBackupClick: () -> Unit,
+    onInboxClick: () -> Unit,
     serverName: String,
     onServerNameChange: (String) -> Unit,
     remoteUrl: String,
@@ -469,6 +478,8 @@ private fun AdminTwoPaneContent(
                     onCollectionsClick = onCollectionsClick,
                     onCategoriesClick = onCategoriesClick,
                     onBackupClick = onBackupClick,
+                    onInboxClick = onInboxClick,
+                    inboxEnabled = inboxEnabled,
                 )
             }
         }
@@ -902,6 +913,8 @@ private fun ManagementSection(
     onCollectionsClick: () -> Unit,
     onCategoriesClick: () -> Unit,
     onBackupClick: () -> Unit,
+    onInboxClick: () -> Unit,
+    inboxEnabled: Boolean,
 ) {
     val colors = MaterialTheme.colorScheme
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -912,6 +925,17 @@ private fun ManagementSection(
             color = colors.onSurface,
             modifier = Modifier.padding(start = 4.dp, bottom = 4.dp),
         )
+        if (inboxEnabled) {
+            ActionTile(
+                title = stringResource(Res.string.admin_inbox),
+                subtitle = stringResource(Res.string.admin_inbox_subtitle),
+                icon = Icons.Outlined.Inbox,
+                onClick = onInboxClick,
+                containerColor = colors.tertiaryContainer,
+                badgeColor = colors.tertiary,
+                badgeContentColor = colors.onTertiary,
+            )
+        }
         ActionTile(
             title = stringResource(Res.string.admin_invite_someone),
             subtitle = stringResource(Res.string.admin_share_your_audiobook_library_with),


### PR DESCRIPTION
The admin inbox review screen (`AdminInboxScreen` + `AdminInboxViewModel` + the `AdminInbox` nav route) already existed but was **unreachable** — nothing in the UI navigated to it, so the "Hold new books for review" toggle held books with no way to review them.

This adds an **Inbox** `ActionTile` to Admin → Management, **gated on the toggle** (it appears when "Hold new books for review" is on), opening the existing review screen. Android + Desktop are both wired; the callback threading follows the existing `onCollectionsClick`/`onBackupClick` pattern.

iOS is a separate follow-up — the inbox review screen doesn't exist there yet (only the toggle), so it needs the whole SwiftUI feature built, not just a button.

Gates: spotlessCheck, detekt, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug` green. No server/contract changes.