### PR TITLE
🐛 fix(server): title multi-file books from the album tag and sum per-track durations

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/TrackEntry.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/TrackEntry.kt
@@ -7,6 +7,11 @@ import kotlinx.serialization.Serializable
  * One audio file in playback order, with its derived position metadata.
  * Phase 2 only fills track/disc from filename or parent folder; embedded-tag
  * sources land in Phase 3 and use [TrackNumberSource.METADATA].
+ *
+ * [durationMs] is the track's own playable length, parsed from embedded metadata
+ * for multi-file books (where it is needed to sum the book's total duration and to
+ * give each `book_audio_files` row its real length). It is `null` for single-file
+ * books, where the book-level embedded duration already equals the one file's length.
  */
 @Serializable
 data class TrackEntry(
@@ -16,6 +21,7 @@ data class TrackEntry(
     val discNumber: Int? = null,
     val trackSource: TrackNumberSource? = null,
     val discSource: TrackNumberSource? = null,
+    val durationMs: Long? = null,
 )
 
 /**

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/AudioTags.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/AudioTags.kt
@@ -43,5 +43,11 @@ data class AudioTags(
          *  comment tag (ID3v2 COMM, MP4 `©cmt`, Vorbis COMMENT). The Analyzer uses it
          *  as the `description` fallback, matching the Go reference. */
         const val COMMENT_KEY: String = "comment"
+
+        /** The [custom] map key under which every format reader stores the album tag
+         *  (ID3 `TALB`, MP4 `©alb`, ID3v1 album). For a multi-file audiobook the album is
+         *  the **book** title (the per-file [title] tag is the chapter title), so the Analyzer
+         *  treats it as the authoritative book title — matching Audiobookshelf. */
+        const val ALBUM_KEY: String = "album"
     }
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -162,6 +162,10 @@ internal class Analyzer(
                             discNumber = embDisc ?: info.discNumber,
                             trackSource = if (embTrack != null) TrackNumberSource.METADATA else info.trackSource,
                             discSource = if (embDisc != null) TrackNumberSource.METADATA else info.discSource,
+                            // Per-track length for multi-file books, so the mapper can sum the book's
+                            // total duration and give each file its real length (parsed is null for
+                            // single-file books, where the book-level embedded duration suffices).
+                            durationMs = parsed?.durationMs,
                         )
                     // Capture the full parse result so synthesis can reuse it without re-parsing.
                     if (multiTrack) perTrackMetadata[entry] = parsed
