### PR TITLE
🐛 fix(shared): persist streamed book covers to disk for offline durability

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImpl.kt
@@ -37,6 +37,10 @@ internal class ImageRepositoryImpl(
 
     override suspend fun downloadBookCover(bookId: BookId): AppResult<Boolean> = imageDownloader.downloadCover(bookId)
 
+    override fun ensureBookCoverCached(bookId: BookId) {
+        appScope.launch { downloadBookCover(bookId) }
+    }
+
     override suspend fun saveBookCoverStaging(
         bookId: BookId,
         imageData: ByteArray,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageRepository.kt
@@ -40,6 +40,19 @@ interface ImageRepository {
     suspend fun downloadBookCover(bookId: BookId): AppResult<Boolean>
 
     /**
+     * Best-effort: ensure a book's cover is cached on local disk for offline use.
+     *
+     * Returns immediately; the download runs on the repository's app scope, so it survives the
+     * caller leaving composition. No-op if the cover already exists locally. Failures are logged
+     * and dropped — the next view or sync retries. Used by cover components to lazily persist a
+     * cover the first time it is streamed from the server, so it stays available offline
+     * independent of the image loader's evictable cache.
+     *
+     * @param bookId Unique identifier for the book
+     */
+    fun ensureBookCoverCached(bookId: BookId)
+
+    /**
      * Upload book cover to the server.
      *
      * @param bookId Unique identifier for the book

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImplTest.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [ImageRepositoryImpl].
+ *
+ * Covers the fire-and-forget [com.calypsan.listenup.client.domain.repository.ImageRepository.ensureBookCoverCached]
+ * trigger that backs lazy offline cover persistence: it must launch a durable cover download on the
+ * app scope so a streamed cover survives offline (independent of Coil/Nuke's evictable caches).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImageRepositoryImplTest :
+    FunSpec({
+        test("ensureBookCoverCached launches a durable cover download on the app scope") {
+            runTest {
+                val imageDownloader: ImageDownloaderContract = mock()
+                everySuspend { imageDownloader.downloadCover(any()) } returns AppResult.Success(true)
+                val repo =
+                    ImageRepositoryImpl(
+                        imageDownloader = imageDownloader,
+                        imageStorage = mock(),
+                        imageApi = mock(),
+                        appScope = this,
+                    )
+
+                repo.ensureBookCoverCached(BookId("book-1"))
+                advanceUntilIdle()
+
+                verifySuspend { imageDownloader.downloadCover(BookId("book-1")) }
+            }
+        }
+    })

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
@@ -171,6 +171,9 @@ private fun rememberCoverRequest(
                             .diskCacheKey(cacheKey)
                             .build()
                     } else {
+                        // No durable file yet — kick off a background download so this streamed
+                        // cover is persisted on disk for offline use, then stream from the server now.
+                        imageRepository.ensureBookCoverCached(BookId(bookId))
                         serverCoverRequest(context, bookId, serverConfig, authSession, localPath, cacheKey)
                     }
                 }


### PR DESCRIPTION
## Problem
Book covers were only cached in Coil's evictable 50 MB LRU (OS-purgeable `cacheDir`). The durable store (`{filesDir}/covers/{bookId}.jpg`) and render-from-disk pipeline already existed, but nothing populated the store in production — so covers always streamed from the server and offline display only worked until eviction.

## Fix
New public fire-and-forget `ImageRepository.ensureBookCoverCached(bookId)` (durable download on the app scope, no-op if present), called from `BookCoverImage`'s server-fallback point. Once on disk, `exists()` flips true and the cover renders from durable disk on the next fresh resolution — offline-permanent.

## Testing
`ImageRepositoryImplTest` seam test (red→green); `:sharedLogic:jvmTest` + `:androidApp:assembleDebug` + detekt/spotless clean.

## Scope
Android/Desktop only. iOS same gap tracked in #720. Contributor photos + avatars (same gap) extended in a follow-up PR.