### PR TITLE
🔒 refactor(shared): internalize the :sharedLogic data.sync package (Increment 4 / DB-unlock part 1)

### DIFF
--- a/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
+++ b/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/DesktopApp.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.calypsan.listenup.client.data.sync.LibraryResetHelperContract
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.design.LocalDeviceContext
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
 import com.calypsan.listenup.client.device.DeviceContext
@@ -209,7 +209,7 @@ fun DesktopApp() {
 private fun DesktopAuthenticatedNavigation() {
     val scope = rememberCoroutineScope()
     val authSession: AuthSession = koinInject()
-    val libraryResetHelper: LibraryResetHelperContract = koinInject()
+    val libraryResetHelper: LibraryResetHelper = koinInject()
     val nowPlayingViewModel: NowPlayingViewModel = koinInject()
     val snackbarHostState = remember { SnackbarHostState() }
 

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -137,8 +137,8 @@
     <ID>LateinitUsage:JvmSecureStorageTest.kt$JvmSecureStorageTest$private lateinit var storageFile: File</ID>
     <ID>LateinitUsage:WithClientSyncEngineAgainstServer.kt$lateinit var statsUpdater: UserStatsUpdater</ID>
     <ID>LongMethod:BookCard.kt$@OptIn(ExperimentalFoundationApi::class) @Composable fun BookCard( cover: BookCoverModel, onClick: () -&gt; Unit, modifier: Modifier = Modifier, duration: String? = null, subtitle: String? = null, progress: Float? = null, timeRemaining: String? = null, isFinished: Boolean = false, isPlaying: Boolean = false, avatarOverlay: AvatarOverlayData? = null, isInSelectionMode: Boolean = false, isSelected: Boolean = false, onLongPress: (() -&gt; Unit)? = null, cardWidth: Dp? = null, )</ID>
-    <ID>LongMethod:WithClientSyncEngineAgainstServer.kt$fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -&gt; Unit)</ID>
-    <ID>LongMethod:WithTagSyncEngineAgainstServer.kt$fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -&gt; Unit)</ID>
+    <ID>LongMethod:WithClientSyncEngineAgainstServer.kt$internal fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -&gt; Unit)</ID>
+    <ID>LongMethod:WithTagSyncEngineAgainstServer.kt$internal fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -&gt; Unit)</ID>
     <ID>LoopWithTooManyJumpStatements:Mp4ChapterExtractor.kt$Mp4ChapterExtractor$for</ID>
     <ID>MagicNumber:AudioUrlSigner.kt$AudioUrlSigner$64</ID>
     <ID>MagicNumber:AuroraBackground.kt$120f</ID>

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
@@ -42,7 +42,7 @@ private val logger = KotlinLogging.logger {}
  * @param reevaluate re-points the active URL at a reachable address (wired to
  *   `ConnectionCoordinator.reevaluate`); a lambda so this stays unit-testable.
  */
