### PR TITLE
♻️ refactor(server): ImageStore/CoverSpool/BackupManifest → commonMain (SHA-256 io seam)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/BackupManifest.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/BackupManifest.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.backup
 
+import com.calypsan.listenup.server.io.hashFileSha256
+import kotlinx.io.files.Path
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import java.nio.file.Files
-import java.nio.file.Path
-import java.security.MessageDigest
 
 /**
  * Describes the contents of a `.listenup.zip` backup archive.
@@ -15,15 +15,15 @@ import java.security.MessageDigest
  */
 @Serializable
 data class BackupManifest(
-    val formatVersion: Int,
-    val serverId: String,
-    val createdAt: Long,
-    val appVersion: String,
-    val schemaVersion: String,
-    val includesImages: Boolean,
-    val checksums: Map<String, String>,
-    val bookCount: Int,
-    val userCount: Int,
+    @SerialName("formatVersion") val formatVersion: Int,
+    @SerialName("serverId") val serverId: String,
+    @SerialName("createdAt") val createdAt: Long,
+    @SerialName("appVersion") val appVersion: String,
+    @SerialName("schemaVersion") val schemaVersion: String,
+    @SerialName("includesImages") val includesImages: Boolean,
+    @SerialName("checksums") val checksums: Map<String, String>,
+    @SerialName("bookCount") val bookCount: Int,
+    @SerialName("userCount") val userCount: Int,
 ) {
     /** Serializes this manifest to pretty-printed JSON. */
     fun toJson(): String = JSON.encodeToString(this)
@@ -44,15 +44,4 @@ data class BackupManifest(
 }
 
 /** Computes the SHA-256 hex digest of a file's bytes, streamed in 64 KiB chunks. */
-fun sha256Of(path: Path): String {
-    val digest = MessageDigest.getInstance("SHA-256")
-    Files.newInputStream(path).use { input ->
-        val buf = ByteArray(64 * 1024)
-        while (true) {
-            val n = input.read(buf)
-            if (n < 0) break
-            digest.update(buf, 0, n)
-        }
-    }
-    return digest.digest().toHexString()
-}
+fun sha256Of(path: Path): String = hashFileSha256(path)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/PathBytes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/PathBytes.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.server.io
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
+
+/** Reads the whole file at [this] as a byte array. */
+internal fun Path.readBytes(): ByteArray = SystemFileSystem.source(this).buffered().use { it.readByteArray() }
+
+/** Writes [bytes] to [this], replacing any existing content. */
+internal fun Path.writeBytes(bytes: ByteArray) {
+    SystemFileSystem.sink(this).buffered().use { it.write(bytes) }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/Sha256.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/Sha256.kt
@@ -1,0 +1,17 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.calypsan.listenup.server.io
+
+import dev.whyoleg.cryptography.CryptographyProvider
+import dev.whyoleg.cryptography.algorithms.SHA256
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+private val sha256Hasher = CryptographyProvider.Default.get(SHA256).hasher()
+
+/** Lowercase 64-char hex SHA-256 of [bytes]. */
+internal fun hashBytesSha256(bytes: ByteArray): String = sha256Hasher.hashBlocking(bytes).toHexString()
+
+/** Lowercase 64-char hex SHA-256 of the file at [path], streamed (the file is never fully loaded). */
+internal fun hashFileSha256(path: Path): String =
+    SystemFileSystem.source(path).use { source -> sha256Hasher.hashBlocking(source).toByteArray().toHexString() }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/media/ImageStore.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/media/ImageStore.kt
@@ -1,10 +1,11 @@
 package com.calypsan.listenup.server.media
 
-import kotlinx.coroutines.Dispatchers
+import com.calypsan.listenup.server.io.fileIoDispatcher
+import com.calypsan.listenup.server.io.hashBytesSha256
+import com.calypsan.listenup.server.io.writeBytes
 import kotlinx.coroutines.withContext
-import java.nio.file.Files
-import java.nio.file.Path
-import java.security.MessageDigest
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 /**
  * Reusable validate-store-serve primitive for user-uploaded images, rooted at [baseDir]
@@ -40,7 +41,7 @@ class ImageStore(
     /**
      * Validates [bytes] by magic number, writes the file to `<baseDir>/<key>.<ext>`, and
      * returns a [StoredImage] describing the result. Any previously stored image for [key]
-     * is replaced atomically (delete-then-write).
+     * is replaced (delete-then-write).
      *
      * @throws InvalidImageException if [bytes] exceed [maxBytes] or carry an unsupported magic number,
      * or if [key] would escape [baseDir] via path traversal.
@@ -50,16 +51,16 @@ class ImageStore(
         bytes: ByteArray,
         declaredContentType: String,
     ): StoredImage =
-        withContext(Dispatchers.IO) {
+        withContext(fileIoDispatcher) {
             if (bytes.size.toLong() > maxBytes) throw InvalidImageException("image exceeds $maxBytes bytes")
             val kind = sniff(bytes) ?: throw InvalidImageException("unsupported image (declared=$declaredContentType)")
-            Files.createDirectories(baseDir)
+            SystemFileSystem.createDirectories(baseDir)
             deleteExisting(key)
             val target =
                 safeResolve(key, kind.ext)
                     ?: throw InvalidImageException("invalid key")
-            Files.write(target, bytes)
-            StoredImage(target, kind.contentType, sha256(bytes))
+            target.writeBytes(bytes)
+            StoredImage(target, kind.contentType, hashBytesSha256(bytes))
         }
 
     /**
@@ -70,24 +71,24 @@ class ImageStore(
     fun pathFor(key: String): Path? =
         Kind.entries
             .mapNotNull { safeResolve(key, it.ext) }
-            .firstOrNull { Files.isRegularFile(it) }
+            .firstOrNull { SystemFileSystem.metadataOrNull(it)?.isRegularFile == true }
 
     /**
      * Returns the MIME content type for a stored image [path] based on its extension,
      * or `"application/octet-stream"` if the extension is unrecognised.
      */
     fun contentTypeFor(path: Path): String =
-        Kind.entries.firstOrNull { path.fileName.toString().endsWith(".${it.ext}") }?.contentType
+        Kind.entries.firstOrNull { path.name.endsWith(".${it.ext}") }?.contentType
             ?: "application/octet-stream"
 
     /** Removes the stored image for [key] if one exists. Idempotent. */
     suspend fun delete(key: String) {
-        withContext(Dispatchers.IO) { deleteExisting(key) }
+        withContext(fileIoDispatcher) { deleteExisting(key) }
     }
 
     private fun deleteExisting(key: String) {
         Kind.entries.forEach { kind ->
-            safeResolve(key, kind.ext)?.let { Files.deleteIfExists(it) }
+            safeResolve(key, kind.ext)?.let { SystemFileSystem.delete(it, mustExist = false) }
         }
     }
 
@@ -100,8 +101,8 @@ class ImageStore(
         ext: String,
     ): Path? {
         if (".." in key || "/" in key || "\\" in key) return null
-        val resolved = baseDir.resolve("$key.$ext").normalize()
-        return resolved.takeIf { it.startsWith(baseDir.normalize()) }
+        val resolved = Path(baseDir, "$key.$ext")
+        return resolved.takeIf { it.toString().startsWith(baseDir.toString()) }
     }
 
     private fun sniff(bytes: ByteArray): Kind? {
@@ -124,9 +125,6 @@ class ImageStore(
             b[OFFSET_2] == WEBP_RIFF_2 && b[OFFSET_3] == WEBP_RIFF_3 &&
             b[WEBP_OFFSET_8] == WEBP_SIG_8 && b[WEBP_OFFSET_9] == WEBP_SIG_9 &&
             b[WEBP_OFFSET_10] == WEBP_SIG_10 && b[WEBP_OFFSET_11] == WEBP_SIG_11
-
-    private fun sha256(bytes: ByteArray): String =
-        MessageDigest.getInstance(SHA256_ALGORITHM).digest(bytes).toHexString()
 
     private companion object {
         const val MIN_SNIFF_BYTES = 4
@@ -162,7 +160,5 @@ class ImageStore(
         val WEBP_SIG_9: Byte = 'E'.code.toByte()
         val WEBP_SIG_10: Byte = 'B'.code.toByte()
         val WEBP_SIG_11: Byte = 'P'.code.toByte()
-
-        const val SHA256_ALGORITHM = "SHA-256"
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
@@ -2,13 +2,15 @@ package com.calypsan.listenup.server.scanner
 
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
 import com.calypsan.listenup.api.dto.scanner.CoverSource
+import com.calypsan.listenup.server.io.deleteRecursively
+import com.calypsan.listenup.server.io.hashBytesSha256
+import com.calypsan.listenup.server.io.readBytes
+import com.calypsan.listenup.server.io.statFile
+import com.calypsan.listenup.server.io.writeBytes
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.nio.file.Files
-import java.nio.file.Path
-import java.security.MessageDigest
-import kotlin.io.path.exists
-import kotlin.io.path.readBytes
-import kotlin.io.path.writeBytes
+import kotlin.time.Clock
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 private val logger = KotlinLogging.logger {}
 
@@ -60,9 +62,9 @@ class CoverSpool(
             return book.copy(embedded = lightenedEmbedded)
         }
         return try {
-            val dir = root.resolve(scanId)
-            Files.createDirectories(dir)
-            val file = dir.resolve(key(book.candidate.rootRelPath) + ".img")
+            val dir = Path(root, scanId)
+            SystemFileSystem.createDirectories(dir)
+            val file = Path(dir, key(book.candidate.rootRelPath) + ".img")
             file.writeBytes(cover.artwork.bytes)
             book.copy(
                 cover = CoverSource.Spooled(path = file.toString(), mime = cover.artwork.mime),
@@ -75,11 +77,11 @@ class CoverSpool(
     }
 
     /** Reads the spooled cover bytes back. */
-    fun read(spooled: CoverSource.Spooled): ByteArray = Path.of(spooled.path).readBytes()
+    fun read(spooled: CoverSource.Spooled): ByteArray = Path(spooled.path).readBytes()
 
     /** Deletes the spool dir for [scanId]. Idempotent; never throws. */
     fun clearScan(scanId: String) {
-        runCatching { root.resolve(scanId).toFile().deleteRecursively() }
+        runCatching { deleteRecursively(Path(root, scanId)) }
             .onFailure { logger.warn(it) { "cover spool clear failed for scan $scanId" } }
     }
 
@@ -92,28 +94,25 @@ class CoverSpool(
      * Never throws.
      */
     fun sweepOrphans() {
-        if (!root.exists()) return
-        val cutoff = System.currentTimeMillis() - ORPHAN_GRACE_MS
+        if (!SystemFileSystem.exists(root)) return
+        val cutoff = Clock.System.now().toEpochMilliseconds() - ORPHAN_GRACE_MS
         runCatching {
-            Files.newDirectoryStream(root).use { stream ->
-                stream.forEach { dir ->
-                    val lastModified = runCatching { Files.getLastModifiedTime(dir).toMillis() }.getOrDefault(0L)
-                    if (lastModified <= cutoff) {
-                        dir.toFile().deleteRecursively()
-                    } else {
-                        logger.info {
-                            "cover spool sweep: keeping recent dir ${dir.fileName} " +
-                                "(modified ${System.currentTimeMillis() - lastModified}ms ago, under grace) — " +
-                                "another scan may be live"
-                        }
+            SystemFileSystem.list(root).forEach { dir ->
+                val lastModified = statFile(dir)?.mtimeMs ?: 0L
+                if (lastModified <= cutoff) {
+                    deleteRecursively(dir)
+                } else {
+                    logger.info {
+                        "cover spool sweep: keeping recent dir ${dir.name} " +
+                            "(modified ${Clock.System.now().toEpochMilliseconds() - lastModified}ms ago, under grace) — " +
+                            "another scan may be live"
                     }
                 }
             }
         }.onFailure { logger.warn(it) { "cover spool orphan sweep failed" } }
     }
 
-    private fun key(rootRelPath: String): String =
-        MessageDigest.getInstance("SHA-256").digest(rootRelPath.toByteArray()).joinToString("") { "%02x".format(it) }
+    private fun key(rootRelPath: String): String = hashBytesSha256(rootRelPath.encodeToByteArray())
 
     companion object {
         /**

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/Sha256Test.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/Sha256Test.kt
@@ -1,0 +1,15 @@
+package com.calypsan.listenup.server.io
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class Sha256Test :
+    FunSpec({
+
+        test("hashBytesSha256 matches known vectors") {
+            hashBytesSha256(ByteArray(0)) shouldBe
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            hashBytesSha256("abc".encodeToByteArray()) shouldBe
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        }
+    })

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
@@ -294,7 +294,7 @@ internal class BookMetadataApplier(
         try {
             val bytes = imageStorage.downloadBytes(url)
             val stored = coverImageStore.store.store(bookId.value, bytes, "image/jpeg")
-            val relPath = "covers/${stored.path.fileName}"
+            val relPath = "covers/${stored.path.name}"
             val result = bookRepository.setManagedCover(bookId, relPath, stored.sha256, CoverSource.UPLOADED)
             if (result is AppResult.Success) {
                 log.info { "Stored wizard-chosen cover for ${bookId.value} → $relPath" }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
@@ -358,7 +358,7 @@ internal class BookServiceImpl(
         val stored = store.store.store(id.value, bytes, contentType)
         // Derive the repo-relative path from the stored absolute path's filename only.
         // stored.path lives under homeDir/covers/<bookId>.<ext>; the repo stores covers/<filename>.
-        val relPath = "covers/${stored.path.fileName}"
+        val relPath = "covers/${stored.path.name}"
         return repo.setManagedCover(id, relPath, stored.sha256, CoverSource.UPLOADED)
     }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -293,7 +293,7 @@ internal class MetadataLookupServiceImpl(
         return try {
             val bytes = imageDeps.imageStorage.downloadBytes(url)
             val stored = imageDeps.coverImageStore.store.store(bookId.value, bytes, "image/jpeg")
-            val relPath = "covers/${stored.path.fileName}"
+            val relPath = "covers/${stored.path.name}"
             bookRepository.setManagedCover(bookId, relPath, stored.sha256, CoverSource.UPLOADED)
         } catch (e: CancellationException) {
             throw e

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/backup/BackupArchive.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/backup/BackupArchive.kt
@@ -13,6 +13,7 @@ import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
+import kotlinx.io.files.Path as IoPath
 
 /**
  * Creates, opens, validates, and extracts `.listenup.zip` backup archives.
@@ -58,7 +59,7 @@ class BackupArchive(
             try {
                 onEvent(BackupEvent.DbSnapshotting)
                 dbHandle.vacuumInto(tmpDb.toAbsolutePath().toString())
-                val dbHash = sha256Of(tmpDb)
+                val dbHash = sha256Of(IoPath(tmpDb.toString()))
                 val dest = paths.archiveFor(id)
                 writeArchive(tmpDb, dbHash, includeImages, onEvent, dest)
                 dest
@@ -279,7 +280,7 @@ class BackupArchive(
     ) {
         val extractedDb = targetDir.resolve(DB_ENTRY)
         val dbExpected = resolveDbExpected(archive, extractedDb, manifest)
-        val dbActual = sha256Of(extractedDb)
+        val dbActual = sha256Of(IoPath(extractedDb.toString()))
         if (dbActual != dbExpected) {
             throw CorruptArchiveException(
                 "$DB_ENTRY checksum mismatch after extract (expected=$dbExpected, actual=$dbActual)",

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/cover/ManagedCoverFiles.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/cover/ManagedCoverFiles.kt
@@ -65,7 +65,7 @@ class ManagedCoverFiles(
         if (coverImageStore == null || pending == null) return null
         return try {
             val stored = coverImageStore.store.store(bookId.value, pending.bytes, pending.mime)
-            val relPath = "covers/${stored.path.fileName}"
+            val relPath = "covers/${stored.path.name}"
             StoredCoverInfo(relPath = relPath, hash = stored.sha256, source = pending.source)
         } catch (e: CancellationException) {
             throw e

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
@@ -38,6 +38,7 @@ import com.calypsan.listenup.server.document.DocumentFileLocator
 import com.calypsan.listenup.server.cover.EmbeddedCoverCache
 import com.calypsan.listenup.server.media.ImageStore
 import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import kotlinx.io.files.Path as IoPath
 import com.calypsan.listenup.server.scanner.metadata.MetadataPrecedence
 import com.calypsan.listenup.server.services.AnalyzedBookMapper
 import com.calypsan.listenup.server.services.BookGenreWriter
@@ -306,10 +307,10 @@ private fun Module.coverAndPersisterBindings(
     embeddedCoverCacheSize: Int,
     homeDir: Path,
 ) {
-    single { CoverImageStore(ImageStore(homeDir.resolve("covers"), COVER_MAX_BYTES)) }
+    single { CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), COVER_MAX_BYTES)) }
     single {
         com.calypsan.listenup.server.scanner
-            .CoverSpool(homeDir.resolve("scan-spool"))
+            .CoverSpool(IoPath(homeDir.resolve("scan-spool").toString()))
     }
     single { EmbeddedCoverCache(maxSize = embeddedCoverCacheSize) }
     single {

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/ProfileModule.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/ProfileModule.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.media.ImageStore
 import com.calypsan.listenup.server.routes.AVATAR_MAX_BYTES
 import java.nio.file.Path
+import kotlinx.io.files.Path as IoPath
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -20,5 +21,5 @@ fun profileModule(avatarsDir: Path): Module =
                 clock = get(),
             )
         }
-        single { ImageStore(avatarsDir, maxBytes = AVATAR_MAX_BYTES) }
+        single { ImageStore(IoPath(avatarsDir.toString()), maxBytes = AVATAR_MAX_BYTES) }
     }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ProfileRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ProfileRoutes.kt
@@ -17,9 +17,10 @@ import io.ktor.server.response.respondBytes
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
+import com.calypsan.listenup.server.io.readBytes
 import io.ktor.utils.io.toByteArray
-import java.nio.file.Files
 import kotlin.time.Clock
+import kotlinx.io.files.SystemFileSystem
 
 private const val AVATAR_CACHE_SECONDS = 86_400 // 24h, mirrors Go
 private const val AVATAR_TYPE_IMAGE = "image"
@@ -85,8 +86,12 @@ fun Route.profileRoutes(
     get("/api/v1/avatars/{userId}") {
         val target = call.parameters["userId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
         val path = imageStore.pathFor(target) ?: return@get call.respond(HttpStatusCode.NotFound)
-        if (!Files.isRegularFile(path)) return@get call.respond(HttpStatusCode.NotFound)
+        if (SystemFileSystem.metadataOrNull(path)?.isRegularFile !=
+            true
+        ) {
+            return@get call.respond(HttpStatusCode.NotFound)
+        }
         call.response.header(HttpHeaders.CacheControl, "private, max-age=$AVATAR_CACHE_SECONDS")
-        call.respondBytes(Files.readAllBytes(path), ContentType.parse(imageStore.contentTypeFor(path)))
+        call.respondBytes(path.readBytes(), ContentType.parse(imageStore.contentTypeFor(path)))
     }
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/document/DocumentCollector.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/document/DocumentCollector.kt
@@ -3,10 +3,10 @@ package com.calypsan.listenup.server.scanner.document
 import com.calypsan.listenup.api.dto.scanner.AnalyzedDocument
 import com.calypsan.listenup.api.dto.scanner.FileEntry
 import com.calypsan.listenup.api.dto.scanner.FileType
-import java.io.InputStream
+import com.calypsan.listenup.server.io.hashFileSha256
 import java.nio.file.Files
 import java.nio.file.Path
-import java.security.MessageDigest
+import kotlinx.io.files.Path as IoPath
 
 /**
  * Collects EBOOK-typed files from a candidate's file list and maps them to
@@ -49,24 +49,7 @@ internal class DocumentCollector {
                             .substringAfterLast('.', "")
                             .lowercase(),
                     size = Files.size(absolutePath),
-                    hash = sha256OfPath(absolutePath),
+                    hash = hashFileSha256(IoPath(absolutePath.toString())),
                 )
             }
-
-    companion object {
-        /** SHA-256 hex digest of the file at [path], streamed in 64 KiB chunks. */
-        private fun sha256OfPath(path: Path): String = Files.newInputStream(path).use { sha256OfStream(it) }
-
-        /** SHA-256 hex of bytes read from [input], streamed in 64 KiB chunks. */
-        internal fun sha256OfStream(input: InputStream): String {
-            val digest = MessageDigest.getInstance("SHA-256")
-            val buf = ByteArray(64 * 1024)
-            while (true) {
-                val n = input.read(buf)
-                if (n < 0) break
-                digest.update(buf, 0, n)
-            }
-            return digest.digest().toHexString()
-        }
-    }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ApplyCoverTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ApplyCoverTest.kt
@@ -127,7 +127,7 @@ private fun withCoverFixture(
                 .upsert(coverBookFixture("book1"), clientOpId = null)
                 .shouldBeInstanceOf<AppResult.Success<*>>()
 
-            val coverStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), MAX_COVER_BYTES))
+            val coverStore = CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), MAX_COVER_BYTES))
             val mockHttp =
                 HttpClient(
                     MockEngine {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplDeleteCoverTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplDeleteCoverTest.kt
@@ -42,6 +42,7 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.writeBytes
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path as IoPath
 
 class BookServiceImplDeleteCoverTest :
     FunSpec({
@@ -175,7 +176,7 @@ class BookServiceImplDeleteCoverTest :
                 // Write a fake managed cover file at covers/<bookId>.jpg
                 val managedFile = coversDir.resolve("b1.jpg").apply { writeBytes(byteArrayOf(1, 2, 3)) }
                 sql.seedTestLibraryAndFolder()
-                val coverImageStore = CoverImageStore(ImageStore(coversDir, MAX_COVER_BYTES))
+                val coverImageStore = CoverImageStore(ImageStore(IoPath(coversDir.toString()), MAX_COVER_BYTES))
                 val (service, repo) = newService(db, coverImageStore, homeDir = home)
                 runTest {
                     // Seed the book with an ENRICHED cover in the DB
@@ -203,7 +204,7 @@ class BookServiceImplDeleteCoverTest :
                 val coversDir = home.resolve("covers").apply { createDirectories() }
                 val managedFile = coversDir.resolve("b2.png").apply { writeBytes(byteArrayOf(4, 5, 6)) }
                 sql.seedTestLibraryAndFolder()
-                val coverImageStore = CoverImageStore(ImageStore(coversDir, MAX_COVER_BYTES))
+                val coverImageStore = CoverImageStore(ImageStore(IoPath(coversDir.toString()), MAX_COVER_BYTES))
                 val (service, repo) = newService(db, coverImageStore, homeDir = home)
                 runTest {
                     repo.upsert(bookFixture(id = "b2", title = "Uploaded Cover Book"))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MatchApplySelectionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MatchApplySelectionTest.kt
@@ -50,6 +50,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import java.nio.file.Files
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path as IoPath
 
 private const val MAX_COVER_BYTES = 10L * 1024 * 1024
 
@@ -175,7 +176,7 @@ class MatchApplySelectionTest :
                 contributorRepository = contributors,
                 seriesRepository = series,
                 imageStorage = ImageStorage(httpClient = HttpClient(engine)),
-                coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), MAX_COVER_BYTES)),
+                coverImageStore = CoverImageStore(ImageStore(IoPath(tempDir.resolve("covers").toString()), MAX_COVER_BYTES)),
                 metadataProvider = provider,
                 genreHierarchy = GenreHierarchyFromLadder(dbs.sql, genreRepo, GenreAutoCreator(genreRepo)),
                 sqlDb = dbs.sql,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataApplyEnrichmentTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataApplyEnrichmentTest.kt
@@ -57,6 +57,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path as IoPath
 
 private val ENRICH_NOW = Instant.parse("2026-05-24T12:00:00Z")
 private const val ENRICH_ASIN = "B0ENRICH01"
@@ -213,7 +214,7 @@ private class EnrichmentCtx(
             contributorRepository = contributorRepo,
             seriesRepository = seriesRepo,
             imageStorage = ImageStorage(HttpClient(MockEngine { _ -> respond(TINY_JPEG, HttpStatusCode.OK) })),
-            coverImageStore = CoverImageStore(ImageStore(Path.of(tempDir).resolve("covers"), MAX_COVER_BYTES)),
+            coverImageStore = CoverImageStore(ImageStore(IoPath(Path.of(tempDir).resolve("covers").toString()), MAX_COVER_BYTES)),
             metadataProvider = AudibleMetadataProvider(metadataService),
             genreHierarchy = GenreHierarchyFromLadder(sql, genreRepo, GenreAutoCreator(genreRepo)),
             sqlDb = sql,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplPermissionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplPermissionTest.kt
@@ -135,7 +135,8 @@ private fun makeMetadataPermService(dbs: SqlTestDatabases): MetadataLookupServic
         imageDeps =
             MetadataImageDeps(
                 imageStorage = ImageStorage(HttpClient(MockEngine { _ -> respond("", HttpStatusCode.OK) })),
-                coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), maxBytes = 10L * 1024 * 1024)),
+                coverImageStore =
+                    CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), maxBytes = 10L * 1024 * 1024)),
                 imageHome = Path(tempDir.toString()),
             ),
         enrichmentDeps = testEnrichmentDeps(dbs.sql, bus, registry),

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
@@ -287,7 +287,7 @@ class MetadataLookupServiceImplTest :
                 val imageStorage =
                     ImageStorage(HttpClient(MockEngine { _ -> respond(jpegBytes, HttpStatusCode.OK) }))
                 val coverImageStore =
-                    CoverImageStore(ImageStore(coversDir, maxBytes = 10L * 1024 * 1024))
+                    CoverImageStore(ImageStore(Path(coversDir.toString()), maxBytes = 10L * 1024 * 1024))
 
                 runTest {
                     bookRepo.upsert(bookFixture(bookId = "book-1"))
@@ -460,7 +460,8 @@ private fun makeService(
         imageDeps =
             MetadataImageDeps(
                 imageStorage = ImageStorage(HttpClient(MockEngine { _ -> respond("", HttpStatusCode.OK) })),
-                coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), maxBytes = 10L * 1024 * 1024)),
+                coverImageStore =
+                    CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), maxBytes = 10L * 1024 * 1024)),
                 imageHome = Path(tempDir.toString()),
             ),
         enrichmentDeps = testEnrichmentDeps(dbs.sql, bus, syncRegistry, productTagSource = productTagSource),

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/BackupArchiveTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/BackupArchiveTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.test.runTest
 import java.nio.file.Files
 import kotlin.io.path.exists
+import kotlinx.io.files.Path as IoPath
 
 class BackupArchiveTest :
     FunSpec({
@@ -53,7 +54,7 @@ class BackupArchiveTest :
 
                     val extractedDb = targetDir.resolve("listenup.db")
                     extractedDb.exists() shouldBe true
-                    sha256Of(extractedDb) shouldBe manifest.checksums["db"]
+                    sha256Of(IoPath(extractedDb.toString())) shouldBe manifest.checksums["db"]
                     manifest.includesImages shouldBe false
                     manifest.serverId shouldBe "srv-test"
                 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/BackupManifestTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/BackupManifestTest.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.backup
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.nio.file.Files
+import kotlinx.io.files.Path as IoPath
 
 class BackupManifestTest :
     FunSpec({
@@ -25,8 +26,8 @@ class BackupManifestTest :
         test("sha256 of a file is stable") {
             val f = Files.createTempFile("chk", ".bin")
             Files.write(f, byteArrayOf(1, 2, 3, 4))
-            val a = sha256Of(f)
-            val b = sha256Of(f)
+            val a = sha256Of(IoPath(f.toString()))
+            val b = sha256Of(IoPath(f.toString()))
             a shouldBe b
             a.length shouldBe 64
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/B2aMetadataApplyE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/B2aMetadataApplyE2ETest.kt
@@ -135,7 +135,8 @@ class B2aMetadataApplyE2ETest :
                         )
                     }
                 val imageStorage = ImageStorage(HttpClient(mockEngine))
-                val coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), MAX_COVER_BYTES))
+                val coverImageStore =
+                    CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), MAX_COVER_BYTES))
 
                 // ── Wire MetadataService + MetadataLookupServiceImpl ────────────
                 val cacheRepo = MetadataCacheRepository(sql, clock = FixedClock(TEST_NOW))
