### PR TITLE
Fix swallowed CancellationException in sync, startup, and networking

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -17,6 +17,8 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import io.ktor.client.call.HttpClientCall
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import io.ktor.http.contentType
@@ -325,36 +327,55 @@ internal class KtorApiClientFactory(
                 request.url.port = parsed.port
             }
 
-            try {
-                execute(request)
-            } catch (cause: Exception) {
-                if (isNetworkError(cause)) {
-                    // Try fallback URL
-                    val fallbackUrl = serverConfig.switchToFallbackUrl()
-                    if (fallbackUrl != null) {
-                        logger.info { "Network error, retrying with fallback URL: ${fallbackUrl.value}" }
-                        val parsed = Url(fallbackUrl.value)
-                        request.url.protocol = parsed.protocol
-                        request.url.host = parsed.host
-                        request.url.port = parsed.port
-                        try {
-                            execute(request)
-                        } catch (retryError: Exception) {
-                            // Fallback also failed, preserve both errors
-                            cause.addSuppressed(retryError)
-                            throw cause
-                        }
-                    } else {
-                        throw cause
-                    }
-                } else {
-                    throw cause
-                }
-            }
+            executeWithFallback(request) { execute(it) }
         }
 
         return client
     }
+
+    /**
+     * Execute [request], retrying once against the fallback URL on a network error.
+     */
+    internal suspend fun executeWithFallback(
+        request: HttpRequestBuilder,
+        execute: suspend (HttpRequestBuilder) -> HttpClientCall,
+    ): HttpClientCall {
+        // Guard clauses keep this flat: a cancelled or non-network failure propagates immediately;
+        // only a network error falls through to the single fallback retry below.
+        val cause =
+            try {
+                return execute(request)
+            } catch (e: Exception) {
+                if (e is CancellationException || !isNetworkError(e)) throw e
+                e
+            }
+
+        val fallbackUrl = serverConfig.switchToFallbackUrl() ?: throw cause
+        logger.info { "Network error, retrying with fallback URL: ${fallbackUrl.value}" }
+        val parsed = Url(fallbackUrl.value)
+        request.url.protocol = parsed.protocol
+        request.url.host = parsed.host
+        request.url.port = parsed.port
+
+        return retryAgainstFallback(request, cause, execute)
+    }
+
+    /**
+     * Retry [request] against the already-applied fallback URL. A cancelled retry propagates; any
+     * other failure surfaces the [original] network error with the retry error suppressed.
+     */
+    private suspend fun retryAgainstFallback(
+        request: HttpRequestBuilder,
+        original: Exception,
+        execute: suspend (HttpRequestBuilder) -> HttpClientCall,
+    ): HttpClientCall =
+        try {
+            execute(request)
+        } catch (retryError: Exception) {
+            if (retryError is CancellationException) throw retryError
+            original.addSuppressed(retryError)
+            throw original
+        }
 
     /**
      * Check if an exception is a network/connection error (not an HTTP error).

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorker.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorker.kt
@@ -6,10 +6,12 @@ import com.calypsan.listenup.client.data.local.db.CoverDownloadDao
 import com.calypsan.listenup.client.data.local.db.CoverDownloadStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 import com.calypsan.listenup.client.core.Failure
 
 private val logger = KotlinLogging.logger {}
@@ -114,8 +116,12 @@ internal class CoverDownloadWorker(
                             }
                         }
                     } catch (e: CancellationException) {
-                        // App is backgrounding — mark task back to pending so it resumes later
-                        coverDownloadDao.updateStatus(task.bookId, CoverDownloadStatus.PENDING)
+                        // App is backgrounding — mark task back to pending so it resumes later. The
+                        // scope is already cancelled, so the write must run under NonCancellable or
+                        // it would be skipped, stranding the task as IN_PROGRESS.
+                        withContext(NonCancellable) {
+                            coverDownloadDao.updateStatus(task.bookId, CoverDownloadStatus.PENDING)
+                        }
                         throw e
                     } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                         throw e

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.dto.SetupStatus
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.getOrDefault
 import com.calypsan.listenup.api.result.onFailure
 import com.calypsan.listenup.core.currentEpochMilliseconds
+import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.remote.LibraryAdminRpcFactory
 import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -277,7 +279,9 @@ class AppStartupViewModel(
      * genuinely no cached library to fall back to (fresh admin, first startup offline).
      */
     private suspend fun resolveOfflineOrFail() {
-        val hasLocal = runCatching { syncRepository.hasLocalLibrary() }.getOrDefault(false)
+        // suspendRunCatching (unlike stdlib runCatching) re-throws CancellationException, so a
+        // cancelled probe propagates instead of being mistaken for "no local library".
+        val hasLocal = suspendRunCatching { syncRepository.hasLocalLibrary() }.getOrDefault { false }
         if (hasLocal) {
             logger.info { "library check failed but a local library exists — opening offline" }
             state.value =

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactoryFallbackTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactoryFallbackTest.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.ServerUrl
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.url
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+
+class ApiClientFactoryFallbackTest :
+    FunSpec({
+        test("executeWithFallback re-throws CancellationException from the fallback retry, not the original error") {
+            runTest {
+                val serverConfig = mock<ServerConfig>()
+                everySuspend { serverConfig.switchToFallbackUrl() } returns ServerUrl("https://fallback.example.com")
+                val factory = KtorApiClientFactory(serverConfig, mock<AuthSession>(), { error("token refresh not used") })
+
+                var attempts = 0
+                val request = HttpRequestBuilder().apply { url("https://primary.example.com/api") }
+
+                // A network error on the primary triggers the fallback; the fallback is then cancelled.
+                // The cancellation must propagate, not be swallowed as the original network error.
+                shouldThrow<CancellationException> {
+                    factory.executeWithFallback(request) {
+                        attempts++
+                        if (attempts == 1) throw IOException("primary unreachable")
+                        throw CancellationException("fallback cancelled")
+                    }
+                }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorkerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorkerTest.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.CoverDownloadDao
 import com.calypsan.listenup.client.data.local.db.CoverDownloadStatus
 import com.calypsan.listenup.client.data.local.db.CoverDownloadTaskEntity
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.every
@@ -16,9 +17,14 @@ import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CoverDownloadWorkerTest :
@@ -63,6 +69,37 @@ class CoverDownloadWorkerTest :
                     verifySuspend { dao.markInProgress(task.bookId) }
                     verifySuspend { dao.markCompleted(task.bookId, any()) }
                 }
+            }
+        }
+
+        test("cancellation mid-download re-queues the task to PENDING despite the cancelled scope") {
+            runTest {
+                val dao: CoverDownloadDao = mock()
+                val downloader: ImageDownloaderContract = mock()
+                val task = createTask("a")
+
+                everySuspend { dao.getNextBatch(limit = any(), maxRetries = any()) } returns listOf(task)
+                everySuspend { dao.markInProgress(any()) } returns Unit
+                every { dao.observeRemainingCount() } returns flowOf(0)
+                every { dao.observeCompletedCount() } returns flowOf(0)
+                every { dao.observeTotalCount() } returns flowOf(0)
+                // Hang the download so the worker can be cancelled mid-flight.
+                everySuspend { downloader.downloadCover(any()) } calls { awaitCancellation() }
+                // The re-queue write must survive cancellation. yield() is a real suspension point:
+                // under the cancelled worker scope it throws (flag stays false); shielded by
+                // NonCancellable it does not (flag flips). So the flag proves the write actually ran.
+                var requeued = false
+                everySuspend { dao.updateStatus(any(), any()) } calls {
+                    yield()
+                    requeued = true
+                }
+
+                val worker = CoverDownloadWorker(dao, downloader)
+                val job = launch { worker.processQueue() }
+                advanceUntilIdle() // let the worker reach the hung download
+                job.cancelAndJoin() // cancel mid-download
+
+                requeued shouldBe true
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -15,12 +15,14 @@ import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.api.result.AppResult as CoreAppResult
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -306,6 +308,31 @@ class AppStartupViewModelTest :
                 viewModel.state.value.isChecking shouldBe false
                 viewModel.state.value.setupCheckFailed shouldBe true
                 viewModel.state.value.needsLibrarySetup shouldBe false
+            }
+        }
+
+        test("setup-check failure does NOT swallow CancellationException into setupCheckFailed") {
+            runTest {
+                // Given - admin user, setup-status fails, and the local-library probe is cancelled
+                // mid-flight (the coroutine scope is being torn down).
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } returns
+                    AppResult.Failure(TransportError.NetworkUnavailable())
+                val sync = createMockSyncRepository()
+                everySuspend { sync.hasLocalLibrary() } throws CancellationException("scope cancelled")
+
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), createNoOpProfileRepository(), sync)
+                advanceUntilIdle()
+
+                // Then - cancellation must propagate, not be mistaken for "no local library" and
+                // surfaced as the retryable-error wall.
+                viewModel.state.value.setupCheckFailed shouldBe false
             }
         }
 


