### PR TITLE
🔒 refactor(shared): reclaim the last 4 data.sync types — empty the allowList (Increment 6)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinator.kt
@@ -42,7 +42,7 @@ private val logger = KotlinLogging.logger {}
  *   stale RPC proxy caches (see [start]). Defaults to an idle holder so existing call sites that
  *   don't drive reconnects (tests) need no change; production wires the live engine state.
  */
-class ConnectionCoordinator(
+class ConnectionCoordinator internal constructor(
     private val serverConfig: ServerConfig,
     private val instanceRepository: InstanceRepository,
     private val discoveryService: ServerDiscoveryService,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ActivityRefreshSignal.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ActivityRefreshSignal.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.asSharedFlow
  * `ActivityChanged` nudge or on firehose reconnect. The activity-feed repository re-fetches
  * the feed head on each ping.
  */
-class ActivityRefreshSignal {
+internal class ActivityRefreshSignal {
     private val flow = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
 
     /** Hot stream of activity-changed pings. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineState.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
 /** Connection state for the SSE firehose. */
-sealed interface ConnectionState {
+internal sealed interface ConnectionState {
     /** Not connected. [reason] is null at engine start, populated on disconnect. */
     data class Disconnected(
         val reason: String?,
@@ -32,7 +32,7 @@ sealed interface ConnectionState {
  * silence is appropriate for normal recovery, signal is appropriate for sustained
  * failure. UI consumes this; below threshold UI shows nothing.
  */
-data class EngineSnapshot(
+internal data class EngineSnapshot(
     val connection: ConnectionState = ConnectionState.Disconnected(reason = null),
     val recentErrorCount: Int = 0,
     val lastSuccessAtMillis: Long? = null,
@@ -48,7 +48,7 @@ private const val SUCCESS_AGE_THRESHOLD_SECONDS = 60L
  * Mutable state holder for [EngineSnapshot]. Engine components mutate via the
  * `setX` / `recordX` methods; UI reads via [value] / [observe].
  */
-class SyncEngineState {
+internal class SyncEngineState {
     private val flow = MutableStateFlow(EngineSnapshot())
 
     /** Current snapshot. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModel.kt
@@ -41,7 +41,7 @@ private const val MAX_ACTIVITIES = 100
  * @property fetchActivitiesUseCase Use case for fetching activities from the feed RPC
  * @property refreshSignal Pings when the feed may have changed (nudge or reconnect)
  */
-class ActivityFeedViewModel(
+class ActivityFeedViewModel internal constructor(
     private val activityRepository: ActivityRepository,
     private val fetchActivitiesUseCase: FetchActivitiesUseCase,
     private val refreshSignal: ActivityRefreshSignal,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataSyncIsInternalRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataSyncIsInternalRule.kt
@@ -17,17 +17,10 @@ import io.kotest.matchers.collections.shouldBeEmpty
  */
 class DataSyncIsInternalRule :
     FunSpec({
-        // Symbols that must stay public despite living in data.sync (cross-module
-        // consumers documented in the spec's "Flip exceptions"). Empty if the flip was clean.
-        val allowList =
-            setOf(
-                // Exposed by the cross-module-public `data.connection.ConnectionCoordinator`
-                // constructor and `presentation.discover.ActivityFeedViewModel`.
-                "SyncEngineState",
-                "EngineSnapshot",
-                "ConnectionState",
-                "ActivityRefreshSignal",
-            )
+        // Empty — the entire data.sync package is internal, no exceptions. The former 4
+        // (SyncEngineState/EngineSnapshot/ConnectionState/ActivityRefreshSignal) were reclaimed by
+        // narrowing the ConnectionCoordinator + ActivityFeedViewModel constructors to internal.
+        val allowList = emptySet<String>()
 
         test("no top-level declaration in data/sync is public") {
             val scope = Konsist.scopeFromProduction()


### PR DESCRIPTION
## Summary

Increment 6 — the **finish line** of the client export-surface trim (#682/#684/#685/#686/#687). Internalizes the 4 `data.sync` types that #686 (Inc 4) had to leave public — `SyncEngineState`, `EngineSnapshot`, `ConnectionState`, `ActivityRefreshSignal` — so the **entire `data.sync` package is now `internal`** with an **empty `DataSyncIsInternalRule` allowList`. Combined with #687 (`data.local.db` fully internal), both halves of the client data layer are now off every client export path (iOS framework, Swift Export, JS, R8).

## How

The 4 types were forced public *only* by two public constructors exposing them as parameters:
- `ConnectionCoordinator` (`data.connection`) — `engineState: SyncEngineState` (→ transitively `EngineSnapshot` via `observe()`, `ConnectionState` via `EngineSnapshot.connection`).
- `ActivityFeedViewModel` (`presentation.discover`) — `refreshSignal: ActivityRefreshSignal`.

Both are **constructed only inside `:sharedLogic` DI and injected** by their cross-module consumers (`MainActivity` calls `reevaluate()`; sharedUI/iOS use `state`/`refresh()`), so the fix is the established **public-class / `internal constructor`** pattern (same as `PlaybackPreparer` and the ViewModels internalized in prior increments): the classes stay public/injectable, but their constructors no longer leak the now-internal types. Then the 4 types flip to `internal` and the allowList empties. No domain seam, no behavior change.

## iOS-safe (checked up front — the Inc-5 lesson)

The investigation grepped `iosApp/` Swift first: **zero** references to any of the 4 types (the iOS app consumes only `ActivityFeedViewModel`, whose public API never exposes `ActivityRefreshSignal`), and **no SKIE name-collision** (all 4 names unique — no domain twins). So no iOS break is expected. Apple compiles only on CI, so the `Test (iOS)` check is the real verifier.

## Verification

Gate green: `:sharedLogic:jvmTest` (incl. the now-empty-allowList `DataSyncIsInternalRule`) + `:androidApp:assembleDebug` + `:androidApp` unit tests + `:sharedUI` androidHostTest + `spotlessCheck` + `detekt`, **plus running** the DI-verify tests (`ConnectionModuleVerifyTest`/`ClientSyncRenovationModuleVerifyTest`/`PlaybackModuleVerifyTest`) to confirm Koin resolution survives the narrowed constructors (compile-only would miss a runtime `verify()` regression). 0 compiler-oracle errors — the two constructors were the sole forcing.

## Result

The export-surface trim's internalization work is **complete**: `data.sync` and `data.local.db` are both fully `internal`, both Konsist allowLists empty. The only remaining export-surface item is the #684 Apple-CI export-inventory calibration (a verification/CI concern, not a code internalization).