### PR TITLE
🐛 fix(shared): persist contributor photos & avatars to disk for offline durability

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImpl.kt
@@ -41,6 +41,14 @@ internal class ImageRepositoryImpl(
         appScope.launch { downloadBookCover(bookId) }
     }
 
+    override fun ensureContributorImageCached(contributorId: String) {
+        appScope.launch { imageDownloader.downloadContributorImage(contributorId) }
+    }
+
+    override fun ensureUserAvatarCached(userId: String) {
+        appScope.launch { imageDownloader.downloadUserAvatar(userId, forceRefresh = false) }
+    }
+
     override suspend fun saveBookCoverStaging(
         bookId: BookId,
         imageData: ByteArray,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageRepository.kt
@@ -53,6 +53,30 @@ interface ImageRepository {
     fun ensureBookCoverCached(bookId: BookId)
 
     /**
+     * Best-effort: ensure a contributor's image is cached on local disk for offline use.
+     *
+     * Fire-and-forget analogue of [ensureBookCoverCached] for contributor photos. Returns
+     * immediately; the download runs on the repository's app scope and is a no-op if the image
+     * already exists locally. Used by contributor image components to lazily persist a photo the
+     * first time it is streamed from the server.
+     *
+     * @param contributorId Unique identifier for the contributor
+     */
+    fun ensureContributorImageCached(contributorId: String)
+
+    /**
+     * Best-effort: ensure a user's avatar is cached on local disk for offline use.
+     *
+     * Fire-and-forget analogue of [ensureBookCoverCached] for user avatars. Returns immediately;
+     * the download runs on the repository's app scope and is a no-op if the avatar already exists
+     * locally. Lets avatars shown in feeds/leaderboards persist (and render the real photo rather
+     * than initials) without first visiting the user's profile.
+     *
+     * @param userId Unique identifier for the user
+     */
+    fun ensureUserAvatarCached(userId: String)
+
+    /**
      * Upload book cover to the server.
      *
      * @param bookId Unique identifier for the book

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImplTest.kt
@@ -41,4 +41,42 @@ class ImageRepositoryImplTest :
                 verifySuspend { imageDownloader.downloadCover(BookId("book-1")) }
             }
         }
+
+        test("ensureContributorImageCached launches a durable contributor-image download on the app scope") {
+            runTest {
+                val imageDownloader: ImageDownloaderContract = mock()
+                everySuspend { imageDownloader.downloadContributorImage(any()) } returns AppResult.Success(true)
+                val repo =
+                    ImageRepositoryImpl(
+                        imageDownloader = imageDownloader,
+                        imageStorage = mock(),
+                        imageApi = mock(),
+                        appScope = this,
+                    )
+
+                repo.ensureContributorImageCached("contrib-1")
+                advanceUntilIdle()
+
+                verifySuspend { imageDownloader.downloadContributorImage("contrib-1") }
+            }
+        }
+
+        test("ensureUserAvatarCached launches a durable avatar download on the app scope") {
+            runTest {
+                val imageDownloader: ImageDownloaderContract = mock()
+                everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns AppResult.Success(true)
+                val repo =
+                    ImageRepositoryImpl(
+                        imageDownloader = imageDownloader,
+                        imageStorage = mock(),
+                        imageApi = mock(),
+                        appScope = this,
+                    )
+
+                repo.ensureUserAvatarCached("user-1")
+                advanceUntilIdle()
+
+                verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = false) }
+            }
+        }
     })

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
@@ -95,6 +95,9 @@ fun ContributorCoverImage(
                         .diskCacheKey(contributorCacheKey(contributorId, imagePath))
                         .build()
                 } else {
+                    // No durable file yet — kick off a background download so this streamed
+                    // contributor photo is persisted on disk for offline use, then stream now.
+                    imageRepository.ensureContributorImageCached(contributorId)
                     val baseUrl = serverConfig.getActiveUrl()?.value
                     val token = authSession.getAccessToken()?.value
                     logger.debug {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -30,6 +31,7 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.calypsan.listenup.client.domain.model.CachedUserProfile
+import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import kotlin.uuid.ExperimentalUuidApi
@@ -123,12 +125,24 @@ internal fun rememberUserAvatarState(
 ): UserAvatarUiState {
     val repo: UserProfileRepository = koinInject()
     val imageStorage: ImageStorage = koinInject()
+    val imageRepository: ImageRepository = koinInject()
     val profile by repo.observeProfile(userId).collectAsStateWithLifecycle(initialValue = null)
 
-    return remember(userId, profile, fallbackName) {
+    val hasLocalAvatar = remember(userId, profile) { imageStorage.userAvatarExists(userId) }
+
+    // Lazily persist an image avatar we don't have on disk yet, so it renders the real photo
+    // (not initials) everywhere it appears — feeds, leaderboards — and survives offline, without
+    // first visiting the user's profile. No-op once the file exists.
+    LaunchedEffect(userId, profile?.avatarType, hasLocalAvatar) {
+        if (profile?.avatarType == "image" && !hasLocalAvatar) {
+            imageRepository.ensureUserAvatarCached(userId)
+        }
+    }
+
+    return remember(userId, profile, fallbackName, hasLocalAvatar) {
         userAvatarUiState(
             profile = profile,
-            hasLocalAvatar = imageStorage.userAvatarExists(userId),
+            hasLocalAvatar = hasLocalAvatar,
             localPath = imageStorage.getUserAvatarPath(userId),
             userId = userId,
             fallbackName = fallbackName,


### PR DESCRIPTION
Follow-up to #719 (book covers), extending the same lazy persist-on-first-view pattern to the other image types that share the gap.

## Problem
Like book covers (fixed in #719), contributor photos and user avatars were never written to the durable on-device store — so they lived only in the platform image loader's evictable cache (or, for avatars, didn't render at all).

## Fix
Two more fire-and-forget methods on the public `ImageRepository`, each `appScope.launch { imageDownloader.downloadX(...) }` (survives composition, no-op if already present), called from the render component:

| Type | Method | Trigger |
|---|---|---|
| **Contributor photos** | `ensureContributorImageCached(contributorId)` | `ContributorCoverImage` server-fallback branch — identical shape to the cover fix |
| **User avatars** | `ensureUserAvatarCached(userId)` | `UserAvatar` `LaunchedEffect` when `avatarType == "image" && !hasLocalAvatar` |

**Avatars are a slightly different shape:** `UserAvatar` has **no server fallback** — an image-type avatar with no local file rendered **initials**, so feed/leaderboard avatars showed initials until you opened that user's profile (`UserProfileViewModel.tryDownloadAvatar` was the only trigger). Now the photo downloads on first render, persists, and shows everywhere — offline included.

Once a file lands, `exists()` flips true, mappers populate the path, and the component renders from durable disk on the next fresh resolution.

**Series covers — intentionally not changed:** the download/exists/path contract exists but has no production trigger and no standalone renderer (series tiles render via member-book covers, covered by #719). Moot until a dedicated series-cover image is added.

## Testing (TDD)
- `ImageRepositoryImplTest` — two new seam tests (`ensureContributorImageCached`, `ensureUserAvatarCached`) each assert the durable download launches on the app scope (red→green).
- `:sharedLogic:jvmTest` (the three `ensureX` tests pass), `:androidApp:assembleDebug` BUILD SUCCESSFUL, `detekt` + `spotlessCheck` clean.
- Pre-existing/flaky failures unrelated to this change: `ViewModelUsesStateInWhileSubscribedRule` (deterministic, `ABSImportViewModel`); `RpcReturnShapesRule` (load-induced konsist timeout, passes in isolation).

## Scope
Android/Desktop only — iOS (own SwiftUI layer) has the same gap for all three image types, tracked in #720; the shared `ensureX` methods are exactly what the iOS triggers reuse. `:server:jvmTest` not run (change is `sharedLogic` + `sharedUI` only).