### PR DESCRIPTION
## What

Fix three places that swallow `CancellationException`, surfaced by running detekt's `coroutines` ruleset *with type resolution* (those rules are configured `active` but currently inert — see notes). Each is a "honest over silent" violation in the offline-first core, and none was caught by the compiler, Konsist, or review.

- **`AppStartupViewModel`** — the offline-fallback probe wrapped a suspend call in stdlib `runCatching { syncRepository.hasLocalLibrary() }`, which swallows cancellation and mistakes a torn-down scope for "no local library" (surfacing the retryable-error wall). Now uses the codebase's `suspendRunCatching`, which re-throws `CancellationException`.
- **`CoverDownloadWorker`** — on cancellation the worker re-queues the task to `PENDING` via a suspend DAO write *inside* the `catch (CancellationException)`. The scope is already cancelled, so that write was silently skipped, stranding the task as `IN_PROGRESS`. Now wrapped in `withContext(NonCancellable)`.
- **`ApiClientFactory`** — the URL-fallback retry caught `Exception` (incl. `CancellationException`) and threw the *original* network error, dropping a cancelled fallback request. Both catch sites now re-throw `CancellationException` first. The fallback logic was extracted into a testable `executeWithFallback` seam (the inline `HttpSend` interceptor couldn't be unit-tested).

## Tests

Each fix is TDD'd red→green:
- `AppStartupViewModelTest` — a cancelled `hasLocalLibrary()` must not become `setupCheckFailed`.
- `CoverDownloadWorkerTest` — cancelling mid-download still re-queues the task to `PENDING` (the fake DAO hits a real suspension point to prove the write actually ran under `NonCancellable`).
- `ApiClientFactoryFallbackTest` — a cancelled fallback retry propagates `CancellationException`, not the original network error.

Full Linux gate green: `spotlessCheck` + `detekt`, `:sharedLogic:jvmTest`, `:server:jvmTest`, `:androidApp:assembleDebug`. iOS on CI.

## Notes

- These were found by a throwaway spike that ran detekt with type resolution. detekt currently runs syntactic-only, so its whole `coroutines` ruleset (which would catch this class of bug) is inert. Wiring TR on permanently is a separate, deferred decision (it's alpha; `InjectDispatcher` is noisy on DI roots) — this PR just harvests the real bugs the spike found.
- Pre-existing dead code left untouched (surgical): `CoverDownloadWorker` has a second, unreachable `catch (kotlin.coroutines.cancellation.CancellationException)` right after the one fixed here (`kotlinx.coroutines.CancellationException` is a typealias for it). Worth a follow-up cleanup.
