### PR TITLE
✨ Phase 4a: file-I/O seam foundation (statFile/canonicalize/helpers + posix native)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileAttributes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileAttributes.kt
@@ -1,0 +1,8 @@
+package com.calypsan.listenup.server.io
+
+/** File attributes not exposed by kotlinx-io's [kotlinx.io.files.FileMetadata]: mtime + inode. */
+internal data class FileAttributes(
+    val size: Long,
+    val mtimeMs: Long,
+    val inode: Long?,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileHelpers.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileHelpers.kt
@@ -1,0 +1,47 @@
+package com.calypsan.listenup.server.io
+
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlin.random.Random
+
+private const val HEX_RADIX = 16
+private const val TEMP_NAME_HEX_CHARS = 16
+private const val MAX_TEMP_FILE_ATTEMPTS = 10_000
+
+/** Deletes [path] and everything under it (post-order: children before parents). No-op if absent. */
+internal fun deleteRecursively(path: Path) {
+    if (!SystemFileSystem.exists(path)) return
+    val meta = SystemFileSystem.metadataOrNull(path)
+    if (meta?.isDirectory == true) {
+        for (child in SystemFileSystem.list(path)) deleteRecursively(child)
+    }
+    SystemFileSystem.delete(path, mustExist = false)
+}
+
+/** Creates a uniquely-named empty file inside [dir] (which must exist) and returns its path. */
+internal fun createTempFileIn(
+    dir: Path,
+    prefix: String,
+    suffix: String,
+): Path {
+    SystemFileSystem.createDirectories(dir)
+    repeat(MAX_TEMP_FILE_ATTEMPTS) {
+        val name = "$prefix${randomHex()}$suffix"
+        val candidate = Path(dir, name)
+        if (!SystemFileSystem.exists(candidate)) {
+            SystemFileSystem.sink(candidate).close() // create empty
+            return candidate
+        }
+    }
+    error("could not allocate a temp file in $dir")
+}
+
+/** [this] relative to [base] as a string, or [this] as-is if it's not under [base]. */
+internal fun Path.relativeTo(base: Path): String {
+    val p = this.toString()
+    val b = base.toString().trimEnd('/')
+    return if (p.startsWith("$b/")) p.removePrefix("$b/") else p
+}
+
+private fun randomHex(): String =
+    (0 until TEMP_NAME_HEX_CHARS).joinToString("") { Random.nextInt(HEX_RADIX).toString(HEX_RADIX) }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileStat.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileStat.kt
@@ -1,0 +1,6 @@
+package com.calypsan.listenup.server.io
+
+import kotlinx.io.files.Path
+
+/** Stats [path] for size/mtime/inode, or null if it doesn't exist / can't be stat'd. JVM=java.nio, native=posix stat. */
+internal expect fun statFile(path: Path): FileAttributes?

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/PathOps.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/PathOps.kt
@@ -1,0 +1,9 @@
+package com.calypsan.listenup.server.io
+
+import kotlinx.io.files.Path
+
+/**
+ * Resolves [path] to a canonical absolute path (collapses `..`/symlinks). The path must exist.
+ * JVM=toAbsolutePath().normalize(), native=realpath(3).
+ */
+internal expect fun canonicalize(path: Path): Path

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/FileStat.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/FileStat.jvm.kt
@@ -1,0 +1,33 @@
+package com.calypsan.listenup.server.io
+
+import kotlinx.io.files.Path
+import java.nio.file.Files
+import java.nio.file.attribute.BasicFileAttributes
+
+/** Matches the `ino=N` segment of a Linux `fileKey()` (`(dev=…,ino=N)`). */
+private val INODE_PATTERN = Regex("""ino=(\d+)""")
+
+internal actual fun statFile(path: Path): FileAttributes? =
+    runCatching {
+        val nioPath =
+            java.nio.file.Path
+                .of(path.toString())
+        val attrs = Files.readAttributes(nioPath, BasicFileAttributes::class.java)
+        FileAttributes(
+            size = attrs.size(),
+            mtimeMs = attrs.lastModifiedTime().toMillis(),
+            inode = inodeOf(attrs),
+        )
+    }.getOrNull()
+
+private fun inodeOf(attrs: BasicFileAttributes): Long? =
+    attrs
+        .fileKey()
+        ?.toString()
+        ?.let {
+            INODE_PATTERN
+                .find(it)
+                ?.groupValues
+                ?.get(1)
+                ?.toLongOrNull()
+        }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/PathOps.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/PathOps.jvm.kt
@@ -1,0 +1,12 @@
+package com.calypsan.listenup.server.io
+
+import kotlinx.io.files.Path
+
+internal actual fun canonicalize(path: Path): Path =
+    Path(
+        java.nio.file.Path
+            .of(path.toString())
+            .toAbsolutePath()
+            .normalize()
+            .toString(),
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/FileIoTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/FileIoTest.kt
@@ -1,0 +1,136 @@
+package com.calypsan.listenup.server.io
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldStartWith
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+
+/** Bridges a java.nio temp dir/file into a kotlinx.io [Path]. */
+private fun java.nio.file.Path.toKxio(): Path = Path(this.toString())
+
+class FileIoTest :
+    FunSpec({
+        test("statFile returns the written file's size") {
+            val dir = createTempDirectory("file-io-stat")
+            val file = dir.resolve("payload.bin").apply { writeText("hello world") }
+
+            val attrs = statFile(file.toKxio())
+
+            attrs.shouldNotBeNull()
+            attrs.size shouldBe "hello world".length.toLong()
+        }
+
+        test("statFile reports a plausible recent mtime in epoch-ms") {
+            val dir = createTempDirectory("file-io-mtime")
+            val file = dir.resolve("recent.txt").apply { writeText("now") }
+
+            val attrs = statFile(file.toKxio())
+
+            attrs.shouldNotBeNull()
+            // Sanity bound: any file written today is well past 2023-11-14 in epoch-ms.
+            attrs.mtimeMs shouldBeGreaterThan 1_700_000_000_000L
+        }
+
+        test("statFile exposes a non-null inode on Linux") {
+            val dir = createTempDirectory("file-io-inode")
+            val file = dir.resolve("ino.txt").apply { writeText("x") }
+
+            val attrs = statFile(file.toKxio())
+
+            attrs.shouldNotBeNull()
+            attrs.inode.shouldNotBeNull()
+        }
+
+        test("statFile returns null for a nonexistent path") {
+            val dir = createTempDirectory("file-io-missing")
+            val missing = dir.resolve("does-not-exist.txt")
+
+            statFile(missing.toKxio()).shouldBeNull()
+        }
+
+        test("canonicalize collapses a `..` round-trip back to the real path") {
+            val dir = createTempDirectory("file-io-canon")
+            val nested = dir.resolve("a").resolve("b")
+            java.nio.file.Files
+                .createDirectories(nested)
+            val real = nested.resolve("file.txt").apply { writeText("c") }
+
+            // a/../a/b/file.txt — the `..` must collapse to the same canonical path.
+            val winding =
+                dir
+                    .resolve("a")
+                    .resolve("..")
+                    .resolve("a")
+                    .resolve("b")
+                    .resolve("file.txt")
+
+            canonicalize(winding.toKxio()).toString() shouldBe canonicalize(real.toKxio()).toString()
+        }
+
+        test("deleteRecursively removes a nested directory tree") {
+            val root = createTempDirectory("file-io-rmtree")
+            val deep = root.resolve("x").resolve("y")
+            java.nio.file.Files
+                .createDirectories(deep)
+            deep.resolve("leaf.txt").writeText("bye")
+            root.resolve("top.txt").writeText("bye")
+
+            val rootKxio = root.toKxio()
+            SystemFileSystem.exists(rootKxio).shouldBeTrue()
+
+            deleteRecursively(rootKxio)
+
+            SystemFileSystem.exists(rootKxio).shouldBeFalse()
+        }
+
+        test("deleteRecursively is a no-op for an absent path") {
+            val dir = createTempDirectory("file-io-rm-absent")
+            val absent = dir.resolve("gone").toKxio()
+
+            deleteRecursively(absent) // must not throw
+
+            SystemFileSystem.exists(absent).shouldBeFalse()
+        }
+
+        test("createTempFileIn creates a prefixed/suffixed file inside the dir") {
+            val dir = createTempDirectory("file-io-temp").toKxio()
+
+            val created = createTempFileIn(dir, prefix = "lu-", suffix = ".tmp")
+
+            SystemFileSystem.exists(created).shouldBeTrue()
+            created.name.shouldStartWith("lu-")
+            created.name.shouldEndWith(".tmp")
+        }
+
+        test("createTempFileIn yields distinct paths on repeated calls") {
+            val dir = createTempDirectory("file-io-temp-distinct").toKxio()
+
+            val first = createTempFileIn(dir, prefix = "lu-", suffix = ".tmp")
+            val second = createTempFileIn(dir, prefix = "lu-", suffix = ".tmp")
+
+            (first.toString() == second.toString()).shouldBeFalse()
+        }
+
+        test("relativeTo strips the base prefix") {
+            val base = Path("/srv/library")
+            val child = Path("/srv/library/author/book/track.m4b")
+
+            child.relativeTo(base) shouldBe "author/book/track.m4b"
+        }
+
+        test("relativeTo returns self when not under base") {
+            val base = Path("/srv/library")
+            val outside = Path("/var/data/track.m4b")
+
+            outside.relativeTo(base) shouldBe "/var/data/track.m4b"
+        }
+    })

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/FileStat.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/FileStat.linuxX64.kt
@@ -1,0 +1,24 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.calypsan.listenup.server.io
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.io.files.Path
+import platform.posix.stat
+
+private const val MILLIS_PER_SECOND = 1_000L
+private const val NANOS_PER_MILLI = 1_000_000L
+
+internal actual fun statFile(path: Path): FileAttributes? =
+    memScoped {
+        val s = alloc<stat>()
+        if (stat(path.toString(), s.ptr) != 0) return null
+        FileAttributes(
+            size = s.st_size,
+            mtimeMs = s.st_mtim.tv_sec * MILLIS_PER_SECOND + s.st_mtim.tv_nsec / NANOS_PER_MILLI,
+            inode = s.st_ino.toLong(),
+        )
+    }

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/PathOps.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/PathOps.linuxX64.kt
@@ -1,0 +1,19 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.calypsan.listenup.server.io
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import kotlinx.io.files.Path
+import platform.posix.free
+import platform.posix.realpath
+
+internal actual fun canonicalize(path: Path): Path =
+    // realpath(…, null) mallocs the resolved buffer; null return means the path doesn't exist /
+    // can't be resolved — stay lenient and hand back the input unchanged (JVM normalizes in-memory
+    // and never fails on a missing path either).
+    realpath(path.toString(), null)?.let {
+        val resolved = it.toKString()
+        free(it)
+        Path(resolved)
+    } ?: path


### PR DESCRIPTION
First increment of **Phase 4** (file-I/O native migration) of the Kotlin/Native `:server` port — the **additive seam foundation**. These are new `internal` files under `server/.../io/` that **nothing consumes yet**, so there is zero behavior change; they establish the posix-backed primitives the file-I/O sweep will wire in (per `docs/superpowers/plans/2026-06-24-kn-server-port-phase4-file-io.md`).

kotlinx-io covers most file ops but lacks file `stat` (mtime/inode), canonicalize, recursive delete, and temp-file-in-a-dir. This adds those, with `platform.posix` native actuals (NO cinterop — de-risked in a throwaway spike: `stat`/`realpath`/`flock`/`chmod`/`lseek`/`pread` all resolve from the bundled posix/linux klibs).

## What's here
- `statFile(path): FileAttributes?` — size + mtimeMs + inode. JVM = `Files.readAttributes`; native = posix `stat` (`st_mtim.tv_sec/tv_nsec`, `st_ino`).
- `canonicalize(path): Path` — JVM = `toAbsolutePath().normalize()`; native = `realpath(3)`.
- `deleteRecursively`, `createTempFileIn`, `Path.relativeTo` — pure commonMain on `SystemFileSystem`.

## Test plan (Linux)
`:server:compileKotlinJvm` + `:server:compileKotlinLinuxX64` + `FileIoTest` (11/11) + root spotless/detekt — all green. (Additive/unused, so the rest of the suite is unaffected; CI runs the full `:server:jvmTest`.)
