### PR TITLE
⚡ feat(server): propagate collection-membership changes to members (Phase 1: revision bump)

### DIFF
--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -528,6 +528,11 @@ internal class CollectionServiceImpl(
         // Every user who can see a target collection just gained access to the released books —
         // nudge each once to re-derive.
         notifyAccessChanged(distinctTargetIds)
+        // Bump each released book's revision so members' incremental `revision > cursor` pull
+        // re-evaluates its now-changed visibility — the access nudge alone never carries the row.
+        for (bookId in assignments.keys) {
+            bookRevisionTouch.touchRevision(BookId(bookId))
+        }
         return AppResult.Success(Unit)
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -231,6 +231,9 @@ internal class CollectionServiceImpl(
         // Removing the book may have severed a visible user's only access path to it — nudge this
         // collection's visible users to re-derive (and prune if needed), matching setBookCollections.
         notifyAccessChanged(listOf(id.value))
+        // Bump the book's revision so each member's incremental `revision > cursor` pull re-evaluates
+        // its now-changed visibility and prunes it when no access path remains.
+        bookRevisionTouch.touchRevision(bookId)
         return AppResult.Success(Unit)
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -23,6 +23,7 @@ import com.calypsan.listenup.server.db.BookTable
 import com.calypsan.listenup.server.db.LibraryTable
 import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.db.UserTable
+import com.calypsan.listenup.server.services.BookRevisionTouch
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
@@ -75,6 +76,7 @@ internal class CollectionServiceImpl(
     private val bus: ChangeBus,
     private val db: Database,
     private val clock: Clock = Clock.System,
+    private val bookRevisionTouch: BookRevisionTouch,
     private val principal: PrincipalProvider,
 ) : CollectionService {
     // ── Observation ─────────────────────────────────────────────────────────
@@ -204,6 +206,9 @@ internal class CollectionServiceImpl(
                 // Adding the book to this collection grants its visible users (owner + active-share
                 // recipients) a new access path — nudge each to re-derive, matching setBookCollections.
                 notifyAccessChanged(listOf(id.value))
+                // Bump the book's revision so each member's incremental `revision > cursor` pull
+                // re-delivers the now-visible book — the access nudge alone never carries the row.
+                bookRevisionTouch.touchRevision(bookId)
                 AppResult.Success(Unit)
             }
             is AppResult.Failure -> {
@@ -570,6 +575,7 @@ internal class CollectionServiceImpl(
             bus = bus,
             db = db,
             clock = clock,
+            bookRevisionTouch = bookRevisionTouch,
             principal = principal,
         )
 
@@ -726,6 +732,7 @@ fun createCollectionService(
     shareRepo: CollectionShareRepository,
     bus: ChangeBus,
     db: Database,
+    bookRevisionTouch: BookRevisionTouch,
     clock: Clock = Clock.System,
 ): CollectionService =
     CollectionServiceImpl(
@@ -737,6 +744,7 @@ fun createCollectionService(
         bus = bus,
         db = db,
         clock = clock,
+        bookRevisionTouch = bookRevisionTouch,
         principal = PrincipalProvider { error("Unscoped CollectionService — call collectionServiceScopedTo") },
     )
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -281,6 +281,11 @@ internal class CollectionServiceImpl(
         // is nudged once to re-derive. The non-enumerable public↔private "everyone" edge converges on
         // the next firehose catch-up — the documented 1b behavior.
         notifyAccessChanged(added + removed)
+        // Bump the subject book's revision once when its membership actually changed, so each member's
+        // incremental `revision > cursor` pull re-evaluates its visibility (delivering or pruning it).
+        if (added.isNotEmpty() || removed.isNotEmpty()) {
+            bookRevisionTouch.touchRevision(bookId)
+        }
         return AppResult.Success(Unit)
     }
 

--- a/server/src/main/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
@@ -209,6 +209,7 @@ fun booksModule(
                 bus = get(),
                 db = get(),
                 clock = get(),
+                bookRevisionTouch = get<BookRepository>(),
                 principal = unscopedPlaceholder("CollectionService"),
             )
         }

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -108,7 +108,8 @@ class BookRepository(
         domainName = "books",
         clock = clock,
     ),
-    BookIngestPort {
+    BookIngestPort,
+    BookRevisionTouch {
     /** Cover file and path helpers — file I/O and path resolution outside the sync seam. */
     private val managedCoverFiles = ManagedCoverFiles(coverImageStore, homeDir, db)
 
@@ -652,6 +653,51 @@ class BookRepository(
                 val saved =
                     readPayload(idStr)
                         ?: error("readPayload returned null immediately after clearManagedCover for $idStr")
+                bus.publish(
+                    repo = this@BookRepository,
+                    event =
+                        SyncEvent.Updated(
+                            id = idStr,
+                            revision = rev,
+                            occurredAt = now,
+                            clientOpId = null,
+                            payload = saved,
+                        ),
+                    userId = null,
+                )
+                AppResult.Success(Unit)
+            }
+        }
+    }
+
+    /**
+     * Bumps the row's revision (and `updatedAt`) without touching any content column, so a
+     * visibility-only change — collection membership add/remove — re-enters every member's
+     * incremental `revision > cursor AND <accessible>` pull and newly-visible books reach them.
+     *
+     * Opens its own transaction. The `SyncEvent.Updated` published to [ChangeBus]
+     * carries the full aggregate so clients refresh immediately. Mirrors
+     * [setManagedCover] minus the cover-column writes.
+     *
+     * @return [AppResult.Success] on success;
+     *   [AppResult.Failure] with [SyncError.NotFound] when [id] has no row.
+     */
+    override suspend fun touchRevision(id: BookId): AppResult<Unit> {
+        val idStr = idAsString(id)
+        return suspendTransaction(db) {
+            val rev = nextRevision()
+            val now = clock.now().toEpochMilliseconds()
+            val rowsAffected =
+                BookTable.update({ BookTable.id eq idStr }) { stmt ->
+                    stmt[BookTable.revision] = rev
+                    stmt[BookTable.updatedAt] = now
+                }
+            if (rowsAffected == 0) {
+                AppResult.Failure(SyncError.NotFound(domain = domainName, entityId = idStr))
+            } else {
+                val saved =
+                    readPayload(idStr)
+                        ?: error("readPayload returned null immediately after touchRevision for $idStr")
                 bus.publish(
                     repo = this@BookRepository,
                     event =

--- a/server/src/main/kotlin/com/calypsan/listenup/server/services/BookRevisionTouch.kt
+++ b/server/src/main/kotlin/com/calypsan/listenup/server/services/BookRevisionTouch.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+
+/**
+ * Bumps a book's sync revision without changing its content, so a visibility-only change
+ * (collection membership add/remove) re-enters every member's incremental
+ * `revision > cursor AND <accessible>` pull and newly-visible books reach them.
+ *
+ * A narrow capability extracted from [BookRepository] so consumers (e.g. CollectionServiceImpl)
+ * depend only on the touch, and seam-level tests can fake it.
+ */
+interface BookRevisionTouch {
+    suspend fun touchRevision(id: BookId): AppResult<Unit>
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.CollectionShareRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
@@ -79,6 +80,7 @@ class AccessChangedEmissionTest :
                     bus = bus,
                     db = db,
                     clock = fixedClock,
+                    bookRevisionTouch = FakeBookRevisionTouch(),
                     principal = principalFor("u1"),
                 )
             return Harness(service, bus)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -24,6 +24,7 @@ import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.seedTestUser
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlin.time.Instant
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -151,6 +152,33 @@ class CollectionMembershipRevisionTest :
                     }
 
                     touch.touched shouldContainExactly listOf("b1")
+                }
+            }
+        }
+
+        test("setBookCollections does not touch when the membership is unchanged") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("u1")
+                seedTestBook(bookId = "b1")
+                runTest(UnconfinedTestDispatcher()) {
+                    val touch = FakeBookRevisionTouch()
+                    val service = makeCollectionService(db, bookRevisionTouch = touch)
+                    val admin = service.actAs("u1", UserRole.ADMIN)
+                    val a = admin.createCollection("test-library", "A")
+                    require(a is AppResult.Success)
+                    admin.addBookToCollection(a.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+                    touch.touched.clear()
+
+                    // Set to the IDENTICAL current membership → added/removed both empty → guard skips the touch.
+                    admin.setBookCollections(BookId("b1"), listOf(a.data.id)).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    touch.touched.shouldBeEmpty()
                 }
             }
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -99,4 +99,30 @@ class CollectionMembershipRevisionTest :
                 }
             }
         }
+
+        test("removeBookFromCollection touches the removed book's revision") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("u1")
+                seedTestBook(bookId = "b1")
+                runTest(UnconfinedTestDispatcher()) {
+                    val touch = FakeBookRevisionTouch()
+                    val service = makeCollectionService(db, bookRevisionTouch = touch)
+                    val owner = service.actAs("u1")
+                    val created = owner.createCollection("test-library", "Shelf")
+                    require(created is AppResult.Success)
+                    owner.addBookToCollection(created.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+                    touch.touched.clear()
+
+                    owner.removeBookFromCollection(created.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    touch.touched shouldContainExactly listOf("b1")
+                }
+            }
+        }
     })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -1,0 +1,102 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.UserPermissionPolicy
