### PR TITLE
🔒 fix(android): stop exporting the debug PreviewGalleryActivity in release

### DIFF
--- a/sharedUI/src/androidMain/AndroidManifest.xml
+++ b/sharedUI/src/androidMain/AndroidManifest.xml
@@ -75,10 +75,11 @@
             </intent-filter>
         </activity>
 
-        <!-- Debug-only: on-device component gallery (mock data). Started via adb, not in launcher. -->
+        <!-- Debug-only: on-device component gallery (mock data). Not exported — launchable via
+             `adb shell am start` only against a debuggable build. -->
         <activity
             android:name="com.calypsan.listenup.client.PreviewGalleryActivity"
-            android:exported="true"
+            android:exported="false"
             android:theme="@style/Theme.ListenUp" />
 
         <service


### PR DESCRIPTION
Advisor batch 3 (Android deep audit), plan 024.

`PreviewGalleryActivity` is a debug-only on-device component gallery launched via `adb`, but it shipped with `android:exported="true"` in the release `androidMain` manifest — launchable by any other app. Set `exported="false"` (an `am start` against a debuggable build still works for local dev). No sensitive data behind it; this is defense-in-depth / attack-surface reduction.

Merged-manifest verified: PreviewGalleryActivity `exported=false`; MainActivity + PlaybackService stay `exported=true`.

Gate: `:androidApp:assembleDebug` ✅, `spotlessCheck detekt` ✅.

Plan: docs/plans/024-preview-gallery-not-exported.md (non-repo).