### PR TITLE
🐛 fix(server): scanner emitted absolute root_rel_path on root-level rescan

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileHelpers.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/FileHelpers.kt
@@ -40,7 +40,11 @@ internal fun createTempFileIn(
 internal fun Path.relativeTo(base: Path): String {
     val p = this.toString()
     val b = base.toString().trimEnd('/')
-    return if (p.startsWith("$b/")) p.removePrefix("$b/") else p
+    return when {
+        p == b -> ""
+        p.startsWith("$b/") -> p.removePrefix("$b/")
+        else -> p
+    }
 }
 
 /** True if [this] is [base] itself or nested under it (string-prefix on normalized paths). */

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/FileHelpersTest.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/FileHelpersTest.kt
@@ -21,4 +21,23 @@ class FileHelpersTest :
         test("isUnder is false for an unrelated path") {
             Path("/other/x").isUnder(Path("/lib/books")) shouldBe false
         }
+
+        test("relativeTo returns empty string when path equals base") {
+            Path("/mnt/lib").relativeTo(Path("/mnt/lib")) shouldBe ""
+        }
+        test("relativeTo treats a trailing slash on base as equal") {
+            Path("/mnt/lib").relativeTo(Path("/mnt/lib/")) shouldBe ""
+        }
+        test("relativeTo strips the base prefix for a direct child") {
+            Path("/mnt/lib/Author").relativeTo(Path("/mnt/lib")) shouldBe "Author"
+        }
+        test("relativeTo strips the base prefix for a deep child") {
+            Path("/mnt/lib/Author/Series/Book").relativeTo(Path("/mnt/lib")) shouldBe "Author/Series/Book"
+        }
+        test("relativeTo preserves special characters in the remainder") {
+            Path("/mnt/lib/John O'Donohue/Anam Cara").relativeTo(Path("/mnt/lib")) shouldBe "John O'Donohue/Anam Cara"
+        }
+        test("relativeTo does NOT strip a sibling that merely shares a name prefix") {
+            Path("/mnt/library2/Book").relativeTo(Path("/mnt/lib")) shouldBe "/mnt/library2/Book"
+        }
     })

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -440,6 +440,13 @@ class BookRepository(
         seriesIds: Map<String, SeriesId>?,
     ): AppResult<IngestOutcome> {
         val rootRelPath = analyzed.candidate.rootRelPath
+        // Defense-in-depth: the natural key is library-relative. An absolute path here means an
+        // upstream scanner bug leaked one (see FileHelpers.relativeTo / the 2026-06-25 regression);
+        // persisting it would miss findByPath on every rescan and mass-trip the inode "moved" branch.
+        // Fail loud and contained — BookPersister.persistOne logs and skips the offending book.
+        require(!rootRelPath.startsWith("/")) {
+            "rootRelPath must be library-relative, got absolute: $rootRelPath"
+        }
 
         // The three identity branches differ only in the resolved BookId and the wasNew flag; the
         // aggregate write (and its threaded pre-resolved id maps) is identical, so close over it once.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/FileIoTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/FileIoTest.kt
@@ -119,18 +119,4 @@ class FileIoTest :
 
             (first.toString() == second.toString()).shouldBeFalse()
         }