+import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.services.BookRevisionTouch
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.CollectionShareRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlin.time.Instant
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * Pins the revision-bump side of collection-membership mutation: adding a book to a collection
+ * must bump that book's sync revision (via [BookRevisionTouch]) so each member's incremental
+ * `revision > cursor` pull re-delivers the now-visible book. Asserted against a recording fake
+ * rather than the real [com.calypsan.listenup.server.services.BookRepository] — the touch is the
+ * contract under test, not the revision-column mechanics.
+ */
+class CollectionMembershipRevisionTest :
+    FunSpec({
+
+        val fixedClock = FixedClock(Instant.fromEpochMilliseconds(1_700_000_000_000L))
+
+        fun principalFor(
+            userId: String,
+            role: UserRole = UserRole.MEMBER,
+        ): PrincipalProvider =
+            PrincipalProvider {
+                UserPrincipal(UserId(userId), SessionId("session-$userId"), role)
+            }
+
+        fun makeCollectionService(
+            db: Database,
+            bookRevisionTouch: BookRevisionTouch = FakeBookRevisionTouch(),
+        ): CollectionServiceImpl {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val collectionRepo = CollectionRepository(db = db, bus = bus, registry = registry)
+            val collectionBookRepo = CollectionBookRepository(db = db, bus = bus, registry = registry)
+            val shareRepo = CollectionShareRepository(db = db, bus = bus, registry = registry)
+            val accessPolicy = CollectionAccessPolicy(collectionRepo, shareRepo)
+            return CollectionServiceImpl(
+                collectionRepo = collectionRepo,
+                collectionBookRepo = collectionBookRepo,
+                shareRepo = shareRepo,
+                accessPolicy = accessPolicy,
+                permissionPolicy = UserPermissionPolicy(db),
+                bus = bus,
+                db = db,
+                clock = fixedClock,
+                bookRevisionTouch = bookRevisionTouch,
+                principal = principalFor("u1"),
+            )
+        }
+
+        fun CollectionServiceImpl.actAs(
+            userId: String,
+            role: UserRole = UserRole.MEMBER,
+        ): CollectionServiceImpl = copyWith(principalFor(userId, role))
+
+        test("addBookToCollection touches the added book's revision") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("u1")
+                seedTestBook(bookId = "b1")
+                runTest(UnconfinedTestDispatcher()) {
+                    val touch = FakeBookRevisionTouch()
+                    val service = makeCollectionService(db, bookRevisionTouch = touch)
+                    val owner = service.actAs("u1")
+                    val created = owner.createCollection("test-library", "Shelf")
+                    require(created is AppResult.Success)
+
+                    owner.addBookToCollection(created.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    touch.touched shouldContainExactly listOf("b1")
+                }
+            }
+        }
+    })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -125,4 +125,32 @@ class CollectionMembershipRevisionTest :
                 }
             }
         }
