### PR TITLE
✅ test(shared): assert settled uiState.value in LibraryViewModel syncState test

### DIFF
--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -1090,14 +1090,12 @@ class LibraryViewModelTest :
 
         // ========== distinctUntilChanged / conflate smoke tests ==========
 
-        // Regression guard: verifies that an identical SyncSnapshot re-emission (same syncState,
-        // isServerScanning, scanProgress) does NOT cause the uiState pipeline to re-run a sort.
-        // We observe this indirectly: if re-emission propagated, a second Loaded state would appear
-        // in the flow; if distinctUntilChanged is working, the state remains unchanged after the
-        // duplicate emission.
-        // Regression guard: changing the sync state propagates to a new uiState emission,
-        // confirming the syncSnapshot pipeline is wired end-to-end.
-        test("changed syncState produces a new uiState emission") {
+        // Regression guard: a real SyncState change (Idle → Syncing) propagates end-to-end through
+        // the syncSnapshot → uiState pipeline. We assert on the settled uiState.value rather than
+        // counting emissions — conflate() makes intermediate emission counts non-deterministic, but
+        // the converged value is stable (mirroring the value-based assertion every other test here
+        // uses).
+        test("changed syncState propagates into uiState") {
             runTest {
                 // Given
                 val fixture = createFixture()
@@ -1105,21 +1103,17 @@ class LibraryViewModelTest :
                 every { fixture.syncRepository.syncState } returns syncStateFlow
 
                 val viewModel = fixture.build()
-                val emissions = mutableListOf<LibraryUiState>()
-                val job = backgroundScope.launch { viewModel.uiState.collect { emissions.add(it) } }
+                backgroundScope.launch { viewModel.uiState.collect { } }
                 advanceUntilIdle()
-
-                val countAfterFirstLoad = emissions.size
+                (viewModel.uiState.value as LibraryUiState.Loaded).syncState shouldBe SyncState.Idle
 
                 // When — emit a genuinely different SyncState
                 syncStateFlow.value = SyncState.Syncing
                 advanceUntilIdle()
 
-                // Then — a new Loaded state is produced reflecting the changed syncState
-                emissions.size shouldBe countAfterFirstLoad + 1
-                val loaded = emissions.last() as LibraryUiState.Loaded
+                // Then — the change is reflected in the settled uiState
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
                 loaded.syncState shouldBe SyncState.Syncing
-                job.cancel()
             }
         }
     })


### PR DESCRIPTION
## What

Rewrite the one assertion in `LibraryViewModelTest` that counted emissions to read the **settled `uiState.value`** instead — matching the pattern every other test in the file already uses.

## Why

`LibraryViewModelTest > changed syncState produces a new uiState emission` was **deterministically failing on `main`** (`expected:<Syncing> but was:<Idle>`), which red-lit the `Test (JVM)` CI job for every PR ("2748 tests completed, 1 failed").

It was the **only** test in the file asserting on `emissions.size` / `emissions.last()`. The `uiState` pipeline is `combine(...).conflate().flowOn(backgroundDispatcher)`, and `conflate()` makes the *count* and *ordering* of intermediate emissions non-deterministic under `runTest`'s virtual clock — so a later combine emission carrying the pre-change (`Idle`) snapshot could land last and be observed as `emissions.last()`. The production code is correct: the change **does** propagate; only the test was fragile.

The fix asserts the **converged** `uiState.value` reflects `Syncing` after the change (with a sanity check that it starts `Idle`). This preserves the regression-guard intent — a syncState change propagates end-to-end through `syncSnapshot → uiState` — while being robust to conflate timing, and is consistent with the 35 other `uiState.value`-based assertions in this file.

## Verification

- `:sharedLogic:jvmTest` now **fully green** (was 1 failed).
- `spotlessCheck` + `detekt` clean.
- Test-only change in `commonTest`; no production code touched.
