### PR TITLE
✨ feat(ios): show profile pictures on the social surfaces (avatar parity)

### DIFF
--- a/iosApp/ListenUp/DesignSystem/Components/UserAvatarView.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/UserAvatarView.swift
@@ -9,11 +9,26 @@ import UIKit
 /// - Colored circle with initials as fallback
 /// - Gray placeholder when user is nil
 struct UserAvatarView: View {
-    let user: User?
-    let size: CGFloat
+    private let userId: String?
+    private let fallbackName: String
+    private let avatarColorHex: String?
+    private let size: CGFloat
 
+    /// Render from a known Kotlin `User`. Used by toolbars / profile screens.
     init(user: User?, size: CGFloat = 36) {
-        self.user = user
+        self.userId = user?.idString
+        self.fallbackName = user?.displayName ?? ""
+        self.avatarColorHex = user?.avatarColor
+        self.size = size
+    }
+
+    /// Render from primitives — for list rows that carry only the user's id (per iOS rule 8,
+    /// we never put a bridged Kotlin `User` in a `ForEach`). Resolves the picture by `userId`,
+    /// falling back to initials derived from `fallbackName`.
+    init(userId: String, fallbackName: String, avatarColor: String? = nil, size: CGFloat = 36) {
+        self.userId = userId
+        self.fallbackName = fallbackName
+        self.avatarColorHex = avatarColor
         self.size = size
     }
 
@@ -30,20 +45,18 @@ struct UserAvatarView: View {
                     .aspectRatio(contentMode: .fill)
                     .frame(width: size, height: size)
                     .clipShape(Circle())
-            } else if let user {
-                initialsAvatar(for: user)
+            } else if userId != nil {
+                initialsAvatar
             } else {
                 placeholderAvatar
             }
         }
