### PR TITLE
✨ feat(server): pure-Kotlin ZIP container (native ZIP, part 2/3)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/MalformedZipException.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/MalformedZipException.kt
@@ -1,0 +1,7 @@
+package com.calypsan.listenup.server.compression.zip
+
+/** Thrown when a ZIP archive is malformed, truncated, or uses an unsupported feature. */
+public class MalformedZipException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNames.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNames.kt
@@ -1,0 +1,13 @@
+package com.calypsan.listenup.server.compression.zip
+
+/**
+ * True if [name] is safe to extract under a target directory: a non-empty relative path with no absolute
+ * root, no Windows drive/backslash, and no `..` segment that could escape. The extracting consumer must
+ * call this before writing each entry (ZIP-slip defense).
+ */
+public fun isSafeEntryName(name: String): Boolean {
+    if (name.isEmpty()) return false
+    if (name.startsWith("/") || name.startsWith("\\")) return false
+    if (name.length >= 2 && name[1] == ':') return false
+    return name.split('/', '\\').none { it == ".." }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNames.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNames.kt
@@ -9,5 +9,8 @@ public fun isSafeEntryName(name: String): Boolean {
     if (name.isEmpty()) return false
     if (name.startsWith("/") || name.startsWith("\\")) return false
     if (name.length >= 2 && name[1] == ':') return false
+    // Reject control characters (code < 0x20, including NUL): a crafted name can use them to truncate or
+    // confuse a filesystem path on extraction.
+    if (name.any { it.code < 0x20 }) return false
     return name.split('/', '\\').none { it == ".." }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormat.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormat.kt
@@ -148,6 +148,56 @@ internal fun parseZip64Extra(extra: ByteArray): Zip64ExtraFields {
     return Zip64ExtraFields(uncompSize = null, compSize = null, localOffset = null)
 }
 
+/**
+ * Sentinel-aware variant of [parseZip64Extra] for the reader. A central-directory header carries a
+ * ZIP64 overflow value only for each base field whose 32-bit slot equals the 0xFFFFFFFF sentinel, and
+ * the 0x0001 record packs exactly those values in fixed order: uncompSize, then compSize, then
+ * localOffset. This walks to the 0x0001 record and assigns its i-th 8-byte value to the i-th field that
+ * [hasUncomp]/[hasComp]/[hasOffset] marks as a sentinel — so a record carrying only compSize (because
+ * uncompSize was a real 32-bit value) decodes to [Zip64ExtraFields.compSize], never mis-assigned to
+ * uncompSize the way a positional read would. A field marked sentinel but absent from the record (a
+ * short or truncated record) decodes to null; the caller treats that as malformed.
+ */
+internal fun parseZip64ExtraFor(
+    extra: ByteArray,
+    hasUncomp: Boolean,
+    hasComp: Boolean,
+    hasOffset: Boolean,
+): Zip64ExtraFields {
+    var pos = 0
+    while (pos + 4 <= extra.size) {
+        val id = (extra[pos].toInt() and 0xFF) or ((extra[pos + 1].toInt() and 0xFF) shl 8)
+        val size = (extra[pos + 2].toInt() and 0xFF) or ((extra[pos + 3].toInt() and 0xFF) shl 8)
+        val dataStart = pos + 4
+        val dataEnd = dataStart + size
+
+        if (dataEnd > extra.size) break // truncated record — stop
+
+        if (id == ZIP64_EXTRA_ID) {
+            val available = size / 8
+            var index = 0
+
+            fun nextValue(): Long? {
+                if (index >= available) return null
+                val off = dataStart + index * 8
+                var v = 0L
+                for (i in 0..7) v = v or ((extra[off + i].toLong() and 0xFFL) shl (i * 8))
+                index++
+                return v
+            }
+            // Left-to-right argument evaluation guarantees the values are consumed in field order.
+            return Zip64ExtraFields(
+                uncompSize = if (hasUncomp) nextValue() else null,
+                compSize = if (hasComp) nextValue() else null,
+                localOffset = if (hasOffset) nextValue() else null,
+            )
+        }
+
+        pos = dataEnd
+    }
+    return Zip64ExtraFields(uncompSize = null, compSize = null, localOffset = null)
+}
+
 // ── EOCD locator ─────────────────────────────────────────────────────────────────────────────────
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormat.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormat.kt
@@ -100,6 +100,7 @@ internal fun encodeZip64Extra(
     localOffset: Long?,
 ): ByteArray {
     val fields = listOfNotNull(uncompSize, compSize, localOffset)
+    if (fields.isEmpty()) return ByteArray(0)
     val buf = Buffer()
     buf.writeU16LE(ZIP64_EXTRA_ID)
     buf.writeU16LE(fields.size * 8)
@@ -110,8 +111,9 @@ internal fun encodeZip64Extra(
 /**
  * Walks [extra] as a sequence of TLV records (id:u16, size:u16, data[size]). Finds the 0x0001
  * record and reads its fields positionally: uncompSize first, then compSize, then localOffset,
- * up to dataSize/8 values. Fields absent from the record are returned as null. Malformed or
- * truncated records are skipped gracefully; if no 0x0001 record is found, all fields are null.
+ * up to dataSize/8 values. Fields absent from the record are returned as null. On a truncated record
+ * the walk stops cleanly (no partial result, no out-of-bounds read); if no 0x0001 record is found, all
+ * fields are null.
  */
 internal fun parseZip64Extra(extra: ByteArray): Zip64ExtraFields {
     var pos = 0
@@ -154,9 +156,8 @@ internal fun parseZip64Extra(extra: ByteArray): Zip64ExtraFields {
  * signature starts, or throws [MalformedZipException] if the signature is not found.
  */
 internal fun findEocdOffset(tail: ByteArray): Long {
-    val start = (tail.size - 22).coerceAtLeast(0)
-    for (i in start downTo 0) {
-        if (i + 4 > tail.size) continue
+    if (tail.size < 22) throw MalformedZipException("tail too short to contain an EOCD (${tail.size} bytes)")
+    for (i in tail.size - 22 downTo 0) {
         val sig =
             (tail[i].toLong() and 0xFFL) or
                 ((tail[i + 1].toLong() and 0xFFL) shl 8) or

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormat.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormat.kt
@@ -1,0 +1,168 @@
+package com.calypsan.listenup.server.compression.zip
+
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+
+// ── Signature constants (Long to avoid sign issues with high-bit 32-bit values) ──────────────────
+
+internal const val LFH_SIG: Long = 0x04034b50L
+internal const val DD_SIG: Long = 0x08074b50L
+internal const val CDH_SIG: Long = 0x02014b50L
+internal const val EOCD_SIG: Long = 0x06054b50L
+internal const val ZIP64_EOCD_SIG: Long = 0x06064b50L
+internal const val ZIP64_LOCATOR_SIG: Long = 0x07064b50L
+internal const val ZIP64_EXTRA_ID: Int = 0x0001
+
+/** Sentinel: a 32-bit slot holding this value means the real value is in the ZIP64 extra field. */
+internal const val ZIP64_U32_MAX: Long = 0xFFFF_FFFFL
+
+/** Maximum value for a 16-bit unsigned ZIP field. */
+internal const val ZIP16_MAX: Int = 0xFFFF
+
+// ── Little-endian Buffer I/O ──────────────────────────────────────────────────────────────────────
+
+/** Writes [v] as a 2-byte little-endian unsigned integer. */
+internal fun Buffer.writeU16LE(v: Int) {
+    writeByte((v and 0xFF).toByte())
+    writeByte(((v shr 8) and 0xFF).toByte())
+}
+
+/** Writes [v] as a 4-byte little-endian unsigned integer. [v] must fit in 0..0xFFFFFFFF. */
+internal fun Buffer.writeU32LE(v: Long) {
+    writeByte((v and 0xFFL).toByte())
+    writeByte(((v shr 8) and 0xFFL).toByte())
+    writeByte(((v shr 16) and 0xFFL).toByte())
+    writeByte(((v shr 24) and 0xFFL).toByte())
+}
+
+/** Writes [v] as an 8-byte little-endian integer. */
+internal fun Buffer.writeU64LE(v: Long) {
+    writeByte((v and 0xFFL).toByte())
+    writeByte(((v shr 8) and 0xFFL).toByte())
+    writeByte(((v shr 16) and 0xFFL).toByte())
+    writeByte(((v shr 24) and 0xFFL).toByte())
+    writeByte(((v shr 32) and 0xFFL).toByte())
+    writeByte(((v shr 40) and 0xFFL).toByte())
+    writeByte(((v shr 48) and 0xFFL).toByte())
+    writeByte(((v shr 56) and 0xFFL).toByte())
+}
+
+/** Reads a 2-byte little-endian unsigned integer, returning it as a non-negative [Int]. */
+internal fun Buffer.readU16LE(): Int {
+    val b0 = readByte().toInt() and 0xFF
+    val b1 = readByte().toInt() and 0xFF
+    return b0 or (b1 shl 8)
+}
+
+/**
+ * Reads a 4-byte little-endian unsigned integer, returning it as a [Long] in 0..0xFFFFFFFF.
+ * Masking each byte to 0xFF guarantees the result is never negative; 0xFFFFFFFF → 4294967295L, not -1.
+ */
+internal fun Buffer.readU32LE(): Long {
+    val b0 = readByte().toLong() and 0xFFL
+    val b1 = readByte().toLong() and 0xFFL
+    val b2 = readByte().toLong() and 0xFFL
+    val b3 = readByte().toLong() and 0xFFL
+    return b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)
+}
+
+/** Reads an 8-byte little-endian integer as a [Long]. */
+internal fun Buffer.readU64LE(): Long {
+    val b0 = readByte().toLong() and 0xFFL
+    val b1 = readByte().toLong() and 0xFFL
+    val b2 = readByte().toLong() and 0xFFL
+    val b3 = readByte().toLong() and 0xFFL
+    val b4 = readByte().toLong() and 0xFFL
+    val b5 = readByte().toLong() and 0xFFL
+    val b6 = readByte().toLong() and 0xFFL
+    val b7 = readByte().toLong() and 0xFFL
+    return b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24) or
+        (b4 shl 32) or (b5 shl 40) or (b6 shl 48) or (b7 shl 56)
+}
+
+// ── ZIP64 extra field (header id 0x0001) ─────────────────────────────────────────────────────────
+
+/** Holds the optional ZIP64 overflow values decoded from the 0x0001 extra field. */
+internal class Zip64ExtraFields(
+    val uncompSize: Long?,
+    val compSize: Long?,
+    val localOffset: Long?,
+)
+
+/**
+ * Encodes a ZIP64 extra field (header id 0x0001) containing only the non-null values, in fixed
+ * order: uncompSize, compSize, localOffset. dataSize = 8 * (count of non-null). Returns an empty
+ * [ByteArray] if all arguments are null.
+ */
+internal fun encodeZip64Extra(
+    uncompSize: Long?,
+    compSize: Long?,
+    localOffset: Long?,
+): ByteArray {
+    val fields = listOfNotNull(uncompSize, compSize, localOffset)
+    val buf = Buffer()
+    buf.writeU16LE(ZIP64_EXTRA_ID)
+    buf.writeU16LE(fields.size * 8)
+    for (field in fields) buf.writeU64LE(field)
+    return buf.readByteArray()
+}
+
+/**
+ * Walks [extra] as a sequence of TLV records (id:u16, size:u16, data[size]). Finds the 0x0001
+ * record and reads its fields positionally: uncompSize first, then compSize, then localOffset,
+ * up to dataSize/8 values. Fields absent from the record are returned as null. Malformed or
+ * truncated records are skipped gracefully; if no 0x0001 record is found, all fields are null.
+ */
+internal fun parseZip64Extra(extra: ByteArray): Zip64ExtraFields {
+    var pos = 0
+    while (pos + 4 <= extra.size) {
+        val id = (extra[pos].toInt() and 0xFF) or ((extra[pos + 1].toInt() and 0xFF) shl 8)
+        val size = (extra[pos + 2].toInt() and 0xFF) or ((extra[pos + 3].toInt() and 0xFF) shl 8)
+        val dataStart = pos + 4
+        val dataEnd = dataStart + size
+
+        if (dataEnd > extra.size) break // truncated record — stop
+
+        if (id == ZIP64_EXTRA_ID) {
+            val count = size / 8
+
+            fun readField(index: Int): Long? {
+                if (index >= count) return null
+                val off = dataStart + index * 8
+                if (off + 8 > dataEnd) return null
+                var v = 0L
+                for (i in 0..7) v = v or ((extra[off + i].toLong() and 0xFFL) shl (i * 8))
+                return v
+            }
+            return Zip64ExtraFields(
+                uncompSize = readField(0),
+                compSize = readField(1),
+                localOffset = readField(2),
+            )
+        }
+
+        pos = dataEnd
+    }
+    return Zip64ExtraFields(uncompSize = null, compSize = null, localOffset = null)
+}
+
+// ── EOCD locator ─────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Scans [tail] (the last ≤ 65557 bytes of the ZIP file) backward from offset [tail.size - 22]
+ * looking for the EOCD signature (0x06054b50 LE). Returns the offset into [tail] where the
+ * signature starts, or throws [MalformedZipException] if the signature is not found.
+ */
+internal fun findEocdOffset(tail: ByteArray): Long {
+    val start = (tail.size - 22).coerceAtLeast(0)
+    for (i in start downTo 0) {
+        if (i + 4 > tail.size) continue
+        val sig =
+            (tail[i].toLong() and 0xFFL) or
+                ((tail[i + 1].toLong() and 0xFFL) shl 8) or
+                ((tail[i + 2].toLong() and 0xFFL) shl 16) or
+                ((tail[i + 3].toLong() and 0xFFL) shl 24)
+        if (sig == EOCD_SIG) return i.toLong()
+    }
+    throw MalformedZipException("end of central directory not found")
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipReader.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipReader.kt
@@ -59,7 +59,7 @@ public class ZipReader(
         }
 
     /** The entries listed in the central directory, in directory order. */
-    public fun entries(): List<ZipEntryInfo> = parsedEntries
+    public fun entries(): List<ZipEntryInfo> = parsedEntries.toList()
 
     /** The entry named [name], or null if no entry has that exact name. */
     public fun entry(name: String): ZipEntryInfo? = parsedEntries.firstOrNull { it.name == name }
@@ -72,16 +72,34 @@ public class ZipReader(
      * past the end of the file.
      */
     public fun openEntry(entry: ZipEntryInfo): RawSource {
-        source.seek(entry.localHeaderOffset)
-        val lfh = Buffer().apply { write(source.readFully(LFH_FIXED_SIZE)) }
+        // Range-check the offset against the live file length first: the directory was validated at
+        // construction, but the file may have been truncated since (disk rot, partial write), and a
+        // crafted ZIP64 offset must never reach a raw read. `source.length - LFH_FIXED_SIZE` can't
+        // overflow; if the file is now shorter than a header, every non-negative offset is rejected.
+        if (entry.localHeaderOffset < 0 || entry.localHeaderOffset > source.length - LFH_FIXED_SIZE) {
+            throw MalformedZipException("local header offset ${entry.localHeaderOffset} out of range")
+        }
+        val lfh =
+            try {
+                source.seek(entry.localHeaderOffset)
+                Buffer().apply { write(source.readFully(LFH_FIXED_SIZE)) }
+            } catch (e: Exception) {
+                // The only failure the reads above can raise is a short/EOF read — meaning the file was
+                // truncated between the range check and this read (TOCTOU). Surface it as a malformed
+                // archive, never a raw EOFException.
+                throw MalformedZipException("entry '${entry.name}' has a truncated local header", e)
+            }
         if (lfh.readU32LE() != LFH_SIG) {
             throw MalformedZipException("entry '${entry.name}' has no local file header")
         }
         lfh.skip(LFH_PRE_NAME_LEN_BYTES) // straight to the nameLen/extraLen fields at offsets 26/28
         val nameLen = lfh.readU16LE()
         val extraLen = lfh.readU16LE()
+        // localHeaderOffset ≤ length − 30 and nameLen/extraLen are u16, so the sum can't overflow a Long.
         val dataStart = entry.localHeaderOffset + LFH_FIXED_SIZE + nameLen + extraLen
-        if (dataStart < 0 || dataStart + entry.compressedSize > source.length) {
+        if (dataStart < 0 || dataStart > source.length ||
+            entry.compressedSize < 0 || entry.compressedSize > source.length - dataStart
+        ) {
             throw MalformedZipException("entry '${entry.name}' data runs past end of file")
         }
         val bounded = BoundedEntrySource(entry.name, dataStart, entry.compressedSize)
@@ -116,6 +134,9 @@ public class ZipReader(
         var totalEntries: Long = totalEntries16.toLong()
         var cdSize: Long = cdSize32
         var cdOffset: Long = cdOffset32
+        // The directory must end exactly where its terminator begins: the classic EOCD when not ZIP64,
+        // the ZIP64 EOCD record when it is. This anchor is resolved alongside the sizes below.
+        var anchorOffset: Long = eocdAbs
 
         val needsZip64 =
             totalEntries16 == ZIP16_MAX || cdSize32 == ZIP64_U32_MAX || cdOffset32 == ZIP64_U32_MAX
@@ -124,9 +145,12 @@ public class ZipReader(
             totalEntries = z64.totalEntries
             cdSize = z64.cdSize
             cdOffset = z64.cdOffset
+            anchorOffset = z64.zip64EocdOffset
         }
 
-        if (cdOffset < 0 || cdSize < 0 || cdOffset > fileLen || cdOffset + cdSize > fileLen) {
+        // Operand-first bounds that can't overflow a Long: `fileLen - cdOffset` is safe once cdOffset is
+        // pinned to 0..fileLen, so cdSize is compared against the real remaining space, never a wrapped sum.
+        if (cdOffset < 0 || cdOffset > fileLen || cdSize < 0 || cdSize > fileLen - cdOffset) {
             throw MalformedZipException(
                 "central directory out of range (offset=$cdOffset size=$cdSize fileLen=$fileLen)",
             )
@@ -134,16 +158,36 @@ public class ZipReader(
         if (totalEntries < 0 || totalEntries > Int.MAX_VALUE) {
             throw MalformedZipException("implausible central-directory entry count ($totalEntries)")
         }
+        // Cross-check the declared directory size against the entry count BEFORE buffering it: every
+        // central-directory header is ≥ CDH_FIXED_SIZE and ≤ that plus a name/extra/comment of ≤ 65535
+        // each, so a crafted `cdSize = fileLen` with one entry rejects in O(1) instead of allocating the
+        // whole file onto the heap. (totalEntries is already pinned to 0..Int.MAX_VALUE, so no overflow.)
+        val maxCdSize = totalEntries * (CDH_FIXED_SIZE + 3L * ZIP16_MAX)
+        if (cdSize > maxCdSize) {
+            throw MalformedZipException(
+                "central directory size $cdSize implausible for $totalEntries entries",
+            )
+        }
+        // Self-consistency anchor: the directory must abut its terminator. This stops a stray EOCD-shaped
+        // signature embedded in entry data from redirecting the parser at attacker-chosen bytes. Safe to
+        // sum here because the range guard above already bounded both operands to ≤ fileLen.
+        if (cdOffset + cdSize != anchorOffset) {
+            throw MalformedZipException("central directory does not abut the end-of-central-directory record")
+        }
 
         val cd = readExactly(cdOffset, cdSize)
         return parseHeaders(cd, totalEntries.toInt(), fileLen)
     }
 
-    /** The three count/size/offset values recovered from a ZIP64 end-of-central-directory record. */
+    /**
+     * The count/size/offset values recovered from a ZIP64 end-of-central-directory record, plus
+     * [zip64EocdOffset] — the record's own absolute offset, which the directory must abut.
+     */
     private class Zip64Eocd(
         val totalEntries: Long,
         val cdSize: Long,
         val cdOffset: Long,
+        val zip64EocdOffset: Long,
     )
 
     /**
@@ -161,7 +205,9 @@ public class ZipReader(
         if (locator.readU32LE() != ZIP64_LOCATOR_SIG) throw MalformedZipException("bad ZIP64 EOCD locator signature")
         locator.skip(4) // diskWithZip64Eocd
         val zip64EocdOffset = locator.readU64LE()
-        if (zip64EocdOffset < 0 || zip64EocdOffset + ZIP64_EOCD_SIZE > fileLen) {
+        // Operand-first bound: `fileLen - ZIP64_EOCD_SIZE` can't overflow, and a u64 offset near Long.MAX
+        // (or negative) is rejected before any seek.
+        if (zip64EocdOffset < 0 || zip64EocdOffset > fileLen - ZIP64_EOCD_SIZE) {
             throw MalformedZipException("ZIP64 EOCD offset out of range ($zip64EocdOffset)")
         }
         source.seek(zip64EocdOffset)
@@ -172,7 +218,7 @@ public class ZipReader(
         val totalEntries = z.readU64LE()
         val cdSize = z.readU64LE()
         val cdOffset = z.readU64LE()
-        return Zip64Eocd(totalEntries, cdSize, cdOffset)
+        return Zip64Eocd(totalEntries, cdSize, cdOffset, zip64EocdOffset)
     }
 
     /** Parses [count] central-directory headers out of [cd], resolving ZIP64 overflow per entry. */
@@ -218,7 +264,7 @@ public class ZipReader(
 
             val (compSize, uncompSize, localOffset) =
                 resolveZip64(name, extra, compSize32, uncompSize32, localOffset32)
-            if (localOffset < 0 || localOffset + LFH_FIXED_SIZE > fileLen) {
+            if (localOffset < 0 || localOffset > fileLen - LFH_FIXED_SIZE) {
                 throw MalformedZipException("local header offset out of range for '$name'")
             }
             if (compSize < 0 || compSize > fileLen || uncompSize < 0) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipReader.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipReader.kt
@@ -1,0 +1,340 @@
+package com.calypsan.listenup.server.compression.zip
+
+import com.calypsan.listenup.server.compression.inflated
+import com.calypsan.listenup.server.io.SeekableSource
+import com.calypsan.listenup.server.io.openSeekableSource
+import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+import kotlinx.io.files.Path
+import kotlinx.io.readByteArray
+
+/**
+ * One entry decoded from a ZIP central directory: its name, compression [method], CRC-32, and the
+ * authoritative compressed/uncompressed sizes (ZIP64-resolved). [localHeaderOffset] is the byte offset
+ * of the entry's local file header and is consumed only by [ZipReader.openEntry]; callers identify an
+ * entry by [name]. Construct these only via [ZipReader].
+ */
+public class ZipEntryInfo internal constructor(
+    public val name: String,
+    public val method: ZipMethod,
+    public val crc32: Long,
+    public val compressedSize: Long,
+    public val uncompressedSize: Long,
+    internal val localHeaderOffset: Long,
+)
+
+/**
+ * Random-access reader for a ZIP archive on disk. It parses the central directory up front (the
+ * authoritative index — STORED and DEFLATE entries, classic and ZIP64), then [openEntry] seeks to an
+ * entry's data and streams it: STORED bytes verbatim, DEFLATE bytes through the pure-Kotlin inflater.
+ *
+ * Built to read every archive `java.util.zip.ZipOutputStream` produces — including the data-descriptor
+ * DEFLATE entries our own [ZipWriter] emits — because the central directory always carries the real
+ * sizes regardless of how the local headers defer them. Every length and offset read from the archive
+ * is treated as untrusted: an out-of-range value or a bad signature raises [MalformedZipException]
+ * rather than an out-of-bounds read or an unbounded allocation. Pure commonMain over [SeekableSource];
+ * the same code reads on the JVM and Kotlin/Native.
+ *
+ * Not thread-safe: a single underlying file handle backs every [openEntry] stream. Read entries
+ * sequentially (each stream tracks its own absolute offset, so a fully-drained stream leaves the next
+ * correct), and [close] when done — closing the reader closes the file handle and invalidates any open
+ * entry streams.
+ */
+public class ZipReader(
+    path: Path,
+) : AutoCloseable {
+    private val source: SeekableSource = openSeekableSource(path)
+
+    private val parsedEntries: List<ZipEntryInfo> =
+        try {
+            parseCentralDirectory()
+        } catch (e: MalformedZipException) {
+            source.close()
+            throw e
+        } catch (e: Exception) {
+            // EOFException from a short read, an arithmetic edge — anything the parse didn't classify is
+            // still a malformed archive from the caller's point of view. Never leak the handle.
+            source.close()
+            throw MalformedZipException("malformed ZIP archive", e)
+        }
+
+    /** The entries listed in the central directory, in directory order. */
+    public fun entries(): List<ZipEntryInfo> = parsedEntries
+
+    /** The entry named [name], or null if no entry has that exact name. */
+    public fun entry(name: String): ZipEntryInfo? = parsedEntries.firstOrNull { it.name == name }
+
+    /**
+     * Opens [entry]'s content as a fresh [RawSource]: the raw bytes for [ZipMethod.STORED], the inflated
+     * bytes for [ZipMethod.DEFLATE]. The stream reads exactly the entry's compressed bytes from disk and
+     * does not verify the CRC-32 (a partial read is legitimate; CRC checking is the consumer's choice).
+     * Throws [MalformedZipException] if the local file header is missing or the entry's data would run
+     * past the end of the file.
+     */
+    public fun openEntry(entry: ZipEntryInfo): RawSource {
+        source.seek(entry.localHeaderOffset)
+        val lfh = Buffer().apply { write(source.readFully(LFH_FIXED_SIZE)) }
+        if (lfh.readU32LE() != LFH_SIG) {
+            throw MalformedZipException("entry '${entry.name}' has no local file header")
+        }
+        lfh.skip(LFH_PRE_NAME_LEN_BYTES) // straight to the nameLen/extraLen fields at offsets 26/28
+        val nameLen = lfh.readU16LE()
+        val extraLen = lfh.readU16LE()
+        val dataStart = entry.localHeaderOffset + LFH_FIXED_SIZE + nameLen + extraLen
+        if (dataStart < 0 || dataStart + entry.compressedSize > source.length) {
+            throw MalformedZipException("entry '${entry.name}' data runs past end of file")
+        }
+        val bounded = BoundedEntrySource(entry.name, dataStart, entry.compressedSize)
+        return if (entry.method == ZipMethod.DEFLATE) bounded.inflated() else bounded
+    }
+
+    override fun close() {
+        source.close()
+    }
+
+    private fun parseCentralDirectory(): List<ZipEntryInfo> {
+        val fileLen = source.length
+        if (fileLen < EOCD_FIXED_SIZE) {
+            throw MalformedZipException("file too small to be a ZIP ($fileLen bytes)")
+        }
+
+        // The EOCD lives in the last 22..65557 bytes (22 fixed + up to a 65535-byte comment).
+        val tailLen = minOf(fileLen, MAX_EOCD_SEARCH)
+        val tailStart = fileLen - tailLen
+        source.seek(tailStart)
+        val tail = source.readFully(tailLen.toInt())
+
+        val eocdRel = findEocdOffset(tail).toInt()
+        val eocdAbs = tailStart + eocdRel
+        val eocd = Buffer().apply { write(tail, eocdRel, eocdRel + EOCD_FIXED_SIZE.toInt()) }
+        if (eocd.readU32LE() != EOCD_SIG) throw MalformedZipException("bad end-of-central-directory signature")
+        eocd.skip(EOCD_DISK_FIELDS_LEN) // disk, cdStartDisk, entriesThisDisk
+        val totalEntries16 = eocd.readU16LE()
+        val cdSize32 = eocd.readU32LE()
+        val cdOffset32 = eocd.readU32LE()
+
+        var totalEntries: Long = totalEntries16.toLong()
+        var cdSize: Long = cdSize32
+        var cdOffset: Long = cdOffset32
+
+        val needsZip64 =
+            totalEntries16 == ZIP16_MAX || cdSize32 == ZIP64_U32_MAX || cdOffset32 == ZIP64_U32_MAX
+        if (needsZip64) {
+            val z64 = readZip64Eocd(eocdAbs, fileLen)
+            totalEntries = z64.totalEntries
+            cdSize = z64.cdSize
+            cdOffset = z64.cdOffset
+        }
+
+        if (cdOffset < 0 || cdSize < 0 || cdOffset > fileLen || cdOffset + cdSize > fileLen) {
+            throw MalformedZipException(
+                "central directory out of range (offset=$cdOffset size=$cdSize fileLen=$fileLen)",
+            )
+        }
+        if (totalEntries < 0 || totalEntries > Int.MAX_VALUE) {
+            throw MalformedZipException("implausible central-directory entry count ($totalEntries)")
+        }
+
+        val cd = readExactly(cdOffset, cdSize)
+        return parseHeaders(cd, totalEntries.toInt(), fileLen)
+    }
+
+    /** The three count/size/offset values recovered from a ZIP64 end-of-central-directory record. */
+    private class Zip64Eocd(
+        val totalEntries: Long,
+        val cdSize: Long,
+        val cdOffset: Long,
+    )
+
+    /**
+     * Follows the ZIP64 EOCD locator (the 20 bytes immediately before the classic EOCD at [eocdAbs]) to
+     * the ZIP64 EOCD record and reads the 64-bit entry count and central-directory size/offset.
+     */
+    private fun readZip64Eocd(
+        eocdAbs: Long,
+        fileLen: Long,
+    ): Zip64Eocd {
+        val locatorAbs = eocdAbs - ZIP64_LOCATOR_SIZE
+        if (locatorAbs < 0) throw MalformedZipException("no room for a ZIP64 EOCD locator")
+        source.seek(locatorAbs)
+        val locator = Buffer().apply { write(source.readFully(ZIP64_LOCATOR_SIZE.toInt())) }
+        if (locator.readU32LE() != ZIP64_LOCATOR_SIG) throw MalformedZipException("bad ZIP64 EOCD locator signature")
+        locator.skip(4) // diskWithZip64Eocd
+        val zip64EocdOffset = locator.readU64LE()
+        if (zip64EocdOffset < 0 || zip64EocdOffset + ZIP64_EOCD_SIZE > fileLen) {
+            throw MalformedZipException("ZIP64 EOCD offset out of range ($zip64EocdOffset)")
+        }
+        source.seek(zip64EocdOffset)
+        val z = Buffer().apply { write(source.readFully(ZIP64_EOCD_SIZE.toInt())) }
+        if (z.readU32LE() != ZIP64_EOCD_SIG) throw MalformedZipException("bad ZIP64 EOCD signature")
+        z.skip(ZIP64_EOCD_PRE_COUNTS_LEN) // recordSize, versionMadeBy, versionNeeded, disk, cdStartDisk
+        z.readU64LE() // entriesThisDisk
+        val totalEntries = z.readU64LE()
+        val cdSize = z.readU64LE()
+        val cdOffset = z.readU64LE()
+        return Zip64Eocd(totalEntries, cdSize, cdOffset)
+    }
+
+    /** Parses [count] central-directory headers out of [cd], resolving ZIP64 overflow per entry. */
+    private fun parseHeaders(
+        cd: Buffer,
+        count: Int,
+        fileLen: Long,
+    ): List<ZipEntryInfo> {
+        val entries = ArrayList<ZipEntryInfo>()
+        repeat(count) {
+            if (cd.size < CDH_FIXED_SIZE) throw MalformedZipException("central-directory header truncated")
+            if (cd.readU32LE() != CDH_SIG) throw MalformedZipException("bad central-directory header signature")
+            cd.skip(CDH_VERSIONS_LEN) // versionMadeBy, versionNeeded
+            val flags = cd.readU16LE()
+            val methodCode = cd.readU16LE()
+            cd.skip(CDH_MODTIME_LEN) // modTime, modDate
+            val crc = cd.readU32LE()
+            val compSize32 = cd.readU32LE()
+            val uncompSize32 = cd.readU32LE()
+            val nameLen = cd.readU16LE()
+            val extraLen = cd.readU16LE()
+            val commentLen = cd.readU16LE()
+            cd.skip(CDH_DISK_ATTRS_LEN) // diskStart, intAttrs, extAttrs
+            val localOffset32 = cd.readU32LE()
+
+            val variableLen = nameLen.toLong() + extraLen + commentLen
+            if (cd.size < variableLen) throw MalformedZipException("central-directory entry overruns the directory")
+            val name = cd.readByteArray(nameLen).decodeToString()
+            val extra = cd.readByteArray(extraLen)
+            cd.skip(commentLen.toLong())
+
+            if ((flags and ENCRYPTION_FLAG) !=
+                0
+            ) {
+                throw MalformedZipException("encrypted entry '$name' is not supported")
+            }
+            val method =
+                when (methodCode) {
+                    METHOD_STORED -> ZipMethod.STORED
+                    METHOD_DEFLATE -> ZipMethod.DEFLATE
+                    else -> throw MalformedZipException("unsupported compression method $methodCode for '$name'")
+                }
+
+            val (compSize, uncompSize, localOffset) =
+                resolveZip64(name, extra, compSize32, uncompSize32, localOffset32)
+            if (localOffset < 0 || localOffset + LFH_FIXED_SIZE > fileLen) {
+                throw MalformedZipException("local header offset out of range for '$name'")
+            }
+            if (compSize < 0 || compSize > fileLen || uncompSize < 0) {
+                throw MalformedZipException("implausible entry sizes for '$name'")
+            }
+            entries += ZipEntryInfo(name, method, crc, compSize, uncompSize, localOffset)
+        }
+        return entries
+    }
+
+    /** Resolves the (compSize, uncompSize, localOffset) triple, reading the ZIP64 extra for sentinel slots. */
+    private fun resolveZip64(
+        name: String,
+        extra: ByteArray,
+        compSize32: Long,
+        uncompSize32: Long,
+        localOffset32: Long,
+    ): Triple<Long, Long, Long> {
+        val hasUncomp = uncompSize32 == ZIP64_U32_MAX
+        val hasComp = compSize32 == ZIP64_U32_MAX
+        val hasOffset = localOffset32 == ZIP64_U32_MAX
+        if (!hasUncomp && !hasComp && !hasOffset) return Triple(compSize32, uncompSize32, localOffset32)
+
+        val z64 = parseZip64ExtraFor(extra, hasUncomp, hasComp, hasOffset)
+        val uncompSize = if (hasUncomp) z64.uncompSize.requireField(name, "uncompressed size") else uncompSize32
+        val compSize = if (hasComp) z64.compSize.requireField(name, "compressed size") else compSize32
+        val localOffset = if (hasOffset) z64.localOffset.requireField(name, "local header offset") else localOffset32
+        return Triple(compSize, uncompSize, localOffset)
+    }
+
+    private fun Long?.requireField(
+        name: String,
+        field: String,
+    ): Long = this ?: throw MalformedZipException("ZIP64 extra for '$name' is missing the $field")
+
+    /** Reads exactly [count] bytes starting at [offset] into a fresh [Buffer], chunking the disk reads. */
+    private fun readExactly(
+        offset: Long,
+        count: Long,
+    ): Buffer {
+        source.seek(offset)
+        val out = Buffer()
+        val chunk = ByteArray(COPY_CHUNK)
+        var remaining = count
+        while (remaining > 0) {
+            val want = minOf(remaining, COPY_CHUNK.toLong()).toInt()
+            val n = source.read(chunk, want)
+            if (n <= 0) throw MalformedZipException("unexpected end of file reading the central directory")
+            out.write(chunk, 0, n)
+            remaining -= n
+        }
+        return out
+    }
+
+    /**
+     * A [RawSource] over exactly [limit] bytes of the archive starting at a fixed offset. It seeks before
+     * every read so multiple entry streams over the shared handle don't corrupt each other, and treats a
+     * short disk read (the file is shorter than the central directory promised) as [MalformedZipException].
+     */
+    private inner class BoundedEntrySource(
+        private val name: String,
+        startOffset: Long,
+        private val limit: Long,
+    ) : RawSource {
+        private var nextOffset = startOffset
+        private var remaining = limit
+        private var closed = false
+
+        override fun readAtMostTo(
+            sink: Buffer,
+            byteCount: Long,
+        ): Long {
+            require(byteCount >= 0) { "byteCount < 0: $byteCount" }
+            check(!closed) { "entry source is closed" }
+            if (remaining == 0L) return -1L
+            if (byteCount == 0L) return 0L
+            val want = minOf(byteCount, remaining, COPY_CHUNK.toLong()).toInt()
+            val buffer = ByteArray(want)
+            source.seek(nextOffset)
+            val n = source.read(buffer, want)
+            if (n <= 0) throw MalformedZipException("entry '$name' data is truncated ($remaining bytes unread)")
+            sink.write(buffer, 0, n)
+            nextOffset += n
+            remaining -= n
+            return n.toLong()
+        }
+
+        override fun close() {
+            // Only releases this view; the shared file handle is owned by the enclosing ZipReader.
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val EOCD_FIXED_SIZE: Long = 22L
+        const val LFH_FIXED_SIZE: Int = 30
+
+        /** Bytes from the start of an LFH up to (not including) its nameLen field: 30 fixed − 4 sig − 2 − 2. */
+        const val LFH_PRE_NAME_LEN_BYTES: Long = 22L
+        const val ZIP64_LOCATOR_SIZE: Long = 20L
+        const val ZIP64_EOCD_SIZE: Long = 56L
+        const val CDH_FIXED_SIZE: Long = 46L
+
+        /** 22-byte EOCD + a 65535-byte max comment — the furthest back the EOCD can sit. */
+        const val MAX_EOCD_SEARCH: Long = 65_557L
+
+        const val EOCD_DISK_FIELDS_LEN: Long = 6L // disk(2) + cdStartDisk(2) + entriesThisDisk(2)
+        const val ZIP64_EOCD_PRE_COUNTS_LEN: Long = 20L // recordSize(8)+made(2)+need(2)+disk(4)+cdStart(4) after sig
+        const val CDH_VERSIONS_LEN: Long = 4L // versionMadeBy(2) + versionNeeded(2)
+        const val CDH_MODTIME_LEN: Long = 4L // modTime(2) + modDate(2)
+        const val CDH_DISK_ATTRS_LEN: Long = 8L // diskStart(2) + intAttrs(2) + extAttrs(4)
+
+        const val ENCRYPTION_FLAG: Int = 0x0001
+        const val METHOD_STORED: Int = 0
+        const val METHOD_DEFLATE: Int = 8
+
+        const val COPY_CHUNK: Int = 65_536
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriter.kt
@@ -1,0 +1,377 @@
+package com.calypsan.listenup.server.compression.zip
+
+import com.calypsan.listenup.server.compression.Crc32
+import com.calypsan.listenup.server.compression.DEFAULT_LEVEL
+import com.calypsan.listenup.server.compression.deflated
+import kotlinx.io.Buffer
+import kotlinx.io.RawSink
+import kotlinx.io.buffered
+import kotlinx.io.readByteArray
+
+/** Compression method for a ZIP entry: [STORED] copies bytes verbatim, [DEFLATE] compresses them. */
+public enum class ZipMethod { STORED, DEFLATE }
+
+/**
+ * Writes a ZIP archive to a sink as a stream — never seeks backward. The central directory written by
+ * [finish] always carries the authoritative CRC-32 and sizes; ZIP64 fields are emitted per-entry when a
+ * size or offset exceeds 32 bits. [close] calls [finish] if needed, then closes the sink. Pure commonMain.
+ *
+ * DEFLATE entries are fully streaming: the local header defers CRC and sizes to a trailing data descriptor
+ * (flag bit 3), so content of any size compresses with bounded memory. STORED entries cannot use a data
+ * descriptor — `java.util.zip` rejects `STORED + EXT` — so a forward-only writer must know their size up
+ * front; their content is buffered in memory, then a complete local header (real CRC/sizes, no descriptor)
+ * precedes the bytes. STORED therefore costs one entry's worth of memory; reserve it for small or already
+ * incompressible payloads.
+ *
+ * Usage: call [putEntry] to begin an entry, write its content to the returned sink, then close that sink
+ * (e.g. via `.buffered().use { }`) before opening the next. [finish] (or [close]) seals the archive.
+ */
+public class ZipWriter(
+    sink: RawSink,
+    private val level: Int = DEFAULT_LEVEL,
+) : AutoCloseable {
+    private val out = sink.buffered()
+
+    /** Total bytes emitted to [out] so far — each entry's local-header offset and the central-directory offset. */
+    private var written = 0L
+    private val centralEntries = mutableListOf<CentralEntry>()
+    private var entryOpen = false
+    private var finished = false
+    private var closed = false
+
+    /**
+     * Begins an entry named [name] compressed with [method] and returns a sink for its (uncompressed)
+     * content. For DEFLATE the local header is written immediately and the CRC/sizes follow in a data
+     * descriptor; for STORED the content is buffered and the whole header is written when the sink closes.
+     * The caller MUST close the returned sink before calling [putEntry] again or [finish]. Safe to wrap in
+     * `.buffered()` and `.use { }`.
+     */
+    public fun putEntry(
+        name: String,
+        method: ZipMethod = ZipMethod.DEFLATE,
+    ): RawSink {
+        check(!finished) { "ZipWriter is finished" }
+        check(!entryOpen) { "previous entry is still open" }
+        entryOpen = true
+        val nameBytes = name.encodeToByteArray()
+        val localOffset = written
+        return when (method) {
+            ZipMethod.DEFLATE -> DeflateEntry(nameBytes, localOffset).sink
+            ZipMethod.STORED -> StoredEntry(nameBytes, localOffset).sink
+        }
+    }
+
+    /**
+     * Seals the archive: writes the central directory, then the EOCD record (and a ZIP64 EOCD + locator
+     * when an offset, size, or entry count overflows its classic field). No entry may be open. Calling
+     * [finish] twice throws; [close] guards against the double call.
+     */
+    public fun finish() {
+        check(!finished) { "ZipWriter is already finished" }
+        check(!entryOpen) { "an entry is still open" }
+        finished = true
+        val cdOffset = written
+        for (entry in centralEntries) writeCentralHeader(entry)
+        val cdSize = written - cdOffset
+        val count = centralEntries.size
+        if (cdOffset > ZIP64_U32_MAX || cdSize > ZIP64_U32_MAX || count > ZIP16_MAX) {
+            writeZip64Eocd(count, cdSize, cdOffset)
+        }
+        writeEocd(count, cdSize, cdOffset)
+        out.flush()
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        if (!finished) finish()
+        out.close()
+    }
+
+    private fun writeCentralHeader(entry: CentralEntry) {
+        val extra =
+            encodeZip64Extra(
+                uncompSize = entry.uncompSize.takeIf { it > ZIP64_U32_MAX },
+                compSize = entry.compSize.takeIf { it > ZIP64_U32_MAX },
+                localOffset = entry.localOffset.takeIf { it > ZIP64_U32_MAX },
+            )
+        emit {
+            writeU32LE(CDH_SIG)
+            writeU16LE(VERSION_MADE_BY)
+            writeU16LE(if (entry.needsZip64) VERSION_ZIP64 else VERSION_DEFAULT)
+            writeU16LE(flagsFor(entry.method))
+            writeU16LE(methodCode(entry.method))
+            writeU16LE(0) // modTime
+            writeU16LE(0) // modDate
+            writeU32LE(entry.crc)
+            writeU32LE(clampU32(entry.compSize))
+            writeU32LE(clampU32(entry.uncompSize))
+            writeU16LE(entry.nameBytes.size)
+            writeU16LE(extra.size)
+            writeU16LE(0) // commentLen
+            writeU16LE(0) // diskStart
+            writeU16LE(0) // intAttrs
+            writeU32LE(0) // extAttrs
+            writeU32LE(clampU32(entry.localOffset))
+            write(entry.nameBytes)
+            if (extra.isNotEmpty()) write(extra)
+        }
+    }
+
+    private fun writeZip64Eocd(
+        count: Int,
+        cdSize: Long,
+        cdOffset: Long,
+    ) {
+        val zip64EocdOffset = written
+        emit {
+            writeU32LE(ZIP64_EOCD_SIG)
+            writeU64LE(ZIP64_EOCD_RECORD_SIZE)
+            writeU16LE(VERSION_MADE_BY)
+            writeU16LE(VERSION_ZIP64)
+            writeU32LE(0) // disk
+            writeU32LE(0) // cdStartDisk
+            writeU64LE(count.toLong())
+            writeU64LE(count.toLong())
+            writeU64LE(cdSize)
+            writeU64LE(cdOffset)
+        }
+        emit {
+            writeU32LE(ZIP64_LOCATOR_SIG)
+            writeU32LE(0) // disk holding the ZIP64 EOCD
+            writeU64LE(zip64EocdOffset)
+            writeU32LE(1) // total disks
+        }
+    }
+
+    private fun writeEocd(
+        count: Int,
+        cdSize: Long,
+        cdOffset: Long,
+    ) {
+        emit {
+            writeU32LE(EOCD_SIG)
+            writeU16LE(0) // disk
+            writeU16LE(0) // cdStartDisk
+            writeU16LE(minOf(count, ZIP16_MAX))
+            writeU16LE(minOf(count, ZIP16_MAX))
+            writeU32LE(clampU32(cdSize))
+            writeU32LE(clampU32(cdOffset))
+            writeU16LE(0) // commentLen
+        }
+    }
+
+    /** Builds a header in a scratch [Buffer], emits it to [out], and advances [written] by its length. */
+    private fun emit(block: Buffer.() -> Unit) {
+        val buffer = Buffer().apply(block)
+        val size = buffer.size
+        out.write(buffer, size)
+        written += size
+    }
+
+    private fun appendCentral(
+        nameBytes: ByteArray,
+        method: ZipMethod,
+        crc: Long,
+        compSize: Long,
+        uncompSize: Long,
+        localOffset: Long,
+    ) {
+        val needsZip64 = compSize > ZIP64_U32_MAX || uncompSize > ZIP64_U32_MAX || localOffset > ZIP64_U32_MAX
+        centralEntries += CentralEntry(nameBytes, method, crc, compSize, uncompSize, localOffset, needsZip64)
+        entryOpen = false
+    }
+
+    /**
+     * A streaming DEFLATE entry. The local header (with deferred CRC/sizes) was already written; content
+     * is CRC-summed and compressed straight to [out] through a counting sink. Closing the content sink
+     * finalizes the deflate stream, writes the data descriptor, and records the central-directory entry.
+     */
+    private inner class DeflateEntry(
+        private val nameBytes: ByteArray,
+        private val localOffset: Long,
+    ) {
+        private val crc = Crc32()
+        private var uncompSize = 0L
+        private var compSize = 0L
+        private var sinkClosed = false
+
+        init {
+            emit {
+                writeU32LE(LFH_SIG)
+                writeU16LE(VERSION_DEFAULT)
+                writeU16LE(DEFLATE_FLAGS)
+                writeU16LE(METHOD_DEFLATE)
+                writeU16LE(0) // modTime
+                writeU16LE(0) // modDate
+                writeU32LE(0) // crc — deferred to the data descriptor
+                writeU32LE(0) // compSize — deferred
+                writeU32LE(0) // uncompSize — deferred
+                writeU16LE(nameBytes.size)
+                writeU16LE(0) // extraLen
+                write(nameBytes)
+            }
+        }
+
+        /** Forwards compressed bytes to [out], counting them toward the archive total and this entry's compSize. */
+        private val countingSink =
+            object : RawSink {
+                override fun write(
+                    source: Buffer,
+                    byteCount: Long,
+                ) {
+                    out.write(source, byteCount)
+                    written += byteCount
+                    compSize += byteCount
+                }
+
+                override fun flush() = out.flush()
+
+                // Flush buffered bytes downstream but never close the shared archive sink.
+                override fun close() = out.flush()
+            }
+
+        private val deflateSink: RawSink = countingSink.deflated(level)
+
+        val sink: RawSink =
+            object : RawSink {
+                override fun write(
+                    source: Buffer,
+                    byteCount: Long,
+                ) {
+                    check(!sinkClosed) { "entry sink is closed" }
+                    var remaining = byteCount
+                    while (remaining > 0) {
+                        val chunk = source.readByteArray(minOf(remaining, COPY_CHUNK).toInt())
+                        crc.update(chunk)
+                        uncompSize += chunk.size
+                        deflateSink.write(Buffer().apply { write(chunk) }, chunk.size.toLong())
+                        remaining -= chunk.size
+                    }
+                }
+
+                override fun flush() = deflateSink.flush()
+
+                override fun close() {
+                    if (sinkClosed) return
+                    sinkClosed = true
+                    deflateSink.close() // emits + counts the final deflate block
+                    val needsZip64 = compSize > ZIP64_U32_MAX || uncompSize > ZIP64_U32_MAX
+                    emit {
+                        writeU32LE(DD_SIG)
+                        writeU32LE(crc.value)
+                        if (needsZip64) {
+                            writeU64LE(compSize)
+                            writeU64LE(uncompSize)
+                        } else {
+                            writeU32LE(compSize)
+                            writeU32LE(uncompSize)
+                        }
+                    }
+                    appendCentral(nameBytes, ZipMethod.DEFLATE, crc.value, compSize, uncompSize, localOffset)
+                }
+            }
+    }
+
+    /**
+     * A STORED entry. Because `java.util.zip` rejects a STORED entry with a data descriptor, the size must
+     * be known before the local header — so content is buffered in memory, CRC-summed, then on close a
+     * complete local header (real CRC/sizes, no descriptor) is written followed by the raw bytes.
+     */
+    private inner class StoredEntry(
+        private val nameBytes: ByteArray,
+        private val localOffset: Long,
+    ) {
+        private val crc = Crc32()
+        private val content = Buffer()
+        private var sinkClosed = false
+
+        val sink: RawSink =
+            object : RawSink {
+                override fun write(
+                    source: Buffer,
+                    byteCount: Long,
+                ) {
+                    check(!sinkClosed) { "entry sink is closed" }
+                    var remaining = byteCount
+                    while (remaining > 0) {
+                        val chunk = source.readByteArray(minOf(remaining, COPY_CHUNK).toInt())
+                        crc.update(chunk)
+                        content.write(chunk)
+                        remaining -= chunk.size
+                    }
+                }
+
+                override fun flush() = Unit
+
+                override fun close() {
+                    if (sinkClosed) return
+                    sinkClosed = true
+                    val size = content.size
+                    val needsZip64 = size > ZIP64_U32_MAX
+                    val extra =
+                        encodeZip64Extra(
+                            uncompSize = size.takeIf { needsZip64 },
+                            compSize = size.takeIf { needsZip64 },
+                            localOffset = null, // only the central header records the local offset
+                        )
+                    emit {
+                        writeU32LE(LFH_SIG)
+                        writeU16LE(if (needsZip64) VERSION_ZIP64 else VERSION_DEFAULT)
+                        writeU16LE(STORED_FLAGS)
+                        writeU16LE(METHOD_STORED)
+                        writeU16LE(0) // modTime
+                        writeU16LE(0) // modDate
+                        writeU32LE(crc.value)
+                        writeU32LE(clampU32(size))
+                        writeU32LE(clampU32(size))
+                        writeU16LE(nameBytes.size)
+                        writeU16LE(extra.size)
+                        write(nameBytes)
+                        if (extra.isNotEmpty()) write(extra)
+                    }
+                    out.write(content, size)
+                    written += size
+                    appendCentral(nameBytes, ZipMethod.STORED, crc.value, size, size, localOffset)
+                }
+            }
+    }
+}
+
+/** A finished entry's authoritative metadata, replayed into the central directory by [ZipWriter.finish]. */
+private class CentralEntry(
+    val nameBytes: ByteArray,
+    val method: ZipMethod,
+    val crc: Long,
+    val compSize: Long,
+    val uncompSize: Long,
+    val localOffset: Long,
+    val needsZip64: Boolean,
+)
+
+/** ZIP method code: 0 = STORED, 8 = DEFLATE. */
+private fun methodCode(method: ZipMethod): Int = if (method == ZipMethod.DEFLATE) METHOD_DEFLATE else METHOD_STORED
+
+/** General-purpose flags: STORED carries sizes in its header (UTF-8 only); DEFLATE adds the data-descriptor bit. */
+private fun flagsFor(method: ZipMethod): Int = if (method == ZipMethod.DEFLATE) DEFLATE_FLAGS else STORED_FLAGS
+
+/** Replaces a value that overflows a 32-bit field with the ZIP64 sentinel; the real value lives in the extra. */
+private fun clampU32(value: Long): Long = if (value > ZIP64_U32_MAX) ZIP64_U32_MAX else value
+
+private const val VERSION_DEFAULT: Int = 20
+private const val VERSION_ZIP64: Int = 45
+private const val VERSION_MADE_BY: Int = 20
+
+/** UTF-8 names (bit 11) only — STORED records its CRC and sizes in the local header. */
+private const val STORED_FLAGS: Int = 0x0800
+
+/** Data descriptor (bit 3) + UTF-8 names (bit 11) — DEFLATE defers its CRC and sizes to a trailing descriptor. */
+private const val DEFLATE_FLAGS: Int = 0x0808
+private const val METHOD_STORED: Int = 0
+private const val METHOD_DEFLATE: Int = 8
+
+/** ZIP64 EOCD record size field: the fixed 56-byte record minus its 12-byte signature+size prefix. */
+private const val ZIP64_EOCD_RECORD_SIZE: Long = 44L
+
+/** Bytes copied per pass when CRC-ing and forwarding entry content — bounds working-set memory. */
+private const val COPY_CHUNK: Long = 65_536L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriter.kt
@@ -17,7 +17,11 @@ public enum class ZipMethod { STORED, DEFLATE }
  * size or offset exceeds 32 bits. [close] calls [finish] if needed, then closes the sink. Pure commonMain.
  *
  * DEFLATE entries are fully streaming: the local header defers CRC and sizes to a trailing data descriptor
- * (flag bit 3), so content of any size compresses with bounded memory. STORED entries cannot use a data
+ * (flag bit 3), so content of any size compresses with bounded memory. The descriptor uses 8-byte sizes only
+ * when the entry exceeds 4 GiB — matching how `java.util.zip` auto-detects descriptor width from the inflated
+ * size (not from a local-header ZIP64 extra), so both its streaming `ZipInputStream` and random-access
+ * `ZipFile` read entries of any size; our `ZipReader` uses the authoritative central directory regardless.
+ * STORED entries cannot use a data
  * descriptor — `java.util.zip` rejects `STORED + EXT` — so a forward-only writer must know their size up
  * front; their content is buffered in memory, then a complete local header (real CRC/sizes, no descriptor)
  * precedes the bytes. STORED therefore costs one entry's worth of memory; reserve it for small or already

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/AudioFormatParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/AudioFormatParser.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.embeddedmeta
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import com.calypsan.listenup.server.io.SeekableSource
 
 /**
  * Per-format parser contract — the extension point for the embeddedmeta
@@ -20,7 +21,7 @@ import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
  * - [com.calypsan.listenup.api.error.AudioMetadataError.TruncatedStream] when
  *   the file ended before declared structure was complete
  * - [com.calypsan.listenup.api.error.AudioMetadataError.IoError] when the
- *   underlying [SeekableAudioSource] fails
+ *   underlying [SeekableSource] fails
  *
  * **Adding a new audio format:**
  *
@@ -43,5 +44,5 @@ internal interface AudioFormatParser {
      * Parse the embedded metadata for the audio stream referenced by [source].
      * Caller is responsible for opening and closing [source].
      */
-    suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata>
+    suspend fun parse(source: SeekableSource): AppResult<EmbeddedAudioMetadata>
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/EmbeddedMetadataParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/EmbeddedMetadataParser.kt
@@ -3,7 +3,9 @@ package com.calypsan.listenup.server.embeddedmeta
 import com.calypsan.listenup.api.error.AudioMetadataError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.io.fileIoDispatcher
+import com.calypsan.listenup.server.io.openSeekableSource
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -32,7 +34,7 @@ import kotlin.text.HexFormat
 internal open class EmbeddedMetadataParser(
     private val detector: AudioFormatDetector,
     private val parsers: List<AudioFormatParser>,
-    private val sourceFactory: (Path) -> SeekableAudioSource = ::defaultSeekableSource,
+    private val sourceFactory: (Path) -> SeekableSource = ::openSeekableSource,
 ) {
     open suspend fun parse(path: Path): AppResult<EmbeddedAudioMetadata> =
         withContext(fileIoDispatcher) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3Parser.kt
@@ -8,7 +8,7 @@ import com.calypsan.listenup.domain.embeddedmeta.AudioTags
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatParser
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import kotlinx.io.IOException
 
 /**
@@ -43,7 +43,7 @@ import kotlinx.io.IOException
 internal class Mp3Parser : AudioFormatParser {
     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp3)
 
-    override suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata> =
+    override suspend fun parse(source: SeekableSource): AppResult<EmbeddedAudioMetadata> =
         try {
             val id3v2 = readId3v2Region(source)
             val id3v1Tags = readId3v1Footer(source)
@@ -87,7 +87,7 @@ internal class Mp3Parser : AudioFormatParser {
             )
         }
 
-    private fun readId3v2Region(source: SeekableAudioSource): Id3v2ReadResult? {
+    private fun readId3v2Region(source: SeekableSource): Id3v2ReadResult? {
         if (source.length < ID3V2_HEADER_SIZE) return null
         source.seek(0)
         val header = source.readFully(ID3V2_HEADER_SIZE)
@@ -99,7 +99,7 @@ internal class Mp3Parser : AudioFormatParser {
         return Id3v2Reader.read(tagBytes)
     }
 
-    private fun readId3v1Footer(source: SeekableAudioSource): AudioTags? {
+    private fun readId3v1Footer(source: SeekableSource): AudioTags? {
         if (source.length < ID3V1_LEN) return null
         source.seek(source.length - ID3V1_LEN)
         val footer = source.readFully(ID3V1_LEN)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/MpegDurationCalculator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/MpegDurationCalculator.kt
@@ -1,7 +1,7 @@
 
 package com.calypsan.listenup.server.embeddedmeta.format.mp3
 
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.embeddedmeta.decode.TextDecoding
 import kotlinx.io.IOException
 
@@ -57,7 +57,7 @@ internal data class MpegFrameInfo(
 @Suppress("MagicNumber")
 internal object MpegDurationCalculator {
     fun compute(
-        source: SeekableAudioSource,
+        source: SeekableSource,
         audioStart: Long,
         hasV1Footer: Boolean,
     ): MpegFrameInfo {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/AtomWalker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/AtomWalker.kt
@@ -1,7 +1,7 @@
 
 package com.calypsan.listenup.server.embeddedmeta.format.mp4
 
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.embeddedmeta.decode.TextDecoding
 
 /**
@@ -191,7 +191,7 @@ internal object AtomWalker {
      * `moov`'s payload is then read back as a sub-range.
      */
     fun findTopLevelAtom(
-        source: SeekableAudioSource,
+        source: SeekableSource,
         type: String,
     ): TopLevelAtom? {
         val length = source.length

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ChapterExtractor.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ChapterExtractor.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.embeddedmeta.format.mp4
 
 import com.calypsan.listenup.domain.embeddedmeta.Chapter
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import kotlinx.io.IOException
 
 /**
@@ -94,7 +94,7 @@ internal object Mp4ChapterExtractor {
         bytes: ByteArray,
         moovAtom: Atom,
         durationMs: Long,
-        source: SeekableAudioSource,
+        source: SeekableSource,
     ): List<Chapter> {
         val chapterTrackId = findChapterTrackRef(bytes, moovAtom) ?: return emptyList()
         val chapterTrak = findTrackById(bytes, moovAtom, chapterTrackId) ?: return emptyList()
@@ -142,7 +142,7 @@ internal object Mp4ChapterExtractor {
         bytes: ByteArray,
         trakAtom: Atom,
         durationMs: Long,
-        source: SeekableAudioSource,
+        source: SeekableSource,
     ): List<Chapter> {
         val mdia = AtomWalker.findChild(bytes, trakAtom.dataOffset, trakAtom.end, "mdia") ?: return emptyList()
         val minf = AtomWalker.findChild(bytes, mdia.dataOffset, mdia.end, "minf") ?: return emptyList()
@@ -341,7 +341,7 @@ internal fun extractMp4Chapters(
     bytes: ByteArray,
     moovAtom: Atom,
     durationMs: Long,
-    source: SeekableAudioSource,
+    source: SeekableSource,
 ): Mp4ChapterResult {
     val nero = Mp4ChapterExtractor.readNeroChpl(bytes, moovAtom, durationMs)
     if (nero.isNotEmpty()) return Mp4ChapterResult(nero, ChapterSource.Mp4Chpl)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4Parser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4Parser.kt
@@ -7,7 +7,7 @@ import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.server.embeddedmeta.AudioFormatParser
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.embeddedmeta.emptyAudioTags
 import kotlinx.coroutines.CancellationException
 import kotlinx.io.IOException
@@ -41,7 +41,7 @@ import kotlinx.io.IOException
 internal class Mp4Parser : AudioFormatParser {
     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp4)
 
-    override suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata> {
+    override suspend fun parse(source: SeekableSource): AppResult<EmbeddedAudioMetadata> {
         val moovBytes =
             try {
                 val topMoov =

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/SeekableSource.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/SeekableSource.kt
@@ -1,14 +1,14 @@
-package com.calypsan.listenup.server.embeddedmeta
+package com.calypsan.listenup.server.io
 
 import kotlinx.io.files.Path
 
 /**
- * Seekable byte source — the only place in the embeddedmeta package that knows
- * how the platform opens a file for random access. Every parser depends on this
+ * Seekable byte source — the only place in the server that knows how the platform
+ * opens a file for random access. Parsers and container readers depend on this
  * interface, never on a platform file primitive directly. If kotlinx-io ships a
- * random-access primitive in a future version, swap [defaultSeekableSource] only.
+ * random-access primitive in a future version, swap [openSeekableSource] only.
  */
-internal interface SeekableAudioSource : AutoCloseable {
+internal interface SeekableSource : AutoCloseable {
     /** Total length of the underlying file in bytes. */
     val length: Long
 
@@ -35,4 +35,4 @@ internal interface SeekableAudioSource : AutoCloseable {
 }
 
 /** Default factory: opens [path] in read-only mode. */
-internal expect fun defaultSeekableSource(path: Path): SeekableAudioSource
+internal expect fun openSeekableSource(path: Path): SeekableSource

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/SeekableSource.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/SeekableSource.jvm.kt
@@ -1,14 +1,14 @@
-package com.calypsan.listenup.server.embeddedmeta
+package com.calypsan.listenup.server.io
 
 import java.io.RandomAccessFile
 import kotlinx.io.files.Path
 
-internal actual fun defaultSeekableSource(path: Path): SeekableAudioSource =
+internal actual fun openSeekableSource(path: Path): SeekableSource =
     RandomAccessFileSource(RandomAccessFile(path.toString(), "r"))
 
 private class RandomAccessFileSource(
     private val raf: RandomAccessFile,
-) : SeekableAudioSource {
+) : SeekableSource {
     override val length: Long get() = raf.length()
 
     override fun position(): Long = raf.filePointer

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNamesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNamesTest.kt
@@ -15,4 +15,11 @@ class ZipEntryNamesTest :
             isSafeEntryName("a/../b") shouldBe false
             isSafeEntryName("") shouldBe false
         }
+
+        test("isSafeEntryName rejects names containing control characters") {
+            isSafeEntryName("x\u0000.txt") shouldBe false // NUL
+            isSafeEntryName("x\u0001.txt") shouldBe false // SOH
+            isSafeEntryName("..") shouldBe false
+            isSafeEntryName("foo/") shouldBe true
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNamesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipEntryNamesTest.kt
@@ -1,0 +1,18 @@
+package com.calypsan.listenup.server.compression.zip
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ZipEntryNamesTest :
+    FunSpec({
+        test("isSafeEntryName accepts relative paths, rejects traversal/absolute") {
+            isSafeEntryName("covers/book-1/cover.jpg") shouldBe true
+            isSafeEntryName("manifest.json") shouldBe true
+            isSafeEntryName("../x") shouldBe false
+            isSafeEntryName("a/../../b") shouldBe false
+            isSafeEntryName("/abs") shouldBe false
+            isSafeEntryName("C:\\x") shouldBe false
+            isSafeEntryName("a/../b") shouldBe false
+            isSafeEntryName("") shouldBe false
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormatTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormatTest.kt
@@ -1,0 +1,69 @@
+package com.calypsan.listenup.server.compression.zip
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+
+class ZipFormatTest :
+    FunSpec({
+        test("u16/u32/u64 little-endian round-trip") {
+            val b = Buffer()
+            b.writeU16LE(0x1234)
+            b.writeU32LE(0x89AB_CDEFL)
+            b.writeU64LE(0x0102_0304_0506_0708L)
+            b.readU16LE() shouldBe 0x1234
+            b.readU32LE() shouldBe 0x89AB_CDEFL
+            b.readU64LE() shouldBe 0x0102_0304_0506_0708L
+        }
+
+        test("u32 reads back as unsigned (high bit set)") {
+            val b = Buffer()
+            b.writeU32LE(0xFFFF_FFFFL)
+            b.readU32LE() shouldBe 0xFFFF_FFFFL
+        }
+
+        test("ZIP64 extra encodes only the overflowed fields and decodes back") {
+            val extra = encodeZip64Extra(uncompSize = 5_000_000_000L, compSize = 4_500_000_000L, localOffset = null)
+            val parsed = parseZip64Extra(extra)
+            parsed.uncompSize shouldBe 5_000_000_000L
+            parsed.compSize shouldBe 4_500_000_000L
+            parsed.localOffset shouldBe null
+            val head = Buffer().apply { write(extra) }
+            head.readU16LE() shouldBe 0x0001 // header id
+            head.readU16LE() shouldBe 16 // dataSize = 2 * 8
+        }
+
+        test("ZIP64 extra with all three fields present") {
+            val extra = encodeZip64Extra(9_000_000_000L, 8_000_000_000L, 7_000_000_000L)
+            val parsed = parseZip64Extra(extra)
+            parsed.uncompSize shouldBe 9_000_000_000L
+            parsed.compSize shouldBe 8_000_000_000L
+            parsed.localOffset shouldBe 7_000_000_000L
+        }
+
+        test("parseZip64Extra finds the 0x0001 record among multiple extra records") {
+            // a 4-byte unknown extra record (id 0x9999, size 0) followed by our zip64 record
+            val b = Buffer()
+            b.writeU16LE(0x9999)
+            b.writeU16LE(0)
+            b.write(encodeZip64Extra(uncompSize = 5_000_000_000L, compSize = null, localOffset = null))
+            val parsed = parseZip64Extra(b.readByteArray())
+            parsed.uncompSize shouldBe 5_000_000_000L
+            parsed.compSize shouldBe null
+        }
+
+        test("findEocdOffset locates the EOCD signature scanning back from the end") {
+            val b = Buffer()
+            b.write(ByteArray(100) { 0 })
+            b.writeU32LE(0x0605_4b50L) // EOCD signature at offset 100
+            b.write(ByteArray(18) { 0 }) // rest of EOCD (commentLen=0)
+            findEocdOffset(b.readByteArray()) shouldBe 100L
+        }
+
+        test("findEocdOffset throws on a buffer with no EOCD") {
+            io.kotest.assertions.throwables.shouldThrow<MalformedZipException> {
+                findEocdOffset(ByteArray(50) { 0x11 })
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormatTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormatTest.kt
@@ -66,4 +66,31 @@ class ZipFormatTest :
                 findEocdOffset(ByteArray(50) { 0x11 })
             }
         }
+
+        test("encodeZip64Extra returns an empty array when all fields are null") {
+            encodeZip64Extra(uncompSize = null, compSize = null, localOffset = null).size shouldBe 0
+        }
+
+        test("findEocdOffset throws (not OOB) on a sub-22-byte buffer") {
+            io.kotest.assertions.throwables
+                .shouldThrow<MalformedZipException> { findEocdOffset(ByteArray(0)) }
+            io.kotest.assertions.throwables
+                .shouldThrow<MalformedZipException> { findEocdOffset(ByteArray(3) { 0 }) }
+        }
+
+        test("parseZip64Extra on an empty array returns all null without throwing") {
+            val parsed = parseZip64Extra(ByteArray(0))
+            parsed.uncompSize shouldBe null
+            parsed.compSize shouldBe null
+            parsed.localOffset shouldBe null
+        }
+
+        test("parseZip64Extra on a truncated 0x0001 record returns all null (no OOB)") {
+            // id=0x0001, dataSize claims 16 bytes (two fields), but only 4 data bytes present.
+            val truncated = byteArrayOf(0x01, 0x00, 0x10, 0x00, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
+            val parsed = parseZip64Extra(truncated)
+            parsed.uncompSize shouldBe null
+            parsed.compSize shouldBe null
+            parsed.localOffset shouldBe null
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormatTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipFormatTest.kt
@@ -93,4 +93,24 @@ class ZipFormatTest :
             parsed.compSize shouldBe null
             parsed.localOffset shouldBe null
         }
+
+        test("parseZip64ExtraFor assigns a lone compSize value (sentinel-aware, not positional)") {
+            // A CDH where only compSize == 0xFFFFFFFF, so the extra carries exactly ONE 8-byte value
+            // (the real compressed size). A positional parse would mis-assign it to uncompSize.
+            val extra = encodeZip64Extra(uncompSize = null, compSize = 4_500_000_000L, localOffset = null)
+            val parsed = parseZip64ExtraFor(extra, hasUncomp = false, hasComp = true, hasOffset = false)
+            parsed.compSize shouldBe 4_500_000_000L
+            parsed.uncompSize shouldBe null
+            parsed.localOffset shouldBe null
+        }
+
+        test("parseZip64ExtraFor assigns values in (uncomp, comp, offset) order to the sentinel fields") {
+            // uncompSize and localOffset are sentinels (comp is a real 32-bit value): the extra holds two
+            // values, the first → uncompSize, the second → localOffset.
+            val extra = encodeZip64Extra(uncompSize = 9_000_000_000L, compSize = null, localOffset = 7_000_000_000L)
+            val parsed = parseZip64ExtraFor(extra, hasUncomp = true, hasComp = false, hasOffset = true)
+            parsed.uncompSize shouldBe 9_000_000_000L
+            parsed.compSize shouldBe null
+            parsed.localOffset shouldBe 7_000_000_000L
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipReaderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipReaderTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.compression.zip
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.io.buffered
@@ -8,6 +9,7 @@ import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.SystemTemporaryDirectory
 import kotlinx.io.readByteArray
 import java.io.ByteArrayOutputStream
+import java.io.RandomAccessFile
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -36,6 +38,18 @@ private fun writeTemp(bytes: ByteArray): Path {
     val p = Path(SystemTemporaryDirectory, "zr-${bytes.size}-${bytes.contentHashCode()}.zip")
     SystemFileSystem.sink(p).buffered().use { it.write(bytes) }
     return p
+}
+
+/** Patches a 4-byte little-endian unsigned int at [offsetFromStart] — used to corrupt EOCD fields. */
+private fun patchU32FromEnd(
+    bytes: ByteArray,
+    offsetFromStart: Int,
+    value: Long,
+) {
+    bytes[offsetFromStart] = (value and 0xFF).toByte()
+    bytes[offsetFromStart + 1] = ((value shr 8) and 0xFF).toByte()
+    bytes[offsetFromStart + 2] = ((value shr 16) and 0xFF).toByte()
+    bytes[offsetFromStart + 3] = ((value shr 24) and 0xFF).toByte()
 }
 
 class ZipReaderTest :
@@ -84,6 +98,57 @@ class ZipReaderTest :
             try {
                 ZipReader(path).use { zr ->
                     zr.openEntry(zr.entry("a")!!).buffered().readByteArray() shouldBe byteArrayOf(1, 2, 3)
+                }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
+        }
+
+        test("a central directory size implausible for the entry count is rejected without buffering the file") {
+            // One entry, but the EOCD claims the directory spans the whole file. The totalEntries↔cdSize
+            // cross-check must reject this in O(1) — never allocate the file onto the heap. The content is
+            // large enough (> ~192 KB, one entry's maximum plausible header) that only the cross-check,
+            // not the range guard, can fire; it is still modest enough that a regression couldn't OOM.
+            val bytes = jdkZip(listOf(Triple("big.bin", ZipEntry.STORED, ByteArray(300_000))))
+            val fileLen = bytes.size.toLong()
+            patchU32FromEnd(bytes, bytes.size - 22 + 12, fileLen) // cdSize := fileLen
+            patchU32FromEnd(bytes, bytes.size - 22 + 16, 0L) // cdOffset := 0
+            val path = writeTemp(bytes)
+            try {
+                shouldThrow<MalformedZipException> { ZipReader(path) }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
+        }
+
+        test("a central directory that does not abut the EOCD record is rejected (anchor mismatch)") {
+            // A valid 2-entry archive whose EOCD cdOffset is redirected to the start of entry data. The
+            // self-consistency anchor (cdOffset + cdSize must equal the EOCD offset) rejects the redirect.
+            val bytes =
+                jdkZip(
+                    listOf(
+                        Triple("one.txt", ZipEntry.STORED, "first".encodeToByteArray()),
+                        Triple("two.txt", ZipEntry.STORED, "second".encodeToByteArray()),
+                    ),
+                )
+            patchU32FromEnd(bytes, bytes.size - 22 + 16, 0L) // cdOffset := 0 (points into entry data)
+            val path = writeTemp(bytes)
+            try {
+                shouldThrow<MalformedZipException> { ZipReader(path) }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
+        }
+
+        test("openEntry on a file truncated after construction throws MalformedZipException, not EOFException") {
+            // The directory parses cleanly, then the file is truncated (disk rot / partial write) before the
+            // entry is opened. openEntry must re-check the live length and surface a typed exception.
+            val path = writeTemp(jdkZip(listOf(Triple("a.txt", ZipEntry.STORED, "hello".encodeToByteArray()))))
+            try {
+                ZipReader(path).use { zr ->
+                    val entry = zr.entry("a.txt")!!
+                    RandomAccessFile(path.toString(), "rw").use { it.setLength(8) }
+                    shouldThrow<MalformedZipException> { zr.openEntry(entry) }
                 }
             } finally {
                 SystemFileSystem.delete(path, mustExist = false)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipReaderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipReaderTest.kt
@@ -1,0 +1,92 @@
+package com.calypsan.listenup.server.compression.zip
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.readByteArray
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+private fun jdkZip(entries: List<Triple<String, Int, ByteArray>>): ByteArray {
+    val bos = ByteArrayOutputStream()
+    ZipOutputStream(bos).use { zos ->
+        for ((name, method, content) in entries) {
+            val e = ZipEntry(name)
+            e.method = method
+            if (method == ZipEntry.STORED) {
+                e.size = content.size.toLong()
+                val crc = java.util.zip.CRC32()
+                crc.update(content)
+                e.crc = crc.value
+                e.compressedSize = content.size.toLong()
+            }
+            zos.putNextEntry(e)
+            zos.write(content)
+            zos.closeEntry()
+        }
+    }
+    return bos.toByteArray()
+}
+
+private fun writeTemp(bytes: ByteArray): Path {
+    val p = Path(SystemTemporaryDirectory, "zr-${bytes.size}-${bytes.contentHashCode()}.zip")
+    SystemFileSystem.sink(p).buffered().use { it.write(bytes) }
+    return p
+}
+
+class ZipReaderTest :
+    FunSpec({
+        test("reads java.util.zip archives by name (DEFLATE + STORED + nested)") {
+            val entries =
+                listOf(
+                    Triple("manifest.json", ZipEntry.STORED, """{"v":1}""".encodeToByteArray()),
+                    Triple("listenup.db", ZipEntry.DEFLATED, ByteArray(80_000) { (it % 5).toByte() }),
+                    Triple("covers/a/b.jpg", ZipEntry.DEFLATED, ByteArray(4000) { (it * 7).toByte() }),
+                )
+            val path = writeTemp(jdkZip(entries))
+            try {
+                ZipReader(path).use { zr ->
+                    zr.entries().map { it.name }.toSet() shouldBe entries.map { it.first }.toSet()
+                    for ((name, _, content) in entries) {
+                        zr.openEntry(zr.entry(name)!!).buffered().readByteArray() shouldBe content
+                    }
+                    zr.entry("nope") shouldBe null
+                }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
+        }
+
+        test("a truncated archive throws MalformedZipException") {
+            val good = jdkZip(listOf(Triple("x", ZipEntry.DEFLATED, ByteArray(5000) { it.toByte() })))
+            val path = writeTemp(good.copyOf(good.size / 2))
+            try {
+                io.kotest.assertions.throwables
+                    .shouldThrow<MalformedZipException> { ZipReader(path) }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
+        }
+
+        test("an archive with a 64KiB comment (EOCD pushed back) still parses") {
+            val bos = ByteArrayOutputStream()
+            ZipOutputStream(bos).use { zos ->
+                zos.setComment("x".repeat(40_000))
+                zos.putNextEntry(ZipEntry("a"))
+                zos.write(byteArrayOf(1, 2, 3))
+                zos.closeEntry()
+            }
+            val path = writeTemp(bos.toByteArray())
+            try {
+                ZipReader(path).use { zr ->
+                    zr.openEntry(zr.entry("a")!!).buffered().readByteArray() shouldBe byteArrayOf(1, 2, 3)
+                }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipRoundTripTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipRoundTripTest.kt
@@ -1,0 +1,110 @@
+package com.calypsan.listenup.server.compression.zip
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.Buffer
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.readByteArray
+import java.io.File
+
+private fun writeOurs(entries: List<Triple<String, ZipMethod, ByteArray>>): ByteArray {
+    val out = Buffer()
+    ZipWriter(out).use { zw ->
+        for ((name, method, content) in entries) {
+            zw.putEntry(name, method).buffered().use {
+                it.write(Buffer().apply { write(content) }, content.size.toLong())
+            }
+        }
+    }
+    return out.readByteArray()
+}
+
+private fun temp(
+    bytes: ByteArray,
+    tag: String,
+): Path {
+    val p = Path(SystemTemporaryDirectory, "zrt-$tag-${bytes.size}.zip")
+    SystemFileSystem.sink(p).buffered().use { it.write(bytes) }
+    return p
+}
+
+class ZipRoundTripTest :
+    FunSpec({
+        test("ours to ours round-trips a varied entry set (STORED + DEFLATE, nested, empty)") {
+            val entries =
+                listOf(
+                    Triple("manifest.json", ZipMethod.STORED, """{"v":1,"n":"x"}""".encodeToByteArray()),
+                    Triple("listenup.db", ZipMethod.DEFLATE, ByteArray(250_000) { (it % 9).toByte() }),
+                    Triple("covers/a/1.jpg", ZipMethod.DEFLATE, ByteArray(3333) { (it * 7).toByte() }),
+                    Triple("covers/b/2.png", ZipMethod.STORED, ByteArray(1500) { (it * 3).toByte() }),
+                    Triple("empty.bin", ZipMethod.DEFLATE, ByteArray(0)),
+                )
+            val p = temp(writeOurs(entries), "varied")
+            try {
+                ZipReader(p).use { zr ->
+                    zr.entries().map { it.name }.toSet() shouldBe entries.map { it.first }.toSet()
+                    for ((name, _, content) in entries) {
+                        zr.openEntry(zr.entry(name)!!).buffered().readByteArray() shouldBe content
+                    }
+                }
+            } finally {
+                SystemFileSystem.delete(p, mustExist = false)
+            }
+        }
+
+        test("ZIP64: more than 65535 entries forces the ZIP64 EOCD; our reader and java.util.zip both read all") {
+            val out = Buffer()
+            ZipWriter(out).use { zw ->
+                repeat(70_000) { i ->
+                    zw.putEntry("e$i", ZipMethod.STORED).buffered().use {
+                        it.write(Buffer().apply { write(byteArrayOf(i.toByte())) }, 1)
+                    }
+                }
+            }
+            val p = temp(out.readByteArray(), "zip64")
+            try {
+                ZipReader(p).use { zr ->
+                    zr.entries().size shouldBe 70_000
+                    zr.openEntry(zr.entry("e69999")!!).buffered().readByteArray() shouldBe byteArrayOf((69_999).toByte())
+                }
+                java.util.zip
+                    .ZipFile(File(p.toString()))
+                    .use { it.size() shouldBe 70_000 }
+            } finally {
+                SystemFileSystem.delete(p, mustExist = false)
+            }
+        }
+
+        test("realistic backup shape round-trips through java.util.zip and ours") {
+            val entries =
+                buildList {
+                    add(Triple("manifest.json", ZipMethod.STORED, """{"v":1}""".encodeToByteArray()))
+                    add(Triple("listenup.db", ZipMethod.DEFLATE, ByteArray(500_000) { (it % 11).toByte() }))
+                    repeat(50) { i ->
+                        add(Triple("covers/b$i/cover.jpg", ZipMethod.DEFLATE, ByteArray(2000) { (it * (i + 1)).toByte() }))
+                    }
+                    repeat(20) { i ->
+                        add(Triple("avatars/u$i.png", ZipMethod.STORED, ByteArray(800) { (it + i).toByte() }))
+                    }
+                }
+            val p = temp(writeOurs(entries), "backup")
+            try {
+                java.util.zip.ZipFile(File(p.toString())).use { jdk ->
+                    jdk.size() shouldBe entries.size
+                    for ((name, _, content) in entries) {
+                        jdk.getInputStream(jdk.getEntry(name)).use { it.readBytes() } shouldBe content
+                    }
+                }
+                ZipReader(p).use { zr ->
+                    for ((name, _, content) in entries) {
+                        zr.openEntry(zr.entry(name)!!).buffered().readByteArray() shouldBe content
+                    }
+                }
+            } finally {
+                SystemFileSystem.delete(p, mustExist = false)
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipRoundTripTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipRoundTripTest.kt
@@ -68,7 +68,7 @@ class ZipRoundTripTest :
             try {
                 ZipReader(p).use { zr ->
                     zr.entries().size shouldBe 70_000
-                    zr.openEntry(zr.entry("e69999")!!).buffered().readByteArray() shouldBe byteArrayOf((69_999).toByte())
+                    zr.openEntry(zr.entry("e69999")!!).buffered().readByteArray() shouldBe byteArrayOf(69_999.toByte())
                 }
                 java.util.zip
                     .ZipFile(File(p.toString()))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriterTest.kt
@@ -4,8 +4,13 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.io.Buffer
 import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
 import kotlinx.io.readByteArray
 import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipFile
 import java.util.zip.ZipInputStream
 
 private fun writeArchive(entries: List<Triple<String, ZipMethod, ByteArray>>): ByteArray {
@@ -16,6 +21,14 @@ private fun writeArchive(entries: List<Triple<String, ZipMethod, ByteArray>>): B
         }
     }
     return out.readByteArray()
+}
+
+/** Writes [entries] to a temp file so it can be opened by [ZipFile], which seeks by central-directory offset. */
+private fun writeTempArchive(entries: List<Triple<String, ZipMethod, ByteArray>>): Path {
+    val archive = writeArchive(entries)
+    val path = Path(SystemTemporaryDirectory, "zw-${archive.size}-${entries.hashCode()}.zip")
+    SystemFileSystem.sink(path).buffered().use { it.write(Buffer().apply { write(archive) }, archive.size.toLong()) }
+    return path
 }
 
 private fun readWithJdk(archive: ByteArray): Map<String, ByteArray> {
@@ -42,6 +55,27 @@ class ZipWriterTest :
             val read = readWithJdk(writeArchive(entries))
             for ((name, _, content) in entries) read[name] shouldBe content
             read.size shouldBe entries.size
+        }
+
+        test("java.util.zip ZipFile reads our archive by name (central directory + seek)") {
+            val entries =
+                listOf(
+                    Triple("manifest.json", ZipMethod.STORED, """{"v":1}""".encodeToByteArray()),
+                    Triple("listenup.db", ZipMethod.DEFLATE, ByteArray(120_000) { (it % 7).toByte() }),
+                    Triple("covers/book-1/cover.jpg", ZipMethod.DEFLATE, ByteArray(6000) { (it * 13).toByte() }),
+                )
+            val path = writeTempArchive(entries)
+            try {
+                ZipFile(File(path.toString())).use { zf ->
+                    for ((name, _, content) in entries) {
+                        val entry = zf.getEntry(name) ?: error("missing entry $name")
+                        zf.getInputStream(entry).use { it.readBytes() } shouldBe content
+                    }
+                    zf.size() shouldBe entries.size
+                }
+            } finally {
+                SystemFileSystem.delete(path, mustExist = false)
+            }
         }
 
         test("empty archive (no entries) is a valid zip java.util.zip accepts") {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/compression/zip/ZipWriterTest.kt
@@ -1,0 +1,55 @@
+package com.calypsan.listenup.server.compression.zip
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.Buffer
+import kotlinx.io.buffered
+import kotlinx.io.readByteArray
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+private fun writeArchive(entries: List<Triple<String, ZipMethod, ByteArray>>): ByteArray {
+    val out = Buffer()
+    ZipWriter(out).use { zw ->
+        for ((name, method, content) in entries) {
+            zw.putEntry(name, method).buffered().use { it.write(Buffer().apply { write(content) }, content.size.toLong()) }
+        }
+    }
+    return out.readByteArray()
+}
+
+private fun readWithJdk(archive: ByteArray): Map<String, ByteArray> {
+    val result = LinkedHashMap<String, ByteArray>()
+    ZipInputStream(ByteArrayInputStream(archive)).use { zis ->
+        while (true) {
+            val e = zis.nextEntry ?: break
+            result[e.name] = zis.readBytes()
+            zis.closeEntry()
+        }
+    }
+    return result
+}
+
+class ZipWriterTest :
+    FunSpec({
+        test("java.util.zip reads our DEFLATE + STORED entries") {
+            val entries =
+                listOf(
+                    Triple("manifest.json", ZipMethod.STORED, """{"v":1}""".encodeToByteArray()),
+                    Triple("listenup.db", ZipMethod.DEFLATE, ByteArray(100_000) { (it % 7).toByte() }),
+                    Triple("covers/book-1/cover.jpg", ZipMethod.DEFLATE, ByteArray(5000) { (it * 13).toByte() }),
+                )
+            val read = readWithJdk(writeArchive(entries))
+            for ((name, _, content) in entries) read[name] shouldBe content
+            read.size shouldBe entries.size
+        }
+
+        test("empty archive (no entries) is a valid zip java.util.zip accepts") {
+            readWithJdk(writeArchive(emptyList())).isEmpty() shouldBe true
+        }
+
+        test("an empty-content entry round-trips") {
+            val read = readWithJdk(writeArchive(listOf(Triple("empty.txt", ZipMethod.DEFLATE, ByteArray(0)))))
+            read["empty.txt"] shouldBe ByteArray(0)
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/AudioFormatParserContractTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/AudioFormatParserContractTest.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.AudioTags
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
+import com.calypsan.listenup.server.io.SeekableSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
@@ -22,7 +23,7 @@ class AudioFormatParserContractTest :
                 object : AudioFormatParser {
                     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp3)
 
-                    override suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata> =
+                    override suspend fun parse(source: SeekableSource): AppResult<EmbeddedAudioMetadata> =
                         AppResult.Failure(
                             AudioMetadataError.IoError("/test", "stub"),
                         )
@@ -35,7 +36,7 @@ class AudioFormatParserContractTest :
                 object : AudioFormatParser {
                     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp4)
 
-                    override suspend fun parse(source: SeekableAudioSource): AppResult<EmbeddedAudioMetadata> =
+                    override suspend fun parse(source: SeekableSource): AppResult<EmbeddedAudioMetadata> =
                         AppResult.Failure(
                             AudioMetadataError.CorruptHeader(
                                 pathString = "/test",
@@ -48,7 +49,7 @@ class AudioFormatParserContractTest :
             // Stub source — the parser never reads it in this stub.
             val result =
                 parser.parse(
-                    object : SeekableAudioSource {
+                    object : SeekableSource {
                         override val length: Long = 0
 
                         override fun position(): Long = 0

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserAdversarialTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserAdversarialTest.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.embeddedmeta.format.mp3
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -260,7 +260,7 @@ class Mp3ParserAdversarialTest :
     })
 
 /**
- * Synthetic [SeekableAudioSource] that reports a large [claimedLength] but
+ * Synthetic [SeekableSource] that reports a large [claimedLength] but
  * only physically holds the [header] bytes. Reads inside the header are
  * served verbatim; reads past it are zero-filled *without ever
  * materialising the multi-hundred-MB body* — exactly like the
@@ -273,7 +273,7 @@ class Mp3ParserAdversarialTest :
 private class HeaderOnlySource(
     private val header: ByteArray,
     private val claimedLength: Long,
-) : SeekableAudioSource {
+) : SeekableSource {
     var maxSingleReadBytes: Int = 0
         private set
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserStreamingTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserStreamingTest.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.embeddedmeta.format.mp3
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.longs.shouldBeLessThan
@@ -62,7 +62,7 @@ class Mp3ParserStreamingTest :
 private class LargePrefixSource(
     private val realPrefix: ByteArray,
     private val totalLength: Long,
-) : SeekableAudioSource {
+) : SeekableSource {
     var totalBytesRead: Long = 0
         private set
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Mp3ParserTest.kt
@@ -6,8 +6,8 @@ import com.calypsan.listenup.domain.embeddedmeta.AudioTags
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.domain.embeddedmeta.SeriesEntry
-import com.calypsan.listenup.server.embeddedmeta.ByteArraySeekableAudioSource
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.ByteArraySeekableSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -216,7 +216,7 @@ class Mp3ParserTest :
 
         test("parse maps IO failure to AudioMetadataError.IoError") {
             val source =
-                object : SeekableAudioSource {
+                object : SeekableSource {
                     override val length: Long = 100
 
                     override fun position(): Long = 0
@@ -288,7 +288,7 @@ class Mp3ParserTest :
                     id3v2 { textFrame("TIT2", "T") }
                     mpegFrames(durationSeconds = 30, bitrate = 64_000, sampleRate = 44_100)
                 }
-            val result = Mp3Parser().parse(ByteArraySeekableAudioSource(bytes))
+            val result = Mp3Parser().parse(ByteArraySeekableSource(bytes))
             result.shouldBeInstanceOf<AppResult.Success<EmbeddedAudioMetadata>>()
             val a = (result as AppResult.Success).data.audioStream
             // mpegFrameHeader encodes channel mode 0b00 (stereo) → 2 channels
@@ -315,8 +315,8 @@ class Mp3ParserTest :
         }
     })
 
-internal fun byteSource(bytes: ByteArray): SeekableAudioSource =
-    object : SeekableAudioSource {
+internal fun byteSource(bytes: ByteArray): SeekableSource =
+    object : SeekableSource {
         private var pos: Long = 0
         override val length: Long = bytes.size.toLong()
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserAdversarialTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserAdversarialTest.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.embeddedmeta.format.mp4
 
 import com.calypsan.listenup.api.error.AudioMetadataError
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -207,7 +207,7 @@ class Mp4ParserAdversarialTest :
     })
 
 /**
- * Synthetic [SeekableAudioSource] that reports a large [claimedLength] but
+ * Synthetic [SeekableSource] that reports a large [claimedLength] but
  * only physically holds the [header] bytes. A `readFully` confined to the
  * header is served verbatim; any read straying past it throws [IOException]
  * — it would have to materialise zero-fill the parser never legitimately
@@ -218,7 +218,7 @@ class Mp4ParserAdversarialTest :
 private class MoovHeaderOnlySource(
     private val header: ByteArray,
     private val claimedLength: Long,
-) : SeekableAudioSource {
+) : SeekableSource {
     var maxSingleReadBytes: Int = 0
         private set
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserStreamingTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserStreamingTest.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.embeddedmeta.format.mp4
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp4File
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.longs.shouldBeLessThan
@@ -15,7 +15,7 @@ import java.io.IOException
 /**
  * Regression coverage for the streaming-MP4 parse path.
  *
- * Uses a synthetic [SeekableAudioSource] that reports a multi-gigabyte
+ * Uses a synthetic [SeekableSource] that reports a multi-gigabyte
  * length (simulating a real M4B audiobook) but only carries the metadata
  * region in memory; any read into the synthetic mdat returns zeros via a
  * small reusable buffer, with strict accounting on total bytes pulled.
@@ -167,7 +167,7 @@ class Mp4ParserStreamingTest :
     })
 
 /**
- * Synthetic [SeekableAudioSource] simulating a non-fast-start MP4 layout
+ * Synthetic [SeekableSource] simulating a non-fast-start MP4 layout
  * (`ftyp` → `mdat` larger than 2 GB → `moov` at the end). Holds only the
  * tiny header + moov regions in memory; the synthetic mdat payload is
  * never materialised. Tracks total bytes pulled to assert the parser
@@ -179,7 +179,7 @@ private class NonFastStartSource(
     private val moovOffset: Long,
     private val moov: ByteArray,
     private val totalLength: Long,
-) : SeekableAudioSource {
+) : SeekableSource {
     var totalBytesRead: Long = 0
         private set
 
@@ -258,7 +258,7 @@ private class NonFastStartSource(
 }
 
 /**
- * Synthetic [SeekableAudioSource] that lies about its total length.
+ * Synthetic [SeekableSource] that lies about its total length.
  *
  * Bytes inside [realPrefix] are returned verbatim; bytes anywhere past
  * its end are returned as zeros without ever materialising a giant
@@ -267,7 +267,7 @@ private class NonFastStartSource(
 private class HugeMdatSource(
     private val realPrefix: ByteArray,
     private val totalLength: Long,
-) : SeekableAudioSource {
+) : SeekableSource {
     var totalBytesRead: Long = 0
         private set
     var maxSingleReadBytes: Int = 0

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserTest.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.domain.embeddedmeta.AudioFormat
 import com.calypsan.listenup.domain.embeddedmeta.ChapterSource
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
 import com.calypsan.listenup.domain.embeddedmeta.SeriesEntry
-import com.calypsan.listenup.server.embeddedmeta.SeekableAudioSource
+import com.calypsan.listenup.server.io.SeekableSource
 import com.calypsan.listenup.domain.embeddedmeta.AudioStreamInfo
 import com.calypsan.listenup.server.embeddedmeta.fixtures.NeroChapter
 import com.calypsan.listenup.server.embeddedmeta.fixtures.TextTrackChapter
@@ -353,7 +353,7 @@ class Mp4ParserTest :
 
         test("parse maps IO failure to AudioMetadataError.IoError") {
             val source =
-                object : SeekableAudioSource {
+                object : SeekableSource {
                     override val length: Long = 100
 
                     override fun position(): Long = 0
@@ -483,8 +483,8 @@ class Mp4ParserTest :
         }
     })
 
-internal fun byteSource(bytes: ByteArray): SeekableAudioSource =
-    object : SeekableAudioSource {
+internal fun byteSource(bytes: ByteArray): SeekableSource =
+    object : SeekableSource {
         private var pos: Long = 0
         override val length: Long = bytes.size.toLong()
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/ByteArraySeekableSource.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/ByteArraySeekableSource.kt
@@ -1,16 +1,16 @@
-package com.calypsan.listenup.server.embeddedmeta
+package com.calypsan.listenup.server.io
 
 import kotlinx.io.EOFException
 
 /**
- * In-memory [SeekableAudioSource] over a fixed byte array — the test-only
+ * In-memory [SeekableSource] over a fixed byte array — the test-only
  * counterpart to the production [RandomAccessFile][java.io.RandomAccessFile]
  * source. Lets parser tests drive a synthetic MP4/MP3 byte array (built by the
  * fixtures DSL) through the real parsing seam without touching the filesystem.
  */
-internal class ByteArraySeekableAudioSource(
+internal class ByteArraySeekableSource(
     private val data: ByteArray,
-) : SeekableAudioSource {
+) : SeekableSource {
     private var pos = 0L
 
     override val length: Long get() = data.size.toLong()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/SeekableSourceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/io/SeekableSourceTest.kt
@@ -1,4 +1,4 @@
-package com.calypsan.listenup.server.embeddedmeta
+package com.calypsan.listenup.server.io
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -6,13 +6,13 @@ import io.kotest.matchers.shouldBe
 import java.nio.file.Files
 import kotlinx.io.IOException
 
-class SeekableAudioSourceTest :
+class SeekableSourceTest :
     FunSpec({
         test("reads, seeks, and reports length") {
             val tmp = Files.createTempFile("seekable", ".bin").toFile()
             try {
                 tmp.writeBytes(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
-                defaultSeekableSource(tmp.toPath().toKotlinxIoPath()).use { src ->
+                openSeekableSource(tmp.toPath().toKotlinxIoPath()).use { src ->
                     src.length shouldBe 8L
                     src.position() shouldBe 0L
                     src.readFully(2).toList() shouldBe listOf<Byte>(1, 2)
@@ -29,7 +29,7 @@ class SeekableAudioSourceTest :
             val tmp = Files.createTempFile("seekable", ".bin").toFile()
             try {
                 tmp.writeBytes(byteArrayOf(1, 2))
-                defaultSeekableSource(tmp.toPath().toKotlinxIoPath()).use { src ->
+                openSeekableSource(tmp.toPath().toKotlinxIoPath()).use { src ->
                     runCatching { src.readFully(4) }.isFailure shouldBe true
                 }
             } finally {
@@ -40,7 +40,7 @@ class SeekableAudioSourceTest :
         test("readFully past EOF throws a catchable kotlinx.io.IOException") {
             // The parsers catch kotlinx.io.IOException; the JVM source throws EOFException (a subtype)
             // and the native source must too — pin the contract so a short read can't crash a scan.
-            val src = ByteArraySeekableAudioSource(byteArrayOf(1, 2, 3, 4))
+            val src = ByteArraySeekableSource(byteArrayOf(1, 2, 3, 4))
             shouldThrow<IOException> { src.readFully(8) }
         }
     })

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/SeekableSource.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/SeekableSource.linuxX64.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalForeignApi::class)
 
-package com.calypsan.listenup.server.embeddedmeta
+package com.calypsan.listenup.server.io
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
@@ -18,7 +18,7 @@ import platform.posix.lseek
 import platform.posix.open
 import platform.posix.read
 
-internal actual fun defaultSeekableSource(path: Path): SeekableAudioSource = PosixFileSource(path)
+internal actual fun openSeekableSource(path: Path): SeekableSource = PosixFileSource(path)
 
 /**
  * Posix-backed seekable source. The cursor is the OS file position — [seek] is an
@@ -27,7 +27,7 @@ internal actual fun defaultSeekableSource(path: Path): SeekableAudioSource = Pos
  */
 private class PosixFileSource(
     path: Path,
-) : SeekableAudioSource {
+) : SeekableSource {
     private val fd: Int =
         open(path.toString(), O_RDONLY).also { if (it < 0) throw IOException("open failed: $path") }
 


### PR DESCRIPTION
A from-scratch, **pure-`commonMain`, zero-cinterop** ZIP container — streaming `ZipWriter` + random-access `ZipReader`, ZIP64-aware — built on the merged DEFLATE codec (#809). Part 2 of 3 of the "backup goes native" arc; part 3 wires `BackupArchive` onto this and takes the whole backup domain native.

## What's here (`com.calypsan.listenup.server.compression.zip`)
- **`ZipWriter(RawSink)`** — streaming, never seeks backward. DEFLATE entries use a data descriptor (bit-3) and stream with bounded memory; STORED entries emit a complete local header (because `java.util.zip` rejects STORED+descriptor). Per-field ZIP64 (64-bit sizes/offsets, ZIP64 EOCD + locator + extra) emitted when a value overflows 32 bits.
- **`ZipReader(path)`** — parses the central directory via random access (over the generalized `io/SeekableSource` seam), exposes `entries()`/`entry(name)`/`openEntry()` (bounded, inflating streams), holds only directory metadata in memory.
- `ZipMethod`, `ZipEntryInfo`, `isSafeEntryName` (ZIP-slip helper), `MalformedZipException`.
- CRC-32 + DEFLATE/inflate reused from the codec — no new compression code.

## Step 0 (foundational)
Generalized the existing seekable-file seam `embeddedmeta/SeekableAudioSource` → `io/SeekableSource` (pure mechanical rename across the audio parsers; their tests prove zero behavior change) so the ZIP reader and the audio parsers share one honestly-named random-access primitive.

## Correctness — `java.util.zip` as a bidirectional oracle
- **`java.util.zip` reads our archives** — verified with both `ZipInputStream` (streaming, local headers + data descriptors) and `ZipFile` (central directory + seek-by-offset, the path `BackupArchive` actually uses).
- **Our reader reads `java.util.zip` archives** — by name, including DEFLATE/STORED, nested paths, and ZIP64.
- Round-trip, **ZIP64 (>65535 entries forces the ZIP64 EOCD)**, and a realistic backup-shape (manifest + db + many covers/avatars) all round-trip through both.

## Robustness on corrupt/untrusted archives ("honest over silent")
The reader fails cleanly with `MalformedZipException` on a corrupt backup, never an untyped exception or an unbounded allocation: overflow-safe bounds on every attacker-influenced 64-bit offset/size, a `totalEntries`↔`cdSize` cross-check (a crafted EOCD can't force a whole-file heap buffer), an EOCD self-consistency anchor, and a typed-exception guard on `openEntry` (incl. TOCTOU truncation). `isSafeEntryName` rejects traversal/absolute/drive/control-char names.

## Notes
- Pure commonMain; `:server:compileKotlinLinuxX64` green. No new dependencies.
- Scope: STORED + DEFLATE + ZIP64 + UTF-8 names; no encryption/multi-disk/other methods (YAGNI).
- Built strictly test-first; adversarial review caught and fixed real issues at each step (an all-null ZIP64-extra contract bug, the untested central-directory path, and the corrupt-archive DoS/typed-exception gaps) — each pinned by a regression test.

Gate: full Linux lane green (native compile, spotless, detekt, `:server:jvmTest`, `:sharedLogic:jvmTest`, `:androidApp:assembleDebug`) + forced Konsist re-scan.