### PR TITLE
⚡️ perf(library): derive in-progress list in the ViewModel, off composition

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryUiState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryUiState.kt
@@ -48,6 +48,8 @@ sealed interface LibraryUiState {
         // Progress derived from playback positions
         val bookProgress: Map<BookId, Float>,
         val bookIsFinished: Map<BookId, Boolean>,
+        /** Books with partial progress: started (progress > 0) but not yet finished. */
+        val booksInProgress: List<BookListItem>,
         /** Per-series finished/total aggregation for the series-list progress affordance. */
         val seriesProgress: Map<SeriesId, SeriesProgress>,
         // Sync

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
@@ -441,6 +441,11 @@ class LibraryViewModel(
             narrators = sortedNarrators,
             bookProgress = progress.progressMap,
             bookIsFinished = progress.finishedMap,
+            booksInProgress =
+                sortedBooks.filter { book ->
+                    val p = progress.progressMap[book.id]
+                    p != null && p > 0f && p < 1f && progress.finishedMap[book.id] != true
+                },
             seriesProgress = seriesProgress,
             syncState = sync.syncState,
             isServerScanning = sync.isServerScanning,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -998,6 +998,73 @@ class LibraryViewModelTest :
             }
         }
 
+        // ========== booksInProgress Derivation Tests ==========
+
+        test("booksInProgress includes only started-but-unfinished books") {
+            runTest {
+                // Given — three books: not started, in progress, finished
+                val books =
+                    listOf(
+                        createTestBook(id = "not-started", duration = 10_000L),
+                        createTestBook(id = "in-progress", duration = 10_000L),
+                        createTestBook(id = "finished", duration = 10_000L),
+                    )
+                val positions =
+                    mapOf(
+                        // "in-progress" has 50% progress and is not finished
+                        BookId("in-progress") to
+                            PlaybackPosition(
+                                bookId = "in-progress",
+                                positionMs = 5_000L,
+                                playbackSpeed = 1.0f,
+                                hasCustomSpeed = false,
+                                updatedAtMs = 0L,
+                                syncedAtMs = null,
+                                lastPlayedAtMs = null,
+                                isFinished = false,
+                            ),
+                        // "finished" is marked finished (isFinished = true)
+                        BookId("finished") to
+                            PlaybackPosition(
+                                bookId = "finished",
+                                positionMs = 10_000L,
+                                playbackSpeed = 1.0f,
+                                hasCustomSpeed = false,
+                                updatedAtMs = 0L,
+                                syncedAtMs = null,
+                                lastPlayedAtMs = null,
+                                isFinished = true,
+                            ),
+                    )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                every { fixture.playbackPositionRepository.observeAll() } returns flowOf(positions)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then — only the in-progress book appears
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksInProgress.map { it.id.value } shouldBe listOf("in-progress")
+            }
+        }
+
+        test("booksInProgress is empty when no books have partial progress") {
+            runTest {
+                // Given — one book, no positions
+                val books = listOf(createTestBook(id = "book-1", duration = 10_000L))
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+
+                // Then
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.booksInProgress shouldBe emptyList()
+            }
+        }
+
         // ========== Per-Upstream Catch Tests ==========
 
         test("transient observeBooks failure keeps state as Loaded with empty books") {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/LibraryScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/LibraryScreen.kt
@@ -218,13 +218,8 @@ private fun LibraryLoadedContent(
     )
 
     // "In progress" view: titles with partial (started-but-unfinished) playback.
-    val booksInProgress =
-        remember(state.books, state.bookProgress, state.bookIsFinished) {
-            state.books.filter { book ->
-                val progress = state.bookProgress[book.id]
-                progress != null && progress > 0f && progress < 1f && state.bookIsFinished[book.id] != true
-            }
-        }
+    // Derived in the ViewModel's combine pipeline — no in-composition filter needed.
+    val booksInProgress = state.booksInProgress
 
     var selectedFilter by rememberSaveable { mutableStateOf(LibraryFilter.Books) }
     val isWide =


### PR DESCRIPTION
Advisor batch 3 (Android deep audit), plan 037.

`LibraryScreen` computed its 'in progress' list inside composition via `remember(state.books, state.bookProgress, state.bookIsFinished) { … filter … }`. `bookProgress` updates during playback, so that O(N) filter re-ran on the long-lived library screen on every progress tick (same class of waste as #823). Moved the derivation into `LibraryViewModel.buildLoaded()` (the existing `combine(...).stateIn(WhileSubscribed)` pipeline), exposed as `LibraryUiState.Loaded.booksInProgress`; the screen now reads `state.booksInProgress` and the in-composition filter is gone. Predicate is identical (started-but-unfinished); `bookProgress`/`bookIsFinished` stay on the state for other UI.

Now unit-tested (the payoff of moving logic into the VM): 2 Kotest cases — only-in-progress-returned, empty-when-no-partial-progress.

Export surface: a new FIELD on an existing exported type — `scripts/export-surface-baseline.txt` unchanged. iOS compile is CI-verified.

Gate: `:sharedLogic:jvmTest` ✅, `:androidApp:assembleDebug` ✅, `:sharedUI:testAndroidHostTest` ✅, `spotlessCheck detekt` ✅.

Plan: docs/plans/037-library-in-progress-filter-to-viewmodel.md (non-repo).