### PR TITLE
✅ test(server): deflake LibraryLessOnboardingE2ETest scan-trigger startup race

### DIFF
--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/LibraryLessOnboardingE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/LibraryLessOnboardingE2ETest.kt
@@ -93,8 +93,21 @@ class LibraryLessOnboardingE2ETest :
                     addFolderResponse.status shouldBe HttpStatusCode.Created
 
                     // 5. Kick the live scan via the already-mounted orchestrator.
-                    val scanResponse = client.post("/api/v1/libraries/scan") { bearerAuth(adminToken) }
-                    scanResponse.status shouldBe HttpStatusCode.Accepted
+                    //    Library bootstrap — which registers the library with the orchestrator and warms
+                    //    its scanner bundle (Application.kt `scope.launch { bootstrapLibraries(...) }`) —
+                    //    runs ASYNCHRONOUSLY at startup. A scan triggered before that registration lands
+                    //    races it and returns 404 (the library isn't known to the orchestrator yet), so we
+                    //    poll the trigger until accepted. Registration is monotonic — once the bundle exists
+                    //    it stays — so this converges; only the startup-race 404 is tolerated, any other
+                    //    status fails fast. (In production the wizard runs long after boot, never racing.)
+                    withTimeout(SCAN_TRIGGER_TIMEOUT_MS) {
+                        while (true) {
+                            val scanResponse = client.post("/api/v1/libraries/scan") { bearerAuth(adminToken) }
+                            if (scanResponse.status == HttpStatusCode.Accepted) break
+                            scanResponse.status shouldBe HttpStatusCode.NotFound
+                            delay(POLL_INTERVAL_MS)
+                        }
+                    }
 
                     // 6. Await books on the always-loaded sync substrate. The scan is async,
                     //    so poll the books page until at least one book lands.
@@ -117,6 +130,7 @@ class LibraryLessOnboardingE2ETest :
         }
     })
 
+private const val SCAN_TRIGGER_TIMEOUT_MS = 15_000L
 private const val SCAN_AWAIT_TIMEOUT_MS = 20_000L
 private const val POLL_INTERVAL_MS = 100L
 


### PR DESCRIPTION
## Summary

`LibraryLessOnboardingE2ETest` has been intermittently failing CI (hit on both #731 and #742, forcing re-runs). This deflakes it.

**Root cause (a test timing artifact, not a product bug):** library bootstrap registers the library with the `ScanOrchestrator` — warming its scanner `bundle` — **asynchronously** at startup (`Application.kt`: `scope.launch { bootstrapLibraries(...) }`). The test drives the wizard (`addFolder` → `POST /api/v1/libraries/scan`) microseconds after the server starts accepting requests, so the scan can beat that registration. When it does, `ScanOrchestrator.scanLibraryAsync` finds no `bundle` for the library and returns `LibraryError.NotFound` → **404**, where the test asserted `202`.

It's a test-only race: in production, bootstrap completes in milliseconds at startup and a real user reaches the wizard long afterward — never racing. The library registration is also *monotonic* (once the bundle exists it stays, and bootstrap re-reads the persisted folder), so the trigger always converges to `202`.

**Fix:** poll the scan trigger until it returns `202 Accepted`, within a bounded timeout, tolerating only the startup-race `404` — any other status still fails fast. Mirrors the existing book-count poll already in the test. No production code touched.

## Test Plan
- [x] Ran the hardened test **10× in isolation → 10/10 pass** (pre-fix it failed ~3 of 4 runs in isolation, and on CI)
- [x] `detekt` + `spotlessCheck` green

> Note: there's a latent sharp edge behind this — `ScanOrchestrator.onFolderAdded` no-ops when `bundle` is null (folder added before the library is registered), relying on bootstrap's later `onLibraryAdded` to re-read the persisted folder. Harmless in practice (bootstrap runs once at startup) but worth a look if the orchestrator registration is ever reworked. Left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)