### PR TITLE
✨ feat: "Saving library" scan-progress phase (no more frozen 100%)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanPhase.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanPhase.kt
@@ -9,5 +9,6 @@ enum class ScanPhase {
     GROUPING,
     ANALYZING,
     DIFFING,
+    PERSISTING,
     COMPLETED,
 }

--- a/docs/superpowers/specs/2026-06-21-scan-persist-progress-phase-design.md
+++ b/docs/superpowers/specs/2026-06-21-scan-persist-progress-phase-design.md
@@ -1,0 +1,96 @@
+# Scan persist-progress phase — design
+
+## Problem
+
+During the initial library setup, the scan progress screen freezes at 100% for ~25 seconds before
+advancing, with no indication that work is happening.
+
+The progress bar is bound to `booksAnalyzed / booksTotal`
+(`ScanProgressState.progressFraction`), so it reaches 100% the instant **analysis** finishes. The
+Scanner then hands its `ScanResult` to `BookPersister`, which writes every book to the DB — the
+~25s — emitting **no events** until the terminal `ScanEvent.Completed`. The client has nothing to
+react to, so the determinate bar sits frozen at 100%. (After `Completed`, the client already shows an
+animated "Finishing up — almost there" state during its reconcile; that window is fine. Only the
+server-persist window is silent.)
+
+## Goal
+
+Make persistence a visible, honest phase: the same progress bar the user already likes keeps moving
+through a second labelled pass — "Saving library… N of M" — instead of freezing. No screen redesign;
+reuse the existing components.
+
+## Design
+
+### 1. Contract — `ScanPhase.PERSISTING`
+
+Add one enum value to `contract/.../api/dto/scanner/ScanPhase.kt`:
+
+```
+WALKING, GROUPING, ANALYZING, DIFFING, PERSISTING, COMPLETED
+```
+
+`ScanEvent.Progress` already carries everything we need (`phase`, `booksAnalyzed`, `booksTotal`, …),
+so no event-shape change.
+
+### 2. Server — `BookPersister.persistAll` emits PERSISTING progress
+
+`persistAll` already loops over the changed books and tracks a `persisted` count; it has the
+`eventBus` it uses for `Completed`, plus `correlationId`/`libraryId`.
+
+- Compute `toPersist` = number of `Added`/`Modified`/`Moved` changes (the books that go through
+  `resolveOrInsert`). `Removed` changes are tombstones, not persisted books, so they're excluded.
+- Emit `ScanEvent.Progress(phase = PERSISTING, booksAnalyzed = persistedSoFar, booksTotal = toPersist, …)`:
+  - **once immediately** at persist start (`persistedSoFar = 0`) so the UI leaves the 100%-analyze
+    state right away;
+  - **throttled** as books land — count-based: emit every `max(1, toPersist / 100)` books, so at most
+    ~100 events regardless of library size (deterministic, no clock dependency, test-friendly);
+  - the running `persisted` count drives `booksAnalyzed`.
+- `totalDurationMs` is carried from the result where cheap; `authorsMatched`/`recentBooks` aren't
+  available in `BookPersister` (Scanner aggregates) and are left at defaults — the **client preserves
+  them** (see §3), so the stats panel doesn't blank during persist.
+- Emit on the existing `eventBus` (`MutableSharedFlow<ScanEvent>`). `FirehoseSuppressed` (active for
+  full scans) gates the cross-domain **ChangeBus firehose**, not the scan `eventBus`, so progress
+  still flows during a suppressed full scan. (Verify in implementation.)
+- The existing `Completed` still fires after the loop; the client's post-`Completed` "Finishing up"
+  covers the reconcile.
+- If `toPersist == 0` (nothing changed), skip PERSISTING emission entirely — no 0/0 bar.
+
+### 3. Client — display name + stat preservation
+
+- `ScanProgressState.phaseDisplayName`: add `"persisting" -> "Saving library"`.
+- `SyncRepositoryImpl.applyScanEvent` (the `ScanEvent.Progress` branch): for the PERSISTING phase,
+  **preserve the prior `ScanProgressState`** and update only `phase`, `books` (= persisted), and
+  `booksTotal` (= toPersist) — e.g. `getProgress()?.copy(phase = "persisting", books = …, booksTotal = …)`.
+  If there is no prior state (defensive — ANALYZING always precedes PERSISTING in a real scan), fall
+  back to building a fresh state from the event as the other phases do. This keeps the
+  hours/authors/recent-books carousel on screen while `progressFraction` (`books/booksTotal`) climbs
+  0→100% under the "Saving library" label. (Non-PERSISTING phases keep building a fresh state from the
+  event, unchanged.)
+
+### Resulting UX
+
+`Discovering files` (indeterminate) → `Analyzing` (bar climbs 0→100%) → **`Saving library` (bar
+climbs 0→100% again, live N of M)** → `Finishing up` (animated, reconcile) → advance. No frozen
+window; every phase communicates.
+
+## Edge cases
+
+- **Incremental (subtree) scans:** also emit PERSISTING (few books, fast) — consistent, harmless.
+- **Failed / OOM books:** `persisted` advances only on success; on OOM the loop stops and `Completed`
+  fires — the bar stops mid-"Saving" then transitions to "Finishing up". Acceptable.
+- **Empty changes:** `toPersist == 0` → no PERSISTING events → straight to `Completed`.
+
+## Testing (TDD)
+
+- **Server (`BookPersisterTest`):** a `persist(ScanResult)` with N changed books asserts the
+  `eventBus` receives ≥1 `ScanEvent.Progress` with `phase == PERSISTING`, `booksTotal == N`, a first
+  event at `booksAnalyzed == 0`, and a final reaching `booksAnalyzed == N` — ordered before
+  `Completed`. Reuses the existing `eventBus.replayCache` capture pattern.
+- **Client (`:sharedLogic`):** `phaseDisplayName` maps `"persisting" -> "Saving library"`; and an
+  `applyScanEvent` test feeds an ANALYZING event then a PERSISTING event and asserts the prior stats
+  (durationMs/authors/recentBooks) are retained while `books`/`booksTotal`/`phase` update.
+
+## Out of scope
+
+- The post-`Completed` reconcile window (already animated). No change.
+- Determinate progress for the reconcile itself (separate, smaller concern).

