### PR TITLE
🐛 fix(server): eliminate spooled-cover 404s from overlapping scans (#703)

### DIFF
--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -106,6 +106,7 @@ import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.syncRoutes
 import com.calypsan.listenup.api.dto.auth.RegistrationStatusEvent
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.db.DataDirLock
 import com.calypsan.listenup.server.db.DatabaseHandle
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
@@ -324,6 +325,7 @@ fun Application.module() {
             resolveDemoLibraryFallback(seedProfile)?.let { listOf(it) } ?: emptyList()
         }
     val homeDir = resolveImageHome()
+    acquireDataDirLockIfEnabled(homeDir)
     val metadataPrecedence = resolveMetadataPrecedence()
     val embeddedCoverCacheSize = resolveEmbeddedCoverCacheSize()
 
@@ -551,6 +553,28 @@ private fun Application.resolveImageHome(): Path =
         envHome = System.getenv("LISTENUP_HOME"),
         userHome = System.getProperty("user.home"),
     )
+
+/**
+ * Takes an exclusive lock on the data directory when `server.dataDirLock` is enabled (production
+ * default in `application.conf`), so a second server on the same `$LISTENUP_HOME` fails fast with a
+ * clear message instead of racing the scan-spool (#703 — a stale JVM whose covers get swept by a
+ * fresh boot). Off by default in code, so the isolated test configs (which omit the key) never
+ * lock. The lock is released on [ApplicationStopped]; the OS frees it anyway on process death.
+ */
+private fun Application.acquireDataDirLockIfEnabled(homeDir: Path) {
+    val enabled =
+        environment.config
+            .propertyOrNull("server.dataDirLock")
+            ?.getString()
+            ?.toBooleanStrictOrNull() ?: false
+    if (!enabled) return
+    val lock = DataDirLock.forDataHome(homeDir)
+    check(lock.tryAcquire()) {
+        "Another ListenUp server is already using the data directory $homeDir. Stop it before " +
+            "starting another instance, or point this one at a different LISTENUP_HOME."
+    }
+    monitor.subscribe(ApplicationStopped) { lock.close() }
+}
 
 /**
  * Reads `scanner.metadataPrecedence` from configuration and parses it into a

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -545,15 +545,12 @@ private fun Application.resolveLibraryPaths(): List<Path> {
  * Reads env / system properties here at the config edge so [resolveListenupHome]
  * stays pure.
  */