@@ -452,16 +456,34 @@ internal class Analyzer(
         embedded: EmbeddedAudioMetadata?,
         metadata: AbsMetadata?,
         sidecar: SidecarMetadata?,
-    ): String =
-        precedence.order.firstNotNullOfOrNull { source ->
+    ): String {
+        val multiFile = candidate.files.count { it.fileType == FileType.AUDIO } > 1
+        return precedence.order.firstNotNullOfOrNull { source ->
             when (source) {
                 MetadataPrecedenceSource.ABS_METADATA -> metadata?.title?.takeUnless { it.isBlank() }
-                MetadataPrecedenceSource.EMBEDDED -> embedded?.tags?.title?.takeUnless { it.isBlank() }
+                MetadataPrecedenceSource.EMBEDDED -> embeddedBookTitle(embedded, multiFile)
                 MetadataPrecedenceSource.SIDECAR -> sidecar?.title?.takeUnless { it.isBlank() }
                 MetadataPrecedenceSource.FILENAME -> parsed.title.takeUnless { it.isBlank() }
                 MetadataPrecedenceSource.FOLDER -> shape.titleFolder.takeUnless { it.isBlank() }
             }
         } ?: candidate.rootRelPath
+    }
+
+    /**
+     * The book title carried by embedded tags, matching Audiobookshelf precedence: the **album**
+     * tag is the book title (authoritative). The per-file `title` tag is the book title only for a
+     * single-file book; for a multi-file book it is the current track's chapter title, so it is
+     * ignored. Returns null when embedded tags carry no usable book title, letting [pickTitle] fall
+     * through to the folder.
+     */
+    private fun embeddedBookTitle(
+        embedded: EmbeddedAudioMetadata?,
+        multiFile: Boolean,
+    ): String? {
+        val tags = embedded?.tags ?: return null
+        tags.custom[AudioTags.ALBUM_KEY]?.takeUnless { it.isBlank() }?.let { return it }
+        return if (!multiFile) tags.title?.takeUnless { it.isBlank() } else null
+    }
 
     private fun pickAuthors(
         shape: FolderShape,

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -470,19 +470,23 @@ internal class Analyzer(
     }
 
     /**
-     * The book title carried by embedded tags, matching Audiobookshelf precedence: the **album**
-     * tag is the book title (authoritative). The per-file `title` tag is the book title only for a
-     * single-file book; for a multi-file book it is the current track's chapter title, so it is
-     * ignored. Returns null when embedded tags carry no usable book title, letting [pickTitle] fall
-     * through to the folder.
+     * The book title carried by embedded tags:
+     *  - **Multi-file book:** the per-file `title` tag is the current track's *chapter* title, so it
+     *    is ignored; the **album** tag is the book title (authoritative, matching Audiobookshelf).
+     *  - **Single-file book:** the `title` tag *is* the book title and is usually cleaner than the
+     *    album (which often appends the series, e.g. `"…: Chaos Seeds, Book 3"`), so it wins; the
+     *    album is only a fallback when there is no title tag.
+     *
+     * Returns null when embedded tags carry no usable book title, letting [pickTitle] fall through
+     * to the folder.
      */
     private fun embeddedBookTitle(
         embedded: EmbeddedAudioMetadata?,
         multiFile: Boolean,
     ): String? {
         val tags = embedded?.tags ?: return null
-        tags.custom[AudioTags.ALBUM_KEY]?.takeUnless { it.isBlank() }?.let { return it }
-        return if (!multiFile) tags.title?.takeUnless { it.isBlank() } else null
+        val album = tags.custom[AudioTags.ALBUM_KEY]?.takeUnless { it.isBlank() }
+        return if (multiFile) album else tags.title?.takeUnless { it.isBlank() } ?: album
     }
 
     private fun pickAuthors(

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
@@ -34,13 +34,11 @@ import kotlin.time.Clock
  *    track's [com.calypsan.listenup.api.dto.scanner.FileEntry].
  *  - `chapters` map to chapter rows (`duration = endMs - startMs`).
  *
- * **Duration caveat.** The Scanner's [AnalyzedBook] carries no per-track
- * duration — `TrackEntry` wraps only a `FileEntry` (path/size/inode), and
- * `codec` is not surfaced anywhere. The single authoritative duration is
- * `embedded.durationMs`, produced by the parser for the *primary* audio file
- * only (spec §3 non-goal: multi-file books parse the first file). So
- * `totalDuration` and the first audio file's `duration` carry that value;
- * non-primary files get `0L`; `codec` is left blank.
+ * **Duration.** Each [com.calypsan.listenup.api.dto.scanner.TrackEntry] carries its own
+ * `durationMs` (parsed per-track for multi-file books by the Analyzer). Every
+ * `book_audio_files` row gets its track's duration, and `totalDuration` is their sum.
+ * Single-file books leave `TrackEntry.durationMs` null, so both the one file's duration
+ * and `totalDuration` fall back to the book-level `embedded.durationMs`. `codec` is left blank.
  *
  * `cover` is left null — cover hashing is a later task; the substrate-owned
  * `revision` / `updatedAt` / `createdAt` placeholders are overwritten by
@@ -70,7 +68,13 @@ class AnalyzedBookMapper(
     ): BookSyncPayload {
         val candidate = analyzed.candidate
         val inode = candidate.files.firstOrNull()?.inode
-        val totalDuration = analyzed.embedded?.durationMs ?: 0L
+        // Sum the per-track durations (multi-file books); fall back to the book-level
+        // embedded duration for single-file books, where TrackEntry.durationMs is null.
+        val totalDuration =
+            analyzed.tracks
+                .sumOf { it.durationMs ?: 0L }
+                .takeIf { it > 0L }
+                ?: (analyzed.embedded?.durationMs ?: 0L)
         return BookSyncPayload(
             id = bookId.value,
             libraryId = libraryId,
@@ -166,7 +170,7 @@ class AnalyzedBookMapper(
                 filename = track.file.name,
                 format = track.file.ext,
                 codec = "",
-                duration = if (index == 0) primaryDuration else 0L,
+                duration = track.durationMs ?: if (index == 0) primaryDuration else 0L,
                 size = track.file.size,
             )
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.server.scanner.audioLibrary
 import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -166,6 +167,40 @@ class AnalyzerMultiFileBookTest :
 
                     book.tracks.size shouldBe 2
                     book.tracks.all { (it.durationMs ?: 0L) > 0L } shouldBe true
+                }
+            }
+        }
+        test("single-file book keeps its title tag and does not inherit the album's series suffix") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    // Real single-file shape: the title tag is the (clean) book title; the album tag
+                    // appends the series ("…: Chaos Seeds, Book 3"). For a single-file book the title
+                    // tag wins, so that series suffix must not leak into the book title.
+                    val rel = "Aleron Kong/Chaos Seeds/Book 3 - The Land - Alliances"
+                    val file =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TIT2", "The Land: Alliances: A LitRPG Saga")
+                                textFrame("TALB", "The Land: Alliances: A LitRPG Saga: Chaos Seeds, Book 3")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val p = fixture.root.writeAudio("$rel/book.mp3", file)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files = listOf(trackEntry("$rel/book.mp3", Files.size(p))),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldNotContain "Chaos Seeds"
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
@@ -1,0 +1,196 @@
+package com.calypsan.listenup.server.scanner.pipeline
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.CandidateBook
+import com.calypsan.listenup.api.dto.scanner.FileEntry
+import com.calypsan.listenup.api.dto.scanner.FileType
+import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
+import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
+import com.calypsan.listenup.server.embeddedmeta.format.mp3.Mp3Parser
+import com.calypsan.listenup.server.scanner.audioLibrary
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Book-level metadata for **multi-file books** — a directory where each file is a
+ * track/chapter (e.g. an audiobook split into 38 per-chapter M4Bs).
+ *
+ * Such a book must become ONE book whose title comes from the **folder** (not the first
+ * track's embedded title, which is a chapter title) and whose tracks each carry their own
+ * duration (so the book's total duration sums every track, not just the primary).
+ */
+class AnalyzerMultiFileBookTest :
+    FunSpec({
+        val metadataReader = AbsMetadataReader(contractJson)
+        val embeddedParser =
+            EmbeddedMetadataParser(
+                detector = AudioFormatDetector(),
+                parsers = listOf(Mp3Parser()),
+            )
+
+        test("multi-file book takes its title from the album tag, not the per-track title or the [N] folder") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    // Real-world shape: the folder carries a series-index prefix ("[1] ..."), each file's
+                    // TIT2 is a chapter title, and the book title lives in the album tag (TALB). The album
+                    // must win — matching Audiobookshelf — over both the chapter title and the raw folder.
+                    val rel = "Joaquin Baldwin/[1] Wolf of Withervale"
+                    val t1 =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TRCK", "1")
+                                textFrame("TALB", "Wolf of Withervale")
+                                textFrame("TIT2", "Opening Credits")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val t2 =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TRCK", "2")
+                                textFrame("TALB", "Wolf of Withervale")
+                                textFrame("TIT2", "Prelude: The Wounded Fox")
+                            }
+                            mpegFrames(durationSeconds = 2)
+                        }
+                    val p1 = fixture.root.writeAudio("$rel/01.mp3", t1)
+                    val p2 = fixture.root.writeAudio("$rel/02.mp3", t2)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    trackEntry("$rel/01.mp3", Files.size(p1)),
+                                    trackEntry("$rel/02.mp3", Files.size(p2)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldBe "Wolf of Withervale"
+                }
+            }
+        }
+
+        test("multi-file book with no album tag falls back to the folder, ignoring the per-track title") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Some Audiobook"
+                    val t1 =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TRCK", "1")
+                                textFrame("TIT2", "Chapter One")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val t2 =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TRCK", "2")
+                                textFrame("TIT2", "Chapter Two")
+                            }
+                            mpegFrames(durationSeconds = 2)
+                        }
+                    val p1 = fixture.root.writeAudio("$rel/01.mp3", t1)
+                    val p2 = fixture.root.writeAudio("$rel/02.mp3", t2)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    trackEntry("$rel/01.mp3", Files.size(p1)),
+                                    trackEntry("$rel/02.mp3", Files.size(p2)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.title shouldBe "Some Audiobook"
+                }
+            }
+        }
+
+        test("multi-file book records each track's own duration") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Author/Multi"
+                    val t1 =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TRCK", "1") }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val t2 =
+                        buildMp3File {
+                            id3v2(version = 4) { textFrame("TRCK", "2") }
+                            mpegFrames(durationSeconds = 3)
+                        }
+                    val p1 = fixture.root.writeAudio("$rel/01.mp3", t1)
+                    val p2 = fixture.root.writeAudio("$rel/02.mp3", t2)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files =
+                                listOf(
+                                    trackEntry("$rel/01.mp3", Files.size(p1)),
+                                    trackEntry("$rel/02.mp3", Files.size(p2)),
+                                ),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    book.tracks.size shouldBe 2
+                    book.tracks.all { (it.durationMs ?: 0L) > 0L } shouldBe true
+                }
+            }
+        }
+    })
+
+private fun trackEntry(
+    relPath: String,
+    size: Long = 0,
+): FileEntry =
+    FileEntry(
+        relPath = relPath,
+        name = relPath.substringAfterLast('/'),
+        ext = relPath.substringAfterLast('.', "").lowercase(),
+        size = size,
+        mtimeMs = 0,
+        inode = null,
+        fileType = FileType.AUDIO,
+    )
+
+private fun Path.writeAudio(
+    relPath: String,
+    bytes: ByteArray,
+): Path {
+    val target = resolve(relPath)
+    Files.createDirectories(target.parent)
+    Files.write(target, bytes)
+    return target
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapperTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapperTest.kt
@@ -245,7 +245,7 @@ class AnalyzedBookMapperTest :
                 )
         }
 
