### PR TITLE
🐛 fix(shared): restore the :server auth E2E client via a public createApiClientFactory seam

### DIFF
--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.e2e
 
 import com.calypsan.listenup.core.SecureStorage
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
-import com.calypsan.listenup.client.data.remote.KtorApiClientFactory
+import com.calypsan.listenup.client.data.remote.createApiClientFactory
 import com.calypsan.listenup.client.di.clientAuthModule
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -121,7 +121,7 @@ internal class AuthEndToEndFixture private constructor(
                 single<ServerConfig> { TestServerConfig(baseUrl) }
                 single<InstanceRepository> { StubInstanceRepository() }
                 single<ApiClientFactory> {
-                    KtorApiClientFactory(
+                    createApiClientFactory(
                         serverConfig = get(),
                         authSession = get(),
                         refreshAccessToken = { get<AuthRepository>().refreshAccessToken() },

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -102,6 +102,20 @@ interface ApiClientFactory : RemoteCache {
 }
 
 /**
+ * Creates the production [ApiClientFactory] from its dependencies.
+ *
+ * The concrete implementation ([KtorApiClientFactory]) is `internal`; this is the public seam for
+ * constructing a real client outside `:sharedLogic` — used by full-stack end-to-end tests (e.g. the
+ * `:server` auth E2E fixture) that wire a client against an in-process test server with test-specific
+ * [ServerConfig] / [AuthSession]. Production code uses the Koin `networkModule` binding instead.
+ */
+fun createApiClientFactory(
+    serverConfig: ServerConfig,
+    authSession: AuthSession,
+    refreshAccessToken: RefreshAccessToken,
+): ApiClientFactory = KtorApiClientFactory(serverConfig, authSession, refreshAccessToken)
+
+/**
  * Ktor-backed production [ApiClientFactory].
  *
  * Provides a single cached client instance that:


### PR DESCRIPTION
## Summary

Fixes the **pre-existing red `main`** on `Test (JVM)`. #685 internalized `KtorApiClientFactory`, but `:server`'s auth E2E fixture (`AuthEndToEndFixture` — the *only* client↔server full-stack E2E test) constructs it directly to wire a real client against the in-process test server. So `:server:compileTestKotlinJvm` has been broken since #685 merged — the export-trim gates never compiled `:server`'s test sources (which consume client types for E2E), so it slipped through red.

## Fix

Add a public top-level seam in `:sharedLogic` (`data/remote/ApiClientFactory.kt`) that returns the already-public `ApiClientFactory` **interface** and wraps the still-`internal` `KtorApiClientFactory` impl:

```kotlin
fun createApiClientFactory(
    serverConfig: ServerConfig,
    authSession: AuthSession,
    refreshAccessToken: RefreshAccessToken,
): ApiClientFactory = KtorApiClientFactory(serverConfig, authSession, refreshAccessToken)
```

`AuthEndToEndFixture` now calls `createApiClientFactory(...)` instead of the internal constructor.

**Why this approach:** it matches the codebase's existing `create*` factory idiom (`createStreamingHttpClient`), keeps the impl `internal` (the export surface gains only one factory function returning the public interface — not the impl class), and needs no Gradle plugin. `java-test-fixtures` isn't viable on the KMP `:sharedLogic` module; the other `:server` E2E tests are server-side-only (no client to construct), so there was no existing pattern to copy.

## Verification

`:sharedLogic:jvmTest` + `:server:jvmTest --tests "*AuthEndToEnd*"` + `spotlessCheck` + `detekt` → `BUILD SUCCESSFUL`, **0 compile errors**. The originally-failing `:server:compileTestKotlinJvm` now compiles and the auth E2E test runs green.

## Follow-up

The export-surface increments' gates should have included `:server:compileTestKotlinJvm` (the `:server` test sources consume client types) — worth adding so a future client-internalization can't silently break the server E2E again.