### PR TITLE
🐛 fix(scanner): scan each library folder against its own root (multi-folder corruption)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -97,78 +97,100 @@ internal class Scanner(
         val primaryRootPath = library.folders.firstOrNull()?.rootPath ?: library.id.value
         eventBus.emit(ScanEvent.Started(correlationId, library.id, primaryRootPath))
 
-        // Walk each folder, rebase its files onto its folder-relative prefix,
-        // then aggregate into a single flat list for the pipeline.
-        val allFiles =
-            library.folders.flatMap { folder ->
-                val rootPath = folder.rootPath ?: return@flatMap emptyList()
-                val walker = Walker()
-                walker
-                    .walk(Path(rootPath))
-                    .toList()
-            }
+        // Walk and group each folder independently so each Analyzer below can be
+        // anchored to the correct folder root. Each file's relPath is relative to
+        // the folder root it was walked from; using the wrong root causes
+        // Path(root, relPath) to resolve a nonexistent path, failing embedded-
+        // metadata parsing for every book in non-first folders.
+        var totalFileCount = 0
+        var totalCandidateCount = 0
+        val folderRoots = mutableListOf<Path>()
+        val candidatesPerFolder = mutableListOf<List<CandidateBook>>()
 
-        emitProgress(correlationId, ScanPhase.WALKING, allFiles.size, 0, 0)
+        for (folder in library.folders) {
+            val rootPath = folder.rootPath ?: continue
+            val folderRoot = Path(rootPath)
+            val files = Walker().walk(folderRoot).toList()
+            val candidates = Grouper().group(files.asFlow()).toList()
+            totalFileCount += files.size
+            totalCandidateCount += candidates.size
+            folderRoots += folderRoot
+            candidatesPerFolder += candidates
+        }
 
-        val grouper = Grouper()
-        emitProgress(correlationId, ScanPhase.GROUPING, allFiles.size, 0, 0)
-        val candidates = grouper.group(allFiles.asFlow()).toList()
+        emitProgress(correlationId, ScanPhase.WALKING, totalFileCount, 0, 0)
+
+        emitProgress(correlationId, ScanPhase.GROUPING, totalFileCount, 0, 0)
 
         emitProgress(
             correlationId,
             ScanPhase.ANALYZING,
-            allFiles.size,
+            totalFileCount,
             0,
             0,
-            totalFiles = allFiles.size,
-            booksTotal = candidates.size,
+            totalFiles = totalFileCount,
+            booksTotal = totalCandidateCount,
         )
-        // Analyzer uses the first folder root as the libraryRoot anchor for
-        // computing rootRelPath and resolving error paths. When the library has
-        // multiple folders, each folder's books will be at absolute paths inside
-        // those roots — the Grouper preserves absolute relPath for multi-folder
-        // libraries. Using the first folder root is consistent with what the
-        // watcher supplies to runIncremental.
-        val primaryRoot =
-            library.folders
-                .firstOrNull()
-                ?.rootPath
-                ?.let { Path(it) }
-                ?: Path(library.id.value)
-        val analyzer =
-            Analyzer(
-                primaryRoot,
-                metadataReader,
-                embeddedMetadataParser,
-                parseSubtitle,
-                sidecarParsers,
-                metadataPrecedence,
-            )
+
         // Build a path-keyed cache from the previous scan so unchanged books can
         // be reused without re-parsing their audio files.
         val previousByPath = lastResult?.books.orEmpty().associateBy { it.candidate.rootRelPath }
-        val pass = collectAnalyzed(analyzer, candidates, correlationId, allFiles.size, primaryRoot, previousByPath)
-        val books = pass.books
-        val errors = pass.errors
+
+        // Analyze each folder with an Analyzer anchored to that folder's root.
+        // Aggregated books and errors replace the single-pass result; the Differ
+        // runs once over the full aggregated set after all folders are processed.
+        val allBooks = mutableListOf<AnalyzedBook>()
+        val allErrors = mutableListOf<ScanError>()
+        var authorsMatched = 0
+        var totalDurationMs = 0L
+        var currentFile: String? = null
+        var recentBooks: List<ScanBookRef> = emptyList()
+
+        for (i in folderRoots.indices) {
+            val analyzer =
+                Analyzer(
+                    folderRoots[i],
+                    metadataReader,
+                    embeddedMetadataParser,
+                    parseSubtitle,
+                    sidecarParsers,
+                    metadataPrecedence,
+                )
+            val pass =
+                collectAnalyzed(
+                    analyzer,
+                    candidatesPerFolder[i],
+                    correlationId,
+                    totalFileCount,
+                    folderRoots[i],
+                    previousByPath,
+                )
+            allBooks += pass.books
+            allErrors += pass.errors
+            authorsMatched += pass.authorsMatched
+            totalDurationMs += pass.totalDurationMs
+            if (pass.currentFile != null) currentFile = pass.currentFile
+            if (pass.recentBooks.isNotEmpty()) recentBooks = pass.recentBooks
+        }
 
         emitProgress(
             correlationId,
             ScanPhase.DIFFING,
-            allFiles.size,
-            books.size,
-            errors.size,
-            totalFiles = allFiles.size,
-            booksTotal = candidates.size,
-            authorsMatched = pass.authorsMatched,
-            totalDurationMs = pass.totalDurationMs,
-            currentFile = pass.currentFile,
-            recentBooks = pass.recentBooks,
+            totalFileCount,
+            allBooks.size,
+            allErrors.size,
+            totalFiles = totalFileCount,
+            booksTotal = totalCandidateCount,
+            authorsMatched = authorsMatched,
+            totalDurationMs = totalDurationMs,
+            currentFile = currentFile,
+            recentBooks = recentBooks,
         )
         // Strip artwork from both diff sides so unchanged books don't falsely show as Modified.
         // lastResult is already artwork-free (stripped at the end of the previous scan); strip
         // the new books for the diff so both sides are comparable without artwork bytes.
         val previousStripped = lastResult?.books.orEmpty() // already stripped from previous scan
-        val booksStripped = books.map { it.withoutArtwork() }
+        val booksStripped = allBooks.map { it.withoutArtwork() }
         val changes = Differ().diff(booksStripped.asFlow(), previousStripped).toList()
         changes.forEach { eventBus.emit(ScanEvent.Change(correlationId, library.id, it)) }
 
@@ -176,11 +198,11 @@ internal class Scanner(
             ScanResult(
                 correlationId = correlationId,
                 rootPath = primaryRootPath,
-                books = books, // artwork-bearing: BookPersister needs these to write covers to disk
+                books = allBooks, // artwork-bearing: BookPersister needs these to write covers to disk
                 changes = changes, // artwork-free: Differ used stripped books
-                errors = errors,
+                errors = allErrors,
                 durationMs = clock() - started,
-                filesWalked = allFiles.size,
+                filesWalked = totalFileCount,
                 filesSkipped = 0,
                 scope = ScanScope.Full,
             )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerMultiFolderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerMultiFolderTest.kt
@@ -1,0 +1,94 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.scanner
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.embeddedmeta.AudioFormatDetector
+import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
+import com.calypsan.listenup.server.embeddedmeta.fixtures.buildMp3File
+import com.calypsan.listenup.server.embeddedmeta.format.mp3.Mp3Parser
+import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
+import com.calypsan.listenup.server.testing.testLibrary
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+
+/**
+ * Regression coverage for the multi-folder scan-corruption bug.
+ *
+ * When a library has multiple root folders, books in non-first folders were
+ * flagged [hasScanWarning] = true because [Analyzer] reconstructed absolute
+ * paths as `Path(firstFolderRoot, relPath)` for all candidates, regardless of
+ * which folder the file was walked from. Files in the second (or later) folder
+ * therefore produced a nonexistent absolute path, causing
+ * [EmbeddedMetadataParser] to throw an IOException that surfaces as a
+ * [MetadataStatus.ParseError] and sets [hasScanWarning].
+ *
+ * The fix walks and groups each folder independently and creates an [Analyzer]
+ * anchored to each folder's own root, so `Path(folderRoot, relPath)` always
+ * resolves to the real file regardless of folder order.
+ */
+class ScannerMultiFolderTest :
+    FunSpec({
+
+        test("books in the second library folder have hasScanWarning == false after a full scan") {
+            runTest {
+                audioLibrary("listenup-folder-a-").use { folderA ->
+                    audioLibrary("listenup-folder-b-").use { folderB ->
+                        // Seed each folder with a real parseable MP3.
+                        val mp3Bytes =
+                            buildMp3File {
+                                id3v2(version = 4) { textFrame("TIT2", "A Multi-Folder Book") }
+                                mpegFrames(durationSeconds = 1)
+                            }
+                        val bookARoot = folderA.book("Author A/Book A")
+                        Files.write(bookARoot.resolve("track.mp3"), mp3Bytes)
+                        val bookBRoot = folderB.book("Author B/Book B")
+                        Files.write(bookBRoot.resolve("track.mp3"), mp3Bytes)
+
+                        val scanner =
+                            Scanner(
+                                library =
+                                    testLibrary(
+                                        folders =
+                                            listOf(
+                                                folderA.root.toString(),
+                                                folderB.root.toString(),
+                                            ),
+                                    ),
+                                metadataReader = AbsMetadataReader(contractJson),
+                                embeddedMetadataParser =
+                                    EmbeddedMetadataParser(
+                                        detector = AudioFormatDetector(),
+                                        parsers = listOf(Mp3Parser()),
+                                    ),
+                                eventBus = MutableSharedFlow(replay = 64, extraBufferCapacity = 64),
+                                scanResultBus = MutableSharedFlow(replay = 1),
+                                correlationIdFactory = { "test-correlation-id" },
+                            )
+
+                        val result = scanner.runFullScan()
+
+                        result.books.size shouldBe 2
+                        result.errors.shouldBeEmpty()
+
+                        val bookA =
+                            result.books.single { it.candidate.rootRelPath == "Author A/Book A" }
+                        val bookB =
+                            result.books.single { it.candidate.rootRelPath == "Author B/Book B" }
+
+                        // Pre-fix: bookB.hasScanWarning was true because Analyzer computed
+                        // Path(folderA_root, "Author B/Book B/track.mp3") — a path that does not
+                        // exist — causing an IOException → ParseError.
+                        bookA.hasScanWarning shouldBe false
+                        bookB.hasScanWarning shouldBe false
+                    }
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerMultiFolderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerMultiFolderTest.kt
@@ -67,8 +67,8 @@ class ScannerMultiFolderTest :
                                         detector = AudioFormatDetector(),
                                         parsers = listOf(Mp3Parser()),
                                     ),
-                                eventBus = MutableSharedFlow(replay = 64, extraBufferCapacity = 64),
-                                scanResultBus = MutableSharedFlow(replay = 1),
+                                eventBus = MutableSharedFlow<ScanEvent>(replay = 64, extraBufferCapacity = 64),
+                                scanResultBus = MutableSharedFlow<ScanResult>(replay = 1),
                                 correlationIdFactory = { "test-correlation-id" },
                             )
 


### PR DESCRIPTION
## Bug
Adding multiple folders to a library flagged **every book in the non-first folders** with a false scan/"corruption" warning (`hasScanWarning`).

## Root cause
`Scanner.runFullScan()` walked each folder with its own root (so `FileEntry.relPath` is folder-relative) but then built **one `Analyzer` anchored to only the first folder's root** and ran *all* candidates through it. Files under other folders were read at `Path(firstFolderRoot, otherFolderRelPath)` → a nonexistent path → embedded-metadata parse failed → `MetadataStatus.ParseError` → `hasScanWarning = true`. (`runIncremental` already does the correct thing: anchor the `Analyzer` to the owning folder's root.)

## Fix
`runFullScan` now walks + groups **each folder independently** and analyzes each folder's candidates with an `Analyzer` anchored to **that folder's root** (and per-folder `errorRoot`), then aggregates the per-folder results. The single `Differ` pass + `ScanResult` are unchanged, operating over the aggregated books. Mirrors the proven `runIncremental` pattern.

Bonus (confirmed by review): also fixes the matching **error-path mislabeling** for non-first folders and the old **cross-folder candidate-merge** bug (two folders sharing a relPath were merged into one candidate). Single-folder behavior is provably unchanged.

## Test
TDD — new `ScannerMultiFolderTest`: a 2-folder library with a real parseable MP3 in each; asserts the folder-B book has `hasScanWarning == false` (failed pre-fix, passes after). `ScannerPathInvariantsTest` previously only covered single-folder.

Gate: `:server:jvmTest` ✅ (2339/0), `spotlessCheck detekt` ✅. No schema change.

Follow-ups (display-only / pre-existing, out of scope): multi-folder ANALYZING progress ticks are per-folder (jumpy bar; end state correct); `authorsMatched` double-counts across folders (progress readout only); identical cross-folder relative book paths collide on `rootRelPath` (pre-existing — would need folder-namespaced identity).