### PR TITLE
👷 ci: export-surface inventory for Shared.framework + discipline note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,18 @@ jobs:
           path: ${{ runner.temp }}/ios-test.xcresult
           retention-days: 7
 
+      # Records the iOS framework's exported Objective-C surface so export-surface
+      # regressions are visible. Informational for now (continue-on-error) — once a
+      # real run confirms the mangled names, the regression list in the script
+      # becomes a hard gate. See CLAUDE.md "Export Surface".
+      - name: Export-surface inventory (informational)
+        if: always()
+        continue-on-error: true
+        run: |
+          ./gradlew :sharedLogic:linkReleaseFrameworkIosArm64 --no-daemon
+          bash scripts/export-surface-inventory.sh \
+            sharedLogic/build/bin/iosArm64/releaseFramework/Shared.framework/Headers/Shared.h
+
   # ── Build ────────────────────────────────────────────────────────────────────
   build-server-native:
     name: Build (server linuxX64)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,16 @@ Full philosophy in the parent `CLAUDE.md`. Day-to-day rules:
 - **Translate once at the boundary.** `ErrorMapper` runs at the Ktor edge; downstream consumers fold the typed value. Never substring-match on `error.message` — it's a constant, so the match is either redundant or wrong.
 - **Konsist enforces it.** `NoLegacyAppErrorRule`, `NoThrowsInDataLayerRule`, `DtosLiveInCommonMainRule`, `NoTransportTypesInDomainRule`, `PublicCommonMainTypesHaveKDocRule`, `StablePropertyOrderRule` — all active in CI. Adding a public commonMain type without KDoc, or a `@Serializable data class` with no `@SerialName` anywhere, fails the build.
 
