### PR TITLE
🎨 chore(android): key chapter list, adaptive grids, drop dead SDK guard, fix doc versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,13 +160,13 @@ Concrete example: `data/remote/` API methods use `apiCall(errorMessage = "...") 
 
 ### Modern Everything
 
-This codebase targets the latest stable versions. Kotlin 2.3.20, Compose Multiplatform 1.10, Room KMP 2.8, Ktor 3.4, Koin 4.2, Navigation 3, Media3. When canonical guidance exists, follow it — do not rely on training-cutoff knowledge. Fetch current docs.
+This codebase targets the latest stable versions. Kotlin 2.4.0, Compose Multiplatform 1.11.1, Room KMP 2.8, Ktor 3.4, Koin 4.2, Navigation 3, Media3. When canonical guidance exists, follow it — do not rely on training-cutoff knowledge. Fetch current docs.
 
 ### The Stack
 
 | Layer | Technology |
 |-------|-----------|
-| Language | Kotlin 2.3.20 (KMP) |
+| Language | Kotlin 2.4.0 (KMP) |
 | UI | Compose Multiplatform |
 | Navigation | Compose Navigation 3 (multiplatform) |
 | DI | Koin 4.2 |

--- a/sharedUI/CLAUDE.md
+++ b/sharedUI/CLAUDE.md
@@ -26,7 +26,7 @@ restate architecture. For ViewModels/MVI/state/error/Compose mechanics, see the 
 ## Platform & language
 4. **Android 14/15 platform modernity.** Adopt predictive back, per-app language, the Photo Picker,
    and granular media permissions where they serve the app.
-5. **Modern Kotlin** — Kotlin 2.3.20 (catalog-pinned). Idiomatic coroutines/Flow per the root rubric.
+5. **Modern Kotlin** — Kotlin 2.4.0 (catalog-pinned). Idiomatic coroutines/Flow per the root rubric.
 
 ## Multiplatform
 6. **`commonMain` is Android + Desktop.** The Expressive APIs are in multiplatform material3, and

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -330,10 +330,8 @@ class ListenUp :
         }
 
         // Log memory-related historical exit reasons so operators can diagnose OOM crashes
-        // from logs alone, without requiring ADB or on-device tooling. API 30+.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            logHistoricalMemoryExits()
-        }
+        // from logs alone, without requiring ADB or on-device tooling.
+        logHistoricalMemoryExits()
 
         // Schedule periodic background sync only after user authenticates
         get<CoroutineScope>().launch {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionDetailScreen.kt
@@ -592,7 +592,7 @@ private fun BooksSection(
         } else {
             val coverSize: Dp = if (cols >= BOOKS_COLS_WIDE) COVER_SIZE_WIDE_DP.dp else COVER_SIZE_NARROW_DP.dp
             LazyVerticalGrid(
-                columns = GridCells.Fixed(cols),
+                columns = GridCells.Adaptive(minSize = 160.dp),
                 modifier = Modifier.height(((coverSize + 8.dp) * 4).coerceAtMost(480.dp)).fillMaxWidth(),
                 contentPadding = PaddingValues(8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/collections/AdminCollectionsScreen.kt
@@ -87,8 +87,6 @@ private const val CARD_PADDING_DP = 18
 private const val CARD_PADDING_WIDE_DP = 22
 private const val GRID_GAP_DP = 16
 private const val GRID_GAP_WIDE_DP = 20
-private const val GRID_COLS_NARROW = 2
-private const val GRID_COLS_WIDE = 4
 private const val FAB_SPACER_DP = 88
 private const val BADGE_SIZE_DP = 56
 private const val DELETE_TILE_SIZE_DP = 40
@@ -289,12 +287,11 @@ private fun CollectionsReadyContent(
                 modifier = Modifier.weight(1f).padding(innerPadding),
             )
         } else {
-            val cols = if (isWide) GRID_COLS_WIDE else GRID_COLS_NARROW
             val gap = if (isWide) GRID_GAP_WIDE_DP.dp else GRID_GAP_DP.dp
             val gridPad = if (isWide) 20.dp else 16.dp
 
             LazyVerticalGrid(
-                columns = GridCells.Fixed(cols),
+                columns = GridCells.Adaptive(minSize = 160.dp),
                 contentPadding =
                     PaddingValues(
                         start = gridPad,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/ChapterPickerSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/ChapterPickerSheet.kt
@@ -42,7 +42,11 @@ fun ChapterPickerSheet(
             modifier = Modifier.fillMaxWidth().heightIn(max = 480.dp),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            itemsIndexed(chapters) { index, chapter ->
+            itemsIndexed(
+                chapters,
+                key = { _, chapter -> chapter.id },
+                contentType = { _, _ -> "chapter" },
+            ) { index, chapter ->
                 PlayerChapterRow(
                     number = index + 1,
                     title = chapter.title,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
@@ -70,7 +70,6 @@ import com.calypsan.listenup.client.presentation.shelf.ShelfBookSort
 import com.calypsan.listenup.client.presentation.shelf.ShelfDetailUiState
 import com.calypsan.listenup.client.presentation.shelf.ShelfDetailViewModel
 import com.calypsan.listenup.client.presentation.shelf.ShelfGridWidth
-import com.calypsan.listenup.client.presentation.shelf.shelfGridColumns
 import com.calypsan.listenup.client.presentation.shelf.sortShelfBooks
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.common_about
@@ -223,11 +222,10 @@ private fun ShelfDetailContent(
                 ShelfGridWidth.Compact
             }
         }
-    val columns = shelfGridColumns(gridWidth)
     val isWide = gridWidth != ShelfGridWidth.Compact
 
     LazyVerticalGrid(
-        columns = GridCells.Fixed(columns),
+        columns = GridCells.Adaptive(minSize = 160.dp),
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),


### PR DESCRIPTION
Advisor batch 3 (Android deep audit), plan 031 — four independent low-risk quick-wins:

1. **ChapterPickerSheet** `itemsIndexed` now has `key = chapter.id` + `contentType` (was unkeyed → scroll/animation state churn).
2. **Adaptive grids** — `GridCells.Fixed(n)`→`GridCells.Adaptive(minSize = 160.dp)` on AdminCollectionsScreen, AdminCollectionDetailScreen, ShelfDetailScreen (rubric prefers continuous reflow; matches the rest of the app). Dead column vars/constants/imports removed. `Fixed(1)` single-column lists left intact.
3. **Dead SDK guard** — removed the always-true `SDK_INT >= R` (API 30) wrapper in ListenUp.kt (minSdk is 33); `logHistoricalMemoryExits()` now unconditional. The real API-37 `CINNAMON_BUN` guard untouched.
4. **Stale docs** — CLAUDE.md + sharedUI/CLAUDE.md version strings 2.3.20/1.10 → 2.4.0/1.11.1 (match the catalog).

Gate: `:androidApp:assembleDebug` ✅, `:sharedUI:testAndroidHostTest` ✅, `spotlessCheck detekt` ✅.

Plan: docs/plans/031-android-quick-wins-bundle.md (non-repo).