--- a/docs/superpowers/specs/2026-06-21-scan-persist-progress-phase-design.md
+++ b/docs/superpowers/specs/2026-06-21-scan-persist-progress-phase-design.md
@@ -55,9 +55,11 @@ so no event-shape change.
   covers the reconcile.
 - If `toPersist == 0` (nothing changed), skip PERSISTING emission entirely — no 0/0 bar.
 
-### 3. Client — display name + stat preservation
+### 3. Client — state, display name + stat preservation
 
 - `ScanProgressState.phaseDisplayName`: add `"persisting" -> "Saving library"`.
+- `ScanProgressState.savingLabel`: new property → `"Saving $books of $booksTotal"` (the label under the
+  bar during persist).
 - `SyncRepositoryImpl.applyScanEvent` (the `ScanEvent.Progress` branch): for the PERSISTING phase,
   **preserve the prior `ScanProgressState`** and update only `phase`, `books` (= persisted), and
   `booksTotal` (= toPersist) — e.g. `getProgress()?.copy(phase = "persisting", books = …, booksTotal = …)`.
@@ -66,6 +68,21 @@ so no event-shape change.
   hours/authors/recent-books carousel on screen while `progressFraction` (`books/booksTotal`) climbs
   0→100% under the "Saving library" label. (Non-PERSISTING phases keep building a fresh state from the
   event, unchanged.)
+
+### 4. Screen — `LibraryScanScreen` (added during implementation)
+
+The original spec assumed the screen needed no change. It does, because the determinate path:
+- hard-codes the subtitle *"Analyzing your audiobooks…"*, and
+- shows *"X% complete · about N min left"* where the ETA is computed from the **whole-scan start** —
+  during persist that elapsed time includes the ~25s analyze, so the ETA would be bogus.
+
+Two localized tweaks (no redesign; existing Expressive components):
+- **Subtitle:** phase-aware — `"Saving your library — almost done."` during persist, else the existing
+  analyzing copy.
+- **Progress label (`ScanProgressLabel`):** early-return for the persist phase showing
+  `progress.savingLabel` ("Saving N of M") instead of the percentage/ETA — the persist phase has no
+  meaningful per-scan ETA. The file-count row and stats panel stay (state is preserved), so only the
+  bar restarts and the label/subtitle reflect the new step.
 
 ### Resulting UX
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.services
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
 import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
 import com.calypsan.listenup.api.dto.scanner.CoverSource
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanScope
 import com.calypsan.listenup.api.event.ScanEvent
