### PR TITLE
Finish explicit-backing-field sweep (:sharedUI + :contract)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/error/ErrorBus.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/error/ErrorBus.kt
@@ -24,10 +24,9 @@ import kotlinx.coroutines.flow.SharedFlow
  * ```
  */
 class ErrorBus {
-    private val _errors = MutableSharedFlow<AppError>(extraBufferCapacity = 16)
-
     /** Stream of errors emitted from anywhere in the app. */
-    val errors: SharedFlow<AppError> = _errors
+    val errors: SharedFlow<AppError>
+        field = MutableSharedFlow<AppError>(extraBufferCapacity = 16)
 
     /**
      * Emit an error to be displayed in the UI.
@@ -36,6 +35,6 @@ class ErrorBus {
      * Drops the error silently if the buffer is full (unlikely with 16 slots).
      */
     fun emit(error: AppError) {
-        _errors.tryEmit(error)
+        errors.tryEmit(error)
     }
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoUnderscoreBackingFieldRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoUnderscoreBackingFieldRule.kt
@@ -24,13 +24,15 @@ class NoUnderscoreBackingFieldRule :
         test(
             "no production class uses the underscore Mutable(StateFlow|SharedFlow) backing pattern; use explicit `field =`",
         ) {
+            // The explicit-backing-field idiom is canonical across the client KMP modules: the 2a
+            // sweep covered :sharedLogic; :sharedUI and :contract are folded in here. :server is a
+            // separate (Kotlin/Native) track with its own conventions and stays out of scope.
+            val inScope = listOf("/sharedLogic/", "/sharedUI/", "/contract/")
             val offenders =
                 Konsist
                     .scopeFromProduction()
                     .classes()
-                    // Scoped to :sharedLogic (the elevation target, like the sibling rules).
-                    // sharedUI / contract / server carry the pattern too but were out of the 2a sweep.
-                    .filter { it.path.contains("/sharedLogic/") }
+                    .filter { cls -> inScope.any { cls.path.contains(it) } }
                     .filter { underscoreBacking.containsMatchIn(it.text) }
                     .filterNot { it.name in allowed }
                     .map { it.name }

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlaybackController.kt
@@ -2,7 +2,6 @@ package com.calypsan.listenup.client.playback
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Desktop implementation of [PlaybackController]. Wraps the existing shared [AudioPlayer]
@@ -18,8 +17,8 @@ class DesktopPlaybackController(
     private val audioPlayer: AudioPlayer,
     private val playbackManager: PlaybackManager,
 ) : PlaybackController {
-    private val _isReady = MutableStateFlow(true)
-    override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+    override val isReady: StateFlow<Boolean>
+        field = MutableStateFlow(true)
 
     override fun acquire() = Unit
 

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/FfmpegAudioPlayer.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/FfmpegAudioPlayer.kt
@@ -38,14 +38,14 @@ class FfmpegAudioPlayer(
     private val tokenProvider: AudioTokenProvider,
     private val scope: CoroutineScope,
 ) : AudioPlayer {
-    private val _state = MutableStateFlow<PlaybackState>(PlaybackState.Idle)
-    override val state: StateFlow<PlaybackState> = _state
+    override val state: StateFlow<PlaybackState>
+        field = MutableStateFlow<PlaybackState>(PlaybackState.Idle)
 
-    private val _positionMs = MutableStateFlow(0L)
-    override val positionMs: StateFlow<Long> = _positionMs
+    override val positionMs: StateFlow<Long>
+        field = MutableStateFlow(0L)
 
-    private val _durationMs = MutableStateFlow(0L)
-    override val durationMs: StateFlow<Long> = _durationMs
+    override val durationMs: StateFlow<Long>
+        field = MutableStateFlow(0L)
 
     private var grabber: FFmpegFrameGrabber? = null
     private var filter: FFmpegFrameFilter? = null
@@ -64,7 +64,7 @@ class FfmpegAudioPlayer(
     override suspend fun load(segments: List<AudioSegment>) {
         if (segments.isEmpty()) {
             logger.error { "Cannot load empty segment list" }
-            _state.value = PlaybackState.Error(message = "Playback error. No audio segments were provided.")
+            state.value = PlaybackState.Error(message = "Playback error. No audio segments were provided.")
             return
         }
 
@@ -72,14 +72,14 @@ class FfmpegAudioPlayer(
         currentSegmentIndex = 0
         hasStartedPlaying = false
         pendingSeekMs = null
-        _durationMs.value = segments.sumOf { it.durationMs }
-        _state.value = PlaybackState.Buffering
+        durationMs.value = segments.sumOf { it.durationMs }
+        state.value = PlaybackState.Buffering
 
-        logger.info { "Loaded ${segments.size} segments, total duration: ${_durationMs.value}ms" }
+        logger.info { "Loaded ${segments.size} segments, total duration: ${durationMs.value}ms" }
     }
 
     override fun play() {
-        if (hasStartedPlaying && _state.value == PlaybackState.Paused) {
+        if (hasStartedPlaying && state.value == PlaybackState.Paused) {
             resumePlayback()
         } else {
             startSegment(currentSegmentIndex)
@@ -93,24 +93,24 @@ class FfmpegAudioPlayer(
         // Sync grabber to the last reported position (discard decoded-but-unplayed audio)
         val segment = segments.getOrNull(currentSegmentIndex)
         if (segment != null && grabber != null) {
-            val segmentOffset = _positionMs.value - segment.offsetMs
+            val segmentOffset = positionMs.value - segment.offsetMs
             grabber?.timestamp = segmentOffset * 1000
         }
-        _state.value = PlaybackState.Paused
+        state.value = PlaybackState.Paused
     }
 
     override fun seekTo(positionMs: Long) {
-        val coercedPosition = positionMs.coerceIn(0, _durationMs.value)
+        val coercedPosition = positionMs.coerceIn(0, durationMs.value)
         val (segmentIndex, segmentOffset) = resolvePosition(coercedPosition)
 
         if (!hasStartedPlaying) {
             currentSegmentIndex = segmentIndex
             pendingSeekMs = coercedPosition
-            _positionMs.value = coercedPosition
+            this.positionMs.value = coercedPosition
             return
         }
 
-        val wasPlaying = _state.value == PlaybackState.Playing
+        val wasPlaying = state.value == PlaybackState.Playing
         stopDecodeLoop()
         audioLine?.flush()
 
@@ -122,7 +122,7 @@ class FfmpegAudioPlayer(
 
         // Seek within the current segment (microseconds)
         grabber?.timestamp = segmentOffset * 1000
-        _positionMs.value = coercedPosition
+        this.positionMs.value = coercedPosition
 
         if (wasPlaying) {
             startDecodeLoop()
@@ -131,7 +131,7 @@ class FfmpegAudioPlayer(
 
     override fun setSpeed(speed: Float) {
         currentSpeed = speed
-        if (hasStartedPlaying && _state.value == PlaybackState.Playing) {
+        if (hasStartedPlaying && state.value == PlaybackState.Playing) {
             val wasPlaying = true
             stopDecodeLoop()
             rebuildFilter(speed)
@@ -151,9 +151,9 @@ class FfmpegAudioPlayer(
         hasStartedPlaying = false
         pendingSeekMs = null
         currentSpeed = 1.0f
-        _state.value = PlaybackState.Idle
-        _positionMs.value = 0L
-        _durationMs.value = 0L
+        state.value = PlaybackState.Idle
+        positionMs.value = 0L
+        durationMs.value = 0L
         logger.info { "FfmpegAudioPlayer released" }
     }
 
@@ -164,7 +164,7 @@ class FfmpegAudioPlayer(
         val segment = segments.getOrNull(index)
         if (segment == null) {
             logger.error { "Invalid segment index: $index" }
-            _state.value = PlaybackState.Error(message = "Playback error. Segment index $index is out of range.")
+            state.value = PlaybackState.Error(message = "Playback error. Segment index $index is out of range.")
             return
         }
 
@@ -199,7 +199,7 @@ class FfmpegAudioPlayer(
                 logger.error { "Invalid audio format: sampleRate=$sampleRate, channels=$channels" }
                 newGrabber.stop()
                 newGrabber.release()
-                _state.value =
+                state.value =
                     PlaybackState.Error(
                         message = "Playback error. Audio stream has invalid format (${sampleRate}Hz, ${channels}ch).",
                     )
@@ -247,7 +247,7 @@ class FfmpegAudioPlayer(
             throw e
         } catch (e: Exception) {
             logger.error(e) { "Failed to open segment $index" }
-            _state.value = PlaybackState.Error(message = "Playback failed: ${e.message}")
+            state.value = PlaybackState.Error(message = "Playback failed: ${e.message}")
         }
     }
 
@@ -289,10 +289,10 @@ class FfmpegAudioPlayer(
         currentSegmentIndex = index
         openSegment(index)
 
-        if (_state.value is PlaybackState.Error) return
+        if (state.value is PlaybackState.Error) return
 
         hasStartedPlaying = true
-        _state.value = PlaybackState.Playing
+        state.value = PlaybackState.Playing
         startDecodeLoop()
     }
 
@@ -301,7 +301,7 @@ class FfmpegAudioPlayer(
      */
     private fun resumePlayback() {
         audioLine?.start()
-        _state.value = PlaybackState.Playing
+        state.value = PlaybackState.Playing
         startDecodeLoop()
     }
 
@@ -320,7 +320,7 @@ class FfmpegAudioPlayer(
                 } catch (e: Exception) {
                     if (isActive) {
                         logger.error(e) { "Decode loop error" }
-                        _state.value = PlaybackState.Error(message = "Playback failed: ${e.message}")
+                        state.value = PlaybackState.Error(message = "Playback failed: ${e.message}")
                     }
                 }
             }
@@ -354,7 +354,7 @@ class FfmpegAudioPlayer(
             // Update book-relative position
             val positionInSegmentMs = currentGrabber.timestamp / 1000
             val bookPosition = segment.offsetMs + positionInSegmentMs
-            _positionMs.value = bookPosition.coerceAtMost(_durationMs.value)
+            positionMs.value = bookPosition.coerceAtMost(durationMs.value)
         }
 
         // End of segment reached naturally
@@ -379,8 +379,8 @@ class FfmpegAudioPlayer(
             startSegment(nextIndex)
         } else {
             logger.info { "All segments finished" }
-            _positionMs.value = _durationMs.value
-            _state.value = PlaybackState.Ended
+            positionMs.value = durationMs.value
+            state.value = PlaybackState.Ended
             audioLine?.drain()
         }
     }


### PR DESCRIPTION
## What

Finish the explicit-backing-field migration repo-wide. Phase 2a (#783) converted the 22 `:sharedLogic` offenders; this folds in the last 3 production offenders outside that module and widens the guard so they can't regress.

- **`:contract` — `ErrorBus`**: `private val _errors = MutableSharedFlow(...)` + `val errors = _errors` → `val errors: SharedFlow<AppError> field = MutableSharedFlow(...)`.
- **`:sharedUI` (desktop) — `DesktopPlaybackController`**: `_isReady` → explicit `field`; drops the now-unused `asStateFlow` import.
- **`:sharedUI` (desktop) — `FfmpegAudioPlayer`**: `_state` / `_positionMs` / `_durationMs` → explicit `field`. The `seekTo(positionMs: Long)` parameter shadows the new `positionMs` property, so the two writes inside `seekTo` are qualified `this.positionMs.value = …`; every other reference is the bare property.
- **`NoUnderscoreBackingFieldRule`**: scope widened from `/sharedLogic/`-only to the three client-elevation modules (`:sharedLogic`, `:sharedUI`, `:contract`). `:server` stays out (separate Kotlin/Native track) and is offender-free anyway.

## Why

One canonical shape for mutable-flow state, repo-wide. Explicit backing fields are Stable as of Kotlin 2.4.0; the underscore + `asStateFlow()` dual-property pattern is the legacy form. This kills the last of the two-pattern tax on the client surface and arms the Konsist guard across every module where the idiom applies.

## Verification

Red→green: widening the rule first flagged exactly `["ErrorBus", "DesktopPlaybackController", "FfmpegAudioPlayer"]`; converting them turned it green. Full Linux gate green locally: `spotlessKotlinCheck` + `detekt`, `:sharedLogic:jvmTest` (the widened rule), `:sharedUI:compileKotlinDesktop` (the desktop conversions — this is what proves the `seekTo` shadow is resolved), `:androidApp:assembleDebug`, `:server:jvmTest`. iOS verified on CI.

Pure refactor — no behavior change; public flow APIs are byte-for-byte identical.
