### PR TITLE
🐛 fix(shared): don't re-show "Building your library" on folder changes after initial scan

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -265,6 +265,12 @@ internal class SyncRepositoryImpl(
      * Completed must not strand the user on the populating screen (see [recoverFromScanStreamEnd]).
      */
     private suspend fun observeScanProgressResiliently() {
+        // A relaunched client whose library is already populated has effectively finished its initial
+        // population. Pre-latch the gate so a later folder-triggered (or watcher) scan this session can't
+        // be mistaken for the initial scan and flash "Building your library" over a usable library.
+        if (shouldPreLatchInitialScanGate(hasCompletedInitialScan, bookDao.count())) {
+            hasCompletedInitialScan = true
+        }
         while (true) {
             // Gate on a live connection. Offline, the scanner RPC stream throws "RpcClient was
             // cancelled" the instant it's subscribed (no network wait), so an unconditional re-subscribe
@@ -513,6 +519,21 @@ internal fun mergeRecentBooks(
  */
 internal fun scanResultHasChanges(result: ScanResultSummary): Boolean =
     result.added > 0 || result.modified > 0 || result.removed > 0 || result.moved > 0
+
+/**
+ * Whether the in-session initial-population latch should be pre-set from an already-populated library.
+ *
+ * `hasCompletedInitialScan` starts `false` every session and only latches when a scan completes that
+ * session. A relaunched client whose Room already holds books has effectively finished its initial
+ * population, so a later folder-triggered (or watcher) scan must NOT be mistaken for the initial scan
+ * and re-arm the "Building your library" gate over an already-usable library. Pre-latch only when the
+ * gate hasn't already fired ([alreadyLatched] false) and the library is non-empty; a genuine first run
+ * (empty library) still shows the gate for the real initial scan.
+ */
+internal fun shouldPreLatchInitialScanGate(
+    alreadyLatched: Boolean,
+    libraryBookCount: Int,
+): Boolean = !alreadyLatched && libraryBookCount > 0
 
 /**
  * Never-stranded recovery for the initial-population gate when the scan-progress stream terminates

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -664,4 +664,25 @@ class SyncRepositoryScanProgressTest :
                 ),
             ) shouldBe false
         }
+
+        // ── Initial-population pre-latch ───────────────────────────────────────────────────────────
+        //
+        // The "Building your library" flash while browsing: `hasCompletedInitialScan` starts false every
+        // session and only latches via a scan that completes THIS session. On a relaunched client whose
+        // library is already populated, the next scan (e.g. a folder add/remove) was mistaken for the
+        // initial scan and re-armed the populating gate — flashing "Building your library" over an
+        // already-usable library. Pre-latching from an already-populated library fixes it: only a genuine
+        // first run (empty library) shows the gate.
+
+        test("pre-latches the initial-scan gate when the library is already populated") {
+            shouldPreLatchInitialScanGate(alreadyLatched = false, libraryBookCount = 1150) shouldBe true
+        }
+
+        test("does not pre-latch on a genuine first run with an empty library") {
+            shouldPreLatchInitialScanGate(alreadyLatched = false, libraryBookCount = 0) shouldBe false
+        }
+
+        test("does not pre-latch again once the gate has already latched this session") {
+            shouldPreLatchInitialScanGate(alreadyLatched = true, libraryBookCount = 1150) shouldBe false
+        }
     })


### PR DESCRIPTION
## Problem
Adding or removing a library folder briefly flashed the full-screen **"Building your library"** populating screen over an already-usable library — jarring while browsing (it's only appropriate during the genuine first-run scan).

## Root cause
`isServerScanning` is the app-readiness gate, and `applyScanEvent` correctly refuses to re-arm it once the initial scan has latched (`hasCompletedInitialScan`). But that flag **starts `false` every session** and only latches when a scan *completes that session*. On a normal launch into an already-populated library, no startup scan runs, so the flag stays `false` — and the **first** scan of the session (triggered by a folder add/remove, or the watcher) is mistaken for the initial scan, re-arms the gate, and flashes the populating screen while the book list briefly churns.

The existing doc comment even assumed "with no scan running nothing re-arms the overlay" — but a folder change *does* run a scan.

## Fix
Pre-latch the gate from an already-populated library. When the scan-progress observer starts, if Room already holds books, treat the initial population as complete (`hasCompletedInitialScan = true`). A genuine first run (empty library) still shows the populating screen for the real initial scan; every later folder/watcher scan stays out of the shell.

Added the pure helper `shouldPreLatchInitialScanGate(alreadyLatched, libraryBookCount)` (mirroring the existing `scanResultHasChanges` pattern) and wired it into `observeScanProgressResiliently` via the already-injected `BookDao.count()`.

## Testing
- 3 new unit tests in `SyncRepositoryScanProgressTest`: pre-latch when populated; no pre-latch on an empty first run; no re-latch once already latched.
- The existing reducer tests (incl. "an incremental scan after the initial scan completes does not re-block the shell") confirm the gate is honored once latched.

## Notes
- Behaviour verified by unit test + root-cause; the visual flash is sub-second so absence-proving on-device is unreliable — the gate logic is the authoritative check.
- Full `:sharedLogic:jvmTest` suite OOMs locally (test-worker heap, machine-specific); the targeted scan-progress suite passes. CI runs the full suite at its configured heap.