-private fun Application.resolveImageHome(): Path {
-    val configured =
-        environment.config
-            .propertyOrNull("listenup.home")
-            ?.getString()
-            ?.takeIf { it.isNotBlank() }
-    if (configured != null) return Path.of(configured)
-    return resolveListenupHome(System.getenv("LISTENUP_HOME"), System.getProperty("user.home"))
-}
+private fun Application.resolveImageHome(): Path =
+    resolveListenupHome(
+        configuredHome = environment.config.propertyOrNull("listenup.home")?.getString(),
+        envHome = System.getenv("LISTENUP_HOME"),
+        userHome = System.getProperty("user.home"),
+    )
 
 /**
  * Reads `scanner.metadataPrecedence` from configuration and parses it into a

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/auth/ServerSecrets.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/auth/ServerSecrets.kt
@@ -130,7 +130,14 @@ class FileSecretStore(
  * secrets are generated/persisted under `$LISTENUP_HOME/secrets.properties`.
  */
 fun resolveServerSecrets(config: ApplicationConfig): ServerSecrets {
-    val home = resolveListenupHome(System.getenv("LISTENUP_HOME"), System.getProperty("user.home"))
+    // Honour `listenup.home` (config) so secrets.properties lands under the SAME home as the DB and
+    // covers/spool — all server data stays under one directory (#703).
+    val home =
+        resolveListenupHome(
+            configuredHome = config.propertyOrNull("listenup.home")?.getString(),
+            envHome = System.getenv("LISTENUP_HOME"),
+            userHome = System.getProperty("user.home"),
+        )
     val store = FileSecretStore(home)
     return ServerSecrets(
         jwtSecret =

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
@@ -1,0 +1,70 @@
+package com.calypsan.listenup.server.db
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * An exclusive, OS-level lock on a ListenUp data directory, so only one server process can use a
+ * given data home at a time.
+ *
+ * Two instances sharing one `$LISTENUP_HOME` — a stale JVM that wasn't fully killed plus a fresh
+ * boot — race the scan-spool: the new boot's `sweepOrphans()` could delete a live scan's covers out
+ * from under the other instance's persist. That is the cause of #703's spooled-cover 404s. This lock
+ * turns that silent corruption into an explicit, fail-fast startup error.
+ *
+ * Backed by a [FileLock] on `<dataHome>/.lock`: the OS releases it automatically on process death,
+ * and [close] releases it on a clean shutdown. [tryAcquire] returns `false` when another process —
+ * or another [DataDirLock] in this JVM — already holds it.
+ */
+class DataDirLock(
+    private val lockFile: Path,
+) : AutoCloseable {
+    private var channel: FileChannel? = null
+    private var lock: FileLock? = null
+
+    /**
+     * Attempts to take the lock. Returns `true` on success; `false` when another instance already
+     * holds this data home. Never throws for the "already held" case — both the cross-process
+     * (`tryLock` returns null) and same-JVM ([OverlappingFileLockException]) outcomes map to `false`.
+     */
+    fun tryAcquire(): Boolean {
+        Files.createDirectories(lockFile.parent)
+        val ch = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+        val acquired =
+            try {
+                ch.tryLock() // null when another PROCESS holds the lock
+            } catch (e: OverlappingFileLockException) {
+                // Another DataDirLock in THIS jvm already holds it — same "already locked" outcome.
+                logger.debug(e) { "Data dir $lockFile is already locked within this JVM" }
+                null
+            }
+        if (acquired == null) {
+            ch.close()
+            return false
+        }
+        channel = ch
+        lock = acquired
+        return true
+    }
+
+    override fun close() {
+        runCatching { lock?.release() }
+        runCatching { channel?.close() }
+        lock = null
+        channel = null
+    }
+
+    companion object {
+        const val LOCK_FILENAME = ".lock"
+
+        /** The lock guarding [dataHome], rooted at `<dataHome>/.lock`. */
+        fun forDataHome(dataHome: Path): DataDirLock = DataDirLock(dataHome.resolve(LOCK_FILENAME))
+    }
+}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataHome.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataHome.kt
@@ -30,6 +30,26 @@ fun resolveListenupHome(
 ): Path = envHome?.takeIf { it.isNotBlank() }?.let { Path.of(it) } ?: defaultListenupHome(userHome)
 
 /**
+ * The effective ListenUp data home with the full precedence used by EVERY data-home consumer
+ * (database, secrets, covers, scan-spool, metadata images): an explicit [configuredHome]
+ * (the `listenup.home` config property) wins, then [envHome] (`LISTENUP_HOME`), else
+ * [userHome]/ListenUp.
+ *
+ * This single resolver is the guarantee that all server data lands under ONE directory — the DB,
+ * secrets, covers, and spool can never diverge because they all resolve through here. (Previously
+ * the DB and secrets read only [envHome], so a `listenup.home` config split them off from the
+ * covers/spool — the bug behind #703's "data isn't where I cleared it" confusion.) Pure —
+ * callers read the config / env / system properties at the edge.
+ */
+fun resolveListenupHome(
+    configuredHome: String?,
+    envHome: String?,
+    userHome: String,
+): Path =
+    configuredHome?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
+        ?: resolveListenupHome(envHome, userHome)
+
+/**
  * Resolve the effective JDBC URL for the application database.
  *
  * - A non-blank [configuredUrl] (the `database.jdbcUrl` config / `LISTENUP_DB_URL`

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -212,6 +212,13 @@ private fun ApplicationConfig.serverName(): String =
  */
 private fun ApplicationConfig.resolveJdbcUrl(): String {
     val configured = propertyOrNull("database.jdbcUrl")?.getString().orEmpty()
-    val home = resolveListenupHome(System.getenv("LISTENUP_HOME"), System.getProperty("user.home"))
+    // Honour `listenup.home` (config) so the DB lands under the SAME home as covers/spool — not just
+    // $LISTENUP_HOME. Keeps all server data under one directory (#703).
+    val home =
+        resolveListenupHome(
+            configuredHome = propertyOrNull("listenup.home")?.getString(),
+            envHome = System.getenv("LISTENUP_HOME"),
+            userHome = System.getProperty("user.home"),
+        )
     return resolveDatabaseUrl(configuredUrl = configured, listenupHome = home)
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
@@ -83,14 +83,45 @@ class CoverSpool(
             .onFailure { logger.warn(it) { "cover spool clear failed for scan $scanId" } }
     }
 
-    /** Startup: delete every leftover scan dir from a crashed scan. Never throws. */
+    /**
+     * Startup: delete leftover scan dirs from a crashed scan — but only those untouched for at
+     * least [ORPHAN_GRACE_MS]. A live scan's dir is modified on every cover write, so it stays far
+     * under this window; recently-modified dirs are therefore left alone. This stops a fresh boot's
+     * sweep from deleting a **concurrent** instance's in-flight scan dir out from under its persist
+     * (the cause of the spooled-cover 404s in #703 when a stale JVM still shares this data dir).
+     * Never throws.
+     */
     fun sweepOrphans() {
         if (!root.exists()) return
+        val cutoff = System.currentTimeMillis() - ORPHAN_GRACE_MS
         runCatching {
-            Files.newDirectoryStream(root).use { stream -> stream.forEach { it.toFile().deleteRecursively() } }
+            Files.newDirectoryStream(root).use { stream ->
+                stream.forEach { dir ->
+                    val lastModified = runCatching { Files.getLastModifiedTime(dir).toMillis() }.getOrDefault(0L)
+                    if (lastModified <= cutoff) {
+                        dir.toFile().deleteRecursively()
+                    } else {
+                        logger.info {
+                            "cover spool sweep: keeping recent dir ${dir.fileName} " +
+                                "(modified ${System.currentTimeMillis() - lastModified}ms ago, under grace) — " +
+                                "another scan may be live"
+                        }
+                    }
+                }
+            }
         }.onFailure { logger.warn(it) { "cover spool orphan sweep failed" } }
     }
 
     private fun key(rootRelPath: String): String =
         MessageDigest.getInstance("SHA-256").digest(rootRelPath.toByteArray()).joinToString("") { "%02x".format(it) }
+
+    companion object {
+        /**
+         * A spool dir untouched for at least this long is treated as a crashed-scan orphan and
+         * swept at startup. A live scan rewrites its dir on every cover spool, so it never ages
+         * past this window — the grace is what keeps the startup sweep from clobbering a live
+         * (possibly other-process) scan.
+         */
+        const val ORPHAN_GRACE_MS: Long = 30 * 60 * 1000L // 30 minutes
+    }
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -264,6 +264,10 @@ internal class Scanner(
         // Build the artwork-bearing result for BookPersister (so covers get written to disk).
         val incrementalResult =
             lastResult?.copy(
+                // Stamp THIS scan's id — never inherit lastResult's. Inheriting it (#703) made the
+                // incremental spool to its real correlationId but clear/report the previous full
+                // scan's, leaking the live spool dir and mis-keying ScanEvent.Completed.
+                correlationId = correlationId,
                 books = books, // artwork-bearing for persist
                 changes = changes,
                 errors = errors,

--- a/server/src/jvmMain/resources/application.conf
+++ b/server/src/jvmMain/resources/application.conf
@@ -81,6 +81,16 @@ seed {
     profile = ${?LISTENUP_SEED_PROFILE}
 }
 
+server {
+    # Take an exclusive OS lock on the data directory ($LISTENUP_HOME) at startup so two server
+    # processes can never share one data home and race the scan-spool — the cause of #703's
+    # spooled-cover 404s (a stale JVM + a fresh boot whose sweep deletes the live scan's covers).
+    # A second instance on the same data dir fails fast with a clear message instead of corrupting.
+    # Tests run on isolated in-memory configs that omit this key, so the lock is off there.
+    dataDirLock = true
+    dataDirLock = ${?LISTENUP_DATA_DIR_LOCK}
+}
+
 scan {
     # Re-walk every library once on startup to catch changes made while the server was down.
     rescanOnStartup = true

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/db/DataDirLockTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/db/DataDirLockTest.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.server.db
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+
+/**
+ * Pins [DataDirLock] — the single-instance guard that stops two servers from sharing one data home
+ * and racing the scan-spool (#703).
+ */
+class DataDirLockTest :
+    FunSpec({
+
+        test("a second lock on the same data home is rejected while the first is held") {
+            val home = Files.createTempDirectory("datadir-lock-")
+            val first = DataDirLock.forDataHome(home)
+            val second = DataDirLock.forDataHome(home)
+
+            first.tryAcquire() shouldBe true
+            second.tryAcquire() shouldBe false // the home is already locked — fail, don't clobber
+
+            first.close()
+            // Once the holder releases, the home becomes acquirable again.
+            second.tryAcquire() shouldBe true
+            second.close()
+        }
+
+        test("locks on different data homes don't interfere") {
+            val homeA = Files.createTempDirectory("datadir-lock-a-")
+            val homeB = Files.createTempDirectory("datadir-lock-b-")
+            val a = DataDirLock.forDataHome(homeA)
+            val b = DataDirLock.forDataHome(homeB)
+
+            a.tryAcquire() shouldBe true
+            b.tryAcquire() shouldBe true // independent homes → independent locks
+
+            a.close()
+            b.close()
+        }
+
+        test("close is idempotent and a closed lock can be re-acquired") {
+            val home = Files.createTempDirectory("datadir-lock-reuse-")
+            val lock = DataDirLock.forDataHome(home)
+
+            lock.tryAcquire() shouldBe true
+            lock.close()
+            lock.close() // idempotent — must not throw
+
+            lock.tryAcquire() shouldBe true
+            lock.close()
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/db/DataHomeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/db/DataHomeTest.kt
@@ -59,4 +59,18 @@ class DataHomeTest :
             resolveListenupHome(envHome = null, userHome = "/Users/x") shouldBe Path.of("/Users/x", "ListenUp")
             resolveListenupHome(envHome = "  ", userHome = "/Users/x") shouldBe Path.of("/Users/x", "ListenUp")
         }
+
+        test("resolveListenupHome (config-aware): listenup.home config wins, then env, then default — ONE home for all data (#703)") {
+            // config wins over env + default — this is what the DB/secrets previously ignored
+            resolveListenupHome(configuredHome = "/data/lu", envHome = "/env/lu", userHome = "/Users/x") shouldBe
+                Path.of("/data/lu")
+            // blank/absent config falls through to env
+            resolveListenupHome(configuredHome = "  ", envHome = "/env/lu", userHome = "/Users/x") shouldBe
+                Path.of("/env/lu")
+            resolveListenupHome(configuredHome = null, envHome = "/env/lu", userHome = "/Users/x") shouldBe
+                Path.of("/env/lu")
+            // no config, no env → userHome/ListenUp
+            resolveListenupHome(configuredHome = null, envHome = null, userHome = "/Users/x") shouldBe
+                Path.of("/Users/x", "ListenUp")
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/CoverSpoolTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/CoverSpoolTest.kt
@@ -10,12 +10,14 @@ import com.calypsan.listenup.domain.embeddedmeta.AudioTags
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedArtwork
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.nio.file.Files
+import java.nio.file.attribute.FileTime
 import kotlin.io.path.exists
 
 // ---------------------------------------------------------------------------
@@ -198,7 +200,7 @@ class CoverSpoolTest :
         // Lifecycle: clearScan / sweepOrphans
         // -------------------------------------------------------------------
 
-        test("clearScan removes the scan's dir; sweepOrphans removes all leftover dirs") {
+        test("clearScan removes the scan's dir; sweepOrphans removes STALE leftover dirs") {
             val root = Files.createTempDirectory("spool-test")
             val spool = CoverSpool(root)
             spool.spoolCover("scanA", bookWithEmbeddedCover("A", byteArrayOf(9)))
@@ -206,8 +208,38 @@ class CoverSpoolTest :
             spool.clearScan("scanA")
             root.resolve("scanA").exists() shouldBe false
             root.resolve("scanB").exists() shouldBe true
+            // Age scanB past the orphan grace so the sweep treats it as a crashed-scan leftover.
+            Files.setLastModifiedTime(
+                root.resolve("scanB"),
+                FileTime.fromMillis(System.currentTimeMillis() - CoverSpool.ORPHAN_GRACE_MS - 60_000L),
+            )
             spool.sweepOrphans()
             root.resolve("scanB").exists() shouldBe false
+        }
+
+        test("sweepOrphans preserves recently-modified dirs — a live scan is never clobbered") {
+            val root = Files.createTempDirectory("spool-test")
+            val spool = CoverSpool(root)
+
+            // A just-created dir stands in for a concurrent (possibly other-process) live scan.
+            val liveDir = root.resolve("live-scan-corr")
+            Files.createDirectories(liveDir)
+
+            val crashedDir = root.resolve("crashed-scan-corr")
+            Files.createDirectories(crashedDir)
+            Files.setLastModifiedTime(
+                crashedDir,
+                FileTime.fromMillis(System.currentTimeMillis() - 2 * 60 * 60 * 1000L), // 2h ago
+            )
+
+            spool.sweepOrphans()
+
+            withClue("a recently-written (live) scan dir must survive the startup sweep") {
+                liveDir.exists() shouldBe true
+            }
+            withClue("a long-stale (crashed) scan dir must be swept") {
+                crashedDir.exists() shouldBe false
+            }
         }
 
         // -------------------------------------------------------------------

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.api.error.ScanError
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import com.calypsan.listenup.server.testing.testLibrary
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -285,6 +286,33 @@ class ScannerTest :
                     val result = bus.replayCache.last()
                     (result.scope is ScanScope.Subtree) shouldBe true
                     (result.scope as ScanScope.Subtree).rootRelPath shouldBe "Author/Title"
+                }
+            }
+        }
+
+        test("runIncremental stamps the result with its OWN correlationId, not the previous full scan's (#703)") {
+            runTest {
+                audioLibrary {
+                    book("Author/Title") { tracks(count = 1) }
+                }.use { fixture ->
+                    val bus = MutableSharedFlow<ScanResult>(replay = 1)
+                    val counter = AtomicLong(0)
+                    val (scanner, _) =
+                        newScanner(
+                            fixture,
+                            correlationIdFactory = { "scan-${counter.incrementAndGet()}" },
+                            scanResultBus = bus,
+                        )
+                    scanner.runFullScan() // scan-1
+
+                    scanner.runIncremental(fixture.root.resolve("Author/Title")) // scan-2
+
+                    // Bug #703: `lastResult?.copy(...)` inherited the prior full scan's correlationId,
+                    // so the incremental spooled to scan-2 but cleared/reported scan-1 — leaking the
+                    // real spool dir and mis-keying ScanEvent.Completed.
+                    withClue("incremental result must carry its own correlationId (scan-2), not inherit scan-1") {
+                        bus.replayCache.last().correlationId shouldBe "scan-2"
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

Scanning a library produced repeated server warnings — *"Could not read spooled cover for X: NoSuchFileException: …/scan-spool/<corr>/<hash>.img"* — and embedded covers silently dropped (#703).

## Root cause

The failure is only possible when something deletes a scan's `scan-spool/<corr>` dir **while a persist is still reading it**. In one clean process that can't happen (the startup sweep runs before the scan; `clearScan` runs after the read). It happens when a **second server boots against the same `$LISTENUP_HOME`** while a prior instance's scan is still persisting — its startup `sweepOrphans()` wipes the live scan's covers. `rescanOnStartup = true` makes every boot immediately persist hundreds of covers, so a rapid restart/clear loop (with the old JVM not fully killed) reliably hits it.

## The fixes

| Commit | |
|---|---|
| age-aware `sweepOrphans` | A startup sweep now only deletes spool dirs untouched past a grace window, so it can never clobber a **recent/live** scan's dir. Direct fix for the 404 mechanism. |
| incremental `correlationId` | `Scanner.runIncremental` no longer inherits the previous full scan's id via `lastResult.copy(...)` — it stamps its own. Fixes a leaked spool dir + a mis-keyed `ScanEvent.Completed`. |
| unified data-home resolution | DB + secrets now honour the `listenup.home` config exactly like covers/spool (they previously read only `$LISTENUP_HOME`), so all server data is guaranteed under one directory and can't diverge. |
| single-instance data-dir lock | A second server on the same data home now **fails fast** with a clear message instead of silently racing the spool. Production-on via `application.conf` (`server.dataDirLock`); off in test configs by default. |

## Testing

TDD throughout (red→green where behavioral). New / extended unit tests: `CoverSpoolTest` (recent dir survives a sweep), `ScannerTest` (incremental keeps its own id), `DataHomeTest` (config-aware resolver precedence), `DataDirLockTest` (second lock rejected, release, independence). Verified green locally: those classes + `BooksModuleStartupTest`, `GracefulShutdownTest`, `PluginSmokeTest`, `AuthModuleVerifyTest`, the `scanner`/`services`/`cover` regression scope, and spotless + detekt.

The lock is confirmed inert in tests: both `:server` and `:sharedLogic` boot the server via `MapApplicationConfig` (which omits `server.dataDirLock`), so it defaults off and the E2E fixtures already use isolated temp homes.

> Note: the full `:server:jvmTest` couldn't complete on the dev box (forked-test-JVM heap OOM, identical before and after these changes — environmental). CI runs it with proper resources.

## Operational note

With the lock on, a stale JVM holding `~/ListenUp` now surfaces *"Another ListenUp server is already using the data directory…"* at startup instead of mystery 404s. For rapid test loops, `LISTENUP_SCAN_RESCAN_ON_STARTUP=false` removes the boot-scan being raced.

## Follow-up (not in this PR)

`useIsolatedTestConfig` resolves to the real `~/ListenUp` when a test doesn't pass `homeDir`, so such tests write covers/spool there. Always using a temp home would isolate them fully — proactive but broad; left for a separate change.

Closes #703.