+
+        test("setBookCollections touches the book once when membership changes") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("u1")
+                seedTestBook(bookId = "b1")
+                runTest(UnconfinedTestDispatcher()) {
+                    val touch = FakeBookRevisionTouch()
+                    val service = makeCollectionService(db, bookRevisionTouch = touch)
+                    val admin = service.actAs("u1", UserRole.ADMIN)
+                    val a = admin.createCollection("test-library", "A")
+                    require(a is AppResult.Success)
+                    val b = admin.createCollection("test-library", "B")
+                    require(b is AppResult.Success)
+                    admin.addBookToCollection(a.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+                    touch.touched.clear()
+
+                    admin.setBookCollections(BookId("b1"), listOf(b.data.id)).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    touch.touched shouldContainExactly listOf("b1")
+                }
+            }
+        }
     })

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPermissionPolicy
 import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.services.BookRevisionTouch
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.CollectionBookRepository
@@ -146,6 +147,32 @@ class CollectionMembershipRevisionTest :
                     touch.touched.clear()
 
                     admin.setBookCollections(BookId("b1"), listOf(b.data.id)).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    touch.touched shouldContainExactly listOf("b1")
+                }
+            }
+        }
+
+        test("releaseBooks touches each released book's revision") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("u1", userRole = UserRoleColumn.ADMIN)
+                seedTestBook(bookId = "b1")
+                runTest(UnconfinedTestDispatcher()) {
+                    val touch = FakeBookRevisionTouch()
+                    val service = makeCollectionService(db, bookRevisionTouch = touch)
+                    val admin = service.actAs("u1", UserRole.ADMIN)
+                    val inbox = admin.getOrCreateInbox("test-library")
+                    require(inbox is AppResult.Success)
+                    admin.addBookToCollection(inbox.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+                    touch.touched.clear()
+
+                    admin.releaseBooks("test-library", mapOf("b1" to emptyList<String>())).let {
                         require(it is AppResult.Success)
                     }
 

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.CollectionShareRepository
 import com.calypsan.listenup.server.sync.ControlFrame
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
@@ -82,6 +83,7 @@ class CollectionServiceImplSetBookCollectionsTest :
                     db = db,
                     clock = fixedClock,
                     permissionPolicy = UserPermissionPolicy(db),
+                    bookRevisionTouch = FakeBookRevisionTouch(),
                     principal = principalFor("u1"),
                 )
             return Harness(service, bus)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplTest.kt
@@ -22,6 +22,7 @@ import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.CollectionShareRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
@@ -73,6 +74,7 @@ class CollectionServiceImplTest :
                 bus = bus,
                 db = db,
                 clock = fixedClock,
+                bookRevisionTouch = FakeBookRevisionTouch(),
                 principal = principalFor("u1"),
             )
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionSyncCatchUpE2ETest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/CollectionSyncCatchUpE2ETest.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.CollectionShareRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.FixedClock
 import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
