### PR TITLE
fix(sharedUI): clear the mini-player across all detail screens

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ScreensUseListenUpScaffoldRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ScreensUseListenUpScaffoldRule.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Authenticated detail/editor screens must use [com.calypsan.listenup.client.design.components.ListenUpScaffold],
+ * never the raw Material3 Scaffold. ListenUpScaffold reserves the floating mini-player's
+ * footprint app-wide; a raw Scaffold silently reintroduces the overlap bug class.
+ *
+ * Scope: files under `sharedUI/.../features/` whose name ends in `Screen.kt`. The allowlist
+ * carries the documented immersive opt-outs (full-screen surfaces that intentionally suppress
+ * or replace the bar) and any non-screen exceptions.
+ */
+class ScreensUseListenUpScaffoldRule :
+    FunSpec({
+        test("feature screens use ListenUpScaffold, not raw Material3 Scaffold") {
+            val offenders =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .filter { it.path.contains("/sharedUI/") }
+                    .filter { it.path.contains("/features/") }
+                    .filter { it.path.endsWith("Screen.kt") }
+                    .filter { file -> file.imports.any { it.name == "androidx.compose.material3.Scaffold" } }
+                    .filter { file -> SCAFFOLD_RULE_ALLOWLIST.none { allowed -> file.path.endsWith(allowed) } }
+                    .map { it.name }
+
+            offenders.shouldBeEmpty()
+        }
+    })
+
+/**
+ * Screens intentionally exempt from [ListenUpScaffold]: full-screen immersive surfaces that
+ * suppress/replace the mini-player, and Shell tabs that are already padded by AppShell. Each
+ * entry carries a one-line reason.
+ */
+private val SCAFFOLD_RULE_ALLOWLIST: Set<String> =
+    setOf(
+        "DocumentViewerScreen.kt", // immersive PDF/ebook reader — no bar overlay
+        "NowPlayingScreen.kt", // the expanded player itself
+        "HomeScreen.kt", // Shell tab — AppShell already reserves player space via its bottomBar; HomeScreen's inner Scaffold consumes the shell's contentPadding and must not re-add insets
+    )

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffoldTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffoldTest.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.test.junit4.createComposeRule
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ListenUpScaffoldTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `content padding reserves the provided player inset`() {
+        var bottomPadding: Dp = (-1).dp
+
+        composeRule.setContent {
+            CompositionLocalProvider(
+                LocalNowPlayingInsets provides WindowInsets(bottom = 88.dp),
+            ) {
+                ListenUpScaffold(modifier = Modifier.fillMaxSize()) { padding: PaddingValues ->
+                    bottomPadding = padding.calculateBottomPadding()
+                    Text("content")
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        bottomPadding shouldBeGreaterThanOrEqualTo 88.dp
+    }
+
+    @Test
+    fun `content padding collapses to system insets when no player inset`() {
+        var bottomPadding: Dp = (-1).dp
+
+        composeRule.setContent {
+            // Default LocalNowPlayingInsets is empty (no provider) → only system bars apply.
+            ListenUpScaffold(modifier = Modifier.fillMaxSize()) { padding: PaddingValues ->
+                bottomPadding = padding.calculateBottomPadding()
+                Text("content")
+            }
+        }
+        composeRule.waitForIdle()
+
+        // Robolectric's default device reports zero nav-bar inset, so with no player inset the
+        // reserved bottom space is exactly 0 — proving we do not pad when idle.
+        bottomPadding shouldBe 0.dp
+    }
+}

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/NowPlayingInsetsTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/NowPlayingInsetsTest.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.ui.unit.dp
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class NowPlayingInsetsTest :
+    FunSpec({
+        test("nowPlayingClearance returns footprint when bar visible") {
+            nowPlayingClearance(barVisible = true, latchedFootprint = 96.dp) shouldBe 96.dp
+        }
+        test("nowPlayingClearance returns zero when bar hidden") {
+            nowPlayingClearance(barVisible = false, latchedFootprint = 96.dp) shouldBe 0.dp
+        }
+        test("latchFootprint adopts a new positive measurement while visible") {
+            latchFootprint(current = 0.dp, measured = 104.dp, barVisible = true) shouldBe 104.dp
+        }
+        test("latchFootprint keeps last value when bar hidden") {
+            latchFootprint(current = 104.dp, measured = 0.dp, barVisible = false) shouldBe 104.dp
+        }
+        test("latchFootprint ignores non-positive measurements while visible") {
+            latchFootprint(current = 104.dp, measured = 0.dp, barVisible = true) shouldBe 104.dp
+        }
+    })

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -149,7 +149,7 @@ fun AdminBackupScreen(
 
     val readyState = backupState as? AdminBackupUiState.Ready
 
-    Scaffold(
+    ListenUpScaffold(
         floatingActionButton = {
             if (readyState != null) {
                 ListenUpFab(

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/RestoreBackupScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/RestoreBackupScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -67,7 +67,7 @@ fun RestoreBackupScreen(
     // navigation in those states to avoid abandoning a destructive operation.
     val canNavigateBack = state is RestoreBackupUiState.Idle
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.admin_restore_backup)) },

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/RestoreFromFileScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/RestoreFromFileScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -76,7 +76,7 @@ fun RestoreFromFileScreen(
 
     val canNavigateBack = state !is RestoreFromFileUiState.Uploading
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.admin_restore_from_file)) },

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/import/ImportFlowScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/import/ImportFlowScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -58,8 +58,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.calypsan.listenup.client.playback.NowPlayingState
-import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.imports.AbsItemRef
 import com.calypsan.listenup.api.dto.imports.AbsUserMatch
@@ -144,9 +142,6 @@ import org.koin.compose.viewmodel.koinViewModel
 
 private val CONTENT_MAX_WIDTH = 560.dp
 
-// Extra bottom clearance when the floating mini-player pill is visible on detail routes.
-private val MiniPlayerClearance = 88.dp
-
 // Zero-based wizard step index for each progress phase, mapped onto the 4-step tracker.
 private const val STEP_UPLOAD = 0
 private const val STEP_REVIEW = 1
@@ -170,17 +165,8 @@ private const val STEP_DONE = 3
 fun ImportFlowScreen(
     onNavigateBack: () -> Unit,
     viewModel: ImportFlowViewModel = koinViewModel(),
-    nowPlayingViewModel: NowPlayingViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val nowPlayingScreenState by nowPlayingViewModel.screenState.collectAsStateWithLifecycle()
-    val miniPlayerBottomPadding =
-        if (nowPlayingScreenState.state is NowPlayingState.Active) {
-            MiniPlayerClearance
-        } else {
-            0
-                .dp
-        }
 
     // The file picker is declared here (at the screen level) so the composable lifecycle
     // that wires the ActivityResult launcher is stable across all phases. It is only
@@ -192,13 +178,12 @@ fun ImportFlowScreen(
             }
         }
 
-    Scaffold { paddingValues ->
+    ListenUpScaffold { paddingValues ->
         Column(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(bottom = miniPlayerBottomPadding),
+                    .padding(paddingValues),
         ) {
             FlowHero(state = uiState, onBack = onNavigateBack)
             CenteredColumn {

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -19,7 +19,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.calypsan.listenup.client.design.LocalDeviceContext
@@ -55,6 +57,7 @@ fun NowPlayingHost(
     onNavigateToContributor: (String) -> Unit,
     onNavigateToDocument: (localPath: String) -> Unit,
     viewModel: NowPlayingViewModel,
+    onBarFootprintChanged: (Dp) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val screenState by viewModel.screenState.collectAsStateWithLifecycle()
@@ -186,7 +189,10 @@ fun NowPlayingHost(
                 modifier =
                     Modifier
                         .align(Alignment.BottomCenter)
-                        .padding(bottom = bottomPadding),
+                        .padding(bottom = bottomPadding)
+                        .onSizeChanged { size ->
+                            onBarFootprintChanged(with(density) { size.height.toDp() })
+                        },
             )
         }
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -191,7 +191,12 @@ fun NowPlayingHost(
                         .align(Alignment.BottomCenter)
                         .padding(bottom = bottomPadding)
                         .onSizeChanged { size ->
-                            onBarFootprintChanged(with(density) { size.height.toDp() })
+                            // Only report the bar's resting footprint. A visible snackbar lifts the
+                            // bar (snackbarPadding) — reporting that would reflow every detail screen
+                            // up for the snackbar's duration, so we skip those measurements.
+                            if (!isSnackbarVisible) {
+                                onBarFootprintChanged(with(density) { size.height.toDp() })
+                            }
                         },
             )
         }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -68,6 +68,7 @@ import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.features.nowplaying.NowPlayingHost
 import com.calypsan.listenup.client.playback.NowPlayingState
 import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
+import com.calypsan.listenup.client.features.nowplaying.DockedNowPlayingBarHeight
 import com.calypsan.listenup.client.features.shell.ShellDestination
 import com.calypsan.listenup.client.features.shell.shellDestinationSaver
 import com.calypsan.listenup.client.presentation.auth.PendingApprovalViewModel
@@ -92,11 +93,12 @@ import com.calypsan.listenup.client.navigation.entries.shellEntry
 private val logger = KotlinLogging.logger {}
 
 /**
- * Initial mini-player clearance used before the bar reports its first measurement. Sized to a
- * typical floating bar plus its bottom padding so detail screens never overlap on the very first
- * frame; replaced by the real measured footprint once [NowPlayingHost] reports it.
+ * Initial mini-player clearance used before the bar reports its first measurement. Tracks
+ * [DockedNowPlayingBarHeight] so the desktop/tablet docked bar (which doesn't self-report its
+ * footprint yet) and the phone floating bar share the same seed value. Replaced by the real
+ * measured footprint once [NowPlayingHost] reports it.
  */
-private val DefaultNowPlayingFootprint = 96.dp
+private val DefaultNowPlayingFootprint = DockedNowPlayingBarHeight
 
 /**
  * Root navigation composable for ListenUp Android app.

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import org.jetbrains.compose.resources.stringResource
@@ -56,6 +57,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
 import com.calypsan.listenup.client.design.components.ListenUpButton
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
+import com.calypsan.listenup.client.design.components.ProvideNowPlayingInsets
+import com.calypsan.listenup.client.design.components.latchFootprint
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.features.connect.ServerSelectScreen
@@ -63,6 +66,7 @@ import com.calypsan.listenup.client.features.connect.ServerSetupScreen
 import com.calypsan.listenup.client.features.invite.JoinScreen
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.features.nowplaying.NowPlayingHost
+import com.calypsan.listenup.client.playback.NowPlayingState
 import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
 import com.calypsan.listenup.client.features.shell.ShellDestination
 import com.calypsan.listenup.client.features.shell.shellDestinationSaver
@@ -86,6 +90,13 @@ import com.calypsan.listenup.client.navigation.entries.shelfEntries
 import com.calypsan.listenup.client.navigation.entries.shellEntry
 
 private val logger = KotlinLogging.logger {}
+
+/**
+ * Initial mini-player clearance used before the bar reports its first measurement. Sized to a
+ * typical floating bar plus its bottom padding so detail screens never overlap on the very first
+ * frame; replaced by the real measured footprint once [NowPlayingHost] reports it.
+ */
+private val DefaultNowPlayingFootprint = 96.dp
 
 /**
  * Root navigation composable for ListenUp Android app.
@@ -520,6 +531,15 @@ private fun AuthenticatedNavigation(
     // ViewModels for shortcut action handling
     val nowPlayingViewModel: NowPlayingViewModel = koinViewModel()
 
+    // Mini-player clearance: the bar is the producer of its own footprint, the detail screens
+    // are the consumers via LocalNowPlayingInsets. The bar is "visible" (and thus reserves space)
+    // only while a book is Active and the full-screen player is collapsed. We latch the measured
+    // footprint so transient zero sizes during the slide-out animation don't collapse the inset.
+    val nowPlayingScreenState by nowPlayingViewModel.screenState.collectAsStateWithLifecycle()
+    val barVisible =
+        nowPlayingScreenState.state is NowPlayingState.Active && !nowPlayingScreenState.isExpanded
+    var latchedFootprint by remember { mutableStateOf(DefaultNowPlayingFootprint) }
+
     // AppStartupViewModel holds the library-setup check result across Activity re-creations.
     // This prevents the loading screen from reappearing on every config change or short
     // foreground resume. The ViewModel lives in the Activity's ViewModelStore, so it is only
@@ -572,61 +592,69 @@ private fun AuthenticatedNavigation(
         onSelectShellDestination = { currentShellDestination = it },
     )
 
-    // Wrap navigation with NowPlayingHost for persistent mini player
-    CompositionLocalProvider(
-        LocalSnackbarHostState provides snackbarHostState,
-        LocalDeviceContext provides koinInject<DeviceContext>(),
-    ) {
-        Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
-            NavDisplay(
-                backStack = backStack,
-                entryDecorators =
-                    listOf(
-                        rememberSaveableStateHolderNavEntryDecorator(),
-                        rememberViewModelStoreNavEntryDecorator(),
-                    ),
-                // Only handle back if we're not at root - let system handle back-to-home
-                onBack = {
-                    if (backStack.size > 1) {
-                        backStack.removeAt(backStack.lastIndex)
-                    }
-                    // When size == 1, don't pop - allows system back-to-home animation
-                },
-                // Global slide transitions for all navigation
-                transitionSpec = {
-                    slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
-                },
-                popTransitionSpec = {
-                    slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
-                },
-                predictivePopTransitionSpec = {
-                    slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
-                },
-                entryProvider =
-                    authenticatedNavEntries(
-                        backStack = backStack,
-                        // Deferred reads: the entry content reads these inside the Shell composable so
-                        // tab/readiness changes recompose it (NavDisplay won't re-invoke the builder).
-                        currentShellDestination = { currentShellDestination },
-                        onShellDestinationChange = { currentShellDestination = it },
-                        nowPlayingViewModel = nowPlayingViewModel,
-                        readiness = { readiness },
-                        onSignOut = onSignOut,
-                        startupViewModel = startupViewModel,
-                        scope = scope,
-                        syncRepository = syncRepository,
-                        profileRefreshKey = profileRefreshKey,
-                        onProfileRefreshed = { profileRefreshKey++ },
-                    ),
-            )
+    // Wrap navigation with NowPlayingHost for persistent mini player.
+    // ProvideNowPlayingInsets publishes the mini-player clearance to every detail screen below,
+    // so NavDisplay content can pad itself clear of the floating bar (the bar measures itself inside
+    // AuthenticatedNavOverlays and latches its footprint back up here).
+    ProvideNowPlayingInsets(barVisible = barVisible, latchedFootprint = latchedFootprint) {
+        CompositionLocalProvider(
+            LocalSnackbarHostState provides snackbarHostState,
+            LocalDeviceContext provides koinInject<DeviceContext>(),
+        ) {
+            Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+                NavDisplay(
+                    backStack = backStack,
+                    entryDecorators =
+                        listOf(
+                            rememberSaveableStateHolderNavEntryDecorator(),
+                            rememberViewModelStoreNavEntryDecorator(),
+                        ),
+                    // Only handle back if we're not at root - let system handle back-to-home
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                        // When size == 1, don't pop - allows system back-to-home animation
+                    },
+                    // Global slide transitions for all navigation
+                    transitionSpec = {
+                        slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                    },
+                    popTransitionSpec = {
+                        slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                    },
+                    predictivePopTransitionSpec = {
+                        slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                    },
+                    entryProvider =
+                        authenticatedNavEntries(
+                            backStack = backStack,
+                            // Deferred reads: the entry content reads these inside the Shell composable so
+                            // tab/readiness changes recompose it (NavDisplay won't re-invoke the builder).
+                            currentShellDestination = { currentShellDestination },
+                            onShellDestinationChange = { currentShellDestination = it },
+                            nowPlayingViewModel = nowPlayingViewModel,
+                            readiness = { readiness },
+                            onSignOut = onSignOut,
+                            startupViewModel = startupViewModel,
+                            scope = scope,
+                            syncRepository = syncRepository,
+                            profileRefreshKey = profileRefreshKey,
+                            onProfileRefreshed = { profileRefreshKey++ },
+                        ),
+                )
 
-            AuthenticatedNavOverlays(
-                backStack = backStack,
-                snackbarHostState = snackbarHostState,
-                nowPlayingViewModel = nowPlayingViewModel,
-                readiness = readiness,
-                onRetryLibrarySetupCheck = { startupViewModel.retryLibrarySetupCheck() },
-            )
+                AuthenticatedNavOverlays(
+                    backStack = backStack,
+                    snackbarHostState = snackbarHostState,
+                    nowPlayingViewModel = nowPlayingViewModel,
+                    readiness = readiness,
+                    onRetryLibrarySetupCheck = { startupViewModel.retryLibrarySetupCheck() },
+                    onBarFootprintChanged = { measured ->
+                        latchedFootprint = latchFootprint(latchedFootprint, measured, barVisible)
+                    },
+                )
+            }
         }
     }
 }
@@ -689,6 +717,7 @@ private fun BoxScope.AuthenticatedNavOverlays(
     nowPlayingViewModel: NowPlayingViewModel,
     readiness: LibraryReadiness,
     onRetryLibrarySetupCheck: () -> Unit,
+    onBarFootprintChanged: (Dp) -> Unit,
 ) {
     // Now Playing overlay - persistent across all navigation
     // Position adjusts based on whether bottom nav is visible (Shell vs detail screens)
@@ -711,6 +740,7 @@ private fun BoxScope.AuthenticatedNavOverlays(
             backStack.add(DocumentViewer(localPath))
         },
         viewModel = nowPlayingViewModel,
+        onBarFootprintChanged = onBarFootprintChanged,
     )
 
     // App-wide snackbar - positioned at bottom, mini player animates up when visible

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffold.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffold.kt
@@ -27,6 +27,10 @@ import androidx.compose.ui.graphics.Color
  *
  * The bottom is owned entirely by the spacer; [androidx.compose.material3.Scaffold]'s
  * `contentWindowInsets` is restricted to top + horizontal so nothing is double-counted.
+ *
+ * @param contentWindowInsets Non-bottom insets applied to content; defaults to status bar +
+ *   horizontal. Immersive screens whose hero bleeds behind the status bar pass
+ *   `WindowInsets(0, 0, 0, 0)`. The bottom is always managed by the mini-player + nav-bar spacer.
  */
 @Composable
 fun ListenUpScaffold(
@@ -37,6 +41,8 @@ fun ListenUpScaffold(
     floatingActionButtonPosition: FabPosition = FabPosition.End,
     snackbarHost: @Composable () -> Unit = {},
     containerColor: Color = MaterialTheme.colorScheme.surface,
+    contentWindowInsets: WindowInsets =
+        WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
     content: @Composable (PaddingValues) -> Unit,
 ) {
     // max-per-side: when the player is active its footprint already includes the nav bar, so it
@@ -56,8 +62,7 @@ fun ListenUpScaffold(
         floatingActionButtonPosition = floatingActionButtonPosition,
         snackbarHost = snackbarHost,
         containerColor = containerColor,
-        contentWindowInsets = WindowInsets.systemBars
-            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+        contentWindowInsets = contentWindowInsets.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
         content = content,
     )
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffold.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpScaffold.kt
@@ -1,0 +1,63 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Drop-in replacement for [androidx.compose.material3.Scaffold] for any screen rendered over
+ * the floating now-playing bar. It reserves the player's footprint (via [LocalNowPlayingInsets])
+ * **and** the system navigation bar in a single bottom spacer, so:
+ *
+ * - scrolling content set up with the supplied `paddingValues` never hides behind the bar,
+ * - a [bottomBar] (e.g. a docked Save action) sits directly above the bar and glides with it,
+ * - a [floatingActionButton] clears the bar automatically (Scaffold lifts it above `bottomBar`).
+ *
+ * The bottom is owned entirely by the spacer; [androidx.compose.material3.Scaffold]'s
+ * `contentWindowInsets` is restricted to top + horizontal so nothing is double-counted.
+ */
+@Composable
+fun ListenUpScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    floatingActionButton: @Composable () -> Unit = {},
+    floatingActionButtonPosition: FabPosition = FabPosition.End,
+    snackbarHost: @Composable () -> Unit = {},
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    // max-per-side: when the player is active its footprint already includes the nav bar, so it
+    // wins; when idle the player inset is zero and the system nav bar applies.
+    val bottomClearance = WindowInsets.systemBars.union(LocalNowPlayingInsets.current)
+
+    Scaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = {
+            Column {
+                bottomBar()
+                Spacer(Modifier.windowInsetsBottomHeight(bottomClearance))
+            }
+        },
+        floatingActionButton = floatingActionButton,
+        floatingActionButtonPosition = floatingActionButtonPosition,
+        snackbarHost = snackbarHost,
+        containerColor = containerColor,
+        contentWindowInsets = WindowInsets.systemBars
+            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+        content = content,
+    )
+}

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/NowPlayingInsets.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/NowPlayingInsets.kt
@@ -1,0 +1,72 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Bottom space currently occupied by the floating now-playing bar, expressed as a
+ * [WindowInsets] so [ListenUpScaffold] can union it with the system bars. Zero when no
+ * mini-player is showing. Provided once at the authenticated navigation root by
+ * [ProvideNowPlayingInsets]; the default is empty so screens shown outside that scope
+ * (and previews) simply see no extra inset.
+ *
+ * Deliberately [compositionLocalOf], not [staticCompositionLocalOf]: the inset animates
+ * per-frame while the bar glides, so read-tracked invalidation (only the actual consumers
+ * recompose) is far cheaper than the whole-subtree recomposition `static` forces on every
+ * change. The other design-system locals are `static` because their values rarely change;
+ * this one does not.
+ */
+val LocalNowPlayingInsets: ProvidableCompositionLocal<WindowInsets> =
+    compositionLocalOf { WindowInsets(0, 0, 0, 0) }
+
+/**
+ * The bottom clearance the mini-player requires, in dp. The bar's measured footprint when
+ * it is visible, otherwise zero — so the space is reclaimed the instant playback stops.
+ */
+fun nowPlayingClearance(barVisible: Boolean, latchedFootprint: Dp): Dp =
+    if (barVisible) latchedFootprint else 0.dp
+
+/**
+ * Latches the bar's full footprint. We only adopt a fresh measurement while the bar is
+ * visible and non-empty; transient zero/partial sizes emitted as the bar animates out are
+ * ignored, so the value stays stable for the next appearance.
+ */
+fun latchFootprint(current: Dp, measured: Dp, barVisible: Boolean): Dp =
+    if (barVisible && measured > 0.dp) measured else current
+
+/**
+ * Publishes the animated mini-player inset to descendants via [LocalNowPlayingInsets].
+ * [barVisible] gates presence; [latchedFootprint] is the bar's measured height. The inset
+ * springs between zero and the footprint so docked content glides in step with the bar's
+ * own slide-in/out rather than snapping.
+ */
+@Composable
+fun ProvideNowPlayingInsets(
+    barVisible: Boolean,
+    latchedFootprint: Dp,
+    content: @Composable () -> Unit,
+) {
+    val target = nowPlayingClearance(barVisible, latchedFootprint)
+    val animated by animateDpAsState(
+        targetValue = target,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "nowPlayingInset",
+    )
+    CompositionLocalProvider(
+        LocalNowPlayingInsets provides WindowInsets(bottom = animated),
+    ) {
+        content()
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/NowPlayingInsets.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/NowPlayingInsets.kt
@@ -32,16 +32,21 @@ val LocalNowPlayingInsets: ProvidableCompositionLocal<WindowInsets> =
  * The bottom clearance the mini-player requires, in dp. The bar's measured footprint when
  * it is visible, otherwise zero — so the space is reclaimed the instant playback stops.
  */
-fun nowPlayingClearance(barVisible: Boolean, latchedFootprint: Dp): Dp =
-    if (barVisible) latchedFootprint else 0.dp
+fun nowPlayingClearance(
+    barVisible: Boolean,
+    latchedFootprint: Dp,
+): Dp = if (barVisible) latchedFootprint else 0.dp
 
 /**
  * Latches the bar's full footprint. We only adopt a fresh measurement while the bar is
  * visible and non-empty; transient zero/partial sizes emitted as the bar animates out are
  * ignored, so the value stays stable for the next appearance.
  */
-fun latchFootprint(current: Dp, measured: Dp, barVisible: Boolean): Dp =
-    if (barVisible && measured > 0.dp) measured else current
+fun latchFootprint(
+    current: Dp,
+    measured: Dp,
+    barVisible: Boolean,
+): Dp = if (barVisible && measured > 0.dp) measured else current
 
 /**
  * Publishes the animated mini-player inset to descendants via [LocalNowPlayingInsets].
@@ -58,10 +63,11 @@ fun ProvideNowPlayingInsets(
     val target = nowPlayingClearance(barVisible, latchedFootprint)
     val animated by animateDpAsState(
         targetValue = target,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioLowBouncy,
-            stiffness = Spring.StiffnessMediumLow,
-        ),
+        animationSpec =
+            spring(
+                dampingRatio = Spring.DampingRatioLowBouncy,
+                stiffness = Spring.StiffnessMediumLow,
+            ),
         label = "nowPlayingInset",
     )
     CompositionLocalProvider(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -181,7 +181,7 @@ fun AdminScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         topBar = {
             ColorBlockHero(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
@@ -368,7 +368,7 @@ private fun AdminContent(
                     .fillMaxSize()
                     .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            contentPadding = PaddingValues(top = 24.dp, bottom = 96.dp),
+            contentPadding = PaddingValues(top = 24.dp),
         ) {
             item {
                 ServerSettingsSection(
@@ -440,7 +440,7 @@ private fun AdminTwoPaneContent(
         LazyColumn(
             modifier = Modifier.weight(1.1f),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            contentPadding = PaddingValues(top = 24.dp, bottom = 96.dp),
+            contentPadding = PaddingValues(top = 24.dp),
         ) {
             item {
                 ServerSettingsSection(
@@ -470,7 +470,7 @@ private fun AdminTwoPaneContent(
         LazyColumn(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            contentPadding = PaddingValues(top = 24.dp, bottom = 96.dp),
+            contentPadding = PaddingValues(top = 24.dp),
         ) {
             item {
                 ManagementSection(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/CreateInviteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/CreateInviteScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -149,7 +149,7 @@ fun CreateInviteScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         topBar = {
             ColorBlockHero(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/LibrarySettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/LibrarySettingsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -95,7 +95,7 @@ fun LibrarySettingsScreen(
 
     val topBarTitle = "Library Settings"
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         topBar = {
             TopAppBar(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/UserDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/UserDetailScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
@@ -83,7 +83,7 @@ fun UserDetailScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         topBar = {
             TopAppBar(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/backup/CreateBackupScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/backup/CreateBackupScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -77,7 +77,7 @@ fun CreateBackupScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.admin_create_backup)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/categories/AdminCategoriesScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/categories/AdminCategoriesScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -150,7 +150,7 @@ fun AdminCategoriesScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionDetailScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -176,7 +176,7 @@ fun AdminCollectionDetailScreen(
 
     val isWide = currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(TwoPaneMinWidth.value.toInt())
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionsScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.material.icons.outlined.FolderSpecial
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -138,7 +138,7 @@ fun AdminCollectionsScreen(
 
     val isWide = currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(TwoPaneMinWidth.value.toInt())
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/inbox/AdminInboxScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/inbox/AdminInboxScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -143,7 +143,7 @@ fun AdminInboxScreen(
 
     val isWide = currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(TwoPaneMinWidth.value.toInt())
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -44,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
+import com.calypsan.listenup.client.design.components.LocalNowPlayingInsets
 import com.calypsan.listenup.client.design.components.LocalSnackbarHostState
 import com.calypsan.listenup.client.design.theme.DisplayFontFamily
 import com.calypsan.listenup.client.design.theme.Spacing
@@ -531,9 +533,10 @@ private fun ImmersiveBookDetail(
             onDeleteClick = onDeleteBookClick,
         )
 
+        val playerInset = LocalNowPlayingInsets.current.asPaddingValues().calculateBottomPadding()
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 32.dp),
+            contentPadding = PaddingValues(bottom = 32.dp + playerInset),
         ) {
             // Offline advisory — streaming unavailable, downloads still play.
             if (showServerWarning) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/BookEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/BookEditScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -254,7 +252,6 @@ private fun BookEditContent(
         } else {
             SingleColumnCardsLayout(state = state, onEvent = onEvent)
         }
-
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/BookEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookedit/BookEditScreen.kt
@@ -13,11 +13,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Save
-import com.calypsan.listenup.client.design.components.ListenUpExtendedFab
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import com.calypsan.listenup.client.design.components.ListenUpButton
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -101,17 +102,23 @@ fun BookEditScreen(
         showUnsavedChangesDialog = true
     }
 
-    Scaffold(
+    ListenUpScaffold(
         containerColor = MaterialTheme.colorScheme.surface,
-        floatingActionButton = {
+        bottomBar = {
             if (!state.isLoading) {
-                ListenUpExtendedFab(
-                    onClick = { viewModel.onEvent(BookEditUiEvent.Save) },
-                    icon = Icons.Default.Save,
-                    text = if (state.isSaving) "Saving..." else "Save Changes",
-                    enabled = state.hasChanges && !state.isSaving,
-                    isLoading = state.isSaving,
-                )
+                Surface(
+                    color = MaterialTheme.colorScheme.surface,
+                    tonalElevation = 3.dp,
+                ) {
+                    ListenUpButton(
+                        text = if (state.isSaving) "Saving..." else "Save Changes",
+                        onClick = { viewModel.onEvent(BookEditUiEvent.Save) },
+                        enabled = state.hasChanges && !state.isSaving,
+                        isLoading = state.isSaving,
+                        leadingIcon = Icons.Default.Save,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
             }
         },
     ) { paddingValues ->
@@ -161,7 +168,7 @@ fun BookEditScreen(
                                 onBackClick()
                             }
                         },
-                        modifier = Modifier.padding(bottom = paddingValues.calculateBottomPadding()),
+                        modifier = Modifier.padding(paddingValues),
                     )
                 }
             }
@@ -248,8 +255,6 @@ private fun BookEditContent(
             SingleColumnCardsLayout(state = state, onEvent = onEvent)
         }
 
-        // Bottom spacing for FAB
-        Spacer(modifier = Modifier.height(88.dp))
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookreaders/BookReadersScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookreaders/BookReadersScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -66,7 +66,7 @@ fun BookReadersScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.book_detail_readers)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/browsegenre/BrowseGenreScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/browsegenre/BrowseGenreScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -116,6 +117,7 @@ fun BrowseGenreScreen(
                     onSelectGenre = { viewModel.selectGenre(it) },
                     onBookClick = onBookClick,
                     topPadding = innerPadding.calculateTopPadding(),
+                    bottomPadding = innerPadding.calculateBottomPadding(),
                 )
             }
         }
@@ -184,6 +186,7 @@ private fun BrowseGenreReadyContent(
     onSelectGenre: (GenreId) -> Unit,
     onBookClick: (BookId) -> Unit,
     topPadding: androidx.compose.ui.unit.Dp,
+    bottomPadding: androidx.compose.ui.unit.Dp,
 ) {
     Column(
         modifier = Modifier.fillMaxSize().padding(top = topPadding),
@@ -194,7 +197,10 @@ private fun BrowseGenreReadyContent(
             if (state.genres.isEmpty()) {
                 EmptyGenresMessage()
             } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(bottom = bottomPadding),
+                ) {
                     items(state.genres, key = { it.id }) { genre ->
                         GenreRow(
                             genre = genre,
@@ -208,7 +214,11 @@ private fun BrowseGenreReadyContent(
 
         if (state.selectedGenreId != null) {
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                BookListForGenre(books = state.books, onBookClick = onBookClick)
+                BookListForGenre(
+                    books = state.books,
+                    onBookClick = onBookClick,
+                    bottomPadding = bottomPadding,
+                )
             }
         }
     }
@@ -256,6 +266,7 @@ private fun GenreRow(
 private fun BookListForGenre(
     books: List<BookId>,
     onBookClick: (BookId) -> Unit,
+    bottomPadding: androidx.compose.ui.unit.Dp,
 ) {
     if (books.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
@@ -267,7 +278,10 @@ private fun BookListForGenre(
         }
         return
     }
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = bottomPadding),
+    ) {
         items(books, key = { it.value }) { bookId ->
             Row(
                 modifier =

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/browsegenre/BrowseGenreScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/browsegenre/BrowseGenreScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
@@ -90,7 +90,7 @@ fun BrowseGenreScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
@@ -392,7 +392,6 @@ private fun ArtistStudioContent(
         } else {
             SingleColumnCardsLayout(state = state, onEvent = onEvent)
         }
-
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -135,8 +135,9 @@ fun ContributorEditScreen(
     val colorScheme = rememberContributorColorScheme(contributorId)
     val surfaceColor = MaterialTheme.colorScheme.surface
 
-    Scaffold(
+    ListenUpScaffold(
         containerColor = Color.Transparent,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             if (!state.isLoading) {
                 SaveFab(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
@@ -6,11 +6,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
@@ -395,8 +393,6 @@ private fun ArtistStudioContent(
             SingleColumnCardsLayout(state = state, onEvent = onEvent)
         }
 
-        // Bottom spacing for FAB
-        Spacer(modifier = Modifier.height(88.dp))
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributormetadata/ContributorMetadataPreviewScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributormetadata/ContributorMetadataPreviewScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -86,7 +86,7 @@ fun ContributorMetadataPreviewScreen(
             if (hasImage && selections.image) true else null,
         ).size
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.contributor_preview_changes)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributormetadata/ContributorMetadataSearchScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributormetadata/ContributorMetadataSearchScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -75,7 +75,7 @@ fun ContributorMetadataSearchScreen(
     onResultClick: (MetadataContributorHit) -> Unit,
     onBack: () -> Unit,
 ) {
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.contributor_find_on_audible)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MatchPreviewScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -151,7 +151,7 @@ fun MatchPreviewScreen(
 ) {
     val hasAnySelected = selections.hasAnySelected()
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             ColorBlockHero(
                 title = stringResource(Res.string.metadata_select_metadata),

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -88,7 +88,7 @@ fun MetadataSearchScreen(
     val searchError = (state.loadState as? SearchLoadState.Failed)?.message
     val searchResults = (state.loadState as? SearchLoadState.Loaded)?.results.orEmpty()
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             ColorBlockHero(
                 title = stringResource(Res.string.metadata_find_on_audible),

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/DockedNowPlayingBar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/DockedNowPlayingBar.kt
@@ -50,10 +50,13 @@ import listenup.composeapp.generated.resources.player_skip_back_10s
 import listenup.composeapp.generated.resources.player_skip_forward_30s
 import org.jetbrains.compose.resources.stringResource
 
+/** Height of the docked mini-player bar rendered on TV, Desktop, and Tablet. */
+internal val DockedNowPlayingBarHeight = 96.dp
+
 /**
  * Docked mini-player bar for TV, Desktop, and Tablet form factors.
  *
- * A full-width bar (~96dp tall, [surfaceContainerLow] background, large rounded corners)
+ * A full-width bar ([DockedNowPlayingBarHeight] tall, [surfaceContainerLow] background, large rounded corners)
  * with three flex regions:
  * - LEFT: 60dp cover + book title / chapter info
  * - CENTRE: transport controls (replay-10 / play-pause FAB / forward-30) above a
@@ -147,7 +150,7 @@ private fun ActiveDockedContent(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(96.dp)
+                .height(DockedNowPlayingBarHeight)
                 .padding(horizontal = 22.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/EditProfileScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/EditProfileScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -137,7 +137,7 @@ fun EditProfileScreen(
 
     val ready = state as? EditProfileUiState.Ready
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
         topBar = {
             EditProfileTopBar(onBack = onBack)

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/UserProfileScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/UserProfileScreen.kt
@@ -10,9 +10,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,7 +32,7 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -109,9 +106,9 @@ fun UserProfileScreen(
 
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    Scaffold(
+    ListenUpScaffold(
         modifier = modifier,
-        contentWindowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Bottom),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
     ) { paddingValues ->
         Box(
             modifier =

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesdetail/SeriesDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesdetail/SeriesDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -94,10 +95,8 @@ fun SeriesDetailScreen(
 
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    // The color hero bleeds edge-to-edge behind the status bar (the system clock sits on the
-    // color block, matching the design); HeroNavRow re-insets the floating back/edit controls
-    // below the status bar. ListenUpScaffold reserves the mini-player footprint at the bottom.
-    ListenUpScaffold { paddingValues ->
+    // Immersive: let the color hero bleed behind the status bar (HeroNavRow self-insets its controls).
+    ListenUpScaffold(contentWindowInsets = WindowInsets(0, 0, 0, 0)) { paddingValues ->
         Box(
             modifier =
                 Modifier

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesdetail/SeriesDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesdetail/SeriesDetailScreen.kt
@@ -8,17 +8,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -41,7 +38,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
@@ -99,9 +95,9 @@ fun SeriesDetailScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     // The color hero bleeds edge-to-edge behind the status bar (the system clock sits on the
-    // color block, matching the design), so the Scaffold keeps only the bottom (nav-bar) inset;
-    // HeroNavRow re-insets the floating back/edit controls below the status bar.
-    Scaffold(contentWindowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Bottom)) { paddingValues ->
+    // color block, matching the design); HeroNavRow re-insets the floating back/edit controls
+    // below the status bar. ListenUpScaffold reserves the mini-player footprint at the bottom.
+    ListenUpScaffold { paddingValues ->
         Box(
             modifier =
                 Modifier

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesedit/SeriesEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesedit/SeriesEditScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -124,8 +124,9 @@ fun SeriesEditScreen(
         showUnsavedChangesDialog = true
     }
 
-    Scaffold(
+    ListenUpScaffold(
         containerColor = MaterialTheme.colorScheme.surface,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             if (!state.isLoading) {
                 SaveFab(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesedit/SeriesEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesedit/SeriesEditScreen.kt
@@ -125,7 +125,6 @@ fun SeriesEditScreen(
     }
 
     ListenUpScaffold(
-        containerColor = MaterialTheme.colorScheme.surface,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             if (!state.isLoading) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/LicenseDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/LicenseDetailScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -38,7 +38,7 @@ fun LicenseDetailScreen(
     val rows by rememberLicenseRows()
     val row = rows.firstOrNull { it.uniqueId == uniqueId }
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(row?.name ?: "") },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/SettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/SettingsScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -231,7 +231,7 @@ fun SettingsScreen(
         )
     }
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.common_settings)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/StorageScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/settings/StorageScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -115,7 +115,7 @@ fun StorageScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(Res.string.common_storage)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -119,7 +119,7 @@ fun ShelfDetailScreen(
         }
     }
 
-    Scaffold(
+    ListenUpScaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/tagdetail/TagDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/tagdetail/TagDetailScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import com.calypsan.listenup.client.design.components.ListenUpScaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -82,7 +82,7 @@ fun TagDetailScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val readyState = state as? TagDetailUiState.Ready
 
-    Scaffold(
+    ListenUpScaffold(
         topBar = {
             TopAppBar(
                 title = {


### PR DESCRIPTION
## Summary

The mini-player is a global overlay that never reserved layout space, so it overlapped content on detail screens (Save button on Book Edit, last book in Series Detail, Credits on Book Detail, Browse Genre lists, and more). This fixes the whole bug class app-wide rather than patching screens one at a time.

**Mechanism**
- `LocalNowPlayingInsets` — a measured, animated bottom inset (CompositionLocal). The bar reports its real footprint via `onSizeChanged` in `NowPlayingHost`; it's published around `NavDisplay` in `ListenUpNavigation`. Zero when nothing is playing, so space is reclaimed; animated so content glides as the bar appears/disappears.
- `ListenUpScaffold` — a drop-in `Scaffold` wrapper that reserves the player **and** the system nav bar in a single bottom spacer (`systemBars ∪ player`), with `contentWindowInsets` restricted to top+horizontal so the bottom is never double-counted. Immersive screens pass `contentWindowInsets = WindowInsets(0,0,0,0)` to keep their hero edge-to-edge under the status bar.
- All 31 authenticated detail screens migrated to `ListenUpScaffold`. Book Edit's "Save Changes" is **docked into a bottom action bar** above the player (and moves with it). Book Detail (Surface-based immersive) consumes the inset directly.
- `AppShell` / Shell tabs (Home/Library/Discover) are intentionally untouched — they already reserve player space via their own `bottomBar`; `HomeScreen` is allowlisted.

**Guardrail**
- `ScreensUseListenUpScaffoldRule` (Konsist) fails the build if an authenticated feature screen uses the raw Material3 `Scaffold`, so the bug can't silently come back. Allowlist: `DocumentViewerScreen`, `NowPlayingScreen`, `HomeScreen` (each with a one-line reason).

## Test Plan

Automated (all green, run from the worktree):
- [x] `:sharedUI:testAndroidHostTest` — incl. new `NowPlayingInsetsTest` (pure inset logic) and `ListenUpScaffoldTest` (reserves the inset / collapses to zero when idle)
- [x] `:sharedLogic:jvmTest` — incl. the new Konsist rule (green)
- [x] `:server:jvmTest`
- [x] `spotlessCheck` + `detekt`
- [x] `:androidApp:assembleDebug`

Manual (debug build on an Android 17 emulator, audio playing):
- [x] Book Edit — Save docked above the player, never overlapping; glides in with the bar
- [x] Book Detail — Credits clear the player
- [x] Series Detail — last book clears the player; hero stays edge-to-edge under the status bar
- [x] Home tab — no regression (renders normally with the player active)

## Notes
- iOS/Apple CI lanes can't run locally (Linux dev box) — relying on this PR's remote CI for them.
- Deferred (documented in the spec/plan, not bugs): unify editor-screen Save docking vs floating; fold a couple of admin lists' clearance into `contentPadding` instead of an outer band; have the desktop docked bar self-report its footprint.
