### PR TITLE
✨ feat(server): carry audio-stream info to the sync payload (Phase 2/4 — pipeline)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookSyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/BookSyncPayload.kt
@@ -92,7 +92,9 @@ data class BookSeriesPayload(
  *
  * `index` mirrors the on-disk order so multi-file books play correctly.
  * `format` and `codec` are informational source-file metadata surfaced to the
- * playback pipeline.
+ * playback pipeline. The optional audio-stream fields (`codecProfile`, `spatial`,
+ * `bitrate`, `sampleRate`, `channels`) default to null for back-compat with
+ * payloads produced by older server versions.
  */
 @Serializable
 @SerialName("BookAudioFilePayload")
@@ -104,6 +106,16 @@ data class BookAudioFilePayload(
     val codec: String,
     val duration: Long,
     val size: Long,
+    /** AAC profile token (`lc`/`he`/`hev2`/`xhe`); null for non-AAC or when undetermined. */
+    val codecProfile: String? = null,
+    /** Spatial-audio marker (e.g. `atmos`); null when not spatial. */
+    val spatial: String? = null,
+    /** Average bitrate in bits/sec; null when undetermined. */
+    val bitrate: Int? = null,
+    /** Sample rate in Hz; null when undetermined. */
+    val sampleRate: Int? = null,
+    /** Channel count; null when undetermined. */
+    val channels: Int? = null,
 )
 
 /**

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/api/sync/BookAudioFilePayloadTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/api/sync/BookAudioFilePayloadTest.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.api.sync
+
+import com.calypsan.listenup.api.contractJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class BookAudioFilePayloadTest :
+    FunSpec({
+        test("round-trips the new audio-stream fields") {
+            val v =
+                BookAudioFilePayload(
+                    id = "af1",
+                    index = 0,
+                    filename = "book.m4b",
+                    format = "m4b",
+                    codec = "ac4",
+                    duration = 1000,
+                    size = 2048,
+                    codecProfile = null,
+                    spatial = "atmos",
+                    bitrate = 320000,
+                    sampleRate = 48000,
+                    channels = 2,
+                )
+            contractJson.decodeFromString<BookAudioFilePayload>(contractJson.encodeToString(v)) shouldBe v
+        }
+
+        test("new fields default to null for back-compat with older payloads") {
+            val json = """{"id":"a","index":0,"filename":"f","format":"mp3","codec":"mp3","duration":1,"size":2}"""
+            val v = contractJson.decodeFromString<BookAudioFilePayload>(json)
+            v.codecProfile shouldBe null
+            v.spatial shouldBe null
+            v.bitrate shouldBe null
+            v.sampleRate shouldBe null
+            v.channels shouldBe null
+        }
+    })

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
@@ -38,7 +38,11 @@ import kotlin.time.Clock
  * `durationMs` (parsed per-track for multi-file books by the Analyzer). Every
  * `book_audio_files` row gets its track's duration, and `totalDuration` is their sum.
  * Single-file books leave `TrackEntry.durationMs` null, so both the one file's duration
- * and `totalDuration` fall back to the book-level `embedded.durationMs`. `codec` is left blank.
+ * and `totalDuration` fall back to the book-level `embedded.durationMs`.
+ *
+ * **Audio stream.** The primary (first) file's `codec`/`codecProfile`/`spatial`/
+ * `bitrate`/`sampleRate`/`channels` come from `embedded.audioStream`; secondary
+ * files leave them null (multi-file per-track audio metadata is a non-goal).
  *
  * `cover` is left null — cover hashing is a later task; the substrate-owned
  * `revision` / `updatedAt` / `createdAt` placeholders are overwritten by
@@ -157,21 +161,35 @@ class AnalyzedBookMapper(
         }
 
     /**
-     * Builds the audio-file payloads for [analyzed]. Only the primary (first)
-     * audio file has an authoritative duration — see the duration caveat on
-     * the class doc.
+     * Builds the audio-file payloads for [analyzed]. Each track carries its own
+     * `durationMs` (multi-file books); single-file books fall back to the primary
+     * `embedded.durationMs` — see the duration note on the class doc. The
+     * primary file's `codec`/`codecProfile`/`spatial`/
+     * `bitrate`/`sampleRate`/`channels` come from `embedded.audioStream`;
+     * secondary files leave them null (multi-file per-track metadata is a
+     * non-goal).
      */
     fun buildAudioFiles(analyzed: AnalyzedBook): List<BookAudioFilePayload> {
         val primaryDuration = analyzed.embedded?.durationMs ?: 0L
+        val primaryStream = analyzed.embedded?.audioStream
         return analyzed.tracks.mapIndexed { index, track ->
+            // The scanner parses embedded metadata for the primary (first) file only — a
+            // documented non-goal for multi-file per-track metadata — so codec/profile/
+            // spatial/bitrate/sampleRate/channels are carried on index 0 and left null elsewhere.
+            val stream = if (index == 0) primaryStream else null
             BookAudioFilePayload(
                 id = "",
                 index = index,
                 filename = track.file.name,
                 format = track.file.ext,
-                codec = "",
+                codec = stream?.codec ?: "",
                 duration = track.durationMs ?: if (index == 0) primaryDuration else 0L,
                 size = track.file.size,
+                codecProfile = stream?.codecProfile,
+                spatial = stream?.spatial,
+                bitrate = stream?.bitrate,
+                sampleRate = stream?.sampleRate,
+                channels = stream?.channels,
             )
         }
     }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapperTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapperTest.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
+import com.calypsan.listenup.domain.embeddedmeta.AudioStreamInfo
 import com.calypsan.listenup.domain.embeddedmeta.AudioTags
 import com.calypsan.listenup.domain.embeddedmeta.Chapter
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
@@ -437,6 +438,58 @@ class AnalyzedBookMapperTest :
             payload.inode shouldBe 999L
             payload.totalDuration shouldBe 7_777L
             payload.hasScanWarning shouldBe true
+        }
+
+        test("primary audio file carries embedded audioStream; secondary files do not") {
+            val f0 =
+                FileEntry(
+                    relPath = "b/01.m4b",
+                    name = "01.m4b",
+                    ext = "m4b",
+                    size = 1024L,
+                    mtimeMs = 0L,
+                    inode = 1L,
+                    fileType = FileType.AUDIO,
+                )
+            val f1 =
+                FileEntry(
+                    relPath = "b/02.m4b",
+                    name = "02.m4b",
+                    ext = "m4b",
+                    size = 2048L,
+                    mtimeMs = 0L,
+                    inode = 2L,
+                    fileType = FileType.AUDIO,
+                )
+            val analyzed =
+                AnalyzedBook(
+                    candidate = CandidateBook(rootRelPath = "b", isFile = false, files = listOf(f0, f1)),
+                    title = "B",
+                    tracks = listOf(TrackEntry(file = f0), TrackEntry(file = f1)),
+                    embedded =
+                        embeddedMeta(durationMs = 100L).copy(
+                            audioStream =
+                                AudioStreamInfo(
+                                    codec = "ac4",
+                                    codecProfile = null,
+                                    spatial = "atmos",
+                                    bitrate = 320000,
+                                    sampleRate = 48000,
+                                    channels = 2,
+                                ),
+                        ),
+                )
+
+            val audioFiles = mapper.buildAudioFiles(analyzed)
+
+            audioFiles[0].codec shouldBe "ac4"
+            audioFiles[0].spatial shouldBe "atmos"
+            audioFiles[0].bitrate shouldBe 320000
+            audioFiles[0].sampleRate shouldBe 48000
+            audioFiles[0].channels shouldBe 2
+            audioFiles[1].codec shouldBe ""
+            audioFiles[1].spatial shouldBe null
+            audioFiles[1].bitrate shouldBe null
         }
     })
 