@@ -80,6 +81,7 @@ class CollectionSyncCatchUpE2ETest :
                 bus = bus,
                 db = db,
                 clock = fixedClock,
+                bookRevisionTouch = FakeBookRevisionTouch(),
                 principal = principalFor("u1"),
             )
         }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/api/InboxApproveReachesMemberTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/api/InboxApproveReachesMemberTest.kt
@@ -1,0 +1,155 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.UserPermissionPolicy
+import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.db.BookTable
+import com.calypsan.listenup.server.db.UserRoleColumn
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.services.GenreRepository
+import com.calypsan.listenup.server.services.SeriesRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.CollectionShareRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * The member-facing end of the collections-propagation fix: when an admin approves a held
+ * (inboxed) book back into the library, the book must become visible to a member *and* its
+ * sync revision must advance — so the member's incremental `revision > cursor AND accessible`
+ * pull re-delivers it. This is the integration counterpart to [CollectionMembershipRevisionTest],
+ * which pins the touch against a fake; here the real [BookRepository] performs the column bump
+ * and a real [BookAccessPolicy] resolves visibility, proving the whole seam end-to-end.
+ */
+class InboxApproveReachesMemberTest :
+    FunSpec({
+
+        val fixedClock = FixedClock(Instant.fromEpochMilliseconds(1_700_000_000_000L))
+
+        fun principalFor(
+            userId: String,
+            role: UserRole = UserRole.MEMBER,
+        ): PrincipalProvider =
+            PrincipalProvider {
+                UserPrincipal(UserId(userId), SessionId("session-$userId"), role)
+            }
+
+        fun makeCollectionService(
+            db: Database,
+            bookRevisionTouch: BookRepository,
+        ): CollectionServiceImpl {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val collectionRepo = CollectionRepository(db = db, bus = bus, registry = registry)
+            val collectionBookRepo = CollectionBookRepository(db = db, bus = bus, registry = registry)
+            val shareRepo = CollectionShareRepository(db = db, bus = bus, registry = registry)
+            val accessPolicy = CollectionAccessPolicy(collectionRepo, shareRepo)
+            return CollectionServiceImpl(
+                collectionRepo = collectionRepo,
+                collectionBookRepo = collectionBookRepo,
+                shareRepo = shareRepo,
+                accessPolicy = accessPolicy,
+                permissionPolicy = UserPermissionPolicy(db),
+                bus = bus,
+                db = db,
+                clock = fixedClock,
+                bookRevisionTouch = bookRevisionTouch,
+                principal = principalFor("admin", UserRole.ADMIN),
+            )
+        }
+
+        fun CollectionServiceImpl.actAs(
+            userId: String,
+            role: UserRole = UserRole.MEMBER,
+        ): CollectionServiceImpl = copyWith(principalFor(userId, role))
+
+        test("a held book is invisible to a member, then visible with an advanced revision after approve") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestUser("admin", userRole = UserRoleColumn.ADMIN)
+                seedTestUser("member")
+                seedTestBook(bookId = "b1")
+                runTest(UnconfinedTestDispatcher()) {
+                    val bookRepo = buildBookRepository(db) // real touch
+                    val accessPolicy = BookAccessPolicy(db)
+                    val service = makeCollectionService(db, bookRevisionTouch = bookRepo)
+                    val admin = service.actAs("admin", UserRole.ADMIN)
+
+                    val inbox = admin.getOrCreateInbox("test-library")
+                    require(inbox is AppResult.Success)
+                    admin.addBookToCollection(inbox.data.id, BookId("b1")).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    // Held → a member cannot see it.
+                    accessPolicy.canAccess("member", UserRole.MEMBER, "b1") shouldBe false
+                    val revisionBeforeApprove = readBookRevision(db, "b1")
+
+                    // Approve to library (empty target list → uncollected → public).
+                    admin.releaseBooks("test-library", mapOf("b1" to emptyList<String>())).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    // Approved → visible AND its revision advanced, so a member's incremental
+                    // `revision > cursor AND accessible` pull will deliver it.
+                    accessPolicy.canAccess("member", UserRole.MEMBER, "b1") shouldBe true
+                    readBookRevision(db, "b1") shouldBeGreaterThan revisionBeforeApprove
+                }
+            }
+        }
+    })
+
+/** Reads the current [BookTable.revision] for [id] directly from [db]. */
+private fun readBookRevision(
+    db: Database,
+    id: String,
+): Long =
+    transaction(db) {
+        BookTable
+            .selectAll()
+            .where { BookTable.id eq id }
+            .single()[BookTable.revision]
+    }
+
+/**
+ * Constructs a real [BookRepository] wired to [db] — used here as the [BookRevisionTouch]
+ * so the approve path performs the genuine revision-column bump (not a recording fake).
+ * Mirrors the builder in `BookRepositoryTouchRevisionTest`, which is `private` to that file.
+ */
+private fun buildBookRepository(db: Database): BookRepository {
+    val bus = ChangeBus()
+    val syncRegistry = SyncRegistry()
+    return BookRepository(
+        db = db,
+        bus = bus,
+        registry = syncRegistry,
+        contributorRepository = ContributorRepository(db, bus, syncRegistry),
+        seriesRepository = SeriesRepository(db, bus, syncRegistry),
+        genreRepository = GenreRepository(db, bus, syncRegistry),
+    )
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerInboxIngestTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/scanner/ScannerInboxIngestTest.kt
@@ -25,6 +25,7 @@ import com.calypsan.listenup.server.sync.CollectionBookRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.CollectionShareRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.seedTestUser
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
@@ -184,6 +185,7 @@ private fun fixture(db: Database): InboxFixture {
             permissionPolicy = UserPermissionPolicy(db),
             bus = bus,
             db = db,
+            bookRevisionTouch = FakeBookRevisionTouch(),
             principal = PrincipalProvider { null },
         )
     return InboxFixture(bookRepo, collectionBookRepo, collections)

--- a/server/src/test/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -24,6 +24,7 @@ import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.CollectionShareRepository
 import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.withInMemoryDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -372,6 +373,7 @@ private fun inertCollectionService(db: Database): CollectionServiceImpl {
         permissionPolicy = UserPermissionPolicy(db),
         bus = bus,
         db = db,
+        bookRevisionTouch = FakeBookRevisionTouch(),
         principal = PrincipalProvider { null },
     )
 }

