### PR TITLE
📝 docs: rewrite README for Android + iOS beta launch

### DIFF
--- a/.github/screenshots/.gitkeep
+++ b/.github/screenshots/.gitkeep
@@ -1,0 +1,2 @@
+# README screenshots live here. See the Screenshots section in README.md.
+# Expected files: library-android.png, player-ios.png, discover-android.png, social-ios.png

--- a/README.md
+++ b/README.md
@@ -9,124 +9,188 @@
 <h1 align="center">ListenUp</h1>
 
 <p align="center">
-  <strong>A modern audiobook player for Android, Android TV &amp; Desktop</strong>
+  <strong>A modern, offline-first audiobook player for Android &amp; iOS</strong>
 </p>
 
 <p align="center">
   <a href="https://kotlinlang.org/docs/multiplatform.html"><img src="https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white" alt="Kotlin Multiplatform" /></a>
-  <a href="https://developer.android.com"><img src="https://img.shields.io/badge/Android-36-3DDC84?logo=android&logoColor=white" alt="Android" /></a>
+  <a href="https://developer.android.com"><img src="https://img.shields.io/badge/Android-13%2B-3DDC84?logo=android&logoColor=white" alt="Android" /></a>
+  <a href="https://developer.apple.com/ios/"><img src="https://img.shields.io/badge/iOS-17%2B-000000?logo=apple&logoColor=white" alt="iOS" /></a>
   <a href="https://www.jetbrains.com/compose-multiplatform/"><img src="https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose&logoColor=white" alt="Compose Multiplatform" /></a>
+  <img src="https://img.shields.io/badge/status-beta%20v0.6.0-orange" alt="Beta v0.6.0" />
   <img src="https://img.shields.io/badge/License-AGPL--3.0-blue" alt="License" />
 </p>
-<p align="center">
-  ListenUp is a <a href="https://kotlinlang.org/docs/multiplatform.html">Kotlin Multiplatform</a> audiobook player that connects to a <a href="#">ListenUp server</a>. It's built with Kotline Multiplatform and designed to be offline-first — download your books, sync your progress in real time, and pick up where you left off on any device.
-</p>
 
+<p align="center">
+  ListenUp is a <strong>self-hosted audiobook platform</strong>: native apps for Android and iOS, backed by a
+  ListenUp server that you run yourself — included right here in this repository. Built with
+  <a href="https://kotlinlang.org/docs/multiplatform.html">Kotlin Multiplatform</a> and designed
+  <strong>offline-first</strong> — download your books, sync your progress in real time, and pick up
+  where you left off on any device.
+</p>
 
 ---
 
 ## Screenshots
 
-<!-- TODO: Add screenshots -->
+<p align="center"><em>Screenshots coming soon.</em></p>
 
-<p align="center"><em>Screenshots coming soon</em></p>
+<!--
+  READY TO GO: once you have the four images, commit them to .github/screenshots/
+  using the filenames referenced below, then delete the "coming soon" line above
+  and uncomment this block. Keep images phone-resolution and optimized
+  (~100–300 KB each — large PNGs bloat git history permanently).
+
+<table>
+  <tr>
+    <td align="center" width="50%">
+      <img src=".github/screenshots/library-android.png" alt="Library" width="260" /><br />
+      <sub><b>Library</b> — browse your collection</sub>
+    </td>
+    <td align="center" width="50%">
+      <img src=".github/screenshots/player-ios.png" alt="Now Playing" width="260" /><br />
+      <sub><b>Now Playing</b> — chapters, speed &amp; sleep timer</sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="50%">
+      <img src=".github/screenshots/discover-android.png" alt="Discover" width="260" /><br />
+      <sub><b>Discover</b> — search your server's catalog</sub>
+    </td>
+    <td align="center" width="50%">
+      <img src=".github/screenshots/social-ios.png" alt="Social" width="260" /><br />
+      <sub><b>Social</b> — activity feed &amp; leaderboard</sub>
+    </td>
+  </tr>
+</table>
+-->
 
 ---
 
+## Why ListenUp
+
+- **Truly yours** — self-hosted from the ground up. Your library, your server, your data. No accounts on someone else's cloud.
+- **Offline-first** — download once, listen anywhere. The app works with or without a connection, and it never strands you with stale state.
+- **Always in sync** — pick up exactly where you left off on any device, in real time.
+- **Made for sharing** — activity feeds and leaderboards turn solitary listening into something you share with the people you read alongside.
+- **Native & beautiful** — Compose Multiplatform on Android and SwiftUI on iOS, for a fast, modern feel on every device.
+
 ## Features
 
