### PR TITLE
🐛 fix(playback): always release ExoPlayer on teardown; drop unsafe !!

### DIFF
--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -226,7 +226,12 @@ class PlaybackService : MediaLibraryService() {
                 )
             }
 
-        val builder = MediaLibrarySession.Builder(this, player!!, LibrarySessionCallback())
+        val activePlayer =
+            player ?: run {
+                logger.error { "initializeMediaSession called before player init" }
+                return
+            }
+        val builder = MediaLibrarySession.Builder(this, activePlayer, LibrarySessionCallback())
         if (sessionIntent != null) {
             builder.setSessionActivity(sessionIntent)
         }
@@ -238,7 +243,8 @@ class PlaybackService : MediaLibraryService() {
 
     private fun initializeNotificationProvider() {
         notificationProvider = AudiobookNotificationProvider(this, playbackManager)
-        setMediaNotificationProvider(notificationProvider!!)
+        val provider = notificationProvider ?: return
+        setMediaNotificationProvider(provider)
         logger.info { "Notification provider initialized" }
     }
 
@@ -357,11 +363,12 @@ class PlaybackService : MediaLibraryService() {
         // Clear chapter change callback to avoid memory leaks
         playbackManager.onChapterChanged = null
 
-        mediaLibrarySession?.run {
-            player.release()
-            release()
-            mediaLibrarySession = null
-        }
+        // Release session before player — the session holds a reference to the player.
+        // player?.release() runs unconditionally so the native decoder is freed even
+        // when mediaLibrarySession was never built or was already null.
+        mediaLibrarySession?.release()
+        mediaLibrarySession = null
+        player?.release()
         player = null
         notificationProvider = null
 


### PR DESCRIPTION
Advisor batch 3 (Android deep audit), plan 033.

In `PlaybackService.onDestroy()` the ExoPlayer was released only INSIDE `mediaLibrarySession?.run { player.release(); release() }` — so if the session was null (build failed / never created), the player (native decoders/buffers/handles) leaked and the field was just nulled. Reordered: release the session first, then `player?.release()` unconditionally (idempotent), freeing the decoder regardless of session state.

Also removed two unsafe `!!`: `player!!` in `initializeMediaSession` → guarded `val activePlayer = player ?: run { log; return }`; `notificationProvider!!` in `initializeNotificationProvider` → `val provider = notificationProvider ?: return`. (The third `player!!` at line ~570 in `onPlayerError` is out of scope and left untouched.)

Deferred (out of scope): the broader decomposition of this 1216-line service — see plan 033 notes / plan 032 for the teardown test.

Gate: `:androidApp:assembleDebug` ✅, `:sharedUI:testAndroidHostTest` ✅, `spotlessCheck detekt` ✅.

Plan: docs/plans/033-playbackservice-null-session-leak-and-bangbang.md (non-repo).