+### Export Surface
+
+The shared modules (`:contract`, `:sharedLogic`) export their public API to every client platform — the iOS framework now, the planned Swift Export and JS bundles next; a leaner surface also lets R8 shrink the Android app. **Export only what client UI consumes; server-only and internal-plumbing types are dead weight on every client.** Levers, strongest first:
+
+1. **Relocate** a type to its real consumer (the REST `@Resource` surface lives in `:server`, not `:contract`) — gone from _every_ export path, no annotation. `NoResourcesInContractRule` pins the `@Resource` case.
+2. **`internal`** for single-module types — honored by ObjC, Swift Export, JS, and R8 alike (not available for genuinely cross-module types).
+3. **`@HiddenFromObjC`** (under `@OptIn(ExperimentalObjCRefinement::class)`) — last resort for cross-module-public types. It refines the **Objective-C framework ONLY — it does NOT govern the planned direct Swift Export**, and it must be applied per-declaration (sealed subtypes and `expect`/`actual` don't inherit it; a type named by an exported public signature ships regardless).
+
+JS export is opt-in (`@JsExport`) — never blanket-export. The macOS CI `Test (iOS)` job records an export-surface inventory of `Shared.framework` so regressions are visible.
+
 ### Code Style
 
 - Functions and variables: clear, descriptive, intention-revealing names

--- a/scripts/export-surface-inventory.sh
+++ b/scripts/export-surface-inventory.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Export-surface inventory for the iOS `Shared.framework` Objective-C header.
+#
+# Informational (always exits 0): records how many Objective-C declarations the
+# framework exports, dumps the ones matching our domain types (so the real
+# Kotlin->ObjC mangled names are visible for calibration), and flags whether
+# known server-only / internal types — which the export-surface trim removed —
+# have crept back in.
+#
+# This is the measurement step. Once a real CI run shows the actual mangled
+# names, the regression list below can be turned into a hard gate (drop the
+# `exit 0` / wire it to fail). Nothing here can run on a non-Apple host — the
+# header only exists after a Kotlin/Native framework link.
+#
+# Usage: export-surface-inventory.sh [path-to-Shared.h]
+#   If no path is given (or it's missing), searches sharedLogic/build/bin.
+set -uo pipefail
+
+HEADER="${1:-}"
+if [[ -z "$HEADER" || ! -f "$HEADER" ]]; then
+  echo "-> header not at '${HEADER:-<unset>}'; searching sharedLogic/build/bin ..."
+  HEADER="$(find sharedLogic/build/bin -name 'Shared.h' -path '*Headers*' 2>/dev/null | head -1)"
+fi
+if [[ -z "$HEADER" || ! -f "$HEADER" ]]; then
+  echo "WARN: Shared.h not found — skipping export-surface inventory (link the framework first)."
+  exit 0
+fi
+
+echo "== Export-surface inventory: $HEADER =="
+
+ifaces=$(grep -cE '^@interface ' "$HEADER" || true)
+protos=$(grep -cE '^@protocol ' "$HEADER" || true)
+echo "exported @interface: ${ifaces}    @protocol: ${protos}"
+
+echo "-- exported decls matching our domain (calibration: shows real mangled names) --"
+grep -E '^@(interface|protocol) ' "$HEADER" \
+  | grep -iE 'Resource|Sync|RoutePath|Domain|DebouncedSearch|PlatformUtils' \
+  | sed 's/^/    /' \
+  | head -60 \
+  || echo "    (none matched)"
+
+# These were removed from the client export by the trim (PR #682). ObjC names
+# are framework-prefixed ("Shared" + the Kotlin name); best-effort until a real
+# run confirms the exact spellings.
+absent_expected=(
+  SharedBookResources SharedAdminUserResources SharedScannerResources
+  SharedBackupRoutePaths SharedImportRoutePaths
+  SharedSyncControl SharedDomainDigest SharedDomainList
+)
+echo "-- regression check (these should be ABSENT from the framework) --"
+leaked=0
+for sym in "${absent_expected[@]}"; do
+  if grep -qE "^@(interface|protocol) ${sym}\b" "$HEADER"; then
+    echo "    PRESENT: ${sym}  <- export-surface regression"
+    leaked=$((leaked + 1))
+  else
+    echo "    absent:  ${sym}"
+  fi
+done
+echo "-- leaked: ${leaked} (informational; not yet gating) --"
+
+exit 0


### PR DESCRIPTION
## Summary

Adds the missing feedback loop for the export-surface work (#682): a macOS-CI step that inventories what `Shared.framework` actually exports, plus codifies the export-surface discipline in `CLAUDE.md`.

## What changed

- **`Test (iOS)` CI step (informational):** links the iOS framework and runs `scripts/export-surface-inventory.sh`, which records the exported Objective-C declaration count, dumps the domain-relevant decls (so the real Kotlin→ObjC mangled names become visible), and flags whether known server-only/internal types the #682 trim removed have crept back in. Non-gating (`if: always()` + `continue-on-error`) — it cannot fail the build.
- **`CLAUDE.md` → "Export Surface":** the lever hierarchy (relocate > `internal` > `@HiddenFromObjC`), that `@HiddenFromObjC` is **Objective-C-only and does NOT govern the planned direct Swift Export**, JS is opt-in, and shared modules export only client API.

## Why informational-first

Kotlin's ObjC name-mangling (plus SKIE) means the exact exported symbol names can't be known without a real framework build — which is Apple-only and unobservable on Linux. This step **measures** the surface and reveals the real names; a follow-up turns the regression list into a hard gate once a CI run confirms them.

## Verification

- `ci.yml` validated as well-formed YAML; the step parses into `test-ios`.
- `scripts/export-surface-inventory.sh` logic unit-tested locally against a synthetic header (counts, calibration dump, regression detection, missing-header safety all correct).
- `spotlessCheck` + `detekt` green. No Kotlin/build changes → JVM tests + `assembleDebug` unaffected (CI runs the full suite).

## Follow-ups

- Flip the inventory to a hard gate once a CI run confirms the real mangled names.
- Increment 3: internalize `:sharedLogic`'s `data/` plumbing (~210 files the apps never reference) — the export-agnostic structural win for Swift Export.