-class ReconnectionSupervisor(
+internal class ReconnectionSupervisor(
     private val engineState: SyncEngineState,
     private val instanceRepository: InstanceRepository,
     private val serverConfig: ServerConfig,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
@@ -6,7 +6,7 @@ import com.calypsan.listenup.api.result.AppResult
  * Engine-facing seam for REST catch-up. Allows [SyncEngine] to be tested with
  * fakes without dragging the full HTTP client. Implemented by [SyncCatchUpClient].
  */
-interface CatchUp {
+internal interface CatchUp {
     suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit>
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncDomainRegistry.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncDomainRegistry.kt
@@ -14,7 +14,7 @@ import kotlinx.atomicfu.locks.synchronized
  * Thread-safe: `register` is called from Koin singleton creation (potentially
  * concurrent), `lookup` is called from the dispatcher's coroutine.
  */
-class ClientSyncDomainRegistry : SynchronizedObject() {
+internal class ClientSyncDomainRegistry : SynchronizedObject() {
     private val handlers = mutableMapOf<String, SyncDomainHandler<*>>()
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/DomainDigestClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/DomainDigestClient.kt
@@ -17,7 +17,7 @@ import io.ktor.client.request.get
  * Constructor shape mirrors [SyncCatchUpClient]: two suspend lambdas so production
  * wiring passes method references and tests pass any [HttpClient] + base URL.
  */
-class DomainDigestClient(
+internal class DomainDigestClient(
     private val httpClientProvider: suspend () -> HttpClient,
     private val serverUrlProvider: suspend () -> String,
 ) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperImpl.kt
@@ -2,50 +2,11 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.LibrarySync
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-/**
- * Contract for resetting library data.
- *
- * Used when detecting library mismatch (server reset) or switching servers.
- */
-interface LibraryResetHelperContract {
-    /**
-     * Clear all library data from local storage.
-     *
-     * This removes:
-     * - All books, series, contributors
-     * - All chapters and playback positions
-     * - All junction tables (book-series, book-contributor)
-     * - All pending sync operations (if discarding local changes)
-     * - User data
-     * - Per-domain sync cursors (so catch-up re-pulls the library on next login)
-     *
-     * Does NOT remove:
-     * - Downloaded audio files (managed separately by DownloadDao)
-     * - Server connection settings
-     * - User preferences (theme, playback speed, etc.)
-     *
-     * @param discardPendingOperations If true, also clears pending sync operations.
-     *        Set to false if you want to preserve unsync'd edits.
-     */
-    suspend fun clearLibraryData(discardPendingOperations: Boolean = true)
-
-    /**
-     * Clear library data and prepare for resync with a new library ID.
-     *
-     * This is the typical flow when handling a library mismatch:
-     * 1. Clear all library data
-     * 2. Clear the stored library ID
-     * 3. Caller then triggers a fresh sync
-     *
-     * @param newLibraryId The new library ID to store after clearing
-     */
-    suspend fun resetForNewLibrary(newLibraryId: String)
-}
 
 /**
  * Implementation of library reset helper.
@@ -59,11 +20,11 @@ interface LibraryResetHelperContract {
  * the [ListenUpDatabase] directly instead of listing each DAO individually; the
  * semantic is "operate on the library as a whole".
  */
-internal class LibraryResetHelper(
+internal class LibraryResetHelperImpl(
     private val database: ListenUpDatabase,
     private val transactionRunner: TransactionRunner,
     private val librarySyncContract: LibrarySync,
-) : LibraryResetHelperContract {
+) : LibraryResetHelper {
     override suspend fun clearLibraryData(discardPendingOperations: Boolean) {
         logger.info { "Clearing library data (discardPendingOperations=$discardPendingOperations)" }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ParsedSseFrame.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ParsedSseFrame.kt
@@ -6,7 +6,7 @@ package com.calypsan.listenup.client.data.sync
  * domain events (e.g. `"tags"`) from out-of-band controls (`"control"`); the
  * concatenated `data:` payload is the JSON body the dispatcher decodes.
  */
-data class ParsedSseFrame(
+internal data class ParsedSseFrame(
     val id: Long?,
     val event: String?,
     val data: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperation.kt
@@ -4,7 +4,7 @@ package com.calypsan.listenup.client.data.sync
  * Snapshot of a pending operation at dispatch time. The wire-bound [payload]
  * is opaque JSON shaped by `(domainName, opType)`; the queue does not parse it.
  */
-data class PendingOperation(
+internal data class PendingOperation(
     val clientOpId: String,
     val domainName: String,
     val entityId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.update
 
 private val logger = KotlinLogging.logger {}
 
-const val MAX_RETRYABLE_ATTEMPTS = 5
+internal const val MAX_RETRYABLE_ATTEMPTS = 5
 
 /**
  * What a single [PendingOperationQueue.drain] wave produced. The engine reads
@@ -29,7 +29,7 @@ const val MAX_RETRYABLE_ATTEMPTS = 5
  * @property terminalFailures count of ops that failed non-retryably (flagged
  *   past [MAX_RETRYABLE_ATTEMPTS] and will not be retried)
  */
-data class DrainOutcome(
+internal data class DrainOutcome(
     val sent: Int,
     val retryableFailures: Int,
     val terminalFailures: Int,
@@ -59,7 +59,7 @@ data class DrainOutcome(
  * via [DrainOutcome].
  */
 @OptIn(ExperimentalUuidApi::class)
-class PendingOperationQueue(
+internal class PendingOperationQueue(
     private val dao: PendingOperationV2Dao,
     private val sender: PendingOperationSender,
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationSender.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationSender.kt
@@ -8,6 +8,6 @@ import com.calypsan.listenup.api.result.AppResult
  * Renovation phase no domain has a write API yet so the registered sender
  * is a no-op stub. Tests inject a fake.
  */
-fun interface PendingOperationSender {
+internal fun interface PendingOperationSender {
     suspend fun send(op: PendingOperation): AppResult<Unit>
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PresenceRefreshSignal.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PresenceRefreshSignal.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.asSharedFlow
  * `ActiveSessionsChanged` nudge or on firehose reconnect. The social repositories
  * (currently-listening, book-readers) re-fetch their ACL-filtered RPC on each ping.
  */
-class PresenceRefreshSignal {
+internal class PresenceRefreshSignal {
     private val flow = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
 
     /** Hot stream of presence-changed pings. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SseClient.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.SharedFlow
  * Engine-facing seam for the SSE client. Allows [SyncEngine] to be tested with
  * fakes without opening real network connections. Implemented by [SyncSseClient].
  */
-interface SseClient {
+internal interface SseClient {
     val frames: SharedFlow<ParsedSseFrame>
 
     fun seedLastEventId(initial: Long?)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCursorStore.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCursorStore.kt
@@ -11,7 +11,7 @@ import com.calypsan.listenup.client.data.local.db.SyncCursorEntity
  * `?since=<rev>`, and on SSE reconnect to set `Last-Event-Id` to
  * [highestCursor].
  */
-class SyncCursorStore(
+internal class SyncCursorStore(
     private val dao: SyncCursorDao,
 ) {
     suspend fun getCursor(domainName: String): Long? = dao.getCursor(domainName)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncDomainHandler.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.KSerializer
  * advance the engine's error metrics. Implementations must NOT throw — Konsist
  * pins this in [com.calypsan.listenup.konsist.SyncDomainHandlersUseAppResultRule].
  */
-interface SyncDomainHandler<T : Any> {
+internal interface SyncDomainHandler<T : Any> {
     /** Domain name as it appears on the wire (e.g. `"tags"`, `"books"`). */
     val domainName: String
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -40,7 +40,7 @@ private val logger = KotlinLogging.logger {}
  * The engine owns the frame collector so every connection has exactly one path
  * from [SseClient.frames] into [SyncEventDispatcher].
  */
-class SyncEngine(
+internal class SyncEngine(
     private val registry: ClientSyncDomainRegistry,
     private val queue: PendingOperationQueue,
     private val state: SyncEngineState,
@@ -211,13 +211,14 @@ class SyncEngine(
         // start's writes overwrite them — net result is engine continues running
         // as if stop() never happened. This is acceptable because:
         //
-        //   1. The dominant caller is MainActivity.onPause() racing onResume() →
-        //      start(). Android's lifecycle FSM serializes pause/resume per
-        //      Activity, so the race is structurally impossible at the call site.
-        //   2. Any caller that needs hard-shutdown semantics uses [stopAndJoin],
-        //      which takes startMutex and join()s every collector.
+        //   1. The production disconnect path does NOT call stop() — it goes
+        //      through [SyncRepository.disconnect] → [stopAndJoin], which takes
+        //      startMutex and join()s every collector, so it can't race a start().
+        //      stop() is retained as the non-suspending soft variant for tests and
+        //      any caller that doesn't need hard-shutdown semantics.
+        //   2. Any caller that needs hard-shutdown semantics uses [stopAndJoin].
         //
-        // If a non-Android caller is added later that depends on stop()'s race
+        // If a caller is added later that calls stop() AND depends on its race
         // semantics, promote this to `suspend` + `startMutex.withLock { ... }`.
         //
         // Note: cancelling engineJob propagates CancellationException through

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -15,7 +15,7 @@ private val logger = KotlinLogging.logger {}
  *  - control events (`CursorStale`, `StreamError`, `AccessChanged`) are recognised and acted on,
  *  - unknown domains are logged and dropped (graceful for forward-compat).
  */
-class SyncEventDispatcher(
+internal class SyncEventDispatcher(
     private val registry: ClientSyncDomainRegistry,
     private val queue: PendingOperationQueue,
     private val state: SyncEngineState,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncReconciler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncReconciler.kt
@@ -19,7 +19,7 @@ private val logger = KotlinLogging.logger {}
  * are reconciled in parallel. Per-domain failures are logged and skipped; reconciliation
  * never throws into the engine or blocks the live stream.
  */
-class SyncReconciler(
+internal class SyncReconciler(
     private val registry: ClientSyncDomainRegistry,
     private val store: SyncCursorStore,
     private val digestClient: DomainDigestClient,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
@@ -101,7 +101,7 @@ internal fun parseSseStream(lines: Sequence<String>): List<ParsedSseFrame> {
  * tests (Tier 3 e2e) pass any [HttpClient] + base URL. Avoids dragging full
  * auth wiring into the test fixture.
  */
-class SyncSseClient(
+internal class SyncSseClient(
     private val serverUrlProvider: suspend () -> String?,
     private val streamingClientProvider: suspend () -> HttpClient,
     private val state: SyncEngineState,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -39,7 +39,7 @@ private const val APP_SCOPE = "appScope"
  *  - [com.calypsan.listenup.client.data.sync.SyncEngine] — `clientSyncRenovationModule`
  *  - [com.calypsan.listenup.client.data.sync.SyncEngineState] — `clientSyncRenovationModule`
  *  - [com.calypsan.listenup.client.domain.repository.AuthSession] — `clientAuthModule`
- *  - [com.calypsan.listenup.client.playback.ListeningEventRecorder] — platform playback modules
+ *  - [com.calypsan.listenup.client.playback.ListeningEventRecorder] — `listeningModule`
  *  - [com.calypsan.listenup.client.data.local.db.BookDao] — `persistenceModule`
  *  - [com.calypsan.listenup.client.data.local.db.PlaybackPositionDao] — `persistenceModule`
  *  - [com.calypsan.listenup.client.data.local.db.LibraryDao] — `persistenceModule`

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -12,8 +12,8 @@ import com.calypsan.listenup.client.data.repository.PendingOperationRepositoryIm
 import com.calypsan.listenup.client.data.repository.SyncRepositoryImpl
 import com.calypsan.listenup.client.data.repository.SyncStatusRepositoryImpl
 import com.calypsan.listenup.client.data.repository.UserPreferencesRepositoryImpl
-import com.calypsan.listenup.client.data.sync.LibraryResetHelper
-import com.calypsan.listenup.client.data.sync.LibraryResetHelperContract
+import com.calypsan.listenup.client.data.sync.LibraryResetHelperImpl
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.domain.repository.LibraryRepository
 import com.calypsan.listenup.client.domain.repository.PendingOperationRepository
@@ -67,12 +67,12 @@ val libraryModule: Module =
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 
         single {
-            LibraryResetHelper(
+            LibraryResetHelperImpl(
                 database = get(),
                 transactionRunner = get(),
                 librarySyncContract = get(),
             )
-        } bind LibraryResetHelperContract::class
+        } bind LibraryResetHelper::class
 
         // ScannerRpcFactory — kotlinx.rpc proxy for ScannerService (public mount):
         // live scan-progress stream that drives the scan UI + post-scan reconcile.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
@@ -5,9 +5,12 @@ import com.calypsan.listenup.client.data.remote.StatsApiContract
 import com.calypsan.listenup.client.data.repository.ListeningEventRepositoryImpl
 import com.calypsan.listenup.client.data.repository.PlaybackPositionRepositoryImpl
 import com.calypsan.listenup.client.data.repository.StatsRepositoryImpl
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.StatsRepository
+import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
@@ -67,6 +70,21 @@ val listeningModule: Module =
                 transactionRunner = get(),
                 pendingQueue = get(),
                 authSession = get(),
+            )
+        }
+
+        // Listening event recorder — span state machine for P2 listening history.
+        // Single source for the binding (previously duplicated across all four platform
+        // playback modules); platform-independent because every dependency resolves via get().
+        single {
+            ListeningEventRecorder(
+                listeningEventDao = get(),
+                tentativeSpanDao = get(),
+                enqueue = { domainName, entityId, opType, payload, ownerUserId ->
+                    get<PendingOperationQueue>().enqueue(domainName, entityId, opType, payload, ownerUserId)
+                },
+                currentUserId = { get<AuthSession>().getUserId() },
+                deviceInfo = get(),
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/LibraryResetHelper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/LibraryResetHelper.kt
@@ -1,0 +1,41 @@
+package com.calypsan.listenup.client.domain.repository
+
+/**
+ * Contract for resetting library data.
+ *
+ * Used when detecting library mismatch (server reset) or switching servers.
+ */
+interface LibraryResetHelper {
+    /**
+     * Clear all library data from local storage.
+     *
+     * This removes:
+     * - All books, series, contributors
+     * - All chapters and playback positions
+     * - All junction tables (book-series, book-contributor)
+     * - All pending sync operations (if discarding local changes)
+     * - User data
+     * - Per-domain sync cursors (so catch-up re-pulls the library on next login)
+     *
+     * Does NOT remove:
+     * - Downloaded audio files (managed separately by DownloadDao)
+     * - Server connection settings
+     * - User preferences (theme, playback speed, etc.)
+     *
+     * @param discardPendingOperations If true, also clears pending sync operations.
+     *        Set to false if you want to preserve unsync'd edits.
+     */
+    suspend fun clearLibraryData(discardPendingOperations: Boolean = true)
+
+    /**
+     * Clear library data and prepare for resync with a new library ID.
+     *
+     * This is the typical flow when handling a library mismatch:
+     * 1. Clear all library data
+     * 2. Clear the stored library ID
+     * 3. Caller then triggers a fresh sync
+     *
+     * @param newLibraryId The new library ID to store after clearing
+     */
+    suspend fun resetForNewLibrary(newLibraryId: String)
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryModuleVerifyTest.kt
@@ -29,7 +29,7 @@ import org.koin.test.verify.verify
  *  - [SyncEngine] — owned by `clientSyncRenovationModule`.
  *  - [SyncEngineState] — owned by `clientSyncRenovationModule`.
  *  - [AuthSession] — owned by `clientAuthModule`.
- *  - [ListeningEventRecorder] — owned by platform playback modules.
+ *  - [ListeningEventRecorder] — owned by `listeningModule`.
  *  - [BookDao] — owned by `persistenceModule`.
  *  - [ListeningEventDao] — owned by `persistenceModule`.
  *  - [PlaybackPositionDao] — owned by `persistenceModule`.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ListeningModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ListeningModuleVerifyTest.kt
@@ -3,9 +3,11 @@ package com.calypsan.listenup.client.di
 import com.calypsan.listenup.client.data.local.db.GenreDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.TentativeSpanDao
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import io.kotest.core.spec.style.FunSpec
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -24,6 +26,11 @@ import org.koin.test.verify.verify
  *  - [AuthSession] — owned by `clientAuthModule`.
  *  - [String] (named `"deviceId"`) — owned by the platform playback modules.
  *  - [PendingOperationQueue] — owned by `clientSyncRenovationModule`.
+ *  - [TentativeSpanDao] — owned by `persistenceModule` (pulled in by the recorder binding).
+ *  - [DeviceInfoProvider] — owned by the platform playback modules (recorder binding).
+ *
+ * The recorder binding also injects suspend lambdas (`enqueue` / `currentUserId`);
+ * `verify()` sees their erased function types, hence the [Function0]/[Function1]/[Function6] entries.
  */
 @OptIn(KoinExperimentalAPI::class)
 class ListeningModuleVerifyTest :
@@ -34,13 +41,20 @@ class ListeningModuleVerifyTest :
                 extraTypes =
                     listOf(
                         ListeningEventDao::class,
+                        TentativeSpanDao::class,
                         GenreDao::class,
                         PlaybackPositionDao::class,
                         TransactionRunner::class,
                         AuthSession::class,
+                        DeviceInfoProvider::class,
                         String::class,
                         PendingOperationQueue::class,
                         ApiClientFactory::class,
+                        // Recorder injects suspend lambdas (enqueue/currentUserId);
+                        // verify() sees their erased function types.
+                        Function0::class,
+                        Function1::class,
+                        Function6::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataSyncIsInternalRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataSyncIsInternalRule.kt
@@ -1,0 +1,68 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * The `data.sync` package — sync engine, queue, registry, dispatcher, handlers — is
+ * `:sharedLogic` plumbing reached only through the `domain/repository` seams
+ * (`SyncRepository`, `LibraryResetHelper`). Keeping the whole package non-public removes
+ * it from every client export path (iOS framework, Swift Export, JS, R8). A new public
+ * declaration here would silently re-bloat the export, so make it a build failure.
+ *
+ * Gates top-level classes, interfaces, objects, properties, and functions. Top-level
+ * typealiases are not gated: Konsist 0.17.3's `KoTypeAliasDeclaration` lacks `isTopLevel`,
+ * so it cannot be filtered with the same predicate as the other declaration kinds.
+ */
+class DataSyncIsInternalRule :
+    FunSpec({
+        // Symbols that must stay public despite living in data.sync (cross-module
+        // consumers documented in the spec's "Flip exceptions"). Empty if the flip was clean.
+        val allowList =
+            setOf(
+                // Exposed by the cross-module-public `data.connection.ConnectionCoordinator`
+                // constructor and `presentation.discover.ActivityFeedViewModel`.
+                "SyncEngineState",
+                "EngineSnapshot",
+                "ConnectionState",
+                "ActivityRefreshSignal",
+            )
+
+        test("no top-level declaration in data/sync is public") {
+            val scope = Konsist.scopeFromProduction()
+            // Only top-level declarations are gated: nested members of an allow-listed public type
+            // (e.g. ConnectionState's sealed subtypes) are public by construction and not export entry
+            // points on their own. `it !in allowList` covers them transitively via their parent.
+            val classes =
+                scope
+                    .classes()
+                    .filter { "/data/sync/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
+            val interfaces =
+                scope
+                    .interfaces()
+                    .filter { "/data/sync/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
+            val objects =
+                scope
+                    .objects()
+                    .filter { "/data/sync/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
+            val properties =
+                scope
+                    .properties()
+                    .filter { "/data/sync/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
+            val functions =
+                scope
+                    .functions()
+                    .filter { "/data/sync/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier }
+                    .map { it.name }
+            // Top-level typealiases are not gated here: Konsist 0.17.3's KoTypeAliasDeclaration
+            // lacks `isTopLevel`, so it can't share the predicate above.
+            val offenders =
+                (classes + interfaces + objects + properties + functions).filterNot { it in allowList }
+            offenders.shouldBeEmpty()
+        }
+    })

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -2,10 +2,7 @@ package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.api.dto.auth.DeviceInfo
 import com.calypsan.listenup.core.IODispatcher
-import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.device.DeviceInfoProvider
-import com.calypsan.listenup.client.data.sync.PendingOperationQueue
-import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.download.AppleDownloadEnqueuer
 import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.download.DownloadFileManager
@@ -13,7 +10,6 @@ import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.CachedAudioTokenProvider
-import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.playback.PlaybackPreparer
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
@@ -104,19 +100,6 @@ val iosPlaybackModule: Module =
                     deviceName = platform.UIKit.UIDevice.currentDevice.name,
                 )
             }
-        }
-
-        // Listening event recorder — span state machine for P2 listening history
-        single {
-            ListeningEventRecorder(
-                listeningEventDao = get<ListenUpDatabase>().listeningEventDao(),
-                tentativeSpanDao = get<ListenUpDatabase>().tentativeSpanDao(),
-                enqueue = { domainName, entityId, opType, payload, ownerUserId ->
-                    get<PendingOperationQueue>().enqueue(domainName, entityId, opType, payload, ownerUserId)
-                },
-                currentUserId = { get<AuthSession>().getUserId() },
-                deviceInfo = get(),
-            )
         }
 
         // Stateless playback-preparation pipeline — consumed directly by PlayerCoordinator

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperTest.kt
@@ -30,7 +30,7 @@ class LibraryResetHelperTest :
                 db.syncCursorDao().setCursor(SyncCursorEntity(domainName = "contributors", revision = 87))
 
                 val helper =
-                    LibraryResetHelper(
+                    LibraryResetHelperImpl(
                         database = db,
                         transactionRunner = RoomTransactionRunner(db),
                         librarySyncContract = mock<LibrarySync>(),

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/RecordingTagSyncDomainHandler.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/RecordingTagSyncDomainHandler.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.asSharedFlow
  * before the `init` block — `ClientSyncDomainRegistry.register` reads
  * `handler.domainName` synchronously.
  */
-class RecordingTagSyncDomainHandler(
+internal class RecordingTagSyncDomainHandler(
     registry: ClientSyncDomainRegistry,
 ) : SyncDomainHandler<Tag> {
     override val domainName = "tags"

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -189,7 +189,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerCon
  * @property dispatcher the dispatcher routing SSE frames to handlers
  * @property queue the pending-operation queue for echo-match scenarios
  */
-data class ClientEngineScope(
+internal data class ClientEngineScope(
     val engine: SyncEngine,
     val recording: RecordingTagSyncDomainHandler,
     val tagRepo: TagRepository,
@@ -232,7 +232,7 @@ data class ClientEngineScope(
  *
  * Stops Koin in `finally` so subsequent tests start with a fresh container.
  */
-fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Unit) {
+internal fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.() -> Unit) {
     testApplication {
         // ---- Server side: in-memory SQLite + Tag and Book domains registered ----
         val tmp = Files.createTempFile("listenup-c3-", ".db").toFile().apply { deleteOnExit() }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
@@ -79,14 +79,14 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerCon
  * id [UserRole.ROOT]; every other bearer token authenticates as a [UserRole.MEMBER]. Owner-only
  * collection operations (create/share/revoke) are driven as this admin.
  */
-const val COLLECTION_E2E_ADMIN_ID = "admin"
+internal const val COLLECTION_E2E_ADMIN_ID = "admin"
 
 /**
  * The fixed member id for [withCollectionSyncEngineAgainstServer]. The member's client engine
  * connects as this user (the harness's client [HttpClient] sends `Authorization: Bearer member`),
  * so the firehose targets per-user `AccessChanged` frames and the access-filtered catch-up at it.
  */
-const val COLLECTION_E2E_MEMBER_ID = "member"
+internal const val COLLECTION_E2E_MEMBER_ID = "member"
 
 /**
  * Test scope for
@@ -97,7 +97,7 @@ const val COLLECTION_E2E_MEMBER_ID = "member"
  * the member's client [ListenUpDatabase] for asserting that events (and the `AccessChanged`
  * prune) land in the member's Room.
  */
-data class CollectionSyncEngineScope(
+internal data class CollectionSyncEngineScope(
     val engine: SyncEngine,
     val adminCollections: CollectionService,
     val serverBookRepository: BookRepository,
@@ -127,7 +127,7 @@ data class CollectionSyncEngineScope(
  *
  * Stops Koin in `finally` so subsequent tests start with a fresh container.
  */
-fun withCollectionSyncEngineAgainstServer(block: suspend CollectionSyncEngineScope.() -> Unit) {
+internal fun withCollectionSyncEngineAgainstServer(block: suspend CollectionSyncEngineScope.() -> Unit) {
     testApplication {
         // ---- Server side: temp-file SQLite + collection/book domains + access policy ----
         val tmp = Files.createTempFile("listenup-collections-e2e-", ".db").toFile().apply { deleteOnExit() }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
@@ -68,7 +68,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerCon
  * triggering writes that publish SSE events, and the client [ListenUpDatabase]
  * for asserting that events landed in Room.
  */
-data class TagSyncEngineScope(
+internal data class TagSyncEngineScope(
     val engine: SyncEngine,
     val tagRepo: TagRepository,
     val bookTagRepo: BookTagRepository,
@@ -89,7 +89,7 @@ data class TagSyncEngineScope(
  * Pre-seeds two book rows (`book-a`, `book-b`) and the required library/folder
  * rows so `book_tags` FK constraints are satisfied throughout the test session.
  */
-fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -> Unit) {
+internal fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.() -> Unit) {
     testApplication {
         // ---- Server side: temp-file SQLite + tag domains ----
         val tmp = Files.createTempFile("listenup-tags-e2e-", ".db").toFile().apply { deleteOnExit() }

--- a/sharedLogic/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/sharedLogic/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -2,10 +2,7 @@ package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.api.dto.auth.DeviceInfo
 import com.calypsan.listenup.core.IODispatcher
-import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.device.DeviceInfoProvider
-import com.calypsan.listenup.client.data.sync.PendingOperationQueue
-import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
@@ -14,7 +11,6 @@ import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.CachedAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.playback.AvFoundationAudioPlayer
-import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.PlaybackManagerImpl
@@ -103,20 +99,6 @@ val macosPlaybackModule: Module =
                     deviceName = NSProcessInfo.processInfo.hostName,
                 )
             }
-        }
-
-        // Listening event recorder — span state machine for P2 listening history
-        single {
-            ListeningEventRecorder(
-                listeningEventDao = get<ListenUpDatabase>().listeningEventDao(),
-                tentativeSpanDao = get<ListenUpDatabase>().tentativeSpanDao(),
-                enqueue = { domainName, entityId, opType, payload, ownerUserId ->
-                    get<PendingOperationQueue>().enqueue(domainName, entityId, opType, payload, ownerUserId)
-                    Unit
-                },
-                currentUserId = { get<AuthSession>().getUserId() },
-                deviceInfo = get(),
-            )
         }
 
         // Sleep timer manager

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/PlaybackModuleVerifyTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/PlaybackModuleVerifyTest.kt
@@ -11,7 +11,6 @@ import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.SeriesDao
 import com.calypsan.listenup.client.data.local.db.TentativeSpanDao
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
-import com.calypsan.listenup.client.data.sync.PendingOperationQueue
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -62,7 +61,6 @@ class PlaybackModuleVerifyTest :
                         DeviceContext::class,
                         ApiClientFactory::class,
                         ImageStorage::class,
-                        PendingOperationQueue::class,
                         PlaybackManager::class,
                         BookDao::class,
                         AudioFileDao::class,
@@ -73,11 +71,6 @@ class PlaybackModuleVerifyTest :
                         ListeningEventDao::class,
                         TentativeSpanDao::class,
                         PlaybackPositionDao::class,
-                        // ListeningEventRecorder injects lambdas (enqueue/currentUserId/
-                        // deviceLabel); verify() sees their erased function types.
-                        Function0::class,
-                        Function1::class,
-                        Function6::class,
                     ),
             )
         }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -497,8 +497,8 @@ class ListenUp :
                 "AuthSession" to {
                     get<com.calypsan.listenup.client.domain.repository.AuthSession>()
                 },
-                "SyncEngine" to {
-                    get<com.calypsan.listenup.client.data.sync.SyncEngine>()
+                "SyncRepository" to {
+                    get<com.calypsan.listenup.client.domain.repository.SyncRepository>()
                 },
                 "ProgressTracker" to {
                     get<ProgressTracker>()

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -36,7 +36,6 @@ import com.calypsan.listenup.client.playback.AndroidAudioTokenProvider
 import com.calypsan.listenup.client.playback.CachedAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.AndroidPlaybackController
-import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.playback.MediaControllerHolder
 import com.calypsan.listenup.client.playback.asControllerHolder
 import com.calypsan.listenup.client.playback.PlaybackController
@@ -195,21 +194,6 @@ val playbackModule =
                     deviceModel = android.os.Build.MODEL,
                 )
             }
-        }
-
-        // Listening event recorder — span state machine for P2 listening history
-        single {
-            ListeningEventRecorder(
-                listeningEventDao = get(),
-                tentativeSpanDao = get(),
-                enqueue = { domainName, entityId, opType, payload, ownerUserId ->
-                    get<com.calypsan.listenup.client.data.sync.PendingOperationQueue>()
-                        .enqueue(domainName, entityId, opType, payload, ownerUserId)
-                    Unit
-                },
-                currentUserId = { get<com.calypsan.listenup.client.domain.repository.AuthSession>().getUserId() },
-                deviceInfo = get(),
-            )
         }
 
         // Playback error handler (needs concrete Android type for onUnauthorized())

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -28,7 +28,6 @@ import com.calypsan.listenup.client.domain.model.ThemeMode
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.SyncRepository
-import com.calypsan.listenup.client.data.sync.SyncEngine
 import com.calypsan.listenup.client.navigation.ListenUpNavigation
 import com.calypsan.listenup.client.shortcuts.ShortcutActions
 import com.calypsan.listenup.client.foldable.PostureProvider
@@ -60,7 +59,6 @@ private val logger = KotlinLogging.logger {}
 class MainActivity : ComponentActivity() {
     private val authSession: AuthSession by inject()
     private val syncRepository: SyncRepository by inject()
-    private val syncEngine: SyncEngine by inject()
     private val localPreferences: LocalPreferences by inject()
     private val connectionCoordinator: ConnectionCoordinator by inject()
     private val deepLinkManager: DeepLinkManager by inject()
@@ -217,7 +215,7 @@ class MainActivity : ComponentActivity() {
 
         // Disconnect realtime sync when app goes to background to save battery
         logger.debug { "App paused, disconnecting realtime sync to save battery" }
-        syncEngine.stop()
+        lifecycleScope.launch { syncRepository.disconnect() }
     }
 }
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -50,7 +50,7 @@ import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.data.repository.DeepLinkManager
 import com.calypsan.listenup.client.data.repository.ShortcutAction
 import com.calypsan.listenup.client.data.repository.ShortcutActionManager
-import com.calypsan.listenup.client.data.sync.LibraryResetHelperContract
+import com.calypsan.listenup.client.domain.repository.LibraryResetHelper
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
@@ -510,7 +510,7 @@ private suspend fun handleShortcutAction(
 @Composable
 private fun AuthenticatedNavigation(
     authSession: AuthSession,
-    libraryResetHelper: LibraryResetHelperContract = koinInject(),
+    libraryResetHelper: LibraryResetHelper = koinInject(),
     syncRepository: SyncRepository = koinInject(),
     shortcutActionManager: ShortcutActionManager = koinInject(),
     homeRepository: HomeRepository = koinInject(),

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -11,14 +11,10 @@ import com.calypsan.listenup.client.download.JvmDownloadEnqueuer
 import com.calypsan.listenup.client.platform.DesktopAudioTokenProvider
 import com.calypsan.listenup.client.platform.StubBackgroundSyncScheduler
 import com.calypsan.listenup.client.platform.StubDownloadService
-import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
-import com.calypsan.listenup.client.data.sync.PendingOperationQueue
 import com.calypsan.listenup.client.device.DeviceInfoProvider
-import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.DesktopPlaybackController
-import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.PlaybackManagerImpl
@@ -124,20 +120,6 @@ val platformModule: Module =
                     deviceName = System.getProperty("user.name"),
                 )
             }
-        }
-
-        // Listening event recorder — span state machine for P2 listening history
-        single {
-            ListeningEventRecorder(
-                listeningEventDao = get<ListenUpDatabase>().listeningEventDao(),
-                tentativeSpanDao = get<ListenUpDatabase>().tentativeSpanDao(),
-                enqueue = { domainName, entityId, opType, payload, ownerUserId ->
-                    get<PendingOperationQueue>().enqueue(domainName, entityId, opType, payload, ownerUserId)
-                    Unit
-                },
-                currentUserId = { get<AuthSession>().getUserId() },
-                deviceInfo = get(),
-            )
         }
 
         // Sleep timer manager


### PR DESCRIPTION
## Summary

Increment 4 of the client export-surface trim (after #682/#684/#685), and **part 1 of the "DB-unlock"**. Makes the `:sharedLogic` `com.calypsan.listenup.client.data.sync` package `internal` — the sync engine, pending-op queue, domain registry, dispatcher, reconciler, SSE client, and the 17 sync handlers now leave **every** client export path (iOS framework, the planned Swift Export, JS, R8). `internal` is the export-mechanism-agnostic lever (per #685): it hides a symbol from all four surfaces at once, unlike `@HiddenFromObjC` (ObjC-only).

## How: three seams, then the flip

`data.sync` was public only because a few `:sharedUI`/app files named three of its types. Three behavior-preserving seams remove those references; the rest is a same-module flip the compiler waved through.

- **Seam A** — route `MainActivity`'s sync lifecycle through the existing `SyncRepository` (`onPause` → `disconnect()`, the startup binding-verifier → `SyncRepository`). Frees `SyncEngine`. The `disconnect()→stopAndJoin()` path is a strictly cleaner shutdown than the old fire-and-forget `stop()`.
- **Seam B** — relocate + rename `data.sync.LibraryResetHelperContract` → `domain/repository/LibraryResetHelper` (impl → `LibraryResetHelperImpl`, kept `internal`), matching the `SyncRepository`/`SyncRepositoryImpl` convention. The domain interface is entity-free (primitive-typed). Frees the contract.
- **Seam C** — the `ListeningEventRecorder` DI binding was duplicated across four platform modules; consolidated into **one** commonMain binding in `listeningModule` (its single-responsibility home). Frees `PendingOperationQueue`, and drops a `ListenUpDatabase` DAO-getter site as a bonus toward Increment 5.
- **The flip** — `scripts/internalize.sh` over `data.sync` + the Kotlin compiler as oracle.

## Result

The whole package is `internal` **except 4 types** that are genuinely forced public by cross-module public consumers: `SyncEngineState`/`EngineSnapshot`/`ConnectionState` (via `ConnectionCoordinator`, injected in `MainActivity`) and `ActivityRefreshSignal` (via `ActivityFeedViewModel`). A public constructor can't expose an internal type, so these are hard-required — documented in the spec's "Flip exceptions" and pinned in the rule's `allowList`.

- `ReconnectionSupervisor` (sibling `data.connection`, no cross-module refs) was internalized to **reclaim `SseClient` + `ParsedSseFrame`** — the allowList is 4, not 6.
- New `DataSyncIsInternalRule` Konsist pin gates top-level classes/interfaces/objects/**properties/functions** so the win can't silently regress.
- `SyncEvent` stays public — it's a `:contract` DTO, never a `data.sync` type.

## Verification

Gate green: `:sharedLogic:jvmTest` (incl. the new Konsist rule + all DI `*VerifyTest`s) + `:androidApp:assembleDebug` + `:androidApp` unit tests + `:sharedUI` androidHostTest + `spotlessCheck` + `detekt`. iOS/apple validates on CI (apple targets don't build on Linux); grep confirms zero cross-module references survive into the now-internal types.

## Notes / follow-ups

- A *generated* baseline-profile artifact (`androidApp/src/release/generated/baselineProfiles/baseline-prof.txt`) still lists the old `LibraryResetHelperContract`/`LibraryResetHelper` names — harmless (ART ignores stale entries) and self-heals on the next profile regeneration; not hand-edited.
- Reclaiming the last 4 public types needs `ConnectionCoordinator`/`ActivityFeedViewModel` moved behind a domain seam — deferred to a future increment.
- **Increment 5** (DB-unlock part 2): internalize the DAO/entity layer + `BrowseTreeProvider`.