### PR TITLE
🐛 fix(bookdetail): show localized download errors, never raw debugInfo

### DIFF
--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -2711,6 +2711,16 @@
         }
       }
     },
+    "book.detail_insufficient_storage": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not enough storage. Need %1$dMB, have %2$dMB available."
+          }
+        }
+      }
+    },
     "book.detail_language": {
       "localizations": {
         "en": {

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -419,7 +419,8 @@
     "reader_scrubber_page_count": "%1$d",
     "detail_document_search": "Search",
     "detail_document_search_placeholder": "Search in document",
-    "detail_document_search_no_results": "No results"
+    "detail_document_search_no_results": "No results",
+    "detail_insufficient_storage": "Not enough storage. Need %1$dMB, have %2$dMB available."
   },
   "series": {
     "book_sequence": "Book %1$s",

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -272,6 +272,7 @@ One beautiful library.</string>
     <string name="book_detail_finished">Finished</string>
     <string name="book_detail_format">Format</string>
     <string name="book_detail_full_cast">Full cast</string>
+    <string name="book_detail_insufficient_storage">Not enough storage. Need %1$dMB, have %2$dMB available.</string>
     <string name="book_detail_language">Language</string>
     <string name="book_detail_length">Length</string>
     <string name="book_detail_mark_as_complete">Mark as Complete</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -77,10 +77,13 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.presentation.error.localizedString
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.book_detail_document_meta
 import listenup.composeapp.generated.resources.book_detail_document_viewer_coming_soon
+import listenup.composeapp.generated.resources.book_detail_insufficient_storage
 import listenup.composeapp.generated.resources.book_detail_scan_warning
 import listenup.composeapp.generated.resources.book_detail_supplementary_materials
 import listenup.composeapp.generated.resources.book_show_all_chapters
@@ -883,14 +886,14 @@ private suspend fun handleDownloadResult(
     showSnackbar: suspend (String) -> Unit,
 ) {
     if (result is AppResult.Failure) {
-        showSnackbar("Download failed: ${result.error.debugInfo ?: "Unknown error"}")
+        showSnackbar(result.error.localizedString())
         return
     }
     val outcome = (result as AppResult.Success).data
     if (outcome is DownloadOutcome.InsufficientStorage) {
-        val requiredMb = outcome.requiredBytes / 1_000_000
-        val availableMb = outcome.availableBytes / 1_000_000
-        showSnackbar("Not enough storage. Need ${requiredMb}MB, have ${availableMb}MB available.")
+        val requiredMb = (outcome.requiredBytes / 1_000_000).toInt()
+        val availableMb = (outcome.availableBytes / 1_000_000).toInt()
+        showSnackbar(getString(Res.string.book_detail_insufficient_storage, requiredMb, availableMb))
     }
     // DownloadOutcome.Started and DownloadOutcome.AlreadyDownloaded: no UI action needed
 }


### PR DESCRIPTION
Advisor batch 3 (Android deep audit), plan 027.

`BookDetailScreen.handleDownloadResult` violated the error rubric (`message` for users, `debugInfo` for logs): it rendered `result.error.debugInfo` directly in a user snackbar and hardcoded two copy strings that bypassed the generated catalog (`verifyStrings` gate).

- Failure → `result.error.localizedString()` (resolves `error_<code>`, falls back to the user-facing `message`; never `debugInfo`).
- InsufficientStorage → new catalog key `book_detail_insufficient_storage` (`detail_insufficient_storage` in en.json; plugin prefixes the detail section). `debugInfo` no longer appears anywhere in the file (grep = 0).

NOT in scope (separate, deeper finding): `DownloadWorker`'s storage-error substring matching — needs an expect/actual disk-full predicate with iOS actuals; tracked in the plan's deferred notes.

Gate: `:androidApp:assembleDebug` ✅, `:sharedUI:verifyStrings` ✅, `spotlessCheck detekt` ✅. (iOS xcstrings regenerated as a tracked build output — iOS compile is CI-verified.)

Plan: docs/plans/027-download-error-no-debuginfo-in-ui.md (non-repo).