### PR TITLE
🐛 fix(server): persist embedded book covers

### DIFF
--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -162,6 +162,16 @@ class BookPersister internal constructor(
         // This represents every rootRelPath present on disk at scan time.
         val seenPaths = result.books.mapTo(mutableSetOf()) { it.candidate.rootRelPath }
 
+        // The books carried by `result.changes` are artwork-FREE: the Scanner strips Embedded/Spooled
+        // covers off the diff copies (AnalyzedBook.withoutArtwork) so the volatile artwork bytes and
+        // the per-scan spool path never pollute change detection. The cover-bearing copies live in
+        // `result.books`. Persist must read each changed book's cover from there, or every embedded
+        // cover lands as a null cover_source. Keyed by rootRelPath — stable across Added/Modified/Moved.
+        val coverBearingByPath = result.books.associateBy { it.candidate.rootRelPath }
+
+        fun coverBearing(change: AnalyzedBook): AnalyzedBook =
+            coverBearingByPath[change.candidate.rootRelPath] ?: change
+
         // Use the scan result's rootPath for filesystem cover reads — aligned
         // with Analyzer's own path resolution (Analyzer.kt: rootPath.resolve(relPath)).
         val scanRoot = JPath.of(result.rootPath)
@@ -188,20 +198,21 @@ class BookPersister internal constructor(
             if (bookId != null) persisted++ else failed++
         }
 
-        // Persist only the books that actually changed. Added/Modified/Moved each carry the
-        // AnalyzedBook directly in the ChangeEventDto — no join against result.books needed.
+        // Persist only the books that actually changed. Added/Modified/Moved each carry the changed
+        // AnalyzedBook in the ChangeEventDto, but artwork-stripped — so we re-resolve the cover-bearing
+        // copy from result.books (by rootRelPath) before persisting, restoring embedded covers.
         for (change in result.changes) {
             when (change) {
                 is ChangeEventDto.Added -> {
-                    persistCounted(change.book)
+                    persistCounted(coverBearing(change.book))
                 }
 
                 is ChangeEventDto.Modified -> {
-                    persistCounted(change.book)
+                    persistCounted(coverBearing(change.book))
                 }
 
                 is ChangeEventDto.Moved -> {
-                    persistCounted(change.book)
+                    persistCounted(coverBearing(change.book))
                 }
 
                 is ChangeEventDto.Removed -> {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -5,16 +5,19 @@ package com.calypsan.listenup.server.services
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
 import com.calypsan.listenup.api.dto.scanner.CandidateBook
 import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.CoverSource
 import com.calypsan.listenup.api.dto.scanner.FileEntry
 import com.calypsan.listenup.api.dto.scanner.FileType
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanScope
 import com.calypsan.listenup.api.dto.scanner.TrackEntry
+import com.calypsan.listenup.api.dto.scanner.withoutArtwork
 import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.domain.embeddedmeta.EmbeddedArtwork
 import com.calypsan.listenup.server.api.CollectionAccessPolicy
 import com.calypsan.listenup.server.api.CollectionServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider
@@ -61,6 +64,35 @@ class BookPersisterTest :
                     )
 
                     fake.resolved shouldContainExactly listOf("a", "b")
+                }
+            }
+        }
+
+        test("persists the cover-bearing book from ScanResult.books, not the artwork-stripped change") {
+            withSqlDatabase {
+                runTest {
+                    val fake = FakeBookIngest()
+                    val persister = persister(fake, scope = this)
+
+                    // The Scanner puts cover-bearing books in `result.books`, but strips artwork
+                    // from the copies it places in `result.changes` (via withoutArtwork, which nulls
+                    // Embedded/Spooled covers so the volatile artwork never pollutes change detection).
+                    // The persister must source each changed book's cover from `result.books`.
+                    val coverBearing =
+                        analyzedBook("a").copy(
+                            cover = CoverSource.Embedded(EmbeddedArtwork(mime = "image/jpeg", bytes = byteArrayOf(1, 2, 3))),
+                        )
+
+                    persister.persist(
+                        scanResult(
+                            books = listOf(coverBearing),
+                            changes = listOf(ChangeEventDto.Added(coverBearing.withoutArtwork())),
+                            scope = ScanScope.Full,
+                        ),
+                    )
+
+                    // resolveOrInsert must see the cover, not the stripped (null-cover) change copy.
+                    fake.coverByPath["a"] shouldBe coverBearing.cover
                 }
             }
         }
@@ -457,6 +489,9 @@ private class FakeBookIngest(
     /** rootRelPaths successfully resolved, in call order. */
     val resolved = mutableListOf<String>()
 
+    /** The [AnalyzedBook.cover] each [resolveOrInsert] saw, keyed by rootRelPath. */
+    val coverByPath = mutableMapOf<String, CoverSource?>()
+
     /** seenPaths sets passed to each [softDeleteAbsentByPaths] call. */
     val softDeleteAbsentByPathsCalls = mutableListOf<Set<String>>()
 
@@ -478,6 +513,7 @@ private class FakeBookIngest(
     ): AppResult<IngestOutcome> {
         suppressionObserved += currentCoroutineContext()[FirehoseSuppressed.Key] != null
         val path = analyzed.candidate.rootRelPath
+        coverByPath[path] = analyzed.cover
         if (path in oomForRootRelPath) {
             throw OutOfMemoryError("simulated OOM for $path")
         }


### PR DESCRIPTION
## Problem

Embedded book covers (artwork inside the audio file, no sidecar `cover.jpg`) were never persisted — every such book got `cover_source = NULL`, so `GET /api/v1/covers/{id}` correctly 404'd. In a real m4b library that's the large majority of books (observed: 970 of 1164 NULL, only the 194 filesystem covers worked).

## Root cause

`BookPersister.persistAll` persisted `change.book` straight from `ScanResult.changes`. But the Scanner builds `changes` from `booksStripped = books.map { it.withoutArtwork() }`, and `AnalyzedBook.withoutArtwork()` **nulls the cover** for `Embedded`/`Spooled` sources (keeping `Filesystem`) so the volatile artwork bytes and the per-scan spool path never pollute the Differ. The cover-bearing copies live in `ScanResult.books` (the Scanner comment even says *"BookPersister needs these to write covers"*) — but the persister read from `changes`, so embedded covers arrived cover-less.

This is why the split was clean: filesystem covers (kept by `withoutArtwork`) persisted; embedded/spooled covers (nulled) did not.

## Fix

In `persistAll`, re-resolve each changed book's cover from `result.books` by `rootRelPath` before persisting:

```kotlin
val coverBearingByPath = result.books.associateBy { it.candidate.rootRelPath }
fun coverBearing(change: AnalyzedBook) = coverBearingByPath[change.candidate.rootRelPath] ?: change
// Added / Modified / Moved:
persistCounted(coverBearing(change.book))
```

The Differ still diffs the artwork-stripped copies (no false "Modified" from the volatile spool path), and the client `ScanEvent.Change` stream stays artwork-free — only the persist read changed.

## Test

New regression test in `BookPersisterTest` ("persists the cover-bearing book from `ScanResult.books`, not the artwork-stripped change"): a `ScanResult` shaped exactly like the Scanner's output (cover-bearing book in `books`, stripped copy in `changes`) asserts the cover reaches `resolveOrInsert`. RED before the fix (`Expected Embedded(...) but actual was null`), GREEN after.

## Verification

- `BookPersisterTest` (incl. new case), `BookPersistCoverTest`, cover-route + `InboxQuarantineE2ETest`: green
- `:sharedLogic:jvmTest` (E2E drives the real server through persist): green
- `spotlessCheck` + `detekt`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)