@@ -30,6 +31,14 @@ import kotlinx.coroutines.withContext
 import java.nio.file.Path as JPath
 
 private val log = KotlinLogging.logger {}
+
+/**
+ * Cap the number of PERSISTING progress ticks emitted per scan, independent of library size: the
+ * persister emits at most this many `ScanEvent.Progress(phase = PERSISTING)` events (plus the
+ * initial 0 and a final at the total). Keeps the scan event stream light while the "Saving library"
+ * bar still advances smoothly on a large library.
+ */
+private const val PERSIST_PROGRESS_TICKS = 100
 
 /**
  * Consumes the Scanner's [ScanResult] stream and persists every
@@ -184,6 +193,33 @@ class BookPersister internal constructor(
         var persisted = 0
         var failed = 0
 
+        // Persistence is a visible phase, not a silent gap. The bar binds to booksAnalyzed/booksTotal
+        // and hits 100% the instant ANALYZING ends; without these events the client would freeze at
+        // 100% for the whole persist. We emit PERSISTING progress so the same bar advances 0→100% again
+        // under a "Saving library" label. [toPersist] is the count of books actually written
+        // (Added/Modified/Moved); Removed changes are tombstones, not persisted books.
+        val toPersist =
+            result.changes.count {
+                it is ChangeEventDto.Added || it is ChangeEventDto.Modified ||
+                    it is ChangeEventDto.Moved
+            }
+        val persistProgressStride = maxOf(1, toPersist / PERSIST_PROGRESS_TICKS)
+        var processed = 0
+
+        suspend fun emitPersistProgress() {
+            eventBus.emit(
+                ScanEvent.Progress(
+                    correlationId = result.correlationId,
+                    libraryId = libraryId,
+                    phase = ScanPhase.PERSISTING,
+                    filesWalked = 0,
+                    booksAnalyzed = processed,
+                    errors = failed,
+                    booksTotal = toPersist,
+                ),
+            )
+        }
+
         // Persist one changed book and count the outcome. An OutOfMemoryError aborts the whole
         // scan: the heap is compromised, so we wrap the partial counts in PersistAbortedByOom and
         // rethrow rather than swallowing it per-book.
@@ -196,7 +232,14 @@ class BookPersister internal constructor(
                     throw PersistAbortedByOom(PersistCounts(persisted, failed), e)
                 }
             if (bookId != null) persisted++ else failed++
+            // Drive the bar by books processed (persisted + failed) so it reaches the total even when
+            // some books fail; throttled to ~PERSIST_PROGRESS_TICKS ticks for a large library.
+            processed++
+            if (processed % persistProgressStride == 0) emitPersistProgress()
         }
+
+        // Initial tick at 0 so the UI leaves the 100%-analyze state the moment persistence begins.
+        if (toPersist > 0) emitPersistProgress()
 
         // Persist only the books that actually changed. Added/Modified/Moved each carry the changed
         // AnalyzedBook in the ChangeEventDto, but artwork-stripped — so we re-resolve the cover-bearing
@@ -232,6 +275,10 @@ class BookPersister internal constructor(
                 }
             }
         }
+
+        // Final tick at the total so the bar lands on 100% before the terminal Completed, even if the
+        // last stride boundary didn't fall exactly on the final book.
+        if (toPersist > 0) emitPersistProgress()
 
         if (result.scope is ScanScope.Full) {
             // Path-based sweep is safe: every book present on disk (including any that failed

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
 import com.calypsan.listenup.api.dto.scanner.CoverSource
 import com.calypsan.listenup.api.dto.scanner.FileEntry
 import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanScope
 import com.calypsan.listenup.api.dto.scanner.TrackEntry
@@ -197,6 +198,46 @@ class BookPersisterTest :
                     val completed = eventBus.replayCache.filterIsInstance<ScanEvent.Completed>().single()
                     completed.result.totalBooks shouldBe 2
                     fake.resolved shouldContainExactly listOf("a", "b")
+                }
+            }
+        }
+
+        test("persistAll emits PERSISTING progress with live counts, ending at the total, before Completed") {
+            withSqlDatabase {
+                runTest {
+                    val eventBus = MutableSharedFlow<ScanEvent>(replay = 64)
+                    val fake = FakeBookIngest()
+                    val persister = persister(fake, scope = this, eventBus = eventBus)
+
+                    persister.persist(
+                        scanResult(
+                            books = listOf(analyzedBook("a"), analyzedBook("b"), analyzedBook("c")),
+                            changes =
+                                listOf(
+                                    ChangeEventDto.Added(analyzedBook("a")),
+                                    ChangeEventDto.Added(analyzedBook("b")),
+                                    ChangeEventDto.Added(analyzedBook("c")),
+                                ),
+                            scope = ScanScope.Full,
+                        ),
+                    )
+
+                    val events = eventBus.replayCache
+                    val persistProgress =
+                        events.filterIsInstance<ScanEvent.Progress>().filter { it.phase == ScanPhase.PERSISTING }
+
+                    // Persistence is now a visible phase, not a silent gap.
+                    persistProgress.isNotEmpty() shouldBe true
+                    // Every event is scoped to the 3 books being written.
+                    persistProgress.all { it.booksTotal == 3 } shouldBe true
+                    // It starts at 0 (so the UI leaves the 100%-analyze state) and reaches the total.
+                    persistProgress.first().booksAnalyzed shouldBe 0
+                    persistProgress.last().booksAnalyzed shouldBe 3
+
+                    // PERSISTING progress lands before the terminal Completed.
+                    val lastPersist = events.indexOfLast { (it as? ScanEvent.Progress)?.phase == ScanPhase.PERSISTING }
+                    val completed = events.indexOfFirst { it is ScanEvent.Completed }
+                    (lastPersist in 0 until completed) shouldBe true
                 }
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
 import com.calypsan.listenup.api.event.ScanBookRef
+import com.calypsan.listenup.api.dto.scanner.ScanPhase
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.streaming.RpcEvent
 import com.calypsan.listenup.client.data.local.db.BookDao
@@ -405,27 +406,40 @@ internal suspend fun applyScanEvent(
         is ScanEvent.Progress -> {
             if (!isInitialScanComplete()) {
                 setScanning(true)
-                setProgress(
-                    ScanProgressState(
-                        phase = event.phase.name.lowercase(),
-                        current = event.filesWalked,
-                        total = event.filesWalked,
-                        added = 0,
-                        updated = 0,
-                        removed = 0,
-                        filesTotal = event.totalFiles,
-                        books = event.booksAnalyzed,
-                        booksTotal = event.booksTotal,
-                        authors = event.authorsMatched,
-                        durationMs = event.totalDurationMs,
-                        currentFile = event.currentFile,
-                        // Accumulate across events rather than render the server's rolling window:
-                        // the carousel grows and an already-shown title keeps its place — it never
-                        // gets swapped out by a freshly-matched book.
-                        recentBooks = mergeRecentBooks(getProgress()?.recentBooks.orEmpty(), event.recentBooks),
-                        startedAtMs = getStartedAt(),
-                    ),
-                )
+                val prior = getProgress()
+                // The PERSISTING phase reports only the save counts — the rich stats (authors, hours,
+                // recent-books carousel) aren't re-sent. Preserve the prior ANALYZING state and advance
+                // only phase + book counts, so the bar climbs 0→100% under "Saving library" without the
+                // stats panel blanking. Every other phase builds a fresh state from the event.
+                val next =
+                    if (event.phase == ScanPhase.PERSISTING && prior != null) {
+                        prior.copy(
+                            phase = event.phase.name.lowercase(),
+                            books = event.booksAnalyzed,
+                            booksTotal = event.booksTotal,
+                        )
+                    } else {
+                        ScanProgressState(
+                            phase = event.phase.name.lowercase(),
+                            current = event.filesWalked,
+                            total = event.filesWalked,
+                            added = 0,
+                            updated = 0,
+                            removed = 0,
+                            filesTotal = event.totalFiles,
+                            books = event.booksAnalyzed,
+                            booksTotal = event.booksTotal,
+                            authors = event.authorsMatched,
+                            durationMs = event.totalDurationMs,
+                            currentFile = event.currentFile,
+                            // Accumulate across events rather than render the server's rolling window:
+                            // the carousel grows and an already-shown title keeps its place — it never
+                            // gets swapped out by a freshly-matched book.
+                            recentBooks = mergeRecentBooks(prior?.recentBooks.orEmpty(), event.recentBooks),
+                            startedAtMs = getStartedAt(),
+                        )
+                    }
+                setProgress(next)
             }
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressState.kt
@@ -32,6 +32,7 @@ data class ScanProgressState(
                 "resolving" -> "Processing"
                 "diffing" -> "Syncing"
                 "applying" -> "Syncing"
+                "persisting" -> "Saving library"
                 "complete" -> "Finishing up"
                 else -> phase.replaceFirstChar { it.uppercase() }
             }
@@ -47,6 +48,14 @@ data class ScanProgressState(
     /** Total matched audio rounded to whole hours, for the "Hours" stat. */
     val hours: Int
         get() = (durationMs / 3_600_000.0).roundToInt()
