### PR TITLE
🐛 fix(ios): give the Swift Export worker the intellij coroutines variant (fix cold-build crash)

### DIFF
--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -292,7 +292,9 @@ configurations.matching { it.name == "swiftExportClasspathResolvable" }.configur
             (requested.name == "kotlinx-coroutines-core" || requested.name == "kotlinx-coroutines-core-jvm")
         ) {
             useTarget("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:1.10.2-intellij-1")
-            because("Swift Export's Analysis API worker needs IntellijCoroutines (only in the intellij coroutines variant)")
+            because(
+                "Swift Export's Analysis API worker needs IntellijCoroutines (only in the intellij coroutines variant)",
+            )
         }
     }
 }

--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -275,3 +275,24 @@ dependencies {
     // JVM target (desktop)
     add("kspJvm", libs.androidx.room.compiler)
 }
+
+// ---- Swift Export worker classpath: IntellijCoroutines fix --------------------------------
+// `embedSwiftExportForXcode` runs the Kotlin Analysis API in a Gradle worker whose classpath is
+// resolved by the `swiftExportClasspathResolvable` configuration. That worker requires
+// `kotlinx.coroutines.internal.intellij.IntellijCoroutines`, which ships ONLY in the JetBrains
+// "intellij deps" coroutines variant — NOT in standard kotlinx-coroutines. The worker otherwise
+// resolves standard `kotlinx-coroutines-core-jvm` (1.8.0, pulled transitively by the Analysis API),
+// so a COLD Swift-export build crashes with `NoClassDefFoundError: …/IntellijCoroutines` (warm
+// Konan/worker caches hide it — which is why the iOS lane looked green until a cache-miss rebuild).
+// Redirect coroutines-core to the intellij variant on THIS worker configuration only; the app's own
+// coroutines (and every other configuration) are untouched.
+configurations.matching { it.name == "swiftExportClasspathResolvable" }.configureEach {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlinx" &&
+            (requested.name == "kotlinx-coroutines-core" || requested.name == "kotlinx-coroutines-core-jvm")
+        ) {
+            useTarget("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:1.10.2-intellij-1")
+            because("Swift Export's Analysis API worker needs IntellijCoroutines (only in the intellij coroutines variant)")
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`Test (iOS)` fails on any **cold** build (cache miss) with:
```
java.lang.NoClassDefFoundError: kotlinx/coroutines/internal/intellij/IntellijCoroutines
ERROR: Worker exited due to exception
```
during `:sharedLogic:embedSwiftExportForXcode`. Warm Konan/worker caches hid it, so the lane looked green until a cache-miss rebuild (e.g. the recent advisor PRs) forced a cold Swift Export and exposed it. **Long-standing; not caused by any feature PR.**

## Root cause (verified empirically)
Swift Export runs the Kotlin **Analysis API** in a Gradle worker whose classpath is the `swiftExportClasspathResolvable` configuration. That worker needs `kotlinx.coroutines.internal.intellij.IntellijCoroutines`, which ships **only** in the JetBrains *intellij* coroutines variant (`org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:1.10.2-intellij-1`). The worker instead resolved **standard** `kotlinx-coroutines-core-jvm:1.8.0` (transitive from the Analysis API), which lacks the class → `NoClassDefFoundError`. (Confirmed: that class exists in *only* the intellij jar across the whole Gradle cache.)

## Fix
Redirect `kotlinx-coroutines-core(-jvm)` to the intellij variant **on the `swiftExportClasspathResolvable` configuration only** (via `resolutionStrategy.eachDependency`). The app's own coroutines (1.11.0) and every other configuration are untouched.

## Validation
Locally re-resolving the config now shows `…coroutines-core-jvm:1.8.0 -> org.jetbrains.intellij.deps.kotlinx:…:1.10.2-intellij-1`, and that jar **does** contain `IntellijCoroutines` — so the missing class is now on the worker classpath. `spotlessCheck` + `detekt` green. **The full cold iOS build is validated by this PR's own `Test (iOS)` run** (the only way to test iOS here — no local Mac).

If `Test (iOS)` goes green here, this is the fix; merging it makes the iOS lane a meaningful gate again for the rest of the open PRs.