-        test("should assign embedded duration only to the primary track when multiple tracks are present") {
+        test("should assign each track its own duration and sum them for the book total when multiple tracks are present") {
             val firstFile =
                 FileEntry(
                     relPath = "books/x/01.m4b",
@@ -275,7 +275,13 @@ class AnalyzedBookMapperTest :
                             files = listOf(firstFile, secondFile),
                         ),
                     title = "X",
-                    tracks = listOf(TrackEntry(file = firstFile), TrackEntry(file = secondFile)),
+                    tracks =
+                        listOf(
+                            TrackEntry(file = firstFile, durationMs = 12_345L),
+                            TrackEntry(file = secondFile, durationMs = 67_890L),
+                        ),
+                    // Primary-only embedded duration is no longer the source of truth for a
+                    // multi-file book; per-track durations are.
                     embedded = embeddedMeta(durationMs = 12_345L),
                 )
 
@@ -289,8 +295,19 @@ class AnalyzedBookMapperTest :
             audioFiles[0].size shouldBe 1024L
             audioFiles[1].index shouldBe 1
             audioFiles[1].filename shouldBe "02.m4b"
-            audioFiles[1].duration shouldBe 0L
+            audioFiles[1].duration shouldBe 67_890L
             audioFiles[1].size shouldBe 2048L
+
+            val payload =
+                mapper.toBookSyncPayload(
+                    bookId = BookId("b-x"),
+                    libraryId = LibraryId("lib-1"),
+                    folderId = FolderId("folder-1"),
+                    analyzed = analyzed,
+                    resolvedContributors = emptyList(),
+                    resolvedSeries = emptyList(),
+                )
+            payload.totalDuration shouldBe 12_345L + 67_890L
         }
 
         test("should compute chapter duration as end minus start") {


### PR DESCRIPTION
## Problem
A book whose audio is split into many per-chapter files (e.g. 38 `.m4b` chapters in one folder) scanned into the library mis-titled and mis-durationed, so it was effectively invisible — the user saw a 45-second "Opening Credits", not the 10-hour "Wolf of Withervale".

Two book-level fields were derived from the **first track**, assuming one-file-per-book:
1. **Title** came from the first track's embedded `title` tag — which for a multi-file book is the *chapter* title ("Opening Credits"), not the book title.
2. **Duration** came from only the primary track. `AnalyzedBookMapper` hardcoded `duration = if (index == 0) primaryDuration else 0L` and `total_duration = embedded?.durationMs` — so 37 of 38 files had duration 0 and the book totaled ~45s.

## Fix
**Title — use the album tag, matching Audiobookshelf.** The book title lives in the **album** tag (`©alb`/`TALB`, already parsed into `AudioTags.custom["album"]`); the per-file `title` tag is the chapter title. `pickTitle` now treats the album tag as the authoritative embedded book title, using the per-file `title` only for single-file books, and falling back to the folder when there's no album. (Added `AudioTags.ALBUM_KEY`, mirroring the existing `COMMENT_KEY` convention.)

**Duration — sum per-track.** Added `TrackEntry.durationMs`, populated in `Analyzer.buildTracks` from the per-track parse that already runs for multi-file books (previously discarded). `AnalyzedBookMapper` now gives each `book_audio_files` row its own duration and sums them for `total_duration`. Single-file books are unchanged (null per-track duration → falls back to the book-level embedded duration).

## Testing
- New `AnalyzerMultiFileBookTest`: album tag wins over the chapter title **and** a `[N]`-prefixed folder; no-album → folder fallback; each track carries its own duration.
- `AnalyzedBookMapperTest`: total = sum of per-track durations; each audio file gets its own duration.
- `AnalyzerTest` (single-file) + `Mp4ParserTest` unchanged and green.
- **End-to-end verified on the real library**: re-scanned the actual 38-file book → `title = "Wolf of Withervale"`, `total_duration = 10.66 h`, all 38 files have real durations summing to the total.

## Notes
- Full `:server:jvmTest` suite OOMs locally (test-worker heap, machine-specific); targeted suites + the contract round-trip (`ScannerDtoContractTest`) + the E2E rescan all pass. CI runs the full suite at its configured heap.