### PR TITLE
🔒 refactor(shared): internalize the :sharedLogic data.local.db package (Increment 5 / DB-unlock part 2)

### DIFF
--- a/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/Main.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import com.calypsan.listenup.client.di.desktopPlaybackModule
 import com.calypsan.listenup.client.di.platformModule
 import com.calypsan.listenup.client.di.playbackPresentationModule
 import com.calypsan.listenup.client.di.sharedModules
@@ -25,6 +26,7 @@ fun main() {
         modules(
             sharedModules + // From :shared module
                 platformModule + // From :composeApp desktopMain
+                desktopPlaybackModule + // PlaybackManager wiring from :sharedLogic
                 playbackPresentationModule + // Shared playback VM bindings
                 desktopAppModule, // Desktop app specific
         )

--- a/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/com/calypsan/listenup/desktop/Main.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import com.calypsan.listenup.client.di.desktopDownloadModule
 import com.calypsan.listenup.client.di.desktopPlaybackModule
 import com.calypsan.listenup.client.di.platformModule
 import com.calypsan.listenup.client.di.playbackPresentationModule
@@ -27,6 +28,7 @@ fun main() {
             sharedModules + // From :shared module
                 platformModule + // From :composeApp desktopMain
                 desktopPlaybackModule + // PlaybackManager wiring from :sharedLogic
+                desktopDownloadModule + // DownloadEnqueuer wiring from :sharedLogic
                 playbackPresentationModule + // Shared playback VM bindings
                 desktopAppModule, // Desktop app specific
         )

--- a/iosApp/ListenUp/Features/ContributorDetail/ContributorDetailObserver.swift
+++ b/iosApp/ListenUp/Features/ContributorDetail/ContributorDetailObserver.swift
@@ -15,7 +15,7 @@ final class ContributorDetailObserver {
     private(set) var roleSections: [RoleSection] = []
     private(set) var bookProgress: [String: Float] = [:]
     private(set) var isDeleting: Bool = false
-    private(set) var series: [SeriesWithBooks_] = []
+    private(set) var series: [SeriesWithBooks] = []
     private(set) var totalDuration: String = ""
     private(set) var bookCount: Int = 0
     private(set) var roles: [RoleChip.Kind] = []

--- a/iosApp/ListenUp/Features/ContributorDetail/SeriesMiniCard.swift
+++ b/iosApp/ListenUp/Features/ContributorDetail/SeriesMiniCard.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Compact series card for the contributor "Series" grid: an overlapping cover stack,
 /// the series name, and a book count, on a rounded surface. Navigates to the series.
 struct SeriesMiniCard: View {
-    let series: SeriesWithBooks_
+    let series: SeriesWithBooks
 
     private var seriesId: String { series.series.idString }
     private var books: [BookListItem] { Array(series.books) }

--- a/iosApp/ListenUp/Features/Library/Components/PersonRow.swift
+++ b/iosApp/ListenUp/Features/Library/Components/PersonRow.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// One contributor in the Contributors list: avatar, name over a role chip + book count,
 /// and a chevron. Rendered inside a `FieldGroup`, so it carries padding but no surface.
 struct PersonRow: View {
-    let contributor: ContributorWithBookCount_
+    let contributor: ContributorWithBookCount
     let kind: RoleChip.Kind
 
     private var contributorId: String { contributor.contributor.idString }

--- a/iosApp/ListenUp/Features/Library/Components/SeriesGridCard.swift
+++ b/iosApp/ListenUp/Features/Library/Components/SeriesGridCard.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Series grid card for the iPad Series list: a centered cover stack over name + meta
 /// + progress, on its own rounded surface.
 struct SeriesGridCard: View {
-    let series: SeriesWithBooks_
+    let series: SeriesWithBooks
     let progress: SeriesProgressState
 
     private var seriesId: String { series.series.idString }

--- a/iosApp/ListenUp/Features/Library/Components/SeriesRowCard.swift
+++ b/iosApp/ListenUp/Features/Library/Components/SeriesRowCard.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Standalone series row card for the iPhone Series list: an overlapping cover stack,
 /// name + meta, a progress affordance, and a chevron — its own rounded surface.
 struct SeriesRowCard: View {
-    let series: SeriesWithBooks_
+    let series: SeriesWithBooks
     let progress: SeriesProgressState
 
     private var seriesId: String { series.series.idString }

--- a/iosApp/ListenUp/Features/Library/Content/ContributorsContent.swift
+++ b/iosApp/ListenUp/Features/Library/Content/ContributorsContent.swift
@@ -5,8 +5,8 @@ import UIKit
 /// The merged Contributors Library tab: a segmented Authors|Narrators control over a
 /// sorted, letter-grouped contributor list (with alphabet scrubber on name sort).
 struct ContributorsContent: View {
-    let authors: [ContributorWithBookCount_]
-    let narrators: [ContributorWithBookCount_]
+    let authors: [ContributorWithBookCount]
+    let narrators: [ContributorWithBookCount]
     let authorsSortState: SortState?
     let narratorsSortState: SortState?
     let onAuthorsCategorySelected: (SortCategory) -> Void
@@ -23,7 +23,7 @@ struct ContributorsContent: View {
     private let sortCategories: [SortCategory] = [.name, .bookCount]
 
     // Active-segment selectors
-    private var list: [ContributorWithBookCount_] { segment == .authors ? authors : narrators }
+    private var list: [ContributorWithBookCount] { segment == .authors ? authors : narrators }
     private var sortState: SortState? { segment == .authors ? authorsSortState : narratorsSortState }
     private var roleKind: RoleChip.Kind { segment == .authors ? .author : .narrator }
     private var isNameSort: Bool { sortState?.category == .name }
@@ -190,6 +190,6 @@ struct ContributorsContent: View {
     }
 }
 
-private extension ContributorWithBookCount_ {
+private extension ContributorWithBookCount {
     var contributorIdString: String { contributor.idString }
 }

--- a/iosApp/ListenUp/Features/Library/Content/SeriesContent.swift
+++ b/iosApp/ListenUp/Features/Library/Content/SeriesContent.swift
@@ -11,7 +11,7 @@ import UIKit
 /// - Alphabet scrubber when sorted by name
 /// - Empty state when no series
 struct SeriesContent: View {
-    let seriesList: [SeriesWithBooks_]
+    let seriesList: [SeriesWithBooks]
     let seriesProgress: [String: SeriesProgressState]
     let sortState: SortState?
     let onCategorySelected: (SortCategory) -> Void
@@ -158,7 +158,7 @@ struct SeriesContent: View {
 
     // MARK: - Helpers
 
-    private func progressFor(seriesId: String, series: SeriesWithBooks_) -> SeriesProgressState {
+    private func progressFor(seriesId: String, series: SeriesWithBooks) -> SeriesProgressState {
         seriesProgress[seriesId] ?? SeriesProgressState(finishedCount: 0, totalCount: Int(series.books.count))
     }
 

--- a/iosApp/ListenUp/Features/Library/ContributorLetterGrouping.swift
+++ b/iosApp/ListenUp/Features/Library/ContributorLetterGrouping.swift
@@ -14,7 +14,7 @@ enum ContributorLetterGrouping {
     /// One rendered group: the header letter and its contributors, input order preserved.
     struct Group: Equatable {
         let letter: String
-        let items: [ContributorWithBookCount_]
+        let items: [ContributorWithBookCount]
     }
 
     /// Buckets keys by their uppercased first letter (A–Z); anything else → "#".
@@ -31,7 +31,7 @@ enum ContributorLetterGrouping {
     }
 
     /// Groups `items` by `key(item)` into letter sections.
-    static func group(_ items: [ContributorWithBookCount_], key: (ContributorWithBookCount_) -> String) -> [Group] {
+    static func group(_ items: [ContributorWithBookCount], key: (ContributorWithBookCount) -> String) -> [Group] {
         let buckets = letterBuckets(items.map(key))
         return buckets.map { bucket in
             Group(letter: bucket.letter, items: bucket.indices.map { items[$0] })

--- a/iosApp/ListenUp/Features/Library/LibraryObserver.swift
+++ b/iosApp/ListenUp/Features/Library/LibraryObserver.swift
@@ -11,12 +11,12 @@ final class LibraryObserver {
     private(set) var books: [BookListItem] = []
     private(set) var bookProgress: [String: Float] = [:]
     private(set) var booksSortState: SortState?
-    private(set) var series: [SeriesWithBooks_] = []
+    private(set) var series: [SeriesWithBooks] = []
     private(set) var seriesProgress: [String: SeriesProgressState] = [:]
     private(set) var seriesSortState: SortState?
-    private(set) var authors: [ContributorWithBookCount_] = []
+    private(set) var authors: [ContributorWithBookCount] = []
     private(set) var authorsSortState: SortState?
-    private(set) var narrators: [ContributorWithBookCount_] = []
+    private(set) var narrators: [ContributorWithBookCount] = []
     private(set) var narratorsSortState: SortState?
     private(set) var isLoading: Bool = true
     private(set) var isEmpty: Bool = false

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/DownloadModule.android.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/DownloadModule.android.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.client.di
+
+import android.content.Context
+import androidx.work.WorkManager
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
+import com.calypsan.listenup.client.download.AndroidDownloadEnqueuer
+import com.calypsan.listenup.client.download.DownloadEnqueuer
+import com.calypsan.listenup.client.download.DownloadFileManager
+import com.calypsan.listenup.client.download.DownloadManager
+import com.calypsan.listenup.client.download.DownloadService
+import org.koin.core.module.Module
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+/**
+ * Android download wiring. Lives in `:sharedLogic` (not `:sharedUI`) so the bindings can
+ * construct `DownloadManager` and `AndroidDownloadEnqueuer` against the now-`internal`
+ * Room DAOs (`DownloadDao`, `BookDao`, `AudioFileDao`) and `TransactionRunner` —
+ * same-module visibility. Mirrors [androidPlaybackModule]: dependencies (including
+ * `Context`, registered by the app's `androidContext(...)` Koin start) come through `get()`,
+ * so this module needs no `koin-android` dependency. Registered by `ListenUp.kt`; UI-only
+ * download bindings stay in `:sharedUI`.
+ */
+val androidDownloadModule: Module =
+    module {
+        // Download file manager — handles local file operations.
+        single { DownloadFileManager(get<Context>()) }
+
+        // Download manager — coordinates download queue and state.
+        // Bound to DownloadService for shared code (PlaybackManager) and exposed as the
+        // concrete type for Android-specific features (BookDetailPlatformActions).
+        single {
+            DownloadManager(
+                downloadDao = get(),
+                bookDao = get(),
+                audioFileDao = get(),
+                workManager = WorkManager.getInstance(get<Context>()),
+                fileManager = get(),
+                localPreferences = get<LocalPreferences>(),
+                downloadRepository = get(),
+                transactionRunner = get(),
+            )
+        } bind DownloadService::class
+
+        // DownloadEnqueuer seam — Android backend for DownloadRepository.resumeIncompleteDownloads.
+        single {
+            AndroidDownloadEnqueuer(
+                workManager = WorkManager.getInstance(get<Context>()),
+                localPreferences = get(),
+            )
+        } bind DownloadEnqueuer::class
+    }

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
@@ -1,0 +1,33 @@
+package com.calypsan.listenup.client.di
+
+import com.calypsan.listenup.client.playback.PlaybackManager
+import com.calypsan.listenup.client.playback.PlaybackManagerImpl
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Android `PlaybackManager` wiring. Lives in `:sharedLogic` (not `:sharedUI`) so the
+ * binding can construct `PlaybackManagerImpl` against the now-`internal` Room DAOs —
+ * same-module visibility. Registered by the Android app's Koin start (`ListenUp.kt`).
+ */
+val androidPlaybackModule: Module =
+    module {
+        single<PlaybackManager> {
+            PlaybackManagerImpl(
+                serverConfig = get(),
+                playbackPreferences = get(),
+                bookDao = get(),
+                audioFileDao = get(),
+                chapterDao = get(),
+                imageStorage = get(),
+                progressTracker = get(),
+                tokenProvider = get(),
+                deviceContext = get(),
+                downloadService = get(),
+                playbackRpcFactory = get(),
+                syncApi = get(),
+                scope = get(),
+                bookIngestPort = get(),
+            )
+        }
+    }

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/AndroidDownloadEnqueuer.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/AndroidDownloadEnqueuer.kt
@@ -15,7 +15,7 @@ import com.calypsan.listenup.client.domain.repository.LocalPreferences
  * Android implementation of [DownloadEnqueuer] backed by WorkManager.
  * Lifted from [DownloadManager]'s existing enqueue pattern (single-file variant).
  */
-class AndroidDownloadEnqueuer(
+internal class AndroidDownloadEnqueuer(
     private val workManager: WorkManager,
     private val localPreferences: LocalPreferences,
 ) : DownloadEnqueuer {

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -43,7 +43,7 @@ private val logger = KotlinLogging.logger {}
  * - Respects network constraints (WiFi-only when enabled)
  * - Allows cancellation via unique work names
  */
-class DownloadManager(
+class DownloadManager internal constructor(
     private val downloadDao: DownloadDao,
     private val bookDao: BookDao,
     private val audioFileDao: AudioFileDao,

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadEnqueuer.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadEnqueuer.kt
@@ -8,7 +8,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadEntity
  * iOS no-op enqueuer. iOS downloads go through [AppleDownloadService] (NSURLSession-based)
  * which is W10 carveout territory; the SSE re-enqueue path is Android-only until W10.
  */
-class AppleDownloadEnqueuer : DownloadEnqueuer {
+internal class AppleDownloadEnqueuer : DownloadEnqueuer {
     override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> =
         AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Re-enqueue not supported on iOS until W10"))
 }

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -84,7 +84,7 @@ private const val BYTES_PER_MEGABYTE = 1_000_000
  * pattern.** Closes Finding 08 D6 (principled asymmetry, not silent omission).
  */
 @OptIn(ExperimentalTime::class)
-class AppleDownloadService(
+class AppleDownloadService internal constructor(
     private val downloadDao: DownloadDao,
     private val bookDao: BookDao,
     private val audioFileDao: AudioFileDao,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
  * Activities are stored locally for offline-first display.
  */
 @Dao
-interface ActivityDao {
+internal interface ActivityDao {
     /**
      * Observe all activities ordered by occurrence time (newest first).
      * Used for the Activity Feed section on Discover screen.
@@ -162,7 +162,7 @@ interface ActivityDao {
  * Projection for leaderboard user stats aggregation.
  * Maps to Room query result columns.
  */
-data class UserLeaderboardStats(
+internal data class UserLeaderboardStats(
     val userId: String,
     val displayName: String,
     val avatarColor: String,
@@ -176,7 +176,7 @@ data class UserLeaderboardStats(
  * Projection for community aggregate stats.
  * Maps to Room query result columns.
  */
-data class CommunityStatsProjection(
+internal data class CommunityStatsProjection(
     val totalTimeMs: Long,
     val totalBooks: Int,
     val activeUsers: Int,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileDao.kt
@@ -17,7 +17,7 @@ import androidx.room.Upsert
  * not own transactions itself.
  */
 @Dao
-interface AudioFileDao {
+internal interface AudioFileDao {
     @Query("SELECT * FROM audio_files WHERE bookId = :bookId ORDER BY `index` ASC")
     suspend fun getForBook(bookId: String): List<AudioFileEntity>
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AudioFileEntity.kt
@@ -38,7 +38,7 @@ import com.calypsan.listenup.core.BookId
     ],
     indices = [Index(value = ["bookId"])],
 )
-data class AudioFileEntity(
+internal data class AudioFileEntity(
     val bookId: BookId,
     val index: Int,
     val id: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookContributorDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookContributorDao.kt
@@ -7,7 +7,7 @@ import androidx.room.Query
 import com.calypsan.listenup.core.BookId
 
 @Dao
-interface BookContributorDao {
+internal interface BookContributorDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(crossRef: BookContributorCrossRef)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
  */
 @Dao
 @Suppress("TooManyFunctions")
-interface BookDao {
+internal interface BookDao {
     /**
      * Insert or update a book entity.
      * If a book with the same ID exists, it will be updated.
@@ -479,7 +479,7 @@ interface BookDao {
  *   re-imaged cover invalidates the stale cached bitmap; null when no cover is stored.
  * @property authorName Primary author's display name, or null when no author is linked.
  */
-data class BookSummary(
+internal data class BookSummary(
     val id: String,
     val title: String,
     val coverBlurHash: String?,
@@ -491,7 +491,7 @@ data class BookSummary(
  * Lightweight book data for discovery sections.
  * Includes only the fields needed for display: ID, title, blurHash, createdAt, and author.
  */
-data class DiscoveryBookWithAuthor(
+internal data class DiscoveryBookWithAuthor(
     val id: BookId,
     val title: String,
     val coverBlurHash: String?,
@@ -507,7 +507,7 @@ data class DiscoveryBookWithAuthor(
  * A book in N series produces N rows. The repository groups by [id] and applies the
  * series-starter filter before limiting.
  */
-data class DiscoveryBookWithSeries(
+internal data class DiscoveryBookWithSeries(
     val id: BookId,
     val title: String,
     val coverBlurHash: String?,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
@@ -30,7 +30,7 @@ import com.calypsan.listenup.client.domain.repository.ImageStorage
  * This mapper handles the book root row only. Chapter, contributor, and series rows are
  * the responsibility of `BookSyncDomainHandler` (Task 27).
  */
-class BookEntityMapper {
+internal class BookEntityMapper {
     /**
      * Produce a [BookEntity] by combining server-authoritative fields from [payload] with
      * the client-computed blur-hash field taken from [existing].
@@ -92,7 +92,7 @@ private const val ROLE_NARRATOR = "narrator"
  * @param contributorsById Lookup map of contributor ID to ContributorEntity
  * @return List of Contributors for the specified role
  */
-fun List<BookContributorCrossRef>.extractByRole(
+internal fun List<BookContributorCrossRef>.extractByRole(
     role: String,
     contributorsById: Map<ContributorId, ContributorEntity>,
 ): List<BookContributor> =
@@ -109,7 +109,7 @@ fun List<BookContributorCrossRef>.extractByRole(
  * Returns the list-shaped projection — no genres, tags, or allContributors. Use
  * [toDetail] when those fields are required.
  */
-fun BookWithContributors.toListItem(imageStorage: ImageStorage): BookListItem {
+internal fun BookWithContributors.toListItem(imageStorage: ImageStorage): BookListItem {
     val contributorsById = contributors.associateBy { it.id }
 
     val authors = contributorRoles.extractByRole(ROLE_AUTHOR, contributorsById)
@@ -161,7 +161,7 @@ fun BookWithContributors.toListItem(imageStorage: ImageStorage): BookListItem {
  * algorithm as the (deleted in Task 12) private mapper in BookRepositoryImpl.
  * Genres, tags, and moods are loaded externally and passed through.
  */
-fun BookWithContributors.toDetail(
+internal fun BookWithContributors.toDetail(
     imageStorage: ImageStorage,
     genres: List<Genre>,
     tags: List<Tag>,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookSeriesDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookSeriesDao.kt
@@ -7,7 +7,7 @@ import androidx.room.Query
 import com.calypsan.listenup.core.BookId
 
 @Dao
-interface BookSeriesDao {
+internal interface BookSeriesDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(crossRef: BookSeriesCrossRef)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ChapterDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ChapterDao.kt
@@ -6,7 +6,7 @@ import androidx.room.Upsert
 import com.calypsan.listenup.core.BookId
 
 @Dao
-interface ChapterDao {
+internal interface ChapterDao {
     @Query("SELECT * FROM chapters WHERE bookId = :bookId ORDER BY startTime ASC")
     suspend fun getChaptersForBook(bookId: BookId): List<ChapterEntity>
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDao.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.Flow
  * [observeAllWithBookCount]. Mirrors [TagDao].
  */
 @Dao
-interface CollectionDao {
+internal interface CollectionDao {
     /** Insert or update a collection. Replaces on conflict using the primary key. */
     @Upsert
     suspend fun upsert(collection: CollectionEntity)
@@ -99,7 +99,7 @@ interface CollectionDao {
  * exclude tombstoned rows so the UI reactively reflects removals. Mirrors [BookTagDao].
  */
 @Dao
-interface CollectionBookDao {
+internal interface CollectionBookDao {
     /** Insert or update a junction row. Replaces on conflict using the composite primary key. */
     @Upsert
     suspend fun upsert(entity: CollectionBookEntity)
@@ -179,7 +179,7 @@ interface CollectionBookDao {
  * observation queries exclude tombstoned rows. Mirrors [TagDao].
  */
 @Dao
-interface CollectionShareDao {
+internal interface CollectionShareDao {
     /** Insert or update a share. Replaces on conflict using the primary key. */
     @Upsert
     suspend fun upsert(share: CollectionShareEntity)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionEntities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionEntities.kt
@@ -24,7 +24,7 @@ import androidx.room.PrimaryKey
         Index(value = ["deletedAt"]),
     ],
 )
-data class CollectionEntity(
+internal data class CollectionEntity(
     @PrimaryKey val id: String,
     /** The library this collection belongs to. */
     val libraryId: String,
@@ -58,7 +58,7 @@ data class CollectionEntity(
         Index(value = ["deletedAt"]),
     ],
 )
-data class CollectionBookEntity(
+internal data class CollectionBookEntity(
     val collectionId: String,
     val bookId: String,
     /** Epoch millis when this junction row was first created. */
@@ -84,7 +84,7 @@ data class CollectionBookEntity(
         Index(value = ["deletedAt"]),
     ],
 )
-data class CollectionShareEntity(
+internal data class CollectionShareEntity(
     @PrimaryKey val id: String,
     /** The collection that was shared. */
     val collectionId: String,
@@ -108,7 +108,7 @@ data class CollectionShareEntity(
  * names aligned with [CollectionEntity] without a manual mapping (the
  * [GenreWithBookCount] precedent).
  */
-data class CollectionWithBookCount(
+internal data class CollectionWithBookCount(
     @Embedded val collection: CollectionEntity,
     val bookCount: Int,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CoverDownloadQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CoverDownloadQueue.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Status of a cover download task in the persistent queue.
  */
-enum class CoverDownloadStatus {
+internal enum class CoverDownloadStatus {
     /** Waiting to be processed. */
     PENDING,
 
@@ -35,7 +35,7 @@ enum class CoverDownloadStatus {
  * replaces the old fire-and-forget coroutine approach.
  */
 @Entity(tableName = "cover_download_queue")
-data class CoverDownloadTaskEntity(
+internal data class CoverDownloadTaskEntity(
     @PrimaryKey
     val bookId: BookId,
     val status: CoverDownloadStatus = CoverDownloadStatus.PENDING,
@@ -49,7 +49,7 @@ data class CoverDownloadTaskEntity(
  * DAO for the cover download queue.
  */
 @Dao
-interface CoverDownloadDao {
+internal interface CoverDownloadDao {
     /**
      * Enqueue cover downloads. Existing entries are ignored (IGNORE strategy)
      * so re-syncing doesn't reset in-progress or completed tasks.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
@@ -12,7 +12,7 @@ import com.calypsan.listenup.core.SeriesId
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface SeriesDao {
+internal interface SeriesDao {
     @Query("SELECT * FROM series WHERE deletedAt IS NULL ORDER BY name ASC")
     fun observeAll(): Flow<List<SeriesEntity>>
 
@@ -125,7 +125,7 @@ interface SeriesDao {
 }
 
 @Dao
-interface ContributorDao {
+internal interface ContributorDao {
     @Query("SELECT * FROM contributors WHERE deletedAt IS NULL")
     fun observeAll(): Flow<List<ContributorEntity>>
 
@@ -300,7 +300,7 @@ interface ContributorDao {
  * `TransactionRunner.atomically { }` block to keep the transaction layer single.
  */
 @Dao
-interface ContributorAliasDao {
+internal interface ContributorAliasDao {
     @Query(
         "SELECT alias FROM contributor_aliases " +
             "WHERE contributorId = :id " +

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseTransactions.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseTransactions.kt
@@ -15,7 +15,7 @@ import androidx.room.useWriterConnection
  * is SQLite's single serialisation point; holding it longer than necessary stalls every
  * other pending write in the app.
  */
-interface TransactionRunner {
+internal interface TransactionRunner {
     suspend fun <R> atomically(block: suspend () -> R): R
 }
 
@@ -26,7 +26,7 @@ interface TransactionRunner {
  * block detect the held transaction and become savepoint-scoped nested transactions, so
  * Room's invalidation tracker fires correctly when the outer block commits.
  */
-class RoomTransactionRunner(
+internal class RoomTransactionRunner(
     private val database: ListenUpDatabase,
 ) : TransactionRunner {
     override suspend fun <R> atomically(block: suspend () -> R): R =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadDao.kt
@@ -7,7 +7,7 @@ import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface DownloadDao {
+internal interface DownloadDao {
     // Observe
     @Query("SELECT * FROM downloads WHERE bookId = :bookId ORDER BY fileIndex")
     fun observeForBook(bookId: String): Flow<List<DownloadEntity>>

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DownloadEntity.kt
@@ -16,7 +16,7 @@ import androidx.room.PrimaryKey
     tableName = "downloads",
     indices = [Index(value = ["bookId"])],
 )
-data class DownloadEntity(
+internal data class DownloadEntity(
     @PrimaryKey
     val audioFileId: String,
     val bookId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Entities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Entities.kt
@@ -19,7 +19,7 @@ import com.calypsan.listenup.core.LibraryId
  * Timestamps are stored as Unix epoch milliseconds for cross-platform compatibility.
  */
 @Entity(tableName = "users")
-data class UserEntity(
+internal data class UserEntity(
     @PrimaryKey
     val id: UserId,
     val email: String,
@@ -73,7 +73,7 @@ data class UserEntity(
  * Enables fully offline display of user avatars and names.
  */
 @Entity(tableName = "user_profiles")
-data class UserProfileEntity(
+internal data class UserProfileEntity(
     @PrimaryKey
     val id: String,
     val displayName: String,
@@ -112,7 +112,7 @@ data class UserProfileEntity(
         Index(value = ["folderId"]),
     ],
 )
-data class BookEntity(
+internal data class BookEntity(
     @PrimaryKey val id: BookId,
     /** The library this book belongs to. */
     val libraryId: LibraryId,
@@ -154,7 +154,7 @@ data class BookEntity(
         Index(value = ["bookId"]),
     ],
 )
-data class ChapterEntity(
+internal data class ChapterEntity(
     @PrimaryKey val id: ChapterId,
     val bookId: BookId,
     val title: String,
@@ -170,7 +170,7 @@ data class ChapterEntity(
  * only, now persisted locally so sort-by-series works offline).
  */
 @Entity(tableName = "series")
-data class SeriesEntity(
+internal data class SeriesEntity(
     @PrimaryKey val id: SeriesId,
     val name: String,
     val sortName: String? = null,
@@ -201,7 +201,7 @@ data class SeriesEntity(
  * via the junction) is planned for a later phase.
  */
 @Entity(tableName = "contributors")
-data class ContributorEntity(
+internal data class ContributorEntity(
     @PrimaryKey val id: ContributorId,
     val name: String,
     val sortName: String? = null,
@@ -227,7 +227,7 @@ data class ContributorEntity(
  * Position is sacred: never lose the user's place.
  */
 @Entity(tableName = "playback_positions")
-data class PlaybackPositionEntity(
+internal data class PlaybackPositionEntity(
     @PrimaryKey val bookId: BookId,
     // Current position in book (book-relative)
     val positionMs: Long,
@@ -277,7 +277,7 @@ data class PlaybackPositionEntity(
     tableName = "tags",
     indices = [Index(value = ["slug"])],
 )
-data class TagEntity(
+internal data class TagEntity(
     @PrimaryKey val id: String,
     /** Human-readable display name, e.g. "Sci-Fi". Mutable via rename. */
     val name: String,
@@ -302,7 +302,7 @@ data class TagEntity(
     tableName = "moods",
     indices = [Index(value = ["slug"])],
 )
-data class MoodEntity(
+internal data class MoodEntity(
     @PrimaryKey val id: String,
     /** Human-readable display name, e.g. "Feel-Good". Mutable via rename. */
     val name: String,
@@ -330,7 +330,7 @@ data class MoodEntity(
         Index(value = ["path"]),
     ],
 )
-data class GenreEntity(
+internal data class GenreEntity(
     @PrimaryKey val id: String,
     /** Display name: "Epic Fantasy" */
     val name: String,
@@ -381,7 +381,7 @@ data class GenreEntity(
         Index(value = ["occurredAt"]),
     ],
 )
-data class ActivityEntity(
+internal data class ActivityEntity(
     @PrimaryKey
     val id: String,
     /** User who performed the activity */
@@ -421,7 +421,7 @@ data class ActivityEntity(
  * tombstones are not emitted in P2 but the substrate shape is required.
  */
 @Entity(tableName = "user_stats")
-data class UserStatsEntity(
+internal data class UserStatsEntity(
     /** Primary key — equals the user's ID. */
     @PrimaryKey val id: String,
     val totalSecondsAllTime: Long,
@@ -448,7 +448,7 @@ data class UserStatsEntity(
  * when an orphan span is detected.
  */
 @Entity(tableName = "tentative_span")
-data class TentativeSpanEntity(
+internal data class TentativeSpanEntity(
     @PrimaryKey val id: String,
     val userId: String,
     val bookId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/GenreDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/GenreDao.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.Flow
  * Genres are system-defined hierarchical categories.
  */
 @Dao
-interface GenreDao {
+internal interface GenreDao {
     // ========== Genre Entity Operations ==========
 
     /**
@@ -304,7 +304,7 @@ interface GenreDao {
  * Projection used by [GenreDao.getGenresForBooks] to join the `book_genres`
  * junction against `genres` and return one flat row per (book, genre) pair.
  */
-data class BookGenreNamePair(
+internal data class BookGenreNamePair(
     val bookId: String,
     val genreName: String,
 )
@@ -316,7 +316,7 @@ data class BookGenreNamePair(
  * maintains genre IDs via [GenreEntity]. This projection is the minimal shape
  * Sync domain handlers need to build [BookGenreCrossRef] rows.
  */
-data class GenreIdName(
+internal data class GenreIdName(
     val id: String,
     val name: String,
 )
@@ -326,7 +326,7 @@ data class GenreIdName(
  * row plus its current live-junction count. Embedding keeps the SQL column
  * names aligned with [GenreEntity] without a manual mapping.
  */
-data class GenreWithBookCount(
+internal data class GenreWithBookCount(
     @androidx.room.Embedded val genre: GenreEntity,
     val bookCount: Int,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/IdRevision.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/IdRevision.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.client.data.local.db
 
 /** Room projection of a syncable row's identity + revision, for digest computation. */
-data class IdRevision(
+internal data class IdRevision(
     val id: String,
     val revision: Long,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -69,7 +69,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
 )
 @ConstructedBy(ListenUpDatabaseConstructor::class)
 @Suppress("TooManyFunctions")
-abstract class ListenUpDatabase : RoomDatabase() {
+internal abstract class ListenUpDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
 
     abstract fun userProfileDao(): UserProfileDao

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.Flow
         Index(value = ["userId", "bookId"]),
     ],
 )
-data class ListeningEventEntity(
+internal data class ListeningEventEntity(
     @PrimaryKey val id: String,
     val userId: String,
     val bookId: String,
@@ -63,7 +63,7 @@ data class ListeningEventEntity(
  * - History browsing (per book, per user)
  */
 @Dao
-interface ListeningEventDao {
+internal interface ListeningEventDao {
     /**
      * Get all events in a date range for stats computation.
      * Returns Flow for automatic UI updates when events are added.
@@ -329,7 +329,7 @@ interface ListeningEventDao {
 /**
  * Result class for duration-by-book query.
  */
-data class BookDuration(
+internal data class BookDuration(
     val bookId: String,
     val totalMs: Long,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/MoodDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/MoodDao.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.Flow
  * Mirrors [TagDao] — moods share the tag stack's shape and sync discipline.
  */
 @Dao
-interface MoodDao {
+internal interface MoodDao {
     /**
      * Insert or update a mood entity. Replaces on conflict using the primary key.
      */
@@ -103,7 +103,7 @@ interface MoodDao {
  * Mirrors [BookTagDao].
  */
 @Dao
-interface BookMoodDao {
+internal interface BookMoodDao {
     /**
      * Insert or update a junction row. Replaces on conflict using the composite primary key.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -14,7 +14,7 @@ private const val MAX_RETRYABLE_ATTEMPTS = 5
  * [PendingOperationV2Entity] for the row schema and ordering contract.
  */
 @Dao
-interface PendingOperationV2Dao {
+internal interface PendingOperationV2Dao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(op: PendingOperationV2Entity)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Entity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Entity.kt
@@ -20,7 +20,7 @@ import androidx.room.PrimaryKey
         Index(value = ["ownerUserId"]),
     ],
 )
-data class PendingOperationV2Entity(
+internal data class PendingOperationV2Entity(
     @PrimaryKey val clientOpId: String,
     val domainName: String,
     val entityId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
  * Position is sacred: saves immediately, syncs eventually.
  */
 @Dao
-interface PlaybackPositionDao {
+internal interface PlaybackPositionDao {
     /**
      * Get the saved position for a book.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PublicProfileEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PublicProfileEntity.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.Flow
  * public-profile sync handler for catch-up and SSE event application.
  */
 @Entity(tableName = "public_profiles")
-data class PublicProfileEntity(
+internal data class PublicProfileEntity(
     /** Primary key — equals the user's ID. */
     @PrimaryKey val id: String,
     /** User-visible display name. */
@@ -53,7 +53,7 @@ data class PublicProfileEntity(
  * This DAO is write-only from the sync layer — the client never originates changes.
  */
 @Dao
-interface PublicProfileDao {
+internal interface PublicProfileDao {
     /**
      * Observe all live public profiles (tombstoned rows excluded).
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Relations.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Relations.kt
@@ -51,7 +51,7 @@ import com.calypsan.listenup.core.SeriesId
         Index(value = ["contributorId"]),
     ],
 )
-data class BookContributorCrossRef(
+internal data class BookContributorCrossRef(
     val bookId: BookId,
     val contributorId: ContributorId,
     // "author", "narrator", etc.
@@ -92,7 +92,7 @@ data class BookContributorCrossRef(
         Index(value = ["seriesId"]),
     ],
 )
-data class BookSeriesCrossRef(
+internal data class BookSeriesCrossRef(
     val bookId: BookId,
     val seriesId: SeriesId,
     val sequence: String? = null,
@@ -109,7 +109,7 @@ data class BookSeriesCrossRef(
  *
  * Series are loaded with sequence info for display (e.g., "Mistborn #1").
  */
-data class BookWithContributors(
+internal data class BookWithContributors(
     @Embedded val book: BookEntity,
     @Relation(
         entity = ContributorEntity::class,
@@ -153,7 +153,7 @@ data class BookWithContributors(
  * Used by queries that join contributors with book_contributors
  * to count how many books a contributor is associated with.
  */
-data class ContributorWithBookCount(
+internal data class ContributorWithBookCount(
     @Embedded val contributor: ContributorEntity,
     val bookCount: Int,
 )
@@ -165,7 +165,7 @@ data class ContributorWithBookCount(
  * through the book_series table, avoiding N+1 query problems when displaying
  * series with cover stacks.
  */
-data class SeriesWithBooks(
+internal data class SeriesWithBooks(
     @Embedded val series: SeriesEntity,
     @Relation(
         entity = BookEntity::class,
@@ -192,7 +192,7 @@ data class SeriesWithBooks(
  * Uses Room's @Relation with Junction to handle the many-to-many relationship
  * through the book_series table.
  */
-data class BookWithSeries(
+internal data class BookWithSeries(
     @Embedded val book: BookEntity,
     @Relation(
         entity = SeriesEntity::class,
@@ -218,7 +218,7 @@ data class BookWithSeries(
  *
  * Used by queries that count books per role for a specific contributor.
  */
-data class RoleWithBookCount(
+internal data class RoleWithBookCount(
     val role: String,
     val bookCount: Int,
 )
@@ -248,7 +248,7 @@ data class RoleWithBookCount(
         Index(value = ["deletedAt"]),
     ],
 )
-data class BookTagEntity(
+internal data class BookTagEntity(
     val bookId: String,
     val tagId: String,
     val createdAt: Long,
@@ -284,7 +284,7 @@ data class BookTagEntity(
         Index(value = ["genreId"]),
     ],
 )
-data class BookGenreCrossRef(
+internal data class BookGenreCrossRef(
     val bookId: BookId,
     val genreId: String,
 )
@@ -296,7 +296,7 @@ data class BookGenreCrossRef(
  * through the book_tags table. Note: Room's Junction does not filter by [BookTagEntity.deletedAt];
  * consumers should call [TagDao.observeForBook] for tombstone-aware observation instead.
  */
-data class BookWithTags(
+internal data class BookWithTags(
     @Embedded val book: BookEntity,
     @Relation(
         entity = TagEntity::class,
@@ -338,7 +338,7 @@ data class BookWithTags(
         Index(value = ["deletedAt"]),
     ],
 )
-data class BookMoodEntity(
+internal data class BookMoodEntity(
     val bookId: String,
     val moodId: String,
     val createdAt: Long,
@@ -373,7 +373,7 @@ data class BookMoodEntity(
     ],
     indices = [Index(value = ["contributorId"])],
 )
-data class ContributorAliasCrossRef(
+internal data class ContributorAliasCrossRef(
     val contributorId: ContributorId,
     val alias: String,
 )
@@ -395,7 +395,7 @@ data class ContributorAliasCrossRef(
  *   support `ORDER BY` on the projected child collection, so the repository is
  *   the canonical ordering seam.
  */
-data class ContributorWithAliases(
+internal data class ContributorWithAliases(
     @Embedded val contributor: ContributorEntity,
     @Relation(
         parentColumn = "id",

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
@@ -8,7 +8,7 @@ import androidx.room.SkipQueryVerification
 /**
  * Result class for book search that includes denormalized author name.
  */
-data class BookSearchResult(
+internal data class BookSearchResult(
     @Embedded val book: BookEntity,
     val authorName: String?,
 )
@@ -30,7 +30,7 @@ data class BookSearchResult(
  * - series_fts: seriesId, name, description
  */
 @Dao
-interface SearchDao {
+internal interface SearchDao {
     // ==================== SEARCH QUERIES ====================
 
     /**
@@ -394,7 +394,7 @@ interface SearchDao {
  * @property authorName The aggregated name string for this dimension (author,
  *   narrator, series names, or genre names depending on the calling query).
  */
-data class BookIdNameRow(
+internal data class BookIdNameRow(
     val bookId: String,
     val authorName: String,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchFtsEntities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchFtsEntities.kt
@@ -28,7 +28,7 @@ package com.calypsan.listenup.client.data.local.db
  * Denormalizes author/narrator names from the cross-reference table
  * into the FTS index for efficient search.
  */
-data class BookFtsEntry(
+internal data class BookFtsEntry(
     val bookId: String,
     val title: String,
     val subtitle: String?,
@@ -42,7 +42,7 @@ data class BookFtsEntry(
 /**
  * FTS5 entry for contributor full-text search.
  */
-data class ContributorFtsEntry(
+internal data class ContributorFtsEntry(
     val contributorId: String,
     val name: String,
     val description: String?,
@@ -51,7 +51,7 @@ data class ContributorFtsEntry(
 /**
  * FTS5 entry for series full-text search.
  */
-data class SeriesFtsEntry(
+internal data class SeriesFtsEntry(
     val seriesId: String,
     val name: String,
     val description: String?,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfBookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfBookDao.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
  * `"$shelfId:$bookId"` is the wire/sync-cursor identity. Mirrors [CollectionBookDao].
  */
 @Dao
-interface ShelfBookDao {
+internal interface ShelfBookDao {
     /** Insert or update a junction row. Replaces on conflict using the primary key. */
     @Upsert
     suspend fun upsert(entity: ShelfBookEntity)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfDao.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.Flow
  * Mirrors [CollectionDao].
  */
 @Dao
-interface ShelfDao {
+internal interface ShelfDao {
     /** Insert or update a shelf. Replaces on conflict using the primary key. */
     @Upsert
     suspend fun upsert(shelf: ShelfEntity)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfEntities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfEntities.kt
@@ -27,7 +27,7 @@ import androidx.room.PrimaryKey
         Index(value = ["deletedAt"]),
     ],
 )
-data class ShelfEntity(
+internal data class ShelfEntity(
     @PrimaryKey val id: String,
     /** Display name of the shelf. */
     val name: String,
@@ -63,7 +63,7 @@ data class ShelfEntity(
         Index(value = ["deletedAt"]),
     ],
 )
-data class ShelfBookEntity(
+internal data class ShelfBookEntity(
     @PrimaryKey val id: String,
     /** The shelf this book belongs to. */
     val shelfId: String,
@@ -87,7 +87,7 @@ data class ShelfBookEntity(
  * aligned with [ShelfEntity] without a manual mapping (the
  * [CollectionWithBookCount] precedent).
  */
-data class ShelfWithBookCount(
+internal data class ShelfWithBookCount(
     @Embedded val shelf: ShelfEntity,
     val bookCount: Int,
 )
@@ -100,7 +100,7 @@ data class ShelfWithBookCount(
  * from Room. A non-null [coverHash] lets the UI version its image-cache key so a re-imaged
  * cover invalidates the stale cached bitmap.
  */
-data class ShelfBookCoverHash(
+internal data class ShelfBookCoverHash(
     val bookId: String,
     val coverHash: String?,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SyncCursorDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SyncCursorDao.kt
@@ -9,7 +9,7 @@ import androidx.room.Upsert
  * [SyncCursorEntity] for the cursor's role in resuming via `Last-Event-Id`.
  */
 @Dao
-interface SyncCursorDao {
+internal interface SyncCursorDao {
     @Query("SELECT revision FROM sync_cursor WHERE domainName = :domainName")
     suspend fun getCursor(domainName: String): Long?
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SyncCursorEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SyncCursorEntity.kt
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey
  * resume via `Last-Event-Id` instead of falling back to REST every time.
  */
 @Entity(tableName = "sync_cursor")
-data class SyncCursorEntity(
+internal data class SyncCursorEntity(
     @PrimaryKey val domainName: String,
     val revision: Long,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SyncState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SyncState.kt
@@ -9,7 +9,7 @@ package com.calypsan.listenup.client.data.local.db
  * - Sync operations transition NOT_SYNCED -> SYNCING -> SYNCED
  * - Conflicts transition to CONFLICT when server has newer version
  */
-enum class SyncState {
+internal enum class SyncState {
     /**
      * Entity is clean and matches server state.
      * No pending local changes or server updates.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TagDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TagDao.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.Flow
  * sync engine can track deletions across devices.
  */
 @Dao
-interface TagDao {
+internal interface TagDao {
     /**
      * Insert or update a tag entity. Replaces on conflict using the primary key.
      */
@@ -99,7 +99,7 @@ interface TagDao {
  * tombstoned rows so the UI reactively reflects removals.
  */
 @Dao
-interface BookTagDao {
+internal interface BookTagDao {
     /**
      * Insert or update a junction row. Replaces on conflict using the composite primary key.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TentativeSpanDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TentativeSpanDao.kt
@@ -16,7 +16,7 @@ import androidx.room.Upsert
  * This table is **not synced** to the server.
  */
 @Dao
-interface TentativeSpanDao {
+internal interface TentativeSpanDao {
     /**
      * Get the current open span, or null if no span is in progress.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.builtins.serializer
  * primitive types for database storage. These converters enable type-safe
  * value classes with zero runtime overhead while maintaining Room compatibility.
  */
-class ValueClassConverters {
+internal class ValueClassConverters {
     /**
      * Convert BookId value class to String for database storage.
      */
@@ -128,7 +128,7 @@ class ValueClassConverters {
  * unknown value, which is what we want: the app refuses to interpret a state
  * it no longer understands rather than silently remap it.
  */
-class Converters {
+internal class Converters {
     @TypeConverter
     fun fromSyncState(value: SyncState): String = value.name
 
@@ -147,7 +147,7 @@ class Converters {
  *
  * Stored by name (not ordinal), so member order is not a wire concern.
  */
-enum class DownloadState {
+internal enum class DownloadState {
     QUEUED, // Waiting to start
     DOWNLOADING, // In progress
     PAUSED, // User paused or interrupted
@@ -161,7 +161,7 @@ enum class DownloadState {
  * Room type converter for [CoverDownloadStatus] enum.
  * Uses string names (not ordinals) for readable queries and forward compatibility.
  */
-class CoverDownloadStatusConverter {
+internal class CoverDownloadStatusConverter {
     @TypeConverter
     fun fromStatus(value: CoverDownloadStatus): String = value.name
 
@@ -181,7 +181,7 @@ class CoverDownloadStatusConverter {
  * columnar approach or junction table would be over-engineering. Do not use
  * for unbounded collections — those still belong in a separate table.
  */
-class StringListJsonConverter {
+internal class StringListJsonConverter {
     @TypeConverter
     fun fromList(value: List<String>): String = appJson.encodeToString(ListSerializer(String.serializer()), value)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserDao.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
  * Uses Upsert for convenience (insert or update if exists).
  */
 @Dao
-interface UserDao {
+internal interface UserDao {
     /**
      * Insert or update a user.
      * If a user with the same ID exists, it will be updated.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserProfileDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserProfileDao.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.Flow
  * - SSE profile.updated events
  */
 @Dao
-interface UserProfileDao {
+internal interface UserProfileDao {
     /**
      * Insert or update a user profile.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserStatsDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserStatsDao.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
  * sync domain. The primary key is the user ID (`id`).
  */
 @Dao
-interface UserStatsDao {
+internal interface UserStatsDao {
     /**
      * Observe all cached user stats (live rows only), ordered by all-time seconds descending.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryDao.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.Flow
  * [findAll].
  */
 @Dao
-interface LibraryDao {
+internal interface LibraryDao {
     /**
      * Observe all live libraries reactively, ordered by name.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryFolderDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryFolderDao.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.Flow
  * `libraryId` makes library-scoped queries efficient.
  */
 @Dao
-interface LibraryFolderDao {
+internal interface LibraryFolderDao {
     /**
      * Observe all live folders reactively across all libraries.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryEntity.kt
@@ -18,7 +18,7 @@ import androidx.room.PrimaryKey
  * they are present today but not enforced client-side.
  */
 @Entity(tableName = "libraries")
-data class LibraryEntity(
+internal data class LibraryEntity(
     @PrimaryKey val id: String,
     val name: String,
     /** Comma-separated source list governing metadata precedence (e.g. `"embedded,abs,sidecar"`). */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryFolderEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryFolderEntity.kt
@@ -28,7 +28,7 @@ import androidx.room.PrimaryKey
     ],
     indices = [Index("libraryId")],
 )
-data class LibraryFolderEntity(
+internal data class LibraryFolderEntity(
     @PrimaryKey val id: String,
     /** Parent library identifier. Foreign key to [LibraryEntity.id]. */
     val libraryId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/AllProgressResponse.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/AllProgressResponse.kt
@@ -46,7 +46,7 @@ data class ProgressSyncItem(
      *
      * @param existing Optional existing entity to preserve local-only fields
      */
-    fun toEntity(existing: PlaybackPositionEntity? = null): PlaybackPositionEntity =
+    internal fun toEntity(existing: PlaybackPositionEntity? = null): PlaybackPositionEntity =
         PlaybackPositionEntity(
             bookId = BookId(bookId),
             positionMs = currentPositionMs,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/PlaybackProgressResponse.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/PlaybackProgressResponse.kt
@@ -45,7 +45,7 @@ data class PlaybackProgressResponse(
      * Using local clock would inflate updatedAt, causing stale local positions
      * to win over newer server positions on subsequent app launches.
      */
-    fun toEntity(): PlaybackPositionEntity {
+    internal fun toEntity(): PlaybackPositionEntity {
         val serverUpdatedAt = updatedAtMillis()
         return PlaybackPositionEntity(
             bookId = BookId(bookId),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookIngestPort.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookIngestPort.kt
@@ -5,8 +5,9 @@ import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 
 /**
- * Data-layer seam for atomically ingesting a book aggregate from the network. Intentionally `public`
- * (not `internal`): consumed from sibling `:sharedUI` DI modules that can't see `:sharedLogic` internals.
+ * Data-layer seam for atomically ingesting a book aggregate from the network. `internal` to
+ * `:sharedLogic`: its implementation ([BookRepositoryImpl]) and the only binding ([BookModule])
+ * both live in `:sharedLogic`, so it never needs to be seen from a sibling module.
  *
  * Lives in the data layer, not the domain layer, because it speaks Room entity types —
  * callers (playback fallback fetch, sync handlers) already hold entities built from
@@ -16,7 +17,7 @@ import com.calypsan.listenup.client.data.local.db.BookEntity
  * data-layer ingest paths. Not part of the [com.calypsan.listenup.client.domain.repository.BookRepository]
  * contract so the domain interface stays free of Room types.
  */
-interface BookIngestPort {
+internal interface BookIngestPort {
     /**
      * Atomically upsert a book row and replace its audio-file rows.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadEnqueuer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadEnqueuer.kt
@@ -11,7 +11,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadEntity
  * Used by [com.calypsan.listenup.client.domain.repository.DownloadRepository.resumeIncompleteDownloads]
  * to re-enqueue workers for downloads interrupted before completion.
  */
-interface DownloadEnqueuer {
+internal interface DownloadEnqueuer {
     /**
      * Enqueue a single audio-file download with `ExistingWorkPolicy.REPLACE` semantics.
      * Returns [AppResult.Success] on success; [AppResult.Failure] if the platform doesn't support

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorder.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ListeningEventRecorder.kt
@@ -58,7 +58,7 @@ private val logger = KotlinLogging.logger {}
  * @property timeZone Injected for deterministic testing. Defaults to
  *   [TimeZone.currentSystemDefault].
  */
-class ListeningEventRecorder(
+class ListeningEventRecorder internal constructor(
     private val listeningEventDao: ListeningEventDao,
     private val tentativeSpanDao: TentativeSpanDao,
     private val enqueue: suspend (

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -42,7 +42,7 @@ private const val BOOK_FINISHED_THRESHOLD = 0.90f
  * into platform code that also constructs this class.
  */
 @Suppress("LongParameterList")
-class PlaybackManagerImpl(
+internal class PlaybackManagerImpl(
     private val serverConfig: ServerConfig,
     private val playbackPreferences: PlaybackPreferences,
     private val bookDao: BookDao,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -74,7 +74,7 @@ data class PreparedPlayback(
  * collaborators. A parameter object would only bag them and ripples into platform code.
  */
 @Suppress("LongParameterList")
-internal class PlaybackPreparer(
+class PlaybackPreparer internal constructor(
     private val serverConfig: ServerConfig,
     private val playbackPreferences: PlaybackPreferences,
     private val bookDao: BookDao,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -74,7 +74,7 @@ data class PreparedPlayback(
  * collaborators. A parameter object would only bag them and ripples into platform code.
  */
 @Suppress("LongParameterList")
-class PlaybackPreparer(
+internal class PlaybackPreparer(
     private val serverConfig: ServerConfig,
     private val playbackPreferences: PlaybackPreferences,
     private val bookDao: BookDao,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModel.kt
@@ -38,7 +38,7 @@ private val logger = KotlinLogging.logger {}
  * "Available users to share with" is fetched on demand from [AdminRepository] and
  * filtered against the already-shared recipients and the current user.
  */
-class AdminCollectionDetailViewModel(
+class AdminCollectionDetailViewModel internal constructor(
     private val collectionId: String,
     private val collectionRepository: CollectionRepository,
     private val adminRepository: AdminRepository,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminInboxViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminInboxViewModel.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.launch
  *
  * Subscribes to admin SSE events for real-time inbox add/release updates.
  */
-class AdminInboxViewModel(
+class AdminInboxViewModel internal constructor(
     private val inboxRepository: InboxRepository,
     private val libraryRepository: LibraryRepository,
     private val eventStreamRepository: EventStreamRepository,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModel.kt
@@ -165,7 +165,7 @@ sealed interface ContributorEditNavAction {
  * @property contributorDao DAO for browsing all contributors as merge-target candidates
  * @property errorBus Global error bus for snackbar emissions
  */
-class ContributorEditViewModel(
+class ContributorEditViewModel internal constructor(
     private val contributorRepository: ContributorRepository,
     private val updateContributorUseCase: UpdateContributorUseCase,
     private val imageRepository: ImageRepository,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/UserProfileViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/UserProfileViewModel.kt
@@ -82,7 +82,7 @@ sealed interface UserProfileUiState {
  * The header never blocks on shelves: a shelf failure renders an empty shelf list, not an error.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
-class UserProfileViewModel(
+class UserProfileViewModel internal constructor(
     private val publicProfileDao: PublicProfileDao,
     private val shelfRepository: ShelfRepository,
     private val userRepository: UserRepository,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/seriesedit/SeriesEditViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/seriesedit/SeriesEditViewModel.kt
@@ -140,7 +140,7 @@ sealed interface SeriesEditNavAction {
  * @property seriesDao DAO for browsing all series as merge-target candidates
  * @property errorBus Global error bus for snackbar emissions
  */
-class SeriesEditViewModel(
+class SeriesEditViewModel internal constructor(
     private val seriesRepository: SeriesRepository,
     private val updateSeriesUseCase: UpdateSeriesUseCase,
     private val imageRepository: ImageRepository,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.update
  * Optional [enqueueFailure] lambda lets tests inject failure for [enqueueForBook] (returns the
  * lambda's value when set; `AppResult.Success(DownloadOutcome.Started)` when null).
  */
-open class FakeDownloadRepository(
+internal open class FakeDownloadRepository(
     initial: List<DownloadEntity> = emptyList(),
     private val enqueueFailure: ((BookId) -> AppResult<DownloadOutcome>)? = null,
 ) : DownloadRepository {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/db/PassThroughTransactionRunner.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/db/PassThroughTransactionRunner.kt
@@ -15,7 +15,7 @@ import dev.mokkery.mock
  * Pair with `verifySuspend(VerifyMode.exactly(1)) { runner.atomically(any<suspend () -> Any>()) }`
  * in the test body to assert the transaction wrapper was used.
  */
-fun passThroughTransactionRunner(): TransactionRunner =
+internal fun passThroughTransactionRunner(): TransactionRunner =
     mock<TransactionRunner> {
         everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
             @Suppress("UNCHECKED_CAST")

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeListeningEventRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeListeningEventRepository.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.map
  * [queueCount] is exposed for tests that care about how many events were queued
  * without examining the emitted flows.
  */
-class FakeListeningEventRepository(
+internal class FakeListeningEventRepository(
     initialEvents: List<ListeningEventEntity> = emptyList(),
 ) : ListeningEventRepository {
     private val events = MutableStateFlow(initialEvents)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataLocalDbIsInternalRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataLocalDbIsInternalRule.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * The `data.local.db` package — Room database, DAOs, and `@Entity` types — is `:sharedLogic`
+ * plumbing reached only through the `domain/repository` seams. Keeping it non-public removes
+ * the whole Room layer from every client export path (iOS framework, Swift Export, JS, R8).
+ * A new public declaration here would silently re-bloat the export, so make it a build failure.
+ */
+class DataLocalDbIsInternalRule :
+    FunSpec({
+        // Symbols that must stay public despite living in data.local.db (cross-module
+        // consumers documented in the spec's "Flip exceptions"). Empty: the flip is clean.
+        // `DownloadEntity` + `DownloadState` were reclaimed by internalizing the
+        // `DownloadEnqueuer` seam — its sole cross-module binding (`:sharedUI` desktop's
+        // no-arg `JvmDownloadEnqueuer`) moved into `:sharedLogic`'s `desktopDownloadModule`.
+        val allowList = emptySet<String>()
+
+        test("no top-level declaration in data/local/db is public") {
+            val scope = Konsist.scopeFromProduction()
+            val classes =
+                scope
+                    .classes()
+                    .filter {
+                        "/data/local/db/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier
+                    }.map { it.name }
+            val interfaces =
+                scope
+                    .interfaces()
+                    .filter {
+                        "/data/local/db/" in it.path && it.isTopLevel &&
+                            it.hasPublicOrDefaultModifier
+                    }.map { it.name }
+            val objects =
+                scope
+                    .objects()
+                    .filter {
+                        "/data/local/db/" in it.path && it.isTopLevel && it.hasPublicOrDefaultModifier
+                    }.map { it.name }
+            val properties =
+                scope
+                    .properties()
+                    .filter {
+                        "/data/local/db/" in it.path && it.isTopLevel &&
+                            it.hasPublicOrDefaultModifier
+                    }.map { it.name }
+            val functions =
+                scope
+                    .functions()
+                    .filter {
+                        "/data/local/db/" in it.path && it.isTopLevel &&
+                            it.hasPublicOrDefaultModifier
+                    }.map { it.name }
+            // Top-level typealiases are not gated here: Konsist 0.17.3's KoTypeAliasDeclaration
+            // lacks `isTopLevel`, so it can't share the predicate above.
+            val offenders = (classes + interfaces + objects + properties + functions).filterNot { it in allowList }
+            offenders.shouldBeEmpty()
+        }
+    })

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/DownloadModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/DownloadModule.jvm.kt
@@ -1,0 +1,16 @@
+package com.calypsan.listenup.client.di
+
+import com.calypsan.listenup.client.download.DownloadEnqueuer
+import com.calypsan.listenup.client.download.JvmDownloadEnqueuer
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Desktop download wiring. Lives in `:sharedLogic` so `DownloadEnqueuer` (whose signature
+ * names the now-`internal` `DownloadEntity`) need not be public for a `:sharedUI` binding —
+ * mirrors `androidDownloadModule`. Registered by the desktop app's Koin start (`Main.kt`).
+ */
+val desktopDownloadModule: Module =
+    module {
+        single<DownloadEnqueuer> { JvmDownloadEnqueuer() }
+    }

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.client.di
+
+import com.calypsan.listenup.client.playback.PlaybackManager
+import com.calypsan.listenup.client.playback.PlaybackManagerImpl
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+/**
+ * Desktop `PlaybackManager` wiring. Lives in `:sharedLogic` so the binding can construct
+ * `PlaybackManagerImpl` against the `internal` Room DAOs. The `playbackScope` qualifier is
+ * provided by the desktop UI platform module; resolved at runtime from the merged graph.
+ */
+val desktopPlaybackModule: Module =
+    module {
+        single<PlaybackManager> {
+            PlaybackManagerImpl(
+                serverConfig = get(),
+                playbackPreferences = get(),
+                bookDao = get(),
+                audioFileDao = get(),
+                chapterDao = get(),
+                imageStorage = get(),
+                progressTracker = get(),
+                tokenProvider = get(),
+                deviceContext = get(),
+                downloadService = get(),
+                playbackRpcFactory = get(),
+                syncApi = get(),
+                scope = get(qualifier = named("playbackScope")),
+                bookIngestPort = get(),
+            )
+        }
+    }

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/download/JvmDownloadEnqueuer.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/download/JvmDownloadEnqueuer.kt
@@ -7,7 +7,7 @@ import com.calypsan.listenup.client.data.local.db.DownloadEntity
 /**
  * Desktop no-op enqueuer. Desktop doesn't support downloads (per W8 Phase A's Desktop hide).
  */
-class JvmDownloadEnqueuer : DownloadEnqueuer {
+internal class JvmDownloadEnqueuer : DownloadEnqueuer {
     override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> =
         AppResult.Failure(DownloadError.DownloadFailed(debugInfo = "Downloads not supported on Desktop"))
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabase.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabase.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.Dispatchers
  *
  * Source: Room KMP testing guide — https://developer.android.com/kotlin/multiplatform/room.
  */
-fun createInMemoryTestDatabase(queryContext: CoroutineContext = Dispatchers.IO): ListenUpDatabase =
+internal fun createInMemoryTestDatabase(queryContext: CoroutineContext = Dispatchers.IO): ListenUpDatabase =
     Room
         .inMemoryDatabaseBuilder<ListenUpDatabase>()
         .setDriver(BundledSQLiteDriver())

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -8,16 +8,18 @@ plugins {
     alias(libs.plugins.aboutlibraries)
 }
 
-// Mokkery is used in desktopTest only — see composeApp/src/desktopTest.
+// Mokkery is used in desktopTest and androidHostTest — see
+// sharedUI/src/desktopTest (DesktopPlaybackControllerTest) and
+// sharedUI/src/androidHostTest (BrowseTreeProviderTest).
 //
-// Scope note: this configuration currently exists for a single test file —
-// DesktopPlaybackControllerTest — which constructs a never-invoked
-// `mock<PlaybackManager>()` to satisfy the controller's constructor. Both flags
-// below are module-wide and therefore apply to every future mokkery mock in
-// composeApp/desktopTest; revisit them when a second test surfaces a different
-// mockability need (e.g. a real test that exercises PlaybackManager behaviour,
-// at which point a hand-rolled FakePlaybackManager + an interface seam is the
-// likely better answer).
+// Scope note: desktopTest's DesktopPlaybackControllerTest constructs a
+// never-invoked `mock<PlaybackManager>()` to satisfy the controller's
+// constructor; androidHostTest's BrowseTreeProviderTest is the second mokkery
+// consumer. Both flags below are module-wide and therefore apply to every
+// future mokkery mock in either source set; revisit them when a test surfaces a
+// different mockability need (e.g. a real test that exercises PlaybackManager
+// behaviour, at which point a hand-rolled FakePlaybackManager + an interface
+// seam is the likely better answer).
 //
 // - `ignoreFinalMembers` lets us mock PlaybackManager (open class) without
 //   having to mark each member as `open` individually.
@@ -196,6 +198,7 @@ kotlin {
         val androidHostTest by getting {
             dependencies {
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.mokkery.runtime)
 
                 // Kotest — canonical FunSpec framework for new androidHostTest tests.
                 // The runner is the JUnit5 platform engine; junit-vintage-engine keeps

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
@@ -4,35 +4,32 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ContributorId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
-import com.calypsan.listenup.core.ContributorId
 import com.calypsan.listenup.core.SeriesId
 import com.calypsan.listenup.core.Timestamp
-import com.calypsan.listenup.client.data.local.db.BookDao
-import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.BookSeriesCrossRef
-import com.calypsan.listenup.client.data.local.db.BookWithContributors
-import com.calypsan.listenup.client.data.local.db.ContributorDao
-import com.calypsan.listenup.client.data.local.db.ContributorEntity
-import com.calypsan.listenup.client.data.local.db.ContributorWithAliases
-import com.calypsan.listenup.client.data.local.db.BookSummary
-import com.calypsan.listenup.client.data.local.db.DiscoveryBookWithAuthor
-import com.calypsan.listenup.client.data.local.db.DiscoveryBookWithSeries
-import com.calypsan.listenup.client.data.local.db.DownloadDao
-import com.calypsan.listenup.client.data.local.db.DownloadEntity
-import com.calypsan.listenup.client.data.local.db.DownloadState
-import com.calypsan.listenup.client.data.local.db.SeriesDao
-import com.calypsan.listenup.client.data.local.db.SeriesEntity
-import com.calypsan.listenup.client.data.local.db.SeriesWithBooks
+import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
 import com.calypsan.listenup.client.domain.model.ContinueListeningItem
+import com.calypsan.listenup.client.domain.model.Contributor
+import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
+import com.calypsan.listenup.client.domain.model.Series
+import com.calypsan.listenup.client.domain.model.SeriesWithBooks
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.ContributorRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.SeriesRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -50,9 +47,9 @@ import org.robolectric.annotation.Config
  * The `junit-vintage-engine` on the classpath keeps these discoverable alongside
  * Kotest specs in `androidHostTest`.
  *
- * The DAO and repository interfaces are satisfied by in-memory fakes that hold data
- * in simple lists. This avoids the complexity of a real Room database while exercising
- * all routing branches of [BrowseTreeProvider.getChildren] without modifying `:shared`.
+ * The provider consumes the public `domain/repository` interfaces, which are satisfied
+ * here by mokkery mocks seeded with domain models. This exercises all routing branches
+ * of [BrowseTreeProvider.getChildren] without naming any `:shared` DAO or `@Entity` type.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
@@ -148,46 +145,21 @@ class BrowseTreeProviderTest {
     @Test
     fun `getChildren LIBRARY_DOWNLOADED returns empty list when no books`(): Unit =
         runBlocking {
-            val provider = makeProvider(allBooks = emptyList())
+            val provider = makeProvider(downloadedBooks = emptyList())
             provider.getChildren(BrowseTree.LIBRARY_DOWNLOADED).shouldBeEmpty()
         }
 
     @Test
-    fun `getChildren LIBRARY_DOWNLOADED includes only books whose downloads are all COMPLETED`(): Unit =
+    fun `getChildren LIBRARY_DOWNLOADED maps each downloaded book to a playable media item`(): Unit =
         runBlocking {
-            val bookDownloaded = makeBookEntity("book-dl", "Downloaded Book")
-            val bookPending = makeBookEntity("book-pending", "Pending Book")
-            val bookNoDownloads = makeBookEntity("book-none", "No Downloads")
-            val downloads =
-                mapOf(
-                    "book-dl" to listOf(makeDownloadEntity("book-dl", "file-1", DownloadState.COMPLETED)),
-                    "book-pending" to listOf(makeDownloadEntity("book-pending", "file-2", DownloadState.DOWNLOADING)),
-                    "book-none" to emptyList(),
-                )
             val provider =
                 makeProvider(
-                    allBooks = listOf(bookDownloaded, bookPending, bookNoDownloads),
-                    downloadsByBookId = downloads,
+                    downloadedBooks = listOf(makeDownloadedBookSummary("book-dl", "Downloaded Book")),
                 )
             val children = provider.getChildren(BrowseTree.LIBRARY_DOWNLOADED)
             children shouldHaveSize 1
             children[0].mediaId shouldBe BrowseTree.bookId("book-dl")
-        }
-
-    @Test
-    fun `getChildren LIBRARY_DOWNLOADED excludes books with mixed download states`(): Unit =
-        runBlocking {
-            val book = makeBookEntity("book-mixed", "Mixed Download Book")
-            val downloads =
-                mapOf(
-                    "book-mixed" to
-                        listOf(
-                            makeDownloadEntity("book-mixed", "file-1", DownloadState.COMPLETED),
-                            makeDownloadEntity("book-mixed", "file-2", DownloadState.FAILED),
-                        ),
-                )
-            val provider = makeProvider(allBooks = listOf(book), downloadsByBookId = downloads)
-            provider.getChildren(BrowseTree.LIBRARY_DOWNLOADED).shouldBeEmpty()
+            children[0].mediaMetadata.isPlayable shouldBe true
         }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -206,8 +178,8 @@ class BrowseTreeProviderTest {
         runBlocking {
             val series =
                 listOf(
-                    makeSeriesEntity("series-1", "The Stormlight Archive"),
-                    makeSeriesEntity("series-2", "Mistborn"),
+                    makeSeries("series-1", "The Stormlight Archive"),
+                    makeSeries("series-2", "Mistborn"),
                 )
             val provider = makeProvider(allSeries = series)
             val children = provider.getChildren(BrowseTree.LIBRARY_SERIES)
@@ -234,8 +206,8 @@ class BrowseTreeProviderTest {
         runBlocking {
             val contributors =
                 listOf(
-                    makeContributorEntity("author-1", "Brandon Sanderson"),
-                    makeContributorEntity("author-2", "Patrick Rothfuss"),
+                    makeContributor("author-1", "Brandon Sanderson"),
+                    makeContributor("author-2", "Patrick Rothfuss"),
                 )
             val provider = makeProvider(allContributors = contributors)
             val children = provider.getChildren(BrowseTree.LIBRARY_AUTHORS)
@@ -253,14 +225,13 @@ class BrowseTreeProviderTest {
     @Test
     fun `getChildren series prefix returns books in that series`(): Unit =
         runBlocking {
-            val book1 = makeBookEntity("book-sw1", "The Way of Kings")
-            val book2 = makeBookEntity("book-sw2", "Words of Radiance")
-            val series = makeSeriesEntity("series-sa", "The Stormlight Archive")
+            val book1 = makeBookListItem("book-sw1", "The Way of Kings")
+            val book2 = makeBookListItem("book-sw2", "Words of Radiance")
             val seriesWithBooks =
                 SeriesWithBooks(
-                    series = series,
+                    series = makeSeries("series-sa", "The Stormlight Archive"),
                     books = listOf(book1, book2),
-                    bookSequences = emptyList(),
+                    bookSequences = emptyMap(),
                 )
             val provider = makeProvider(seriesWithBooksById = mapOf("series-sa" to seriesWithBooks))
             val children = provider.getChildren(BrowseTree.seriesId("series-sa"))
@@ -283,13 +254,11 @@ class BrowseTreeProviderTest {
     @Test
     fun `getChildren author prefix returns books by that author`(): Unit =
         runBlocking {
-            val book = makeBookEntity("book-1", "The Name of the Wind")
-            val author = makeContributorEntity("author-pr", "Patrick Rothfuss")
             val provider =
                 makeProvider(
                     bookIdsForContributor = mapOf("author-pr" to listOf("book-1")),
-                    contributorsById = mapOf("author-pr" to author),
-                    booksById = mapOf("book-1" to book),
+                    contributorsById = mapOf("author-pr" to makeContributor("author-pr", "Patrick Rothfuss")),
+                    booksById = mapOf("book-1" to makeBookListItem("book-1", "The Name of the Wind")),
                 )
             val children = provider.getChildren(BrowseTree.authorId("author-pr"))
             children shouldHaveSize 1
@@ -303,7 +272,7 @@ class BrowseTreeProviderTest {
             val provider =
                 makeProvider(
                     bookIdsForContributor = mapOf("author-empty" to emptyList()),
-                    contributorsById = mapOf("author-empty" to makeContributorEntity("author-empty", "No Books Author")),
+                    contributorsById = mapOf("author-empty" to makeContributor("author-empty", "No Books Author")),
                 )
             provider.getChildren(BrowseTree.authorId("author-empty")).shouldBeEmpty()
         }
@@ -327,7 +296,7 @@ class BrowseTreeProviderTest {
     @Test
     fun `getChildren LIBRARY_SERIES caps result at 8 items even with more series`(): Unit =
         runBlocking {
-            val manySeries = (1..12).map { makeSeriesEntity("s-$it", "Series $it") }
+            val manySeries = (1..12).map { makeSeries("s-$it", "Series $it") }
             val provider = makeProvider(allSeries = manySeries)
             provider.getChildren(BrowseTree.LIBRARY_SERIES) shouldHaveSize 8
         }
@@ -335,7 +304,7 @@ class BrowseTreeProviderTest {
     @Test
     fun `getChildren LIBRARY_AUTHORS caps result at 8 items`(): Unit =
         runBlocking {
-            val manyAuthors = (1..15).map { makeContributorEntity("a-$it", "Author $it") }
+            val manyAuthors = (1..15).map { makeContributor("a-$it", "Author $it") }
             val provider = makeProvider(allContributors = manyAuthors)
             provider.getChildren(BrowseTree.LIBRARY_AUTHORS) shouldHaveSize 8
         }
@@ -358,8 +327,7 @@ class BrowseTreeProviderTest {
     @Test
     fun `getChildren LIBRARY_SERIES items are browsable and not playable`(): Unit =
         runBlocking {
-            val series = makeSeriesEntity("s-1", "A Series")
-            val provider = makeProvider(allSeries = listOf(series))
+            val provider = makeProvider(allSeries = listOf(makeSeries("s-1", "A Series")))
             val item = provider.getChildren(BrowseTree.LIBRARY_SERIES).first()
             item.mediaMetadata.isBrowsable shouldBe true
             item.mediaMetadata.isPlayable shouldBe false
@@ -371,37 +339,50 @@ class BrowseTreeProviderTest {
 
     private fun makeProvider(
         continueListeningBooks: List<ContinueListeningBook> = emptyList(),
-        allBooks: List<BookEntity> = emptyList(),
-        downloadsByBookId: Map<String, List<DownloadEntity>> = emptyMap(),
-        allSeries: List<SeriesEntity> = emptyList(),
+        downloadedBooks: List<DownloadedBookSummary> = emptyList(),
+        allSeries: List<Series> = emptyList(),
         seriesWithBooksById: Map<String, SeriesWithBooks> = emptyMap(),
-        allContributors: List<ContributorEntity> = emptyList(),
+        allContributors: List<Contributor> = emptyList(),
         bookIdsForContributor: Map<String, List<String>> = emptyMap(),
-        contributorsById: Map<String, ContributorEntity> = emptyMap(),
-        booksById: Map<String, BookEntity> = emptyMap(),
-    ): BrowseTreeProvider =
-        BrowseTreeProvider(
-            homeRepository =
-                FakeHomeRepository(continueListeningBooks),
-            bookDao =
-                FakeBookDao(
-                    allBooks = allBooks,
-                    booksById = booksById,
-                ),
-            seriesDao =
-                FakeSeriesDao(
-                    allSeries = allSeries,
-                    seriesWithBooksById = seriesWithBooksById,
-                ),
-            contributorDao =
-                FakeContributorDao(
-                    allContributors = allContributors,
-                    bookIdsForContributor = bookIdsForContributor,
-                    contributorsById = contributorsById,
-                ),
-            downloadDao = FakeDownloadDao(downloadsByBookId),
+        contributorsById: Map<String, Contributor> = emptyMap(),
+        booksById: Map<String, BookListItem> = emptyMap(),
+    ): BrowseTreeProvider {
+        val bookRepository = mock<BookRepository>()
+        everySuspend { bookRepository.getBookListItem(any()) } returns null
+        booksById.forEach { (id, book) ->
+            everySuspend { bookRepository.getBookListItem(id) } returns book
+        }
+
+        val seriesRepository = mock<SeriesRepository>()
+        every { seriesRepository.observeAll() } returns flowOf(allSeries)
+        every { seriesRepository.observeSeriesWithBooks(any()) } returns flowOf(null)
+        seriesWithBooksById.forEach { (id, value) ->
+            every { seriesRepository.observeSeriesWithBooks(id) } returns flowOf(value)
+        }
+
+        val contributorRepository = mock<ContributorRepository>()
+        every { contributorRepository.observeAll() } returns flowOf(allContributors)
+        everySuspend { contributorRepository.getById(any()) } returns null
+        everySuspend { contributorRepository.getBookIdsForContributor(any()) } returns emptyList()
+        contributorsById.forEach { (id, value) ->
+            everySuspend { contributorRepository.getById(id) } returns value
+        }
+        bookIdsForContributor.forEach { (id, ids) ->
+            everySuspend { contributorRepository.getBookIdsForContributor(id) } returns ids
+        }
+
+        val downloadRepository = mock<DownloadRepository>()
+        every { downloadRepository.observeDownloadedBooks() } returns flowOf(downloadedBooks)
+
+        return BrowseTreeProvider(
+            homeRepository = FakeHomeRepository(continueListeningBooks),
+            bookRepository = bookRepository,
+            seriesRepository = seriesRepository,
+            contributorRepository = contributorRepository,
+            downloadRepository = downloadRepository,
             imageStorage = FakeImageStorage(),
         )
+    }
 
     private fun makeContinueListeningBook(
         bookId: String,
@@ -419,65 +400,48 @@ class BrowseTreeProviderTest {
         lastPlayedAt = "2024-01-01T12:00:00Z",
     )
 
-    private fun makeBookEntity(
+    private fun makeBookListItem(
         id: String,
         title: String,
-    ) = BookEntity(
+    ) = BookListItem(
         id = BookId(id),
         libraryId = TEST_LIBRARY_ID,
         folderId = TEST_FOLDER_ID,
         title = title,
-        sortTitle = null,
-        subtitle = null,
-        coverHash = null,
-        coverBlurHash = null,
-        totalDuration = 7_200_000L,
-        createdAt = EPOCH,
+        authors = emptyList(),
+        narrators = emptyList(),
+        duration = 7_200_000L,
+        coverPath = null,
+        addedAt = EPOCH,
         updatedAt = EPOCH,
     )
 
-    private fun makeSeriesEntity(
+    private fun makeSeries(
         id: String,
         name: String,
-    ) = SeriesEntity(
+    ) = Series(
         id = SeriesId(id),
         name = name,
-        description = null,
-        createdAt = EPOCH,
-        updatedAt = EPOCH,
     )
 
-    private fun makeContributorEntity(
+    private fun makeContributor(
         id: String,
         name: String,
-    ) = ContributorEntity(
+    ) = Contributor(
         id = ContributorId(id),
         name = name,
-        sortName = null,
-        asin = null,
-        description = null,
-        imagePath = null,
-        createdAt = EPOCH,
-        updatedAt = EPOCH,
     )
 
-    private fun makeDownloadEntity(
+    private fun makeDownloadedBookSummary(
         bookId: String,
-        audioFileId: String,
-        state: DownloadState,
-    ) = DownloadEntity(
-        audioFileId = audioFileId,
+        title: String,
+    ) = DownloadedBookSummary(
         bookId = bookId,
-        filename = "audio.mp3",
-        fileIndex = 0,
-        state = state,
-        localPath = if (state == DownloadState.COMPLETED) "/data/$bookId/audio.mp3" else null,
-        totalBytes = 10_000_000L,
-        downloadedBytes = if (state == DownloadState.COMPLETED) 10_000_000L else 0L,
-        queuedAt = 1_700_000_000_000L,
-        startedAt = null,
-        completedAt = if (state == DownloadState.COMPLETED) 1_700_000_001_000L else null,
-        errorMessage = null,
+        title = title,
+        authorNames = "An Author",
+        coverBlurHash = null,
+        sizeBytes = 10_000_000L,
+        fileCount = 1,
     )
 
     companion object {
@@ -488,7 +452,7 @@ class BrowseTreeProviderTest {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// In-memory fakes for :shared DAO and repository interfaces
+// In-memory fake for the HomeRepository interface (mokkery-free, list-backed)
 // ──────────────────────────────────────────────────────────────────────────────
 
 private class FakeHomeRepository(
@@ -497,236 +461,6 @@ private class FakeHomeRepository(
     override suspend fun getContinueListening(limit: Int): AppResult<List<ContinueListeningBook>> = AppResult.Success(books.take(limit))
 
     override fun observeContinueListening(limit: Int): Flow<List<ContinueListeningItem>> = flowOf(books.take(limit).map { book -> ContinueListeningItem.Ready(bookId = book.bookId, book = book) })
-}
-
-private class FakeBookDao(
-    private val allBooks: List<BookEntity> = emptyList(),
-    private val booksById: Map<String, BookEntity> = emptyMap(),
-) : BookDao {
-    override suspend fun getAllLive(): List<BookEntity> = allBooks
-
-    override suspend fun getById(id: BookId): BookEntity? = booksById[id.value]
-
-    override suspend fun upsert(book: BookEntity) = Unit
-
-    override suspend fun upsertAll(books: List<BookEntity>) = Unit
-
-    override suspend fun count(): Int = allBooks.size
-
-    override fun observeAllWithContributors(): Flow<List<BookWithContributors>> = flowOf(emptyList())
-
-    override suspend fun getByIdWithContributors(id: BookId): BookWithContributors? = null
-
-    override fun observeByIdWithContributors(id: BookId): Flow<BookWithContributors?> = flowOf(null)
-
-    override suspend fun getByIdsWithContributors(ids: List<BookId>): List<BookWithContributors> = emptyList()
-
-    override fun observeByIdsWithContributors(ids: List<BookId>): Flow<List<BookWithContributors>> = flowOf(emptyList())
-
-    override suspend fun deleteById(id: BookId) = Unit
-
-    override suspend fun deleteByIds(ids: List<BookId>) = Unit
-
-    override suspend fun deleteAll() = Unit
-
-    override suspend fun updateRevisionAndTimestamp(
-        id: BookId,
-        revision: Long,
-        updatedAt: Timestamp,
-    ) = Unit
-
-    override suspend fun softDelete(
-        id: BookId,
-        deletedAt: Long,
-        revision: Long,
-    ) = Unit
-
-    override suspend fun touchUpdatedAt(
-        id: BookId,
-        timestamp: Timestamp,
-    ) = Unit
-
-    override fun observeBySeriesId(seriesId: String): Flow<List<BookEntity>> = flowOf(emptyList())
-
-    override fun observeBySeriesIdWithContributors(seriesId: String): Flow<List<BookWithContributors>> = flowOf(emptyList())
-
-    override fun observeByContributorAndRole(
-        contributorId: String,
-        role: String,
-    ): Flow<List<BookWithContributors>> = flowOf(emptyList())
-
-    override fun observeRecentlyAdded(limit: Int): Flow<List<BookEntity>> = flowOf(emptyList())
-
-    override fun observeRandomUnstartedBooks(limit: Int): Flow<List<BookEntity>> = flowOf(emptyList())
-
-    override fun observeRecentlyAddedWithAuthor(limit: Int): Flow<List<DiscoveryBookWithAuthor>> = flowOf(emptyList())
-
-    override fun observeRandomUnstartedBooksWithAuthor(limit: Int): Flow<List<DiscoveryBookWithAuthor>> = flowOf(emptyList())
-
-    override fun observeUnstartedCandidatesWithSeries(): Flow<List<DiscoveryBookWithSeries>> = flowOf(emptyList())
-
-    override suspend fun getBookSummary(id: String): BookSummary? = null
-
-    override suspend fun liveIds(): List<String> = allBooks.map { it.id.value }
-
-    override suspend fun tombstoneNotIn(
-        accessibleIds: Collection<String>,
-        now: Long,
-    ) = Unit
-
-    override suspend fun digestRows(max: Long): List<com.calypsan.listenup.client.data.local.db.IdRevision> = emptyList()
-}
-
-private class FakeSeriesDao(
-    private val allSeries: List<SeriesEntity> = emptyList(),
-    private val seriesWithBooksById: Map<String, SeriesWithBooks> = emptyMap(),
-) : SeriesDao {
-    override suspend fun getAll(): List<SeriesEntity> = allSeries
-
-    override suspend fun getByIdWithBooks(id: String): SeriesWithBooks? = seriesWithBooksById[id]
-
-    override suspend fun getById(id: String): SeriesEntity? = allSeries.firstOrNull { it.id.value == id }
-
-    override fun observeAll(): Flow<List<SeriesEntity>> = flowOf(allSeries)
-
-    override fun observeById(id: String): Flow<SeriesEntity?> = flowOf(allSeries.firstOrNull { it.id.value == id })
-
-    override fun observeByBookId(bookId: String): Flow<SeriesEntity?> = flowOf(null)
-
-    override suspend fun getBookIdsForSeries(seriesId: String): List<String> = emptyList()
-
-    override fun observeBookIdsForSeries(seriesId: String): Flow<List<String>> = flowOf(emptyList())
-
-    override suspend fun upsert(series: SeriesEntity) = Unit
-
-    override suspend fun upsertAll(series: List<SeriesEntity>) = Unit
-
-    override suspend fun deleteById(id: String) = Unit
-
-    override fun observeAllWithBooks(): Flow<List<SeriesWithBooks>> = flowOf(emptyList())
-
-    override fun observeByIdWithBooks(id: String): Flow<SeriesWithBooks?> = flowOf(null)
-
-    override suspend fun count(): Int = allSeries.size
-
-    override suspend fun deleteAll() = Unit
-
-    override suspend fun softDelete(
-        id: SeriesId,
-        deletedAt: Long,
-        revision: Long,
-    ) = Unit
-
-    override suspend fun digestRows(max: Long): List<com.calypsan.listenup.client.data.local.db.IdRevision> = emptyList()
-}
-
-private class FakeContributorDao(
-    private val allContributors: List<ContributorEntity> = emptyList(),
-    private val bookIdsForContributor: Map<String, List<String>> = emptyMap(),
-    private val contributorsById: Map<String, ContributorEntity> = emptyMap(),
-) : ContributorDao {
-    override suspend fun getAll(): List<ContributorEntity> = allContributors
-
-    override suspend fun getById(id: String): ContributorEntity? = contributorsById[id] ?: allContributors.firstOrNull { it.id.value == id }
-
-    override suspend fun getBookIdsForContributor(contributorId: String): List<String> = bookIdsForContributor[contributorId] ?: emptyList()
-
-    override fun observeAll(): Flow<List<ContributorEntity>> = flowOf(allContributors)
-
-    override fun observeAllWithAliases(): Flow<List<ContributorWithAliases>> = flowOf(emptyList())
-
-    override fun observeByIdWithAliases(id: String): Flow<ContributorWithAliases?> = flowOf(null)
-
-    override suspend fun getByIdWithAliases(id: String): ContributorWithAliases? = null
-
-    override suspend fun upsert(contributor: ContributorEntity) = Unit
-
-    override suspend fun upsertAll(contributors: List<ContributorEntity>) = Unit
-
-    override suspend fun deleteById(id: String) = Unit
-
-    override fun observeByRoleWithCount(role: String): Flow<List<com.calypsan.listenup.client.data.local.db.ContributorWithBookCount>> = flowOf(emptyList())
-
-    override fun observeById(id: String): Flow<ContributorEntity?> = flowOf(null)
-
-    override fun observeRolesWithCountForContributor(contributorId: String): Flow<List<com.calypsan.listenup.client.data.local.db.RoleWithBookCount>> = flowOf(emptyList())
-
-    override suspend fun count(): Int = allContributors.size
-
-    override suspend fun deleteAll() = Unit
-
-    override suspend fun softDelete(
-        id: ContributorId,
-        deletedAt: Long,
-        revision: Long,
-    ) = Unit
-
-    override fun observeByBookId(bookId: String): Flow<List<ContributorEntity>> = flowOf(emptyList())
-
-    override suspend fun getByBookId(bookId: String): List<ContributorEntity> = emptyList()
-
-    override fun observeBookIdsForContributor(contributorId: String): Flow<List<String>> = flowOf(bookIdsForContributor[contributorId] ?: emptyList())
-
-    override suspend fun digestRows(max: Long): List<com.calypsan.listenup.client.data.local.db.IdRevision> = emptyList()
-}
-
-private class FakeDownloadDao(
-    private val downloadsByBookId: Map<String, List<DownloadEntity>> = emptyMap(),
-) : DownloadDao {
-    override suspend fun getForBook(bookId: String): List<DownloadEntity> = downloadsByBookId[bookId] ?: emptyList()
-
-    override fun observeForBook(bookId: String): Flow<List<DownloadEntity>> = flowOf(emptyList())
-
-    override fun observeAll(): Flow<List<DownloadEntity>> = flowOf(emptyList())
-
-    override suspend fun getByAudioFileId(audioFileId: String): DownloadEntity? = null
-
-    override suspend fun getIncomplete(): List<DownloadEntity> = emptyList()
-
-    override suspend fun getLocalPath(audioFileId: String): String? = null
-
-    override suspend fun insert(download: DownloadEntity) = Unit
-
-    override suspend fun insertAll(downloads: List<DownloadEntity>) = Unit
-
-    override suspend fun updateState(
-        audioFileId: String,
-        state: DownloadState,
-        startedAt: Long?,
-    ) = Unit
-
-    override suspend fun updateStateForBookExcluding(
-        bookId: String,
-        newState: DownloadState,
-        excludeState: DownloadState,
-    ) = Unit
-
-    override suspend fun updateProgress(
-        audioFileId: String,
-        downloaded: Long,
-        total: Long,
-    ) = Unit
-
-    override suspend fun markCompletedWithState(
-        audioFileId: String,
-        localPath: String,
-        completedAt: Long,
-        state: DownloadState,
-    ) = Unit
-
-    override suspend fun updateErrorWithState(
-        audioFileId: String,
-        error: String,
-        state: DownloadState,
-    ) = Unit
-
-    override suspend fun markDeletedForBook(bookId: String) = Unit
-
-    override suspend fun hasDeletedRecords(bookId: String): Boolean = false
-
-    override suspend fun deleteForBook(bookId: String) = Unit
-
-    override suspend fun deleteAll() = Unit
 }
 
 /** [ImageStorage] fake that reports no cover exists for any book. */

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/PlaybackModuleVerifyTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/PlaybackModuleVerifyTest.kt
@@ -1,25 +1,18 @@
 package com.calypsan.listenup.client.di
 
 import android.content.Context
-import com.calypsan.listenup.client.data.local.db.AudioFileDao
-import com.calypsan.listenup.client.data.local.db.BookDao
-import com.calypsan.listenup.client.data.local.db.ChapterDao
-import com.calypsan.listenup.client.data.local.db.ContributorDao
-import com.calypsan.listenup.client.data.local.db.DownloadDao
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
-import com.calypsan.listenup.client.data.local.db.SeriesDao
-import com.calypsan.listenup.client.data.local.db.TentativeSpanDao
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.ContributorRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.domain.repository.SeriesRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.playback.PlaybackManager
@@ -62,15 +55,8 @@ class PlaybackModuleVerifyTest :
                         ApiClientFactory::class,
                         ImageStorage::class,
                         PlaybackManager::class,
-                        BookDao::class,
-                        AudioFileDao::class,
-                        ChapterDao::class,
-                        ContributorDao::class,
-                        SeriesDao::class,
-                        DownloadDao::class,
-                        ListeningEventDao::class,
-                        TentativeSpanDao::class,
-                        PlaybackPositionDao::class,
+                        ContributorRepository::class,
+                        SeriesRepository::class,
                     ),
             )
         }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.core.ImageLoaderFactory
 import com.calypsan.listenup.api.dto.auth.DeviceInfo
 import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.notifications.NotificationChannels
+import com.calypsan.listenup.client.di.androidPlaybackModule
 import com.calypsan.listenup.client.di.playbackPresentationModule
 import com.calypsan.listenup.client.di.sharedModules
 import com.calypsan.listenup.client.download.AndroidDownloadEnqueuer
@@ -41,7 +42,6 @@ import com.calypsan.listenup.client.playback.asControllerHolder
 import com.calypsan.listenup.client.playback.PlaybackController
 import com.calypsan.listenup.client.playback.PlaybackErrorHandler
 import com.calypsan.listenup.client.playback.PlaybackManager
-import com.calypsan.listenup.client.playback.PlaybackManagerImpl
 import com.calypsan.listenup.client.playback.PlaybackStateWriter
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
@@ -204,26 +204,6 @@ val playbackModule =
             )
         }
 
-        // Playback manager - orchestrates playback startup
-        single<PlaybackManager> {
-            PlaybackManagerImpl(
-                serverConfig = get(),
-                playbackPreferences = get(),
-                bookDao = get(),
-                audioFileDao = get(),
-                chapterDao = get(),
-                imageStorage = get(),
-                progressTracker = get(),
-                tokenProvider = get(),
-                deviceContext = get(),
-                downloadService = get(),
-                playbackRpcFactory = get(),
-                syncApi = get(),
-                scope = get(),
-                bookIngestPort = get(),
-            )
-        }
-
         // Bind the PlaybackStateWriter write-seam to the same PlaybackManager
         // singleton. MediaControllerHolder depends on PlaybackStateWriter (not the
         // full PlaybackManager), and Koin resolves by the requested type — without
@@ -337,7 +317,10 @@ class ListenUp :
             androidContext(this@ListenUp)
 
             // Load all shared and Android-specific modules
-            modules(sharedModules + androidModule + playbackModule + playbackPresentationModule + downloadModule)
+            modules(
+                sharedModules + androidModule + playbackModule + androidPlaybackModule + playbackPresentationModule +
+                    downloadModule,
+            )
         }
 
         // Configure WorkManager with custom factory for dependency injection.

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -239,10 +239,10 @@ val playbackModule =
         single {
             BrowseTreeProvider(
                 homeRepository = get(),
-                bookDao = get(),
-                seriesDao = get(),
-                contributorDao = get(),
-                downloadDao = get(),
+                bookRepository = get(),
+                seriesRepository = get(),
+                contributorRepository = get(),
+                downloadRepository = get(),
                 imageStorage = get(),
             )
         }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -20,16 +20,12 @@ import com.calypsan.listenup.core.ImageLoaderFactory
 import com.calypsan.listenup.api.dto.auth.DeviceInfo
 import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.notifications.NotificationChannels
+import com.calypsan.listenup.client.di.androidDownloadModule
 import com.calypsan.listenup.client.di.androidPlaybackModule
 import com.calypsan.listenup.client.di.playbackPresentationModule
 import com.calypsan.listenup.client.di.sharedModules
-import com.calypsan.listenup.client.download.AndroidDownloadEnqueuer
-import com.calypsan.listenup.client.download.DownloadEnqueuer
-import com.calypsan.listenup.client.download.DownloadFileManager
-import com.calypsan.listenup.client.download.DownloadManager
 import com.calypsan.listenup.client.features.bookdetail.AndroidBookDetailPlatformActions
 import com.calypsan.listenup.client.features.bookdetail.BookDetailPlatformActions
-import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.ListenUpWorkerFactory
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.shortcuts.ListenUpShortcutManager
@@ -246,41 +242,13 @@ val playbackModule =
     }
 
 /**
- * Download module for offline audiobook downloads.
- * Contains download management and file storage components.
+ * UI-facing download wiring. The DB-touching bindings (`DownloadFileManager`,
+ * `DownloadManager`, `AndroidDownloadEnqueuer`) live in `:sharedLogic`'s
+ * [androidDownloadModule] so they can construct against the `internal` Room DAOs;
+ * this module keeps only the `:sharedUI`-coupled platform-actions binding.
  */
 val downloadModule =
     module {
-        // Download file manager - handles local file operations
-        single { DownloadFileManager(androidContext()) }
-
-        // Download manager - coordinates download queue and state
-        // Bound to DownloadService interface for shared code (PlaybackManager)
-        // Uses localPreferences for WiFi-only download constraint
-        single<DownloadService> {
-            DownloadManager(
-                downloadDao = get(),
-                bookDao = get(),
-                audioFileDao = get(),
-                workManager = WorkManager.getInstance(androidContext()),
-                fileManager = get(),
-                localPreferences = get<com.calypsan.listenup.client.domain.repository.LocalPreferences>(),
-                downloadRepository = get(),
-                transactionRunner = get(),
-            )
-        }
-
-        // Also expose the concrete type for Android-specific features
-        single { get<DownloadService>() as DownloadManager }
-
-        // DownloadEnqueuer seam — Android backend for DownloadRepository.resumeIncompleteDownloads
-        single<DownloadEnqueuer> {
-            AndroidDownloadEnqueuer(
-                workManager = WorkManager.getInstance(androidContext()),
-                localPreferences = get(),
-            )
-        }
-
         // Platform actions for BookDetailScreen (download + playback integration)
         single<BookDetailPlatformActions> {
             AndroidBookDetailPlatformActions(
@@ -319,7 +287,7 @@ class ListenUp :
             // Load all shared and Android-specific modules
             modules(
                 sharedModules + androidModule + playbackModule + androidPlaybackModule + playbackPresentationModule +
-                    downloadModule,
+                    androidDownloadModule + downloadModule,
             )
         }
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
@@ -5,15 +5,15 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.client.data.local.db.BookDao
-import com.calypsan.listenup.client.data.local.db.ContributorDao
-import com.calypsan.listenup.client.data.local.db.DownloadDao
-import com.calypsan.listenup.client.data.local.db.DownloadState
-import com.calypsan.listenup.client.data.local.db.SeriesDao
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.ContributorRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.SeriesRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.first
 
 private val logger = KotlinLogging.logger {}
 
@@ -33,10 +33,10 @@ private const val MAX_ITEMS_PER_LEVEL = 8
  */
 class BrowseTreeProvider(
     private val homeRepository: HomeRepository,
-    private val bookDao: BookDao,
-    private val seriesDao: SeriesDao,
-    private val contributorDao: ContributorDao,
-    private val downloadDao: DownloadDao,
+    private val bookRepository: BookRepository,
+    private val seriesRepository: SeriesRepository,
+    private val contributorRepository: ContributorRepository,
+    private val downloadRepository: DownloadRepository,
     private val imageStorage: ImageStorage,
 ) {
     /**
@@ -178,35 +178,17 @@ class BrowseTreeProvider(
         return result.data.map { book -> createPlayableBookItem(book) }
     }
 
-    private suspend fun getDownloadedBooks(): List<MediaItem> {
-        // Get all downloads and find fully downloaded books
-        // For now, use a simpler approach - get books that have completed downloads
-        val books = bookDao.getAllLive()
-        val downloadedBookIds = mutableSetOf<String>()
-
-        // Check each book's download status
-        for (book in books) {
-            val bookDownloads = downloadDao.getForBook(book.id.value)
-            if (bookDownloads.isNotEmpty() && bookDownloads.all { it.state == DownloadState.COMPLETED }) {
-                downloadedBookIds.add(book.id.value)
-            }
-        }
-
-        return books
-            .filter { it.id.value in downloadedBookIds }
+    private suspend fun getDownloadedBooks(): List<MediaItem> =
+        downloadRepository
+            .observeDownloadedBooks()
+            .first()
             .take(MAX_ITEMS_PER_LEVEL)
-            .map { book ->
-                createPlayableBookItemFromEntity(
-                    bookId = book.id.value,
-                    title = book.title,
-                    subtitle = null,
-                )
-            }
-    }
+            .map { book -> createBookMediaItem(bookId = book.bookId, title = book.title, subtitle = null) }
 
-    private suspend fun getSeriesList(): List<MediaItem> {
-        val seriesWithCount = seriesDao.getAll()
-        return seriesWithCount
+    private suspend fun getSeriesList(): List<MediaItem> =
+        seriesRepository
+            .observeAll()
+            .first()
             .take(MAX_ITEMS_PER_LEVEL)
             .map { series ->
                 createBrowsableItem(
@@ -215,11 +197,11 @@ class BrowseTreeProvider(
                     mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
                 )
             }
-    }
 
-    private suspend fun getAuthorsList(): List<MediaItem> {
-        val authors = contributorDao.getAll()
-        return authors
+    private suspend fun getAuthorsList(): List<MediaItem> =
+        contributorRepository
+            .observeAll()
+            .first()
             .take(MAX_ITEMS_PER_LEVEL)
             .map { author ->
                 createBrowsableItem(
@@ -228,7 +210,6 @@ class BrowseTreeProvider(
                     mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
                 )
             }
-    }
 
     // ========== Dynamic Nodes ==========
 
@@ -247,32 +228,23 @@ class BrowseTreeProvider(
     }
 
     private suspend fun getBooksInSeries(seriesId: String): List<MediaItem> {
-        val series = seriesDao.getByIdWithBooks(seriesId) ?: return emptyList()
+        val series = seriesRepository.observeSeriesWithBooks(seriesId).first() ?: return emptyList()
         return series.books
             .take(MAX_ITEMS_PER_LEVEL)
             .map { book ->
-                createPlayableBookItemFromEntity(
-                    bookId = book.id.value,
-                    title = book.title,
-                    subtitle = series.series.name,
-                )
+                createBookMediaItem(bookId = book.id.value, title = book.title, subtitle = series.series.name)
             }
     }
 
     private suspend fun getBooksByAuthor(authorId: String): List<MediaItem> {
-        val bookIds = contributorDao.getBookIdsForContributor(authorId)
-        val author = contributorDao.getById(authorId)
-        val authorName = author?.name
+        val bookIds = contributorRepository.getBookIdsForContributor(authorId)
+        val authorName = contributorRepository.getById(authorId)?.name
 
         return bookIds
             .take(MAX_ITEMS_PER_LEVEL)
             .mapNotNull { bookId ->
-                val book = bookDao.getById(BookId(bookId)) ?: return@mapNotNull null
-                createPlayableBookItemFromEntity(
-                    bookId = book.id.value,
-                    title = book.title,
-                    subtitle = authorName,
-                )
+                val book = bookRepository.getBookListItem(bookId) ?: return@mapNotNull null
+                createBookMediaItem(bookId = book.id.value, title = book.title, subtitle = authorName)
             }
     }
 
@@ -282,12 +254,8 @@ class BrowseTreeProvider(
      * Used by voice search to return search results.
      */
     suspend fun getBookItem(bookId: String): MediaItem? {
-        val book = bookDao.getById(BookId(bookId)) ?: return null
-        return createPlayableBookItemFromEntity(
-            bookId = book.id.value,
-            title = book.title,
-            subtitle = null,
-        )
+        val book = bookRepository.getBookListItem(bookId) ?: return null
+        return createBookMediaItem(bookId = book.id.value, title = book.title, subtitle = null)
     }
 
     // ========== Item Builders ==========
@@ -330,7 +298,7 @@ class BrowseTreeProvider(
             ).build()
     }
 
-    private fun createPlayableBookItemFromEntity(
+    private fun createBookMediaItem(
         bookId: String,
         title: String,
         subtitle: String?,

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -4,10 +4,8 @@ import com.calypsan.listenup.api.dto.auth.DeviceInfo
 import com.calypsan.listenup.core.IODispatcher
 import com.calypsan.listenup.client.features.bookdetail.BookDetailPlatformActions
 import com.calypsan.listenup.client.features.bookdetail.DesktopBookDetailPlatformActions
-import com.calypsan.listenup.client.download.DownloadEnqueuer
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
-import com.calypsan.listenup.client.download.JvmDownloadEnqueuer
 import com.calypsan.listenup.client.platform.DesktopAudioTokenProvider
 import com.calypsan.listenup.client.platform.StubBackgroundSyncScheduler
 import com.calypsan.listenup.client.platform.StubDownloadService
@@ -95,8 +93,8 @@ val platformModule: Module =
         // Download service (stub)
         single<DownloadService> { StubDownloadService() }
 
-        // DownloadEnqueuer seam — Desktop no-op (downloads not supported)
-        single<DownloadEnqueuer> { JvmDownloadEnqueuer() }
+        // DownloadEnqueuer seam (Desktop no-op) is bound in `:sharedLogic`'s
+        // `desktopDownloadModule` so the now-`internal` `DownloadEntity` need not be public.
 
         // Progress tracker
         single {

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -16,8 +16,6 @@ import com.calypsan.listenup.client.playback.AudioPlayer
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.DesktopPlaybackController
 import com.calypsan.listenup.client.playback.PlaybackController
-import com.calypsan.listenup.client.playback.PlaybackManager
-import com.calypsan.listenup.client.playback.PlaybackManagerImpl
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
 import com.calypsan.listenup.client.playback.FfmpegAudioPlayer
@@ -126,26 +124,6 @@ val platformModule: Module =
         single {
             SleepTimerManager(
                 scope = get(qualifier = named("playbackScope")),
-            )
-        }
-
-        // Playback manager
-        single<PlaybackManager> {
-            PlaybackManagerImpl(
-                serverConfig = get(),
-                playbackPreferences = get(),
-                bookDao = get(),
-                audioFileDao = get(),
-                chapterDao = get(),
-                imageStorage = get(),
-                progressTracker = get(),
-                tokenProvider = get(),
-                downloadService = get(),
-                playbackRpcFactory = get(),
-                syncApi = get(),
-                deviceContext = get(),
-                scope = get(qualifier = named("playbackScope")),
-                bookIngestPort = get(),
             )
         }
 


### PR DESCRIPTION
## Summary

Increment 5 of the client export-surface trim (after #682/#684/#685/#686), and **part 2 of the "DB-unlock"** — it completes it. Makes the `:sharedLogic` `com.calypsan.listenup.client.data.local.db` package `internal`: all 23 DAOs, 31 `@Entity` classes, their relation/projection types, and `ListenUpDatabase` itself now leave **every** client export path (iOS framework, the planned Swift Export, JS, R8). `internal` is the export-mechanism-agnostic lever (per #685).

## How: two seams, then the flip

`data.local.db` was public only because `BrowseTreeProvider` (Android Auto) named DAOs/entities and a couple of `:sharedUI` DI bindings inferred `get<BookDao>()`.

- **Seam 1** — `BrowseTreeProvider` rewritten to consume the existing public `domain/repository` interfaces (`Book`/`Series`/`Contributor`/`DownloadRepository`), `.first()` on the observe-flows for one-shot browse reads. **Zero new public surface** (the repos already covered every read), and it **removed an N+1 query** from the Android Auto path. Its test was rebuilt from hand-written DAO fakes to mokkery repo mocks.
- **Seam 2** — the `PlaybackManagerImpl` Koin binding moved out of `:sharedUI` into new `:sharedLogic` per-platform modules (`androidPlaybackModule`/`desktopPlaybackModule`), preserving each platform's scope qualifier (apple binds none — native Swift owns playback).
- **The flip** — `scripts/internalize.sh` + the Kotlin compiler as oracle. **100% clean — empty Konsist allowList.** The `DownloadEntity`/`DownloadState` pair that initially had to stay public (a `DownloadEnqueuer.enqueue(DownloadEntity)` exposure) was reclaimed by relocating the desktop `DownloadEnqueuer` binding into `:sharedLogic` (mirroring Seam 2). The compiler-forced cascade also internalized the download enqueuers, `DownloadManager`, `PlaybackManagerImpl`/`PlaybackPreparer`, `BookIngestPort`, and several ViewModel constructors — each confirmed same-module. New `DataLocalDbIsInternalRule` Konsist pin.

## ⚠️ Behavior change to ratify (Android Auto "Downloaded" node)

The "Downloaded" browse node now uses the **app-wide** `DownloadRepository.observeDownloadedBooks()` definition — a book appears if it has **any** completed file — whereas the old provider-local logic required **all** files complete. This is a deliberate consistency change (one definition of "downloaded," shared with the storage UI), but it's a real UX shift: a partially-downloaded book can now appear as playable in the car. Routing through the shared definition is the architecturally correct move (keeping the old logic would mean keeping DAO filtering in the UI, defeating the seam), but it deserves an explicit sign-off. The Auto nodes also now take a one-shot `.first()` snapshot of the observe-flows (correct for a browse pull).

## Verification

Gate green: `:sharedLogic:jvmTest` (incl. the new Konsist rule + all DI `*VerifyTest`s) + `:androidApp:assembleDebug` + `:androidApp` unit tests + `:sharedUI` androidHostTest + `spotlessCheck` + `detekt`. Crucially, the DI-verify + `BrowseTreeProviderTest` were **run** (not just compiled) — a mid-effort finding showed the gate compiles host tests without running them, which can hide runtime Koin `verify()` failures. iOS/desktop validate on CI (don't build on Linux); grep confirms zero `data.local.db` code references survive outside `:sharedLogic`.

## Follow-ups (non-blocking)

- Add `verify()` coverage for the moved per-platform modules (`androidPlaybackModule`/`androidDownloadModule`/desktop) — currently covered only at app-assembly, a pre-existing pattern gap.
- Reconcile `DownloadedBookSummary`'s "fully downloaded" KDoc with its "any completed file" impl, and decide whether the Auto node wants a stricter "fully downloaded" predicate (ties to the behavior change above).
- (Separate / Inc-4) The 4 `data.sync` types still public via `ConnectionCoordinator`/`ActivityFeedViewModel` — reclaim by moving those behind a domain seam.