### PR TITLE
🐛 fix(profile): pre-fill Edit Profile name + render avatars via the canonical UserAvatar

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/DisplayNameParsing.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/DisplayNameParsing.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.client.core
+
+/**
+ * Splits a combined display name into `(firstName, lastName)`. The first whitespace-delimited token
+ * is the first name; the remainder (joined) is the last name. Blank input yields `("", "")`.
+ *
+ * Heuristic: registration stores only a joined `displayName`, so this reconstructs editable
+ * first/last fields. Names with more than two words put the remainder in the last name.
+ */
+fun splitDisplayName(displayName: String): Pair<String, String> {
+    val trimmed = displayName.trim()
+    if (trimmed.isEmpty()) return "" to ""
+    val first = trimmed.substringBefore(' ')
+    val last = trimmed.substringAfter(' ', missingDelimiterValue = "").trim()
+    return first to last
+}
+
+/**
+ * Resolves the first/last names to seed an edit form: prefers stored non-blank [firstName]/
+ * [lastName], otherwise derives them from [displayName] via [splitDisplayName].
+ */
+fun resolveNameFields(
+    displayName: String,
+    firstName: String?,
+    lastName: String?,
+): Pair<String, String> {
+    val storedFirst = firstName?.trim().orEmpty()
+    val storedLast = lastName?.trim().orEmpty()
+    return if (storedFirst.isNotEmpty() || storedLast.isNotEmpty()) {
+        storedFirst to storedLast
+    } else {
+        splitDisplayName(displayName)
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModel.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.model.User
 import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ProfileEditRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
+import com.calypsan.listenup.client.core.resolveNameFields
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -144,12 +145,14 @@ class EditProfileViewModel(
                 // seeded FormState equals the initial FormState(), StateFlow conflates the
                 // identical assignment away, no re-emission arrives, and the screen is stuck
                 // on the spinner forever.
+                val (seedFirst, seedLast) = resolveNameFields(user.displayName, user.firstName, user.lastName)
+
                 val effectiveForm =
                     if (!formInitialized) {
                         formInitialized = true
                         FormState(
-                            firstName = user.firstName ?: "",
-                            lastName = user.lastName ?: "",
+                            firstName = seedFirst,
+                            lastName = seedLast,
                             tagline = user.tagline ?: "",
                         ).also { formFlow.value = it }
                     } else {
@@ -157,8 +160,8 @@ class EditProfileViewModel(
                     }
 
                 val isDirty =
-                    effectiveForm.firstName != (user.firstName ?: "") ||
-                        effectiveForm.lastName != (user.lastName ?: "") ||
+                    effectiveForm.firstName != seedFirst ||
+                        effectiveForm.lastName != seedLast ||
                         effectiveForm.tagline != (user.tagline ?: "") ||
                         effectiveForm.currentPassword.isNotEmpty() ||
                         effectiveForm.newPassword.isNotEmpty() ||
@@ -306,7 +309,8 @@ class EditProfileViewModel(
         user: User,
     ): Boolean {
         val changedTagline = form.tagline.takeIf { it != (user.tagline ?: "") }
-        val nameChanged = form.firstName != (user.firstName ?: "") || form.lastName != (user.lastName ?: "")
+        val (baselineFirst, baselineLast) = resolveNameFields(user.displayName, user.firstName, user.lastName)
+        val nameChanged = form.firstName != baselineFirst || form.lastName != baselineLast
         val passwordChange =
             if (anyPasswordField(form)) {
                 PasswordChange(currentPassword = form.currentPassword, newPassword = form.newPassword)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/DisplayNameParsingTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/DisplayNameParsingTest.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.core
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DisplayNameParsingTest :
+    FunSpec({
+        test("splitDisplayName: two tokens → first / last") {
+            splitDisplayName("Ada Lovelace") shouldBe ("Ada" to "Lovelace")
+        }
+        test("splitDisplayName: single token → first only") {
+            splitDisplayName("Ada") shouldBe ("Ada" to "")
+        }
+        test("splitDisplayName: 3+ tokens → first / remainder") {
+            splitDisplayName("Ada B Lovelace") shouldBe ("Ada" to "B Lovelace")
+        }
+        test("splitDisplayName: blank → empty pair") {
+            splitDisplayName("   ") shouldBe ("" to "")
+        }
+        test("resolveNameFields: stored non-blank names win (no override)") {
+            resolveNameFields("Ignored Joined", "Grace", "Hopper") shouldBe ("Grace" to "Hopper")
+        }
+        test("resolveNameFields: null stored names derive from displayName") {
+            resolveNameFields("Ada Lovelace", null, null) shouldBe ("Ada" to "Lovelace")
+        }
+        test("resolveNameFields: blank stored names derive from displayName") {
+            resolveNameFields("Ada Lovelace", "", "  ") shouldBe ("Ada" to "Lovelace")
+        }
+        test("resolveNameFields: partial stored (first only) is kept as-is") {
+            resolveNameFields("Ada Lovelace", "Ada", null) shouldBe ("Ada" to "")
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
@@ -147,7 +147,7 @@ class EditProfileViewModelTest :
                 // FormState equal to the initial FormState(). The old code mutated formFlow to
                 // that identical value and waited for a re-emission that StateFlow conflated
                 // away — leaving the Edit Profile screen stuck on the Loading spinner forever.
-                val user = createUser(firstName = null, lastName = null, tagline = null)
+                val user = createUser(displayName = "", firstName = null, lastName = null, tagline = null)
                 val fixture = createFixture().apply { configure(currentUser = user) }
                 val viewModel = fixture.build()
                 keepStateHot(viewModel)
@@ -157,6 +157,21 @@ class EditProfileViewModelTest :
                 ready.firstName shouldBe ""
                 ready.lastName shouldBe ""
                 ready.tagline shouldBe ""
+                ready.isDirty shouldBe false
+            }
+        }
+
+        test("Ready seeds first/last from displayName when stored names are null") {
+            runTest {
+                val user = createUser(displayName = "Ada Lovelace", firstName = null, lastName = null)
+                val fixture = createFixture().apply { configure(currentUser = user) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                val ready = viewModel.state.value.shouldBeInstanceOf<EditProfileUiState.Ready>()
+                ready.firstName shouldBe "Ada"
+                ready.lastName shouldBe "Lovelace"
                 ready.isDirty shouldBe false
             }
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/EditProfileViewModelTest.kt
@@ -176,6 +176,23 @@ class EditProfileViewModelTest :
             }
         }
 
+        test("save() with derived names and no edits does not call updateProfile") {
+            runTest {
+                val user = createUser(displayName = "Ada Lovelace", firstName = null, lastName = null, tagline = null)
+                val fixture = createFixture().apply { configure(currentUser = user) }
+                val viewModel = fixture.build()
+                keepStateHot(viewModel)
+                advanceUntilIdle()
+
+                viewModel.save()
+                advanceUntilIdle()
+
+                verifySuspend(dev.mokkery.verify.VerifyMode.not) {
+                    fixture.profileEditRepository.updateProfile(any(), any(), any(), any())
+                }
+            }
+        }
+
         test("Ready reflects cached avatar path when avatar is an image") {
             runTest {
                 val user = createUser(avatarType = "image", avatarValue = "avatar.jpg")

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatarMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatarMenu.kt
@@ -1,6 +1,7 @@
 
 package com.calypsan.listenup.client.design.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,27 +23,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil3.PlatformContext
-import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
-import coil3.request.CachePolicy
-import coil3.request.ImageRequest
 import com.calypsan.listenup.client.domain.model.User
-import com.calypsan.listenup.client.domain.repository.ImageStorage
-import com.calypsan.listenup.client.domain.repository.ServerConfig
-import org.koin.compose.koinInject
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.common_administration
-import listenup.composeapp.generated.resources.common_displayname_avatar
 import listenup.composeapp.generated.resources.common_loading
 import listenup.composeapp.generated.resources.common_my_profile
 import listenup.composeapp.generated.resources.common_settings
@@ -77,15 +65,6 @@ fun UserAvatarMenu(
     modifier: Modifier = Modifier,
     showLabel: Boolean = false,
 ) {
-    val platformContext = LocalPlatformContext.current
-    val serverConfig: ServerConfig = koinInject()
-    val imageStorage: ImageStorage = koinInject()
-    val serverUrl by produceState<String?>(null) {
-        value = serverConfig.getServerUrl()?.value
-    }
-
-    val hasImageAvatar = user?.avatarType == "image" && !user.avatarValue.isNullOrEmpty()
-
     Box(modifier = modifier) {
         // Anchor: a labelled pill (name + email + chevron) on wide chrome, or the bare circle.
         if (showLabel && user != null) {
@@ -93,10 +72,6 @@ fun UserAvatarMenu(
         } else {
             UserAvatarCircle(
                 user = user,
-                hasImageAvatar = hasImageAvatar,
-                serverUrl = serverUrl,
-                imageStorage = imageStorage,
-                platformContext = platformContext,
                 onClick = { onExpandedChange(true) },
             )
         }
@@ -163,99 +138,22 @@ private fun UserAvatarPill(
 @Composable
 private fun UserAvatarCircle(
     user: User?,
-    hasImageAvatar: Boolean,
-    serverUrl: String?,
-    imageStorage: ImageStorage,
-    platformContext: PlatformContext,
     onClick: () -> Unit,
 ) {
-    Surface(
-        onClick = onClick,
-        shape = CircleShape,
-        color =
-            if (hasImageAvatar) {
-                Color.Transparent
-            } else {
-                user?.let { Color.hsl((it.id.value.hashCode() and 0x7FFFFFFF).rem(360).toFloat(), 0.4f, 0.65f) }
-                    ?: MaterialTheme.colorScheme.surfaceContainerHighest
-            },
-        modifier = Modifier.size(48.dp),
-    ) {
-        if (hasImageAvatar && user != null) {
-            // Offline-first: prefer local cached avatar
-            val localPath =
-                if (imageStorage.userAvatarExists(user.id.value)) {
-                    imageStorage.getUserAvatarPath(user.id.value)
-                } else {
-                    null
-                }
-
-            if (localPath != null) {
-                // Version the key on updatedAtMs (bumped on avatar upload) so a re-uploaded avatar
-                // busts the stale cached bitmap — mirrors the canonical UserAvatar key shape.
-                val avatarKey = "${user.id.value}-avatar-${user.updatedAtMs}"
-                AsyncImage(
-                    model =
-                        ImageRequest
-                            .Builder(platformContext)
-                            .data(localPath)
-                            .memoryCacheKey(avatarKey)
-                            .diskCacheKey(avatarKey)
-                            .build(),
-                    contentDescription = stringResource(Res.string.common_displayname_avatar, user.displayName),
-                    modifier =
-                        Modifier
-                            .size(48.dp)
-                            .clip(CircleShape),
-                    contentScale = ContentScale.Crop,
-                )
-            } else if (serverUrl != null) {
-                // Fallback: fetch from server with disabled caching
-                val avatarUrl = "$serverUrl${user.avatarValue}"
-                AsyncImage(
-                    model =
-                        ImageRequest
-                            .Builder(platformContext)
-                            .data(avatarUrl)
-                            .memoryCachePolicy(CachePolicy.DISABLED)
-                            .diskCachePolicy(CachePolicy.DISABLED)
-                            .build(),
-                    contentDescription = stringResource(Res.string.common_displayname_avatar, user.displayName),
-                    modifier =
-                        Modifier
-                            .size(48.dp)
-                            .clip(CircleShape),
-                    contentScale = ContentScale.Crop,
-                )
-            } else {
-                // No local file and no server URL - show initials
-                AvatarInitials(displayName = user.displayName)
-            }
-        } else {
-            AvatarInitials(displayName = user?.displayName)
-        }
-    }
-}
-
-@Composable
-private fun AvatarInitials(displayName: String?) {
-    Box(contentAlignment = Alignment.Center) {
-        Text(
-            text =
-                displayName?.let { name ->
-                    name
-                        .trim()
-                        .split("\\s+".toRegex())
-                        .let { parts ->
-                            when {
-                                parts.size >= 2 -> "${parts[0].first()}${parts[1].first()}"
-                                name.length >= 2 -> name.take(2)
-                                else -> name.take(1)
-                            }
-                        }.uppercase()
-                } ?: "?",
-            style = MaterialTheme.typography.titleSmall,
-            color = Color.White,
+    if (user != null) {
+        UserAvatar(
+            userId = user.id.value,
+            size = AvatarSize.Medium,
+            onClick = onClick,
+            fallbackName = user.displayName,
+        )
+    } else {
+        Box(
+            modifier =
+                Modifier
+                    .size(AvatarSize.Medium.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
         )
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatarMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatarMenu.kt
@@ -2,6 +2,7 @@
 package com.calypsan.listenup.client.design.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -113,7 +114,7 @@ private fun UserAvatarPill(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            UserAvatar(userId = user.id.value, size = AvatarSize.Small)
+            UserAvatar(userId = user.id.value, size = AvatarSize.Small, fallbackName = user.displayName)
             Column {
                 Text(
                     text = user.displayName,
@@ -149,12 +150,20 @@ private fun UserAvatarCircle(
         )
     } else {
         Box(
+            contentAlignment = Alignment.Center,
             modifier =
                 Modifier
                     .size(AvatarSize.Medium.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-        )
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .clickable(onClick = onClick),
+        ) {
+            Text(
+                text = "?",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/discover/components/LeaderboardList.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/discover/components/LeaderboardList.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.calypsan.listenup.client.design.components.AvatarSize
 import com.calypsan.listenup.client.design.components.RankBadge
+import com.calypsan.listenup.client.design.components.UserAvatar
 import com.calypsan.listenup.client.domain.leaderboard.LeaderboardCategory
 import com.calypsan.listenup.client.domain.leaderboard.LeaderboardEntry
 import org.jetbrains.compose.resources.stringResource
@@ -145,6 +147,13 @@ private fun LeaderboardEntryRow(
         }
 
         Spacer(Modifier.width(14.dp))
+
+        UserAvatar(
+            userId = entry.userId,
+            size = AvatarSize.Small,
+            fallbackName = entry.displayName,
+        )
+        Spacer(Modifier.width(12.dp))
 
         // User name
         Text(


### PR DESCRIPTION
Two small bug fixes (Android/shared; iOS follow-up tracked separately). Brainstorm→spec→plan→subagent-driven (spec + code-quality review both passed).

## 1. Edit Profile didn't pre-fill the user's name
Registration joins first+last into a single `displayName`; the `User` contract DTO has no separate first/last, so domain `user.firstName/lastName` are always null and the edit form seeded blank. Added a pure, unit-tested `resolveNameFields(displayName, firstName, lastName)` / `splitDisplayName(...)` helper (`sharedLogic/.../core/DisplayNameParsing.kt`) that derives first/last from `displayName` when stored names are null. `EditProfileViewModel` now uses it for the form seed, the `isDirty` check, AND the save change-detection baseline — the same baseline in all three places, so an unedited form is neither phantom-dirty nor fires a no-op `updateProfile` (pinned by a `VerifyMode.not` test). **iOS gets this for free** — its `EditProfileObserver` mirrors this shared VM.

## 2. Profile pictures didn't show (top bar + leaderboard)
The canonical `UserAvatar(userId, …)` already resolves a user's picture by id (Coil + local cache + initials fallback). The top-bar `UserAvatarMenu` compact circle was hand-rolling its own avatar loading (so the current user's picture never showed) — it now delegates to `UserAvatar` (≈115 lines of bespoke loading + the private `AvatarInitials` deleted). The Leaderboard row had no avatar — now uses `UserAvatar(userId = entry.userId, …)`. Net: one avatar path, consistent everywhere. Null-user menu anchor stays clickable with a `?` placeholder; `fallbackName` wired on both anchors.

Gate: `:sharedLogic:jvmTest` ✅, `:sharedUI:testAndroidHostTest` ✅, `:androidApp:assembleDebug` ✅, `spotlessCheck detekt` ✅. `OneUserAvatarComposableRule` stays green.

Spec/plan: docs/superpowers/specs/2026-06-26-profile-name-and-avatar-fixes-design.md (non-repo).
Follow-up: iOS avatar surfaces (Leaderboard/Activity/Readers/What-Others) in a separate plan, after the iOS Swift-Export toolchain fix (#860) lands.