### PR TITLE
✨ feat(server): smarter title/subtitle parsing for colon-heavy & series-suffixed titles

### DIFF
--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcher.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcher.kt
@@ -9,44 +9,53 @@ package com.calypsan.listenup.server.scanner.inference
  * touched. No confident match -> the input is returned unchanged.
  */
 internal object SeriesSuffixMatcher {
+    // Cardinal number: a digit run, or an English word one..twenty. Kept as a word list so [NUM]
+    // interpolates as a short raw string (a single inline literal would exceed the line-length limit).
+    private val WORD_NUMBERS =
+        listOf(
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+            "twenty",
+        )
+    private val NUM = """(?:\d+|${WORD_NUMBERS.joinToString("|")})"""
 
-    // Matches a cardinal number written as a digit or as English words one..twenty.
-    private const val NUM =
-        "(?:\\d+|one|two|three|four|five|six|seven|eight|nine|ten" +
-            "|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)"
+    // Series-position keyword: Book, Vol, Vol., Volume, Part.
+    private const val LABEL = """(?:book|vol\.?|volume|part)"""
 
-    // Matches the series-position keyword: Book, Vol, Vol., Volume, Part.
-    private const val LABEL = "(?:book|vol\\.?|volume|part)"
-
-    // Trailing suffix forms recognised:
-    //
-    //   Form A — colon-prefixed: ": <series name>, Book N" at end of title
-    //            (handles "Title: Series, Book N" → "Title")
-    //   Form B — bare comma: ", Book N" or ", Volume N"
-    //            (handles "Title, Book 6" → "Title")
-    //   Form C — parenthesised: "(<anything>, Book N)" or "(<anything> #N)"
-    //            (handles "Title (Series, Book One)" and "Title (Series #4)" → "Title")
-    //
-    // Forms are tried longest-match first by alternation ordering so that Form A
-    // (which consumes more characters) wins over Form B when both could match.
+    // Trailing suffix forms, tried longest-match first by alternation order so the colon form
+    // (which consumes more) wins over the bare-comma form when both could match:
+    //   Form A — colon-prefixed:  ": <series>, Book N"   ("Title: Series, Book N" -> "Title")
+    //   Form B — bare comma:      ", Book N" / ", Volume N"
+    //   Form C — parenthesised:   "(<...>, Book N)" / "(<...> #N)"
     private val trailingSuffix =
         Regex(
-            // Form A: strip ":<ws>series-name, LABEL NUM" from the end
-            "\\s*(?::\\s*[^:]+,\\s*$LABEL\\s+$NUM" +
-                // Form B: strip ", LABEL NUM" from the end
-                "|,\\s*$LABEL\\s+$NUM" +
-                // Form C: strip "(<...>, LABEL NUM)" or "(<...> #NUM)" from the end
-                "|\\([^)]*(?:$LABEL\\s+$NUM|#\\s*$NUM)\\))\\s*\$",
+            """\s*(?::\s*[^:]+,\s*$LABEL\s+$NUM|,\s*$LABEL\s+$NUM|\([^)]*(?:$LABEL\s+$NUM|#\s*$NUM)\))\s*$""",
             RegexOption.IGNORE_CASE,
         )
 
-    // A string that IS a series reference (rather than a real title).
-    // Matches, optionally wrapped in parens:
-    //   - bare "LABEL NUM" (e.g. "Book 3", "Volume 14")
-    //   - "<series name>, LABEL NUM" (e.g. "Chaos Seeds, Book 3")
+    // A standalone string that IS a series reference (rather than a real title), optionally in parens:
+    //   - bare "LABEL NUM" ("Book 3", "Volume 14")
+    //   - "<series name>, LABEL NUM" ("Chaos Seeds, Book 3")
     private val seriesReference =
         Regex(
-            "^\\(?\\s*(?:[^,()]+,\\s*)?$LABEL\\s+$NUM\\s*\\)?\$",
+            """^\(?\s*(?:[^,()]+,\s*)?$LABEL\s+$NUM\s*\)?$""",
             RegexOption.IGNORE_CASE,
         )
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcher.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcher.kt
@@ -1,0 +1,68 @@
+package com.calypsan.listenup.server.scanner.inference
+
+/**
+ * Conservative recognition / removal of a **trailing series suffix** in a book title, and detection
+ * of a string that is really a series reference (a bogus "subtitle" tag that actually holds the series).
+ *
+ * High precision by design: only a strict, *trailing*, anchored `Book/Vol/Part + number` suffix is ever
+ * stripped; a series *name* in the title's prose (e.g. "Harry Potter and the Half-Blood Prince") is never
+ * touched. No confident match -> the input is returned unchanged.
+ */
+internal object SeriesSuffixMatcher {
+
+    // Matches a cardinal number written as a digit or as English words one..twenty.
+    private const val NUM =
+        "(?:\\d+|one|two|three|four|five|six|seven|eight|nine|ten" +
+            "|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)"
+
+    // Matches the series-position keyword: Book, Vol, Vol., Volume, Part.
+    private const val LABEL = "(?:book|vol\\.?|volume|part)"
+
+    // Trailing suffix forms recognised:
+    //
+    //   Form A — colon-prefixed: ": <series name>, Book N" at end of title
+    //            (handles "Title: Series, Book N" → "Title")
+    //   Form B — bare comma: ", Book N" or ", Volume N"
+    //            (handles "Title, Book 6" → "Title")
+    //   Form C — parenthesised: "(<anything>, Book N)" or "(<anything> #N)"
+    //            (handles "Title (Series, Book One)" and "Title (Series #4)" → "Title")
+    //
+    // Forms are tried longest-match first by alternation ordering so that Form A
+    // (which consumes more characters) wins over Form B when both could match.
+    private val trailingSuffix =
+        Regex(
+            // Form A: strip ":<ws>series-name, LABEL NUM" from the end
+            "\\s*(?::\\s*[^:]+,\\s*$LABEL\\s+$NUM" +
+                // Form B: strip ", LABEL NUM" from the end
+                "|,\\s*$LABEL\\s+$NUM" +
+                // Form C: strip "(<...>, LABEL NUM)" or "(<...> #NUM)" from the end
+                "|\\([^)]*(?:$LABEL\\s+$NUM|#\\s*$NUM)\\))\\s*\$",
+            RegexOption.IGNORE_CASE,
+        )
+
+    // A string that IS a series reference (rather than a real title).
+    // Matches, optionally wrapped in parens:
+    //   - bare "LABEL NUM" (e.g. "Book 3", "Volume 14")
+    //   - "<series name>, LABEL NUM" (e.g. "Chaos Seeds, Book 3")
+    private val seriesReference =
+        Regex(
+            "^\\(?\\s*(?:[^,()]+,\\s*)?$LABEL\\s+$NUM\\s*\\)?\$",
+            RegexOption.IGNORE_CASE,
+        )
+
+    /**
+     * Returns [title] with any trailing series suffix stripped, or [title] unchanged when no
+     * high-confidence suffix is found.
+     */
+    fun stripTrailingSeriesSuffix(title: String): String {
+        val stripped = trailingSuffix.replaceFirst(title, "").trim()
+        return stripped.ifBlank { title.trim() }
+    }
+
+    /**
+     * Returns `true` when [text] is itself a series reference — i.e. the whole string encodes a
+     * series-and-position rather than a real subtitle (e.g. a mistagged SUBTITLE tag whose value is
+     * "Chaos Seeds, Book 3").
+     */
+    fun isSeriesReference(text: String): Boolean = seriesReference.matches(text.trim())
+}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcher.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcher.kt
@@ -4,9 +4,11 @@ package com.calypsan.listenup.server.scanner.inference
  * Conservative recognition / removal of a **trailing series suffix** in a book title, and detection
  * of a string that is really a series reference (a bogus "subtitle" tag that actually holds the series).
  *
- * High precision by design: only a strict, *trailing*, anchored `Book/Vol/Part + number` suffix is ever
+ * High precision by design: only a strict, *trailing*, anchored `Book/Vol/Volume + number` suffix is ever
  * stripped; a series *name* in the title's prose (e.g. "Harry Potter and the Half-Blood Prince") is never
- * touched. No confident match -> the input is returned unchanged.
+ * touched. No confident match -> the input is returned unchanged. `Part` is deliberately excluded from the
+ * keyword set: a trailing "Part N" is far more often a real title's internal structure (Dostoevsky, memoirs)
+ * than a series position, so stripping it would destroy legitimate text.
  */
 internal object SeriesSuffixMatcher {
     // Cardinal number: a digit run, or an English word one..twenty. Kept as a word list so [NUM]
@@ -36,17 +38,24 @@ internal object SeriesSuffixMatcher {
         )
     private val NUM = """(?:\d+|${WORD_NUMBERS.joinToString("|")})"""
 
-    // Series-position keyword: Book, Vol, Vol., Volume, Part.
-    private const val LABEL = """(?:book|vol\.?|volume|part)"""
+    // Series-position keyword: Book, Vol, Vol., Volume. `Part` is intentionally absent (see class KDoc).
+    private const val LABEL = """(?:book|vol\.?|volume)"""
 
-    // Trailing suffix forms, tried longest-match first by alternation order so the colon form
-    // (which consumes more) wins over the bare-comma form when both could match:
-    //   Form A — colon-prefixed:  ": <series>, Book N"   ("Title: Series, Book N" -> "Title")
-    //   Form B — bare comma:      ", Book N" / ", Volume N"
-    //   Form C — parenthesised:   "(<...>, Book N)" / "(<...> #N)"
+    // Form A — colon-prefixed series tail: ": <series>, Book N"  ("…: Chaos Seeds, Book 3" -> dropped).
+    // Applied by [stripTrailingSeriesSuffix] ONLY to titles with 2+ colons. With a single colon, that
+    // colon is the primary title:subtitle boundary, and "Title: Subtitle, Book N" far more often holds a
+    // real subtitle ("Dune: Messiah, Book 2") than a colon-delimited series — stripping across it would
+    // destroy the subtitle, which nothing downstream can recover. With 2+ colons an earlier colon already
+    // carries the subtitle, so a trailing ": <words>, Book N" segment is confidently a series tail.
+    private val colonSeriesSuffix =
+        Regex("""\s*:\s*[^:]+,\s*$LABEL\s+$NUM\s*$""", RegexOption.IGNORE_CASE)
+
+    // Forms B/C are always safe — end-anchored and they never cross a colon — so they apply unconditionally:
+    //   Form B — bare comma:      ", Book N" / ", Volume N"   ("Wheel of Time, Volume 14" -> "Wheel of Time")
+    //   Form C — parenthesised:   "(<...>, Book N)" / "(<...> #N)"   ("Catching Fire (Hunger Games, Book Two)")
     private val trailingSuffix =
         Regex(
-            """\s*(?::\s*[^:]+,\s*$LABEL\s+$NUM|,\s*$LABEL\s+$NUM|\([^)]*(?:$LABEL\s+$NUM|#\s*$NUM)\))\s*$""",
+            """\s*(?:,\s*$LABEL\s+$NUM|\([^)]*(?:$LABEL\s+$NUM|#\s*$NUM)\))\s*$""",
             RegexOption.IGNORE_CASE,
         )
 
@@ -64,7 +73,9 @@ internal object SeriesSuffixMatcher {
      * high-confidence suffix is found.
      */
     fun stripTrailingSeriesSuffix(title: String): String {
-        val stripped = trailingSuffix.replaceFirst(title, "").trim()
+        val deColoned =
+            if (title.count { it == ':' } >= 2) colonSeriesSuffix.replaceFirst(title, "") else title
+        val stripped = trailingSuffix.replaceFirst(deColoned, "").trim()
         return stripped.ifBlank { title.trim() }
     }
 
@@ -72,6 +83,12 @@ internal object SeriesSuffixMatcher {
      * Returns `true` when [text] is itself a series reference — i.e. the whole string encodes a
      * series-and-position rather than a real subtitle (e.g. a mistagged SUBTITLE tag whose value is
      * "Chaos Seeds, Book 3").
+     *
+     * Precision/recall note: `"<phrase>, Book N"` and `"<phrase>, Volume N"` are treated as series
+     * references, so a genuine subtitle of exactly that shape (e.g. "A Memoir, Volume 1") is a deliberate,
+     * accepted false positive. It is rare in practice and the cost — discarding the subtitle — is far
+     * cheaper than letting an obvious series tag masquerade as one. `Part` is excluded (see [LABEL]),
+     * which removes the most common false-positive family ("…, Part Two").
      */
     fun isSeriesReference(text: String): Boolean = seriesReference.matches(text.trim())
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -23,6 +23,7 @@ import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
 import com.calypsan.listenup.server.scanner.inference.AbsTitleParser
 import com.calypsan.listenup.server.scanner.inference.FolderShape
 import com.calypsan.listenup.server.scanner.inference.ParsedTitle
+import com.calypsan.listenup.server.scanner.inference.SeriesSuffixMatcher
 import com.calypsan.listenup.server.scanner.inference.TrackInference
 import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import com.calypsan.listenup.server.scanner.metadata.MetadataPrecedence
@@ -339,21 +340,28 @@ internal class Analyzer(
         perTrackMetadata: Map<TrackEntry, EmbeddedAudioMetadata?>,
     ): AnalyzedBook {
         val rawTitle = pickTitle(candidate, shape, parsed, embedded, metadata, sidecar)
-        val (strippedTitle, titleAbridged) = parseAbridgedFromTitle(rawTitle)
+        val (abridgedStripped, titleAbridged) = parseAbridgedFromTitle(rawTitle)
+        // Strip a strict trailing series suffix the tag/album baked into the title (", Book 6",
+        // "(Series, Book Two)", ": Series, Book 3"). Conservative — leaves prose series names alone.
+        val cleanedTitle = SeriesSuffixMatcher.stripTrailingSeriesSuffix(abridgedStripped)
 
         // An explicit subtitle (metadata.json, embedded TIT3/freeform, OPF dc:subtitle, or the
         // gated folder " - " split) always wins; only when none exists do we derive one from the
         // title string. Applied uniformly to whatever source pickTitle chose.
+        // Discard an explicit subtitle that is really the series (a mistagged SUBTITLE/TIT3), so the
+        // real subtitle can be split out of the title below.
         val explicitSubtitle =
-            metadata?.subtitle
-                ?: embedded?.tags?.subtitle
-                ?: sidecar?.subtitle
-                ?: parsed.subtitle
+            (
+                metadata?.subtitle
+                    ?: embedded?.tags?.subtitle
+                    ?: sidecar?.subtitle
+                    ?: parsed.subtitle
+            )?.takeUnless { SeriesSuffixMatcher.isSeriesReference(it) }
         val (title, subtitle) =
             if (explicitSubtitle != null) {
-                strippedTitle to explicitSubtitle
+                cleanedTitle to explicitSubtitle
             } else {
-                TitleSubtitleSplitter.split(strippedTitle)
+                TitleSubtitleSplitter.split(cleanedTitle)
             }
 
         val (resolvedChapters, chaptersSource) = pickChapters(embedded, metadata, tracks, perTrackMetadata, title)

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/TitleSubtitleSplitter.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/TitleSubtitleSplitter.kt
@@ -26,6 +26,7 @@ package com.calypsan.listenup.server.scanner.pipeline
  */
 object TitleSubtitleSplitter {
     private val colonSpace = Regex("""^(.+?): (.+)$""")
+
     // Greedy title so the split lands at the LAST ": A/An/The …" segment.
     private val descriptiveTail =
         Regex("""^(.+):\s+((?:A|An|The)\s+\S.*)$""", RegexOption.IGNORE_CASE)

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/TitleSubtitleSplitter.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/TitleSubtitleSplitter.kt
@@ -1,12 +1,20 @@
 package com.calypsan.listenup.server.scanner.pipeline
 
 /**
- * Derives a `title` / `subtitle` pair from a single title string by splitting on
- * the first `": "` (colon + space). Colon is the standard title/subtitle
- * publishing convention; a spaced dash in a title string is too low-precision to
- * split on (it is a filename-field separator), so only the colon is used here.
+ * Derives a `title` / `subtitle` pair from a single title string.
  *
- * Guardrails keep precision high:
+ * Two split strategies, tried in order:
+ *  - D0 (descriptive tail): a trailing `: A …`/`: An …`/`: The …` segment is a
+ *    clearly-descriptive subtitle. With a **greedy** title, this splits at the
+ *    *last* such segment — so a multi-colon title like
+ *    `"The Land: Alliances: A LitRPG Saga"` keeps `"The Land: Alliances"` whole
+ *    and lifts off `"A LitRPG Saga"`. A single-colon descriptive title
+ *    (`"Sapiens: A Brief History…"`) splits identically to the first-colon rule.
+ *  - First-colon: otherwise, split on the first `": "` (colon + space). Colon is
+ *    the standard title/subtitle publishing convention; a spaced dash is too
+ *    low-precision to split on (it is a filename-field separator).
+ *
+ * Guardrails keep precision high (applied to both strategies):
  *  - G1: requires `": "` (colon + space), so times/ratios/namespaces
  *    ("1:30", "Ratio 3:1", "Vol:2") are never split.
  *  - G2: both sides must be non-empty after trimming.
@@ -18,11 +26,21 @@ package com.calypsan.listenup.server.scanner.pipeline
  */
 object TitleSubtitleSplitter {
     private val colonSpace = Regex("""^(.+?): (.+)$""")
+    // Greedy title so the split lands at the LAST ": A/An/The …" segment.
+    private val descriptiveTail =
+        Regex("""^(.+):\s+((?:A|An|The)\s+\S.*)$""", RegexOption.IGNORE_CASE)
     private val volumeSubtitle =
         Regex("""^(?:\d+|(?:book|vol\.?|volume|part|pt\.?|#)\s*\d+)$""", RegexOption.IGNORE_CASE)
 
     fun split(title: String): Pair<String, String?> {
         val trimmed = title.trim()
+        descriptiveTail.matchEntire(trimmed)?.let { match ->
+            val left = match.groupValues[1].trim()
+            val right = match.groupValues[2].trim()
+            if (left.isNotEmpty() && right.isNotEmpty() && !volumeSubtitle.matches(right)) {
+                return left to right
+            }
+        }
         val match = colonSpace.matchEntire(trimmed) ?: return trimmed to null
         val left = match.groupValues[1].trim()
         val right = match.groupValues[2].trim()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcherTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcherTest.kt
@@ -9,9 +9,14 @@ class SeriesSuffixMatcherTest :
             listOf(
                 "Harry Potter and the Half-Blood Prince, Book 6" to "Harry Potter and the Half-Blood Prince",
                 "Harry Potter and the Sorcerer's Stone, Book 1" to "Harry Potter and the Sorcerer's Stone",
-                "The Girl Who Kicked the Hornet's Nest: The Millennium Series, Book 3" to
-                    "The Girl Who Kicked the Hornet's Nest",
+                // Multi-colon: an earlier colon already carries the subtitle, so the trailing colon
+                // segment is confidently a series tail and is dropped whole.
                 "The Land: Alliances: A LitRPG Saga: Chaos Seeds, Book 3" to "The Land: Alliances: A LitRPG Saga",
+                // Single-colon: that colon is the title:subtitle boundary, so we never strip across it —
+                // only the ", Book N" comes off; the colon segment survives to become the subtitle.
+                "The Girl Who Kicked the Hornet's Nest: The Millennium Series, Book 3" to
+                    "The Girl Who Kicked the Hornet's Nest: The Millennium Series",
+                "Dune: Messiah, Book 2" to "Dune: Messiah",
                 "Catching Fire (Hunger Games, Book Two)" to "Catching Fire",
                 "Mockingjay (The Hunger Games, Book Three)" to "Mockingjay",
                 "The Hunger Games (The Hunger Games, Book One)" to "The Hunger Games",
@@ -33,6 +38,9 @@ class SeriesSuffixMatcherTest :
                 "Harry Potter and the Half-Blood Prince",
                 "The Bunnicula Collection: Books 1-3",
                 "Mistborn",
+                // `Part N` is internal book structure, not a series position — never stripped.
+                "It's a Wonderful Life, Part 2",
+                "Notes from Underground, Part 4",
             ).forEach { input ->
                 test("'$input' unchanged") {
                     SeriesSuffixMatcher.stripTrailingSeriesSuffix(input) shouldBe input
@@ -50,6 +58,8 @@ class SeriesSuffixMatcherTest :
                 "A LitRPG Saga" to false,
                 "Book of Atrus" to false,
                 "An Essential Guide to Contemplative Spirituality" to false,
+                // `Part` is excluded, so a "…, Part N" subtitle is not mistaken for a series reference.
+                "A Memoir, Part Two" to false,
             ).forEach { (input, expected) ->
                 test("isSeriesReference('$input') == $expected") {
                     SeriesSuffixMatcher.isSeriesReference(input) shouldBe expected

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcherTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/inference/SeriesSuffixMatcherTest.kt
@@ -1,0 +1,59 @@
+package com.calypsan.listenup.server.scanner.inference
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SeriesSuffixMatcherTest :
+    FunSpec({
+        context("stripTrailingSeriesSuffix removes a strict trailing Book/Vol+number suffix") {
+            listOf(
+                "Harry Potter and the Half-Blood Prince, Book 6" to "Harry Potter and the Half-Blood Prince",
+                "Harry Potter and the Sorcerer's Stone, Book 1" to "Harry Potter and the Sorcerer's Stone",
+                "The Girl Who Kicked the Hornet's Nest: The Millennium Series, Book 3" to
+                    "The Girl Who Kicked the Hornet's Nest",
+                "The Land: Alliances: A LitRPG Saga: Chaos Seeds, Book 3" to "The Land: Alliances: A LitRPG Saga",
+                "Catching Fire (Hunger Games, Book Two)" to "Catching Fire",
+                "Mockingjay (The Hunger Games, Book Three)" to "Mockingjay",
+                "The Hunger Games (The Hunger Games, Book One)" to "The Hunger Games",
+                "Some Title (Some Series #4)" to "Some Title",
+                "Wheel of Time, Volume 14" to "Wheel of Time",
+            ).forEach { (input, expected) ->
+                test("'$input' -> '$expected'") {
+                    SeriesSuffixMatcher.stripTrailingSeriesSuffix(input) shouldBe expected
+                }
+            }
+        }
+
+        context("stripTrailingSeriesSuffix leaves false positives untouched") {
+            listOf(
+                "Myst - The Book of Atrus",
+                "The Black Book of Power",
+                "The New Big Book of Christian Mysticism",
+                "The Land: Alliances: A LitRPG Saga",
+                "Harry Potter and the Half-Blood Prince",
+                "The Bunnicula Collection: Books 1-3",
+                "Mistborn",
+            ).forEach { input ->
+                test("'$input' unchanged") {
+                    SeriesSuffixMatcher.stripTrailingSeriesSuffix(input) shouldBe input
+                }
+            }
+        }
+
+        context("isSeriesReference detects a string that is really the series") {
+            listOf(
+                "Chaos Seeds, Book 3" to true,
+                "The Millennium Series, Book 3" to true,
+                "Book 3" to true,
+                "(Hunger Games, Book Two)" to true,
+                "Volume 14" to true,
+                "A LitRPG Saga" to false,
+                "Book of Atrus" to false,
+                "An Essential Guide to Contemplative Spirituality" to false,
+            ).forEach { (input, expected) ->
+                test("isSeriesReference('$input') == $expected") {
+                    SeriesSuffixMatcher.isSeriesReference(input) shouldBe expected
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
@@ -170,6 +170,44 @@ class AnalyzerMultiFileBookTest :
                 }
             }
         }
+        test("single-file book: bogus series-subtitle discarded, real subtitle split from the title") {
+            audioLibrary {}.use { fixture ->
+                runTest {
+                    val rel = "Aleron Kong/Chaos Seeds/Book 3 - The Land - Alliances"
+                    val file =
+                        buildMp3File {
+                            id3v2(version = 4) {
+                                textFrame("TIT2", "The Land: Alliances: A LitRPG Saga")
+                                // The SUBTITLE tag wrongly carries the series (the real-world bug).
+                                textFrame("TIT3", "Chaos Seeds, Book 3")
+                            }
+                            mpegFrames(durationSeconds = 1)
+                        }
+                    val p = fixture.root.writeAudio("$rel/book.mp3", file)
+                    val candidate =
+                        CandidateBook(
+                            rootRelPath = rel,
+                            isFile = false,
+                            files = listOf(trackEntry("$rel/book.mp3", Files.size(p))),
+                        )
+
+                    val book =
+                        Analyzer(fixture.root, metadataReader, embeddedParser)
+                            .analyze(flowOf(candidate))
+                            .toList()
+                            .single()
+                            .getOrThrow()
+
+                    // TIT3 "Chaos Seeds, Book 3" is a series reference — discarded.
+                    // TitleSubtitleSplitter splits at the first ": ", giving:
+                    //   title = "The Land"
+                    //   subtitle = "Alliances: A LitRPG Saga"
+                    book.title shouldBe "The Land"
+                    book.subtitle shouldBe "Alliances: A LitRPG Saga"
+                }
+            }
+        }
+
         test("single-file book keeps its title tag and does not inherit the album's series suffix") {
             audioLibrary {}.use { fixture ->
                 runTest {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerMultiFileBookTest.kt
@@ -198,12 +198,8 @@ class AnalyzerMultiFileBookTest :
                             .single()
                             .getOrThrow()
 
-                    // TIT3 "Chaos Seeds, Book 3" is a series reference — discarded.
-                    // TitleSubtitleSplitter splits at the first ": ", giving:
-                    //   title = "The Land"
-                    //   subtitle = "Alliances: A LitRPG Saga"
-                    book.title shouldBe "The Land"
-                    book.subtitle shouldBe "Alliances: A LitRPG Saga"
+                    book.title shouldBe "The Land: Alliances"
+                    book.subtitle shouldBe "A LitRPG Saga"
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/TitleSubtitleSplitterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/TitleSubtitleSplitterTest.kt
@@ -13,6 +13,17 @@ class TitleSubtitleSplitterTest :
         test("non-greedy first colon — later colons stay in the subtitle") {
             TitleSubtitleSplitter.split("A: B: C") shouldBe ("A" to "B: C")
         }
+        test("descriptive tail: a multi-colon title splits at the last ': A/An/The …' segment") {
+            TitleSubtitleSplitter.split("The Land: Alliances: A LitRPG Saga") shouldBe
+                ("The Land: Alliances" to "A LitRPG Saga")
+        }
+        test("descriptive tail: a single-colon descriptive subtitle is unchanged") {
+            TitleSubtitleSplitter.split("Sapiens: A Brief History of Humankind") shouldBe
+                ("Sapiens" to "A Brief History of Humankind")
+        }
+        test("descriptive tail: a non-descriptive final segment falls back to the first-colon split") {
+            TitleSubtitleSplitter.split("It: Chapter Two") shouldBe ("It" to "Chapter Two")
+        }
         test("no colon-space returns the title whole") {
             TitleSubtitleSplitter.split("Mistborn") shouldBe ("Mistborn" to null)
         }


### PR DESCRIPTION
## Summary

Audiobook titles often bake the subtitle **and** the series into one colon-heavy string, e.g. `"The Land: Alliances: A LitRPG Saga: Chaos Seeds, Book 3"`. This derives a cleaner title/subtitle and discards a baked-in trailing series reference — going beyond Audiobookshelf (which does no colon-splitting or series-stripping) but **conservatively**, governed by one rule: *match less with higher confidence, never strip a series name out of prose.*

Three pieces:
- **`SeriesSuffixMatcher`** (new, `internal`) — `stripTrailingSeriesSuffix` removes a strict, end-anchored series tail (`, Book N` / `(Series, Book N)` / `(Series #N)`), and for **multi-colon** titles a `: <series>, Book N` tail; `isSeriesReference` flags a mistagged "subtitle" that actually holds the series.
- **`TitleSubtitleSplitter`** — new descriptive-tail rule: split a trailing `": A/An/The …"` segment as the subtitle, before the existing first-colon split.
- **`Analyzer.compose`** — strips the baked-in series suffix from the cleaned title and discards an explicit subtitle that is itself a series reference.

### Conservatism guarantees (verified by tests)
- A series **name in prose** is never touched: `"Harry Potter and the Half-Blood Prince"` → unchanged.
- `Part N` is **excluded** from the series keywords — `"It's a Wonderful Life, Part 2"` → unchanged (it's internal book structure, not a series position).
- The colon-strip is **gated to 2+-colon titles**, so a single-colon real subtitle survives: `"Dune: Messiah, Book 2"` → `"Dune: Messiah"` (only `, Book 2` comes off). This matters because the title is the *only* series source when there's no series tag — an over-strip would be permanent data loss.
- Number-literal titles (`Catch-22`, `1984`, `Slaughterhouse-Five`) pass through unchanged.

## Test Plan
- [x] `SeriesSuffixMatcherTest` (28) — acceptance table incl. Harry Potter / `Part N` / `Dune: Messiah` false-positive guards
- [x] `TitleSubtitleSplitterTest` (11) — descriptive-tail split + volume-token rejection
- [x] `AnalyzerMultiFileBookTest` (5) — single-file series-subtitle discarded, real subtitle split from the title
- [x] `detekt` + `spotlessCheck` green
- [x] Full `:server:jvmTest` — only pre-existing Auth E2E flakes (pass in isolation; green in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)