### PR TITLE
✨ feat(android): request POST_NOTIFICATIONS runtime permission on API 33+

### DIFF
--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/permission/PostNotificationsPermission.android.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/permission/PostNotificationsPermission.android.kt
@@ -1,0 +1,65 @@
+package com.calypsan.listenup.client.features.permission
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+/**
+ * Android actual for [RequestPostNotificationsPermission].
+ *
+ * [Manifest.permission.POST_NOTIFICATIONS] was introduced in API 33 (Android 13 /
+ * TIRAMISU). Without a runtime grant the playback media notification is silently
+ * suppressed; playback itself is unaffected.
+ *
+ * The request is launched at most once per session:
+ * - [rememberSaveable] ensures the flag survives configuration changes, so a
+ *   device rotation while the dialog is visible does not trigger a second prompt.
+ * - The already-granted check skips the dialog when the user has previously
+ *   accepted.
+ *
+ * On API 32 and below the permission does not exist and this composable is a no-op.
+ */
+@Composable
+actual fun RequestPostNotificationsPermission() {
+    // POST_NOTIFICATIONS was introduced in API 33 (TIRAMISU). This check is a static
+    // device property — the API level never changes at runtime — so it is safe to
+    // return early here without disturbing Compose hook ordering on API 33+ devices.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+    val context = LocalContext.current
+    val permission = Manifest.permission.POST_NOTIFICATIONS
+
+    // rememberSaveable must be called unconditionally (after the static SDK guard above).
+    // It survives configuration changes so a rotation does not re-trigger the dialog.
+    var alreadyAsked by rememberSaveable { mutableStateOf(false) }
+
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+            onResult = {
+                // Grant or deny — playback works either way; no action required here.
+            },
+        )
+
+    // LaunchedEffect(Unit) runs once per composition session. The alreadyAsked guard
+    // inside covers the re-entry case (e.g. after a configuration change LaunchedEffect
+    // re-fires but rememberSaveable preserves the true value).
+    LaunchedEffect(Unit) {
+        if (!alreadyAsked &&
+            ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED
+        ) {
+            alreadyAsked = true
+            launcher.launch(permission)
+        }
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/permission/PostNotificationsPermission.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/permission/PostNotificationsPermission.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.client.features.permission
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Composable that requests [android.Manifest.permission.POST_NOTIFICATIONS] exactly
+ * once per session and has no further effect.
+ *
+ * - **Android (API 33+):** Launches the system permission dialog via
+ *   [androidx.activity.compose.rememberLauncherForActivityResult]. The permission
+ *   was introduced with Android 13 (TIRAMISU / API 33) and is required for the
+ *   playback media notification to appear. Playback itself is unaffected by a denial.
+ * - **Desktop:** No dialog is shown — the permission concept does not apply to
+ *   JVM desktop; this composable is a no-op.
+ *
+ * The composable does not block navigation or require a grant; it is fire-and-forget.
+ */
+@Composable
+expect fun RequestPostNotificationsPermission()

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/AppShell.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shell/AppShell.kt
@@ -40,6 +40,7 @@ import com.calypsan.listenup.client.presentation.sync.SyncIndicatorViewModel
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.client.features.permission.RequestPostNotificationsPermission
 import com.calypsan.listenup.client.features.shell.components.GlobalErrorSnackbar
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.launch
@@ -107,6 +108,11 @@ fun AppShell(
     val searchViewModel: SearchViewModel = koinViewModel()
     val syncIndicatorViewModel: SyncIndicatorViewModel = koinViewModel()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // Request POST_NOTIFICATIONS once at the post-auth entry point. The composable is
+    // fire-and-forget: it prompts exactly once per session and has no effect on playback
+    // regardless of whether the user grants or denies.
+    RequestPostNotificationsPermission()
 
     // Trigger sync on shell entry (not just when Library is visible)
     val scope = rememberCoroutineScope()

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/features/permission/PostNotificationsPermission.desktop.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/features/permission/PostNotificationsPermission.desktop.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.client.features.permission
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Desktop actual for [RequestPostNotificationsPermission].
+ *
+ * The [android.Manifest.permission.POST_NOTIFICATIONS] concept does not apply to
+ * JVM desktop targets. This composable is intentionally a no-op.
+ */
+@Composable
+actual fun RequestPostNotificationsPermission() {
+    // No permission model on desktop — nothing to do.
+}


### PR DESCRIPTION
Advisor batch 3 (Android deep audit), plan 029.

`POST_NOTIFICATIONS` is declared in the manifest but was never requested at runtime — so on Android 13+ (the app's minSdk) the playback media notification (the primary playback control surface) is silently suppressed until/unless the user grants it elsewhere. Adds a one-shot runtime request mirroring the existing `RequestLocalNetworkPermission` expect/actual seam:

- New `RequestPostNotificationsPermission` — commonMain `expect`, androidMain `actual` (SDK≥TIRAMISU guard, `rememberSaveable` one-shot, `checkSelfPermission` skip, `rememberLauncherForActivityResult`), desktopMain no-op `actual`.
- Invoked once at the **post-auth** shell entry (`AppShell`), fire-and-forget; denial doesn't affect playback. (Placed at the authenticated entry rather than next to the pre-auth network-permission request, per the plan's post-auth intent.)

Gate: `:androidApp:assembleDebug` ✅, `:sharedUI:testAndroidHostTest` ✅, `spotlessCheck detekt` ✅.

Plan: docs/plans/029-post-notifications-runtime-request.md (non-repo).