### PR TITLE
⚡ perf(androidApp): lean R8 keep rules — APK 48→18 MB

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,57 +1,38 @@
 # ============================================================================
 # ProGuard/R8 rules for ListenUp Android client
+#
+# Keep this file minimal. Every dependency the app relies on (Compose, Media3,
+# Room, kotlinx.serialization, Koin, Ktor) ships its own consumer keep rules
+# inside its artifact, so a blanket "-keep <pkg>.** { *; }" here only fences code
+# off from R8 full mode with no functional benefit. Add a rule only for a
+# concrete, observed reflective failure, and scope it as narrowly as possible.
+#
+# The "-dontwarn" rules below suppress missing-class warnings for optional
+# transitive APIs. They do not affect shrinking, so they are kept as a low-cost
+# safety net rather than removed.
 # ============================================================================
 
 # --- kotlinx.serialization ---
+# Keep annotation + inner-class metadata for (de)serialization reflection. The
+# serialization runtime bundles the keep rules for the generated $$serializer
+# classes, companions, and serializer() on every @Serializable type, so no
+# manual class keeps are required here.
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.AnnotationsKt
 
--keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
--keepclasseswithmembers class kotlinx.serialization.json.** {
-    kotlinx.serialization.KSerializer serializer(...);
-}
+# --- Ktor (OkHttp engine) ---
+# The authenticated client is built with a no-arg HttpClient { }, which resolves
+# its engine via ServiceLoader at runtime. Keep the OkHttp engine container so R8
+# full mode cannot strip the discovered implementation. The rest of Ktor is
+# preserved by normal reachability plus Ktor's own consumer rules.
+-keep class io.ktor.client.engine.okhttp.** { *; }
 
-# Keep serializable classes and their serializers
--keep,includedescriptorclasses class com.calypsan.listenup.**$$serializer { *; }
--keepclassmembers class com.calypsan.listenup.** {
-    *** Companion;
-}
--keepclasseswithmembers class com.calypsan.listenup.** {
-    kotlinx.serialization.KSerializer serializer(...);
-}
-
-# --- Ktor ---
--keep class io.ktor.** { *; }
+# --- Warning suppression (does not affect shrinking) ---
 -dontwarn io.ktor.**
-
-# --- OkHttp (used by Ktor engine) ---
 -dontwarn okhttp3.**
 -dontwarn okio.**
-
-# --- Room ---
--keep class * extends androidx.room.RoomDatabase
--keep @androidx.room.Entity class *
--keep @androidx.room.Dao interface *
-
-# --- Koin ---
--keep class org.koin.** { *; }
-
-# --- Media3 / ExoPlayer ---
--keep class androidx.media3.** { *; }
--dontwarn androidx.media3.**
-
-# --- Coil ---
 -dontwarn coil3.**
-
-# --- AndroidX general ---
 -dontwarn androidx.**
-
-# --- SLF4J ---
 -dontwarn org.slf4j.**
-
-# --- Kotlin ---
 -dontwarn kotlin.**
 -dontwarn kotlinx.**
-
-# --- Keep R8 from stripping Compose ---
--keep class androidx.compose.** { *; }


### PR DESCRIPTION
## What

Trims `androidApp/proguard-rules.pro` down to only the rules R8 actually needs, so R8 (full mode) can shrink the app instead of being fenced off by blanket keeps.

## Why

The old rules carried package-wide `-keep <pkg>.** { *; }` blankets for Compose, Media3, Room, Koin, and kotlinx.serialization. Every one of those libraries already ships its own consumer keep rules, so the blankets were redundant **and** actively forced R8 to retain the entire surface of each library.

Measured across three real builds (`benchmarkRelease` = R8 on, debug-signed; `nonMinifiedRelease` = R8 off):

| | APK | Download | DEX method refs |
|---|---:|---:|---:|
| R8 off | 94 MB | 32 MB | 375k (6 dex) |
| R8 on, old blanket keeps | 48 MB | 19 MB | 169k (3 dex) |
| **R8 on, lean keeps (this PR)** | **18 MB** | **10 MB** | **51k (1 dex)** |

The cleanup alone is **−62% APK / −47% download** vs the old keeps — the blankets had been leaving ~30 MB on the table.

## Changes

- Removed the redundant blanket keeps (Compose / Media3 / Room / Koin / serialization) — each library's bundled consumer rules cover them.
- Refined Ktor: dropped `-keep class io.ktor.** { *; }`, kept only `-keep class io.ktor.client.engine.okhttp.** { *; }` — the no-arg `HttpClient { }` resolves its engine via ServiceLoader, so the OkHttp engine container must survive R8 full mode.
- Kept all `-dontwarn` lines (no shrinking cost) and `-keepattributes` for serialization.

## Verification

- Minified R8 build succeeds with the lean rules (`:androidApp:assembleBenchmarkRelease`, R8 full mode + `strictFullModeForKeepRules`).
- On-device runtime verification still pending — a clean R8 build proves the config is valid, not that every reflective path works. Smoke-test networking/RPC, DI, Room, playback, and JSON before merge.