### PR DESCRIPTION
## Summary

Phase 2 of the scanner rich-audio-format work: carry the primary file's audio-stream info (`codec`, `codecProfile`, `spatial`, `bitrate`, `sampleRate`, `channels`) from the parser through the server pipeline into the sync payload.

- **contract:** `BookAudioFilePayload` gains five nullable audio-stream fields (`codecProfile`, `spatial`, `bitrate`, `sampleRate`, `channels`), defaulted `null` for back-compat with older-server payloads.
- **server:** `AnalyzedBookMapper.buildAudioFiles` populates them on the primary (first) file from `embedded.audioStream`; secondary files stay null (multi-file per-track metadata remains a non-goal). `codec` stops being hardcoded blank.

Phase 1 (#741, parser extraction) has merged to `main`; this branch is rebased cleanly onto current `main` (it now carries only the two Phase 2 commits). The merge picked up #731's per-track-duration logic — `buildAudioFiles` combines both (`duration = track.durationMs ?: …` **and** the audio-stream fields).

## Test Plan

- [x] `:server:jvmTest` — `AnalyzedBookMapperTest` covers the primary-carries / secondary-null audio-stream case alongside #731's per-track-duration tests.
- [x] `:sharedLogic:jvmTest` (contract ripple) + `spotlessCheck` + `detekt` — green locally.
- Phase 3 (client Room migration + domain + sync mapper) and Phase 4 (Book Detail UI) follow in stacked PRs.