### PR TITLE
✨ feat(server): server observability — runtime log level + hot-path coverage

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -191,7 +191,7 @@ internal class Scanner(
         // books are persisted (see BookPersister.persist). The Scanner must NOT emit Completed here
         // — that would signal "done" before any book is queryable.
         scanResultBus.emit(result)
-        logger.info { "scan walk complete [library=${library.id.value}]: ${formatScanCompleteLog(result.toSummary())}" }
+        logger.info { "scan walk complete [library=${library.id.value}]: ${formatScanCompleteLog(result.toSummary())} corr=$correlationId" }
         return result
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -92,6 +92,7 @@ internal class Scanner(
     suspend fun runFullScan(): ScanResult {
         val correlationId = correlationIdFactory()
         val started = clock()
+        logger.info { "scan started: library=${library.id.value} corr=$correlationId" }
         // Use the first folder path as the canonical rootPath for the ScanResult
         // and event label; all folders are walked but share a single correlation id.
         val primaryRootPath = library.folders.firstOrNull()?.rootPath ?: library.id.value
@@ -210,6 +211,7 @@ internal class Scanner(
     suspend fun runIncremental(bookRoot: Path) {
         val correlationId = correlationIdFactory()
         val started = clock()
+        logger.info { "incremental scan started: library=${library.id.value} root=$bookRoot corr=$correlationId" }
         eventBus.emit(ScanEvent.Started(correlationId, library.id, bookRoot.toString()))
 
         // Identify which folder owns this subtree to compute the relative path.
@@ -299,6 +301,10 @@ internal class Scanner(
             )
         // Store a stripped copy in lastResult so artwork bytes are not retained between scans.
         lastResult = incrementalResult.copy(books = patchedStripped)
+        logger.info {
+            "incremental scan complete: library=${library.id.value} root=$bookRoot" +
+                " books=${books.size} changes=${changes.size} errors=${errors.size} in ${durationMs}ms corr=$correlationId"
+        }
         // BookPersister emits ScanEvent.Completed after persisting this incremental result.
         scanResultBus.emit(incrementalResult)
     }
@@ -349,6 +355,9 @@ internal class Scanner(
                 val previous = previousByPath[candidate.rootRelPath] ?: return@partition false
                 fingerprintMatches(candidate, previous.candidate)
             }
+        logger.debug {
+            "scan cache: library=${library.id.value} hits=${cacheHits.size} misses=${toAnalyze.size} total=${candidates.size}"
+        }
 
         // Accept all cache hits immediately — no parse, no IO.
         for (cached in cacheHits) {
@@ -367,7 +376,11 @@ internal class Scanner(
                     currentFile = book.candidate.rootRelPath
                     recent.addLast(ScanBookRef(title = book.title, author = book.authors.firstOrNull().orEmpty()))
                     while (recent.size > RECENT_BOOKS_CAP) recent.removeFirst()
-                }.onFailure { errors += toScanError(it, errorRoot) }
+                }.onFailure { t ->
+                    val relPath = (t as? BookAnalysisFailure)?.rootRelPath ?: errorRoot.toString()
+                    logger.warn(t) { "analyze failed: path=$relPath library=${library.id.value}" }
+                    errors += toScanError(t, errorRoot)
+                }
             val now = clock()
             if (now - lastEmit >= PROGRESS_THROTTLE_MS) {
                 emitProgress(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -191,7 +191,11 @@ internal class Scanner(
         // books are persisted (see BookPersister.persist). The Scanner must NOT emit Completed here
         // — that would signal "done" before any book is queryable.
         scanResultBus.emit(result)
-        logger.info { "scan walk complete [library=${library.id.value}]: ${formatScanCompleteLog(result.toSummary())} corr=$correlationId" }
+        logger.info {
+            "scan walk complete [library=${library.id.value}]: ${formatScanCompleteLog(
+                result.toSummary(),
+            )} corr=$correlationId"
+        }
         return result
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
@@ -73,7 +73,9 @@ internal class Differ {
             }
 
             previous.candidate.rootRelPath != current.candidate.rootRelPath -> {
-                logger.debug { "book moved: from=${previous.candidate.rootRelPath} to=${current.candidate.rootRelPath}" }
+                logger.debug {
+                    "book moved: from=${previous.candidate.rootRelPath} to=${current.candidate.rootRelPath}"
+                }
                 ChangeEventDto.Moved(
                     from = previous.candidate.rootRelPath,
                     to = current.candidate.rootRelPath,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
@@ -3,8 +3,11 @@ package com.calypsan.listenup.server.scanner.pipeline
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
 import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
 import com.calypsan.listenup.api.dto.scanner.FileType
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Stage 4 of the scanner pipeline: emits a [ChangeEventDto] per book that
@@ -53,6 +56,7 @@ internal class Differ {
 
             previous.forEach { previousBook ->
                 if (previousBook.candidate.rootRelPath !in matchedRoots) {
+                    logger.debug { "book removed: path=${previousBook.candidate.rootRelPath}" }
                     emit(ChangeEventDto.Removed(previousBook.candidate.rootRelPath))
                 }
             }
@@ -64,10 +68,12 @@ internal class Differ {
     ): ChangeEventDto? =
         when {
             previous == null -> {
+                logger.debug { "book added: path=${current.candidate.rootRelPath}" }
                 ChangeEventDto.Added(current)
             }
 
             previous.candidate.rootRelPath != current.candidate.rootRelPath -> {
+                logger.debug { "book moved: from=${previous.candidate.rootRelPath} to=${current.candidate.rootRelPath}" }
                 ChangeEventDto.Moved(
                     from = previous.candidate.rootRelPath,
                     to = current.candidate.rootRelPath,
@@ -76,6 +82,7 @@ internal class Differ {
             }
 
             previous != current -> {
+                logger.debug { "book modified: path=${current.candidate.rootRelPath}" }
                 ChangeEventDto.Modified(
                     book = current,
                     previousRootRelPath = previous.candidate.rootRelPath,

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLogProvider.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLogProvider.kt
@@ -16,6 +16,10 @@ import org.slf4j.spi.SLF4JServiceProvider
  * Format selection: reads `LISTENUP_LOG_FORMAT` environment variable at [initialize] time.
  * Value `json` (case-insensitive) → JSON; anything else → plain text.
  *
+ * Level selection: reads `LISTENUP_LOG_LEVEL` (default `INFO`). Per-package overrides are
+ * expressed as `LISTENUP_LOG_LEVEL_<pkg_with_underscores>` (e.g.
+ * `LISTENUP_LOG_LEVEL_com_calypsan_listenup_server_sync=DEBUG`). See [LogLevelConfig].
+ *
  * MDC: delegates to SLF4J's built-in [org.slf4j.helpers.BasicMDCAdapter] so that
  * `kotlinx-coroutines-slf4j` can propagate correlation IDs across coroutine boundaries
  * without any custom adapter.
@@ -38,8 +42,8 @@ class ListenUpLogProvider : SLF4JServiceProvider {
         checkNotNull(loggerFactory) { "ListenUpLogProvider.initialize() has not been called" }
 
     override fun initialize() {
-        val logFormat = System.getenv("LISTENUP_LOG_FORMAT")
-        val isJson = logFormat.equals("json", ignoreCase = true)
-        loggerFactory = ListenUpLoggerFactory(isJsonFormat = isJson)
+        val env = System.getenv()
+        val isJson = env["LISTENUP_LOG_FORMAT"].equals("json", ignoreCase = true)
+        loggerFactory = ListenUpLoggerFactory(isJsonFormat = isJson, levelConfig = LogLevelConfig.fromEnv(env))
     }
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLogger.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLogger.kt
@@ -15,6 +15,17 @@ import org.slf4j.helpers.MessageFormatter
  * Each [handleNormalizedLoggingCall] call writes a single [println] to [System.out],
  * which is internally synchronized, guaranteeing atomic multi-line output under
  * concurrent access.
+ *
+ * ## Level convention
+ * - **ERROR** — a failure needing operator attention (unhandled exception, failed restore, corruption).
+ * - **WARN**  — a recoverable anomaly or fallback (server search failed → local; transient retry; auth rejection).
+ * - **INFO**  — a lifecycle milestone (server started, scan completed, backup created, user registered).
+ * - **DEBUG** — flow + decisions (entered handler X; resolved metadata from source Y; conflict resolved last-write-wins).
+ * - **TRACE** — verbose payload dumps (rare).
+ *
+ * Always carry the correlation id (propagated via MDC) and key entity ids (bookId/userId/scanId) in the message.
+ * New code obtains loggers via `io.github.oshai.kotlinlogging.KotlinLogging.logger {}`, never `org.slf4j` directly.
+ * Never log tokens, password hashes, secrets, or user content.
  */
 class ListenUpLogger(
     name: String,

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLoggerFactory.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLoggerFactory.kt
@@ -25,68 +25,68 @@ class ListenUpLoggerFactory
         val isJsonFormat: Boolean,
         private val levelConfig: LogLevelConfig = LogLevelConfig.DEFAULT,
     ) : ILoggerFactory {
-    private val cache = ConcurrentHashMap<String, ListenUpLogger>()
+        private val cache = ConcurrentHashMap<String, ListenUpLogger>()
 
-    /** Non-null only when a test has called [installTestCapture]. */
-    @Volatile
-    var testCapture: TestCapture? = null
-        internal set
-
-    /**
-     * When non-null, overrides the configured minimum level for every logger so that tests
-     * can assert on DEBUG-level log output regardless of the configured default (INFO).
-     * Set by [installTestCapture] and cleared by [removeTestCapture].
-     */
-    @Volatile
-    internal var testMinLevel: Level? = null
-
-    override fun getLogger(name: String): ListenUpLogger = cache.computeIfAbsent(name) { ListenUpLogger(it, this) }
-
-    /**
-     * Returns the minimum [Level] that should be emitted for [loggerName].
-     *
-     * When [testMinLevel] is set (i.e. a test capture is active) it takes the lower (more
-     * permissive) of the override and the configured level, so that DEBUG events are visible
-     * to test assertions without changing the production configuration.
-     */
-    fun levelFor(loggerName: String): Level {
-        val override = testMinLevel
-        val configured = levelConfig.levelFor(loggerName)
-        return if (override != null && override.toInt() < configured.toInt()) override else configured
-    }
-
-    // ----- Test helpers -----------------------------------------------------
-
-    companion object {
-        /**
-         * Installs a fresh [TestCapture] on the current factory and returns it.
-         *
-         * Also lowers the effective log level to [Level.DEBUG] for the duration of the capture
-         * so that tests can assert on DEBUG-level output regardless of the production default.
-         *
-         * Must be paired with [removeTestCapture] in a `finally` block.
-         */
-        fun installTestCapture(): TestCapture {
-            val factory =
-                LoggerFactory.getILoggerFactory() as? ListenUpLoggerFactory
-                    ?: error(
-                        "SLF4J backend is not ListenUpLoggerFactory — " +
-                            "ensure META-INF/services/org.slf4j.spi.SLF4JServiceProvider is on the test classpath.",
-                    )
-            val capture = TestCapture()
-            factory.testCapture = capture
-            factory.testMinLevel = Level.DEBUG
-            return capture
-        }
+        /** Non-null only when a test has called [installTestCapture]. */
+        @Volatile
+        var testCapture: TestCapture? = null
+            internal set
 
         /**
-         * Removes any installed [TestCapture] and restores the configured log level,
-         * returning the factory to normal stdout-only logging.
+         * When non-null, overrides the configured minimum level for every logger so that tests
+         * can assert on DEBUG-level log output regardless of the configured default (INFO).
+         * Set by [installTestCapture] and cleared by [removeTestCapture].
          */
-        fun removeTestCapture() {
-            val factory = LoggerFactory.getILoggerFactory() as? ListenUpLoggerFactory ?: return
-            factory.testCapture = null
-            factory.testMinLevel = null
+        @Volatile
+        internal var testMinLevel: Level? = null
+
+        override fun getLogger(name: String): ListenUpLogger = cache.computeIfAbsent(name) { ListenUpLogger(it, this) }
+
+        /**
+         * Returns the minimum [Level] that should be emitted for [loggerName].
+         *
+         * When [testMinLevel] is set (i.e. a test capture is active) it takes the lower (more
+         * permissive) of the override and the configured level, so that DEBUG events are visible
+         * to test assertions without changing the production configuration.
+         */
+        fun levelFor(loggerName: String): Level {
+            val override = testMinLevel
+            val configured = levelConfig.levelFor(loggerName)
+            return if (override != null && override.toInt() < configured.toInt()) override else configured
+        }
+
+        // ----- Test helpers -----------------------------------------------------
+
+        companion object {
+            /**
+             * Installs a fresh [TestCapture] on the current factory and returns it.
+             *
+             * Also lowers the effective log level to [Level.DEBUG] for the duration of the capture
+             * so that tests can assert on DEBUG-level output regardless of the production default.
+             *
+             * Must be paired with [removeTestCapture] in a `finally` block.
+             */
+            fun installTestCapture(): TestCapture {
+                val factory =
+                    LoggerFactory.getILoggerFactory() as? ListenUpLoggerFactory
+                        ?: error(
+                            "SLF4J backend is not ListenUpLoggerFactory — " +
+                                "ensure META-INF/services/org.slf4j.spi.SLF4JServiceProvider is on the test classpath.",
+                        )
+                val capture = TestCapture()
+                factory.testCapture = capture
+                factory.testMinLevel = Level.DEBUG
+                return capture
+            }
+
+            /**
+             * Removes any installed [TestCapture] and restores the configured log level,
+             * returning the factory to normal stdout-only logging.
+             */
+            fun removeTestCapture() {
+                val factory = LoggerFactory.getILoggerFactory() as? ListenUpLoggerFactory ?: return
+                factory.testCapture = null
+                factory.testMinLevel = null
+            }
         }
     }
-}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLoggerFactory.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLoggerFactory.kt
@@ -32,16 +32,37 @@ class ListenUpLoggerFactory
     var testCapture: TestCapture? = null
         internal set
 
+    /**
+     * When non-null, overrides the configured minimum level for every logger so that tests
+     * can assert on DEBUG-level log output regardless of the configured default (INFO).
+     * Set by [installTestCapture] and cleared by [removeTestCapture].
+     */
+    @Volatile
+    internal var testMinLevel: Level? = null
+
     override fun getLogger(name: String): ListenUpLogger = cache.computeIfAbsent(name) { ListenUpLogger(it, this) }
 
-    /** Returns the minimum [Level] that should be emitted for [loggerName] (delegates to [LogLevelConfig]). */
-    fun levelFor(loggerName: String): Level = levelConfig.levelFor(loggerName)
+    /**
+     * Returns the minimum [Level] that should be emitted for [loggerName].
+     *
+     * When [testMinLevel] is set (i.e. a test capture is active) it takes the lower (more
+     * permissive) of the override and the configured level, so that DEBUG events are visible
+     * to test assertions without changing the production configuration.
+     */
+    fun levelFor(loggerName: String): Level {
+        val override = testMinLevel
+        val configured = levelConfig.levelFor(loggerName)
+        return if (override != null && override.toInt() < configured.toInt()) override else configured
+    }
 
     // ----- Test helpers -----------------------------------------------------
 
     companion object {
         /**
          * Installs a fresh [TestCapture] on the current factory and returns it.
+         *
+         * Also lowers the effective log level to [Level.DEBUG] for the duration of the capture
+         * so that tests can assert on DEBUG-level output regardless of the production default.
          *
          * Must be paired with [removeTestCapture] in a `finally` block.
          */
@@ -54,15 +75,18 @@ class ListenUpLoggerFactory
                     )
             val capture = TestCapture()
             factory.testCapture = capture
+            factory.testMinLevel = Level.DEBUG
             return capture
         }
 
         /**
-         * Removes any installed [TestCapture], returning the factory to normal stdout-only logging.
+         * Removes any installed [TestCapture] and restores the configured log level,
+         * returning the factory to normal stdout-only logging.
          */
         fun removeTestCapture() {
             val factory = LoggerFactory.getILoggerFactory() as? ListenUpLoggerFactory ?: return
             factory.testCapture = null
+            factory.testMinLevel = null
         }
     }
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLoggerFactory.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLoggerFactory.kt
@@ -12,16 +12,19 @@ import java.util.concurrent.ConcurrentHashMap
  * the lifetime of the JVM. Logger instances are cached by name; [getLogger] always
  * returns the same object for the same name.
  *
- * Level filtering is prefix-based:
- * - `io.netty.*` → [Level.WARN]
- * - `org.eclipse.jetty.*` → [Level.WARN]
- * - everything else → [Level.INFO]
+ * Level filtering delegates to [LogLevelConfig], which is built from environment variables
+ * at startup. `LISTENUP_LOG_LEVEL` sets the default level; per-package overrides are
+ * expressed as `LISTENUP_LOG_LEVEL_<pkg_with_underscores>`. The `io.netty.*` /
+ * `org.eclipse.jetty.*` WARN floor is always enforced regardless of env config.
  *
  * @param isJsonFormat `true` → JSON one-per-line; `false` → human-readable plain text.
+ * @param levelConfig  level resolution config, defaulting to INFO-everywhere if omitted.
  */
-class ListenUpLoggerFactory(
-    val isJsonFormat: Boolean,
-) : ILoggerFactory {
+class ListenUpLoggerFactory
+    internal constructor(
+        val isJsonFormat: Boolean,
+        private val levelConfig: LogLevelConfig = LogLevelConfig.DEFAULT,
+    ) : ILoggerFactory {
     private val cache = ConcurrentHashMap<String, ListenUpLogger>()
 
     /** Non-null only when a test has called [installTestCapture]. */
@@ -31,17 +34,8 @@ class ListenUpLoggerFactory(
 
     override fun getLogger(name: String): ListenUpLogger = cache.computeIfAbsent(name) { ListenUpLogger(it, this) }
 
-    /**
-     * Returns the minimum [Level] that should be emitted for [loggerName].
-     *
-     * Matching is prefix-based so sub-packages are suppressed automatically.
-     */
-    fun levelFor(loggerName: String): Level =
-        when {
-            loggerName.startsWith("io.netty") -> Level.WARN
-            loggerName.startsWith("org.eclipse.jetty") -> Level.WARN
-            else -> Level.INFO
-        }
+    /** Returns the minimum [Level] that should be emitted for [loggerName] (delegates to [LogLevelConfig]). */
+    fun levelFor(loggerName: String): Level = levelConfig.levelFor(loggerName)
 
     // ----- Test helpers -----------------------------------------------------
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/LogLevelConfig.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/LogLevelConfig.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.server.logging
+
+import org.slf4j.event.Level
+
+/**
+ * Resolves the minimum emitted [Level] for a logger name, from environment configuration.
+ *
+ * Precedence (first match wins):
+ * 1. `io.netty.*` / `org.eclipse.jetty.*` → [Level.WARN] (noise floor, always).
+ * 2. The longest matching `LISTENUP_LOG_LEVEL_<prefix>` override.
+ * 3. The `LISTENUP_LOG_LEVEL` default (or [Level.INFO] when unset/unparseable).
+ */
+internal class LogLevelConfig(
+    private val defaultLevel: Level,
+    private val overrides: List<Pair<String, Level>>,
+) {
+    fun levelFor(loggerName: String): Level =
+        when {
+            loggerName.startsWith("io.netty") -> Level.WARN
+            loggerName.startsWith("org.eclipse.jetty") -> Level.WARN
+            else -> overrides.firstOrNull { loggerName.startsWith(it.first) }?.second ?: defaultLevel
+        }
+
+    companion object {
+        /** INFO everywhere, no overrides — preserves the pre-config behaviour. */
+        val DEFAULT = LogLevelConfig(Level.INFO, emptyList())
+
+        private const val LEVEL_KEY = "LISTENUP_LOG_LEVEL"
+        private const val PREFIX_KEY = "LISTENUP_LOG_LEVEL_"
+
+        /**
+         * Builds a config from an environment map. `LISTENUP_LOG_LEVEL` sets the default;
+         * each `LISTENUP_LOG_LEVEL_<pkg_with_underscores>` sets a prefix override (underscores
+         * become dots). Overrides are sorted longest-prefix-first so the most specific wins.
+         * Keys with an empty suffix (`LISTENUP_LOG_LEVEL_`) are ignored.
+         *
+         * The nullable value type is for test ergonomics; production passes `System.getenv()`.
+         */
+        fun fromEnv(env: Map<String, String?>): LogLevelConfig {
+            val default = parseLevel(env[LEVEL_KEY]) ?: Level.INFO
+            val overrides =
+                env.entries
+                    .filter { it.key.startsWith(PREFIX_KEY) && it.key.length > PREFIX_KEY.length }
+                    .mapNotNull { (key, value) ->
+                        val level = parseLevel(value) ?: return@mapNotNull null
+                        key.removePrefix(PREFIX_KEY).replace('_', '.') to level
+                    }.sortedByDescending { it.first.length }
+            return LogLevelConfig(default, overrides)
+        }
+
+        private fun parseLevel(raw: String?): Level? =
+            raw?.trim()?.takeIf { it.isNotEmpty() }?.let { token ->
+                runCatching { Level.valueOf(token.uppercase()) }.getOrNull()
+            }
+    }
+}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -247,7 +247,9 @@ class AudibleClient(
 
                 else -> {
                     if (response.status.value in 500..599) {
-                        logger.warn { "Audible API server error: region=$region path=$path status=${response.status.value}" }
+                        logger.warn {
+                            "Audible API server error: region=$region path=$path status=${response.status.value}"
+                        }
                         AppResult.Failure(
                             MetadataError.ExternalUnavailable(
                                 debugInfo = "HTTP ${response.status.value}",
@@ -325,7 +327,9 @@ class AudibleClient(
                 }
 
                 else -> {
-                    logger.warn { "Audible web request server error: region=$region path=$path status=${response.status.value}" }
+                    logger.warn {
+                        "Audible web request server error: region=$region path=$path status=${response.status.value}"
+                    }
                     AppResult.Failure(
                         MetadataError.ExternalUnavailable(debugInfo = "HTTP ${response.status.value}"),
                     )

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -241,11 +241,13 @@ class AudibleClient(
                 }
 
                 HttpStatusCode.TooManyRequests -> {
+                    logger.warn { "Audible API rate-limited: region=$region path=$path" }
                     AppResult.Failure(MetadataError.ExternalRateLimited())
                 }
 
                 else -> {
                     if (response.status.value in 500..599) {
+                        logger.warn { "Audible API server error: region=$region path=$path status=${response.status.value}" }
                         AppResult.Failure(
                             MetadataError.ExternalUnavailable(
                                 debugInfo = "HTTP ${response.status.value}",
@@ -263,6 +265,7 @@ class AudibleClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "Audible API request failed: region=$region path=$path" }
             AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = e.message))
         }
 
@@ -317,6 +320,7 @@ class AudibleClient(
                 }
 
                 response.status == HttpStatusCode.TooManyRequests -> {
+                    logger.warn { "Audible web request rate-limited: region=$region path=$path" }
                     AppResult.Failure(MetadataError.ExternalRateLimited())
                 }
 
@@ -329,6 +333,7 @@ class AudibleClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "Audible web request failed: region=$region path=$path" }
             AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = e.message))
         }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -325,6 +325,7 @@ class AudibleClient(
                 }
 
                 else -> {
+                    logger.warn { "Audible web request server error: region=$region path=$path status=${response.status.value}" }
                     AppResult.Failure(
                         MetadataError.ExternalUnavailable(debugInfo = "HTTP ${response.status.value}"),
                     )

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.metadata.itunes
 import com.calypsan.listenup.api.error.MetadataError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -11,6 +12,8 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Ktor-backed adapter for the iTunes Search API. Used **only** for cover art —
@@ -92,6 +95,7 @@ class ITunesClient(
         author: String,
     ): AppResult<List<ITunesSearchResult>> =
         try {
+            logger.debug { "iTunes cover search: title='$title' author='$author'" }
             rateLimiter.await()
             val response =
                 httpClient.get(SEARCH_BASE_URL) {
@@ -103,7 +107,9 @@ class ITunesClient(
             when (response.status) {
                 HttpStatusCode.OK -> {
                     try {
-                        AppResult.Success(json.decodeFromString<ITunesSearchResponse>(response.bodyAsText()).results)
+                        val results = json.decodeFromString<ITunesSearchResponse>(response.bodyAsText()).results
+                        logger.debug { "iTunes cover search result: matches=${results.size}" }
+                        AppResult.Success(results)
                     } catch (e: SerializationException) {
                         AppResult.Failure(MetadataError.Malformed(debugInfo = e.message))
                     } catch (e: IllegalArgumentException) {
@@ -113,10 +119,12 @@ class ITunesClient(
                 }
 
                 HttpStatusCode.TooManyRequests -> {
+                    logger.warn { "iTunes cover search rate-limited: title='$title'" }
                     AppResult.Failure(MetadataError.ExternalRateLimited())
                 }
 
                 else -> {
+                    logger.warn { "iTunes cover search failed: title='$title' status=${response.status.value}" }
                     AppResult.Failure(
                         MetadataError.ExternalUnavailable(debugInfo = "HTTP ${response.status.value}"),
                     )
@@ -125,6 +133,7 @@ class ITunesClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "iTunes cover search network failure: title='$title'" }
             AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = e.message))
         }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
-private val logger = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 /**
  * Ktor-backed adapter for the iTunes Search API. Used **only** for cover art —
@@ -95,7 +95,7 @@ class ITunesClient(
         author: String,
     ): AppResult<List<ITunesSearchResult>> =
         try {
-            logger.debug { "iTunes cover search: title='$title' author='$author'" }
+            log.debug { "iTunes cover search: title='$title' author='$author'" }
             rateLimiter.await()
             val response =
                 httpClient.get(SEARCH_BASE_URL) {
@@ -108,7 +108,7 @@ class ITunesClient(
                 HttpStatusCode.OK -> {
                     try {
                         val results = json.decodeFromString<ITunesSearchResponse>(response.bodyAsText()).results
-                        logger.debug { "iTunes cover search result: matches=${results.size}" }
+                        log.debug { "iTunes cover search result: matches=${results.size}" }
                         AppResult.Success(results)
                     } catch (e: SerializationException) {
                         AppResult.Failure(MetadataError.Malformed(debugInfo = e.message))
@@ -119,12 +119,12 @@ class ITunesClient(
                 }
 
                 HttpStatusCode.TooManyRequests -> {
-                    logger.warn { "iTunes cover search rate-limited: title='$title'" }
+                    log.warn { "iTunes cover search rate-limited: title='$title'" }
                     AppResult.Failure(MetadataError.ExternalRateLimited())
                 }
 
                 else -> {
-                    logger.warn { "iTunes cover search failed: title='$title' status=${response.status.value}" }
+                    log.warn { "iTunes cover search failed: title='$title' status=${response.status.value}" }
                     AppResult.Failure(
                         MetadataError.ExternalUnavailable(debugInfo = "HTTP ${response.status.value}"),
                     )
@@ -133,7 +133,7 @@ class ITunesClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            logger.warn(e) { "iTunes cover search network failure: title='$title'" }
+            log.warn(e) { "iTunes cover search network failure: title='$title'" }
             AppResult.Failure(MetadataError.ExternalUnavailable(debugInfo = e.message))
         }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
@@ -71,7 +71,9 @@ internal class AudibleMetadataProvider(
                 null
             } else {
                 MetadataChapters(chapters = chapters.map { it.toMetadataChapter() }).also { result ->
-                    log.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=${result.chapters.size}" }
+                    log.debug {
+                        "metadata lookup result: source=AUDIBLE chapters asin=$id count=${result.chapters.size}"
+                    }
                 }
             }
         }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
@@ -16,7 +16,7 @@ import com.calypsan.listenup.server.metadata.audible.SearchParams
 import com.calypsan.listenup.server.services.MetadataService
 import io.github.oshai.kotlinlogging.KotlinLogging
 
-private val logger = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 /**
  * [MetadataProvider] backed by Audible via [MetadataService] (which adds TTL caching +
@@ -32,7 +32,7 @@ internal class AudibleMetadataProvider(
         query: String,
         region: AudibleRegion?,
     ): AppResult<List<MetadataBook>> {
-        logger.debug { "metadata lookup: source=AUDIBLE query='$query' region=${region?.name ?: "default+fallback"}" }
+        log.debug { "metadata lookup: source=AUDIBLE query='$query' region=${region?.name ?: "default+fallback"}" }
         val params = SearchParams(keywords = query)
         val result =
             if (region == null) {
@@ -42,7 +42,7 @@ internal class AudibleMetadataProvider(
             }
         return result.map { hits ->
             hits.map { it.toMetadataBook() }.also { books ->
-                logger.debug { "metadata lookup result: source=AUDIBLE matches=${books.size}" }
+                log.debug { "metadata lookup result: source=AUDIBLE matches=${books.size}" }
             }
         }
     }
@@ -52,10 +52,10 @@ internal class AudibleMetadataProvider(
         region: AudibleRegion,
         refresh: Boolean,
     ): AppResult<MetadataBook?> {
-        logger.debug { "metadata lookup: source=AUDIBLE asin=$id region=${region.name} refresh=$refresh" }
+        log.debug { "metadata lookup: source=AUDIBLE asin=$id region=${region.name} refresh=$refresh" }
         return metadataService.getBook(region, id, refresh = refresh).map { book ->
             book?.toMetadataBook().also { mapped ->
-                logger.debug { "metadata lookup result: source=AUDIBLE asin=$id found=${mapped != null}" }
+                log.debug { "metadata lookup result: source=AUDIBLE asin=$id found=${mapped != null}" }
             }
         }
     }
@@ -64,14 +64,14 @@ internal class AudibleMetadataProvider(
         id: String,
         region: AudibleRegion,
     ): AppResult<MetadataChapters?> {
-        logger.debug { "metadata lookup: source=AUDIBLE chapters asin=$id region=${region.name}" }
+        log.debug { "metadata lookup: source=AUDIBLE chapters asin=$id region=${region.name}" }
         return metadataService.getBookChapters(region, id).map { chapters ->
             if (chapters.isEmpty()) {
-                logger.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=0" }
+                log.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=0" }
                 null
             } else {
                 MetadataChapters(chapters = chapters.map { it.toMetadataChapter() }).also { result ->
-                    logger.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=${result.chapters.size}" }
+                    log.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=${result.chapters.size}" }
                 }
             }
         }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
@@ -14,6 +14,9 @@ import com.calypsan.listenup.server.metadata.audible.AudibleSearchResult
 import com.calypsan.listenup.server.metadata.audible.AudibleSeriesEntry
 import com.calypsan.listenup.server.metadata.audible.SearchParams
 import com.calypsan.listenup.server.services.MetadataService
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * [MetadataProvider] backed by Audible via [MetadataService] (which adds TTL caching +
@@ -29,6 +32,7 @@ internal class AudibleMetadataProvider(
         query: String,
         region: AudibleRegion?,
     ): AppResult<List<MetadataBook>> {
+        logger.debug { "metadata lookup: source=AUDIBLE query='$query' region=${region?.name ?: "default+fallback"}" }
         val params = SearchParams(keywords = query)
         val result =
             if (region == null) {
@@ -36,22 +40,42 @@ internal class AudibleMetadataProvider(
             } else {
                 metadataService.search(region, params)
             }
-        return result.map { hits -> hits.map { it.toMetadataBook() } }
+        return result.map { hits ->
+            hits.map { it.toMetadataBook() }.also { books ->
+                logger.debug { "metadata lookup result: source=AUDIBLE matches=${books.size}" }
+            }
+        }
     }
 
     override suspend fun getBook(
         id: String,
         region: AudibleRegion,
         refresh: Boolean,
-    ): AppResult<MetadataBook?> = metadataService.getBook(region, id, refresh = refresh).map { it?.toMetadataBook() }
+    ): AppResult<MetadataBook?> {
+        logger.debug { "metadata lookup: source=AUDIBLE asin=$id region=${region.name} refresh=$refresh" }
+        return metadataService.getBook(region, id, refresh = refresh).map { book ->
+            book?.toMetadataBook().also { mapped ->
+                logger.debug { "metadata lookup result: source=AUDIBLE asin=$id found=${mapped != null}" }
+            }
+        }
+    }
 
     override suspend fun getChapters(
         id: String,
         region: AudibleRegion,
-    ): AppResult<MetadataChapters?> =
-        metadataService.getBookChapters(region, id).map { chapters ->
-            if (chapters.isEmpty()) null else MetadataChapters(chapters = chapters.map { it.toMetadataChapter() })
+    ): AppResult<MetadataChapters?> {
+        logger.debug { "metadata lookup: source=AUDIBLE chapters asin=$id region=${region.name}" }
+        return metadataService.getBookChapters(region, id).map { chapters ->
+            if (chapters.isEmpty()) {
+                logger.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=0" }
+                null
+            } else {
+                MetadataChapters(chapters = chapters.map { it.toMetadataChapter() }).also { result ->
+                    logger.debug { "metadata lookup result: source=AUDIBLE chapters asin=$id count=${result.chapters.size}" }
+                }
+            }
         }
+    }
 }
 
 // ─── Audible → wire DTO mappers (moved from MetadataLookupServiceImpl) ─────────

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/plugins/JwtAuth.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/plugins/JwtAuth.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.JwtVerificationException
 import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.auth.UserPrincipal
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
@@ -11,6 +12,13 @@ import io.ktor.server.auth.AuthenticationConfig
 import io.ktor.server.auth.bearer
 import io.ktor.server.auth.principal
 import io.ktor.server.application.Application as KtorApplication
+
+private val logger = KotlinLogging.logger("com.calypsan.listenup.server.plugins.JwtAuth")
+
+/** Logs an auth rejection at WARN. [reason] must never contain the token or any secret. */
+internal fun logJwtRejection(reason: String) {
+    logger.warn { "auth rejected: $reason" }
+}
 
 /** Name of the bearer-JWT provider — referenced by route handlers. */
 const val JWT_PROVIDER = "jwt"
@@ -40,9 +48,13 @@ private fun AuthenticationConfig.bearerJwt(
                 try {
                     jwt.verify(credential.token)
                 } catch (_: JwtVerificationException) {
+                    logJwtRejection("token verification failed")
                     return@authenticate null
                 }
-            if (!sessions.isLive(claims.sessionId)) return@authenticate null
+            if (!sessions.isLive(claims.sessionId)) {
+                logJwtRejection("session no longer live for sessionId=${claims.sessionId}")
+                return@authenticate null
+            }
             UserPrincipal(claims.userId, claims.sessionId, claims.role)
         }
     }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AuthRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AuthRoutes.kt
@@ -7,27 +7,21 @@ import com.calypsan.listenup.api.dto.auth.RegisterResult
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.SessionSummary
 import com.calypsan.listenup.api.dto.auth.User
-import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.routes.resources.AuthResources
 import com.calypsan.listenup.server.auth.AuthServiceImpl
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.plugins.JWT_PROVIDER
 import com.calypsan.listenup.server.plugins.RateLimitBuckets
-import com.calypsan.listenup.server.plugins.toHttpStatus
 import com.calypsan.listenup.server.plugins.userPrincipalOrNull
-import com.calypsan.listenup.server.plugins.withCorrelationId
 import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
-import io.ktor.server.plugins.callid.callId
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.request.receive
 import io.ktor.server.resources.delete
 import io.ktor.server.resources.get
 import io.ktor.server.resources.post
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 
 /**
@@ -99,33 +93,3 @@ private fun AuthServiceImpl.asCaller(call: ApplicationCall): AuthServiceImpl =
 private fun AuthServiceImpl.withUa(call: ApplicationCall): AuthServiceImpl =
     withUserAgent(call.request.headers[HttpHeaders.UserAgent])
 
-/**
- * Fold an [AppResult] into a Ktor response. Success → 200 with the result
- * body; failure → the error's mapped HTTP status with the result body
- * (correlation id stamped on the error).
- *
- * The body is always the whole [AppResult] so the wire shape is uniform —
- * clients deserialize one type per endpoint regardless of outcome.
- *
- * The explicit `: AppResult<T>` annotation on the local `body` keeps the
- * static type at the [respond] call as the sealed parent so kotlinx.serialization
- * emits the polymorphic discriminator. Smart-casting to a concrete variant
- * would silently strip it.
- */
-private suspend inline fun <reified T : Any> ApplicationCall.respondAppResult(result: AppResult<T>) {
-    val status: HttpStatusCode
-    val body: AppResult<T>
-    when (result) {
-        is AppResult.Success -> {
-            status = HttpStatusCode.OK
-            body = result
-        }
-
-        is AppResult.Failure -> {
-            val typed = result.error.withCorrelationId(callId)
-            status = typed.toHttpStatus()
-            body = AppResult.Failure(typed)
-        }
-    }
-    respond(status, body)
-}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AuthRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/AuthRoutes.kt
@@ -92,4 +92,3 @@ private fun AuthServiceImpl.asCaller(call: ApplicationCall): AuthServiceImpl =
  */
 private fun AuthServiceImpl.withUa(call: ApplicationCall): AuthServiceImpl =
     withUserAgent(call.request.headers[HttpHeaders.UserAgent])
-

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RouteResponses.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RouteResponses.kt
@@ -32,6 +32,7 @@ internal suspend inline fun <reified T : Any> ApplicationCall.respondAppResult(r
             status = HttpStatusCode.OK
             body = result
         }
+
         is AppResult.Failure -> {
             val typed = result.error.withCorrelationId(callId)
             status = typed.toHttpStatus()

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RouteResponses.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RouteResponses.kt
@@ -1,0 +1,59 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.plugins.toHttpStatus
+import com.calypsan.listenup.server.plugins.withCorrelationId
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.uri
+import io.ktor.server.response.respond
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Renders an [AppResult] as the canonical wire response: `Success → 200`, `Failure →` the
+ * error's mapped status. The explicit `: AppResult<T>` type on [body] keeps kotlinx.serialization's
+ * polymorphic discriminator (smart-casting to a concrete variant would strip it).
+ *
+ * Every rendered failure is logged centrally: 5xx at ERROR, everything else at DEBUG, with the
+ * error code, correlation id, and request path.
+ *
+ * Declared `internal` so the inline function can access the `internal` helpers
+ * [toHttpStatus] and [withCorrelationId] from the `plugins` package (same module).
+ */
+internal suspend inline fun <reified T : Any> ApplicationCall.respondAppResult(result: AppResult<T>) {
+    val status: HttpStatusCode
+    val body: AppResult<T>
+    when (result) {
+        is AppResult.Success -> {
+            status = HttpStatusCode.OK
+            body = result
+        }
+        is AppResult.Failure -> {
+            val typed = result.error.withCorrelationId(callId)
+            status = typed.toHttpStatus()
+            body = AppResult.Failure(typed)
+            logAppErrorResponse(typed, status, request.uri)
+        }
+    }
+    respond(status, body)
+}
+
+/** Logs a domain-error response: 5xx → ERROR, else DEBUG. Non-inline so it can hold the private logger. */
+internal fun logAppErrorResponse(
+    error: AppError,
+    status: HttpStatusCode,
+    path: String,
+) {
+    val msg = "domain error: code=${error.code} status=${status.value} path=$path correlationId=${error.correlationId}"
+    if (status.value >= HTTP_SERVER_ERROR_FLOOR) {
+        logger.error { msg }
+    } else {
+        logger.debug { msg }
+    }
+}
+
+private const val HTTP_SERVER_ERROR_FLOOR = 500

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
@@ -6,16 +6,9 @@ import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.server.routes.resources.ScannerResources
-import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.server.plugins.toHttpStatus
-import com.calypsan.listenup.server.plugins.withCorrelationId
-import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
-import io.ktor.server.plugins.callid.callId
 import io.ktor.server.resources.get
 import io.ktor.server.resources.post
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
@@ -58,20 +51,3 @@ fun Route.scannerRoutes(
     }
 }
 
-private suspend inline fun <reified T : Any> ApplicationCall.respondAppResult(result: AppResult<T>) {
-    val status: HttpStatusCode
-    val body: AppResult<T>
-    when (result) {
-        is AppResult.Success -> {
-            status = HttpStatusCode.OK
-            body = result
-        }
-
-        is AppResult.Failure -> {
-            val typed = result.error.withCorrelationId(callId)
-            status = typed.toHttpStatus()
-            body = AppResult.Failure(typed)
-        }
-    }
-    respond(status, body)
-}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
@@ -50,4 +50,3 @@ fun Route.scannerRoutes(
         }
     }
 }
-

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/CoverSearchService.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/CoverSearchService.kt
@@ -62,11 +62,15 @@ class CoverSearchService(
     ): List<CoverOption> {
         log.debug { "cover search: source=${provider.source.name} title='${book.title}' author='${book.author}'" }
         return when (val r = provider.searchCovers(book, region)) {
-            is AppResult.Failure -> throw SourceException(r.error)
-            is AppResult.Success ->
+            is AppResult.Failure -> {
+                throw SourceException(r.error)
+            }
+
+            is AppResult.Success -> {
                 r.data.map { option(provider.source, it.url, it.sourceId) }.also { opts ->
                     log.debug { "cover search result: source=${provider.source.name} candidates=${opts.size}" }
                 }
+            }
         }
     }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/CoverSearchService.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/CoverSearchService.kt
@@ -59,11 +59,16 @@ class CoverSearchService(
         provider: CoverProvider,
         book: BookSummary,
         region: AudibleRegion?,
-    ): List<CoverOption> =
-        when (val r = provider.searchCovers(book, region)) {
+    ): List<CoverOption> {
+        log.debug { "cover search: source=${provider.source.name} title='${book.title}' author='${book.author}'" }
+        return when (val r = provider.searchCovers(book, region)) {
             is AppResult.Failure -> throw SourceException(r.error)
-            is AppResult.Success -> r.data.map { option(provider.source, it.url, it.sourceId) }
+            is AppResult.Success ->
+                r.data.map { option(provider.source, it.url, it.sourceId) }.also { opts ->
+                    log.debug { "cover search result: source=${provider.source.name} candidates=${opts.size}" }
+                }
         }
+    }
 
     private suspend fun option(
         source: CoverOptionSource,
@@ -83,7 +88,7 @@ class CoverSearchService(
         } catch (e: CancellationException) {
             throw e
         } catch (e: SourceException) {
-            log.warn { "cover search: $source source failed: ${e.error.code}" }
+            log.warn { "cover search: $source source failed (${e.error.code}: ${e.error.debugInfo}) — skipping" }
             emptyList()
         } catch (e: Exception) {
             log.warn(e) { "cover search: $source source threw" }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
@@ -93,15 +93,18 @@ internal class MetadataService(
         }
         if (defaultRegion == AudibleRegion.US) return primaryResult
         when (primaryResult) {
-            is AppResult.Failure ->
+            is AppResult.Failure -> {
                 log.warn {
                     "metadata provider failed: source=AUDIBLE region=$defaultRegion " +
                         "(${primaryResult.error.code}) — falling back to US"
                 }
-            is AppResult.Success ->
+            }
+
+            is AppResult.Success -> {
                 log.debug {
                     "metadata lookup: source=AUDIBLE region=$defaultRegion returned 0 results — falling back to US"
                 }
+            }
         }
         return search(AudibleRegion.US, params)
     }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
-private val logger = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 /**
  * Orchestrator for external metadata lookups. Wraps [AudibleApi] + [ITunesApi]
@@ -94,12 +94,12 @@ internal class MetadataService(
         if (defaultRegion == AudibleRegion.US) return primaryResult
         when (primaryResult) {
             is AppResult.Failure ->
-                logger.warn {
+                log.warn {
                     "metadata provider failed: source=AUDIBLE region=$defaultRegion " +
                         "(${primaryResult.error.code}) — falling back to US"
                 }
             is AppResult.Success ->
-                logger.debug {
+                log.debug {
                     "metadata lookup: source=AUDIBLE region=$defaultRegion returned 0 results — falling back to US"
                 }
         }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
@@ -16,10 +16,13 @@ import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Orchestrator for external metadata lookups. Wraps [AudibleApi] + [ITunesApi]
@@ -89,6 +92,17 @@ internal class MetadataService(
             return primaryResult
         }
         if (defaultRegion == AudibleRegion.US) return primaryResult
+        when (primaryResult) {
+            is AppResult.Failure ->
+                logger.warn {
+                    "metadata provider failed: source=AUDIBLE region=$defaultRegion " +
+                        "(${primaryResult.error.code}) — falling back to US"
+                }
+            is AppResult.Success ->
+                logger.debug {
+                    "metadata lookup: source=AUDIBLE region=$defaultRegion returned 0 results — falling back to US"
+                }
+        }
         return search(AudibleRegion.US, params)
     }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -113,7 +113,9 @@ class ChangeBus {
         event: SyncEvent<T>,
         userId: String? = null,
     ) {
-        log.debug { "change emitted post-commit: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
+        log.debug {
+            "change emitted post-commit: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}"
+        }
         flow.tryEmit(BusEvent(repo, event, userId))
     }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -2,10 +2,13 @@ package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+
+private val logger = KotlinLogging.logger {}
 
 private const val LIVE_TAIL_BUFFER = 256
 
@@ -88,7 +91,10 @@ class ChangeBus {
         repo: SyncableRepo<T>,
         event: SyncEvent<T>,
         userId: String? = null,
-    ) = emitOrDefer { flow.tryEmit(BusEvent(repo, event, userId)) }
+    ) {
+        logger.debug { "change published: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
+        emitOrDefer { flow.tryEmit(BusEvent(repo, event, userId)) }
+    }
 
     /**
      * Emits [event] (paired with [repo]) onto the live tail **immediately**, with no
@@ -107,6 +113,7 @@ class ChangeBus {
         event: SyncEvent<T>,
         userId: String? = null,
     ) {
+        logger.debug { "change emitted post-commit: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
         flow.tryEmit(BusEvent(repo, event, userId))
     }
 
@@ -119,7 +126,10 @@ class ChangeBus {
     suspend fun publishControl(
         control: SyncControl,
         userId: String,
-    ) = emitOrDefer { controlFlow.tryEmit(ControlFrame(control, userId)) }
+    ) {
+        logger.debug { "control published: type=${control::class.simpleName} userId=$userId" }
+        emitOrDefer { controlFlow.tryEmit(ControlFrame(control, userId)) }
+    }
 
     /**
      * Publishes a [control] frame to EVERY connected subscriber, addressed to the
@@ -127,8 +137,10 @@ class ChangeBus {
      * regardless of their own userId. Use for content-free nudges only — a
      * broadcast frame carries no per-user or per-resource data, so it cannot leak.
      */
-    suspend fun broadcastControl(control: SyncControl) =
+    suspend fun broadcastControl(control: SyncControl) {
+        logger.debug { "control broadcast: type=${control::class.simpleName}" }
         emitOrDefer { controlFlow.tryEmit(ControlFrame(control, BROADCAST)) }
+    }
 
     fun subscribeControl(): SharedFlow<ControlFrame> = controlFlow.asSharedFlow()
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-private val logger = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 private const val LIVE_TAIL_BUFFER = 256
 
@@ -92,7 +92,7 @@ class ChangeBus {
         event: SyncEvent<T>,
         userId: String? = null,
     ) {
-        logger.debug { "change published: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
+        log.debug { "change published: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
         emitOrDefer { flow.tryEmit(BusEvent(repo, event, userId)) }
     }
 
@@ -113,7 +113,7 @@ class ChangeBus {
         event: SyncEvent<T>,
         userId: String? = null,
     ) {
-        logger.debug { "change emitted post-commit: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
+        log.debug { "change emitted post-commit: domain=${repo.domainName} event=${event::class.simpleName} id=${event.id}" }
         flow.tryEmit(BusEvent(repo, event, userId))
     }
 
@@ -127,7 +127,7 @@ class ChangeBus {
         control: SyncControl,
         userId: String,
     ) {
-        logger.debug { "control published: type=${control::class.simpleName} userId=$userId" }
+        log.debug { "control published: type=${control::class.simpleName} userId=$userId" }
         emitOrDefer { controlFlow.tryEmit(ControlFrame(control, userId)) }
     }
 
@@ -138,7 +138,7 @@ class ChangeBus {
      * broadcast frame carries no per-user or per-resource data, so it cannot leak.
      */
     suspend fun broadcastControl(control: SyncControl) {
-        logger.debug { "control broadcast: type=${control::class.simpleName}" }
+        log.debug { "control broadcast: type=${control::class.simpleName}" }
         emitOrDefer { controlFlow.tryEmit(ControlFrame(control, BROADCAST)) }
     }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 
-private val logger = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 /**
  * SQLDelight twin of [SyncableRepository] — the abstract base every syncable
@@ -232,7 +232,7 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
             if (!suppressed) {
                 deferEmit(event, userId)
             } else {
-                logger.debug { "change suppressed (firehose): domain=$domainName id=$idStr" }
+                log.debug { "change suppressed (firehose): domain=$domainName id=$idStr" }
             }
 
             AppResult.Success(saved)
@@ -341,7 +341,7 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                         userId = userId,
                     )
                 } else {
-                    logger.debug { "change suppressed (firehose): domain=$domainName id=$idStr" }
+                    log.debug { "change suppressed (firehose): domain=$domainName id=$idStr" }
                 }
                 AppResult.Success(Unit)
             }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.sync.SyncEvent
 import app.cash.sqldelight.TransactionCallbacks
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.security.MessageDigest
 import kotlin.time.Clock
 import kotlinx.coroutines.currentCoroutineContext
@@ -19,6 +20,8 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * SQLDelight twin of [SyncableRepository] — the abstract base every syncable
@@ -228,6 +231,8 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                 }
             if (!suppressed) {
                 deferEmit(event, userId)
+            } else {
+                logger.debug { "change suppressed (firehose): domain=$domainName id=$idStr" }
             }
 
             AppResult.Success(saved)
@@ -335,6 +340,8 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                             ),
                         userId = userId,
                     )
+                } else {
+                    logger.debug { "change suppressed (firehose): domain=$domainName id=$idStr" }
                 }
                 AppResult.Success(Unit)
             }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -133,6 +133,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
         @Suppress("UNCHECKED_CAST")
         val typedRepo = repo as SyncableRepo<Any>
         val page: Page<Any> = typedRepo.pullSince(userId, since, limit, extraWhere)
+        log.debug { "sync pull: domain=$domainName since=$since → ${page.items.size} rows userId=$userId" }
         // call.respond(page) would fail at runtime: kotlinx.serialization cannot
         // infer the concrete element serializer from the type-erased Page<Any>.
         // encodePageAsJson uses the concrete KSerializer<T> each repository provides.
@@ -159,6 +160,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
         @Suppress("UNCHECKED_CAST")
         val typedRepo = repo as SyncableRepo<Any>
         val digest: DomainDigest = typedRepo.digest(userId, cursor, extraWhere)
+        log.debug { "sync digest: domain=$domainName cursor=$cursor → ${digest.count} rows userId=$userId" }
         call.respond(digest)
     }
 
@@ -195,6 +197,7 @@ private suspend fun ServerSSESession.streamFirehose(
     val lastEventId: Long? =
         call.request.headers["Last-Event-ID"]?.let { raw ->
             raw.toLongOrNull() ?: run {
+                log.debug { "sync stream cursor malformed for userId=$userId; sending CursorStale" }
                 sendCursorStale(bus.oldestRetainedRevision() ?: 0L)
                 return
             }
@@ -205,9 +208,12 @@ private suspend fun ServerSSESession.streamFirehose(
     // the bus has already evicted the events the client needs.
     // "clientCursor < oldestRetained" → stale; "null" → fresh subscriber, stream normally.
     if (lastEventId != null && oldestRetained != null && lastEventId < oldestRetained) {
+        log.debug { "sync stream cursor stale: userId=$userId lastEventId=$lastEventId oldestRetained=$oldestRetained; sending CursorStale" }
         sendCursorStale(oldestRetained)
         return
     }
+
+    log.info { "sync stream opened: userId=$userId" }
 
     // Comment-line keepalive every [heartbeatIntervalMillis] ms. The frames
     // (`:keepalive\r\n`) are ignored by the EventSource spec on the client
@@ -255,6 +261,7 @@ private suspend fun ServerSSESession.streamFirehose(
                 if (isLibraryFolderEventHidden(busEvent, role)) return@collect
                 // Type-bound: repo and event match by construction, so the repo's
                 // serializer is guaranteed to fit the event's payload type.
+                log.trace { "sse emit: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} revision=${busEvent.event.revision}" }
                 send(
                     id = busEvent.event.revision.toString(),
                     event = busEvent.repo.domainName,
@@ -275,6 +282,7 @@ private suspend fun ServerSSESession.streamFirehose(
     } finally {
         heartbeatJob.cancel()
         controlJob.cancel()
+        log.info { "sync stream closed: userId=$userId" }
     }
 }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -208,7 +208,10 @@ private suspend fun ServerSSESession.streamFirehose(
     // the bus has already evicted the events the client needs.
     // "clientCursor < oldestRetained" → stale; "null" → fresh subscriber, stream normally.
     if (lastEventId != null && oldestRetained != null && lastEventId < oldestRetained) {
-        log.debug { "sync stream cursor stale: userId=$userId lastEventId=$lastEventId oldestRetained=$oldestRetained; sending CursorStale" }
+        log.debug {
+            "sync stream cursor stale: userId=$userId lastEventId=$lastEventId " +
+                "oldestRetained=$oldestRetained; sending CursorStale"
+        }
         sendCursorStale(oldestRetained)
         return
     }
@@ -256,21 +259,26 @@ private suspend fun ServerSSESession.streamFirehose(
                 // Access gating: a live content event the subscriber may not see is dropped
                 // before send. ROOT/ADMIN and tombstones bypass — see [isBookEventHidden] /
                 // [isCollectionEventHidden].
-                if (isBookEventHidden(busEvent, userId, role, bookAccessPolicy)) {
-                    log.trace { "sse gated: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} userId=$userId reason=access" }
-                    return@collect
-                }
-                if (isCollectionEventHidden(busEvent, userId, role, bookAccessPolicy)) {
-                    log.trace { "sse gated: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} userId=$userId reason=access" }
-                    return@collect
-                }
-                if (isLibraryFolderEventHidden(busEvent, role)) {
-                    log.trace { "sse gated: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} userId=$userId reason=access" }
+                val gatedReason =
+                    when {
+                        isBookEventHidden(busEvent, userId, role, bookAccessPolicy) -> "book"
+                        isCollectionEventHidden(busEvent, userId, role, bookAccessPolicy) -> "collection"
+                        isLibraryFolderEventHidden(busEvent, role) -> "libraryFolder"
+                        else -> null
+                    }
+                if (gatedReason != null) {
+                    log.trace {
+                        "sse gated: domain=${busEvent.repo.domainName} " +
+                            "event=${busEvent.event::class.simpleName} userId=$userId reason=$gatedReason"
+                    }
                     return@collect
                 }
                 // Type-bound: repo and event match by construction, so the repo's
                 // serializer is guaranteed to fit the event's payload type.
-                log.trace { "sse emit: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} revision=${busEvent.event.revision}" }
+                log.trace {
+                    "sse emit: domain=${busEvent.repo.domainName} " +
+                        "event=${busEvent.event::class.simpleName} revision=${busEvent.event.revision}"
+                }
                 send(
                     id = busEvent.event.revision.toString(),
                     event = busEvent.repo.domainName,

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -256,9 +256,18 @@ private suspend fun ServerSSESession.streamFirehose(
                 // Access gating: a live content event the subscriber may not see is dropped
                 // before send. ROOT/ADMIN and tombstones bypass — see [isBookEventHidden] /
                 // [isCollectionEventHidden].
-                if (isBookEventHidden(busEvent, userId, role, bookAccessPolicy)) return@collect
-                if (isCollectionEventHidden(busEvent, userId, role, bookAccessPolicy)) return@collect
-                if (isLibraryFolderEventHidden(busEvent, role)) return@collect
+                if (isBookEventHidden(busEvent, userId, role, bookAccessPolicy)) {
+                    log.trace { "sse gated: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} userId=$userId reason=access" }
+                    return@collect
+                }
+                if (isCollectionEventHidden(busEvent, userId, role, bookAccessPolicy)) {
+                    log.trace { "sse gated: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} userId=$userId reason=access" }
+                    return@collect
+                }
+                if (isLibraryFolderEventHidden(busEvent, role)) {
+                    log.trace { "sse gated: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} userId=$userId reason=access" }
+                    return@collect
+                }
                 // Type-bound: repo and event match by construction, so the repo's
                 // serializer is guaranteed to fit the event's payload type.
                 log.trace { "sse emit: domain=${busEvent.repo.domainName} event=${busEvent.event::class.simpleName} revision=${busEvent.event.revision}" }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/logging/LoggingBackendTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/logging/LoggingBackendTest.kt
@@ -50,4 +50,56 @@ class LoggingBackendTest :
                 ListenUpLoggerFactory.removeTestCapture()
             }
         }
+
+        test("LISTENUP_LOG_LEVEL=DEBUG enables debug on app loggers") {
+            val factory =
+                ListenUpLoggerFactory(
+                    isJsonFormat = false,
+                    levelConfig = LogLevelConfig.fromEnv(mapOf("LISTENUP_LOG_LEVEL" to "DEBUG")),
+                )
+            factory.getLogger("com.calypsan.listenup.server.sync.SyncRoutes").isDebugEnabled.shouldBeTrue()
+        }
+
+        test("unset or unparseable LISTENUP_LOG_LEVEL defaults to INFO") {
+            val unset = ListenUpLoggerFactory(isJsonFormat = false, levelConfig = LogLevelConfig.fromEnv(emptyMap()))
+            unset.getLogger("com.calypsan.x").isInfoEnabled.shouldBeTrue()
+            unset.getLogger("com.calypsan.x").isDebugEnabled.shouldBeFalse()
+
+            val garbage =
+                ListenUpLoggerFactory(
+                    isJsonFormat = false,
+                    levelConfig = LogLevelConfig.fromEnv(mapOf("LISTENUP_LOG_LEVEL" to "LOUD")),
+                )
+            garbage.getLogger("com.calypsan.x").isInfoEnabled.shouldBeTrue()
+            garbage.getLogger("com.calypsan.x").isDebugEnabled.shouldBeFalse()
+        }
+
+        test("an empty-suffix LISTENUP_LOG_LEVEL_ key is ignored (no silent catch-all)") {
+            val cfg = LogLevelConfig.fromEnv(mapOf("LISTENUP_LOG_LEVEL" to "INFO", "LISTENUP_LOG_LEVEL_" to "TRACE"))
+            val factory = ListenUpLoggerFactory(isJsonFormat = false, levelConfig = cfg)
+            // the malformed key must NOT enable TRACE/DEBUG everywhere — the INFO default stands
+            factory.getLogger("com.calypsan.listenup.server.anything").isDebugEnabled.shouldBeFalse()
+            factory.getLogger("com.calypsan.listenup.server.anything").isInfoEnabled.shouldBeTrue()
+        }
+
+        test("per-prefix override targets only matching loggers") {
+            val cfg =
+                LogLevelConfig.fromEnv(
+                    mapOf(
+                        "LISTENUP_LOG_LEVEL" to "WARN",
+                        "LISTENUP_LOG_LEVEL_com_calypsan_listenup_server_sync" to "DEBUG",
+                    ),
+                )
+            val factory = ListenUpLoggerFactory(isJsonFormat = false, levelConfig = cfg)
+            factory.getLogger("com.calypsan.listenup.server.sync.SyncRoutes").isDebugEnabled.shouldBeTrue()
+            factory.getLogger("com.calypsan.listenup.server.book.BookServiceImpl").isInfoEnabled.shouldBeFalse()
+            factory.getLogger("com.calypsan.listenup.server.book.BookServiceImpl").isWarnEnabled.shouldBeTrue()
+        }
+
+        test("netty/jetty WARN floor still wins over a broad DEBUG default") {
+            val cfg = LogLevelConfig.fromEnv(mapOf("LISTENUP_LOG_LEVEL" to "DEBUG"))
+            val factory = ListenUpLoggerFactory(isJsonFormat = false, levelConfig = cfg)
+            factory.getLogger("io.netty.some.Class").isInfoEnabled.shouldBeFalse()
+            factory.getLogger("io.netty.some.Class").isWarnEnabled.shouldBeTrue()
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/plugins/JwtAuthTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/plugins/JwtAuthTest.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.server.plugins
+
+import com.calypsan.listenup.server.logging.ListenUpLoggerFactory
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.slf4j.event.Level
+
+class JwtAuthTest :
+    FunSpec({
+        test("a failed JWT verification is logged at WARN without the token") {
+            val capture = ListenUpLoggerFactory.installTestCapture()
+            try {
+                logJwtRejection("token verification failed")
+                val event = capture.events.lastOrNull { it.loggerName.contains("JwtAuth") }.shouldNotBeNull()
+                event.level shouldBe Level.WARN
+                event.message.contains("token verification failed").shouldBeTrue()
+            } finally {
+                ListenUpLoggerFactory.removeTestCapture()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/RouteResponsesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/RouteResponsesTest.kt
@@ -1,0 +1,75 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.error.BookError
+import com.calypsan.listenup.api.error.InternalError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.logging.ListenUpLoggerFactory
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.slf4j.event.Level
+
+// BookError.NotFound → 404 (4xx); InternalError → 500 (5xx)
+private val FOUR_XX_ERROR = BookError.NotFound()
+private val FIVE_XX_ERROR = InternalError()
+
+class RouteResponsesTest :
+    FunSpec({
+
+        test("a 4xx domain Failure is logged at DEBUG with code + correlationId") {
+            val capture = ListenUpLoggerFactory.installTestCapture()
+            try {
+                testApplication {
+                    routing {
+                        get("/boom") {
+                            call.respondAppResult<String>(AppResult.Failure(FOUR_XX_ERROR))
+                        }
+                    }
+                    client.get("/boom")
+                }
+                val event =
+                    capture.events.firstOrNull { it.message.contains(FOUR_XX_ERROR.code) }.shouldNotBeNull()
+                event.level shouldBe Level.DEBUG
+            } finally {
+                ListenUpLoggerFactory.removeTestCapture()
+            }
+        }
+
+        test("a 5xx Failure is logged at ERROR") {
+            val capture = ListenUpLoggerFactory.installTestCapture()
+            try {
+                testApplication {
+                    routing {
+                        get("/fail") {
+                            call.respondAppResult<String>(AppResult.Failure(FIVE_XX_ERROR))
+                        }
+                    }
+                    client.get("/fail")
+                }
+                val event =
+                    capture.events.firstOrNull { it.level == Level.ERROR && it.message.contains(FIVE_XX_ERROR.code) }
+                        .shouldNotBeNull()
+                event.level shouldBe Level.ERROR
+            } finally {
+                ListenUpLoggerFactory.removeTestCapture()
+            }
+        }
+
+        test("a Success response produces no error log") {
+            val capture = ListenUpLoggerFactory.installTestCapture()
+            try {
+                testApplication {
+                    routing { get("/ok") { call.respondAppResult(AppResult.Success("ok")) } }
+                    client.get("/ok")
+                }
+                capture.events.none { it.message.contains("domain error") }.shouldBeTrue()
+            } finally {
+                ListenUpLoggerFactory.removeTestCapture()
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/RouteResponsesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/RouteResponsesTest.kt
@@ -52,7 +52,8 @@ class RouteResponsesTest :
                     client.get("/fail")
                 }
                 val event =
-                    capture.events.firstOrNull { it.level == Level.ERROR && it.message.contains(FIVE_XX_ERROR.code) }
+                    capture.events
+                        .firstOrNull { it.level == Level.ERROR && it.message.contains(FIVE_XX_ERROR.code) }
                         .shouldNotBeNull()
                 event.level shouldBe Level.ERROR
             } finally {


### PR DESCRIPTION
Makes the server actually debuggable. Before this, the server logged HTTP requests and unhandled exceptions but little else — sync, scans, and metadata lookups were opaque, and the log level was hardcoded. Done first (ahead of the Cluster B native-HTTP work) so it pays off now and helps debug the native migration itself.

### Runtime control + convention
- **`LISTENUP_LOG_LEVEL`** (+ optional `LISTENUP_LOG_LEVEL_<prefix>` for targeting a single subsystem) → runtime verbosity. Default INFO; netty/jetty WARN noise-floor intact; malformed empty-suffix key ignored. Injected as a parsed `LogLevelConfig` into the existing `ListenUpLoggerFactory` (production-inert when unset).
- A **level convention** documented as KDoc on the logging facade. New logging uses `io.github.oshai KotlinLogging` (multiplatform-ready for the native move).

### Central choke points
- The duplicated per-route `respondAppResult` is **consolidated into one shared helper** that logs every domain-error response (5xx→ERROR, else→DEBUG, with code + correlationId + path).
- **`JwtAuth`** logs auth rejections at WARN (no token/secret leakage — only the non-secret sessionId).
- (`AppErrorStatusPages` and the RPC guard already logged their surfaces.)

### Hot-path coverage (trace a subsystem at DEBUG)
- **sync** — change-bus publish/suppress, the SSE firehose (stream open/close at INFO, cursor states, per-emit + access-gating at TRACE), pull/digest counts.
- **scanner** — scan start/phases, per-book add/move/modify/remove decisions (DEBUG), analyze failures (WARN, scan continues).
- **metadata** — Audible/iTunes lookup attempts + outcomes, provider failures → fallback (WARN, the "Never Stranded" path made visible).

### Safety / gate
- Behaviour unchanged — observational only; no control-flow changes; `CancellationException` re-raise + fallback logic intact. No tokens/secrets/user-content logged.
- Gate green: `spotlessCheck` + `detekt` + `:sharedLogic:jvmTest` (465/0) + `:server:jvmTest` + `:server:compileKotlinLinuxX64` (the scanner instrumentation is commonMain and compiles native). The only red is the pre-existing load-sensitive `ScannerSseRouteTest` flake (passes in isolation; unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