-- 🎧 **Audiobook playback** — chapter navigation, sleep timer, playback speed control
-- 📥 **Offline downloads** — download books for listening without a connection
-- 🔄 **Real-time sync** — progress syncs across devices via Server-Sent Events (SSE)
-- 📚 **Collection-based library** — browse by collection, contributor, series, or tag
-- 📖 **Shelves** — organize your library with custom shelves
-- 👥 **Social features** — activity feed, listening leaderboard
-- 🔍 **Discover** — browse and search your server's catalog
-- 🛠️ **Admin tools** — manage collections, categories, inbox, and backups from the app
-- 🎨 **Material 3 Expressive** — dynamic color, adaptive layouts, modern design
-- 📺 **Android TV** — lean-back experience with d-pad navigation, stream-only playback
-- 🖥️ **Cross-platform** — single codebase for Android, Android TV, and Desktop (JVM)
+- 🎧 **Audiobook playback** — chapter navigation, sleep timer, variable speed, resume anywhere
+- 📥 **Offline downloads** — download books and listen without a connection
+- 🔄 **Real-time sync** — progress syncs across your devices instantly via Server-Sent Events (SSE)
+- 📚 **Rich library** — browse by collection, contributor, series, or tag
+- 📖 **Shelves** — organize your library with your own custom shelves
+- 📄 **In-app reading** — built-in reader for PDF & ebook supplements that ship with a title
+- 🔍 **Discover** — search and browse your server's catalog, with a local fallback when you're offline
+- 👥 **Social** — activity feed and listening leaderboard
+- 🛠️ **Admin tools** — manage collections, categories, the import inbox, and backups from the app
+- 🎨 **Modern design** — Material 3 Expressive with dynamic color on Android, native SwiftUI on iOS
 
 ## Platforms
 
+Beta ships on the two platforms below; more are on the way.
+
 | Platform | Status | Audio Engine |
 |----------|--------|-------------|
