### PR TITLE
🐛 fix(shared): resolve Edit Profile loading hang for users with no name

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModel.kt
@@ -138,38 +138,43 @@ class EditProfileViewModel(
                 EditProfileUiState.Error("No user data available")
             } else {
                 // Seed the form exactly once from the first non-null user so that
-                // re-emissions from Room don't overwrite edits already in progress.
-                if (!formInitialized) {
-                    formInitialized = true
-                    formFlow.value =
+                // re-emissions from Room don't overwrite edits already in progress, then
+                // build Ready from the seeded values in the same pass. We must NOT seed and
+                // return Loading awaiting a re-emission: when the user has no name/tagline the
+                // seeded FormState equals the initial FormState(), StateFlow conflates the
+                // identical assignment away, no re-emission arrives, and the screen is stuck
+                // on the spinner forever.
+                val effectiveForm =
+                    if (!formInitialized) {
+                        formInitialized = true
                         FormState(
                             firstName = user.firstName ?: "",
                             lastName = user.lastName ?: "",
                             tagline = user.tagline ?: "",
-                        )
-                    // Return Loading briefly — the next emission will carry the seeded form.
-                    return@combine EditProfileUiState.Loading
-                }
+                        ).also { formFlow.value = it }
+                    } else {
+                        form
+                    }
 
                 val isDirty =
-                    form.firstName != (user.firstName ?: "") ||
-                        form.lastName != (user.lastName ?: "") ||
-                        form.tagline != (user.tagline ?: "") ||
-                        form.currentPassword.isNotEmpty() ||
-                        form.newPassword.isNotEmpty() ||
-                        form.confirmPassword.isNotEmpty() ||
-                        form.avatarChange != AvatarChange.None
+                    effectiveForm.firstName != (user.firstName ?: "") ||
+                        effectiveForm.lastName != (user.lastName ?: "") ||
+                        effectiveForm.tagline != (user.tagline ?: "") ||
+                        effectiveForm.currentPassword.isNotEmpty() ||
+                        effectiveForm.newPassword.isNotEmpty() ||
+                        effectiveForm.confirmPassword.isNotEmpty() ||
+                        effectiveForm.avatarChange != AvatarChange.None
 
                 EditProfileUiState.Ready(
                     user = user,
                     localAvatarPath = resolveLocalAvatarPath(user),
-                    firstName = form.firstName,
-                    lastName = form.lastName,
-                    tagline = form.tagline,
-                    currentPassword = form.currentPassword,
-                    newPassword = form.newPassword,
-                    confirmPassword = form.confirmPassword,
-                    avatarChange = form.avatarChange,
+                    firstName = effectiveForm.firstName,
+                    lastName = effectiveForm.lastName,
+                    tagline = effectiveForm.tagline,
+                    currentPassword = effectiveForm.currentPassword,
+                    newPassword = effectiveForm.newPassword,
+                    confirmPassword = effectiveForm.confirmPassword,
+                    avatarChange = effectiveForm.avatarChange,
                     isDirty = isDirty,
                     isSaving = isSaving,
                 )

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
@@ -141,6 +141,26 @@ class EditProfileViewModelTest :
             }
         }
 
+        test("state emits Ready (not stuck on Loading) when user has no name or tagline") {
+            runTest {
+                // Regression: a user whose first/last name and tagline are all null seeds a
+                // FormState equal to the initial FormState(). The old code mutated formFlow to
+                // that identical value and waited for a re-emission that StateFlow conflated
+                // away — leaving the Edit Profile screen stuck on the Loading spinner forever.
+                val user = createUser(firstName = null, lastName = null, tagline = null)
+                val fixture = createFixture().apply { configure(currentUser = user) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Ready>()
+                ready.firstName shouldBe ""
+                ready.lastName shouldBe ""
+                ready.tagline shouldBe ""
+                ready.isDirty shouldBe false
+            }
+        }
+
         test("Ready reflects cached avatar path when avatar is an image") {
             runTest {
                 val user = createUser(avatarType = "image", avatarValue = "avatar.jpg")


### PR DESCRIPTION
## Problem

The Edit Profile screen loads indefinitely (spinner never resolves) for any account whose **first name, last name, and tagline are all empty/null** — e.g. a self-hosted account created with just credentials and no display name set.

## Root cause

`EditProfileViewModel`'s `combine` block seeded the form edit-buffer, returned `Loading`, and relied on `formFlow` re-emitting to advance to `Ready`:

```kotlin
if (!formInitialized) {
    formInitialized = true
    formFlow.value = FormState(firstName = ..., lastName = ..., tagline = ...)
    return@combine EditProfileUiState.Loading   // waits for a second emission
}
```

`formFlow` is a `MutableStateFlow`, which conflates equal values. When the user has no name/tagline, the seeded `FormState(...)` equals the initial `FormState()`, so the assignment is a silent no-op — **no re-emission fires, `combine` never re-runs, and the state stays `Loading` forever.** Named users dodged it because their seeded form differed, which is why the bug looked intermittent and the existing test suite stayed green.

## Fix

Build `Ready` directly from the seeded form in the same pass — no bounce through `Loading`, no dependency on a `StateFlow` re-emission. The once-only seeding semantics (Room re-emissions don't clobber in-progress edits) are preserved exactly. Because the ViewModel lives in `sharedLogic/commonMain`, this fixes Android, Desktop, and iOS.

## Testing

- Added a failing-first regression test (`state emits Ready (not stuck on Loading) when user has no name or tagline`) — confirmed **red** (stuck on `Loading`) before the fix, **green** after.
- All 17 `EditProfileViewModelTest` cases pass (16 existing + new).
- `spotlessCheck` / `detekt` clean on the changed files.

## CI note

Two unrelated failures pre-exist on `main` (verified at `c9348506b`, without this change) and are **not** introduced here:
- `ScannerSseRouteTest` — flaky server SSE test
- `ViewModelUsesStateInWhileSubscribedRule` — deterministically flags `ABSImportViewModel` (pre-existing architecture-debt backlog)