### PR TITLE
🐛 fix(server): retry transactions on SQLITE_BUSY_SNAPSHOT + add busy_timeout

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/db/DatabaseFactory.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/db/DatabaseFactory.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.server.db
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.core.DatabaseConfig as ExposedDatabaseConfig
 import org.jetbrains.exposed.v1.jdbc.Database
 import java.nio.file.Path
 
@@ -35,7 +36,7 @@ object DatabaseFactory {
         val swappable = SwappableDataSource(pool)
         val dbFile = Path.of(config.jdbcUrl.removePrefix("jdbc:sqlite:"))
         return DatabaseHandle(
-            database = Database.connect(swappable),
+            database = Database.connect(swappable, databaseConfig = retryDatabaseConfig()),
             dataSource = swappable,
             poolFactory = { buildPool(config) },
             dbFilePath = dbFile,
@@ -55,6 +56,15 @@ object DatabaseFactory {
      * self-identifying log line the next time it happens.
      */
     private const val LEAK_DETECTION_MS = 20_000L
+
+    /**
+     * SQLite will wait up to this many milliseconds for a write-lock before returning
+     * SQLITE_BUSY. Cures ordinary write-lock contention (e.g. a long-running writer
+     * temporarily blocks a second writer). Does NOT cure SQLITE_BUSY_SNAPSHOT — that
+     * error is returned immediately regardless of busy_timeout because the snapshot is
+     * stale, not locked; only re-running the transaction fixes it (see [retryDatabaseConfig]).
+     */
+    private const val BUSY_TIMEOUT_MS = 5_000
 
     internal fun buildPool(config: DatabaseConfig): HikariDataSource =
         HikariDataSource(
@@ -80,7 +90,60 @@ object DatabaseFactory {
                 // testApplication instances in parallel. The pragma key is accepted by
                 // sqlite-jdbc's SQLiteConfig and applied at connection-open time.
                 addDataSourceProperty("journal_mode", "wal")
+                // Waits up to 5 s for a write-lock before surfacing SQLITE_BUSY to the
+                // caller. Covers the common case of a briefly-held writer; does not cover
+                // SQLITE_BUSY_SNAPSHOT (stale snapshot — needs transaction retry instead,
+                // configured in retryDatabaseConfig below).
+                addDataSourceProperty("busy_timeout", BUSY_TIMEOUT_MS.toString())
                 validate()
             },
         )
+
+    /**
+     * Maximum number of times Exposed will re-run a transaction that throws a
+     * [java.sql.SQLException] (including SQLITE_BUSY and SQLITE_BUSY_SNAPSHOT).
+     * Exposed's default is 3 with zero delay, which is insufficient under 8 concurrent
+     * writers. Ten attempts with jittered backoff reduces the failure probability to
+     * near zero while staying well within the 5 s busy_timeout ceiling.
+     */
+    private const val DEFAULT_MAX_TX_ATTEMPTS = 10
+
+    /**
+     * Minimum milliseconds between transaction retry attempts (jitter lower bound).
+     * Together with [DEFAULT_MAX_TX_RETRY_DELAY_MS] this produces a progressive jittered
+     * backoff: first retry ≈ 10–55 ms, later retries up to ~500 ms.
+     */
+    private const val DEFAULT_MIN_TX_RETRY_DELAY_MS = 10L
+
+    /**
+     * Maximum milliseconds between transaction retry attempts (jitter upper bound).
+     * Keeps the total wait time well within user-perceptible latency even in the worst case.
+     */
+    private const val DEFAULT_MAX_TX_RETRY_DELAY_MS = 500L
+
+    /**
+     * Exposed [ExposedDatabaseConfig] wired into every [Database.connect] call.
+     *
+     * Why retry at the Exposed layer, not the pool layer?
+     * SQLITE_BUSY_SNAPSHOT is distinct from SQLITE_BUSY: it fires when a deferred
+     * transaction's snapshot is already superseded by a committed write from another
+     * connection. SQLite rejects the stale snapshot immediately — no amount of
+     * busy_timeout waiting will resolve it. The only cure is to re-run the entire
+     * transaction against the current snapshot. Exposed's [org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction]
+     * already implements this: it catches any [java.sql.SQLException] and retries the
+     * whole transaction block up to [ExposedDatabaseConfig.defaultMaxAttempts] times with
+     * a jittered delay between attempts.
+     *
+     * Default vs override:
+     * Exposed defaults to `defaultMaxAttempts = 3`, `defaultMinRetryDelay = 0`,
+     * `defaultMaxRetryDelay = 0` — meaning three immediate back-to-back attempts with no
+     * pause. Under a pool of 8 concurrent writers that is not enough: the probability of
+     * all three retries also landing on a stale snapshot is non-trivial.
+     */
+    private fun retryDatabaseConfig(): ExposedDatabaseConfig =
+        ExposedDatabaseConfig {
+            defaultMaxAttempts = DEFAULT_MAX_TX_ATTEMPTS
+            defaultMinRetryDelay = DEFAULT_MIN_TX_RETRY_DELAY_MS
+            defaultMaxRetryDelay = DEFAULT_MAX_TX_RETRY_DELAY_MS
+        }
 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/db/TransactionRetryConcurrencyTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/db/TransactionRetryConcurrencyTest.kt
@@ -1,0 +1,92 @@
+package com.calypsan.listenup.server.db
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.coroutineScope
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.nio.file.Files
+
+/**
+ * Stress-tests SQLite concurrency under WAL + a Hikari pool to reproduce
+ * SQLITE_BUSY_SNAPSHOT and verify the fix.
+ *
+ * Why a file-backed DB, not :memory:?  Each Hikari pool connection opens its own
+ * SQLite handle; in :memory: mode every handle gets a completely private, independent
+ * database — there is no shared WAL, so there is nothing to contend on.  File-backed
+ * WAL is the only mode where multiple pool connections share a single page-cache and
+ * therefore race to commit, which is what triggers SQLITE_BUSY_SNAPSHOT.
+ *
+ * The BUSY_SNAPSHOT error occurs when a deferred transaction reads a snapshot that has
+ * already been superseded by a committed write from another connection.  busy_timeout
+ * does NOT cure it (it only waits for a write lock; a snapshot mismatch is rejected
+ * immediately regardless of the timeout).  The only cure is to re-run the whole
+ * transaction against the current snapshot — i.e., retry.
+ *
+ * Exposed 1.3.0's [suspendTransaction] already retries any [java.sql.SQLException] up to
+ * [org.jetbrains.exposed.v1.core.DatabaseConfig.defaultMaxAttempts] times.  The fix in
+ * [DatabaseFactory] wires the [org.jetbrains.exposed.v1.core.DatabaseConfig] with a
+ * [org.jetbrains.exposed.v1.jdbc.Database.connect] call that sets `defaultMaxAttempts = 10`,
+ * `defaultMinRetryDelay = 10`, `defaultMaxRetryDelay = 500`, and adds `busy_timeout = 5000`
+ * so ordinary write-lock contention also resolves without surfacing to callers.
+ */
+class TransactionRetryConcurrencyTest :
+    FunSpec({
+
+        // Drives DatabaseFactory.init (WAL pool size 8 + retry config) against 8 concurrent
+        // coroutines each doing 50 read-then-write transactions. Before the fix this failed
+        // with SQLITE_BUSY because Exposed's default 3 immediate retries were not enough
+        // under this level of contention. After the fix (defaultMaxAttempts=10, jittered
+        // backoff 10–500 ms, busy_timeout=5000) all 400 increments land without error.
+        test("concurrent read-then-write transactions succeed under WAL contention") {
+            val tmp =
+                Files.createTempFile("listenup-busy-snapshot-", ".db").also {
+                    it.toFile().deleteOnExit()
+                }
+            val handle = DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.toAbsolutePath()}"))
+            val db = handle.database
+
+            // Create a counter table and seed the initial value.
+            transaction(db) {
+                exec("CREATE TABLE IF NOT EXISTS counters (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+                exec("INSERT INTO counters(id, value) VALUES (1, 0)")
+            }
+
+            val coroutines = 8
+            val iterationsPerCoroutine = 50
+            val expectedTotal = coroutines * iterationsPerCoroutine
+
+            // Each coroutine does a read-then-write inside a single transaction (deferred
+            // by default in SQLite).  Under WAL + concurrent writers, some transactions
+            // will land on a snapshot that another connection has already advanced past;
+            // those return SQLITE_BUSY_SNAPSHOT, which Exposed surfaces as a SQLException.
+            coroutineScope {
+                repeat(coroutines) {
+                    launch(Dispatchers.IO) {
+                        repeat(iterationsPerCoroutine) {
+                            suspendTransaction(db) {
+                                val current =
+                                    exec("SELECT value FROM counters WHERE id = 1") { rs ->
+                                        rs.next()
+                                        rs.getInt(1)
+                                    }!!
+                                exec("UPDATE counters SET value = ${current + 1} WHERE id = 1")
+                            }
+                        }
+                    }
+                }
+            }
+
+            val finalCount =
+                transaction(db) {
+                    exec("SELECT value FROM counters WHERE id = 1") { rs ->
+                        rs.next()
+                        rs.getInt(1)
+                    }!!
+                }
+
+            finalCount shouldBe expectedTotal
+        }
+    })


### PR DESCRIPTION
Fixes a `SQLITE_BUSY_SNAPSHOT` ("database is locked") error that fired on `SessionService.rotate` (session refresh) during the concurrent request burst at app boot.

**Root cause:** WAL mode + an 8-connection Hikari pool + DEFERRED read-then-write transactions, with no `busy_timeout` and no retry. `rotate` (and ~45 other write paths) `SELECT` a row then `UPDATE` it in one transaction; if another connection commits between the read and the flush, SQLite rejects the stale snapshot immediately with `BUSY_SNAPSHOT` — which `busy_timeout` cannot cure (the snapshot is stale, not locked). Only re-running the transaction fixes it.

**Fix (shared layer — covers all 92 `suspendTransaction` sites, no per-site changes):**
- `busy_timeout = 5000` for ordinary `SQLITE_BUSY` write-lock waits.
- Exposed `DatabaseConfig` retry (`defaultMaxAttempts = 10`, jittered 10–500ms backoff) at `Database.connect`. Exposed 1.3.0's `suspendTransaction` already re-runs the whole transaction on `SQLException`, so a fresh snapshot is taken on retry — curing `BUSY_SNAPSHOT`.

**Test:** a new concurrency stress test (8 coroutines × 50 read-then-write txns on a file-backed WAL pool) reproduces the lock (loses ~90 updates before the fix) and lands all 400 after. Non-flaky across reruns.

Gates: spotlessCheck, detekt, `:server:test`, `:sharedLogic:jvmTest` green.