### PR TITLE
✨ feat(library): article-aware 'Title sort' toggle on the Series tab

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
@@ -413,7 +413,7 @@ class LibraryViewModel(
         val sortedBooks = sortBooks(content.books, intent.booksSortState, intent.ignoreTitleArticles)
         val visibleSeries =
             if (intent.hideSingleBookSeries) content.series.filter { it.books.size > 1 } else content.series
-        val sortedSeries = sortSeries(visibleSeries, intent.seriesSortState)
+        val sortedSeries = sortSeries(visibleSeries, intent.seriesSortState, intent.ignoreTitleArticles)
         val sortedAuthors = sortContributors(content.authors, intent.authorsSortState)
         val sortedNarrators = sortContributors(content.narrators, intent.narratorsSortState)
         val seriesProgress =
@@ -579,13 +579,14 @@ class LibraryViewModel(
     private fun sortSeries(
         series: List<SeriesWithBooks>,
         state: SortState,
+        ignoreArticles: Boolean,
     ): List<SeriesWithBooks> {
         val isAsc = state.direction == SortDirection.ASCENDING
 
         return when (state.category) {
             SortCategory.NAME -> {
-                // Key: name lowercase — computed once per element.
-                val keyed = series.map { it to it.series.name.lowercase() }
+                // Key: article-aware sortable name (so "The Wandering Inn" files under W) — computed once.
+                val keyed = series.map { it to it.series.name.sortableTitle(ignoreArticles) }
                 val sorted = if (isAsc) keyed.sortedBy { it.second } else keyed.sortedByDescending { it.second }
                 sorted.map { it.first }
             }
@@ -604,7 +605,7 @@ class LibraryViewModel(
 
             // Default to name sort for unsupported categories
             else -> {
-                val keyed = series.map { it to it.series.name.lowercase() }
+                val keyed = series.map { it to it.series.name.sortableTitle(ignoreArticles) }
                 keyed.sortedBy { it.second }.map { it.first }
             }
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -755,6 +755,41 @@ class LibraryViewModelTest :
             }
         }
 
+        test("series sorted by name ignores leading articles when enabled") {
+            runTest {
+                // "The Wandering Inn" must sort as "Wandering Inn" (under W, after Villains) — not under T.
+                val seriesList =
+                    listOf(
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "1", name = "The Wandering Inn"),
+                            books = listOf(createDummyBook("w1"), createDummyBook("w2")),
+                            bookSequences = emptyMap(),
+                        ),
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "2", name = "Villains Code"),
+                            books = listOf(createDummyBook("v1"), createDummyBook("v2")),
+                            bookSequences = emptyMap(),
+                        ),
+                        SeriesWithBooks(
+                            series = createTestSeries(id = "3", name = "Apple Saga"),
+                            books = listOf(createDummyBook("a1"), createDummyBook("a2")),
+                            bookSequences = emptyMap(),
+                        ),
+                    )
+                val fixture = createFixture()
+                everySuspend { fixture.libraryPreferences.getIgnoreTitleArticles() } returns true
+                every { fixture.seriesRepository.observeAllWithBooks() } returns flowOf(seriesList)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then - article stripped: Apple (A), Villains (V), The Wandering Inn (as Wandering, W)
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.series.map { it.series.name } shouldBe
+                    listOf("Apple Saga", "Villains Code", "The Wandering Inn")
+            }
+        }
+
         test("series sorted by book count descending") {
             runTest {
                 // Given - each series needs 2+ books to avoid filtering by hideSingleBookSeries

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/LibraryScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/LibraryScreen.kt
@@ -287,8 +287,10 @@ private fun LibraryLoadedContent(
                         SeriesContent(
                             series = state.series,
                             sortState = state.seriesSortState,
+                            ignoreArticles = state.ignoreTitleArticles,
                             onCategorySelected = { onEvent(LibraryUiEvent.SeriesCategoryChanged(it)) },
                             onDirectionToggle = { onEvent(LibraryUiEvent.SeriesDirectionToggled) },
+                            onToggleIgnoreArticles = { onEvent(LibraryUiEvent.ToggleIgnoreTitleArticles) },
                             onSeriesClick = onSeriesClick,
                         )
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/SeriesContent.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/SeriesContent.kt
@@ -34,6 +34,7 @@ import com.calypsan.listenup.client.design.components.SortSplitButton
 import com.calypsan.listenup.client.domain.model.SeriesWithBooks
 import com.calypsan.listenup.client.presentation.library.SortCategory
 import com.calypsan.listenup.client.presentation.library.SortState
+import com.calypsan.listenup.client.util.sortableTitle
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
@@ -49,8 +50,10 @@ import listenup.composeapp.generated.resources.library_empty_tab_description
  *
  * @param series List of series with their books
  * @param sortState Current sort state (category + direction)
+ * @param ignoreArticles Whether leading articles (A / An / The) are ignored when sorting by name
  * @param onCategorySelected Called when user selects a new category
  * @param onDirectionToggle Called when user toggles sort direction
+ * @param onToggleIgnoreArticles Called when the "Title sort" toggle is tapped (article-aware name sort)
  * @param onSeriesClick Callback when a series is clicked (passes series ID)
  * @param modifier Optional modifier
  */
@@ -58,8 +61,10 @@ import listenup.composeapp.generated.resources.library_empty_tab_description
 fun SeriesContent(
     series: List<SeriesWithBooks>,
     sortState: SortState,
+    ignoreArticles: Boolean,
     onCategorySelected: (SortCategory) -> Unit,
     onDirectionToggle: () -> Unit,
+    onToggleIgnoreArticles: () -> Unit,
     onSeriesClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -67,90 +72,103 @@ fun SeriesContent(
         if (series.isEmpty()) {
             SeriesEmptyState()
         } else {
-            val gridState = rememberLazyGridState()
-            val scope = rememberCoroutineScope()
+            Column(modifier = Modifier.fillMaxSize()) {
+                // Mirrors the Books tab: the "Title sort" toggle flips article-aware name sorting.
+                LibrarySortBar(
+                    count = series.size,
+                    unit = "series",
+                    ignoreArticles = ignoreArticles,
+                    onToggleArticles = onToggleIgnoreArticles,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 4.dp),
+                )
 
-            // Build alphabet index for name-based sort
-            val alphabetIndex =
-                remember(series, sortState) {
-                    if (sortState.category == SortCategory.NAME) {
-                        AlphabetIndex.build(series) { it.series.name }
-                    } else {
-                        null
+                Box(modifier = Modifier.fillMaxSize()) {
+                    val gridState = rememberLazyGridState()
+                    val scope = rememberCoroutineScope()
+
+                    // Alphabet index for name sort — article-aware so "The Wandering Inn" files under W.
+                    val alphabetIndex =
+                        remember(series, sortState, ignoreArticles) {
+                            if (sortState.category == SortCategory.NAME) {
+                                AlphabetIndex.build(series) { it.series.name.sortableTitle(ignoreArticles) }
+                            } else {
+                                null
+                            }
+                        }
+
+                    val isScrolling by remember {
+                        derivedStateOf { gridState.isScrollInProgress }
+                    }
+
+                    // Track scroll direction for button visibility
+                    var previousScrollOffset by remember { mutableIntStateOf(0) }
+                    val showSortButton by remember {
+                        derivedStateOf {
+                            val firstVisible = gridState.firstVisibleItemIndex
+                            val currentOffset = gridState.firstVisibleItemScrollOffset
+
+                            val isAtTop = firstVisible == 0 && currentOffset < 50
+                            val isScrollingUp = currentOffset < previousScrollOffset
+
+                            previousScrollOffset = currentOffset
+                            isAtTop || isScrollingUp || !gridState.isScrollInProgress
+                        }
+                    }
+
+                    LazyVerticalGrid(
+                        state = gridState,
+                        columns = GridCells.Adaptive(minSize = 200.dp),
+                        contentPadding =
+                            PaddingValues(
+                                start = 16.dp,
+                                end = 16.dp,
+                                top = 48.dp,
+                                bottom = 16.dp,
+                            ),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        items(
+                            items = series,
+                            key = { it.series.id.value },
+                        ) { seriesWithBooks ->
+                            SeriesCard(
+                                seriesWithBooks = seriesWithBooks,
+                                onClick = { onSeriesClick(seriesWithBooks.series.id.value) },
+                            )
+                        }
+                    }
+
+                    // Sort split button
+                    SortSplitButton(
+                        state = sortState,
+                        categories = SortCategory.seriesCategories,
+                        onCategorySelected = onCategorySelected,
+                        onDirectionToggle = onDirectionToggle,
+                        visible = showSortButton,
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopStart)
+                                .padding(start = 16.dp, top = 8.dp),
+                    )
+
+                    // Alphabet scrollbar (only for name sort)
+                    // Anchored to TopEnd so it stays fixed relative to content start
+                    if (alphabetIndex != null) {
+                        AlphabetScrollbar(
+                            alphabetIndex = alphabetIndex,
+                            onLetterSelected = { index ->
+                                scope.launch { gridState.scrollToItem(index) }
+                            },
+                            isScrolling = isScrolling,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(top = 56.dp, end = 4.dp, bottom = 0.dp),
+                        )
                     }
                 }
-
-            val isScrolling by remember {
-                derivedStateOf { gridState.isScrollInProgress }
-            }
-
-            // Track scroll direction for button visibility
-            var previousScrollOffset by remember { mutableIntStateOf(0) }
-            val showSortButton by remember {
-                derivedStateOf {
-                    val firstVisible = gridState.firstVisibleItemIndex
-                    val currentOffset = gridState.firstVisibleItemScrollOffset
-
-                    val isAtTop = firstVisible == 0 && currentOffset < 50
-                    val isScrollingUp = currentOffset < previousScrollOffset
-
-                    previousScrollOffset = currentOffset
-                    isAtTop || isScrollingUp || !gridState.isScrollInProgress
-                }
-            }
-
-            LazyVerticalGrid(
-                state = gridState,
-                columns = GridCells.Adaptive(minSize = 200.dp),
-                contentPadding =
-                    PaddingValues(
-                        start = 16.dp,
-                        end = 16.dp,
-                        top = 48.dp,
-                        bottom = 16.dp,
-                    ),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                items(
-                    items = series,
-                    key = { it.series.id.value },
-                ) { seriesWithBooks ->
-                    SeriesCard(
-                        seriesWithBooks = seriesWithBooks,
-                        onClick = { onSeriesClick(seriesWithBooks.series.id.value) },
-                    )
-                }
-            }
-
-            // Sort split button
-            SortSplitButton(
-                state = sortState,
-                categories = SortCategory.seriesCategories,
-                onCategorySelected = onCategorySelected,
-                onDirectionToggle = onDirectionToggle,
-                visible = showSortButton,
-                modifier =
-                    Modifier
-                        .align(Alignment.TopStart)
-                        .padding(start = 16.dp, top = 8.dp),
-            )
-
-            // Alphabet scrollbar (only for name sort)
-            // Anchored to TopEnd so it stays fixed relative to content start
-            if (alphabetIndex != null) {
-                AlphabetScrollbar(
-                    alphabetIndex = alphabetIndex,
-                    onLetterSelected = { index ->
-                        scope.launch { gridState.scrollToItem(index) }
-                    },
-                    isScrolling = isScrolling,
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(top = 56.dp, end = 4.dp, bottom = 0.dp),
-                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Mirrors the Books tab's "Title sort" toggle onto the **Series** tab. Series were sorted by raw `name.lowercase()`, so "The Wandering Inn" filed under **T** — hard to find when you're looking under **W**. Now the same pill flips article-aware sorting (A / An / The ignored), so it files under **W**.

- **`LibraryViewModel.sortSeries`** — keys the Name sort on `series.name.sortableTitle(ignoreArticles)` instead of `.lowercase()`.
- **`SeriesContent`** — adds the shared `LibrarySortBar` "Title sort" pill (+ a "{n} series" count) at the top; the alphabet scrollbar is now article-aware too.
- **`LibraryScreen`** — passes the existing `ignoreTitleArticles` preference + `ToggleIgnoreTitleArticles` event.

Reuses the **single shared** `ignoreTitleArticles` preference, so the toggle is consistent across the Books and Series tabs (flipping it on one applies to both).

## Test Plan
- [x] `LibraryViewModelTest` — new test "series sorted by name ignores leading articles when enabled" (TDD: written red, confirmed failing on the old `.lowercase()` behavior, then green). 37/37 pass.
- [x] `detekt` + `spotlessCheck` green
- [x] `:androidApp:assembleDebug` green (compiles the Compose UI change)

> UX note: the Series tab now shows both the "Title sort" pill (top) and the existing category sort button (Name / Book Count / Added, floating below). Functional but slightly busy — happy to streamline if it doesn't feel right on device.