-
-        test("relativeTo strips the base prefix") {
-            val base = Path("/srv/library")
-            val child = Path("/srv/library/author/book/track.m4b")
-
-            child.relativeTo(base) shouldBe "author/book/track.m4b"
-        }
-
-        test("relativeTo returns self when not under base") {
-            val base = Path("/srv/library")
-            val outside = Path("/var/data/track.m4b")
-
-            outside.relativeTo(base) shouldBe "/var/data/track.m4b"
-        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerPathInvariantsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerPathInvariantsTest.kt
@@ -1,0 +1,208 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
+import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.testing.testLibrary
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+
+/**
+ * Behavioural invariants for the scanner's path handling. These encode the
+ * 2026-06-25 regression where a root-level incremental scan
+ * (`bookRoot == folderRoot`) rebased every book onto an ABSOLUTE
+ * `rootRelPath` — `FileHelpers.relativeTo` returned the absolute path instead
+ * of `""` for the equal-paths case. The unit test on `relativeTo`
+ * (`FileHelpersTest`) pins the helper; these prove the *mechanism* — a no-op
+ * add must never make the scanner treat every book as moved.
+ *
+ * The fixture deliberately spans depth, apostrophes/spaces, a multi-disc book,
+ * and a loose single file at the library root, so the assertions hold across
+ * the path shapes the corpus actually contains.
+ */
+class ScannerPathInvariantsTest :
+    FunSpec({
+
+        // --- Invariant A: no scan ever produces an absolute rootRelPath -------
+
+        test("full scan produces only library-relative rootRelPaths") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val (scanner, _) = newScanner(fixture)
+
+                    val result = scanner.runFullScan()
+
+                    result.absoluteRootRelPaths(fixture) shouldBe emptyList()
+                }
+            }
+        }
+
+        test("root-level incremental (bookRoot == folderRoot) produces only relative rootRelPaths") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val (scanner, _) = newScanner(fixture)
+
+                    // THE bug trigger: an incremental scan rooted at the library
+                    // folder itself. Pre-fix this rebased every book onto an
+                    // absolute path.
+                    scanner.runIncremental(Path(fixture.root.toString()))
+
+                    scanner.lastResult().shouldNotBeNull().absoluteRootRelPaths(fixture) shouldBe emptyList()
+                }
+            }
+        }
+
+        test("deep-subtree incremental produces only relative rootRelPaths") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val (scanner, _) = newScanner(fixture)
+
+                    val subtree = Path(fixture.root.resolve("Sanderson/Stormlight/The Way of Kings").toString())
+                    scanner.runIncremental(subtree)
+
+                    scanner.lastResult().shouldNotBeNull().absoluteRootRelPaths(fixture) shouldBe emptyList()
+                }
+            }
+        }
+
+        // --- Invariant B: re-scan is idempotent (the headline guard) ----------
+
+        test("a second full scan over an unchanged tree emits zero changes") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+                    scanner.runFullScan()
+                    eventBus.resetReplayCache()
+
+                    val result = scanner.runFullScan()
+
+                    withClue("an unchanged re-scan must produce no Added/Modified/Removed/Moved") {
+                        result.changes shouldBe emptyList()
+                        eventBus.replayCache.count { it is ScanEvent.Change } shouldBe 0
+                    }
+                }
+            }
+        }
+
+        test("a root-level incremental over an unchanged tree emits zero changes") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val (scanner, eventBus) = newScanner(fixture)
+                    scanner.runFullScan()
+                    eventBus.resetReplayCache()
+
+                    // Encodes the user's symptom directly: nothing changed, but a
+                    // root-rooted incremental made every book look moved.
+                    scanner.runIncremental(Path(fixture.root.toString()))
+
+                    withClue("a no-op root incremental must not report a single change") {
+                        eventBus.replayCache.count { it is ScanEvent.Change } shouldBe 0
+                    }
+                }
+            }
+        }
+
+        // --- Invariant C: incremental matches full ----------------------------
+
+        test("root-level incremental yields the same rootRelPath set as a full scan") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val full = newScanner(fixture).first.runFullScan()
+                    val fullPaths = full.books.map { it.candidate.rootRelPath }
+
+                    val (incremental, _) = newScanner(fixture)
+                    incremental.runIncremental(Path(fixture.root.toString()))
+                    val incrementalPaths =
+                        incremental
+                            .lastResult()
+                            .shouldNotBeNull()
+                            .books
+                            .map { it.candidate.rootRelPath }
+
+                    incrementalPaths shouldContainExactlyInAnyOrder fullPaths
+                }
+            }
+        }
+
+        test("a deep-subtree incremental reproduces that book's full-scan rootRelPath") {
+            runTest {
+                richLibrary().use { fixture ->
+                    val full = newScanner(fixture).first.runFullScan()
+                    val expected =
+                        full.books
+                            .single { it.title == "The Way of Kings" }
+                            .candidate.rootRelPath
+
+                    val (incremental, _) = newScanner(fixture)
+                    incremental.runIncremental(
+                        Path(fixture.root.resolve("Sanderson/Stormlight/The Way of Kings").toString()),
+                    )
+                    val actual =
+                        incremental
+                            .lastResult()
+                            .shouldNotBeNull()
+                            .books
+                            .single { it.title == "The Way of Kings" }
+                            .candidate.rootRelPath
+
+                    actual shouldBe expected
+                }
+            }
+        }
+    })
+
+/**
+ * A library spanning the path shapes the real corpus contains: nested
+ * author/series/title depth, apostrophes and spaces, a multi-disc book, and a
+ * loose single file directly at the library root.
+ */
+private fun richLibrary(): AudioLibraryFixture =
+    audioLibrary {
+        book("Sanderson/Stormlight/The Way of Kings") { tracks(count = 2) }
+        book("John O'Donohue/Anam Cara") { tracks(count = 1) }
+        book("Sanderson/Multi Disc Saga") {
+            disc("CD1") { audio("01 - Track.mp3") }
+            disc("CD2") { audio("01 - Track.mp3") }
+        }
+        audio("Loose Single.m4b")
+    }
+
+/**
+ * The `rootRelPath`s in this result that are NOT library-relative — absolute
+ * paths, or any path leaking the fixture's temp-dir prefix. Asserting this is
+ * `emptyList()` names the offenders directly on failure.
+ */
+private fun ScanResult.absoluteRootRelPaths(fixture: AudioLibraryFixture): List<String> {
+    val absolutePrefix = fixture.root.toString()
+    return books
+        .map { it.candidate.rootRelPath }
+        .filter { it.startsWith("/") || it.contains(absolutePrefix) }
+}
+
+private fun newScanner(
+    fixture: AudioLibraryFixture,
+    scanResultBus: MutableSharedFlow<ScanResult> = MutableSharedFlow(replay = 1),
+): Pair<Scanner, MutableSharedFlow<ScanEvent>> {
+    val eventBus = MutableSharedFlow<ScanEvent>(replay = 64, extraBufferCapacity = 64)
+    val scanner =
+        Scanner(
+            library = testLibrary(folders = listOf(fixture.root.toString())),
+            metadataReader = AbsMetadataReader(contractJson),
+            embeddedMetadataParser = EmbeddedMetadataParser(detector = AudioFormatDetector(), parsers = emptyList()),
+            eventBus = eventBus,
+            scanResultBus = scanResultBus,
+            correlationIdFactory = { "test-correlation-id" },
+        )
+    return scanner to eventBus
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryResolveTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryResolveTest.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.server.logging.ListenUpLoggerFactory
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -99,6 +100,57 @@ class BookRepositoryResolveTest :
             }
         }
 
