### PR TITLE
🐛 fix(shared): re-throw swallowed CancellationException in playback, shortcuts, network monitor

### DIFF
--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadWorker.kt
@@ -10,11 +10,9 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.onFailure
 import com.calypsan.listenup.api.error.DownloadError
 import com.calypsan.listenup.core.error.ErrorBus
-import com.calypsan.listenup.client.domain.model.DownloadStatus
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
-import kotlinx.io.files.SystemFileSystem
 
 private val logger = KotlinLogging.logger {}
 
@@ -70,11 +68,10 @@ class DownloadWorker(
             }
         } catch (e: CancellationException) {
             logger.info { "Download cancelled: $audioFileId" }
-            downloadRepository
-                .markPaused(audioFileId)
-                .onFailure { logger.warn { "Failed to persist paused state on cancel: $audioFileId" } }
-            deleteTempIfCancelled(audioFileId, bookId, filename)
-            Result.failure()
+            // Persist the pause + temp cleanup under NonCancellable (the scope is already being
+            // cancelled here), then re-throw so the worker is recorded as cancelled, not failed.
+            persistDownloadCancellation(downloadRepository, fileManager, audioFileId, bookId, filename)
+            throw e
         }
     }
 
@@ -129,29 +126,6 @@ class DownloadWorker(
             Result.retry()
         } else {
             Result.failure()
-        }
-    }
-
-    // If the row was explicitly cancelled by the user (state = CANCELLED), delete the partial .tmp
-    // so it does not linger on disk. Network-paused downloads (state = PAUSED after markPaused)
-    // keep their .tmp for Range-resume.
-    // Note: cancelForBook() is called by DownloadManager after WorkManager.await(), so CANCELLED
-    // may not yet be written at this point. The startup sweep in resumeIncompleteDownloads is the
-    // durable catch-all; this path handles the cases where the state has already been written.
-    private suspend fun deleteTempIfCancelled(
-        audioFileId: String,
-        bookId: String,
-        filename: String,
-    ) {
-        val rowState = downloadRepository.getStateForAudioFile(audioFileId)
-        if (rowState != DownloadStatus.CANCELLED) return
-        val tempPath = fileManager.getAudioFilePath(bookId, audioFileId, filename, isTemp = true)
-        if (!SystemFileSystem.exists(tempPath)) return
-        try {
-            SystemFileSystem.delete(tempPath)
-            logger.info { "Deleted orphaned .tmp for cancelled download: $audioFileId" }
-        } catch (deleteEx: Exception) {
-            logger.warn(deleteEx) { "Failed to delete .tmp for cancelled download: $audioFileId" }
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadCancellation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadCancellation.kt
@@ -1,0 +1,58 @@
+package com.calypsan.listenup.client.download
+
+import com.calypsan.listenup.api.result.onFailure
+import com.calypsan.listenup.client.domain.model.DownloadStatus
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import kotlinx.io.files.SystemFileSystem
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Persists the outcome of a cancelled download: marks it paused, and removes the partial `.tmp`
+ * if the row has already been moved to CANCELLED.
+ *
+ * Extracted from [DownloadWorker]'s cancellation catch so it can be exercised without WorkManager.
+ *
+ * Runs under [NonCancellable] because it is invoked from a coroutine that is *already being
+ * cancelled* (the worker's cancellation catch). Without it the first suspending write
+ * ([DownloadRepository.markPaused]) aborts at its suspension point and the pause — plus any temp
+ * cleanup — is silently lost.
+ */
+internal suspend fun persistDownloadCancellation(
+    repository: DownloadRepository,
+    fileManager: DownloadFileManager,
+    audioFileId: String,
+    bookId: String,
+    filename: String,
+) = withContext(NonCancellable) {
+    repository
+        .markPaused(audioFileId)
+        .onFailure { logger.warn { "Failed to persist paused state on cancel: $audioFileId" } }
+    deleteTempIfCancelled(repository, fileManager, audioFileId, bookId, filename)
+}
+
+// If the row was explicitly cancelled by the user (state = CANCELLED), delete the partial .tmp so it
+// does not linger. Network-paused downloads (state = PAUSED after markPaused) keep their .tmp for
+// Range-resume. cancelForBook() runs after WorkManager.await(), so CANCELLED may not yet be written
+// here; the startup sweep in resumeIncompleteDownloads is the durable catch-all.
+private suspend fun deleteTempIfCancelled(
+    repository: DownloadRepository,
+    fileManager: DownloadFileManager,
+    audioFileId: String,
+    bookId: String,
+    filename: String,
+) {
+    val rowState = repository.getStateForAudioFile(audioFileId)
+    if (rowState != DownloadStatus.CANCELLED) return
+    val tempPath = fileManager.getAudioFilePath(bookId, audioFileId, filename, isTemp = true)
+    if (!SystemFileSystem.exists(tempPath)) return
+    try {
+        SystemFileSystem.delete(tempPath)
+        logger.info { "Deleted orphaned .tmp for cancelled download: $audioFileId" }
+    } catch (deleteEx: Exception) {
+        logger.warn(deleteEx) { "Failed to delete .tmp for cancelled download: $audioFileId" }
+    }
+}

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/repository/JvmNetworkMonitor.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/repository/JvmNetworkMonitor.kt
@@ -8,6 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.request.get
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -20,6 +21,18 @@ private val logger = KotlinLogging.logger {}
 
 private const val HEALTH_CHECK_INTERVAL_MS = 30_000L
 private const val HEALTH_CHECK_TIMEOUT_MS = 5_000L
+
+private fun createHealthCheckClient(): HttpClient =
+    HttpClient(OkHttp) {
+        installListenUpErrorHandling()
+
+        engine {
+            config {
+                connectTimeout(HEALTH_CHECK_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+                readTimeout(HEALTH_CHECK_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+            }
+        }
+    }
 
 /**
  * JVM desktop implementation of [NetworkMonitor] using health check polling.
@@ -37,19 +50,9 @@ private const val HEALTH_CHECK_TIMEOUT_MS = 5_000L
  */
 class JvmNetworkMonitor(
     private val serverUrlProvider: () -> String?,
+    private val httpClient: HttpClient = createHealthCheckClient(),
 ) : NetworkMonitor {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO + appCoroutineExceptionHandler)
-    private val httpClient =
-        HttpClient(OkHttp) {
-            installListenUpErrorHandling()
-
-            engine {
-                config {
-                    connectTimeout(HEALTH_CHECK_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
-                    readTimeout(HEALTH_CHECK_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
-                }
-            }
-        }
 
     override val isOnlineFlow: StateFlow<Boolean>
         field = MutableStateFlow(true) // Optimistic default
@@ -64,6 +67,9 @@ class JvmNetworkMonitor(
 
     override fun isOnline(): Boolean = isOnlineFlow.value
 
+    // checkHealth is widened from private to internal solely so the cancellation contract
+    // can be exercised directly in jvmTest (the polling loop is otherwise unobservable).
+
     private fun startHealthCheckLoop() {
         scope.launch {
             while (true) {
@@ -73,7 +79,7 @@ class JvmNetworkMonitor(
         }
     }
 
-    private suspend fun checkHealth() {
+    internal suspend fun checkHealth() {
         val serverUrl = serverUrlProvider()
 
         if (serverUrl == null) {
@@ -86,6 +92,8 @@ class JvmNetworkMonitor(
             try {
                 val response = httpClient.get("$serverUrl/healthz")
                 response.status.isSuccess()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logger.debug(e) { "Health check failed for $serverUrl" }
                 false

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/JvmNetworkMonitorTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/JvmNetworkMonitorTest.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.client.data.repository
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
+
+/**
+ * Regression coverage for the health-check cancellation contract on [JvmNetworkMonitor].
+ *
+ * The polling loop runs suspending HTTP calls; the per-check `try`/`catch` must obey the
+ * Error Model rubric — re-throw [CancellationException] so a cancelled poll propagates
+ * instead of being misreported as "server unreachable". Other failures (timeouts, refused
+ * connections) are the legitimate offline signal and stay swallowed.
+ */
+class JvmNetworkMonitorTest :
+    FunSpec({
+
+        test("checkHealth re-throws CancellationException instead of reporting offline") {
+            val monitor =
+                JvmNetworkMonitor(
+                    serverUrlProvider = { "http://localhost:1" },
+                    httpClient = HttpClient(MockEngine { throw CancellationException("poll cancelled mid-flight") }),
+                )
+
+            shouldThrow<CancellationException> { monitor.checkHealth() }
+        }
+
+        test("checkHealth swallows a genuine connection failure and reports offline") {
+            val monitor =
+                JvmNetworkMonitor(
+                    serverUrlProvider = { "http://localhost:1" },
+                    httpClient = HttpClient(MockEngine { throw IOException("connection refused") }),
+                )
+
+            monitor.checkHealth() // must NOT throw — a failed reachability check is normal
+            monitor.isOnline() shouldBe false
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadCancellationTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadCancellationTest.kt
@@ -9,6 +9,7 @@ import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
@@ -28,6 +29,7 @@ import java.io.File
  *
  * Per project memory `feedback_fakes_for_seams.md`: hand-rolled fakes, not mokkery.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class DownloadCancellationTest :
     FunSpec({
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadCancellationTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadCancellationTest.kt
@@ -1,0 +1,124 @@
+package com.calypsan.listenup.client.download
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.DownloadEntity
+import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.data.local.images.StoragePaths
+import com.calypsan.listenup.client.data.repository.FakeDownloadRepository
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.write
+import java.io.File
+
+/**
+ * Contract tests for [persistDownloadCancellation], the cancellation-cleanup seam extracted from
+ * [DownloadWorker.doWork]'s catch block so it can be exercised without WorkManager.
+ *
+ * Per project memory `feedback_fakes_for_seams.md`: hand-rolled fakes, not mokkery.
+ */
+class DownloadCancellationTest :
+    FunSpec({
+
+        fun entity(
+            audioFileId: String,
+            state: DownloadState,
+        ) = DownloadEntity(
+            audioFileId = audioFileId,
+            bookId = "book-1",
+            filename = "$audioFileId.mp3",
+            fileIndex = 0,
+            state = state,
+            localPath = null,
+            totalBytes = 1000L,
+            downloadedBytes = 0L,
+            queuedAt = 0L,
+            startedAt = null,
+            completedAt = null,
+            errorMessage = null,
+            retryCount = 0,
+        )
+
+        fun fileManagerFor(tmpRoot: File): DownloadFileManager =
+            DownloadFileManager(
+                storagePaths =
+                    object : StoragePaths {
+                        override val filesDir: Path = Path(tmpRoot.absolutePath)
+                    },
+            )
+
+        fun tempDir(): File = File(System.getProperty("java.io.tmpdir"), "dwct-${System.nanoTime()}").apply { mkdirs() }
+
+        // The cleanup runs inside an already-cancelled coroutine (the worker's cancellation catch).
+        // NonCancellable lets the pause write complete even though the scope is being cancelled —
+        // without it, markPaused aborts at its suspension point (modelled by the fake's ensureActive)
+        // and the pause is silently lost.
+        test("cancel cleanup persists PAUSED even when invoked from a cancelled coroutine") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val repo =
+                        object : FakeDownloadRepository(
+                            initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)),
+                        ) {
+                            override suspend fun markPaused(audioFileId: String): AppResult<Unit> {
+                                // Model the real Room-backed write: it observes cancellation here.
+                                currentCoroutineContext().ensureActive()
+                                return super.markPaused(audioFileId)
+                            }
+                        }
+                    val fileManager = fileManagerFor(tmpRoot)
+
+                    val job =
+                        launch {
+                            try {
+                                awaitCancellation()
+                            } catch (e: CancellationException) {
+                                persistDownloadCancellation(repo, fileManager, "file-1", "book-1", "file-1.mp3")
+                                throw e
+                            }
+                        }
+                    advanceUntilIdle()
+                    job.cancelAndJoin()
+
+                    repo.entities.single().state shouldBe DownloadState.PAUSED
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+
+        // A network-paused download (state PAUSED, not CANCELLED) keeps its partial .tmp for
+        // Range-resume; the cleanup must not delete it. Guards the extraction's temp-handling branch.
+        test("cancel cleanup keeps the partial .tmp for a paused (non-cancelled) download") {
+            runTest {
+                val tmpRoot = tempDir()
+                try {
+                    val repo = FakeDownloadRepository(initial = listOf(entity("file-1", state = DownloadState.DOWNLOADING)))
+                    val fileManager = fileManagerFor(tmpRoot)
+                    val tempPath = fileManager.getAudioFilePath("book-1", "file-1", "file-1.mp3", isTemp = true)
+                    SystemFileSystem.sink(tempPath).buffered().use { sink -> sink.write(ByteArray(128) { 0x41 }) }
+
+                    persistDownloadCancellation(repo, fileManager, "file-1", "book-1", "file-1.mp3")
+
+                    repo.entities.single().state shouldBe DownloadState.PAUSED
+                    withClue("paused download must keep its .tmp for Range-resume") {
+                        SystemFileSystem.exists(tempPath) shouldBe true
+                    }
+                } finally {
+                    tmpRoot.deleteRecursively()
+                }
+            }
+        }
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/shortcuts/ListenUpShortcutManagerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/shortcuts/ListenUpShortcutManagerTest.kt
@@ -6,12 +6,15 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
 import com.calypsan.listenup.client.domain.model.ContinueListeningItem
 import com.calypsan.listenup.client.domain.repository.HomeRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -47,6 +50,26 @@ class ListenUpShortcutManagerTest {
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
     }
+
+    // ──────────────────────────── cancellation contract ────────────────────────────
+
+    @Test
+    fun `updateShortcutsInternal re-throws CancellationException instead of swallowing it`() =
+        runTest {
+            val cancellingManager =
+                ListenUpShortcutManager(
+                    context = RuntimeEnvironment.getApplication(),
+                    homeRepository =
+                        object : HomeRepository {
+                            override suspend fun getContinueListening(limit: Int): AppResult<List<ContinueListeningBook>> = throw CancellationException("shortcut refresh cancelled")
+
+                            override fun observeContinueListening(limit: Int): Flow<List<ContinueListeningItem>> = flowOf(emptyList())
+                        },
+                    scope = CoroutineScope(Dispatchers.Unconfined),
+                )
+
+            shouldThrow<CancellationException> { cancellingManager.updateShortcutsInternal() }
+        }
 
     // ───────────────────────────── calculateSampleSize ──────────────────────────────
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -662,6 +663,8 @@ class PlaybackService : MediaLibraryService() {
                     try {
                         val children = browseTreeProvider.getChildren(parentId)
                         completer.set(LibraryResult.ofItemList(ImmutableList.copyOf(children), params))
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         logger.error(e) { "Failed to get children for $parentId" }
                         completer.set(LibraryResult.ofError(LibraryResult.RESULT_ERROR_UNKNOWN))
@@ -687,6 +690,8 @@ class PlaybackService : MediaLibraryService() {
                         } else {
                             completer.set(LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE))
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         logger.error(e) { "Failed to get item $mediaId" }
                         completer.set(LibraryResult.ofError(LibraryResult.RESULT_ERROR_UNKNOWN))
@@ -800,6 +805,8 @@ class PlaybackService : MediaLibraryService() {
 
                     // Notify that search results are ready
                     session.notifySearchResultChanged(browser, query, items.size, params)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logger.error(e) { "Search failed for query: $query" }
                     // Still notify with 0 results on error
@@ -920,6 +927,8 @@ class PlaybackService : MediaLibraryService() {
                         }
 
                         completer.set(resolvedItems)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         logger.error(e) { "Failed to resolve media items" }
                         completer.setException(e)
@@ -1095,6 +1104,8 @@ class PlaybackService : MediaLibraryService() {
                                 startPosition.positionInFileMs,
                             ),
                         )
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         logger.error(e) { "Playback resumption failed" }
                         completer.setException(e)

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/shortcuts/ListenUpShortcutManager.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/shortcuts/ListenUpShortcutManager.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -69,8 +70,12 @@ class ListenUpShortcutManager(
 
     /**
      * Internal implementation that runs on background thread.
+     *
+     * Widened from private to internal solely so the cancellation contract can be
+     * exercised directly in androidHostTest (the public [updateShortcuts] launches
+     * fire-and-forget, so its propagation is otherwise unobservable).
      */
-    private suspend fun updateShortcutsInternal() =
+    internal suspend fun updateShortcutsInternal() =
         withContext(Dispatchers.IO) {
             try {
                 // Get recent books from local database
@@ -95,6 +100,8 @@ class ListenUpShortcutManager(
                         // Don't clear existing shortcuts on failure - keep stale data
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logger.error(e) { "Error updating shortcuts" }
             }


### PR DESCRIPTION
## What

Re-throw `CancellationException` at the catch sites that were swallowing it, so a cancelled coroutine propagates instead of being misreported or silently no-oped:

- **`JvmNetworkMonitor.checkHealth`** (`:sharedLogic`) — a cancelled health poll no longer reports the server "offline".
- **`ListenUpShortcutManager.updateShortcutsInternal`** (`:sharedUI`) — a cancelled shortcut refresh propagates.
- **`PlaybackService` ×5** Media3 `MediaLibrarySession.Callback` wrappers: `onGetChildren`, `onGetItem`, `onSearch`, `onAddMediaItems`, `onPlaybackResumption`.
- **`DownloadWorker.doWork`** (`:sharedLogic`) — the cancellation cleanup (`markPaused` + temp `.tmp` removal) now runs under `NonCancellable` and the worker **re-throws** instead of returning `Result.failure()`. Previously the cleanup ran in the already-cancelled scope, so the suspend writes aborted at their first suspension point and the pause was silently lost; the worker was also recorded as **failed** rather than **cancelled**. Cleanup extracted to `persistDownloadCancellation` (commonMain) so it's testable without WorkManager.

The first four use the canonical `catch (e: CancellationException) { throw e }` clause (as in `ApiClientFactory` / #791).

## Why

These violate the Error Model rubric ("always re-throw `CancellationException`" / "honest over silent"). Found via a throwaway detekt `SuspendFunSwallowedCancellation` type-resolution spike across `:contract` / `:sharedLogic` / `:sharedUI` — a follow-up to #791 (sync / startup / networking).

## Tests (TDD)

- **`JvmNetworkMonitorTest`** (new) — `MockEngine` throws `CancellationException`, asserts `checkHealth` re-throws; guard test asserts a genuine connection failure is still swallowed → offline.
- **`ListenUpShortcutManagerTest`** (new case) — asserts `updateShortcutsInternal` re-throws on cancellation.
- **`DownloadCancellationTest`** (new) — asserts `persistDownloadCancellation` persists `PAUSED` even when invoked from an already-cancelled coroutine (the fake's `markPaused` models the real Room write observing cancellation), plus a guard that a paused download keeps its `.tmp` for Range-resume.
- **`PlaybackService` ×5** — no unit-test seam (the file's own `PlaybackServiceTest` documents that booting the `MediaLibraryService` is impractical; these callbacks are an accepted coverage gap). Verified by re-running the detekt rule (findings **5 → 0**) plus compile + existing `PlaybackServiceTest` / `ControllerGatingTest` staying green.

## Triage notes

- **False positives, left untouched** (they already re-throw; the rule trips on cleanup-before-rethrow): `AuthRepositoryImpl:74`, `NowPlayingScreen:87`.
- The spike's `InjectDispatcher` / `RedundantSuspendModifier` rules were noise for this codebase (dispatcher providers, DI wiring) and are **not** being adopted.

## Gate

Linux lane green for everything this PR touches: `spotlessCheck`, `detekt`, `:sharedUI:testAndroidHostTest`, `:androidApp:assembleDebug`, and the new tests. One **pre-existing** failure in untouched code, unrelated to this change: `LibraryViewModelTest > changed syncState produces a new uiState emission` — **fails identically on clean `main`** (verified by running it with this branch's changes stashed) and on CI ("2748 tests completed, 1 failed"). Tracked + fixed separately. iOS lane runs on CI.