--- a/server/src/test/kotlin/com/calypsan/listenup/server/services/BookRepositoryTouchRevisionTest.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/services/BookRepositoryTouchRevisionTest.kt
@@ -1,0 +1,93 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.db.BookTable
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.withInMemoryDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+class BookRepositoryTouchRevisionTest :
+    FunSpec({
+
+        test("touchRevision bumps the book's revision") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                seedTestBook(bookId = "b1")
+                val repo = buildBookRepository(db)
+                runTest {
+                    // The seed inserts the row with a hardcoded revision that doesn't track the
+                    // global counter, so establish the baseline through one touch first — then
+                    // assert the next touch advances past it (the global counter is monotonic).
+                    repo.touchRevision(BookId("b1"))
+                    val oldRevision =
+                        transaction(db) {
+                            BookTable
+                                .selectAll()
+                                .where { BookTable.id eq "b1" }
+                                .single()[BookTable.revision]
+                        }
+
+                    val result = repo.touchRevision(BookId("b1"))
+
+                    result shouldBe AppResult.Success(Unit)
+                    val newRevision =
+                        transaction(db) {
+                            BookTable
+                                .selectAll()
+                                .where { BookTable.id eq "b1" }
+                                .single()[BookTable.revision]
+                        }
+                    newRevision shouldBeGreaterThan oldRevision
+                }
+            }
+        }
+
+        test("touchRevision on a missing book returns NotFound") {
+            withInMemoryDatabase {
+                val db = this
+                seedTestLibraryAndFolder()
+                val repo = buildBookRepository(db)
+                runTest {
+                    val result = repo.touchRevision(BookId("nope"))
+
+                    val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                    failure.error.shouldBeInstanceOf<SyncError.NotFound>()
+                }
+            }
+        }
+    })
+
+/**
+ * Constructs a [BookRepository] wired to [db] with a fresh [ChangeBus] and
+ * [SyncRegistry] and the minimal child repositories. Mirrors the inline
+ * construction in `BookRepositoryUpsertTest` — extracted here so both
+ * `touchRevision` tests share one builder.
+ */
+private fun buildBookRepository(db: Database): BookRepository {
+    val bus = ChangeBus()
+    val syncRegistry = SyncRegistry()
+    return BookRepository(
+        db = db,
+        bus = bus,
+        registry = syncRegistry,
+        contributorRepository = ContributorRepository(db, bus, syncRegistry),
+        seriesRepository = SeriesRepository(db, bus, syncRegistry),
+        genreRepository = GenreRepository(db, bus, syncRegistry),
+    )
+}