+        test("resolveOrInsert rejects an absolute rootRelPath and writes nothing") {
+            withSqlDatabase {
+                val (repo, registry) = repository(sql, driver)
+                runTest {
+                    val libId = registry.currentLibrary()
+                    val absolute =
+                        analyzedFor(rootRelPath = "/mnt/Igni/Audiobooks/Sanderson/Way of Kings", inode = 1001L)
+
+                    // Defense-in-depth: an absolute rootRelPath is always a programming
+                    // error (the scanner must emit library-relative paths). The guard
+                    // rejects it BEFORE any identity lookup or write.
+                    shouldThrow<IllegalArgumentException> {
+                        repo.resolveOrInsert(libId, TEST_FOLDER_ID, absolute)
+                    }
+
+                    // The rejected attempt left no trace: a fresh RELATIVE book reusing
+                    // the same inode resolves as NEW — proving no half-written row exists
+                    // for it to "move" off of.
+                    val relative = analyzedFor(rootRelPath = "Sanderson/Way of Kings", inode = 1001L)
+                    repo.resolveOrInsert(libId, TEST_FOLDER_ID, relative).outcome().wasNew shouldBe true
+                }
+            }
+        }
+
+        test("re-resolving the same relative path resolves by natural key without logging a move") {
+            withSqlDatabase {
+                val (repo, registry) = repository(sql, driver)
+                runTest {
+                    val libId = registry.currentLibrary()
+                    val capture = ListenUpLoggerFactory.installTestCapture()
+                    try {
+                        val analyzed = analyzedFor(rootRelPath = "Sanderson/Way of Kings", inode = 1001L)
+
+                        val first = repo.resolveOrInsert(libId, TEST_FOLDER_ID, analyzed).outcome()
+                        first.wasNew shouldBe true
+
+                        // An unchanged re-scan: same relative natural key. This MUST hit
+                        // findByPath (wasNew == false) and never fall through to the inode
+                        // "Book moved" branch — the headline symptom of the absolute-path bug.
+                        val second = repo.resolveOrInsert(libId, TEST_FOLDER_ID, analyzed).outcome()
+                        second.wasNew shouldBe false
+                        second.bookId shouldBe first.bookId
+
+                        capture.events.none { it.message.startsWith("Book moved:") } shouldBe true
+                    } finally {
+                        ListenUpLoggerFactory.removeTestCapture()
+                    }
+                }
+            }
+        }
+
         test("inode match logs the move at INFO") {
             withSqlDatabase {
                 val (repo, registry) = repository(sql, driver)
@@ -142,6 +194,17 @@ private val TEST_FOLDER_ID = FolderId("test-folder")
 private fun AppResult<IngestOutcome>.resolved(): BookId =
     when (this) {
         is AppResult.Success -> data.bookId
+        is AppResult.Failure -> error("resolveOrInsert failed: ${error.message}")
+    }
+
+/**
+ * Asserts the [resolveOrInsert] result landed and returns the full
+ * [IngestOutcome] — including the `wasNew` flag the natural-key/inode/new
+ * identity branches set.
+ */
+private fun AppResult<IngestOutcome>.outcome(): IngestOutcome =
+    when (this) {
+        is AppResult.Success -> data
         is AppResult.Failure -> error("resolveOrInsert failed: ${error.message}")
     }
 


### PR DESCRIPTION
## Summary

Fixes a severe scanner regression where **adding one book made the scanner treat every book as moved/corrupted** and OOM-crashed the client. Root cause: a one-line bug in a path helper.

`FileHelpers.relativeTo(base)` returned the **absolute** path instead of `""` when `this == base` (the guard `p.startsWith("$b/")` is false for the equal-paths case — no trailing slash). A **root-level incremental scan** makes `bookRoot == folderRoot`, so every walked file got rebased onto an absolute prefix → every book's `rootRelPath` became absolute → `BookRepository.findByPath` (keyed by the relative natural key) missed → mass false "Book moved", `has_scan_warning=1`, a 1000+ change storm to the client, and OOM.

The sibling `isUnder` already handled the equal-paths case correctly; this aligns `relativeTo` with it.

## What changed

- **`relativeTo` fix** — returns `""` when `path == base` (the equal-paths case), plus exhaustive `FileHelpersTest` coverage (equal, trailing-slash, direct/deep child, special chars, sibling-with-shared-prefix). Consolidated the two `relativeTo` cases out of `FileIoTest` into their natural home.
- **Scanner path invariants** (`ScannerPathInvariantsTest`) — behavioural regression guards over a fixture spanning depth, apostrophes/spaces, a multi-disc book, and a loose root-level file:
  - **A** — no scan (full, root-level incremental, deep-subtree incremental) ever produces an absolute `rootRelPath`.
  - **B** — a no-op re-scan (full *and* root-level incremental) emits **zero** changes — directly encodes "nothing changed but every book moved".
  - **C** — incremental matches full (same `rootRelPath` set / per-book value).
- **Defense-in-depth guard** — `BookRepository.resolveOrInsert` now rejects an absolute `rootRelPath` before any identity lookup/write (`require`). It's loud but contained: `BookPersister.persistOne` already logs and skips a throwing book, so one bad path can never silently corrupt the DB again. Plus a natural-key re-resolve guard (same relative path → `wasNew=false`, no "Book moved" log) and an absolute-path-rejection test.

## Test plan

- [x] `./gradlew spotlessCheck detekt :server:jvmTest` — green (`:server:jvmTest` 2339 tests, 0 failures)
- [x] `./gradlew :sharedLogic:jvmTest` — green (2754 tests, 0 failures)
- [x] New tests fail with the bug reintroduced (verified: only the `bookRoot == folderRoot` cases) and pass with the fix
- [x] Data repair done out-of-band (server nuked-and-paved; no migration — server not in production)

Follow-up (separate branch, not in scope): client resilience to a legitimate large change set (bounded download concurrency / streaming) and treating `AndroidSecureStorage` Keystore "Pruned" failures as transient.
