### PR TITLE
🐛 fix(shared): keep post-import catch-up alive past import-wizard dismissal

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -142,10 +142,14 @@ internal class SyncRepositoryImpl(
         // rows past the cursor; handleCursorStale runs catchUpAll + reseeds the firehose, landing the
         // imported progress live. (forceFullResync stays the right tool for a server *restore*, where
         // the whole DB diverges and the digest genuinely differs at the cursor.)
-        when (val started = startEngineForCurrentUser()) {
-            is AppResult.Success -> suspendRunCatching { syncEngine.handleCursorStale() }
-            is AppResult.Failure -> started
-        }
+        //
+        // Driven through [refreshListeningHistoryDetached] so the catch-up runs on the app-scoped
+        // [scope], not the import wizard's viewModelScope that fires this — see that function's KDoc.
+        refreshListeningHistoryDetached(
+            scope = scope,
+            ensureStarted = ::startEngineForCurrentUser,
+            recover = syncEngine::handleCursorStale,
+        )
 
     override suspend fun forceFullResync(): AppResult<Unit> =
         when (val started = startEngineForCurrentUser()) {
@@ -544,3 +548,34 @@ internal suspend fun recoverFromScanStreamEnd(
     setScanning(false)
     markInitialScanComplete()
 }
+
+/**
+ * Ensure the engine is up via [ensureStarted], then run the post-import [recover] catch-up on
+ * [scope] — the app-scoped sync scope — **not** the caller's context, and join it.
+ *
+ * `refreshListeningHistory` is fired from the ABS import wizard's `viewModelScope`, which is
+ * cancelled the instant the wizard is dismissed — and the wizard shows "Done" before this catch-up
+ * finishes draining the firehose-suppressed imported positions into Room. Running [recover] in the
+ * caller's context let a dismissal cancel it mid-drain: the imported history never landed (and
+ * [SyncEngine.handleCursorStale]'s SSE reconnect never ran, leaving the firehose down) until a
+ * later, app-scoped sync trigger. Launched on [scope] the catch-up completes regardless of the
+ * wizard's lifecycle; the `join()` keeps the awaitable contract for callers that aren't transient.
+ *
+ * Extracted as a top-level function — like [recoverFromScanStreamEnd] — so it is testable with
+ * recording lambdas, no [SyncEngine] mock required.
+ */
+internal suspend fun refreshListeningHistoryDetached(
+    scope: CoroutineScope,
+    ensureStarted: suspend () -> AppResult<Unit>,
+    recover: suspend () -> Unit,
+): AppResult<Unit> =
+    when (val started = ensureStarted()) {
+        is AppResult.Success -> {
+            scope.launch { suspendRunCatching { recover() } }.join()
+            AppResult.Success(Unit)
+        }
+
+        is AppResult.Failure -> {
+            started
+        }
+    }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImplTest.kt
@@ -1,0 +1,78 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.error.InternalError
+import com.calypsan.listenup.api.result.AppResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression coverage for the post-import resync lifecycle ([refreshListeningHistoryDetached]).
+ *
+ * `refreshListeningHistory` is fired from the ABS import wizard's `viewModelScope` the moment the
+ * wizard shows "Done" — and the imported playback positions reach Room only via the catch-up it
+ * drives (the import writes them firehose-suppressed, so there is no live SSE push). The wizard is
+ * dismissable the instant "Done" appears, so running the catch-up in the caller's context let a
+ * dismissal cancel it mid-drain: the imported history never landed (and the firehose was left
+ * disconnected) until a later, app-scoped sync trigger. The catch-up must run on the app-scoped sync
+ * scope and complete regardless of the caller's lifecycle.
+ */
+class SyncRepositoryImplTest :
+    FunSpec({
+        test("post-import catch-up completes even when the calling scope is cancelled mid-drain") {
+            runTest {
+                val recoveryStarted = CompletableDeferred<Unit>()
+                val releaseRecovery = CompletableDeferred<Unit>()
+                var recoveryCompleted = false
+
+                // The app-scoped sync scope: long-lived, independent of any one screen.
+                val appScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+
+                // Stand in for the import wizard's viewModelScope: a caller we cancel mid-catch-up.
+                val caller =
+                    launch(UnconfinedTestDispatcher(testScheduler)) {
+                        refreshListeningHistoryDetached(
+                            scope = appScope,
+                            ensureStarted = { AppResult.Success(Unit) },
+                            recover = {
+                                recoveryStarted.complete(Unit)
+                                releaseRecovery.await()
+                                recoveryCompleted = true
+                            },
+                        )
+                    }
+
+                recoveryStarted.await()
+                caller.cancel() // wizard dismissed while the catch-up is still draining
+                releaseRecovery.complete(Unit)
+                advanceUntilIdle()
+
+                recoveryCompleted shouldBe true
+
+                appScope.cancel()
+            }
+        }
+
+        test("post-import catch-up is skipped, and the failure surfaced, when the engine won't start") {
+            runTest {
+                var recovered = false
+
+                val result =
+                    refreshListeningHistoryDetached(
+                        scope = backgroundScope,
+                        ensureStarted = { AppResult.Failure(InternalError()) },
+                        recover = { recovered = true },
+                    )
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                recovered shouldBe false
+            }
+        }
+    })


### PR DESCRIPTION
## Problem

After an Audiobookshelf import, the user's imported history was slow to appear in **Continue Listening** — it only showed up after interacting with the app or waiting, "feeling like it didn't work" (reported on Android).

## Root cause

Continue Listening is a reactive Room query, so it updates the instant rows land in Room. The import writes playback positions server-side under `FirehoseSuppressed` (no live SSE push), so the client only learns about them via the post-import catch-up: `refreshListeningHistory()` → `SyncEngine.handleCursorStale()` → full `catchUpAll()`.

That catch-up ran inside the **import wizard's `viewModelScope`**, and the wizard shows its "Done" screen *before* the catch-up finishes draining. On Android the wizard is a `koinViewModel()`-scoped screen, so dismissing it (tapping Finish) clears the VM and **cancels the catch-up mid-drain** — the imported positions never reached Room, and `handleCursorStale`'s SSE reconnect never ran, leaving the firehose down. The history then only landed on a *later*, app-scoped sync trigger (restart / scan / background-foreground) — exactly the observed symptom.

## Fix

Extracted `refreshListeningHistoryDetached(scope, ensureStarted, recover)` (following this file's existing "top-level function tested with recording lambdas, no SyncEngine mock required" pattern) and made it launch the catch-up on the **app-scoped sync scope** and `join()` it. The recovery now completes regardless of the wizard's lifecycle; the `join()` keeps the awaitable contract for non-transient callers.

## Tests

TDD: the regression test was written first and **failed** against the old caller-scoped behavior (caller cancellation killed the recovery), then **passed** after the fix. Covers both the cancellation-survival invariant and the engine-fail short-circuit.

Gate green locally: `spotlessCheck`, `detekt`, `:sharedLogic:jvmTest`, `:server:jvmTest`.