--- a/server/src/test/kotlin/com/calypsan/listenup/server/testing/FakeBookRevisionTouch.kt
+++ b/server/src/test/kotlin/com/calypsan/listenup/server/testing/FakeBookRevisionTouch.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.server.testing
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.services.BookRevisionTouch
+
+/**
+ * A recording [BookRevisionTouch] fake for seam-level tests: every [touchRevision] call
+ * appends the book id to [touched] and reports success, so a test can assert exactly which
+ * books a collection-membership change bumped — without a real [BookRepository] in the graph.
+ */
+class FakeBookRevisionTouch : BookRevisionTouch {
+    val touched = mutableListOf<String>()
+
+    override suspend fun touchRevision(id: BookId): AppResult<Unit> {
+        touched += id.value
+        return AppResult.Success(Unit)
+    }
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
@@ -171,6 +171,7 @@ fun withCollectionSyncEngineAgainstServer(block: suspend CollectionSyncEngineSco
                 shareRepo = shareRepo,
                 bus = bus,
                 db = serverDb,
+                bookRevisionTouch = bookRepo,
             )
         val adminCollections =
             collectionServiceScopedTo(


### PR DESCRIPTION
## Summary

Collection-membership changes never bumped the affected book's sync `revision`, so a newly-visible book — e.g. one approved out of the admin inbox — never re-entered a member's incremental `revision > cursor AND <accessible>` pull, and members never received it. This is **Phase 1 (server-only)** of the Collections access-model overhaul.

- New narrow `BookRevisionTouch` interface + `BookRepository.touchRevision(id)` — bumps `revision` + `updatedAt` and publishes `SyncEvent.Updated`, mirroring `setManagedCover`.
- `CollectionServiceImpl` calls `touchRevision` in the **success path** of all four membership mutations: `addBookToCollection`, `removeBookFromCollection`, `setBookCollections` (guarded to fire once on a real change), and `releaseBooks` (each released book).
- The client `AccessChanged`/prune path and the normal incremental-sync path already exist and are unchanged — this is purely the missing server-side revision bump.

**Deferred to Phase 2 by design:** the retract-from-public "everyone" notify, and the model change (All-Books-as-collection, principal-based grants). Tracked in the Collections access-model design doc (`2026-06-19-collections-access-model-design.md`).

## Test plan

- [x] `BookRepositoryTouchRevisionTest` — touch strictly increases revision; missing book → `NotFound`.
- [x] `CollectionMembershipRevisionTest` — each of the four mutations touches the right book; a no-op `setBookCollections` does **not** touch.
- [x] `InboxApproveReachesMemberTest` (e2e) — a held book is invisible to a member; after approve it is visible **and** its revision advanced (so the member's incremental pull delivers it).
- [x] Local gate green: `spotlessCheck` + `detekt`, `:sharedLogic:jvmTest` + `:server:test`, `:androidApp:assembleDebug`.
- [ ] On-device: confirm an approved book reaches a member without a full resync.