### PR TITLE
♻️ refactor: trim the client export surface (REST @Resource → :server; hide shared-internal types)

### DIFF
--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.rpc.core)
-            implementation(libs.ktor.resources)
+            implementation(libs.ktor.io) // io.ktor.utils.io.ByteReadChannel (FileSource)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.io.core)

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/AdminUserService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/AdminUserService.kt
@@ -19,8 +19,8 @@ import kotlinx.rpc.annotations.Rpc
  * instance-wide [RegistrationPolicy] that governs how new accounts are admitted.
  *
  * REST mirrors are defined in
- * [com.calypsan.listenup.api.resources.AdminUserResources] and
- * [com.calypsan.listenup.api.resources.RegistrationPolicyResource].
+ * `AdminUserResources` and
+ * `RegistrationPolicyResource`.
  */
 @Rpc
 interface AdminUserService {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/BackupRoutePaths.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/BackupRoutePaths.kt
@@ -1,4 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.api
+
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 /**
  * Canonical REST route paths for the admin backup endpoints, shared by server + client to prevent drift.
@@ -8,6 +13,7 @@ package com.calypsan.listenup.api
  * uploader. Defining it once here makes client/server drift a compile-time concern, not a
  * runtime 404. Everything else in the backup surface is RPC ([BackupService]).
  */
+@HiddenFromObjC
 object BackupRoutePaths {
     /** `POST` — streams a `.listenup.zip` backup; responds a [com.calypsan.listenup.api.dto.backup.BackupSummary]. */
     const val UPLOAD: String = "/api/v1/admin/backups/upload"

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/BookService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/BookService.kt
@@ -18,7 +18,7 @@ import kotlinx.rpc.annotations.Rpc
  *   [deleteBookCover] mutate server state; SSE delivers the authoritative
  *   payload back to all connected clients.
  *
- * REST mirrors are defined in [com.calypsan.listenup.api.resources.BookResources].
+ * REST mirrors are defined in `BookResources`.
  *
  * // TODO: gate mutations by user permissions when Multi-user lands
  */

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/CollectionService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/CollectionService.kt
@@ -30,7 +30,7 @@ import kotlinx.rpc.annotations.Rpc
  * collections on the server.
  *
  * REST mirrors are defined in
- * [com.calypsan.listenup.api.resources.CollectionResources].
+ * `CollectionResources`.
  */
 @Rpc
 interface CollectionService {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ImportRoutePaths.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ImportRoutePaths.kt
@@ -1,4 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.api
+
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 /**
  * Canonical REST paths for the admin Audiobookshelf import surface.
@@ -8,6 +13,7 @@ package com.calypsan.listenup.api
  * uploader. Defining it once here makes client/server drift a compile-time concern, not a
  * runtime 404. Everything else in the import surface is RPC ([ImportService]).
  */
+@HiddenFromObjC
 object ImportRoutePaths {
     /** `POST` — streams a `.audiobookshelf` zip; responds an [com.calypsan.listenup.api.dto.imports.ImportSummary]. */
     const val ABS_UPLOAD: String = "/api/v1/admin/imports/abs/upload"

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/InviteService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/InviteService.kt
@@ -18,7 +18,7 @@ import kotlinx.rpc.annotations.Rpc
  * [InviteServicePublic].
  *
  * REST mirrors are defined in
- * [com.calypsan.listenup.api.resources.InviteResources].
+ * `InviteResources`.
  */
 @Rpc
 interface InviteService {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/InviteServicePublic.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/InviteServicePublic.kt
@@ -15,7 +15,7 @@ import kotlinx.rpc.annotations.Rpc
  * exceptions, so they survive both transports as in-band data.
  *
  * REST mirrors are defined in
- * [com.calypsan.listenup.api.resources.InviteResources].
+ * `InviteResources`.
  */
 @Rpc
 interface InviteServicePublic {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/LibraryAdminService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/LibraryAdminService.kt
@@ -24,7 +24,7 @@ import kotlinx.rpc.annotations.Rpc
  * members can browse content and the onboarding wizard can run before an admin exists.
  *
  * REST mirrors are defined in
- * [com.calypsan.listenup.api.resources.LibraryResources].
+ * `LibraryResources`.
  *
  * Two surface categories:
  * - **Observation + setup** — [getLibrary], [getSetupStatus], [browseFilesystem]

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
@@ -22,7 +22,7 @@ import kotlinx.rpc.annotations.Rpc
  *
  * Wire shapes are defined in [com.calypsan.listenup.api.dto.MetadataBook] and
  * siblings. The third-party REST mirrors are in
- * [com.calypsan.listenup.api.resources.MetadataResources].
+ * `MetadataResources`.
  *
  * Two complementary surfaces:
  * - **Search / fetch** — [searchBooks], [getBookMetadata], [getBookChapters],

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/SearchService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/SearchService.kt
@@ -14,7 +14,7 @@ import kotlinx.rpc.annotations.Rpc
  * books only (filters/sort are book concepts). An empty or blank query always returns
  * empty lists — it is never an error.
  *
- * REST mirror: [com.calypsan.listenup.api.resources.SearchResources].
+ * REST mirror: `SearchResources`.
  */
 @Rpc
 interface SearchService {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ShelfService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ShelfService.kt
@@ -31,7 +31,7 @@ import kotlinx.rpc.annotations.Rpc
  *   public shelves with access-filtered book lists; private shelves return
  *   [com.calypsan.listenup.api.error.ShelfError.NotFound] to non-owners.
  *
- * REST mirrors are defined in `com.calypsan.listenup.api.resources.ShelfResources`.
+ * REST mirrors are defined in `ShelfResources`.
  */
 @Rpc
 interface ShelfService {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/TagService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/TagService.kt
@@ -23,8 +23,8 @@ import kotlinx.rpc.annotations.Rpc
  * The `book_tags` junction is a global cross-user association (curator model).
  * Per-user ACL enforcement is deferred to the Multi-user phase.
  *
- * REST mirrors are defined in [com.calypsan.listenup.api.resources.TagResources]
- * and [com.calypsan.listenup.api.resources.BookTagsResources].
+ * REST mirrors are defined in `TagResources`
+ * and `BookTagsResources`.
  */
 @Rpc
 interface TagService {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainDigest.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainDigest.kt
@@ -1,5 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.api.sync
 
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,6 +19,7 @@ import kotlinx.serialization.Serializable
  * Used by clients to detect drift cheaply — match `(count, hash)` between local and server;
  * mismatch triggers a full domain re-pull (`?since=0`).
  */
+@HiddenFromObjC
 @Serializable
 data class DomainDigest(
     @SerialName("cursor")

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainList.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/DomainList.kt
@@ -1,5 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.api.sync
 
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,6 +16,7 @@ import kotlinx.serialization.Serializable
  *
  * Order: server returns names sorted lexicographically for stability.
  */
+@HiddenFromObjC
 @Serializable
 data class DomainList(
     @SerialName("domains") val domains: List<String>,

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
@@ -1,5 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.api.sync
 
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import com.calypsan.listenup.api.error.AppError
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,6 +17,7 @@ import kotlinx.serialization.Serializable
  *
  * Stable `@SerialName` discriminators — wire contract.
  */
+@HiddenFromObjC
 @Serializable
 sealed interface SyncControl {
     /**
@@ -20,6 +25,7 @@ sealed interface SyncControl {
      * replay window. Client must fall back to REST per-domain catch-up against
      * each registered domain.
      */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.CursorStale")
     data class CursorStale(
@@ -32,6 +38,7 @@ sealed interface SyncControl {
      * [error] is the same typed [AppError] surface the rest of the contract
      * uses; stacktraces never cross the wire.
      */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.StreamError")
     data class StreamError(
@@ -45,6 +52,7 @@ sealed interface SyncControl {
      * The client treats this as "re-derive your accessible library" and re-pulls
      * the access-aware books digest. A bare signal is enough; no scope is carried.
      */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.AccessChanged")
     data object AccessChanged : SyncControl
@@ -54,6 +62,7 @@ sealed interface SyncControl {
      * and may surface [reason]. Delivered per-user on the firehose control channel, published
      * before session revocation so the still-authed connection receives it.
      */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.UserDeleted")
     data class UserDeleted(
@@ -61,11 +70,13 @@ sealed interface SyncControl {
     ) : SyncControl
 
     /** Content-free broadcast nudge: active-session presence changed; re-fetch via SocialService. */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.ActiveSessionsChanged")
     data object ActiveSessionsChanged : SyncControl
 
     /** Content-free broadcast nudge: a new activity was recorded; re-fetch via ActivityService. */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.ActivityChanged")
     data object ActivityChanged : SyncControl
@@ -76,6 +87,7 @@ sealed interface SyncControl {
      * their stored remote-URL fallback — so an admin's new domain reaches connected clients without a
      * cold start. No payload: the value travels on the existing getServerInfo probe (one source of truth).
      */
+    @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.ServerInfoChanged")
     data object ServerInfoChanged : SyncControl

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncCursor.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncCursor.kt
@@ -1,6 +1,10 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.api.sync
 
+import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.jvm.JvmInline
+import kotlin.native.HiddenFromObjC
 import kotlinx.serialization.Serializable
 
 /**
@@ -10,6 +14,7 @@ import kotlinx.serialization.Serializable
  * resume or as the `?since=` query parameter on REST catch-up. The underlying
  * type is [Long]; the value class is for call-site clarity only.
  */
+@HiddenFromObjC
 @Serializable
 @JvmInline
 value class SyncCursor(

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/DebouncedSearch.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/DebouncedSearch.kt
@@ -14,56 +14,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
-/**
- * Reusable debounced search utility.
- *
- * Encapsulates the common pattern of:
- * - MutableStateFlow for query input
- * - Debouncing to avoid excessive API calls
- * - Minimum query length filtering
- * - Job management to cancel in-flight searches
- * - Loading state tracking
- *
- * Single-channel usage (search bar):
- * ```kotlin
- * class SearchViewModel(private val repository: SearchRepository) : ViewModel() {
- *     private val search = DebouncedSearch<Unit, List<Book>>(
- *         scope = viewModelScope,
- *         onSearch = { _, query -> repository.search(query) },
- *         onResult = { _, results -> state.update { it.copy(results = results, isLoading = false) } },
- *         onClear = { _ -> state.update { it.copy(results = emptyList()) } },
- *         onLoadingChange = { _, loading -> state.update { it.copy(isLoading = loading) } }
- *     )
- *
- *     fun onQueryChanged(query: String) = search.setQuery(Unit, query)
- * }
- * ```
- *
- * Multi-channel usage (per-role contributor search):
- * ```kotlin
- * private val search = DebouncedSearch<ContributorRole, List<Contributor>>(
- *     scope = scope,
- *     onSearch = { role, query -> repository.search(query) },
- *     onResult = { role, results -> state.update { it.copy(roleResults = it.roleResults + (role to results)) } },
- *     onClear = { role -> state.update { it.copy(roleResults = it.roleResults - role) } },
- *     onLoadingChange = { role, loading -> state.update { it.copy(roleLoading = it.roleLoading + (role to loading)) } }
- * )
- *
- * fun onQueryChanged(role: ContributorRole, query: String) = search.setQuery(role, query)
- * ```
- *
- * @param K Key type for multi-channel search (use Unit for single channel)
- * @param R Result type returned by search
- * @param scope CoroutineScope for launching search operations
- * @param debounceMs Debounce delay in milliseconds (default 300ms)
- * @param minQueryLength Minimum query length to trigger search (default 2)
- * @param onSearch Suspend function to perform the search
- * @param onResult Callback when results are received
- * @param onClear Callback when query is cleared
- * @param onLoadingChange Optional callback for loading state changes
- * @param onError Optional callback for search errors
- */
-class DebouncedSearch<K, R>(
+internal class DebouncedSearch<K, R>(
     private val scope: CoroutineScope,
     private val debounceMs: Long = DEFAULT_DEBOUNCE_MS,
     private val minQueryLength: Int = DEFAULT_MIN_QUERY_LENGTH,

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/DebouncedSearch.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/DebouncedSearch.kt
@@ -1,7 +1,9 @@
-@file:OptIn(FlowPreview::class)
+@file:OptIn(FlowPreview::class, ExperimentalObjCRefinement::class)
 
 package com.calypsan.listenup.core
 
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -170,6 +172,7 @@ internal class DebouncedSearch<K, R>(
  * fun onQueryChanged(query: String) = search.setQuery(query)
  * ```
  */
+@HiddenFromObjC
 class SingleDebouncedSearch<R>(
     scope: CoroutineScope,
     debounceMs: Long = DebouncedSearch.DEFAULT_DEBOUNCE_MS,

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/PlatformUtils.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/PlatformUtils.kt
@@ -1,4 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.core
+
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 /**
  * Platform-specific utilities for cross-platform code.
@@ -12,6 +17,7 @@ package com.calypsan.listenup.core
  * - getPlatformName(): Gets the platform name ("Android" or "iOS")
  * - getPlatformVersion(): Gets the OS version string
  */
+@HiddenFromObjC
 expect object PlatformUtils {
     /**
      * Checks if the app is running on an emulator/simulator.

--- a/contract/src/iosMain/kotlin/com/calypsan/listenup/core/PlatformUtils.kt
+++ b/contract/src/iosMain/kotlin/com/calypsan/listenup/core/PlatformUtils.kt
@@ -1,5 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.core
 
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import platform.UIKit.UIDevice
 
 /**
@@ -9,6 +13,7 @@ import platform.UIKit.UIDevice
  * This is the standard approach for iOS and works reliably across
  * all simulator types (iPhone, iPad, etc.).
  */
+@HiddenFromObjC
 actual object PlatformUtils {
     actual fun isEmulator(): Boolean = UIDevice.currentDevice.name.contains("Simulator", ignoreCase = true)
 

--- a/contract/src/macosMain/kotlin/com/calypsan/listenup/core/PlatformUtils.kt
+++ b/contract/src/macosMain/kotlin/com/calypsan/listenup/core/PlatformUtils.kt
@@ -1,5 +1,9 @@
+@file:OptIn(ExperimentalObjCRefinement::class)
+
 package com.calypsan.listenup.core
 
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import platform.Foundation.NSProcessInfo
 
 /**
@@ -8,6 +12,7 @@ import platform.Foundation.NSProcessInfo
  * Uses NSProcessInfo for system information.
  * Desktop is never an emulator.
  */
+@HiddenFromObjC
 actual object PlatformUtils {
     actual fun isEmulator(): Boolean = false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,8 +128,10 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
-# Ktor Resources — KMP @Resource annotation (shared commonMain contract surface)
+# Ktor Resources — @Resource REST-route annotation (used by :server routes/resources)
 ktor-resources = { module = "io.ktor:ktor-resources", version.ref = "ktor" }
+# Ktor IO — multiplatform io.ktor.utils.io.* (ByteReadChannel, etc.)
+ktor-io = { module = "io.ktor:ktor-io", version.ref = "ktor" }
 # Ktor server (core)
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AdminUserRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AdminUserRoutes.kt
@@ -6,8 +6,8 @@ import com.calypsan.listenup.api.dto.auth.PendingRegistrationDecision
 import com.calypsan.listenup.api.dto.auth.RegistrationPolicy
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.AdminUserResources
-import com.calypsan.listenup.api.resources.RegistrationPolicyResource
+import com.calypsan.listenup.server.routes.resources.AdminUserResources
+import com.calypsan.listenup.server.routes.resources.RegistrationPolicyResource
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.api.AdminUserServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AuthRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AuthRoutes.kt
@@ -8,7 +8,7 @@ import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.SessionSummary
 import com.calypsan.listenup.api.dto.auth.User
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.api.resources.AuthResources
+import com.calypsan.listenup.server.routes.resources.AuthResources
 import com.calypsan.listenup.server.auth.AuthServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.plugins.JWT_PROVIDER

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/BookRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/BookRoutes.kt
@@ -6,7 +6,7 @@ import com.calypsan.listenup.api.dto.BookGenreInput
 import com.calypsan.listenup.api.dto.BookSeriesInput
 import com.calypsan.listenup.api.dto.BookUpdate
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.BookResources
+import com.calypsan.listenup.server.routes.resources.BookResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.BookSyncPayload
 import com.calypsan.listenup.core.BookId

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/CollectionRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/CollectionRoutes.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.api.dto.CreateCollectionBody
 import com.calypsan.listenup.api.dto.SharePermission
 import com.calypsan.listenup.api.dto.ShareCollectionBody
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.CollectionResources
+import com.calypsan.listenup.server.routes.resources.CollectionResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.CollectionId

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ContributorRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ContributorRoutes.kt
@@ -2,10 +2,10 @@ package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.ContributorService
 import com.calypsan.listenup.api.dto.ContributorUpdate
-import com.calypsan.listenup.api.dto.MergeContributorsBody
-import com.calypsan.listenup.api.dto.UnmergeContributorBody
+import com.calypsan.listenup.server.routes.resources.MergeContributorsBody
+import com.calypsan.listenup.server.routes.resources.UnmergeContributorBody
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.ContributorResources
+import com.calypsan.listenup.server.routes.resources.ContributorResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.BookSyncPayload
 import com.calypsan.listenup.api.sync.ContributorSyncPayload

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/GenreRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/GenreRoutes.kt
@@ -1,13 +1,13 @@
 package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.GenreService
-import com.calypsan.listenup.api.dto.CreateGenreBody
+import com.calypsan.listenup.server.routes.resources.CreateGenreBody
 import com.calypsan.listenup.api.dto.GenreUpdate
-import com.calypsan.listenup.api.dto.MapUnmappedBody
-import com.calypsan.listenup.api.dto.MergeGenresBody
-import com.calypsan.listenup.api.dto.MoveGenreBody
+import com.calypsan.listenup.server.routes.resources.MapUnmappedBody
+import com.calypsan.listenup.server.routes.resources.MergeGenresBody
+import com.calypsan.listenup.server.routes.resources.MoveGenreBody
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.GenreResources
+import com.calypsan.listenup.server.routes.resources.GenreResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.GenreId
 import com.calypsan.listenup.server.api.BookAccessPolicy

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/InviteRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/InviteRoutes.kt
@@ -6,8 +6,8 @@ import com.calypsan.listenup.api.dto.invite.ClaimInviteRequest
 import com.calypsan.listenup.api.dto.invite.CreateInviteRequest
 import com.calypsan.listenup.api.dto.invite.InviteId
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.InvitePreviewResource
-import com.calypsan.listenup.api.resources.InviteResources
+import com.calypsan.listenup.server.routes.resources.InvitePreviewResource
+import com.calypsan.listenup.server.routes.resources.InviteResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.api.InviteServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/LibraryAdminRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/LibraryAdminRoutes.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.LibraryAdminService
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.LibraryResources
+import com.calypsan.listenup.server.routes.resources.LibraryResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.server.api.LibraryAdminServiceImpl

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/MetadataRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/MetadataRoutes.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.api.dto.MetadataApplySelection
 import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.api.metadata.AudibleRegion
-import com.calypsan.listenup.api.resources.MetadataResources
+import com.calypsan.listenup.server.routes.resources.MetadataResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ContributorId

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/PlaybackProgressRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/PlaybackProgressRoutes.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.PlaybackProgressService
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.PlaybackProgressResources
+import com.calypsan.listenup.server.routes.resources.PlaybackProgressResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.api.BookAccessPolicy

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/PlaybackRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/PlaybackRoutes.kt
@@ -4,10 +4,10 @@ import com.calypsan.listenup.api.PlaybackService
 import com.calypsan.listenup.api.dto.RecordListeningEventRequest
 import com.calypsan.listenup.api.dto.RecordPositionRequest
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.Events
-import com.calypsan.listenup.api.resources.Position
-import com.calypsan.listenup.api.resources.Prepare
-import com.calypsan.listenup.api.resources.Stats
+import com.calypsan.listenup.server.routes.resources.Events
+import com.calypsan.listenup.server.routes.resources.Position
+import com.calypsan.listenup.server.routes.resources.Prepare
+import com.calypsan.listenup.server.routes.resources.Stats
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.api.PlaybackServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
 import com.calypsan.listenup.api.event.ScanEvent
-import com.calypsan.listenup.api.resources.ScannerResources
+import com.calypsan.listenup.server.routes.resources.ScannerResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.plugins.toHttpStatus
 import com.calypsan.listenup.server.plugins.withCorrelationId

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/SearchRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/SearchRoutes.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.api.dto.SearchFilters
 import com.calypsan.listenup.api.dto.SearchQuery
 import com.calypsan.listenup.api.dto.SearchSort
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.SearchResources
+import com.calypsan.listenup.server.routes.resources.SearchResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.api.SearchServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/SeriesRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/SeriesRoutes.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.SeriesService
-import com.calypsan.listenup.api.dto.MergeSeriesBody
+import com.calypsan.listenup.server.routes.resources.MergeSeriesBody
 import com.calypsan.listenup.api.dto.SeriesUpdate
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.SeriesResources
+import com.calypsan.listenup.server.routes.resources.SeriesResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.BookSyncPayload
 import com.calypsan.listenup.api.sync.SeriesSyncPayload

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/TagRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/TagRoutes.kt
@@ -2,8 +2,8 @@ package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.TagService
 import com.calypsan.listenup.api.error.AppError
-import com.calypsan.listenup.api.resources.BookTagsResources
-import com.calypsan.listenup.api.resources.TagResources
+import com.calypsan.listenup.server.routes.resources.BookTagsResources
+import com.calypsan.listenup.server.routes.resources.TagResources
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.TagId

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/AdminUserResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/AdminUserResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/AuthResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/AuthResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/BookResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/BookResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.BookId
 import io.ktor.resources.Resource

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/CollectionResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/CollectionResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/ContributorResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/ContributorResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/CreateGenreBody.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/CreateGenreBody.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.dto
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.GenreId
 import kotlinx.serialization.SerialName

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/GenreResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/GenreResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/InviteResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/InviteResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/LibraryResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/LibraryResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MapUnmappedBody.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MapUnmappedBody.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.dto
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.GenreId
 import kotlinx.serialization.SerialName

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MergeDtos.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MergeDtos.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.dto
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.ContributorId
 import com.calypsan.listenup.core.SeriesId

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MergeGenresBody.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MergeGenresBody.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.dto
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.GenreId
 import kotlinx.serialization.SerialName

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MetadataResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MetadataResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MoveGenreBody.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/MoveGenreBody.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.dto
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.GenreId
 import kotlinx.serialization.SerialName

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/PlaybackProgressResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/PlaybackProgressResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/PlaybackResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/PlaybackResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import com.calypsan.listenup.core.BookId
 import io.ktor.resources.Resource

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/ScannerResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/ScannerResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/SearchResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/SearchResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/SeriesResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/SeriesResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/TagResources.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/resources/TagResources.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.api.resources
+package com.calypsan.listenup.server.routes.resources
 
 import io.ktor.resources.Resource
 

--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -67,7 +67,6 @@ kotlin {
             implementation(libs.ktor.serialization.json)
             implementation(libs.ktor.client.logging)
             implementation(libs.ktor.client.auth)
-            implementation(libs.ktor.resources) // @Resource annotation for REST surface mirror
 
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlincrypto.sha2)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ContractHasNoKtorClientRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ContractHasNoKtorClientRule.kt
@@ -5,9 +5,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 
 /**
- * `:contract` is the cross-platform wire/domain contract. It may use `io.ktor.resources`
- * (the `@Resource` REST-route surface) and `io.ktor.http`/`io.ktor.utils.io` (FileSource),
- * but it must NOT depend on the Ktor CLIENT transport — that coupling moved to the client
+ * `:contract` is the cross-platform wire/domain contract. It may use `io.ktor.http`/`io.ktor.utils.io`
+ * (FileSource), but it must NOT depend on the Ktor CLIENT transport — that coupling moved to the client
  * with ErrorMapper. Pin the boundary so a client-transport import can't creep back into :contract.
  */
 class ContractHasNoKtorClientRule :

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoResourcesInContractRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoResourcesInContractRule.kt
@@ -1,0 +1,27 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * The REST `@Resource` route surface is server-side only — third-party REST integrations
+ * consume it; first-party Kotlin clients use the `@Rpc` proxies. It lives in `:server`
+ * (`routes/resources/`), NOT in `:contract`, so it never enters the iOS Swift framework
+ * (`:sharedLogic` exports `:contract` wholesale) or the future JS bundle. This rule pins
+ * that boundary: a new `@Resource` added to `:contract` would silently re-bloat every
+ * client export, so make it a build failure.
+ */
+class NoResourcesInContractRule :
+    FunSpec({
+        test("no :contract type is annotated @Resource (REST surface lives in :server)") {
+            val offenders =
+                Konsist
+                    .scopeFromProduction()
+                    .classes(includeNested = true)
+                    .filter { "/contract/src/" in it.path }
+                    .filter { cls -> cls.annotations.any { it.name == "Resource" } }
+                    .map { it.name }
+            offenders.shouldBeEmpty()
+        }
+    })


### PR DESCRIPTION
## Summary

Trims what the shared modules (`:contract`, `:sharedLogic`) export to client platforms — the iOS framework today, the planned Swift Export / JS bundles next, and it lets R8 keep less on Android. The headline lever is structural: the REST `@Resource` surface (server/third-party-only) leaves `:contract` entirely, removing ~101 symbols from every client export at once, with zero annotations.

## What changed

- **Relocate the REST surface to `:server`** (its sole consumer): 15 `@Resource` route files + 7 `*Body` request DTOs move from `:contract/commonMain` → `:server/routes/resources/`. The wrapped DTOs stay in `:contract` for RPC. Swaps the now-unused `ktor-resources` dep in `:contract` for the minimal `ktor-io` (the only ktor symbol `:contract` uses is `ByteReadChannel`). New Konsist rule `NoResourcesInContractRule` pins the boundary.
- **`DebouncedSearch` → `internal`** — used only by `SingleDebouncedSearch`, so it drops from the public/export surface on every path.
- **Drop the vestigial `ktor-resources` dep from `:sharedLogic`** (the `@Resource` classes it existed for just left).
- **`@HiddenFromObjC`** on the cleanly-hideable shared-internal types (route-path constants, `DomainDigest`/`DomainList`/`SyncCursor`, `SyncControl` + its sealed subtypes, `PlatformUtils` expect + apple actuals, `SingleDebouncedSearch`).

## Notes / scope

- `@HiddenFromObjC` only affects the classic Objective-C interop framework (what ships today) — it does **not** govern the planned direct Swift Export. The structural relocation above is the export-mechanism-agnostic win; the annotations are a near-term iOS-framework trim.
- `SyncEvent` is deliberately **not** hidden: it's reachable through `:sharedLogic`'s public `SyncDomainHandler` API, so hiding it requires internalizing that surface — deferred.
- **Next (separate effort):** internalize `:sharedLogic`'s `data/` plumbing layer (~210 files the app modules never reference) — the high-leverage, Swift-Export-agnostic structural win that subsumes the `SyncEvent` deferral.

## Verification

- `:sharedLogic:jvmTest` + `:server:jvmTest` + `spotlessCheck` + `detekt` + `:androidApp:assembleDebug` — all green, rebased onto `main` (#681's Exposed→SQLDelight migration).
- Konsist `NoResourcesInContractRule` + `BookServiceHasRestMirror` pass.
- iOS framework size + the `@HiddenFromObjC` ObjC-export effect are validated on the Apple CI job (not observable on Linux).