### PR TITLE
Fix Audiobookshelf import bugs (cards, mini-player, post-import sync, dual-recorder)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImpl.kt
@@ -1,73 +1,26 @@
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.core.BookId
-import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.local.db.BookDuration
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
-import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.domain.model.BookListeningDuration
 import com.calypsan.listenup.client.domain.model.ListeningEvent
 import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
-import com.calypsan.listenup.client.util.NanoId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /**
  * Room-backed implementation of [ListeningEventRepository].
  *
- * The write path wraps the DAO upsert inside [TransactionRunner.atomically].
- * The pending-op enqueue is **not** part of this transaction — the P2 canonical
- * recording path ([com.calypsan.listenup.client.playback.ListeningEventRecorder])
- * handles that directly.
- *
- * [suspendRunCatching] handles [kotlinx.coroutines.CancellationException] rethrow
- * automatically (EM-R1).
+ * Read-only: listening-event writes are owned by the canonical P2 recording path
+ * ([com.calypsan.listenup.client.playback.ListeningEventRecorder]). This class
+ * surfaces DAO read queries as domain types.
  *
  * @param listeningEventDao Room DAO for listening event operations.
- * @param transactionRunner Wraps the DAO upsert in a single DB transaction.
- * @param userId Authenticated user ID injected from the DI graph.
- * @param tz IANA timezone name injected from the DI graph (e.g. `"Europe/London"`).
- * @param deviceLabel Human-readable device label (null if unavailable).
  */
 internal class ListeningEventRepositoryImpl(
     private val listeningEventDao: ListeningEventDao,
-    private val transactionRunner: TransactionRunner,
-    private val userId: String,
-    private val tz: String,
-    private val deviceLabel: String?,
 ) : ListeningEventRepository {
-    override suspend fun queueListeningEvent(
-        bookId: BookId,
-        startPositionMs: Long,
-        endPositionMs: Long,
-        startedAt: Long,
-        endedAt: Long,
-        playbackSpeed: Float,
-    ): AppResult<Unit> =
-        suspendRunCatching {
-            val eventId = NanoId.generate("evt")
-
-            val entity =
-                ListeningEventEntity(
-                    id = eventId,
-                    userId = userId,
-                    bookId = bookId.value,
-                    startPositionMs = startPositionMs,
-                    endPositionMs = endPositionMs,
-                    startedAt = startedAt,
-                    endedAt = endedAt,
-                    playbackSpeed = playbackSpeed,
-                    tz = tz,
-                    deviceLabel = deviceLabel,
-                )
-
-            transactionRunner.atomically {
-                listeningEventDao.upsert(entity)
-            }
-        }
-
     // ==================== Read methods ====================
 
     override fun observeEventsForBook(bookId: String): Flow<List<ListeningEvent>> =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -90,6 +90,17 @@ internal class SyncEngine(
     private var cursorStaleRunning = false
     private var cursorStalePending = false
 
+    // Completion signals for coalesced callers. A caller that finds a recovery already running
+    // (e.g. `refreshListeningHistory()` right after a large ABS import, while start()'s reconcile or
+    // a scan-completion recovery is still draining) must AWAIT a forward catch-up that runs at-or-
+    // after its request — otherwise it returns before the imported rows reach Room (Continue
+    // Listening / streak starved until a restart). Each coalesced caller registers a deferred here
+    // while the leading recovery is in flight; the leading loop snapshots the outstanding waiters at
+    // the START of every pass and completes them when that pass ENDS. Because a waiter is only
+    // satisfied by a pass that began after it registered (and the pending flag guarantees that pass
+    // runs), the caller suspends exactly until a catch-up pass covering its request has drained.
+    private val cursorStaleWaiters = mutableListOf<CompletableDeferred<Unit>>()
+
     // Flips to true on the last line of [runStart] for the active user. If
     // [runStart] throws before that line, the flag stays false even though
     // engineJob has completed — that's the signal start() uses to retry
@@ -287,25 +298,37 @@ internal class SyncEngine(
      *  4. Reconnect SSE. Live tail resumes from the new cursor.
      */
     internal suspend fun handleCursorStale() {
-        // Coalesce: if a recovery is already running, request a single follow-up pass and return
-        // instead of starting a concurrent catchUpAll. The first caller drains the pending flag in a
-        // loop so the last-requested signal is honoured exactly once.
-        val shouldRun =
+        // Coalesce: if a recovery is already running, request a single follow-up pass instead of
+        // starting a concurrent catchUpAll, and AWAIT that follow-up so the caller does not return
+        // before the rows its request needs have drained. The leading caller drains the pending flag
+        // in a loop so a burst of triggers collapses to one follow-up pass, and completes each
+        // coalesced waiter when the pass that began after its request ends.
+        val coalescedWaiter =
             cursorStaleMutex.withLock {
                 if (cursorStaleRunning) {
                     cursorStalePending = true
-                    false
+                    CompletableDeferred<Unit>().also { cursorStaleWaiters += it }
                 } else {
                     cursorStaleRunning = true
-                    true
+                    null
                 }
             }
-        if (!shouldRun) return
+        if (coalescedWaiter != null) {
+            // Suspend until the leading loop's next pass (forced by the pending flag we just set)
+            // completes and resolves this waiter. join() returns normally on cancellation, so a
+            // cancelled recovery propagates through the leading caller, not here.
+            coalescedWaiter.join()
+            return
+        }
 
         try {
             var more = true
             while (more) {
+                // Snapshot the waiters registered BEFORE this pass starts. They are satisfied the
+                // moment this pass ends — it began after their request, so it covers it.
+                val satisfiedByThisPass = cursorStaleMutex.withLock { drainWaiters() }
                 runCursorStaleRecovery()
+                satisfiedByThisPass.forEach { it.complete(Unit) }
                 more =
                     cursorStaleMutex.withLock {
                         if (cursorStalePending) {
@@ -319,14 +342,27 @@ internal class SyncEngine(
             }
         } finally {
             // Normal exit already cleared cursorStaleRunning in the loop; this only fires when a
-            // recovery threw or was cancelled, so a future CursorStale can still recover.
+            // recovery threw or was cancelled, so a future CursorStale can still recover. Any waiters
+            // still outstanding (their covering pass never completed) must be released so coalesced
+            // callers are not stranded — cancelled, not completed, since their request was not served.
             if (cursorStaleRunning) {
-                cursorStaleMutex.withLock {
-                    cursorStaleRunning = false
-                    cursorStalePending = false
-                }
+                val stranded =
+                    cursorStaleMutex.withLock {
+                        cursorStaleRunning = false
+                        cursorStalePending = false
+                        drainWaiters()
+                    }
+                stranded.forEach { it.cancel() }
             }
         }
+    }
+
+    /** Remove and return all outstanding cursor-stale waiters. MUST be called holding [cursorStaleMutex]. */
+    private fun drainWaiters(): List<CompletableDeferred<Unit>> {
+        if (cursorStaleWaiters.isEmpty()) return emptyList()
+        val snapshot = cursorStaleWaiters.toList()
+        cursorStaleWaiters.clear()
+        return snapshot
     }
 
     private suspend fun runCursorStaleRecovery() {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
@@ -12,7 +12,6 @@ import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.StatsRepository
 import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import org.koin.core.module.Module
-import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -27,7 +26,6 @@ import org.koin.dsl.module
  *  - [com.calypsan.listenup.client.data.local.db.PlaybackPositionDao] — `persistenceModule`
  *  - [com.calypsan.listenup.client.data.local.db.TransactionRunner] — `persistenceModule`
  *  - [com.calypsan.listenup.client.domain.repository.AuthSession] — `clientAuthModule`
- *  - [String] (named `"deviceId"`) — platform playback modules
  *  - [com.calypsan.listenup.client.data.sync.PendingOperationQueue] — `clientSyncRenovationModule`
  */
 val listeningModule: Module =
@@ -46,20 +44,12 @@ val listeningModule: Module =
             )
         }
 
-        // ListeningEventRepository — transactional write (upsert + pending-op) + DAO read surface.
-        // TODO(P2-session): Replace userId placeholder with the authenticated user ID from the
-        //  active session once the P2 session-context DI binding lands. For now we use the
-        //  deviceId as a stable surrogate so that existing events can be distinguished by device.
+        // ListeningEventRepository — read-only DAO surface for stats/leaderboard.
+        // Listening-event writes are owned by the P2 canonical recording path
+        // (ListeningEventRecorder, bound below).
         single<ListeningEventRepository> {
             ListeningEventRepositoryImpl(
                 listeningEventDao = get(),
-                transactionRunner = get(),
-                userId = get(qualifier = named("deviceId")),
-                tz =
-                    kotlinx.datetime.TimeZone
-                        .currentSystemDefault()
-                        .id,
-                deviceLabel = null,
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ListeningEventRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ListeningEventRepository.kt
@@ -1,43 +1,24 @@
 package com.calypsan.listenup.client.domain.repository
 
-import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.BookListeningDuration
 import com.calypsan.listenup.client.domain.model.ListeningEvent
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Repository for listening events.
+ * Read-only repository for listening events.
  *
- * Encapsulates the two-write atomic operation (local upsert + pending-op queue) behind
- * a single transactional call. All read methods surface DAO queries to callers that
- * currently access [com.calypsan.listenup.client.data.local.db.ListeningEventDao] directly
+ * Surfaces DAO queries to callers that currently access
+ * [com.calypsan.listenup.client.data.local.db.ListeningEventDao] directly
  * (Stats, Leaderboard) — so those callers can migrate through this interface later.
+ *
+ * Listening-event writes are owned exclusively by the canonical P2 recording path
+ * ([com.calypsan.listenup.client.playback.ListeningEventRecorder]); this interface
+ * exposes no write method.
  *
  * Read methods return domain types ([ListeningEvent], [BookListeningDuration]); mapping
  * from the data layer happens once in the implementation.
  */
 interface ListeningEventRepository {
-    /**
-     * Save a listening event locally (Room-only write).
-     *
-     * Writes through [com.calypsan.listenup.client.data.local.db.ListeningEventDao.upsert]
-     * inside a [com.calypsan.listenup.client.data.local.db.TransactionRunner.atomically] block.
-     * The server-sync pending-op is **not** enqueued here — the P2 canonical recording path
-     * ([com.calypsan.listenup.client.playback.ListeningEventRecorder.finalizeCurrentSpan])
-     * handles the pending-op enqueue directly.
-     *
-     * [kotlinx.coroutines.CancellationException] is always rethrown (EM-R1).
-     */
-    suspend fun queueListeningEvent(
-        bookId: BookId,
-        startPositionMs: Long,
-        endPositionMs: Long,
-        startedAt: Long,
-        endedAt: Long,
-        playbackSpeed: Float,
-    ): AppResult<Unit>
-
     // ==================== Read methods (external callers today) ====================
 
     /** All events for [bookId], newest first. Used by future per-book stats. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -6,7 +6,6 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
-import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,7 +13,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
@@ -22,18 +20,12 @@ import kotlin.time.ExperimentalTime
 
 private val logger = KotlinLogging.logger {}
 
-/** Minimum elapsed playback within a chunk before it is recorded as a listening event. */
-private const val MIN_LISTENING_CHUNK_MS = 10_000L
-
 /**
- * Coordinates position persistence and event recording.
+ * Coordinates position persistence and playback-session tracking.
  *
- * Two separate concerns:
- * 1. Position persistence (local-first, instant) - never lose user's place
- * 2. Event recording (append-only, eventually consistent) - listening history
- *
- * Position is sacred: saves immediately on every pause/seek.
- * Events are queued locally via the unified push sync system.
+ * Position is sacred: saves immediately on every pause/seek. Listening-event
+ * history is owned exclusively by the canonical P2 path
+ * ([ListeningEventRecorder]) — this tracker never records listening events.
  *
  * Note on `open`: this class (and its overridable methods below) are `open`
  * solely so seam-level tests can substitute a hand-rolled
@@ -44,7 +36,6 @@ private const val MIN_LISTENING_CHUNK_MS = 10_000L
  */
 open class ProgressTracker(
     private val downloadRepository: DownloadRepository,
-    private val listeningEventRepository: ListeningEventRepository,
     private val positionRepository: PlaybackPositionRepository,
     private val scope: CoroutineScope,
 ) {
@@ -63,8 +54,6 @@ open class ProgressTracker(
         _sessionState.value =
             SessionState.Active(
                 bookId = bookId,
-                chunkStartPositionMs = positionMs,
-                chunkStartedAt = now,
                 playbackStartPositionMs = positionMs,
                 playbackStartedAt = now,
                 speed = speed,
@@ -98,7 +87,7 @@ open class ProgressTracker(
 
     /**
      * Called when playback pauses/stops.
-     * Saves position immediately, queues event for sync.
+     * Saves position immediately.
      */
     open fun onPlaybackPaused(
         bookId: BookId,
@@ -108,13 +97,11 @@ open class ProgressTracker(
         val now = Clock.System.now().toEpochMilliseconds()
 
         // Atomic transition: Active(matching bookId) -> Paused; else no-op
-        val priorState = _sessionState.value // capture for side effects below
+        val priorState = _sessionState.value // capture for transition logging
         _sessionState.update { current ->
             if (current is SessionState.Active && current.bookId == bookId) {
                 SessionState.Paused(
                     bookId = current.bookId,
-                    chunkStartPositionMs = current.chunkStartPositionMs,
-                    chunkStartedAt = current.chunkStartedAt,
                     playbackStartPositionMs = current.playbackStartPositionMs,
                     playbackStartedAt = current.playbackStartedAt,
                     pausedAt = now,
@@ -128,23 +115,8 @@ open class ProgressTracker(
         logPausedTransition(bookId, positionMs, priorState)
 
         scope.launch {
-            // CONCERN 1: Save position immediately
+            // Save position immediately
             savePosition(bookId, positionMs, speed)
-
-            // CONCERN 2: Queue listening event (if meaningful session)
-            if (priorState is SessionState.Active && priorState.bookId == bookId) {
-                val chunkDurationMs = positionMs - priorState.chunkStartPositionMs
-                if (chunkDurationMs >= MIN_LISTENING_CHUNK_MS) {
-                    queueListeningEvent(
-                        bookId = bookId,
-                        startPositionMs = priorState.chunkStartPositionMs,
-                        endPositionMs = positionMs,
-                        startedAt = priorState.chunkStartedAt,
-                        endedAt = now,
-                        playbackSpeed = priorState.speed,
-                    )
-                }
-            }
         }
     }
 
@@ -175,8 +147,7 @@ open class ProgressTracker(
 
     /**
      * Called periodically during playback (every 30 seconds).
-     * Updates local position AND flushes the current session as a listening event.
-     * This enables real-time stats updates during playback.
+     * Updates local position so the user's place is never lost.
      */
     fun onPositionUpdate(
         bookId: BookId,
@@ -186,36 +157,6 @@ open class ProgressTracker(
         scope.launch {
             // Save position locally
             savePosition(bookId, positionMs, speed)
-
-            val state = _sessionState.value
-            if (state is SessionState.Active && state.bookId == bookId) {
-                val chunkDurationMs = positionMs - state.chunkStartPositionMs
-                if (chunkDurationMs >= MIN_LISTENING_CHUNK_MS) {
-                    val now = Clock.System.now().toEpochMilliseconds()
-                    queueListeningEvent(
-                        bookId = bookId,
-                        startPositionMs = state.chunkStartPositionMs,
-                        endPositionMs = positionMs,
-                        startedAt = state.chunkStartedAt,
-                        endedAt = now,
-                        playbackSpeed = state.speed,
-                    )
-                    // Atomic chunk-window advance: only update if state is still Active for the same book.
-                    // If a concurrent onPlaybackPaused / onBookFinished / onPlaybackStarted has changed
-                    // state, leave the new state in place — the chunk has already been recorded.
-                    _sessionState.update { current ->
-                        if (current is SessionState.Active && current.bookId == bookId) {
-                            current.copy(
-                                chunkStartPositionMs = positionMs,
-                                chunkStartedAt = now,
-                                speed = speed,
-                            )
-                        } else {
-                            current
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -353,22 +294,10 @@ open class ProgressTracker(
         bookId: BookId,
         finalPositionMs: Long,
     ) {
-        val priorState = _sessionState.getAndUpdate { _ -> SessionState.Idle }
+        _sessionState.update { _ -> SessionState.Idle }
 
         scope.launch {
             logger.info { "Book finished: ${bookId.value}, finalPosition=$finalPositionMs" }
-
-            // Record listening-event chunk if Active for this book
-            if (priorState is SessionState.Active && priorState.bookId == bookId) {
-                queueListeningEvent(
-                    bookId = bookId,
-                    startPositionMs = priorState.chunkStartPositionMs,
-                    endPositionMs = finalPositionMs,
-                    startedAt = priorState.chunkStartedAt,
-                    endedAt = Clock.System.now().toEpochMilliseconds(),
-                    playbackSpeed = priorState.speed,
-                )
-            }
 
             // Clear any DELETED download records so future playback will auto-download again
             // This means that the next time a user wants to listen to the same book. We assume
@@ -432,62 +361,4 @@ open class ProgressTracker(
             is SessionState.Paused -> s.speed
             SessionState.Idle -> 1.0f
         }
-
-    /**
-     * Validate and delegate a listening event to [ListeningEventRepository].
-     *
-     * Position validation is applied here (not in the repository) because ProgressTracker
-     * owns the "what counts as a valid event" decision at the playback layer. The repository
-     * owns atomicity of the write, not event semantics.
-     */
-    private suspend fun queueListeningEvent(
-        bookId: BookId,
-        startPositionMs: Long,
-        endPositionMs: Long,
-        startedAt: Long,
-        endedAt: Long,
-        playbackSpeed: Float,
-    ) {
-        // Validate positions to prevent corrupted events.
-        // Max reasonable audiobook position: 7 days worth of audio (168 hours).
-        val maxReasonablePositionMs = 7L * 24 * 60 * 60 * 1000 // ~604,800,000ms
-        if (endPositionMs < 0 || endPositionMs > maxReasonablePositionMs) {
-            logger.error {
-                "🎧 REJECTING CORRUPTED EVENT: book=${bookId.value}, " +
-                    "endPositionMs=$endPositionMs is invalid (expected 0-$maxReasonablePositionMs)"
-            }
-            return
-        }
-        if (startPositionMs < 0 || startPositionMs > endPositionMs) {
-            logger.error {
-                "🎧 REJECTING CORRUPTED EVENT: book=${bookId.value}, " +
-                    "startPositionMs=$startPositionMs is invalid (expected 0-$endPositionMs)"
-            }
-            return
-        }
-
-        when (
-            val result =
-                listeningEventRepository.queueListeningEvent(
-                    bookId = bookId,
-                    startPositionMs = startPositionMs,
-                    endPositionMs = endPositionMs,
-                    startedAt = startedAt,
-                    endedAt = endedAt,
-                    playbackSpeed = playbackSpeed,
-                )
-        ) {
-            is AppResult.Success -> {
-                logger.info {
-                    "🎧 EVENT QUEUED: book=${bookId.value}, start=$startPositionMs, end=$endPositionMs"
-                }
-            }
-
-            is AppResult.Failure -> {
-                logger.warn {
-                    "🎧 FAILED TO QUEUE EVENT: book=${bookId.value}: ${result.error.message}"
-                }
-            }
-        }
-    }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/SessionState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/SessionState.kt
@@ -11,21 +11,17 @@ import com.calypsan.listenup.core.BookId
  * unrepresentable: a book is either Idle (no playback in flight), Active
  * (playing), or Paused.
  *
- * The chunked listening-event session (the 30-second-flush window) lives on
- * [Active] / [Paused] as `chunkStartPositionMs` + `chunkStartedAt`. The full
- * playback session (used by activity-feed `endPlaybackSession` signals) lives
- * inline as `playbackStartPositionMs` + `playbackStartedAt`. Both are reset
- * together on book finish or new-book takeover.
+ * The full playback session (used by activity-feed `endPlaybackSession` signals)
+ * lives on [Active] / [Paused] as `playbackStartPositionMs` + `playbackStartedAt`.
+ * It is reset on book finish or new-book takeover.
  */
 sealed interface SessionState {
     /** No active playback session. Default state. */
     data object Idle : SessionState
 
-    /** Playing. Both chunked and full-session tracking live here. */
+    /** Playing. Full-session tracking lives here. */
     data class Active(
         val bookId: BookId,
-        val chunkStartPositionMs: Long,
-        val chunkStartedAt: Long,
         val playbackStartPositionMs: Long,
         val playbackStartedAt: Long,
         val speed: Float,
@@ -34,8 +30,6 @@ sealed interface SessionState {
     /** Paused. Same fields as Active plus pausedAt. */
     data class Paused(
         val bookId: BookId,
-        val chunkStartPositionMs: Long,
-        val chunkStartedAt: Long,
         val playbackStartPositionMs: Long,
         val playbackStartedAt: Long,
         val pausedAt: Long,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeListeningEventRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeListeningEventRepository.kt
@@ -1,7 +1,5 @@
 package com.calypsan.listenup.client.test.fake
 
-import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
 import com.calypsan.listenup.client.data.repository.toDomain
 import com.calypsan.listenup.client.domain.model.BookListeningDuration
@@ -13,52 +11,19 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 
 /**
- * In-memory fake of [ListeningEventRepository].
+ * In-memory fake of the read-only [ListeningEventRepository].
  *
  * Backed by a [MutableStateFlow] of [ListeningEventEntity] so reactive
- * `observe*` methods emit on every [queueListeningEvent] call — matching the
+ * `observe*` methods emit on every [setEvents] call — matching the
  * read-after-write semantics of the Room-backed implementation.
  *
  * Mapping from entity to domain is delegated to the canonical `toDomain()` extension
  * defined in [com.calypsan.listenup.client.data.repository.ListeningEventRepositoryImpl].
- *
- * [queueCount] is exposed for tests that care about how many events were queued
- * without examining the emitted flows.
  */
 internal class FakeListeningEventRepository(
     initialEvents: List<ListeningEventEntity> = emptyList(),
 ) : ListeningEventRepository {
     private val events = MutableStateFlow(initialEvents)
-
-    /** Number of times [queueListeningEvent] was called successfully. */
-    var queueCount: Int = 0
-        private set
-
-    override suspend fun queueListeningEvent(
-        bookId: BookId,
-        startPositionMs: Long,
-        endPositionMs: Long,
-        startedAt: Long,
-        endedAt: Long,
-        playbackSpeed: Float,
-    ): AppResult<Unit> {
-        val entity =
-            ListeningEventEntity(
-                id = "fake-evt-${queueCount + 1}",
-                userId = "fake-user",
-                bookId = bookId.value,
-                startPositionMs = startPositionMs,
-                endPositionMs = endPositionMs,
-                startedAt = startedAt,
-                endedAt = endedAt,
-                playbackSpeed = playbackSpeed,
-                tz = "UTC",
-                deviceLabel = null,
-            )
-        events.value = events.value + entity
-        queueCount++
-        return AppResult.Success(Unit)
-    }
 
     override fun observeEventsForBook(bookId: String): Flow<List<ListeningEvent>> =
         events.asStateFlow().map { list -> list.filter { it.bookId == bookId }.map { it.toDomain() } }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeProgressTracker.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeProgressTracker.kt
@@ -3,7 +3,6 @@ package com.calypsan.listenup.client.test.fake
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
-import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.playback.ProgressTracker
 import kotlinx.coroutines.CoroutineScope
@@ -23,12 +22,10 @@ import kotlinx.coroutines.CoroutineScope
  */
 class FakeProgressTracker(
     downloadRepository: DownloadRepository,
-    listeningEventRepository: ListeningEventRepository,
     positionRepository: PlaybackPositionRepository,
     scope: CoroutineScope,
 ) : ProgressTracker(
         downloadRepository = downloadRepository,
-        listeningEventRepository = listeningEventRepository,
         positionRepository = positionRepository,
         scope = scope,
     ) {

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -83,7 +83,6 @@ val iosPlaybackModule: Module =
         single {
             ProgressTracker(
                 downloadRepository = get(),
-                listeningEventRepository = get(),
                 positionRepository = get(),
                 scope = get(qualifier = named(PLAYBACK_SCOPE)),
             )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleCoalescedAwaitTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CursorStaleCoalescedAwaitTest.kt
@@ -1,0 +1,250 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.serialization.KSerializer
+
+/**
+ * Regression guard for the post-import "Continue Listening empty until restart" bug.
+ *
+ * `SyncRepositoryImpl.refreshListeningHistory()` calls [SyncEngine.handleCursorStale] to force a
+ * forward catch-up that drains the import's `FirehoseSuppressed` rows (written above the client's
+ * cursor) into Room. But `handleCursorStale` COALESCES: if a recovery is already running (the common
+ * case right after a large import, while `start()`'s own reconcile or a scan-completion recovery is
+ * still draining), the second caller used to set `cursorStalePending = true` and return IMMEDIATELY
+ * — before the follow-up pass that covers its request had run. So `refreshListeningHistory()` reported
+ * "done" while the imported rows were still not in Room → Continue Listening + streak starved until a
+ * restart.
+ *
+ * The fix makes a coalesced caller AWAIT a follow-up catch-up pass that runs at-or-after its request.
+ * This test pins that: while a leading recovery is parked mid-`catchUpAll`, a second
+ * `handleCursorStale()` call must not return until a *subsequent* `catchUpAll` (the follow-up pass it
+ * triggered) has completed.
+ */
+class CursorStaleCoalescedAwaitTest :
+    FunSpec({
+
+        test("a coalesced handleCursorStale awaits the follow-up catch-up pass before returning") {
+            // A single confined thread makes coroutine interleaving deterministic: each `yield()` is a
+            // precise hand-off, so we can drive the leading caller to its gated park, then the coalesced
+            // caller to its registration/await point, with no real-time races.
+            val executor = Executors.newSingleThreadExecutor()
+            val confined = executor.asCoroutineDispatcher()
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + confined)
+                val db = createInMemoryTestDatabase()
+                try {
+                    // Gate the leading catch-up pass so a second handleCursorStale() coalesces while it
+                    // is still in flight. `passesCompleted` counts catchUpAll passes that have fully
+                    // returned — the signal for "a follow-up pass finished".
+                    val leadingPassStarted = CompletableDeferred<Unit>()
+                    val releaseLeadingPass = CompletableDeferred<Unit>()
+                    val passesCompleted = AtomicInteger(0)
+
+                    val catchUp =
+                        GatedCatchUp(
+                            onPassStart = { passNumber ->
+                                if (passNumber == 1) {
+                                    leadingPassStarted.complete(Unit)
+                                    releaseLeadingPass.await()
+                                }
+                            },
+                            onPassComplete = { passesCompleted.incrementAndGet() },
+                        )
+
+                    val state = SyncEngineState()
+                    val sse = FakeCoalesceSseClient(state)
+                    val registry = ClientSyncDomainRegistry()
+                    registry.register(CoalesceTagHandler())
+                    val store = SyncCursorStore(db.syncCursorDao())
+                    val engine = buildCoalesceEngine(db, registry, store, state, catchUp, sse, scope)
+
+                    withContext(confined) {
+                        // Leading caller: enters handleCursorStale, runs catch-up pass #1, parks on the gate.
+                        scope.launch { engine.handleCursorStale() }
+                        withTimeout(5_000) { leadingPassStarted.await() }
+
+                        // Second caller coalesces (a recovery is already running). Under the fix it must
+                        // suspend until the follow-up pass it requests completes. Snapshot the completed-pass
+                        // count at the instant it returns.
+                        val passesCompletedWhenSecondReturned = CompletableDeferred<Int>()
+                        scope.launch {
+                            engine.handleCursorStale()
+                            passesCompletedWhenSecondReturned.complete(passesCompleted.get())
+                        }
+
+                        // On the confined thread, yield enough for the coalesced caller to run through
+                        // handleCursorStale's entry `withLock` (registering its pending request) and reach
+                        // its suspension point — all while the leading pass is still parked on the gate, so
+                        // the drain loop cannot yet observe the pending flag.
+                        repeat(10) { yield() }
+
+                        // Release the leading pass: pass #1 returns, the drain loop sees the coalesced
+                        // caller's pending request and runs the follow-up pass #2.
+                        releaseLeadingPass.complete(Unit)
+
+                        val snapshot = withTimeout(5_000) { passesCompletedWhenSecondReturned.await() }
+
+                        // The coalesced caller returned only after a follow-up pass completed: pass #1
+                        // (leading) + pass #2 (the follow-up it requested) = at least 2 completed passes.
+                        // Pre-fix the coalesced caller returned immediately after merely SETTING the pending
+                        // flag — snapshot would be < 2 (the follow-up had not run yet).
+                        snapshot shouldBeGreaterThanOrEqual 2
+                    }
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                    confined.close()
+                    executor.shutdown()
+                }
+            }
+        }
+    })
+
+private fun buildCoalesceEngine(
+    db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+    registry: ClientSyncDomainRegistry,
+    store: SyncCursorStore,
+    state: SyncEngineState,
+    catchUp: CatchUp,
+    sse: SseClient,
+    scope: CoroutineScope,
+): SyncEngine {
+    val queue =
+        PendingOperationQueue(
+            dao = db.pendingOperationV2Dao(),
+            sender = PendingOperationSender { AppResult.Failure(SyncError.NotFound(domain = "tags", entityId = "t1")) },
+        )
+    val dispatcher =
+        SyncEventDispatcher(
+            registry = registry,
+            queue = queue,
+            state = state,
+            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+        )
+    return SyncEngine(
+        registry = registry,
+        queue = queue,
+        state = state,
+        store = store,
+        catchUp = catchUp,
+        sseClient = sse,
+        reconciler =
+            SyncReconciler(
+                registry = registry,
+                store = store,
+                // handleCursorStale never touches the reconciler; providers are never invoked.
+                digestClient =
+                    DomainDigestClient(
+                        httpClientProvider = { error("digest client unused in coalesce test") },
+                        serverUrlProvider = { error("digest client unused in coalesce test") },
+                    ),
+                catchUp = catchUp,
+            ),
+        dispatcher = dispatcher,
+        presenceRefreshSignal = PresenceRefreshSignal(),
+        activityRefreshSignal = ActivityRefreshSignal(),
+        scope = scope,
+    )
+}
+
+/**
+ * [CatchUp] fake that gates each `catchUpAll` pass. [onPassStart] is invoked with the 1-based pass
+ * number BEFORE the pass body (used to park the leading pass on a deferred); [onPassComplete] fires
+ * after the pass body returns (used to count completed passes).
+ */
+private class GatedCatchUp(
+    private val onPassStart: suspend (Int) -> Unit,
+    private val onPassComplete: () -> Unit,
+) : CatchUp {
+    private val passCounter = AtomicInteger(0)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
+        val passNumber = passCounter.incrementAndGet()
+        onPassStart(passNumber)
+        onPassComplete()
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpFromZero(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>> = AppResult.Success(emptySet())
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+/** Minimal no-op tag handler so the registry is non-empty during catch-up. */
+private class CoalesceTagHandler : SyncDomainHandler<Tag> {
+    override val domainName = "tags"
+    override val payloadSerializer: KSerializer<Tag> = Tag.serializer()
+
+    override fun syncId(item: Tag): String = item.id
+
+    override suspend fun onEvent(
+        event: SyncEvent<Tag>,
+        isOwnEcho: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun onCatchUpItem(
+        item: Tag,
+        isTombstone: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun localDigestRows(maxRevision: Long): List<Pair<String, Long>> = emptyList()
+}
+
+/** Fake SSE client mirroring production's `connect()`-flips-state semantics. */
+private class FakeCoalesceSseClient(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seeded = newLastEventId
+    }
+
+    override fun reconnectNow() = Unit
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
@@ -13,7 +13,6 @@ import com.calypsan.listenup.api.sync.UserStatsSyncPayload
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
-import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.test.fake.FakeProgressTracker
 import dev.mokkery.answering.returns
@@ -38,7 +37,6 @@ fun buildProgressTracker(
 ): ProgressTracker =
     ProgressTracker(
         downloadRepository = mock<DownloadRepository>(),
-        listeningEventRepository = mock<ListeningEventRepository>(),
         positionRepository = positionRepository,
         scope = scope,
     )
@@ -54,7 +52,6 @@ fun buildFakeProgressTracker(
 ): FakeProgressTracker =
     FakeProgressTracker(
         downloadRepository = mock<DownloadRepository>(),
-        listeningEventRepository = mock<ListeningEventRepository>(),
         positionRepository = positionRepository,
         scope = scope,
     )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerDoesNotRecordEventsTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerDoesNotRecordEventsTest.kt
@@ -1,0 +1,59 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the contract that [ProgressTracker] does **not** record listening events.
+ *
+ * Listening history is owned exclusively by the canonical P2 path
+ * ([ListeningEventRecorder]). [ProgressTracker]'s sole responsibilities are
+ * position persistence, full-playback-session tracking, and finished-marking —
+ * never listening-event writes. The pre-removal tracker queued an
+ * account-orphaned `evt-` row on every pause longer than 10s that never synced;
+ * this test fails the moment any such write path is reintroduced.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProgressTrackerDoesNotRecordEventsTest :
+    FunSpec({
+
+        test("a play→pause session longer than 10s writes no listening events") {
+            runTest {
+                val queryContext = StandardTestDispatcher(testScheduler)
+                val db = createInMemoryTestDatabase(queryContext = queryContext)
+                try {
+                    val dao = db.listeningEventDao()
+
+                    val tracker =
+                        ProgressTracker(
+                            downloadRepository = mock<DownloadRepository>(),
+                            positionRepository = defaultPositionRepository(),
+                            scope = CoroutineScope(queryContext),
+                        )
+
+                    val bookId = BookId("book-1")
+                    // Position-driven chunk threshold: 20s of audio elapses between start and pause,
+                    // comfortably over the pre-removal 10s MIN_LISTENING_CHUNK_MS gate.
+                    tracker.onPlaybackStarted(bookId = bookId, positionMs = 0L, speed = 1.0f)
+                    tracker.onPlaybackPaused(bookId = bookId, positionMs = 20_000L, speed = 1.0f)
+
+                    advanceUntilIdle()
+
+                    // No listening event may have been written.
+                    dao.getLatestEventTimestamp() shouldBe null
+                    dao.getTotalDurationSince(0L) shouldBe 0L
+                } finally {
+                    db.close()
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/sharedLogic/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -83,7 +83,6 @@ val macosPlaybackModule: Module =
         single {
             ProgressTracker(
                 downloadRepository = get(),
-                listeningEventRepository = get(),
                 positionRepository = get(),
                 scope = get(qualifier = named(PLAYBACK_SCOPE)),
             )

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -50,7 +50,6 @@ import androidx.media3.exoplayer.video.spherical.CameraMotionListener
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
-import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import kotlinx.coroutines.CoroutineScope
@@ -450,7 +449,6 @@ private class FakeProgressTracker {
     val tracker: ProgressTracker =
         object : ProgressTracker(
             downloadRepository = ThrowingDownloadRepository,
-            listeningEventRepository = ThrowingListeningEventRepository,
             positionRepository = repo,
             scope = CoroutineScope(Dispatchers.Unconfined),
         ) {}
@@ -539,41 +537,6 @@ private object ThrowingDownloadRepository : DownloadRepository {
     override suspend fun deleteForBook(bookId: String) = TODO("not used in handler test")
 
     override suspend fun resumeIncompleteDownloads() = TODO("not used in handler test")
-}
-
-private object ThrowingListeningEventRepository : ListeningEventRepository {
-    override suspend fun queueListeningEvent(
-        bookId: BookId,
-        startPositionMs: Long,
-        endPositionMs: Long,
-        startedAt: Long,
-        endedAt: Long,
-        playbackSpeed: Float,
-    ) = TODO("not used in handler test")
-
-    override fun observeEventsForBook(bookId: String) = TODO("not used in handler test")
-
-    override fun observeEventsInRange(
-        startMs: Long,
-        endMs: Long,
-    ) = TODO("not used in handler test")
-
-    override fun observeEventsSince(startMs: Long) = TODO("not used in handler test")
-
-    override suspend fun getTotalDurationSince(startMs: Long): Long = TODO("not used in handler test")
-
-    override fun observeTotalDurationSince(startMs: Long) = TODO("not used in handler test")
-
-    override fun observeDistinctBooksSince(startMs: Long) = TODO("not used in handler test")
-
-    override fun observeDistinctDaysSince(startMs: Long) = TODO("not used in handler test")
-
-    override suspend fun getDistinctDaysWithActivity(startMs: Long) = TODO("not used in handler test")
-
-    override suspend fun getDurationByBook(
-        startMs: Long,
-        endMs: Long,
-    ) = TODO("not used in handler test")
 }
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackServiceTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackServiceTest.kt
@@ -4,7 +4,6 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.DownloadStatus
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
-import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import io.kotest.core.spec.style.FunSpec
@@ -105,7 +104,6 @@ class PlaybackServiceTest :
 private fun makeTracker(repo: PlaybackPositionRepository): ProgressTracker =
     object : ProgressTracker(
         downloadRepository = ThrowingDownloadRepository2,
-        listeningEventRepository = ThrowingListeningEventRepository2,
         positionRepository = repo,
         scope = CoroutineScope(Dispatchers.Unconfined),
     ) {}
@@ -192,39 +190,4 @@ private object ThrowingDownloadRepository2 : DownloadRepository {
     override suspend fun deleteForBook(bookId: String) = TODO("not used")
 
     override suspend fun resumeIncompleteDownloads() = TODO("not used")
-}
-
-private object ThrowingListeningEventRepository2 : ListeningEventRepository {
-    override suspend fun queueListeningEvent(
-        bookId: BookId,
-        startPositionMs: Long,
-        endPositionMs: Long,
-        startedAt: Long,
-        endedAt: Long,
-        playbackSpeed: Float,
-    ) = TODO("not used")
-
-    override fun observeEventsForBook(bookId: String) = TODO("not used")
-
-    override fun observeEventsInRange(
-        startMs: Long,
-        endMs: Long,
-    ) = TODO("not used")
-
-    override fun observeEventsSince(startMs: Long) = TODO("not used")
-
-    override suspend fun getTotalDurationSince(startMs: Long): Long = TODO("not used")
-
-    override fun observeTotalDurationSince(startMs: Long) = TODO("not used")
-
-    override fun observeDistinctBooksSince(startMs: Long) = TODO("not used")
-
-    override fun observeDistinctDaysSince(startMs: Long) = TODO("not used")
-
-    override suspend fun getDistinctDaysWithActivity(startMs: Long) = TODO("not used")
-
-    override suspend fun getDurationByBook(
-        startMs: Long,
-        endMs: Long,
-    ) = TODO("not used")
 }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -167,11 +167,10 @@ val playbackModule =
         single { AndroidAudioTokenProvider(core = get()) }
         single<AudioTokenProvider> { get<AndroidAudioTokenProvider>() }
 
-        // Progress tracker for position persistence and event recording
+        // Progress tracker for position persistence and playback-session tracking
         single {
             ProgressTracker(
                 downloadRepository = get(),
-                listeningEventRepository = get(),
                 positionRepository = get(),
                 scope = get(),
             )

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/import/ImportFlowScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/import/ImportFlowScreen.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.calypsan.listenup.client.playback.NowPlayingState
+import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.imports.AbsItemRef
 import com.calypsan.listenup.api.dto.imports.AbsUserMatch
@@ -142,6 +144,9 @@ import org.koin.compose.viewmodel.koinViewModel
 
 private val CONTENT_MAX_WIDTH = 560.dp
 
+// Extra bottom clearance when the floating mini-player pill is visible on detail routes.
+private val MiniPlayerClearance = 88.dp
+
 // Zero-based wizard step index for each progress phase, mapped onto the 4-step tracker.
 private const val STEP_UPLOAD = 0
 private const val STEP_REVIEW = 1
@@ -165,8 +170,17 @@ private const val STEP_DONE = 3
 fun ImportFlowScreen(
     onNavigateBack: () -> Unit,
     viewModel: ImportFlowViewModel = koinViewModel(),
+    nowPlayingViewModel: NowPlayingViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val nowPlayingScreenState by nowPlayingViewModel.screenState.collectAsStateWithLifecycle()
+    val miniPlayerBottomPadding =
+        if (nowPlayingScreenState.state is NowPlayingState.Active) {
+            MiniPlayerClearance
+        } else {
+            0
+                .dp
+        }
 
     // The file picker is declared here (at the screen level) so the composable lifecycle
     // that wires the ActivityResult launcher is stable across all phases. It is only
@@ -183,7 +197,8 @@ fun ImportFlowScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(paddingValues),
+                    .padding(paddingValues)
+                    .padding(bottom = miniPlayerBottomPadding),
         ) {
             FlowHero(state = uiState, onBack = onNavigateBack)
             CenteredColumn {

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/import/ImportFlowScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/import/ImportFlowScreen.kt
@@ -127,14 +127,12 @@ import listenup.composeapp.generated.resources.import_stat_users_merged
 import listenup.composeapp.generated.resources.import_to_review_count
 import listenup.composeapp.generated.resources.import_uploading_subtitle
 import listenup.composeapp.generated.resources.import_uploading_title
-import listenup.composeapp.generated.resources.import_user_accept_suggestion
 import listenup.composeapp.generated.resources.import_user_assign
 import listenup.composeapp.generated.resources.import_user_assigned_to
 import listenup.composeapp.generated.resources.import_user_needs_review
 import listenup.composeapp.generated.resources.import_user_pick_user
 import listenup.composeapp.generated.resources.import_user_skip
 import listenup.composeapp.generated.resources.import_user_skipped
-import listenup.composeapp.generated.resources.import_user_suggested
 import listenup.composeapp.generated.resources.import_users_in_backup
 import listenup.composeapp.generated.resources.import_writing_current_item
 import listenup.composeapp.generated.resources.import_writing_history_subtitle
@@ -344,7 +342,7 @@ private fun IdleContent(onChooseFile: () -> Unit) {
         Spacer(Modifier.height(24.dp))
         Surface(
             modifier = Modifier.fillMaxWidth(),
-            shape = MaterialTheme.shapes.extraLarge,
+            shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceContainerLow,
         ) {
             Column(modifier = Modifier.padding(20.dp)) {
@@ -535,7 +533,6 @@ private fun ReviewContent(
                     assignedUserId = state.userMappings[match.absUserId],
                     isSkipped = state.skippedUsers.contains(match.absUserId),
                     listenupUsers = state.listenupUsers,
-                    onAcceptSuggestion = { suggestedId -> onSetUserMapping(match.absUserId, suggestedId) },
                     onAssign = { pickedUser -> onSetUserMapping(match.absUserId, UserId(pickedUser.id)) },
                     onSkip = { onSkipUser(match.absUserId) },
                 )
@@ -638,7 +635,6 @@ private fun UserMatchCard(
     assignedUserId: UserId?,
     isSkipped: Boolean,
     listenupUsers: List<AdminUserInfo>,
-    onAcceptSuggestion: (UserId) -> Unit,
     onAssign: (AdminUserInfo) -> Unit,
     onSkip: () -> Unit,
 ) {
@@ -648,7 +644,7 @@ private fun UserMatchCard(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color =
             when {
                 isSkipped -> MaterialTheme.colorScheme.surfaceContainerLowest
@@ -667,9 +663,7 @@ private fun UserMatchCard(
                 AssignedToRow(label = assignedUser?.displayableName ?: assignedUserId.value)
             } else if (!isSkipped) {
                 UnresolvedUserActions(
-                    match = match,
                     listenupUsers = listenupUsers,
-                    onAcceptSuggestion = onAcceptSuggestion,
                     onAssign = onAssign,
                     onSkip = onSkip,
                 )
@@ -765,20 +759,10 @@ private fun AssignedToRow(label: String) {
 
 @Composable
 private fun UnresolvedUserActions(
-    match: AbsUserMatch,
     listenupUsers: List<AdminUserInfo>,
-    onAcceptSuggestion: (UserId) -> Unit,
     onAssign: (AdminUserInfo) -> Unit,
     onSkip: () -> Unit,
 ) {
-    val suggestedUserId = match.suggestedUserId
-    if (suggestedUserId != null) {
-        UserSuggestionRow(
-            suggestedId = suggestedUserId,
-            listenupUsers = listenupUsers,
-            onAccept = onAcceptSuggestion,
-        )
-    }
     Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
         UserAssignDropdown(listenupUsers = listenupUsers, onAssign = onAssign, modifier = Modifier.weight(1f))
         ListenUpButton(
@@ -787,47 +771,6 @@ private fun UnresolvedUserActions(
             leadingIcon = Icons.Outlined.Block,
             filled = false,
             modifier = Modifier.weight(1f),
-        )
-    }
-}
-
-@Composable
-private fun UserSuggestionRow(
-    suggestedId: UserId,
-    listenupUsers: List<AdminUserInfo>,
-    onAccept: (UserId) -> Unit,
-) {
-    val suggestedUser = listenupUsers.find { it.id == suggestedId.value }
-    val suggestionLabel = suggestedUser?.displayableName ?: suggestedId.value
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(MaterialTheme.shapes.large)
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .padding(start = 14.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.AutoAwesome,
-            contentDescription = null,
-            modifier = Modifier.size(18.dp),
-            tint = MaterialTheme.colorScheme.primary,
-        )
-        Spacer(Modifier.width(10.dp))
-        Text(
-            text = stringResource(Res.string.import_user_suggested, suggestionLabel),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.weight(1f),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        ListenUpButton(
-            text = stringResource(Res.string.import_user_accept_suggestion),
-            onClick = { onAccept(suggestedId) },
-            leadingIcon = Icons.Filled.Check,
-            fillMaxWidth = false,
         )
     }
 }
@@ -913,7 +856,7 @@ private fun BookReviewCard(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color =
             when {
                 isSkipped -> MaterialTheme.colorScheme.surfaceContainerLowest
@@ -1084,7 +1027,7 @@ private fun ApplyingContent(state: ImportFlowUiState.Applying) {
             Spacer(Modifier.height(20.dp))
             Surface(
                 modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.extraLarge,
+                shape = MaterialTheme.shapes.large,
                 color = MaterialTheme.colorScheme.surfaceContainerLow,
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -100,7 +100,6 @@ val platformModule: Module =
         single {
             ProgressTracker(
                 downloadRepository = get(),
-                listeningEventRepository = get(),
                 positionRepository = get(),
                 scope = get(qualifier = named("playbackScope")),
             )


### PR DESCRIPTION
## Summary
Fixes the batch of Audiobookshelf-import bugs found during device testing.

- **🐛 Import cards cropped** — the review/match cards used `MaterialTheme.shapes.extraLarge` (`CircleShape`), which clipped wide content into stadiums. Switched to `shapes.large`, and stripped an unsupported "user suggestion" affordance the cards rendered but the VM never backed.
- **🐛 Mini-player covered the import CTA** — the floating mini-player overlapped the "Choose Backup File" / apply buttons. The import flow now insets its content by the mini-player clearance when a book is active.
- **🐛 Post-import progress needed a restart** — continue-listening and stats didn't reflect an import until a full app restart. `refreshListeningHistory` now awaits the forward catch-up (coalesced, race-free in `SyncEngine`) so imported data lands immediately. Adds `CursorStaleCoalescedAwaitTest`.
- **🐛 Listening events were double-recorded** — every local listen was written twice: by the canonical `ListeningEventRecorder` (account id, server-synced) *and* by a legacy `ProgressTracker → ListeningEventRepository` path that stamped the device's `ANDROID_ID` and never enqueued a server sync — orphaned from stats and unsynced on every platform. Retired the legacy path; the Recorder is now the sole writer. Net −271 lines; adds `ProgressTrackerDoesNotRecordEventsTest`.

## Test plan
- `:sharedLogic:jvmTest` 2665/0 · `:server:jvmTest` (green, run clean) · `:androidApp:assembleDebug` · `:sharedUI:testAndroidHostTest` · `:sharedUI:desktopTest` · spotless/detekt clean.
- Device-verified on a Pixel 9 Pro Fold: card cropping gone, mini-player CTA reachable, Discover/leaderboard render with no error snackbar.

## Notes
- The "Discover 500" reported alongside these did not reproduce on a settled account; all Discover endpoints (`discoverShelves`, `currentlyListening`, `activityFeed`) were verified to have no throw on the imported data shape. It matched transient import-time SQLite contention rather than an endpoint bug.
- Follow-up #702: wire `ListeningEventRecorder` into `PlaybackManagerImpl` so iOS/Desktop record under the account id and sync (those platforms record only via the now-removed legacy path today).