-| Android  | ✅ Primary | Media3 / ExoPlayer |
-| Android TV | ✅ Supported | Media3 / ExoPlayer |
-| Desktop (JVM) | 🚧 In progress | FFmpeg via JavaCV |
+| Android  | ✅ Beta | Media3 / ExoPlayer |
+| iOS      | ✅ Beta | AVFoundation |
+
+**Coming soon:** Desktop (JVM) and Android TV — both already build from this codebase and will graduate to supported releases after the mobile beta settles.
+
+## Getting the Beta
+
+> Public beta links are being set up — check the [Releases](https://github.com/ListenUpApp/ListenUp/releases) page for the latest.
+
+- **iOS** — via TestFlight _(invite coming soon)_
+- **Android** — via the Google Play internal track _(invite coming soon)_
+
+### Connecting to a Server
+
+ListenUp is a client-server app — you connect the app to your own [ListenUp server](#run-your-own-server).
+
+1. Launch the app.
+2. On the connect screen, enter your server URL (e.g. `http://192.168.1.100:8080`), or let the app discover servers on your local network automatically via mDNS.
+3. Sign in, or accept an invite link.
+
+## Run Your Own Server
+
+The ListenUp server lives in this repository as the `:server` module — there's no separate download. To run it from source:
+
+```bash
+./gradlew :server:runJvm
+```
+
+It serves on port `8080` by default. Point the app at `http://<your-host>:8080` (or rely on mDNS on the same network) and sign in. See [`server/`](server/) for configuration and deployment details.
+
+## Building From Source
+
+For contributors who want to build the apps and server locally.
+
+### Prerequisites
+
+- **JDK 17+** (the build enforces Java 17 compatibility)
+- **Android SDK** with API 33+ (for Android builds) — Android Studio Otter or later recommended
+- **Xcode 26** (for iOS builds, macOS only)
+
+### Build & Run
+
+```bash
+# Clone
+git clone https://github.com/ListenUpApp/ListenUp.git
+cd ListenUp
+
+# Android (debug APK)
+./gradlew :androidApp:assembleDebug
+
+# Server
+./gradlew :server:runJvm
+
+# Desktop (JVM, in progress)
+./gradlew :desktopApp:run
+```
+
+For iOS, open `iosApp/ListenUp.xcodeproj` in Xcode and run the `ListenUp` scheme against a simulator or device.
+
+## Architecture
+
+```
+ListenUp/
+├── contract/      # Client↔server contract: @Rpc service interfaces, @Serializable DTOs, error hierarchy
+├── sharedLogic/   # KMP shared core — domain models, repositories, sync engine, DI, ViewModels (no UI)
+├── sharedUI/      # Compose Multiplatform UI (Android + Desktop), organized by feature
+├── server/        # Self-hostable Ktor server — the hub Android & iOS clients connect to
+├── androidApp/    # Android application entry point
+├── iosApp/        # iOS app — SwiftUI shell over the shared Kotlin core
+├── desktopApp/    # Desktop (JVM) application entry point (in progress)
+├── build-logic/   # Gradle convention plugins + custom Detekt rules
+└── rpc-guard-ksp/ # KSP processor guarding the RPC boundary
+```
+
+ListenUp follows **MVVM** with offline-first data flow and a clean separation between layers:
+
+- **`contract`** is the single source of truth for the client↔server boundary — shared by both sides so a field rename breaks at compile time, not in production.
+- **`sharedLogic`** holds all business logic, data access, the sync engine, and ViewModels (shared across Android & iOS). The local database is the single source of truth; the UI reads from it, never from the network directly.
+- **`sharedUI`** holds the Compose Multiplatform screens, organized by feature.
+- **`androidApp`**, **`iosApp`**, and **`desktopApp`** are thin entry points that wire up platform-specific services and launch the shared experience.
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
+| Language | [Kotlin 2.3](https://kotlinlang.org/) (Multiplatform) |
 | UI | [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/), Material 3, Navigation 3 |
 | DI | [Koin](https://insert-koin.io/) |
-| Networking | [Ktor](https://ktor.io/) |
-| Database | [Room](https://developer.android.com/training/data-storage/room) (Multiplatform) |
-| Image Loading | [Coil](https://coil-kt.github.io/coil/) |
+| Networking | [Ktor](https://ktor.io/) + [kotlinx.rpc](https://github.com/Kotlin/kotlinx-rpc) |
+| Client persistence | [Room](https://developer.android.com/training/data-storage/room) (Multiplatform) |
+| Server persistence | [SQLDelight](https://cashapp.github.io/sqldelight/) + SQLite |
+| Image loading | [Coil](https://coil-kt.github.io/coil/) |
 | Playback (Android) | [Media3 / ExoPlayer](https://developer.android.com/media/media3) |
-| Playback (Desktop) | [JavaCV / FFmpeg](https://github.com/bytedeco/javacv) |
+| Playback (iOS) | AVFoundation |
 | Serialization | [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) |
-| Code Quality | Detekt, Spotless (ktlint) |
-| Language | Kotlin 2.3, Java 17 |
-
-## Architecture
-
-```
-listenup/client
-├── shared/            # Kotlin Multiplatform library (Android, Desktop, iOS)
-│   ├── domain/        #   Models, repositories, use cases, playback interfaces
-│   ├── data/          #   API clients (Ktor), Room database, sync engine (SSE)
-│   └── core/          #   Error handling, shared utilities
-├── composeApp/        # Compose Multiplatform UI (Android + Desktop)
-│   ├── features/      #   Feature-based packages (home, library, nowplaying, ...)
-│   ├── design/        #   Design system — theme, components, utilities
-│   ├── navigation/    #   Navigation 3 graph and routes
-│   └── platform/      #   Platform expect/actual declarations
-├── androidApp/        # Android application entry point
-└── desktopApp/        # Desktop (JVM) application entry point
-```
-
-The app follows **MVVM** with a clean separation between layers:
-
-- **`shared`** contains all business logic, data access, and platform abstractions. No UI dependencies.
-- **`composeApp`** contains all Compose UI code, organized by feature. Each feature typically has a Screen, ViewModel, and composable components.
-- **`androidApp`** and **`desktopApp`** are thin entry points that wire up platform-specific services and launch the shared Compose UI.
-
-## Getting Started
-
-### Prerequisites
-
-- **JDK 17+** (the build enforces Java 17 compatibility)
-- **Android SDK** with API 33 (for Android builds)
-- **Android Studio** Otter or later (recommended)
-
-### Building
-
-```bash
-# Clone
-git clone https://github.com/calypsan/listenup-client.git
-cd listenup-client
-
-# Android (debug APK)
-./gradlew androidApp:assembleDebug
-
-# Desktop
-./gradlew desktopApp:run
-```
-
-### Connecting to a Server
-
-ListenUp is a client-server app. You need a running [ListenUp server](# "Link TBD") to use it.
-
-1. Launch the app
-2. On the connect screen, enter your server URL (e.g. `http://192.168.1.100:3000`) Or, use MDNS if on the same network.
-3. Sign in or accept an invite link
-
-The app supports automatic server discovery on local networks via mDNS (desktop).
+| Code quality | Detekt, Spotless (ktlint) |
 
 ## License
 
-
-
-AGPL-3.0.
+ListenUp is licensed under the **AGPL-3.0**. See [LICENSE](LICENSE) for the full text.


### PR DESCRIPTION
Rewrites the README ahead of the first beta (Android + iOS).

## What changed
- **iOS is now a first-class platform** (it was omitted entirely). Android + iOS are featured; Desktop + Android TV move to a brief "Coming soon" note.
- **Unified-project framing** — drops the dead external "server" links and documents the in-repo `:server` module via a new "Run Your Own Server" section.
- **Corrected stale facts** — clone URL → `ListenUpApp/ListenUp`; example server port → `8080`; architecture tree → actual modules (`contract` / `sharedLogic` / `sharedUI` / `server` / `iosApp`); refreshed tech stack (kotlinx.rpc, SQLDelight server persistence, AVFoundation).
- **Restructured** users-first / contributors-below, with a new "Why ListenUp" highlights section; fixed the `Kotline` typo and the empty License section.
- **Screenshot scaffold** — a 2×2 grid (Library · Now Playing · Discover · Social) wired but commented out so nothing renders broken. Drop four PNGs into `.github/screenshots/` and uncomment to go live.

## Notes for reviewers
- Beta download links (TestFlight / Play internal) are intentional `coming soon` placeholders.
- Screenshots are not included yet.
- Docs-only change; no code touched.