-        .task(id: user?.idString) {
-            // Read the Sendable primitives on the main actor; only the String id crosses into the
-            // nonisolated loader (the Kotlin `User` isn't Sendable).
-            guard let user, user.hasImageAvatar else {
+        .task(id: userId) {
+            guard let userId else {
                 avatarImage = nil
                 return
             }
-            avatarImage = await Self.loadAvatar(userId: user.idString)
+            avatarImage = await Self.loadAvatar(userId: userId)
         }
     }
 
@@ -61,12 +74,12 @@ struct UserAvatarView: View {
 
     // MARK: - Private Views
 
-    private func initialsAvatar(for user: User) -> some View {
+    private var initialsAvatar: some View {
         Circle()
-            .fill(avatarColor(for: user))
+            .fill(initialsColor)
             .frame(width: size, height: size)
             .overlay {
-                Text(user.initials)
+                Text(Self.initials(from: fallbackName))
                     .font(.system(size: size * 0.4, weight: .medium))
                     .foregroundStyle(.white)
             }
@@ -83,16 +96,23 @@ struct UserAvatarView: View {
             }
     }
 
-    private func avatarColor(for user: User) -> Color {
-        Color(hex: user.avatarColor)
+    private var initialsColor: Color {
+        if let avatarColorHex { return Color(hex: avatarColorHex) }
+        return Color.luFill
+    }
+
+    /// Up to two uppercased initials from a display name; "?" when blank.
+    static func initials(from name: String) -> String {
+        let words = name.split(separator: " ").prefix(2)
+        let letters = words.compactMap { $0.first }.map(String.init).joined().uppercased()
+        return letters.isEmpty ? "?" : letters
     }
 }
 
 // MARK: - Preview
 
 #Preview("With User") {
-    // Can't easily create a User in preview without Kotlin, so show placeholder
-    UserAvatarView(user: nil, size: 40)
+    UserAvatarView(userId: "u1", fallbackName: "Ada Lovelace")
 }
 
 #Preview("Placeholder") {

--- a/iosApp/ListenUp/Features/BookDetail/Components/BookReadersSection.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/BookReadersSection.swift
@@ -83,15 +83,7 @@ struct BookReadersSection: View {
     }
 
     private func avatar(_ reader: BookReaderRow) -> some View {
-        let tint = avatarColorForUserId(reader.id)
-        return Circle()
-            .fill(tint.opacity(0.2))
-            .frame(width: 44, height: 44)
-            .overlay {
-                Text(reader.initials)
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundStyle(tint)
-            }
+        UserAvatarView(userId: reader.id, fallbackName: reader.displayName, size: 44)
             .overlay {
                 // A coral ring marks the readers listening right now.
                 if reader.isReading {

--- a/iosApp/ListenUp/Features/Discover/ActivityFeedObserver.swift
+++ b/iosApp/ListenUp/Features/Discover/ActivityFeedObserver.swift
@@ -66,6 +66,7 @@ enum ActivityFeedPhase: Equatable {
 /// fragment is optional — milestone/join activities have no book and render the phrase only.
 struct ActivityRowItem: Identifiable, Equatable {
     let id: String
+    let userId: String
     let who: String
     let initials: String
     let avatarColor: String
@@ -79,6 +80,7 @@ struct ActivityRowItem: Identifiable, Equatable {
 
     init(from model: ActivityUiModel) {
         self.id = model.id
+        self.userId = model.userId
         self.who = model.userDisplayName
         self.initials = LeaderboardRow.initials(from: model.userDisplayName)
         self.avatarColor = model.userAvatarColor
@@ -90,6 +92,7 @@ struct ActivityRowItem: Identifiable, Equatable {
 
     init(
         id: String,
+        userId: String,
         who: String,
         initials: String,
         avatarColor: String,
@@ -99,6 +102,7 @@ struct ActivityRowItem: Identifiable, Equatable {
         occurredAt: Date
     ) {
         self.id = id
+        self.userId = userId
         self.who = who
         self.initials = initials
         self.avatarColor = avatarColor

--- a/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
@@ -29,7 +29,7 @@ struct ActivityRow: View {
 
     private var content: some View {
         HStack(spacing: 13) {
-            InitialsAvatar(initials: item.initials, tint: Color(hex: item.avatarColor))
+            UserAvatarView(userId: item.userId, fallbackName: item.who, avatarColor: item.avatarColor)
 
             VStack(alignment: .leading, spacing: 2) {
                 phrase

--- a/iosApp/ListenUp/Features/Discover/Components/CurrentlyListeningCard.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/CurrentlyListeningCard.swift
@@ -22,7 +22,7 @@ struct CurrentlyListeningCard: View {
                     .bookSelectionCircle(bookId: row.bookId, selection: selection)
 
                 HStack(spacing: 8) {
-                    InitialsAvatar(initials: row.initials, size: 26, tint: Color(hex: row.avatarColor))
+                    UserAvatarView(userId: row.userId, fallbackName: row.displayName, avatarColor: row.avatarColor, size: 26)
 
                     Text(row.displayName)
                         .font(.subheadline.weight(.medium))

--- a/iosApp/ListenUp/Features/Discover/Components/LeaderRow.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/LeaderRow.swift
@@ -13,7 +13,7 @@ struct LeaderRow: View {
                 .foregroundStyle(rankColor)
                 .frame(width: 22)
 
-            InitialsAvatar(initials: row.initials, isCurrentUser: row.isCurrentUser)
+            UserAvatarView(userId: row.id, fallbackName: row.displayName, size: 38)
 
             Text(name)
                 .font(.callout.weight(row.isCurrentUser ? .semibold : .regular))


### PR DESCRIPTION
iOS half of the avatar work (Android shipped in #864). Generalizes the avatar component and adopts it everywhere a user appears. **CI-verified only** (no local Mac); depends on #860 (Swift Export toolchain fix, now on `main`).

## What
`UserAvatarView` already resolved a user's picture by `userId` internally but required a Kotlin `User?` — so list rows (which carry only native projected structs, never a bridged `User`, per iOS rule 8) fell back to initials. Added a **primitives `init(userId:fallbackName:avatarColor:size:)`** alongside the existing `init(user:)`, then adopted it:
- **Leaderboard** (`LeaderRow`) — `userId: row.id`
- **Readers** (`BookReadersSection`) — `userId: reader.id`; the coral "listening now" ring is preserved
- **Activity Feed** (`ActivityRow`) — added `userId` to `ActivityRowItem` (from `ActivityUiModel.userId`)
- **What Others Are Listening To** (`CurrentlyListeningCard`) — `userId: row.userId`

Top-bar toolbars already used `UserAvatarView(user:)` — no change. `InitialsAvatar` kept (still used by admin screens). Name pre-fill is already fixed via the shared VM (#864) — iOS inherits it.

## Verification
No local Mac → this PR's `Test (iOS)` lane is the build gate. Spec + Swift-correctness reviewed statically.

Minor follow-up (non-blocking): the now-unused `initials` stored field on `ActivityRowItem`/`LeaderboardRow` can be removed in a cleanup.

Plan: docs/superpowers/plans/2026-06-26-profile-name-and-avatars-ios.md (non-repo).