### PR TITLE
🐛 fix: harden client against bulk-change storm (firehose-suppress large incrementals + retry transient Keystore reads)

### DIFF
--- a/contract/src/androidMain/kotlin/com/calypsan/listenup/core/AndroidSecureStorage.kt
+++ b/contract/src/androidMain/kotlin/com/calypsan/listenup/core/AndroidSecureStorage.kt
@@ -7,14 +7,24 @@ import android.security.keystore.KeyProperties
 import android.util.Base64
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.security.KeyStore
+import java.security.KeyStoreException
 import javax.crypto.Cipher
+import javax.crypto.IllegalBlockSizeException
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
+import kotlin.coroutines.cancellation.CancellationException
 
 private val logger = KotlinLogging.logger {}
+
+/** Keystore reads retry this many times before a transient fault is treated as unavailable. */
+private const val KEYSTORE_READ_ATTEMPTS = 3
+
+/** Backoff between Keystore read retries — a pruned key reloads almost immediately. */
+private const val KEYSTORE_RETRY_DELAY_MS = 20L
 
 /**
  * Modern Android implementation of SecureStorage using Android KeyStore directly.
@@ -129,6 +139,15 @@ class AndroidSecureStorage(
         return String(plaintext, Charsets.UTF_8)
     }
 
+    /**
+     * True for Keystore faults that are typically transient — the key was pruned or briefly
+     * unavailable (e.g. under memory pressure) and a retry usually succeeds. AES/GCM authentication
+     * failures (BadPadding/AEADBadTag) and decode errors are NOT transient: those mean the stored
+     * bytes are genuinely corrupt and the caller should see null.
+     */
+    private fun isTransientKeystoreFailure(e: Throwable): Boolean =
+        e is IllegalBlockSizeException || e is KeyStoreException
+
     override suspend fun save(
         key: String,
         value: String,
@@ -141,10 +160,25 @@ class AndroidSecureStorage(
         withContext(Dispatchers.IO) {
             val encrypted = prefs.getString(key, null) ?: return@withContext null
             try {
-                decrypt(encrypted)
+                // Retry transient Keystore faults (key pruned/unavailable under memory pressure) so a
+                // momentary blip can't masquerade as "no value" — which would wipe server_url / tokens
+                // and strand the user. Genuine corruption (auth-tag/decode failure) is not transient and
+                // falls straight through to null.
+                retryOnTransient(
+                    maxAttempts = KEYSTORE_READ_ATTEMPTS,
+                    isTransient = ::isTransientKeystoreFailure,
+                    onRetry = { _, _ -> delay(KEYSTORE_RETRY_DELAY_MS) },
+                ) {
+                    decrypt(encrypted)
+                }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                // If decryption fails (corrupted data, key change), return null
-                logger.warn(e) { "Decryption failed for key '$key' - data may be corrupted" }
+                if (isTransientKeystoreFailure(e)) {
+                    logger.warn(e) { "Keystore read for '$key' failed transiently; treated as unavailable" }
+                } else {
+                    logger.warn(e) { "Decryption failed for key '$key' — data may be corrupted" }
+                }
                 null
             }
         }

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/RetryOnTransient.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/RetryOnTransient.kt
@@ -1,0 +1,36 @@
+package com.calypsan.listenup.core
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Runs [block], retrying up to [maxAttempts] times when it fails with a *transient* error — one for
+ * which [isTransient] returns true.
+ *
+ * A non-transient failure propagates immediately without retrying; a [CancellationException] is always
+ * re-thrown without being retried or classified; and when every attempt fails transiently the last
+ * transient error is re-thrown. [onRetry] runs between attempts (e.g. to back off), receiving the
+ * zero-based index of the attempt that just failed and its error.
+ *
+ * The broad `catch` is intentional: a retry helper cannot know which exception types its [block] may
+ * raise, so it catches everything and delegates the keep-or-propagate decision to [isTransient].
+ */
+internal suspend fun <T> retryOnTransient(
+    maxAttempts: Int,
+    isTransient: (Throwable) -> Boolean,
+    onRetry: suspend (attempt: Int, error: Throwable) -> Unit = { _, _ -> },
+    block: suspend () -> T,
+): T {
+    repeat(maxAttempts) { attempt ->
+        try {
+            return block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Propagate a non-transient failure immediately, and a transient one once the final
+            // attempt is spent; otherwise back off and retry.
+            if (!isTransient(e) || attempt == maxAttempts - 1) throw e
+            onRetry(attempt, e)
+        }
+    }
+    error("retryOnTransient requires maxAttempts >= 1, was $maxAttempts")
+}

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/core/RetryOnTransientTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/core/RetryOnTransientTest.kt
@@ -1,0 +1,87 @@
+package com.calypsan.listenup.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import kotlin.coroutines.cancellation.CancellationException
+
+private class Transient : Exception()
+
+private class NotTransient : Exception()
+
+class RetryOnTransientTest :
+    FunSpec({
+
+        test("returns the value on first success without retrying") {
+            runBlocking {
+                var calls = 0
+                val result =
+                    retryOnTransient(maxAttempts = 3, isTransient = { true }) {
+                        calls++
+                        "value"
+                    }
+                result shouldBe "value"
+                calls shouldBe 1
+            }
+        }
+
+        test("retries a transient failure and returns once it succeeds") {
+            runBlocking {
+                var calls = 0
+                val retried = mutableListOf<Int>()
+                val result =
+                    retryOnTransient(
+                        maxAttempts = 3,
+                        isTransient = { it is Transient },
+                        onRetry = { attempt, _ -> retried += attempt },
+                    ) {
+                        calls++
+                        if (calls < 3) throw Transient()
+                        "recovered"
+                    }
+                result shouldBe "recovered"
+                calls shouldBe 3
+                retried shouldBe listOf(0, 1)
+            }
+        }
+
+        test("propagates a non-transient failure immediately without retrying") {
+            runBlocking {
+                var calls = 0
+                shouldThrow<NotTransient> {
+                    retryOnTransient(maxAttempts = 3, isTransient = { it is Transient }) {
+                        calls++
+                        throw NotTransient()
+                    }
+                }
+                calls shouldBe 1
+            }
+        }
+
+        test("throws the last transient failure once attempts are exhausted") {
+            runBlocking {
+                var calls = 0
+                shouldThrow<Transient> {
+                    retryOnTransient(maxAttempts = 3, isTransient = { it is Transient }) {
+                        calls++
+                        throw Transient()
+                    }
+                }
+                calls shouldBe 3
+            }
+        }
+
+        test("re-throws CancellationException without retrying or classifying it") {
+            runBlocking {
+                var calls = 0
+                shouldThrow<CancellationException> {
+                    retryOnTransient(maxAttempts = 3, isTransient = { true }) {
+                        calls++
+                        throw CancellationException("cancelled")
+                    }
+                }
+                calls shouldBe 1
+            }
+        }
+    })

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -42,6 +42,16 @@ private val log = KotlinLogging.logger {}
 private const val PERSIST_PROGRESS_TICKS = 100
 
 /**
+ * A bulk incremental scan with more than this many changed books is firehose-suppressed like a
+ * full scan, rather than published per-book to the live tail. Above this, the per-event burst
+ * would flood the lossy [com.calypsan.listenup.server.sync.ChangeBus] (replay=256, DROP_OLDEST)
+ * and storm connected clients into a per-event transaction GC storm; below it, incrementals stay
+ * live so a normal one-or-few-book change is a real-time delta. Kept well under the live tail's
+ * 256-deep buffer so a suppressed burst can never overflow it.
+ */
+private const val INCREMENTAL_FIREHOSE_SUPPRESS_THRESHOLD = 50
+
+/**
  * Consumes the Scanner's [ScanResult] stream and persists every
  * [com.calypsan.listenup.api.dto.scanner.AnalyzedBook] through [BookIngestPort].
  *
@@ -109,15 +119,20 @@ class BookPersister internal constructor(
             // block persistence; the TODO below tracks proper error surfacing.
             val folderId = resolveFolderId(result.rootPath)
 
-            // A FULL scan is bulk population (onboarding, re-scan): suppress the per-book firehose
-            // PUBLISH so the lossy live tail (ChangeBus replay=256, DROP_OLDEST) never carries the
-            // burst — an arbitrarily large library would otherwise overflow it and trip a client
-            // CursorStale → catch-up spin. Revisions still bump, so the client does one clean REST
-            // catch-up after the Completed below. Incremental scans ARE live deltas; they publish.
+            // Suppress the per-book firehose PUBLISH for any BULK persist so the lossy live tail
+            // (ChangeBus replay=256, DROP_OLDEST) never carries the burst — otherwise it overflows
+            // and storms connected clients into a per-event transaction GC storm. A FULL scan is
+            // always bulk (onboarding, re-scan); a large INCREMENTAL (dropping a folder of many
+            // books, or a big subtree re-persist) is bulk too. Revisions still bump, so the client
+            // does one clean REST catch-up after the Completed below. Small incrementals stay live —
+            // they ARE real-time deltas.
+            val suppressFirehose =
+                result.scope is ScanScope.Full ||
+                    result.changes.size > INCREMENTAL_FIREHOSE_SUPPRESS_THRESHOLD
             val counts: PersistCounts
             try {
                 counts =
-                    if (result.scope is ScanScope.Full) {
+                    if (suppressFirehose) {
                         withContext(FirehoseSuppressed) { persistAll(result, libraryId, folderId) }
                     } else {
                         persistAll(result, libraryId, folderId)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -424,6 +424,32 @@ class BookPersisterTest :
             }
         }
 
+        test("a large incremental scan suppresses the firehose to avoid a live-tail storm") {
+            withSqlDatabase {
+                runTest {
+                    val fake = FakeBookIngest()
+                    val persister = persister(fake, scope = this)
+
+                    // A bulk incremental — dropping a folder of many books, or a large
+                    // subtree re-persist — would flood the lossy live tail (ChangeBus
+                    // replay=256, DROP_OLDEST) and storm connected clients into a per-event
+                    // transaction GC storm. It must suppress like a full scan; the client
+                    // reconciles once via catch-up on ScanEvent.Completed. Small incrementals
+                    // stay live (covered by the test above).
+                    val many = (1..LARGE_INCREMENTAL_COUNT).map { "book-$it" }
+                    persister.persist(
+                        scanResult(
+                            books = many.map { analyzedBook(it) },
+                            changes = many.map { ChangeEventDto.Added(analyzedBook(it)) },
+                            scope = ScanScope.Subtree("big/folder"),
+                        ),
+                    )
+
+                    fake.suppressionObserved shouldContainExactly List(LARGE_INCREMENTAL_COUNT) { true }
+                }
+            }
+        }
+
         test("incremental scan does NOT sweep absent books") {
             withSqlDatabase {
                 runTest {
@@ -550,6 +576,9 @@ class BookPersisterTest :
             }
         }
     })
+
+/** Changed-book count for the large-incremental suppression test — above the production threshold. */
+private const val LARGE_INCREMENTAL_COUNT = 60
 
 // --- Fakes ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Hardens the client against the bulk-change storm that crashed it (the scanner-corruption incident), fixing **two confirmed mechanisms** found by tracing the code:

### 1. Large incremental scans now firehose-suppress (server) — the OOM driver
Full-scan persist already wraps in `withContext(FirehoseSuppressed)` so a bulk burst can't flood the lossy live tail (`ChangeBus` replay=256, DROP_OLDEST). **Incremental persist did not** — it published per-book. The scanner corruption re-persisted ~1092 books via the *incremental* path (the root-level `relativeTo` bug), and a connected client applied each as its own Room transaction → invalidation storm → per-event GC storm → OOM. The same gap hits any large incremental add (drop a folder of 1000 books).

`BookPersister.persist` now suppresses the firehose for a **full scan OR a large incremental** (`changes.size > 50`); small incrementals stay live (real-time deltas). Revisions still bump, so connected clients reconcile once via the existing `ScanEvent.Completed` → catch-up path (page-batched, already OOM-hardened). Reuses the ABS-import pattern; no client sync-engine changes.

### 2. `AndroidSecureStorage.read` retries transient Keystore faults — the "server URL invalid" spam
`read()` swallowed **any** decrypt failure as "data may be corrupted" → `null`. A *transient* Keystore fault (`IllegalBlockSizeException`/`KeyStoreException`, e.g. a key pruned under the memory pressure the storm caused) is indistinguishable there from real corruption — and a null `server_url`/token fans out to `error("Server URL not configured")` across ~25 RPC factories + auth, stranding the user. Now: transient faults are **retried** (3×, 20 ms) and, if still failing, logged distinctly as *unavailable* (not corruption); only genuine auth-tag/decode corruption returns `null`.

Extracted a pure, `internal` `retryOnTransient(...)` helper in `:contract/commonMain` (lambda-based: classifier + backoff injected) so the retry policy is unit-tested; `read()` wires it with the Keystore classifier.

## Test plan

- [x] `BookPersisterTest`: new "a large incremental scan suppresses the firehose" (RED without the fix); existing full-scan-suppressed and small-incremental-live still pass.
- [x] `RetryOnTransientTest` (5 cases): first-success no-retry, transient-then-succeed, non-transient propagates immediately, exhausted-transient rethrows, `CancellationException` re-thrown un-retried.
- [x] `./gradlew spotlessCheck detekt :sharedLogic:jvmTest :server:jvmTest :contract:jvmTest` — green (sharedLogic 2754/0, server 2328/0, contract 58/0).
- [x] `./gradlew :androidApp:assembleDebug` — green.
- [ ] iOS lane — CI-verified (the `retryOnTransient` helper is pure commonMain, native-compatible).

## Notes

- `AndroidSecureStorage.read`'s wiring + classifier are androidMain; the gate has no `:contract` android unit-test source set, so the retry *policy* is what's unit-tested (the wiring compiles via `compileAndroidMain` + `:androidApp:assembleDebug`).
- Complements the scanner `relativeTo` fix (#807), which removes the specific trigger; this makes the client resilient to *any* large legitimate bulk change.