+
+    /**
+     * The label shown under the bar during the PERSISTING phase — "Saving N of M" over the books
+     * being written. Distinct from the ANALYZING label (a percentage + ETA) because the persist
+     * phase has no meaningful per-scan ETA: the bar restarts at 0 after analysis already elapsed.
+     */
+    val savingLabel: String
+        get() = "Saving $books of $booksTotal"
 
     val changesSummary: String?
         get() {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -288,6 +288,69 @@ class SyncRepositoryScanProgressTest :
             }
         }
 
+        // The persist phase: after ANALYZING hits 100%, the server emits PERSISTING progress so the bar
+        // advances again under "Saving library" instead of freezing. Those events only carry book counts
+        // — the rich stats (authors, hours, recent-books carousel) aren't re-sent, so the reducer must
+        // PRESERVE the prior state and update only phase + save counts, or the stats panel blanks.
+        test("Progress for the PERSISTING phase preserves analyze stats and only advances the save counts") {
+            runTest {
+                var progress: ScanProgressState? = null
+                val apply: suspend (ScanEvent.Progress) -> Unit = { event ->
+                    applyScanEvent(
+                        event = event,
+                        isInitialScanComplete = { false },
+                        setScanning = {},
+                        setProgress = { progress = it },
+                        markInitialScanComplete = {},
+                        reconcile = {},
+                        getProgress = { progress },
+                        nowMs = { 5_000L },
+                        getStartedAt = { 1_000L },
+                        setStartedAt = {},
+                    )
+                }
+
+                // ANALYZING establishes the rich stats.
+                apply(
+                    ScanEvent.Progress(
+                        "c1",
+                        LibraryId("lib-1"),
+                        ScanPhase.ANALYZING,
+                        filesWalked = 100,
+                        booksAnalyzed = 1000,
+                        errors = 0,
+                        totalFiles = 1647,
+                        booksTotal = 1000,
+                        authorsMatched = 42,
+                        totalDurationMs = 7_200_000L,
+                        recentBooks = listOf(ScanBookRef("Dune", "Herbert")),
+                    ),
+                )
+
+                // PERSISTING carries only the save counts (as the server sends it).
+                apply(
+                    ScanEvent.Progress(
+                        "c1",
+                        LibraryId("lib-1"),
+                        ScanPhase.PERSISTING,
+                        filesWalked = 0,
+                        booksAnalyzed = 250,
+                        errors = 0,
+                        booksTotal = 1000,
+                    ),
+                )
+
+                // Phase + save progress advance…
+                progress!!.phase shouldBe "persisting"
+                progress!!.books shouldBe 250
+                progress!!.booksTotal shouldBe 1000
+                // …but the analyze stats are preserved, not blanked.
+                progress!!.authors shouldBe 42
+                progress!!.hours shouldBe 2
+                progress!!.recentBooks shouldBe listOf(ScanBookRef("Dune", "Herbert"))
+            }
+        }
+
         test("Started stamps the start time") {
             runTest {
                 var started = 0L

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressStateTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/ScanProgressStateTest.kt
@@ -48,4 +48,12 @@ class ScanProgressStateTest :
             // filesTotal == current (all files walked) but only 30% of books analyzed → 0.3, not 1.0.
             state(books = 30, booksTotal = 100, current = 1647, filesTotal = 1647).progressFraction shouldBe 0.3f
         }
+
+        test("phaseDisplayName maps the persisting phase to 'Saving library'") {
+            state(books = 10, booksTotal = 100).copy(phase = "persisting").phaseDisplayName shouldBe "Saving library"
+        }
+
+        test("savingLabel reads 'Saving N of M' from the book counts") {
+            state(books = 250, booksTotal = 1000).savingLabel shouldBe "Saving 250 of 1000"
+        }
     })

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/LibraryScanScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/LibraryScanScreen.kt
@@ -172,7 +172,13 @@ private fun ScanBody(
             Spacer(Modifier.height(26.dp))
             LinearWavyProgressIndicator(modifier = Modifier.fillMaxWidth())
         } else {
-            ScanHeader(wide = wide, subtitle = "Analyzing your audiobooks — this'll just take a moment.")
+            val subtitle =
+                if (progress.phase == "persisting") {
+                    "Saving your library — almost done."
+                } else {
+                    "Analyzing your audiobooks — this'll just take a moment."
+                }
+            ScanHeader(wide = wide, subtitle = subtitle)
             Spacer(Modifier.height(26.dp))
             ScanProgressBlock(progress = progress)
             Spacer(Modifier.height(26.dp))
@@ -254,6 +260,17 @@ private fun ScanProgressLabel(progress: ScanProgressState) {
     if (fraction == null) {
         Text(
             text = progress.phaseDisplayName,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+    if (progress.phase == "persisting") {
+        // The persist phase has no meaningful per-scan ETA (the bar restarts at 0 after analysis
+        // already elapsed), so show the honest "Saving N of M" count instead of a bogus time.
+        Text(
+            text = progress.savingLabel,
             style = MaterialTheme.typography.labelLarge,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Problem

During initial library setup, the scan progress bar hits 100% and then **freezes for ~25s** with no
indication before advancing. The bar binds to `booksAnalyzed / booksTotal`, so it reaches 100% the
instant *analysis* finishes — but the server then silently *persists* every book (the ~25s), emitting
nothing until the terminal `ScanEvent.Completed`. The screen has no event to react to.

## Fix — make persistence a visible, honest phase

The same bar keeps moving through a second labelled pass — **"Saving library"** — instead of freezing.

- **Contract:** add `ScanPhase.PERSISTING`.
- **Server (`BookPersister.persistAll`):** emit `ScanEvent.Progress(phase = PERSISTING, booksAnalyzed = processed, booksTotal = toPersist)` — once at start (0, so the UI leaves the 100%-analyze state immediately), throttled as books are written (count-based, ≤~100 ticks regardless of library size), and a final tick at the total before `Completed`. Runs fine under `FirehoseSuppressed` (that gates the firehose, not the scan event stream).
- **Client state:** `phaseDisplayName → "Saving library"`; new `savingLabel` → "Saving N of M"; `applyScanEvent` **preserves the prior analyze stats** (hours/authors/recent-books carousel) on PERSISTING events and advances only phase + book counts, so the panel never blanks.
- **Screen (`LibraryScanScreen`):** phase-aware subtitle ("Saving your library — almost done.") and a persist label showing "Saving N of M" instead of the percentage/ETA — the persist phase has no meaningful per-scan ETA (the bar restarts at 0 after analysis already elapsed), so the old label would have shown a bogus "about N min left."

Resulting UX: `Analyzing` (0→100%) → **`Saving library` (0→100%, "Saving N of M")** → `Finishing up` (reconcile) → advance. No frozen window.

## Tests (TDD)

- `BookPersisterTest`: PERSISTING progress emitted, starts at 0, reaches the total, ordered before `Completed`.
- `ScanProgressStateTest`: `phaseDisplayName` → "Saving library"; `savingLabel` → "Saving N of M".
- `SyncRepositoryScanProgressTest`: PERSISTING events preserve analyze stats while advancing the save counts.

## Verification

- `:sharedLogic:jvmTest`, `BookPersisterTest`, Spotless + Detekt: green
- `:androidApp:assembleDebug`: green (Compose screen change compiles)
- (Full `:server:jvmTest` OOMs locally on this machine under concurrent load — CI runs it cleanly.)

Design doc: `docs/superpowers/specs/2026-06-21-scan-persist-progress-phase-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)