@@ -211,7 +212,8 @@ class B2aMetadataApplyE2ETest :
 
                 val mockEngine = MockEngine { _ -> respond(TINY_JPEG, HttpStatusCode.OK) }
                 val imageStorage = ImageStorage(HttpClient(mockEngine))
-                val coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), MAX_COVER_BYTES))
+                val coverImageStore =
+                    CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), MAX_COVER_BYTES))
 
                 val cacheRepo = MetadataCacheRepository(sql, clock = FixedClock(TEST_NOW))
                 val metadataService =
@@ -279,7 +281,8 @@ class B2aMetadataApplyE2ETest :
                     )
                 val imageStorage =
                     ImageStorage(HttpClient(MockEngine { _ -> respond("", HttpStatusCode.OK) }))
-                val coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), MAX_COVER_BYTES))
+                val coverImageStore =
+                    CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), MAX_COVER_BYTES))
                 val service =
                     buildService(
                         this,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/ChapterNameApplyE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/ChapterNameApplyE2ETest.kt
@@ -173,7 +173,8 @@ private fun wire(
             imageDeps =
                 MetadataImageDeps(
                     imageStorage = ImageStorage(HttpClient(MockEngine { _ -> respond("", HttpStatusCode.OK) })),
-                    coverImageStore = CoverImageStore(ImageStore(tempDir.resolve("covers"), 10L * 1024 * 1024)),
+                    coverImageStore =
+                        CoverImageStore(ImageStore(Path(tempDir.resolve("covers").toString()), 10L * 1024 * 1024)),
                     imageHome = Path(tempDir.toString()),
                 ),
             enrichmentDeps = testEnrichmentDeps(dbs.sql, bus, registry),

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/PathBytesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/PathBytesTest.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.server.io
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import kotlinx.io.files.Path
+
+class PathBytesTest :
+    FunSpec({
+
+        test("writeBytes then readBytes round-trips") {
+            val dir = Files.createTempDirectory("listenup-pathbytes-")
+            try {
+                val file = Path(dir.resolve("b.bin").toString())
+                val bytes = byteArrayOf(1, 2, 3, 4, 5)
+                file.writeBytes(bytes)
+                file.readBytes() shouldBe bytes
+            } finally {
+                dir.toFile().deleteRecursively()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/Sha256FileTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/Sha256FileTest.kt
@@ -1,0 +1,20 @@
+package com.calypsan.listenup.server.io
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import kotlinx.io.files.Path
+
+class Sha256FileTest :
+    FunSpec({
+
+        test("hashFileSha256 streams a file to the same digest as its bytes") {
+            val f = Files.createTempFile("listenup-sha256-", ".txt")
+            try {
+                Files.write(f, "abc".encodeToByteArray())
+                hashFileSha256(Path(f.toString())) shouldBe hashBytesSha256("abc".encodeToByteArray())
+            } finally {
+                Files.deleteIfExists(f)
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/media/ImageStoreTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/media/ImageStoreTest.kt
@@ -4,8 +4,10 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import com.calypsan.listenup.server.io.readBytes
 import kotlinx.coroutines.test.runTest
 import java.nio.file.Files
+import kotlinx.io.files.Path as IoPath
 
 class ImageStoreTest :
     FunSpec({
@@ -15,17 +17,17 @@ class ImageStoreTest :
         test("stores a valid PNG and serves it back with content type") {
             val dir = Files.createTempDirectory("imagestore-")
             runTest {
-                val store = ImageStore(dir, maxBytes = 1_000_000)
+                val store = ImageStore(IoPath(dir.toString()), maxBytes = 1_000_000)
                 val stored = store.store("u1", pngBytes, "image/png")
                 stored.contentType shouldBe "image/png"
                 store.pathFor("u1").shouldNotBeNull()
-                Files.readAllBytes(store.pathFor("u1")!!) shouldBe pngBytes
+                store.pathFor("u1")!!.readBytes() shouldBe pngBytes
             }
         }
         test("rejects bytes whose magic number is not a supported image") {
             val dir = Files.createTempDirectory("imagestore-")
             runTest {
-                val store = ImageStore(dir, maxBytes = 1_000_000)
+                val store = ImageStore(IoPath(dir.toString()), maxBytes = 1_000_000)
                 shouldThrowInvalid { store.store("u1", "not an image".encodeToByteArray(), "image/png") }
                 store.pathFor("u1").shouldBeNull()
             }
@@ -33,14 +35,14 @@ class ImageStoreTest :
         test("rejects oversize input") {
             val dir = Files.createTempDirectory("imagestore-")
             runTest {
-                val store = ImageStore(dir, maxBytes = 4)
+                val store = ImageStore(IoPath(dir.toString()), maxBytes = 4)
                 shouldThrowInvalid { store.store("u1", jpegBytes, "image/jpeg") }
             }
         }
         test("delete removes the stored image") {
             val dir = Files.createTempDirectory("imagestore-")
             runTest {
-                val store = ImageStore(dir, maxBytes = 1_000_000)
+                val store = ImageStore(IoPath(dir.toString()), maxBytes = 1_000_000)
                 store.store("u1", pngBytes, "image/png")
                 store.delete("u1")
                 store.pathFor("u1").shouldBeNull()
@@ -48,13 +50,13 @@ class ImageStoreTest :
         }
         test("pathFor returns null for a path-traversal key") {
             val dir = Files.createTempDirectory("imagestore-")
-            val store = ImageStore(dir, maxBytes = 1_000_000)
+            val store = ImageStore(IoPath(dir.toString()), maxBytes = 1_000_000)
             store.pathFor("../../etc/passwd").shouldBeNull()
         }
         test("store throws InvalidImageException for a path-traversal key") {
             val dir = Files.createTempDirectory("imagestore-")
             runTest {
-                val store = ImageStore(dir, maxBytes = 1_000_000)
+                val store = ImageStore(IoPath(dir.toString()), maxBytes = 1_000_000)
                 shouldThrowInvalid { store.store("../x", pngBytes, "image/png") }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/CoverSpoolTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/CoverSpoolTest.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
 import kotlin.io.path.exists
+import kotlinx.io.files.Path as IoPath
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -101,7 +102,7 @@ class CoverSpoolTest :
 
         test("spoolCover writes embedded bytes to disk and returns a Spooled ref") {
             val root = Files.createTempDirectory("spool-test")
-            val spool = CoverSpool(root)
+            val spool = CoverSpool(IoPath(root.toString()))
             val out = spool.spoolCover("scan1", bookWithEmbeddedCover("A/B", COVER_BYTES))
 
             val cover = out.cover.shouldBeInstanceOf<CoverSource.Spooled>()
@@ -110,7 +111,7 @@ class CoverSpoolTest :
 
         test("spoolCover: embedded-metadata book — artwork emptied, marker + mime kept, originals spooled") {
             val root = Files.createTempDirectory("spool-test")
-            val spool = CoverSpool(root)
+            val spool = CoverSpool(IoPath(root.toString()))
             val book =
                 bookWithEmbeddedCover(
                     rootRelPath = "A/B",
@@ -144,7 +145,7 @@ class CoverSpoolTest :
 
         test("spoolCover — filesystem-cover book WITH embedded artwork: artwork bytes emptied, marker kept, filesystem cover unchanged") {
             val root = Files.createTempDirectory("spool-test")
-            val spool = CoverSpool(root)
+            val spool = CoverSpool(IoPath(root.toString()))
             val book =
                 bookWithFilesystemCover(
                     rootRelPath = "A/B",
@@ -172,7 +173,7 @@ class CoverSpoolTest :
         // -------------------------------------------------------------------
 
         test("spoolCover leaves a no-cover book with no embedded metadata unchanged") {
-            val spool = CoverSpool(Files.createTempDirectory("spool-test"))
+            val spool = CoverSpool(IoPath(Files.createTempDirectory("spool-test").toString()))
             val book =
                 AnalyzedBook(
                     candidate = CandidateBook(rootRelPath = "A", isFile = false, files = emptyList()),
@@ -182,14 +183,14 @@ class CoverSpoolTest :
         }
 
         test("spoolCover leaves a filesystem-cover book with no embedded metadata unchanged") {
-            val spool = CoverSpool(Files.createTempDirectory("spool-test"))
+            val spool = CoverSpool(IoPath(Files.createTempDirectory("spool-test").toString()))
             val book = bookWithFilesystemCover("A/B", embedded = null)
             spool.spoolCover("scan1", book) shouldBe book
         }
 
         test("spoolCover does not touch an embedded.artwork that already has empty bytes") {
             val root = Files.createTempDirectory("spool-test")
-            val spool = CoverSpool(root)
+            val spool = CoverSpool(IoPath(root.toString()))
             val book = bookWithFilesystemCover("A/B", embedded = minimalEmbedded(artworkBytes = ByteArray(0)))
             // already-empty bytes → returned as-is (no unnecessary copy)
             val out = spool.spoolCover("scan1", book)
@@ -202,7 +203,7 @@ class CoverSpoolTest :
 
         test("clearScan removes the scan's dir; sweepOrphans removes STALE leftover dirs") {
             val root = Files.createTempDirectory("spool-test")
-            val spool = CoverSpool(root)
+            val spool = CoverSpool(IoPath(root.toString()))
             spool.spoolCover("scanA", bookWithEmbeddedCover("A", byteArrayOf(9)))
             spool.spoolCover("scanB", bookWithEmbeddedCover("B", byteArrayOf(8)))
             spool.clearScan("scanA")
@@ -219,7 +220,7 @@ class CoverSpoolTest :
 
         test("sweepOrphans preserves recently-modified dirs — a live scan is never clobbered") {
             val root = Files.createTempDirectory("spool-test")
-            val spool = CoverSpool(root)
+            val spool = CoverSpool(IoPath(root.toString()))
 
             // A just-created dir stands in for a concurrent (possibly other-process) live scan.
             val liveDir = root.resolve("live-scan-corr")
@@ -248,7 +249,7 @@ class CoverSpoolTest :
 
         test("a write failure keeps the cover in memory but still empties embedded artwork bytes") {
             val file = Files.createTempFile("not-a-dir", "") // root is a FILE → createDirectories fails
-            val spool = CoverSpool(file)
+            val spool = CoverSpool(IoPath(file.toString()))
             val originalBytes = byteArrayOf(1)
             val book =
                 bookWithEmbeddedCover(
@@ -274,7 +275,7 @@ class CoverSpoolTest :
 
         test("a write failure on a book without embedded metadata returns cover unchanged") {
             val file = Files.createTempFile("not-a-dir", "")
-            val spool = CoverSpool(file)
+            val spool = CoverSpool(IoPath(file.toString()))
             val book = bookWithEmbeddedCover("A", byteArrayOf(1))
             // no embedded metadata — result is byte-for-byte equal to input
             spool.spoolCover("scan1", book) shouldBe book

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersistCoverTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersistCoverTest.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.test.runTest
 import org.koin.ktor.ext.inject
 import java.nio.file.Files
+import kotlinx.io.files.Path as IoPath
 
 /**
  * Integration tests for Task 5: persist-at-scan and sticky-upload-merge.
@@ -81,7 +82,7 @@ class BookPersistCoverTest :
                     val homeDir = Files.createTempDirectory("listenup-cover-persist-")
                     try {
                         val coverStore =
-                            CoverImageStore(ImageStore(homeDir.resolve("covers"), MAX_COVER_BYTES))
+                            CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), MAX_COVER_BYTES))
                         val bus = ChangeBus()
                         val syncRegistry = SyncRegistry()
                         val repo =
@@ -203,7 +204,7 @@ class BookPersistCoverTest :
                     val homeDir = Files.createTempDirectory("listenup-sticky-upload-")
                     try {
                         val coverStore =
-                            CoverImageStore(ImageStore(homeDir.resolve("covers"), MAX_COVER_BYTES))
+                            CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), MAX_COVER_BYTES))
                         val bus = ChangeBus()
                         val syncRegistry = SyncRegistry()
                         val repo =
@@ -233,7 +234,7 @@ class BookPersistCoverTest :
                         val stored = coverStore.store.store(bookId.value, uploadedBytes, "image/jpeg")
                         repo.setManagedCover(
                             id = bookId,
-                            relPath = "covers/${stored.path.fileName}",
+                            relPath = "covers/${stored.path.name}",
                             hash = stored.sha256,
                             source = CoverSource.UPLOADED,
                         )
@@ -272,7 +273,7 @@ class BookPersistCoverTest :
                     val homeDir = Files.createTempDirectory("listenup-sticky-control-")
                     try {
                         val coverStore =
-                            CoverImageStore(ImageStore(homeDir.resolve("covers"), MAX_COVER_BYTES))
+                            CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), MAX_COVER_BYTES))
                         val bus = ChangeBus()
                         val syncRegistry = SyncRegistry()
                         val repo =
@@ -333,7 +334,7 @@ class BookPersistCoverTest :
                     val homeDir = Files.createTempDirectory("listenup-single-event-")
                     try {
                         val coverStore =
-                            CoverImageStore(ImageStore(homeDir.resolve("covers"), MAX_COVER_BYTES))
+                            CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), MAX_COVER_BYTES))
                         val bus = ChangeBus()
                         val syncRegistry = SyncRegistry()
                         val repo =
@@ -403,7 +404,7 @@ class BookPersistCoverTest :
                     val homeDir = Files.createTempDirectory("listenup-cover-concurrent-")
                     try {
                         val coverStore =
-                            CoverImageStore(ImageStore(homeDir.resolve("covers"), MAX_COVER_BYTES))
+                            CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), MAX_COVER_BYTES))
                         val bus = ChangeBus()
                         val syncRegistry = SyncRegistry()
                         val repo =
@@ -492,7 +493,7 @@ class BookPersistCoverTest :
                     val homeDir = Files.createTempDirectory("listenup-no-orphan-")
                     try {
                         val coverStore =
-                            CoverImageStore(ImageStore(homeDir.resolve("covers"), MAX_COVER_BYTES))
+                            CoverImageStore(ImageStore(IoPath(homeDir.resolve("covers").toString()), MAX_COVER_BYTES))
                         val bus = ChangeBus()
                         val syncRegistry = SyncRegistry()
                         val repo =
@@ -522,7 +523,7 @@ class BookPersistCoverTest :
                         val stored = coverStore.store.store(bookId.value, uploadedBytes, "image/jpeg")
                         repo.setManagedCover(
                             id = bookId,
-                            relPath = "covers/${stored.path.fileName}",
+                            relPath = "covers/${stored.path.name}",
                             hash = stored.sha256,
                             source = CoverSource.UPLOADED,
                         )


### PR DESCRIPTION
PR-3 of the Cluster C file-I/O sweep. Adds two pure-commonMain `io/` seams and moves the three clean-closure leaf stores to `commonMain` so they compile for `jvm()` + `linuxX64()`, with **zero behavior change**.

## New io/ seams (commonMain)
- `io/Sha256.kt` — `hashBytesSha256(ByteArray)` + `hashFileSha256(Path)`. The streaming file hash uses **cryptography-kotlin** `Hasher.hashBlocking(RawSource)` over `SystemFileSystem.source` — multi-GB-safe, no expect/actual, no manual chunk loop. Replaces five hand-rolled `MessageDigest` sites.
- `io/PathBytes.kt` — `Path.readBytes()` / `Path.writeBytes(ByteArray)` (kotlinx-io).

## Moved to commonMain (zero behavior change)
- `media/ImageStore.kt`, `scanner/CoverSpool.kt`, `backup/BackupManifest.kt`. `MessageDigest`→`hashBytesSha256`/`hashFileSha256`; `Files.*`→`SystemFileSystem`; `Dispatchers.IO`→`fileIoDispatcher`; `System.currentTimeMillis()`→`Clock.System` (kotlinx-datetime). `ImageStore.safeResolve` path-traversal guard preserved verbatim (pinned by its `../../etc/passwd` test). `ImageStore`'s write stays a plain (non-atomic) delete-then-write — unchanged.

## In-place + bridges (stay jvmMain)
- `DocumentCollector` swaps its file hashing to `hashFileSha256` (its `collect(java.nio.Path…)` signature defers with the scanner pipeline). The `StoredImage.path` type flip (`java.nio.Path`→`kotlinx.io.Path`) rippled to **4 cover-deriving consumers** the plan under-counted — `BookMetadataApplier`, `BookServiceImpl`, `MetadataLookupServiceImpl`, `ManagedCoverFiles` (`stored.path.fileName` → `stored.path.name`, same final-segment string). `ProfileRoutes`/`BackupArchive`/DI bridge `java.nio.Path → kotlinx.io.Path` at construction. **`BookPersister` deferred** — its `scanRoot: java.nio.Path` param keeps it java.nio-bound regardless.

## Notable
- **`BackupManifest` gained per-property `@SerialName`.** Moving a `@Serializable data class` jvmMain→commonMain pulls it into `StablePropertyOrderRule`'s scope (commonMain-only); it had no `@SerialName` and would fail the gate. Added per-property tags with the existing field names — reproduces the default JSON keys, **zero wire change** to on-disk `manifest.json`, pinned by `BackupManifestTest`. (This jvmMain→commonMain `@Serializable` trap is now documented in the Cluster C roadmap for the remaining PRs + Phase 5.)
- Path factories (`DataHome`/`ImportPaths`/`BackupPaths`) NOT here — their `java.nio.Path` return types ripple into ~7 jvmMain files each; they move with their import/backup domains (deferred).

## Verification
- Full Linux-lane gate green: `compileKotlinLinuxX64` + spotless + detekt + `:server:jvmTest` (2312/0) + `:sharedLogic:jvmTest` (2738/0) + `:androidApp:assembleDebug` + forced Konsist re-scan. The `ImageStore`/`CoverSpool`/`BackupManifest`/`BackupArchive` suites — which assert **exact SHA-256 hex** — pass unchanged (the zero-behavior-change proof: cryptography-kotlin `.toHexString()` byte-matches the old `MessageDigest`).

Rebased onto current `main` (Kotlin 2.4.0 #782 + sidecar #781). Next in Cluster C: the import/backup path-factory + scanner-pipeline migrations. See `docs/superpowers/specs/2026-06-24-kn-port-cluster-c-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)