### PR TITLE
Discover: offline activity feed + reconnect refresh

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -63,6 +63,7 @@ internal class SyncEngine(
     private var enqueueDrainJob: Job? = null
     private var queueDepthJob: Job? = null
     private var failureCountJob: Job? = null
+    private var reconnectRefreshJob: Job? = null
 
     // Serializes drain waves so concurrent triggers (connection-up + enqueue +
     // retry) coalesce into one wave at a time. drain() reads from the DAO and
@@ -126,8 +127,9 @@ internal class SyncEngine(
      *    [runStart] is in flight (catch-up, suspended `ready.await()` inside
      *    `ensure*` setup, `sseClient.connect()`). It does NOT tear down the
      *    long-running collectors — `frameCollectorJob`, `connectionUpDrainJob`,
-     *    `enqueueDrainJob`, `queueDepthJob`, `failureCountJob` are launched
-     *    into [scope], not as children of `engineJob`, so they survive the
+     *    `enqueueDrainJob`, `queueDepthJob`, `failureCountJob`,
+     *    `reconnectRefreshJob` are launched into [scope], not as children of
+     *    `engineJob`, so they survive the
      *    cancellation. That's intentional: they're user-agnostic (the queue
      *    is wiped on user change via `clearForUserChange`, dispatcher and
      *    sseClient are singletons), so leaving them in place avoids a
@@ -205,6 +207,9 @@ internal class SyncEngine(
         // replayed value at subscribe time gets dropped, and there's nothing
         // after it).
         ensureDrainScheduling()
+        // Step 5b: refresh the Discover surfaces on every reconnect. Subscribed before connect so
+        // the initial start-connect is the dropped first edge (start already primed + reconciled).
+        ensureReconnectRefresh()
         // Step 6: forward queue-depth and failure-count observers into
         // SyncEngineState so the diagnostics surface reflects reality. Without
         // this wire-up `pendingQueueDepth` / `pendingFailureCount` stay stuck
@@ -270,6 +275,8 @@ internal class SyncEngine(
         queueDepthJob = null
         failureCountJob?.cancel()
         failureCountJob = null
+        reconnectRefreshJob?.cancel()
+        reconnectRefreshJob = null
         sseClient.disconnect()
     }
 
@@ -457,6 +464,7 @@ internal class SyncEngine(
             val enqueue = enqueueDrainJob
             val depth = queueDepthJob
             val failure = failureCountJob
+            val reconnectRefresh = reconnectRefreshJob
             engineJob = null
             currentUser = null
             currentUserStarted = false
@@ -465,12 +473,14 @@ internal class SyncEngine(
             enqueueDrainJob = null
             queueDepthJob = null
             failureCountJob = null
+            reconnectRefreshJob = null
             engine?.cancelAndJoin()
             collector?.cancelAndJoin()
             connectionUp?.cancelAndJoin()
             enqueue?.cancelAndJoin()
             depth?.cancelAndJoin()
             failure?.cancelAndJoin()
+            reconnectRefresh?.cancelAndJoin()
             sseClient.disconnect()
         }
     }
@@ -553,6 +563,56 @@ internal class SyncEngine(
                         .collect { runDrain() }
                 }
             ready.await()
+        }
+    }
+
+    /**
+     * Refresh the Discover surfaces on every reconnect — NOT the initial start-connect.
+     *
+     * The offline→online path ([ReconnectionSupervisor] → [SseClient.reconnectNow]) only resumes the
+     * SSE stream; without this the activity feed and leaderboard stay stale until the server happens
+     * to emit a `CursorStale`. On each reconnect edge we deterministically prime the activity feed
+     * into Room (UI-independent), ping presence so currently-listening re-fetches, and run the
+     * digest-gated [SyncReconciler.reconcileAll] (refreshing `public_profiles` → the leaderboard).
+     *
+     * Subscribed before [SseClient.connect] and [drop]ping the first Connected, so the initial
+     * start-connect (already covered by [runStart]'s prime + reconcile) does not double-fire.
+     */
+    private suspend fun ensureReconnectRefresh() {
+        if (reconnectRefreshJob?.isActive == true) return
+        val ready = CompletableDeferred<Unit>()
+        reconnectRefreshJob =
+            scope.launch {
+                state
+                    .observe()
+                    .onSubscription { ready.complete(Unit) }
+                    .map { it.connection is ConnectionState.Connected }
+                    .distinctUntilChanged()
+                    .filter { it }
+                    .drop(1) // skip the initial start-connect; runStart already primed + reconciled
+                    .collect { runReconnectRefresh() }
+            }
+        ready.await()
+    }
+
+    private suspend fun runReconnectRefresh() {
+        // Presence ping is a non-throwing tryEmit. The two suspend actions are guarded independently
+        // so one failure neither tears down the collector nor starves the other. Cancellation always
+        // propagates.
+        presenceRefreshSignal.ping()
+        try {
+            primeActivityFeed()
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Reconnect activity-feed prime failed; continuing" }
+        }
+        try {
+            reconciler.reconcileAll()
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Reconnect reconcile failed; continuing" }
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -22,6 +22,9 @@ import kotlinx.coroutines.sync.withLock
 
 private val logger = KotlinLogging.logger {}
 
+/** How many feed items the engine pulls when priming the activity-feed Room cache. */
+internal const val ACTIVITY_PRIME_LIMIT = 50
+
 /**
  * Lifecycle composer for the client sync engine.
  *
@@ -52,6 +55,7 @@ internal class SyncEngine(
     private val presenceRefreshSignal: PresenceRefreshSignal,
     private val activityRefreshSignal: ActivityRefreshSignal,
     private val scope: CoroutineScope,
+    private val primeActivityFeed: suspend () -> Unit = {},
     private val retryBackoffMillis: Long = DEFAULT_RETRY_BACKOFF_MILLIS,
 ) {
     private var frameCollectorJob: Job? = null
@@ -186,6 +190,10 @@ internal class SyncEngine(
         queue.clearForUserChange(currentUserId)
         // Step 2: catch-up across all registered domains.
         catchUp.catchUpAll(registry)
+        // Step 2b: prime the activity feed into Room so it is available offline even if the user
+        // never opens Discover. Best-effort — offline at start must not abort the engine; the
+        // reconnect path and ActivityChanged nudges recover.
+        primeActivityFeedSafely()
         // Step 3: seed SSE resume cursor.
         sseClient.seedLastEventId(store.highestCursor())
         // Step 4: collect frames before connecting so immediate frames are not dropped.
@@ -212,6 +220,17 @@ internal class SyncEngine(
         // start() for the same user is a no-op. If any step above threw, this
         // line is never reached, the flag stays false, and start() retries.
         currentUserStarted = true
+    }
+
+    /** Invoke [primeActivityFeed], swallowing non-cancellation failures so priming never aborts a caller. */
+    private suspend fun primeActivityFeedSafely() {
+        try {
+            primeActivityFeed()
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Activity-feed prime failed; continuing" }
+        }
     }
 
     fun stop() {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.client.data.remote.KtorPlaybackRpcFactory
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.client.data.connection.ConnectionCoordinator
 import com.calypsan.listenup.client.data.connection.ReconnectionSupervisor
+import com.calypsan.listenup.client.data.sync.ACTIVITY_PRIME_LIMIT
 import com.calypsan.listenup.client.data.sync.ActivityRefreshSignal
 import com.calypsan.listenup.client.data.sync.CatchUp
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
@@ -47,6 +48,7 @@ import com.calypsan.listenup.client.data.sync.handlers.UserStatsSyncDomainHandle
 import com.calypsan.listenup.client.data.repository.DefaultBookAvailability
 import com.calypsan.listenup.client.data.repository.SseServerReachability
 import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.usecase.activity.FetchActivitiesUseCase
 import com.calypsan.listenup.client.domain.repository.BookAvailability
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
@@ -341,6 +343,7 @@ val clientSyncRenovationModule =
         }
 
         single {
+            val fetchActivities: FetchActivitiesUseCase = get()
             SyncEngine(
                 registry = get(),
                 queue = get(),
@@ -353,6 +356,8 @@ val clientSyncRenovationModule =
                 presenceRefreshSignal = get(),
                 activityRefreshSignal = get(),
                 scope = get(qualifier = named(APP_SCOPE)),
+                // Prime / refresh the activity-feed Room cache on sync-start and reconnect, UI-independent.
+                primeActivityFeed = { fetchActivities(ACTIVITY_PRIME_LIMIT) },
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModel.kt
@@ -31,11 +31,11 @@ private const val MAX_ACTIVITIES = 100
  * ViewModel for the Activity Feed section on the Discover screen.
  *
  * Offline-first architecture:
- * - On first launch, fetches initial activities from the feed RPC and stores in Room
- * - UI observes Room Flow and automatically updates
- * - On each [ActivityRefreshSignal] ping (server nudge or firehose reconnect), re-fetches the
- *   feed head into Room — the Room observation then repaints the UI
- * - After initial fetch, works completely offline
+ * - The sync engine primes the feed head into Room on every online sync-start and reconnect, so
+ *   the feed is available offline without ever opening this screen.
+ * - UI observes the Room Flow and automatically updates.
+ * - On each [ActivityRefreshSignal] ping (live ActivityChanged nudge or CursorStale recovery),
+ *   re-fetches the feed head into Room — the Room observation then repaints the UI.
  *
  * @property activityRepository Repository for activity feed operations
  * @property fetchActivitiesUseCase Use case for fetching activities from the feed RPC
@@ -47,9 +47,9 @@ class ActivityFeedViewModel internal constructor(
     private val refreshSignal: ActivityRefreshSignal,
 ) : ViewModel() {
     init {
-        // Fetch initial activities if Room is empty
-        fetchInitialActivitiesIfNeeded()
-        // Re-fetch the feed head whenever the server signals a change; Room observation repaints.
+        // The feed is primed into Room by the sync engine on every online sync-start and reconnect
+        // (so it is available offline without opening this screen). Here we only react to live
+        // ActivityChanged nudges: re-fetch the feed head; the Room observation repaints.
         refreshSignal.signal
             .onEach { fetchActivitiesUseCase(limit = INITIAL_FETCH_SIZE) }
             .launchIn(viewModelScope)
@@ -73,24 +73,6 @@ class ActivityFeedViewModel internal constructor(
                 started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
                 initialValue = ActivityFeedUiState.Loading,
             )
-
-    /**
-     * Fetch the feed head from the RPC into Room if the cache is empty.
-     * This ensures data is available on first launch before any ActivityChanged nudge arrives.
-     */
-    private fun fetchInitialActivitiesIfNeeded() {
-        viewModelScope.launch {
-            val existingCount = activityRepository.count()
-            if (existingCount > 0) {
-                logger.debug { "Room has $existingCount activities, skipping initial fetch" }
-                return@launch
-            }
-
-            logger.debug { "Room is empty, fetching the feed head from the RPC" }
-            fetchActivitiesUseCase(limit = INITIAL_FETCH_SIZE)
-            // Not fatal if it fails — Room shows the empty state and the next nudge/reconnect refills.
-        }
-    }
 
     /**
      * Refresh the feed from the RPC.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModel.kt
@@ -3,6 +3,8 @@ package com.calypsan.listenup.client.presentation.discover
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.core.error.ErrorBus
 import com.calypsan.listenup.client.core.fallbackTo
 import com.calypsan.listenup.client.domain.model.ActiveSession
@@ -236,8 +238,15 @@ class DiscoverViewModel(
                 }
 
                 is AppResult.Failure -> {
-                    errorBus.emit(result.error)
-                    logger.error { "Failed to load discover shelves: ${result.error.message}" }
+                    // Offline is an expected state on this background load, not a snackbar-worthy fault —
+                    // the section degrades to its local empty/error state. Only genuine (non-connectivity)
+                    // errors reach the global bus and the error log; connectivity misses are logged quietly.
+                    if (result.error.isConnectivityError()) {
+                        logger.debug { "Discover shelves unavailable offline: ${result.error.message}" }
+                    } else {
+                        errorBus.emit(result.error)
+                        logger.error { "Failed to load discover shelves: ${result.error.message}" }
+                    }
                     discoverShelvesState.value = DiscoverShelvesUiState.Error("Failed to load discover shelves")
                 }
             }
@@ -420,3 +429,10 @@ data class RecentlyAddedUiBook(
     val coverHash: String?,
     val createdAt: Long,
 )
+
+/**
+ * Connectivity faults (offline / timed-out) are expected states on a background load, not
+ * snackbar-worthy errors. Matched by typed subtype — never by `message` string.
+ */
+private fun AppError.isConnectivityError(): Boolean =
+    this is TransportError.NetworkUnavailable || this is TransportError.Timeout

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/ActivityFeedViewModelTest.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.test.setMain
  * - Initial `Loading` state before the pipeline subscribes
  * - Reactive `Ready` emissions from the repository flow
  * - `Error` emission when the upstream flow throws
- * - Initial fetch gate: skip when Room already has activities, run when empty
  * - `refresh()` delegating to `FetchActivitiesUseCase`
  *
  * Uses Mokkery for mocking `ActivityRepository` and `FetchActivitiesUseCase`.
@@ -60,11 +59,10 @@ class ActivityFeedViewModelTest :
                 )
         }
 
-        fun createFixture(existingCount: Int = 0): TestFixture {
+        fun createFixture(): TestFixture {
             val fixture = TestFixture()
 
             every { fixture.activityRepository.observeRecent(any()) } returns fixture.activitiesFlow
-            everySuspend { fixture.activityRepository.count() } returns existingCount
             everySuspend { fixture.fetchActivitiesUseCase(any()) } returns AppResult.Success(0)
 
             return fixture
@@ -175,7 +173,6 @@ class ActivityFeedViewModelTest :
                     flow {
                         throw RuntimeException("boom")
                     }
-                everySuspend { fixture.activityRepository.count() } returns 0
                 everySuspend { fixture.fetchActivitiesUseCase(any()) } returns AppResult.Success(0)
 
                 // When
@@ -188,42 +185,12 @@ class ActivityFeedViewModelTest :
             }
         }
 
-        // ========== Initial Fetch Gate Tests ==========
-
-        test("fetchInitialActivitiesIfNeeded triggers fetch when count is zero") {
-            runTest {
-                // Given - Room is empty
-                val fixture = createFixture(existingCount = 0)
-
-                // When - init runs
-                fixture.build()
-                advanceUntilIdle()
-
-                // Then - use case invoked with the initial fetch size
-                verifySuspend { fixture.fetchActivitiesUseCase(INITIAL_FETCH_SIZE) }
-            }
-        }
-
-        test("fetchInitialActivitiesIfNeeded skips when count is positive") {
-            runTest {
-                // Given - Room already has activities
-                val fixture = createFixture(existingCount = 5)
-
-                // When - init runs
-                fixture.build()
-                advanceUntilIdle()
-
-                // Then - use case NOT invoked
-                verifySuspend(VerifyMode.not) { fixture.fetchActivitiesUseCase(any()) }
-            }
-        }
-
         // ========== Refresh Tests ==========
 
         test("refresh calls fetchActivitiesUseCase with INITIAL_FETCH_SIZE") {
             runTest {
-                // Given - Room already populated (prevent init fetch from confusing the verification)
-                val fixture = createFixture(existingCount = 5)
+                // Given - a built ViewModel
+                val fixture = createFixture()
                 val viewModel = fixture.build()
                 advanceUntilIdle()
 
@@ -240,8 +207,8 @@ class ActivityFeedViewModelTest :
 
         test("refresh signal ping re-fetches the feed head") {
             runTest {
-                // Given - Room already populated (suppress the init fetch so the ping is isolated)
-                val fixture = createFixture(existingCount = 5)
+                // Given - a built ViewModel subscribed to the refresh signal
+                val fixture = createFixture()
                 fixture.build()
                 advanceUntilIdle()
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModelTest.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.error.ErrorBus
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.TransportError
 
 /**
  * Tests for [DiscoverViewModel].
@@ -130,6 +132,7 @@ class DiscoverViewModelTest :
             val authStateFlow = MutableStateFlow<AuthState>(AuthState.Initializing)
             val activeSessionsFlow = MutableStateFlow<List<ActiveSession>>(emptyList())
             val recentlyAddedFlow = MutableStateFlow<List<DiscoveryBook>>(emptyList())
+            val errorBus = ErrorBus()
 
             fun build(): DiscoverViewModel =
                 DiscoverViewModel(
@@ -137,7 +140,7 @@ class DiscoverViewModelTest :
                     activeSessionRepository = activeSessionRepository,
                     authSession = authSession,
                     shelfRepository = shelfRepository,
-                    errorBus = ErrorBus(),
+                    errorBus = errorBus,
                 )
         }
 
@@ -333,6 +336,69 @@ class DiscoverViewModelTest :
                 // Then
                 val err = viewModel.discoverShelvesState.value.shouldBeInstanceOf<DiscoverShelvesUiState.Error>()
                 err.message shouldBe "Failed to load discover shelves"
+            }
+        }
+
+        test("connectivity failure on discover shelves does NOT emit to the global errorBus") {
+            runTest {
+                // Given - offline: the discover RPC fails with a connectivity error
+                val fixture = createFixture()
+                everySuspend { fixture.shelfRepository.discoverShelves() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
+
+                // Subscribe to the bus BEFORE init runs (SharedFlow has no replay)
+                val emitted = mutableListOf<AppError>()
+                backgroundScope.launch { fixture.errorBus.errors.collect { emitted += it } }
+                advanceUntilIdle()
+
+                // When - init triggers loadDiscoverShelves
+                val viewModel = fixture.build().also { keepStateHot(it.discoverShelvesState) }
+                advanceUntilIdle()
+
+                // Then - no global snackbar flash; the section degrades to its local Error state
+                emitted shouldBe emptyList()
+                viewModel.discoverShelvesState.value.shouldBeInstanceOf<DiscoverShelvesUiState.Error>()
+            }
+        }
+
+        test("timeout failure on discover shelves does NOT emit to the global errorBus") {
+            runTest {
+                // Given - a connection timeout (the second connectivity subtype)
+                val fixture = createFixture()
+                everySuspend { fixture.shelfRepository.discoverShelves() } returns
+                    AppResult.Failure(TransportError.Timeout())
+
+                val emitted = mutableListOf<AppError>()
+                backgroundScope.launch { fixture.errorBus.errors.collect { emitted += it } }
+                advanceUntilIdle()
+
+                // When
+                fixture.build().also { keepStateHot(it.discoverShelvesState) }
+                advanceUntilIdle()
+
+                // Then - timeouts are suppressed from the global snackbar too
+                emitted shouldBe emptyList()
+            }
+        }
+
+        test("non-connectivity failure on discover shelves still emits to the global errorBus") {
+            runTest {
+                // Given - a genuine server error (not connectivity)
+                val fixture = createFixture()
+                val serverError = TransportError.Server5xx(statusCode = 500)
+                everySuspend { fixture.shelfRepository.discoverShelves() } returns
+                    AppResult.Failure(serverError)
+
+                val emitted = mutableListOf<AppError>()
+                backgroundScope.launch { fixture.errorBus.errors.collect { emitted += it } }
+                advanceUntilIdle()
+
+                // When
+                fixture.build().also { keepStateHot(it.discoverShelvesState) }
+                advanceUntilIdle()
+
+                // Then - real errors still surface globally
+                emitted shouldBe listOf(serverError)
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineDiscoverRefreshTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineDiscoverRefreshTest.kt
@@ -1,16 +1,37 @@
 package com.calypsan.listenup.client.data.sync
 
+import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.DomainDigest
+import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tag
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SyncEngineDiscoverRefreshTest :
@@ -28,7 +49,7 @@ class SyncEngineDiscoverRefreshTest :
                         sender = PendingOperationSender { AppResult.Success(Unit) },
                     )
                 val state = SyncEngineState()
-                val catchUp = NoopRefreshCatchUp()
+                val catchUp = NoopRefreshCatchUp
                 val dispatcher =
                     SyncEventDispatcher(
                         registry = registry,
@@ -60,10 +81,106 @@ class SyncEngineDiscoverRefreshTest :
                 db.close()
             }
         }
+
+        test("a reconnect (not the initial connect) primes the feed, pings presence, and reconciles") {
+            runBlocking {
+                val scope = CoroutineScope(
+                    SupervisorJob() + Dispatchers.Default,
+                )
+                val db = createInMemoryTestDatabase()
+                try {
+                    val primeCount = AtomicInteger(0)
+                    val presencePings = AtomicInteger(0)
+                    val catchUp = CountingReconcileCatchUp()
+                    val state = SyncEngineState()
+                    val sse = FlippingFakeSse(state)
+
+                    // Reconciler sees a stored cursor (so reconcileAll does not early-return) and a
+                    // drifted server digest for "tags" — so every reconcileAll re-pulls (fromZero++).
+                    val max = 100L
+                    val driftedServerDigest = DigestComputer.compute(max, listOf("t1" to 999L))
+                    val handler = DriftingRefreshHandler(rows = listOf("t1" to 5L))
+                    val registry = ClientSyncDomainRegistry()
+                    registry.register(handler)
+                    val store = SyncCursorStore(db.syncCursorDao())
+                    store.setCursor("tags", max)
+                    val reconciler =
+                        SyncReconciler(
+                            registry = registry,
+                            store = store,
+                            digestClient = fakeRefreshDigestClient(mapOf("tags" to driftedServerDigest)),
+                            catchUp = catchUp,
+                        )
+
+                    val presence = PresenceRefreshSignal()
+                    scope.launch { presence.signal.collect { presencePings.incrementAndGet() } }
+
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = PendingOperationSender { AppResult.Success(Unit) },
+                        )
+                    val dispatcher =
+                        SyncEventDispatcher(
+                            registry = registry,
+                            queue = queue,
+                            state = state,
+                            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+                        )
+                    val engine =
+                        SyncEngine(
+                            registry = registry,
+                            queue = queue,
+                            state = state,
+                            store = store,
+                            catchUp = catchUp,
+                            sseClient = sse,
+                            reconciler = reconciler,
+                            dispatcher = dispatcher,
+                            presenceRefreshSignal = presence,
+                            activityRefreshSignal = ActivityRefreshSignal(),
+                            scope = scope,
+                            primeActivityFeed = { primeCount.incrementAndGet() },
+                        )
+
+                    engine.start(currentUserId = "u1")
+
+                    // After start: prime ran once (Step 2b); start's own reconcile re-pulled once
+                    // (drifted); the initial connect was DROPPED so presence was not pinged.
+                    primeCount.get() shouldBe 1
+                    catchUp.fromZeroInvocations.get() shouldBe 1
+                    // Let the reconnect observer settle on (and drop) the initial Connected.
+                    delay(150)
+                    presencePings.get() shouldBe 0
+
+                    // Drive a real reconnect edge: drop, let the observer see Disconnected, then connect.
+                    sse.disconnect()
+                    delay(150)
+                    sse.connect()
+
+                    // The reconnect fires all three actions exactly once more.
+                    withTimeout(5_000L) {
+                        while (primeCount.get() < 2 ||
+                            presencePings.get() < 1 ||
+                            catchUp.fromZeroInvocations.get() < 2
+                        ) {
+                            delay(10)
+                        }
+                    }
+                    primeCount.get() shouldBe 2
+                    presencePings.get() shouldBe 1
+                    catchUp.fromZeroInvocations.get() shouldBe 2
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children.forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
     })
 
 /** No-op catch-up that flips no state — start completes without doing per-domain work. */
-private class NoopRefreshCatchUp : CatchUp {
+private object NoopRefreshCatchUp : CatchUp {
     override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
 
     override suspend fun <T : Any> catchUpFromZero(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
@@ -103,4 +220,86 @@ private class FlippingFakeSse(
     }
 
     override fun reconnectNow() = Unit
+}
+
+/**
+ * Counts `catchUpFromZero` (the re-pull the reconciler triggers on drift) and `catchUpAll`
+ * (start's forward drain), so a reconcile-driven re-pull is observable independently of start.
+ */
+private class CountingReconcileCatchUp : CatchUp {
+    val fromZeroInvocations = AtomicInteger(0)
+
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpFromZero(handler: SyncDomainHandler<T>): AppResult<Unit> {
+        fromZeroInvocations.incrementAndGet()
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>> = AppResult.Success(emptySet())
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+/** Minimal handler whose [localDigestRows] returns fixed rows so the reconciler can compare digests. */
+private class DriftingRefreshHandler(
+    private val rows: List<Pair<String, Long>>,
+) : SyncDomainHandler<Tag> {
+    override val domainName = "tags"
+    override val payloadSerializer = Tag.serializer()
+
+    override fun syncId(item: Tag): String = item.id
+
+    override suspend fun onEvent(
+        event: SyncEvent<Tag>,
+        isOwnEcho: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun onCatchUpItem(
+        item: Tag,
+        isTombstone: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun localDigestRows(maxRevision: Long): List<Pair<String, Long>> = rows
+}
+
+/** Digest client backed by an in-memory map: GET `/api/v1/sync/<domain>/digest` → preset digest or 404. */
+private fun fakeRefreshDigestClient(
+    domainDigests: Map<String, DomainDigest>,
+): DomainDigestClient {
+    val mockClient =
+        HttpClient(
+            MockEngine { req ->
+                val domain =
+                    req.url.pathSegments
+                        .dropLast(1)
+                        .last()
+                val digest = domainDigests[domain]
+                if (digest != null) {
+                    respond(
+                        content =
+                            contractJson.encodeToString(
+                                DomainDigest.serializer(),
+                                digest,
+                            ),
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                } else {
+                    respond(
+                        content = "not found",
+                        status = HttpStatusCode.NotFound,
+                    )
+                }
+            },
+        ) {
+            install(ContentNegotiation) {
+                json(contractJson)
+            }
+        }
+    return DomainDigestClient(
+        httpClientProvider = { mockClient },
+        serverUrlProvider = { "http://test" },
+    )
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineDiscoverRefreshTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineDiscoverRefreshTest.kt
@@ -84,9 +84,10 @@ class SyncEngineDiscoverRefreshTest :
 
         test("a reconnect (not the initial connect) primes the feed, pings presence, and reconciles") {
             runBlocking {
-                val scope = CoroutineScope(
-                    SupervisorJob() + Dispatchers.Default,
-                )
+                val scope =
+                    CoroutineScope(
+                        SupervisorJob() + Dispatchers.Default,
+                    )
                 val db = createInMemoryTestDatabase()
                 try {
                     val primeCount = AtomicInteger(0)
@@ -172,7 +173,8 @@ class SyncEngineDiscoverRefreshTest :
                     catchUp.fromZeroInvocations.get() shouldBe 2
                 } finally {
                     scope.cancel()
-                    scope.coroutineContext.job.children.forEach { it.join() }
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
                     db.close()
                 }
             }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineDiscoverRefreshTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineDiscoverRefreshTest.kt
@@ -1,0 +1,106 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncEngineDiscoverRefreshTest :
+    FunSpec({
+
+        test("start primes the activity feed once, after catch-up") {
+            runTest {
+                val primeCount = AtomicInteger(0)
+                val db = createInMemoryTestDatabase(StandardTestDispatcher(testScheduler))
+                val registry = ClientSyncDomainRegistry()
+                val store = SyncCursorStore(db.syncCursorDao())
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                    )
+                val state = SyncEngineState()
+                val catchUp = NoopRefreshCatchUp()
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = registry,
+                        queue = queue,
+                        state = state,
+                        cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+                    )
+                val engine =
+                    SyncEngine(
+                        registry = registry,
+                        queue = queue,
+                        state = state,
+                        store = store,
+                        catchUp = catchUp,
+                        sseClient = FlippingFakeSse(state),
+                        reconciler = noopSyncReconciler(registry, store, catchUp),
+                        dispatcher = dispatcher,
+                        presenceRefreshSignal = PresenceRefreshSignal(),
+                        activityRefreshSignal = ActivityRefreshSignal(),
+                        scope = backgroundScope,
+                        primeActivityFeed = { primeCount.incrementAndGet() },
+                    )
+
+                engine.start(currentUserId = "u1")
+
+                primeCount.get() shouldBe 1
+
+                engine.stopAndJoin()
+                db.close()
+            }
+        }
+    })
+
+/** No-op catch-up that flips no state — start completes without doing per-domain work. */
+private class NoopRefreshCatchUp : CatchUp {
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpFromZero(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>> = AppResult.Success(emptySet())
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+/** Fake SSE that flips [SyncEngineState] on connect/disconnect, mirroring production semantics. */
+private class FlippingFakeSse(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seeded = newLastEventId
+    }
+
+    override fun reconnectNow() = Unit
+}


### PR DESCRIPTION
## What

Fixes three Discover-screen defects, all rooted in the activity feed not being a first-class offline/reconnect citizen.

1. **Activity feed unavailable offline** — `SyncEngine` now primes the feed into Room on every online sync-start (UI-independent, via a `primeActivityFeed` lambda seam wired to `FetchActivitiesUseCase`), so it's present before going offline.
2. **"Can't connect" flash when offline** — `DiscoverViewModel.loadDiscoverShelves()` no longer pushes connectivity errors (`TransportError.NetworkUnavailable`/`Timeout`) to the global snackbar; genuine server/auth errors still surface, and the section degrades to empty.
3. **No refresh on reconnect** — a new `SyncEngine` reconnect observer (connection-up edge, initial start-connect dropped via `.drop(1)`) deterministically primes the feed, pings presence, and runs the digest-gated `reconcileAll()` → the leaderboard (`public_profiles`) updates. Previously this only happened if the server emitted a `CursorStale`.

`ActivityFeedViewModel` drops its now-redundant init-fetch (the engine primes it); it keeps observing Room, its live-nudge subscription, and pull-to-refresh.

## Tests

- `DiscoverViewModelTest` — connectivity (`NetworkUnavailable`/`Timeout`) failures do **not** emit to `errorBus`; a non-connectivity failure does.
- `SyncEngineDiscoverRefreshTest` — `start()` primes once after catch-up; a reconnect (not the initial connect) primes the feed, pings presence, and reconciles exactly once each (digest-drift harness).

## Scope

`:sharedLogic` only — no `:contract`/`:server`/`:sharedUI`/Room-schema changes, no new exported types (lambda seam avoids a new class).

## Gate

Local Linux gate green: `detekt`, `:sharedLogic:jvmTest`, `:server:jvmTest`, `:androidApp:assembleDebug`, `spotlessCheck`. iOS gates run on CI.

Design spec + plan: `docs/superpowers/specs/2026-06-24-discover-offline-reconnect-design.md`, `docs/superpowers/plans/2026-06-24-discover-offline-reconnect.md` (non-repo docs tree).