### PR TITLE
✨ feat(cast): Android Chromecast support in Now Playing

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/PreparedPlayback.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/PreparedPlayback.kt
@@ -26,6 +26,8 @@ data class PreparedPlayback(
     val bookId: String,
     val audioFiles: List<PreparedAudioFile>,
     val resumePosition: PlaybackPositionSyncPayload?,
+    /** Server-relative, signature-authed cover URL a Cast receiver can fetch (no header). Null when not minted. */
+    val coverUrl: String? = null,
 )
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -224,6 +224,7 @@ media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", versio
 media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 media3-datasource-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "media3" }
+media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
 # Async/Future support for Media3 callbacks
 concurrent-futures = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "concurrent-futures" }
 # Markdown Rendering

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -60,6 +60,7 @@ import com.calypsan.listenup.server.plugins.installMaintenanceGate
 import com.calypsan.listenup.server.api.InviteServiceImpl
 import com.calypsan.listenup.server.audio.AudioFileLocator
 import com.calypsan.listenup.server.audio.AudioUrlSigner
+import com.calypsan.listenup.server.audio.CoverUrlSigner
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
@@ -76,6 +77,7 @@ import com.calypsan.listenup.server.scheduler.OrphanImageCleanupTask
 import com.calypsan.listenup.server.routes.adminRoutes
 import com.calypsan.listenup.server.routes.adminUserRoutes
 import com.calypsan.listenup.server.routes.audioRoutes
+import com.calypsan.listenup.server.routes.coverCastRoutes
 import com.calypsan.listenup.server.routes.authRoutes
 import com.calypsan.listenup.server.routes.backupRoutes
 import com.calypsan.listenup.server.routes.importRoutes
@@ -413,6 +415,7 @@ private fun Application.installAppRoutes(homeDir: Path) {
     val searchReindexService by inject<SearchReindexService>()
     val audioFileLocator by inject<AudioFileLocator>()
     val audioUrlSigner by inject<AudioUrlSigner>()
+    val coverUrlSigner by inject<CoverUrlSigner>()
     val contributorRepository by inject<ContributorRepository>()
     val seriesRepository by inject<SeriesRepository>()
     val metadataLookupService by inject<MetadataLookupService>()
@@ -510,6 +513,7 @@ private fun Application.installAppRoutes(homeDir: Path) {
         }
         scannerRoutes(scannerService, eventBus)
         audioRoutes(audioFileLocator, audioUrlSigner, audioRoleLookup, bookAccessPolicy)
+        coverCastRoutes(coverResponder, coverUrlSigner, audioRoleLookup, bookAccessPolicy)
     }
 }
 

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImpl.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImpl.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.api.sync.UserStatsSyncPayload
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.audio.AudioFileLocator
 import com.calypsan.listenup.server.audio.AudioUrlSigner
+import com.calypsan.listenup.server.audio.CoverUrlSigner
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
@@ -44,6 +45,7 @@ internal class PlaybackServiceImpl(
     private val bookRepository: BookRepository,
     private val audioFileLocator: AudioFileLocator,
     private val audioUrlSigner: AudioUrlSigner,
+    private val coverUrlSigner: CoverUrlSigner,
     private val playbackPositionRepository: PlaybackPositionRepository,
     private val listeningEventRepository: ListeningEventRepository,
     private val userStatsRepository: UserStatsRepository,
@@ -83,12 +85,16 @@ internal class PlaybackServiceImpl(
             }
 
         val resumePosition = playbackPositionRepository.getPosition(userId, bookId.value)
+        val coverUrl =
+            "/api/v1/cover-cast/${bookId.value.encodeURLParameter()}?" +
+                coverUrlSigner.signedQuery(userId = userId, bookId = bookId.value)
 
         return AppResult.Success(
             PreparedPlayback(
                 bookId = bookId.value,
                 audioFiles = audioFiles,
                 resumePosition = resumePosition,
+                coverUrl = coverUrl,
             ),
         )
     }
@@ -167,6 +173,7 @@ internal class PlaybackServiceImpl(
             bookRepository = bookRepository,
             audioFileLocator = audioFileLocator,
             audioUrlSigner = audioUrlSigner,
+            coverUrlSigner = coverUrlSigner,
             playbackPositionRepository = playbackPositionRepository,
             listeningEventRepository = listeningEventRepository,
             userStatsRepository = userStatsRepository,

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImpl.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImpl.kt
@@ -85,6 +85,8 @@ internal class PlaybackServiceImpl(
             }
 
         val resumePosition = playbackPositionRepository.getPosition(userId, bookId.value)
+        // Always mint — the route resolves covers lazily (embedded covers aren't persisted), so
+        // guarding here would cost a resolution. No cover → route 404s → receiver shows no art.
         val coverUrl =
             "/api/v1/cover-cast/${bookId.value.encodeURLParameter()}?" +
                 coverUrlSigner.signedQuery(userId = userId, bookId = bookId.value)

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/audio/CoverUrlSigner.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/audio/CoverUrlSigner.kt
@@ -1,0 +1,141 @@
+package com.calypsan.listenup.server.audio
+
+import dev.whyoleg.cryptography.CryptographyProvider
+import dev.whyoleg.cryptography.algorithms.HMAC
+import dev.whyoleg.cryptography.algorithms.SHA256
+import io.ktor.http.encodeURLParameter
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Mints and verifies short-lived signed cover URLs.
+ *
+ * The cover route is NOT JWT-gated — Cast and native players cannot reliably
+ * set an Authorization header on a media URL — so access is a per-book,
+ * time-boxed HMAC signature instead.
+ *
+ * `playback/prepare` calls [signedQuery] to produce
+ * `?u=<userId>&exp=<epochSec>&sig=<hex>`. The cover route calls [verify]. A
+ * leaked URL grants ONE book's cover to ONE user for [ttl] — far tighter than
+ * a full access token in the query string.
+ *
+ * The key-derivation label `"listenup-cover-url-v1"` is distinct from the
+ * audio signer's label, ensuring an audio signature can never authorize a
+ * cover request and vice versa.
+ *
+ * @param signingKey derived from the JWT secret so operators manage no new
+ *   secret: `HMAC-SHA256(jwtSecret, "listenup-cover-url-v1")`.
+ * @param ttl default 12h — consistent with [AudioUrlSigner].
+ */
+@OptIn(kotlin.time.ExperimentalTime::class)
+class CoverUrlSigner(
+    signingKey: ByteArray,
+    private val ttl: Duration = 12.hours,
+    private val clock: Clock = Clock.System,
+) {
+    private val key: HMAC.Key =
+        CryptographyProvider.Default
+            .get(HMAC)
+            .keyDecoder(SHA256)
+            .decodeFromByteArrayBlocking(HMAC.Key.Format.RAW, signingKey)
+
+    /**
+     * Returns `u=<userId>&exp=<epochSec>&sig=<hex>` for the cover URL of
+     * `(userId, bookId)`. The `bookId` is a path segment owned by the route
+     * and is not repeated in the query string.
+     */
+    fun signedQuery(
+        userId: String,
+        bookId: String,
+    ): String {
+        val exp = (clock.now() + ttl).epochSeconds
+        val sig = hmacHex(payload(userId, bookId, exp))
+        return "u=${userId.encodeURLParameter()}&exp=$exp&sig=$sig"
+    }
+
+    /**
+     * Returns true when [sig] is a valid, unexpired HMAC signature for the
+     * given `(userId, bookId, exp)` tuple.
+     *
+     * Verification is constant-time: the expected signature is always computed
+     * in full and compared byte-by-byte via XOR accumulation, so timing does
+     * not reveal how many bytes matched.
+     */
+    fun verify(
+        userId: String,
+        bookId: String,
+        exp: Long,
+        sig: String,
+    ): Boolean {
+        if (exp <= clock.now().epochSeconds) return false
+        val expectedBytes = hmacBytes(payload(userId, bookId, exp))
+        val actualBytes = hexToBytes(sig) ?: return false
+        return constantTimeEquals(expectedBytes, actualBytes)
+    }
+
+    private fun payload(
+        userId: String,
+        bookId: String,
+        exp: Long,
+    ) = "$userId|$bookId|$exp"
+
+    private fun hmacHex(message: String): String = hmacBytes(message).toHexString()
+
+    private fun hmacBytes(message: String): ByteArray =
+        key.signatureGenerator().generateSignatureBlocking(message.encodeToByteArray())
+
+    /**
+     * Constant-time byte comparison via XOR accumulation. Returns true only
+     * when both arrays have the same length and every byte pair is equal.
+     * Does not short-circuit on the first mismatch, so timing does not leak
+     * how many bytes matched.
+     */
+    private fun constantTimeEquals(
+        a: ByteArray,
+        b: ByteArray,
+    ): Boolean {
+        if (a.size != b.size) return false
+        var diff = 0
+        for (i in a.indices) diff = diff or (a[i].toInt() xor b[i].toInt())
+        return diff == 0
+    }
+
+    /**
+     * Decodes a lowercase-hex string to bytes, or returns null when the string
+     * is not valid hex (odd length, non-hex chars, wrong length for SHA-256).
+     */
+    private fun hexToBytes(hex: String): ByteArray? {
+        if (hex.length != 64) return null // SHA-256 produces 32 bytes = 64 hex chars
+        return try {
+            hex.hexToByteArray()
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+
+    companion object {
+        /**
+         * Derives the signing key from a JWT secret so operators manage no new
+         * secret. The derivation uses HMAC-SHA256 itself as a KDF:
+         * `HMAC-SHA256(jwtSecret.encodeToByteArray(), "listenup-cover-url-v1")`.
+         *
+         * The distinct label ensures audio signatures can never authorize cover
+         * requests and vice versa.
+         *
+         * Uses the blocking API — safe to call from Koin module construction
+         * (non-suspend context).
+         */
+        fun deriveSigningKey(jwtSecret: String): ByteArray {
+            val provider = CryptographyProvider.Default
+            val tempKey =
+                provider
+                    .get(HMAC)
+                    .keyDecoder(SHA256)
+                    .decodeFromByteArrayBlocking(HMAC.Key.Format.RAW, jwtSecret.encodeToByteArray())
+            return tempKey
+                .signatureGenerator()
+                .generateSignatureBlocking("listenup-cover-url-v1".encodeToByteArray())
+        }
+    }
+}

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/audio/CoverUrlSigner.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/audio/CoverUrlSigner.kt
@@ -24,11 +24,14 @@ import kotlin.time.Duration.Companion.hours
  * audio signer's label, ensuring an audio signature can never authorize a
  * cover request and vice versa.
  *
+ * This class deliberately mirrors [AudioUrlSigner]; the constant-time
+ * comparison and the hex-length guard must stay in sync between the two
+ * (a shared base is a deferred follow-up).
+ *
  * @param signingKey derived from the JWT secret so operators manage no new
  *   secret: `HMAC-SHA256(jwtSecret, "listenup-cover-url-v1")`.
  * @param ttl default 12h — consistent with [AudioUrlSigner].
  */
-@OptIn(kotlin.time.ExperimentalTime::class)
 class CoverUrlSigner(
     signingKey: ByteArray,
     private val ttl: Duration = 12.hours,

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/audio/CoverUrlSigner.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/audio/CoverUrlSigner.kt
@@ -109,7 +109,7 @@ class CoverUrlSigner(
      * is not valid hex (odd length, non-hex chars, wrong length for SHA-256).
      */
     private fun hexToBytes(hex: String): ByteArray? {
-        if (hex.length != 64) return null // SHA-256 produces 32 bytes = 64 hex chars
+        if (hex.length != SHA256_HEX_LENGTH) return null // SHA-256 produces 32 bytes = 64 hex chars
         return try {
             hex.hexToByteArray()
         } catch (_: IllegalArgumentException) {
@@ -118,6 +118,9 @@ class CoverUrlSigner(
     }
 
     companion object {
+        /** SHA-256 produces 32 bytes, which encode as exactly 64 lowercase hex characters. */
+        private const val SHA256_HEX_LENGTH = 64
+
         /**
          * Derives the signing key from a JWT secret so operators manage no new
          * secret. The derivation uses HMAC-SHA256 itself as a KDF:

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.server.api.PlaybackServiceImpl
 import com.calypsan.listenup.server.api.SocialServiceImpl
 import com.calypsan.listenup.server.audio.AudioFileLocator
 import com.calypsan.listenup.server.audio.AudioUrlSigner
+import com.calypsan.listenup.server.audio.CoverUrlSigner
 import com.calypsan.listenup.server.auth.JwtConfiguration
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserRoleLookup
@@ -70,6 +71,11 @@ fun playbackModule(): Module =
         single {
             AudioUrlSigner(
                 signingKey = AudioUrlSigner.deriveSigningKey(get<JwtConfiguration>().secret),
+            )
+        }
+        single {
+            CoverUrlSigner(
+                signingKey = CoverUrlSigner.deriveSigningKey(get<JwtConfiguration>().secret),
             )
         }
         single { UserRoleLookup(db = get<ListenUpDatabase>()) }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
@@ -131,6 +131,7 @@ fun playbackModule(): Module =
                 bookRepository = get<BookRepository>(),
                 audioFileLocator = get(),
                 audioUrlSigner = get(),
+                coverUrlSigner = get(),
                 playbackPositionRepository = get(),
                 listeningEventRepository = get(),
                 userStatsRepository = get(),

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutes.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.api.BookAccessPolicy
+import com.calypsan.listenup.server.audio.CoverUrlSigner
+import com.calypsan.listenup.server.auth.UserRoleLookup
+import com.calypsan.listenup.server.cover.CoverResponder
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+/**
+ * Cast cover route. NOT JWT-gated — the URL signature IS the auth, mirroring
+ * [audioRoutes]. A Chromecast receiver fetches the cover with no Authorization
+ * header, so `playback/prepare` mints a signed `?u&exp&sig` query via
+ * [CoverUrlSigner] and this route validates it on every request.
+ *
+ * The signature proves *who*, not *role*, so after it verifies we resolve the
+ * caller's role and gate through [BookAccessPolicy]; a book the caller cannot
+ * reach answers 404 (never 403 — no existence probe). A forged/missing
+ * signature is the distinct auth failure and answers 403.
+ */
+internal fun Route.coverCastRoutes(
+    coverResponder: CoverResponder,
+    signer: CoverUrlSigner,
+    roleLookup: UserRoleLookup,
+    accessPolicy: BookAccessPolicy,
+) {
+    get("/api/v1/cover-cast/{bookId}") {
+        val bookId = call.parameters["bookId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val exp = call.request.queryParameters["exp"]?.toLongOrNull()
+        val sig = call.request.queryParameters["sig"]
+        val userId = call.request.queryParameters["u"]
+        if (exp == null || sig == null || userId == null || !signer.verify(userId, bookId, exp, sig)) {
+            return@get call.respond(HttpStatusCode.Forbidden)
+        }
+        val role = roleLookup.roleOf(userId) ?: return@get call.respond(HttpStatusCode.NotFound)
+        if (!accessPolicy.canAccess(userId, role, bookId)) {
+            return@get call.respond(HttpStatusCode.NotFound)
+        }
+        coverResponder.respondCover(call, BookId(bookId))
+    }
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
@@ -53,6 +53,7 @@ import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
 
@@ -271,6 +272,35 @@ class PlaybackServiceImplTest :
                     val exp = params["exp"]?.toLong().shouldNotBeNull()
                     val sig = params["sig"].shouldNotBeNull()
                     deps.signer.verify(userId, "b1", file.fileId, exp, sig) shouldBe true
+                }
+            }
+        }
+
+        test("prepare returns a signed cover URL that the cover signer verifies") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("u1")
+                val deps = buildDeps(sql, driver)
+                runTest {
+                    deps.bookRepo.upsert(bookWithThreeFiles("b1"))
+                    deps.makeReachable("b1", "u1")
+
+                    val service = deps.service(sql, "u1")
+
+                    val result = service.prepare(BookId("b1"))
+                    val success = result.shouldBeInstanceOf<AppResult.Success<PreparedPlayback>>()
+
+                    // URL shape: /api/v1/cover-cast/{bookId}?u=...&exp=...&sig=...
+                    val coverUrl = success.data.coverUrl.shouldNotBeNull()
+                    coverUrl shouldStartWith "/api/v1/cover-cast/"
+                    val params =
+                        coverUrl.substringAfter("?").split("&").associate {
+                            it.substringBefore("=") to it.substringAfter("=")
+                        }
+                    val userId = params["u"].shouldNotBeNull()
+                    val exp = params["exp"]?.toLong().shouldNotBeNull()
+                    val sig = params["sig"].shouldNotBeNull()
+                    deps.coverSigner.verify(userId, "b1", exp, sig) shouldBe true
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImplTest.kt
@@ -22,6 +22,7 @@ import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.api.dto.PreparedPlayback
 import com.calypsan.listenup.server.audio.AudioFileLocator
 import com.calypsan.listenup.server.audio.AudioUrlSigner
+import com.calypsan.listenup.server.audio.CoverUrlSigner
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
@@ -62,6 +63,7 @@ class PlaybackServiceImplTest :
             val bookRepo: BookRepository,
             val positionRepo: PlaybackPositionRepository,
             val signer: AudioUrlSigner,
+            val coverSigner: CoverUrlSigner,
             val eventRepo: ListeningEventRepository,
             val statsRepo: UserStatsRepository,
             val accessPolicy: BookAccessPolicy,
@@ -88,6 +90,7 @@ class PlaybackServiceImplTest :
                 )
             val positionRepo = PlaybackPositionRepository(db = sql, bus = bus, registry = SyncRegistry())
             val signer = AudioUrlSigner(AudioUrlSigner.deriveSigningKey("x".repeat(32)))
+            val coverSigner = CoverUrlSigner(CoverUrlSigner.deriveSigningKey("x".repeat(32)))
             val statsRepo = UserStatsRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
             val updater =
                 UserStatsUpdater(
@@ -106,6 +109,7 @@ class PlaybackServiceImplTest :
                 bookRepo = bookRepo,
                 positionRepo = positionRepo,
                 signer = signer,
+                coverSigner = coverSigner,
                 eventRepo = eventRepo,
                 statsRepo = statsRepo,
                 accessPolicy = BookAccessPolicy(sql, driver),
@@ -154,6 +158,7 @@ class PlaybackServiceImplTest :
                 bookRepository = bookRepo,
                 audioFileLocator = AudioFileLocator(sql),
                 audioUrlSigner = signer,
+                coverUrlSigner = coverSigner,
                 playbackPositionRepository = positionRepo,
                 listeningEventRepository = eventRepo,
                 userStatsRepository = statsRepo,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/audio/CoverUrlSignerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/audio/CoverUrlSignerTest.kt
@@ -1,0 +1,44 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.audio
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+class CoverUrlSignerTest : FunSpec({
+    val key = CoverUrlSigner.deriveSigningKey("test-jwt-secret")
+
+    fun fixedClock(epochSec: Long) = object : Clock {
+        override fun now(): Instant = Instant.fromEpochSeconds(epochSec)
+    }
+
+    test("a freshly signed query verifies") {
+        val signer = CoverUrlSigner(key, ttl = 12.hours, clock = fixedClock(1000))
+        val query = signer.signedQuery(userId = "u1", bookId = "b1")
+        val params = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
+        signer.verify("u1", "b1", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe true
+    }
+
+    test("a different book does not verify against another book's signature") {
+        val signer = CoverUrlSigner(key, clock = fixedClock(1000))
+        val query = signer.signedQuery("u1", "b1")
+        val params = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
+        signer.verify("u1", "b2", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe false
+    }
+
+    test("an expired signature does not verify") {
+        val signer = CoverUrlSigner(key, ttl = 12.hours, clock = fixedClock(1000))
+        val query = signer.signedQuery("u1", "b1")
+        val params = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
+        val later = CoverUrlSigner(key, clock = fixedClock(1000 + 13 * 3600))
+        later.verify("u1", "b1", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe false
+    }
+
+    test("a malformed signature does not verify") {
+        val signer = CoverUrlSigner(key, clock = fixedClock(1000))
+        signer.verify("u1", "b1", exp = 999_999_999, sig = "not-hex") shouldBe false
+    }
+})

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/audio/CoverUrlSignerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/audio/CoverUrlSignerTest.kt
@@ -12,8 +12,7 @@ class CoverUrlSignerTest :
     FunSpec({
         val key = CoverUrlSigner.deriveSigningKey("test-jwt-secret")
 
-        fun parse(query: String): Map<String, String> =
-            query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
+        fun parse(query: String): Map<String, String> = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
 
         test("a freshly signed query verifies") {
             val signer = CoverUrlSigner(key, ttl = 12.hours, clock = FixedClock(Instant.fromEpochSeconds(1000)))

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/audio/CoverUrlSignerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/audio/CoverUrlSignerTest.kt
@@ -2,43 +2,40 @@
 
 package com.calypsan.listenup.server.audio
 
+import com.calypsan.listenup.server.testing.FixedClock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
-class CoverUrlSignerTest : FunSpec({
-    val key = CoverUrlSigner.deriveSigningKey("test-jwt-secret")
+class CoverUrlSignerTest :
+    FunSpec({
+        val key = CoverUrlSigner.deriveSigningKey("test-jwt-secret")
 
-    fun fixedClock(epochSec: Long) = object : Clock {
-        override fun now(): Instant = Instant.fromEpochSeconds(epochSec)
-    }
+        fun parse(query: String): Map<String, String> =
+            query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
 
-    test("a freshly signed query verifies") {
-        val signer = CoverUrlSigner(key, ttl = 12.hours, clock = fixedClock(1000))
-        val query = signer.signedQuery(userId = "u1", bookId = "b1")
-        val params = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
-        signer.verify("u1", "b1", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe true
-    }
+        test("a freshly signed query verifies") {
+            val signer = CoverUrlSigner(key, ttl = 12.hours, clock = FixedClock(Instant.fromEpochSeconds(1000)))
+            val params = parse(signer.signedQuery(userId = "u1", bookId = "b1"))
+            signer.verify("u1", "b1", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe true
+        }
 
-    test("a different book does not verify against another book's signature") {
-        val signer = CoverUrlSigner(key, clock = fixedClock(1000))
-        val query = signer.signedQuery("u1", "b1")
-        val params = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
-        signer.verify("u1", "b2", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe false
-    }
+        test("a different book does not verify against another book's signature") {
+            val signer = CoverUrlSigner(key, clock = FixedClock(Instant.fromEpochSeconds(1000)))
+            val params = parse(signer.signedQuery("u1", "b1"))
+            signer.verify("u1", "b2", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe false
+        }
 
-    test("an expired signature does not verify") {
-        val signer = CoverUrlSigner(key, ttl = 12.hours, clock = fixedClock(1000))
-        val query = signer.signedQuery("u1", "b1")
-        val params = query.split("&").associate { it.substringBefore("=") to it.substringAfter("=") }
-        val later = CoverUrlSigner(key, clock = fixedClock(1000 + 13 * 3600))
-        later.verify("u1", "b1", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe false
-    }
+        test("an expired signature does not verify") {
+            val signer = CoverUrlSigner(key, ttl = 12.hours, clock = FixedClock(Instant.fromEpochSeconds(1000)))
+            val params = parse(signer.signedQuery("u1", "b1"))
+            val later = CoverUrlSigner(key, clock = FixedClock(Instant.fromEpochSeconds(1000 + 13 * 3600)))
+            later.verify("u1", "b1", params.getValue("exp").toLong(), params.getValue("sig")) shouldBe false
+        }
 
-    test("a malformed signature does not verify") {
-        val signer = CoverUrlSigner(key, clock = fixedClock(1000))
-        signer.verify("u1", "b1", exp = 999_999_999, sig = "not-hex") shouldBe false
-    }
-})
+        test("a malformed signature does not verify") {
+            val signer = CoverUrlSigner(key, clock = FixedClock(Instant.fromEpochSeconds(1000)))
+            signer.verify("u1", "b1", exp = 999_999_999, sig = "not-hex") shouldBe false
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
@@ -1,8 +1,14 @@
 package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.sync.BookAudioFilePayload
+import com.calypsan.listenup.api.sync.BookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
 import com.calypsan.listenup.api.sync.CoverPayload
 import com.calypsan.listenup.api.sync.CoverSource
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.server.audio.CoverUrlSigner
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.module
@@ -70,7 +76,7 @@ class CoverCastRoutesTest :
 
                     val repo by application.inject<BookRepository>()
                     repo.upsert(
-                        coverCastFixture(
+                        coverFixture(
                             id = "b1",
                             source = CoverSource.FILESYSTEM,
                         ),
@@ -82,8 +88,8 @@ class CoverCastRoutesTest :
                     sql.seedTestUser("user1")
                     val collectionRepo by application.inject<CollectionRepository>()
                     val collectionBookRepo by application.inject<CollectionBookRepository>()
-                    collectionRepo.upsert(coverCastPrivateCollection("owned-col", owner = "user1"))
-                    collectionBookRepo.upsert(coverCastMembership("owned-col", "b1"))
+                    collectionRepo.upsert(privateCollection("owned-col", owner = "user1"))
+                    collectionBookRepo.upsert(membership("owned-col", "b1"))
 
                     val signer = CoverUrlSigner(signingKey = TEST_SIGNING_KEY)
                     val query = signer.signedQuery("user1", "b1")
@@ -152,7 +158,7 @@ class CoverCastRoutesTest :
 
                     val repo by application.inject<BookRepository>()
                     repo.upsert(
-                        coverCastFixture(
+                        coverFixture(
                             id = "b1",
                             source = CoverSource.FILESYSTEM,
                         ),
@@ -164,8 +170,8 @@ class CoverCastRoutesTest :
                     sql.seedTestUser("member")
                     val collectionRepo by application.inject<CollectionRepository>()
                     val collectionBookRepo by application.inject<CollectionBookRepository>()
-                    collectionRepo.upsert(coverCastPrivateCollection("private-col", owner = "stranger"))
-                    collectionBookRepo.upsert(coverCastMembership("private-col", "b1"))
+                    collectionRepo.upsert(privateCollection("private-col", owner = "stranger"))
+                    collectionBookRepo.upsert(membership("private-col", "b1"))
 
                     val signer = CoverUrlSigner(signingKey = TEST_SIGNING_KEY)
                     val query = signer.signedQuery("member", "b1")
@@ -180,11 +186,11 @@ class CoverCastRoutesTest :
         }
     })
 
-private fun coverCastPrivateCollection(
+private fun privateCollection(
     id: String,
     owner: String,
-): com.calypsan.listenup.api.sync.CollectionSyncPayload =
-    com.calypsan.listenup.api.sync.CollectionSyncPayload(
+): CollectionSyncPayload =
+    CollectionSyncPayload(
         id = id,
         libraryId = "test-library",
         ownerId = owner,
@@ -194,25 +200,25 @@ private fun coverCastPrivateCollection(
         updatedAt = 0L,
     )
 
-private fun coverCastMembership(
+private fun membership(
     collectionId: String,
     bookId: String,
-): com.calypsan.listenup.api.sync.CollectionBookSyncPayload =
-    com.calypsan.listenup.api.sync.CollectionBookSyncPayload(
+): CollectionBookSyncPayload =
+    CollectionBookSyncPayload(
         collectionId = collectionId,
         bookId = bookId,
         createdAt = 0L,
         revision = 0L,
     )
 
-private fun coverCastFixture(
+private fun coverFixture(
     id: String,
     source: CoverSource?,
-): com.calypsan.listenup.api.sync.BookSyncPayload =
-    com.calypsan.listenup.api.sync.BookSyncPayload(
+): BookSyncPayload =
+    BookSyncPayload(
         id = id,
-        libraryId = com.calypsan.listenup.core.LibraryId("test-library"),
-        folderId = com.calypsan.listenup.core.FolderId("test-folder"),
+        libraryId = LibraryId("test-library"),
+        folderId = FolderId("test-folder"),
         title = "Cover Cast Book $id",
         sortTitle = "Cover Cast Book $id",
         subtitle = null,
@@ -233,7 +239,7 @@ private fun coverCastFixture(
         series = emptyList(),
         audioFiles =
             listOf(
-                com.calypsan.listenup.api.sync.BookAudioFilePayload(
+                BookAudioFilePayload(
                     id = "af-$id",
                     index = 0,
                     filename = "01.m4b",

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/CoverCastRoutesTest.kt
@@ -1,0 +1,251 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.sync.CoverPayload
+import com.calypsan.listenup.api.sync.CoverSource
+import com.calypsan.listenup.server.audio.CoverUrlSigner
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import org.koin.ktor.ext.inject
+import java.nio.file.Files
+
+/**
+ * Integration tests for `GET /api/v1/cover-cast/{bookId}`.
+ *
+ * The route is NOT JWT-gated — the HMAC-signed query string is the auth,
+ * mirroring [AudioRoutes]. A Chromecast receiver fetches the cover with no
+ * Authorization header; `playback/prepare` mints the signed query via
+ * [CoverUrlSigner] and this route validates it on every request.
+ *
+ * The signing key is derived from the test JWT secret configured by
+ * `useIsolatedTestConfig` ("x" * 32).
+ */
+
+private val TEST_JWT_SECRET = "x".repeat(32) // must match the value in useIsolatedTestConfig
+private val TEST_SIGNING_KEY = CoverUrlSigner.deriveSigningKey(TEST_JWT_SECRET)
+
+class CoverCastRoutesTest :
+    FunSpec({
+
+        test("GET with a valid signed query and a book with a cover returns 200 with image bytes") {
+            val libraryRoot = Files.createTempDirectory("listenup-cover-cast-200-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), rescanOnStartup = false)
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+
+                    // Trigger application startup before inject
+                    client.get("/healthz")
+                    seedTestLibraryAndFolder(folderPath = libraryRoot.toString())
+
+                    // Write a real cover file under the book's rootRelPath
+                    val bookDir = Files.createDirectories(libraryRoot.resolve("books/b1"))
+                    val jpegBytes =
+                        byteArrayOf(
+                            0xFF.toByte(),
+                            0xD8.toByte(),
+                            0xFF.toByte(),
+                            0xE0.toByte(),
+                            0x00,
+                            0x10,
+                            'J'.code.toByte(),
+                            'F'.code.toByte(),
+                        )
+                    Files.write(bookDir.resolve("cover.jpg"), jpegBytes)
+
+                    val repo by application.inject<BookRepository>()
+                    repo.upsert(
+                        coverCastFixture(
+                            id = "b1",
+                            source = CoverSource.FILESYSTEM,
+                        ),
+                    )
+
+                    // Seed user1 so roleOf("user1") resolves; then place b1 in a collection
+                    // that user1 owns — the owner branch makes the book reachable.
+                    val sql by application.inject<ListenUpDatabase>()
+                    sql.seedTestUser("user1")
+                    val collectionRepo by application.inject<CollectionRepository>()
+                    val collectionBookRepo by application.inject<CollectionBookRepository>()
+                    collectionRepo.upsert(coverCastPrivateCollection("owned-col", owner = "user1"))
+                    collectionBookRepo.upsert(coverCastMembership("owned-col", "b1"))
+
+                    val signer = CoverUrlSigner(signingKey = TEST_SIGNING_KEY)
+                    val query = signer.signedQuery("user1", "b1")
+
+                    val response = client.get("/api/v1/cover-cast/b1?$query")
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.bodyAsBytes().toList() shouldBe jpegBytes.toList()
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+
+        test("GET with no u/exp/sig parameters returns 403 Forbidden") {
+            val libraryRoot = Files.createTempDirectory("listenup-cover-cast-403-missing-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), rescanOnStartup = false)
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+
+                    val response = client.get("/api/v1/cover-cast/b1")
+
+                    response.status shouldBe HttpStatusCode.Forbidden
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+
+        test("GET with a forged sig returns 403 Forbidden") {
+            val libraryRoot = Files.createTempDirectory("listenup-cover-cast-403-forged-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), rescanOnStartup = false)
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+
+                    val signer = CoverUrlSigner(signingKey = TEST_SIGNING_KEY)
+                    val query = signer.signedQuery("user1", "b1")
+                    val tamperedSig = query.substringBefore("sig=") + "sig=" + "0".repeat(64)
+
+                    val response = client.get("/api/v1/cover-cast/b1?$tamperedSig")
+
+                    response.status shouldBe HttpStatusCode.Forbidden
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+
+        test("valid signature but user cannot access the book returns 404") {
+            val libraryRoot = Files.createTempDirectory("listenup-cover-cast-access-deny-")
+            try {
+                testApplication {
+                    useIsolatedTestConfig(libraryPath = libraryRoot.toString(), rescanOnStartup = false)
+                    application { module() }
+                    val client = createClient { install(ContentNegotiation) { json(contractJson) } }
+
+                    client.get("/healthz")
+                    seedTestLibraryAndFolder(folderPath = libraryRoot.toString())
+
+                    val bookDir = Files.createDirectories(libraryRoot.resolve("books/b1"))
+                    Files.write(bookDir.resolve("cover.jpg"), byteArrayOf(0xFF.toByte(), 0xD8.toByte()))
+
+                    val repo by application.inject<BookRepository>()
+                    repo.upsert(
+                        coverCastFixture(
+                            id = "b1",
+                            source = CoverSource.FILESYSTEM,
+                        ),
+                    )
+
+                    // Seed member so roleOf("member") resolves; then lock b1 in a private
+                    // collection owned by a stranger — member has no relationship → gate 404.
+                    val sql by application.inject<ListenUpDatabase>()
+                    sql.seedTestUser("member")
+                    val collectionRepo by application.inject<CollectionRepository>()
+                    val collectionBookRepo by application.inject<CollectionBookRepository>()
+                    collectionRepo.upsert(coverCastPrivateCollection("private-col", owner = "stranger"))
+                    collectionBookRepo.upsert(coverCastMembership("private-col", "b1"))
+
+                    val signer = CoverUrlSigner(signingKey = TEST_SIGNING_KEY)
+                    val query = signer.signedQuery("member", "b1")
+
+                    val response = client.get("/api/v1/cover-cast/b1?$query")
+
+                    response.status shouldBe HttpStatusCode.NotFound
+                }
+            } finally {
+                libraryRoot.toFile().deleteRecursively()
+            }
+        }
+    })
+
+private fun coverCastPrivateCollection(
+    id: String,
+    owner: String,
+): com.calypsan.listenup.api.sync.CollectionSyncPayload =
+    com.calypsan.listenup.api.sync.CollectionSyncPayload(
+        id = id,
+        libraryId = "test-library",
+        ownerId = owner,
+        name = id,
+        isInbox = false,
+        revision = 0L,
+        updatedAt = 0L,
+    )
+
+private fun coverCastMembership(
+    collectionId: String,
+    bookId: String,
+): com.calypsan.listenup.api.sync.CollectionBookSyncPayload =
+    com.calypsan.listenup.api.sync.CollectionBookSyncPayload(
+        collectionId = collectionId,
+        bookId = bookId,
+        createdAt = 0L,
+        revision = 0L,
+    )
+
+private fun coverCastFixture(
+    id: String,
+    source: CoverSource?,
+): com.calypsan.listenup.api.sync.BookSyncPayload =
+    com.calypsan.listenup.api.sync.BookSyncPayload(
+        id = id,
+        libraryId = com.calypsan.listenup.core.LibraryId("test-library"),
+        folderId = com.calypsan.listenup.core.FolderId("test-folder"),
+        title = "Cover Cast Book $id",
+        sortTitle = "Cover Cast Book $id",
+        subtitle = null,
+        description = null,
+        publishYear = null,
+        publisher = null,
+        language = null,
+        isbn = null,
+        asin = null,
+        abridged = false,
+        explicit = false,
+        totalDuration = 3_600_000L,
+        cover = source?.let { CoverPayload(source = it, hash = "hash-$id") },
+        rootRelPath = "books/$id",
+        inode = null,
+        scannedAt = 1_730_000_000_000L,
+        contributors = emptyList(),
+        series = emptyList(),
+        audioFiles =
+            listOf(
+                com.calypsan.listenup.api.sync.BookAudioFilePayload(
+                    id = "af-$id",
+                    index = 0,
+                    filename = "01.m4b",
+                    format = "m4b",
+                    codec = "aac",
+                    duration = 3_600_000L,
+                    size = 256L,
+                ),
+            ),
+        chapters = emptyList(),
+        revision = 0L,
+        updatedAt = 0L,
+        createdAt = 0L,
+        deletedAt = null,
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/SyncTestApplication.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.server.api.BookAccessPolicy
 import com.calypsan.listenup.server.api.PlaybackServiceImpl
 import com.calypsan.listenup.server.audio.AudioFileLocator
 import com.calypsan.listenup.server.audio.AudioUrlSigner
+import com.calypsan.listenup.server.audio.CoverUrlSigner
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.db.DatabaseConfig
 import com.calypsan.listenup.server.db.DatabaseFactory
@@ -192,6 +193,7 @@ internal fun withTestApplication(
                 )
             val positionRepoForPlayback = PlaybackPositionRepository(sqlDb, bus, SyncRegistry())
             val signer = AudioUrlSigner(AudioUrlSigner.deriveSigningKey("x".repeat(32)))
+            val coverSigner = CoverUrlSigner(CoverUrlSigner.deriveSigningKey("x".repeat(32)))
             val bookRepo = buildPlaybackBookRepository(sqlDb, driver, bus)
             bookRepoForScope = bookRepo
             // Seed the library + folder a test book FKs to, so playback-event tests
@@ -202,6 +204,7 @@ internal fun withTestApplication(
                     bookRepository = bookRepo,
                     audioFileLocator = AudioFileLocator(sqlDb),
                     audioUrlSigner = signer,
+                    coverUrlSigner = coverSigner,
                     playbackPositionRepository = positionRepoForPlayback,
                     listeningEventRepository = eventRepo,
                     userStatsRepository = statsRepo,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/PreparedPlaybackContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/PreparedPlaybackContractTest.kt
@@ -100,7 +100,7 @@ class PreparedPlaybackContractTest :
         test("PreparedPlayback decodes without coverUrl field (backward compat)") {
             // A payload from an older server that predates coverUrl must still decode cleanly.
             val json =
-                """{"type":"PreparedPlayback","bookId":"b1","audioFiles":[],"resumePosition":null}"""
+                """{"bookId":"b1","audioFiles":[],"resumePosition":null}"""
             val decoded = contractJson.decodeFromString(PreparedPlayback.serializer(), json)
             decoded.bookId shouldBe "b1"
             decoded.coverUrl shouldBe null

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/PreparedPlaybackContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/PreparedPlaybackContractTest.kt
@@ -75,6 +75,37 @@ class PreparedPlaybackContractTest :
             contractJson.decodeFromString(PreparedPlayback.serializer(), encoded) shouldBe original
         }
 
+        test("PreparedPlayback round-trips with coverUrl set") {
+            val original =
+                PreparedPlayback(
+                    bookId = "b1",
+                    audioFiles =
+                        listOf(
+                            PreparedAudioFile(
+                                fileId = "af-1",
+                                index = 0,
+                                url = "/api/v1/audio/b1/af-1?u=u1&exp=9999999999&sig=aabbcc",
+                                format = "m4b",
+                                durationMs = 3_600_000L,
+                                sizeBytes = 500_000_000L,
+                            ),
+                        ),
+                    resumePosition = null,
+                    coverUrl = "/api/v1/cover-cast/b1?u=u1&exp=9999999999&sig=ab",
+                )
+            val encoded = contractJson.encodeToString(PreparedPlayback.serializer(), original)
+            contractJson.decodeFromString(PreparedPlayback.serializer(), encoded) shouldBe original
+        }
+
+        test("PreparedPlayback decodes without coverUrl field (backward compat)") {
+            // A payload from an older server that predates coverUrl must still decode cleanly.
+            val json =
+                """{"type":"PreparedPlayback","bookId":"b1","audioFiles":[],"resumePosition":null}"""
+            val decoded = contractJson.decodeFromString(PreparedPlayback.serializer(), json)
+            decoded.bookId shouldBe "b1"
+            decoded.coverUrl shouldBe null
+        }
+
         test("RecordPositionRequest round-trips with currentChapterId null") {
             val original =
                 RecordPositionRequest(

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -119,6 +119,7 @@ kotlin {
             implementation(libs.media3.session)
             implementation(libs.media3.ui)
             implementation(libs.media3.datasource.okhttp)
+            implementation(libs.media3.cast)
 
             // Async/Future support for Media3 callbacks
             implementation(libs.concurrent.futures)

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/PlaybackModuleVerifyTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/PlaybackModuleVerifyTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.di
 
 import android.content.Context
+import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.domain.repository.AuthRepository
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -53,6 +54,7 @@ class PlaybackModuleVerifyTest :
                         DeviceContext::class,
                         ImageStorage::class,
                         PlaybackManager::class,
+                        PlaybackRpcFactory::class,
                         ContributorRepository::class,
                         SeriesRepository::class,
                     ),

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactoryTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactoryTest.kt
@@ -24,6 +24,7 @@ class CastMediaItemFactoryTest : FunSpec({
         result.tracks[0].artworkUri shouldBe "http://s/cover?sig=3"
         result.tracks[0].title shouldBe "Book"
         result.droppedUncastable shouldBe 0
+        result.droppedUnmatched shouldBe 0
     }
 
     test("drops un-castable files and counts them") {
@@ -35,6 +36,7 @@ class CastMediaItemFactoryTest : FunSpec({
         result.tracks shouldHaveSize 1
         result.tracks[0].fileId shouldBe "f1"
         result.droppedUncastable shouldBe 1
+        result.droppedUnmatched shouldBe 0
     }
 
     test("preserves the order of the currently-loaded items") {
@@ -44,5 +46,52 @@ class CastMediaItemFactoryTest : FunSpec({
         )
         val result = factory.build(current, prepared, coverUrlAbsolute = null)
         result.tracks.map { it.fileId } shouldBe listOf("f1", "f2")
+    }
+
+    test("empty currentItems yields no tracks and no drops") {
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+        )
+        val result = factory.build(emptyList(), prepared, coverUrlAbsolute = null)
+        result.tracks shouldHaveSize 0
+        result.droppedUncastable shouldBe 0
+        result.droppedUnmatched shouldBe 0
+    }
+
+    test("drops a current item with no matching prepared file and counts it as unmatched") {
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+        )
+        val result = factory.build(current, prepared, coverUrlAbsolute = null)
+        result.tracks shouldHaveSize 1
+        result.tracks[0].fileId shouldBe "f1"
+        result.droppedUnmatched shouldBe 1
+        result.droppedUncastable shouldBe 0
+    }
+
+    test("propagates a null cover as a null artworkUri") {
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+        )
+        val result = factory.build(current.take(1), prepared, coverUrlAbsolute = null)
+        result.tracks shouldHaveSize 1
+        result.tracks[0].artworkUri shouldBe null
+    }
+
+    test("distinguishes un-castable and unmatched drops in one build") {
+        val items = listOf(
+            CastSourceItem(fileId = "f1", title = "Book", artist = "Author", albumTitle = "Series"),
+            CastSourceItem(fileId = "f2", title = "Book", artist = "Author", albumTitle = "Series"),
+            CastSourceItem(fileId = "f3", title = "Book", artist = "Author", albumTitle = "Series"),
+        )
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+            CastPreparedFile(fileId = "f2", absoluteUrl = "u2", format = "wma"),
+            // f3 deliberately absent → unmatched
+        )
+        val result = factory.build(items, prepared, coverUrlAbsolute = null)
+        result.tracks.map { it.fileId } shouldBe listOf("f1")
+        result.droppedUncastable shouldBe 1
+        result.droppedUnmatched shouldBe 1
     }
 })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactoryTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactoryTest.kt
@@ -4,94 +4,104 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldHaveSize
 
-class CastMediaItemFactoryTest : FunSpec({
-    val factory = CastMediaItemFactory()
+class CastMediaItemFactoryTest :
+    FunSpec({
+        val factory = CastMediaItemFactory()
 
-    val current = listOf(
-        CastSourceItem(fileId = "f1", title = "Book", artist = "Author", albumTitle = "Series"),
-        CastSourceItem(fileId = "f2", title = "Book", artist = "Author", albumTitle = "Series"),
-    )
+        val current =
+            listOf(
+                CastSourceItem(fileId = "f1", title = "Book", artist = "Author", albumTitle = "Series"),
+                CastSourceItem(fileId = "f2", title = "Book", artist = "Author", albumTitle = "Series"),
+            )
 
-    test("builds one cast track per matched, castable file with absolute URL + MIME + cover") {
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f1", absoluteUrl = "http://s/a/f1?sig=1", format = "mp3"),
-            CastPreparedFile(fileId = "f2", absoluteUrl = "http://s/a/f2?sig=2", format = "m4b"),
-        )
-        val result = factory.build(current, prepared, coverUrlAbsolute = "http://s/cover?sig=3")
-        result.tracks shouldHaveSize 2
-        result.tracks[0].uri shouldBe "http://s/a/f1?sig=1"
-        result.tracks[0].mimeType shouldBe "audio/mpeg"
-        result.tracks[0].artworkUri shouldBe "http://s/cover?sig=3"
-        result.tracks[0].title shouldBe "Book"
-        result.droppedUncastable shouldBe 0
-        result.droppedUnmatched shouldBe 0
-    }
+        test("builds one cast track per matched, castable file with absolute URL + MIME + cover") {
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "http://s/a/f1?sig=1", format = "mp3"),
+                    CastPreparedFile(fileId = "f2", absoluteUrl = "http://s/a/f2?sig=2", format = "m4b"),
+                )
+            val result = factory.build(current, prepared, coverUrlAbsolute = "http://s/cover?sig=3")
+            result.tracks shouldHaveSize 2
+            result.tracks[0].uri shouldBe "http://s/a/f1?sig=1"
+            result.tracks[0].mimeType shouldBe "audio/mpeg"
+            result.tracks[0].artworkUri shouldBe "http://s/cover?sig=3"
+            result.tracks[0].title shouldBe "Book"
+            result.droppedUncastable shouldBe 0
+            result.droppedUnmatched shouldBe 0
+        }
 
-    test("drops un-castable files and counts them") {
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f1", absoluteUrl = "http://s/a/f1", format = "mp3"),
-            CastPreparedFile(fileId = "f2", absoluteUrl = "http://s/a/f2", format = "wma"),
-        )
-        val result = factory.build(current, prepared, coverUrlAbsolute = null)
-        result.tracks shouldHaveSize 1
-        result.tracks[0].fileId shouldBe "f1"
-        result.droppedUncastable shouldBe 1
-        result.droppedUnmatched shouldBe 0
-    }
+        test("drops un-castable files and counts them") {
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "http://s/a/f1", format = "mp3"),
+                    CastPreparedFile(fileId = "f2", absoluteUrl = "http://s/a/f2", format = "wma"),
+                )
+            val result = factory.build(current, prepared, coverUrlAbsolute = null)
+            result.tracks shouldHaveSize 1
+            result.tracks[0].fileId shouldBe "f1"
+            result.droppedUncastable shouldBe 1
+            result.droppedUnmatched shouldBe 0
+        }
 
-    test("preserves the order of the currently-loaded items") {
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f2", absoluteUrl = "u2", format = "mp3"),
-            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
-        )
-        val result = factory.build(current, prepared, coverUrlAbsolute = null)
-        result.tracks.map { it.fileId } shouldBe listOf("f1", "f2")
-    }
+        test("preserves the order of the currently-loaded items") {
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f2", absoluteUrl = "u2", format = "mp3"),
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+                )
+            val result = factory.build(current, prepared, coverUrlAbsolute = null)
+            result.tracks.map { it.fileId } shouldBe listOf("f1", "f2")
+        }
 
-    test("empty currentItems yields no tracks and no drops") {
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
-        )
-        val result = factory.build(emptyList(), prepared, coverUrlAbsolute = null)
-        result.tracks shouldHaveSize 0
-        result.droppedUncastable shouldBe 0
-        result.droppedUnmatched shouldBe 0
-    }
+        test("empty currentItems yields no tracks and no drops") {
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+                )
+            val result = factory.build(emptyList(), prepared, coverUrlAbsolute = null)
+            result.tracks shouldHaveSize 0
+            result.droppedUncastable shouldBe 0
+            result.droppedUnmatched shouldBe 0
+        }
 
-    test("drops a current item with no matching prepared file and counts it as unmatched") {
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
-        )
-        val result = factory.build(current, prepared, coverUrlAbsolute = null)
-        result.tracks shouldHaveSize 1
-        result.tracks[0].fileId shouldBe "f1"
-        result.droppedUnmatched shouldBe 1
-        result.droppedUncastable shouldBe 0
-    }
+        test("drops a current item with no matching prepared file and counts it as unmatched") {
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+                )
+            val result = factory.build(current, prepared, coverUrlAbsolute = null)
+            result.tracks shouldHaveSize 1
+            result.tracks[0].fileId shouldBe "f1"
+            result.droppedUnmatched shouldBe 1
+            result.droppedUncastable shouldBe 0
+        }
 
-    test("propagates a null cover as a null artworkUri") {
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
-        )
-        val result = factory.build(current.take(1), prepared, coverUrlAbsolute = null)
-        result.tracks shouldHaveSize 1
-        result.tracks[0].artworkUri shouldBe null
-    }
+        test("propagates a null cover as a null artworkUri") {
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+                )
+            val result = factory.build(current.take(1), prepared, coverUrlAbsolute = null)
+            result.tracks shouldHaveSize 1
+            result.tracks[0].artworkUri shouldBe null
+        }
 
-    test("distinguishes un-castable and unmatched drops in one build") {
-        val items = listOf(
-            CastSourceItem(fileId = "f1", title = "Book", artist = "Author", albumTitle = "Series"),
-            CastSourceItem(fileId = "f2", title = "Book", artist = "Author", albumTitle = "Series"),
-            CastSourceItem(fileId = "f3", title = "Book", artist = "Author", albumTitle = "Series"),
-        )
-        val prepared = listOf(
-            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
-            CastPreparedFile(fileId = "f2", absoluteUrl = "u2", format = "wma"),
-            // f3 deliberately absent → unmatched
-        )
-        val result = factory.build(items, prepared, coverUrlAbsolute = null)
-        result.tracks.map { it.fileId } shouldBe listOf("f1")
-        result.droppedUncastable shouldBe 1
-        result.droppedUnmatched shouldBe 1
-    }
-})
+        test("distinguishes un-castable and unmatched drops in one build") {
+            val items =
+                listOf(
+                    CastSourceItem(fileId = "f1", title = "Book", artist = "Author", albumTitle = "Series"),
+                    CastSourceItem(fileId = "f2", title = "Book", artist = "Author", albumTitle = "Series"),
+                    CastSourceItem(fileId = "f3", title = "Book", artist = "Author", albumTitle = "Series"),
+                )
+            val prepared =
+                listOf(
+                    CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+                    CastPreparedFile(fileId = "f2", absoluteUrl = "u2", format = "wma"),
+                    // f3 deliberately absent → unmatched
+                )
+            val result = factory.build(items, prepared, coverUrlAbsolute = null)
+            result.tracks.map { it.fileId } shouldBe listOf("f1")
+            result.droppedUncastable shouldBe 1
+            result.droppedUnmatched shouldBe 1
+        }
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactoryTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactoryTest.kt
@@ -1,0 +1,48 @@
+package com.calypsan.listenup.client.playback.cast
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldHaveSize
+
+class CastMediaItemFactoryTest : FunSpec({
+    val factory = CastMediaItemFactory()
+
+    val current = listOf(
+        CastSourceItem(fileId = "f1", title = "Book", artist = "Author", albumTitle = "Series"),
+        CastSourceItem(fileId = "f2", title = "Book", artist = "Author", albumTitle = "Series"),
+    )
+
+    test("builds one cast track per matched, castable file with absolute URL + MIME + cover") {
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f1", absoluteUrl = "http://s/a/f1?sig=1", format = "mp3"),
+            CastPreparedFile(fileId = "f2", absoluteUrl = "http://s/a/f2?sig=2", format = "m4b"),
+        )
+        val result = factory.build(current, prepared, coverUrlAbsolute = "http://s/cover?sig=3")
+        result.tracks shouldHaveSize 2
+        result.tracks[0].uri shouldBe "http://s/a/f1?sig=1"
+        result.tracks[0].mimeType shouldBe "audio/mpeg"
+        result.tracks[0].artworkUri shouldBe "http://s/cover?sig=3"
+        result.tracks[0].title shouldBe "Book"
+        result.droppedUncastable shouldBe 0
+    }
+
+    test("drops un-castable files and counts them") {
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f1", absoluteUrl = "http://s/a/f1", format = "mp3"),
+            CastPreparedFile(fileId = "f2", absoluteUrl = "http://s/a/f2", format = "wma"),
+        )
+        val result = factory.build(current, prepared, coverUrlAbsolute = null)
+        result.tracks shouldHaveSize 1
+        result.tracks[0].fileId shouldBe "f1"
+        result.droppedUncastable shouldBe 1
+    }
+
+    test("preserves the order of the currently-loaded items") {
+        val prepared = listOf(
+            CastPreparedFile(fileId = "f2", absoluteUrl = "u2", format = "mp3"),
+            CastPreparedFile(fileId = "f1", absoluteUrl = "u1", format = "mp3"),
+        )
+        val result = factory.build(current, prepared, coverUrlAbsolute = null)
+        result.tracks.map { it.fileId } shouldBe listOf("f1", "f2")
+    }
+})

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypesTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypesTest.kt
@@ -3,24 +3,25 @@ package com.calypsan.listenup.client.playback.cast
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class CastMimeTypesTest : FunSpec({
-    test("maps mp4-family formats to audio/mp4") {
-        listOf("m4b", "m4a", "mp4", "m4p").forEach { castMimeType(it) shouldBe "audio/mp4" }
-    }
-    test("maps raw aac to audio/aac") { castMimeType("aac") shouldBe "audio/aac" }
-    test("maps mp3 to audio/mpeg") { castMimeType("mp3") shouldBe "audio/mpeg" }
-    test("maps flac/wav/ogg/opus/webm") {
-        castMimeType("flac") shouldBe "audio/flac"
-        castMimeType("wav") shouldBe "audio/wav"
-        castMimeType("wave") shouldBe "audio/wav"
-        castMimeType("ogg") shouldBe "audio/ogg"
-        castMimeType("oga") shouldBe "audio/ogg"
-        castMimeType("opus") shouldBe "audio/ogg"
-        castMimeType("webm") shouldBe "audio/webm"
-    }
-    test("is case-insensitive") { castMimeType("MP3") shouldBe "audio/mpeg" }
-    test("returns null for Cast-incompatible formats") {
-        castMimeType("wma") shouldBe null
-        castMimeType("aiff") shouldBe null
-    }
-})
+class CastMimeTypesTest :
+    FunSpec({
+        test("maps mp4-family formats to audio/mp4") {
+            listOf("m4b", "m4a", "mp4", "m4p").forEach { castMimeType(it) shouldBe "audio/mp4" }
+        }
+        test("maps raw aac to audio/aac") { castMimeType("aac") shouldBe "audio/aac" }
+        test("maps mp3 to audio/mpeg") { castMimeType("mp3") shouldBe "audio/mpeg" }
+        test("maps flac/wav/ogg/opus/webm") {
+            castMimeType("flac") shouldBe "audio/flac"
+            castMimeType("wav") shouldBe "audio/wav"
+            castMimeType("wave") shouldBe "audio/wav"
+            castMimeType("ogg") shouldBe "audio/ogg"
+            castMimeType("oga") shouldBe "audio/ogg"
+            castMimeType("opus") shouldBe "audio/ogg"
+            castMimeType("webm") shouldBe "audio/webm"
+        }
+        test("is case-insensitive") { castMimeType("MP3") shouldBe "audio/mpeg" }
+        test("returns null for Cast-incompatible formats") {
+            castMimeType("wma") shouldBe null
+            castMimeType("aiff") shouldBe null
+        }
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypesTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypesTest.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.client.playback.cast
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CastMimeTypesTest : FunSpec({
+    test("maps mp4-family formats to audio/mp4") {
+        listOf("m4b", "m4a", "mp4", "aac").forEach { castMimeType(it) shouldBe "audio/mp4" }
+    }
+    test("maps mp3 to audio/mpeg") { castMimeType("mp3") shouldBe "audio/mpeg" }
+    test("maps flac/wav/ogg/opus/webm") {
+        castMimeType("flac") shouldBe "audio/flac"
+        castMimeType("wav") shouldBe "audio/wav"
+        castMimeType("ogg") shouldBe "audio/ogg"
+        castMimeType("opus") shouldBe "audio/ogg"
+        castMimeType("webm") shouldBe "audio/webm"
+    }
+    test("is case-insensitive") { castMimeType("MP3") shouldBe "audio/mpeg" }
+    test("returns null for Cast-incompatible formats") {
+        castMimeType("wma") shouldBe null
+        castMimeType("aiff") shouldBe null
+    }
+})

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypesTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypesTest.kt
@@ -5,13 +5,16 @@ import io.kotest.matchers.shouldBe
 
 class CastMimeTypesTest : FunSpec({
     test("maps mp4-family formats to audio/mp4") {
-        listOf("m4b", "m4a", "mp4", "aac").forEach { castMimeType(it) shouldBe "audio/mp4" }
+        listOf("m4b", "m4a", "mp4", "m4p").forEach { castMimeType(it) shouldBe "audio/mp4" }
     }
+    test("maps raw aac to audio/aac") { castMimeType("aac") shouldBe "audio/aac" }
     test("maps mp3 to audio/mpeg") { castMimeType("mp3") shouldBe "audio/mpeg" }
     test("maps flac/wav/ogg/opus/webm") {
         castMimeType("flac") shouldBe "audio/flac"
         castMimeType("wav") shouldBe "audio/wav"
+        castMimeType("wave") shouldBe "audio/wav"
         castMimeType("ogg") shouldBe "audio/ogg"
+        castMimeType("oga") shouldBe "audio/ogg"
         castMimeType("opus") shouldBe "audio/ogg"
         castMimeType("webm") shouldBe "audio/webm"
     }

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparerTest.kt
@@ -1,0 +1,123 @@
+package com.calypsan.listenup.client.playback.cast
+
+import com.calypsan.listenup.api.PlaybackService
+import com.calypsan.listenup.api.dto.PreparedAudioFile
+import com.calypsan.listenup.api.dto.PreparedPlayback
+import com.calypsan.listenup.api.error.InternalError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ServerUrl
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+class CastPreparerTest : FunSpec({
+
+    val bookId = BookId("book-1")
+    val serverUrl = "http://s"
+
+    fun twoFilePreparedPlayback(coverUrl: String?) =
+        PreparedPlayback(
+            bookId = bookId.value,
+            audioFiles =
+                listOf(
+                    PreparedAudioFile(
+                        fileId = "f1",
+                        index = 0,
+                        url = "/api/v1/audio/b/f1?sig=1",
+                        format = "mp3",
+                        durationMs = 1_000L,
+                        sizeBytes = 1_000L,
+                    ),
+                    PreparedAudioFile(
+                        fileId = "f2",
+                        index = 1,
+                        url = "/api/v1/audio/b/f2?sig=2",
+                        format = "m4b",
+                        durationMs = 2_000L,
+                        sizeBytes = 2_000L,
+                    ),
+                ),
+            resumePosition = null,
+            coverUrl = coverUrl,
+        )
+
+    test("success — maps files to absolute URLs and prefixes cover URL") {
+        runTest {
+            val service = mock<PlaybackService>()
+            val factory = mock<PlaybackRpcFactory>()
+            val serverConfig = mock<ServerConfig>()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
+            everySuspend { factory.playbackService() } returns service
+            everySuspend { service.prepare(any()) } returns
+                AppResult.Success(twoFilePreparedPlayback("/api/v1/cover-cast/b?sig=c"))
+
+            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+
+            result.shouldNotBeNull()
+            result.files.size shouldBe 2
+            result.files[0].fileId shouldBe "f1"
+            result.files[0].absoluteUrl shouldBe "http://s/api/v1/audio/b/f1?sig=1"
+            result.files[0].format shouldBe "mp3"
+            result.files[1].fileId shouldBe "f2"
+            result.files[1].absoluteUrl shouldBe "http://s/api/v1/audio/b/f2?sig=2"
+            result.files[1].format shouldBe "m4b"
+            result.coverUrlAbsolute shouldBe "http://s/api/v1/cover-cast/b?sig=c"
+        }
+    }
+
+    test("null coverUrl in PreparedPlayback yields null coverUrlAbsolute, files still mapped") {
+        runTest {
+            val service = mock<PlaybackService>()
+            val factory = mock<PlaybackRpcFactory>()
+            val serverConfig = mock<ServerConfig>()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
+            everySuspend { factory.playbackService() } returns service
+            everySuspend { service.prepare(any()) } returns AppResult.Success(twoFilePreparedPlayback(null))
+
+            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+
+            result.shouldNotBeNull()
+            result.files.size shouldBe 2
+            result.coverUrlAbsolute.shouldBeNull()
+        }
+    }
+
+    test("no server URL — returns null without calling the RPC") {
+        runTest {
+            val factory = mock<PlaybackRpcFactory>()
+            val serverConfig = mock<ServerConfig>()
+            everySuspend { serverConfig.getServerUrl() } returns null
+
+            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+
+            result.shouldBeNull()
+            verifySuspend(exactly(0)) { factory.playbackService() }
+        }
+    }
+
+    test("RPC failure — returns null") {
+        runTest {
+            val service = mock<PlaybackService>()
+            val factory = mock<PlaybackRpcFactory>()
+            val serverConfig = mock<ServerConfig>()
+            everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
+            everySuspend { factory.playbackService() } returns service
+            everySuspend { service.prepare(any()) } returns AppResult.Failure(InternalError())
+
+            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+
+            result.shouldBeNull()
+        }
+    }
+})

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparerTest.kt
@@ -21,103 +21,104 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 
-class CastPreparerTest : FunSpec({
+class CastPreparerTest :
+    FunSpec({
 
-    val bookId = BookId("book-1")
-    val serverUrl = "http://s"
+        val bookId = BookId("book-1")
+        val serverUrl = "http://s"
 
-    fun twoFilePreparedPlayback(coverUrl: String?) =
-        PreparedPlayback(
-            bookId = bookId.value,
-            audioFiles =
-                listOf(
-                    PreparedAudioFile(
-                        fileId = "f1",
-                        index = 0,
-                        url = "/api/v1/audio/b/f1?sig=1",
-                        format = "mp3",
-                        durationMs = 1_000L,
-                        sizeBytes = 1_000L,
+        fun twoFilePreparedPlayback(coverUrl: String?) =
+            PreparedPlayback(
+                bookId = bookId.value,
+                audioFiles =
+                    listOf(
+                        PreparedAudioFile(
+                            fileId = "f1",
+                            index = 0,
+                            url = "/api/v1/audio/b/f1?sig=1",
+                            format = "mp3",
+                            durationMs = 1_000L,
+                            sizeBytes = 1_000L,
+                        ),
+                        PreparedAudioFile(
+                            fileId = "f2",
+                            index = 1,
+                            url = "/api/v1/audio/b/f2?sig=2",
+                            format = "m4b",
+                            durationMs = 2_000L,
+                            sizeBytes = 2_000L,
+                        ),
                     ),
-                    PreparedAudioFile(
-                        fileId = "f2",
-                        index = 1,
-                        url = "/api/v1/audio/b/f2?sig=2",
-                        format = "m4b",
-                        durationMs = 2_000L,
-                        sizeBytes = 2_000L,
-                    ),
-                ),
-            resumePosition = null,
-            coverUrl = coverUrl,
-        )
+                resumePosition = null,
+                coverUrl = coverUrl,
+            )
 
-    test("success — maps files to absolute URLs and prefixes cover URL") {
-        runTest {
-            val service = mock<PlaybackService>()
-            val factory = mock<PlaybackRpcFactory>()
-            val serverConfig = mock<ServerConfig>()
-            everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
-            everySuspend { factory.playbackService() } returns service
-            everySuspend { service.prepare(any()) } returns
-                AppResult.Success(twoFilePreparedPlayback("/api/v1/cover-cast/b?sig=c"))
+        test("success — maps files to absolute URLs and prefixes cover URL") {
+            runTest {
+                val service = mock<PlaybackService>()
+                val factory = mock<PlaybackRpcFactory>()
+                val serverConfig = mock<ServerConfig>()
+                everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
+                everySuspend { factory.playbackService() } returns service
+                everySuspend { service.prepare(any()) } returns
+                    AppResult.Success(twoFilePreparedPlayback("/api/v1/cover-cast/b?sig=c"))
 
-            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+                val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
 
-            result.shouldNotBeNull()
-            result.files.size shouldBe 2
-            result.files[0].fileId shouldBe "f1"
-            result.files[0].absoluteUrl shouldBe "http://s/api/v1/audio/b/f1?sig=1"
-            result.files[0].format shouldBe "mp3"
-            result.files[1].fileId shouldBe "f2"
-            result.files[1].absoluteUrl shouldBe "http://s/api/v1/audio/b/f2?sig=2"
-            result.files[1].format shouldBe "m4b"
-            result.coverUrlAbsolute shouldBe "http://s/api/v1/cover-cast/b?sig=c"
+                result.shouldNotBeNull()
+                result.files.size shouldBe 2
+                result.files[0].fileId shouldBe "f1"
+                result.files[0].absoluteUrl shouldBe "http://s/api/v1/audio/b/f1?sig=1"
+                result.files[0].format shouldBe "mp3"
+                result.files[1].fileId shouldBe "f2"
+                result.files[1].absoluteUrl shouldBe "http://s/api/v1/audio/b/f2?sig=2"
+                result.files[1].format shouldBe "m4b"
+                result.coverUrlAbsolute shouldBe "http://s/api/v1/cover-cast/b?sig=c"
+            }
         }
-    }
 
-    test("null coverUrl in PreparedPlayback yields null coverUrlAbsolute, files still mapped") {
-        runTest {
-            val service = mock<PlaybackService>()
-            val factory = mock<PlaybackRpcFactory>()
-            val serverConfig = mock<ServerConfig>()
-            everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
-            everySuspend { factory.playbackService() } returns service
-            everySuspend { service.prepare(any()) } returns AppResult.Success(twoFilePreparedPlayback(null))
+        test("null coverUrl in PreparedPlayback yields null coverUrlAbsolute, files still mapped") {
+            runTest {
+                val service = mock<PlaybackService>()
+                val factory = mock<PlaybackRpcFactory>()
+                val serverConfig = mock<ServerConfig>()
+                everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
+                everySuspend { factory.playbackService() } returns service
+                everySuspend { service.prepare(any()) } returns AppResult.Success(twoFilePreparedPlayback(null))
 
-            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+                val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
 
-            result.shouldNotBeNull()
-            result.files.size shouldBe 2
-            result.coverUrlAbsolute.shouldBeNull()
+                result.shouldNotBeNull()
+                result.files.size shouldBe 2
+                result.coverUrlAbsolute.shouldBeNull()
+            }
         }
-    }
 
-    test("no server URL — returns null without calling the RPC") {
-        runTest {
-            val factory = mock<PlaybackRpcFactory>()
-            val serverConfig = mock<ServerConfig>()
-            everySuspend { serverConfig.getServerUrl() } returns null
+        test("no server URL — returns null without calling the RPC") {
+            runTest {
+                val factory = mock<PlaybackRpcFactory>()
+                val serverConfig = mock<ServerConfig>()
+                everySuspend { serverConfig.getServerUrl() } returns null
 
-            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+                val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
 
-            result.shouldBeNull()
-            verifySuspend(exactly(0)) { factory.playbackService() }
+                result.shouldBeNull()
+                verifySuspend(exactly(0)) { factory.playbackService() }
+            }
         }
-    }
 
-    test("RPC failure — returns null") {
-        runTest {
-            val service = mock<PlaybackService>()
-            val factory = mock<PlaybackRpcFactory>()
-            val serverConfig = mock<ServerConfig>()
-            everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
-            everySuspend { factory.playbackService() } returns service
-            everySuspend { service.prepare(any()) } returns AppResult.Failure(InternalError())
+        test("RPC failure — returns null") {
+            runTest {
+                val service = mock<PlaybackService>()
+                val factory = mock<PlaybackRpcFactory>()
+                val serverConfig = mock<ServerConfig>()
+                everySuspend { serverConfig.getServerUrl() } returns ServerUrl(serverUrl)
+                everySuspend { factory.playbackService() } returns service
+                everySuspend { service.prepare(any()) } returns AppResult.Failure(InternalError())
 
-            val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
+                val result = CastPreparer(factory, serverConfig).prepareForCast(bookId)
 
-            result.shouldBeNull()
+                result.shouldBeNull()
+            }
         }
-    }
-})
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayerTest.kt
@@ -2,6 +2,8 @@ package com.calypsan.listenup.client.playback.cast
 
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -24,5 +26,26 @@ class SpeedAwareCastPlayerTest : FunSpec({
         player.setPlaybackSpeed(2.0f)
         lastRate shouldBe 2.0
         player.playbackParameters.speed shouldBe 2.0f
+    }
+
+    // Note: getAvailableCommands() can't be unit-tested in this source set — it builds a
+    // Player.Commands via buildUpon(), whose FlagSet touches android.util.SparseBooleanArray,
+    // which is "not mocked" here (androidHostTest runs without Robolectric). isCommandAvailable
+    // is the primary query path the UI uses, and it IS covered below.
+    test("advertises COMMAND_SET_SPEED_AND_PITCH so the UI speed control stays enabled") {
+        val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { })
+        player.isCommandAvailable(Player.COMMAND_SET_SPEED_AND_PITCH) shouldBe true
+    }
+
+    test("isCommandAvailable still delegates for non-speed commands") {
+        val delegate = mock<Player>()
+        every { delegate.isCommandAvailable(Player.COMMAND_PLAY_PAUSE) } returns true
+        val player = SpeedAwareCastPlayer(delegate, CastRateSetter { })
+        player.isCommandAvailable(Player.COMMAND_PLAY_PAUSE) shouldBe true
+    }
+
+    test("reports DEFAULT (1.0x) before any speed is set") {
+        val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { })
+        player.playbackParameters shouldBe PlaybackParameters.DEFAULT
     }
 })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayerTest.kt
@@ -8,44 +8,45 @@ import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class SpeedAwareCastPlayerTest : FunSpec({
-    test("setPlaybackParameters routes the speed to the rate setter and reports it back") {
-        var lastRate = -1.0
-        val rateSetter = CastRateSetter { rate -> lastRate = rate }
-        val player = SpeedAwareCastPlayer(mock<Player>(), rateSetter)
+class SpeedAwareCastPlayerTest :
+    FunSpec({
+        test("setPlaybackParameters routes the speed to the rate setter and reports it back") {
+            var lastRate = -1.0
+            val rateSetter = CastRateSetter { rate -> lastRate = rate }
+            val player = SpeedAwareCastPlayer(mock<Player>(), rateSetter)
 
-        player.setPlaybackParameters(PlaybackParameters(1.5f))
+            player.setPlaybackParameters(PlaybackParameters(1.5f))
 
-        lastRate shouldBe 1.5
-        player.playbackParameters.speed shouldBe 1.5f
-    }
+            lastRate shouldBe 1.5
+            player.playbackParameters.speed shouldBe 1.5f
+        }
 
-    test("setPlaybackSpeed also routes through the rate setter") {
-        var lastRate = -1.0
-        val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { lastRate = it })
-        player.setPlaybackSpeed(2.0f)
-        lastRate shouldBe 2.0
-        player.playbackParameters.speed shouldBe 2.0f
-    }
+        test("setPlaybackSpeed also routes through the rate setter") {
+            var lastRate = -1.0
+            val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { lastRate = it })
+            player.setPlaybackSpeed(2.0f)
+            lastRate shouldBe 2.0
+            player.playbackParameters.speed shouldBe 2.0f
+        }
 
-    // Note: getAvailableCommands() can't be unit-tested in this source set — it builds a
-    // Player.Commands via buildUpon(), whose FlagSet touches android.util.SparseBooleanArray,
-    // which is "not mocked" here (androidHostTest runs without Robolectric). isCommandAvailable
-    // is the primary query path the UI uses, and it IS covered below.
-    test("advertises COMMAND_SET_SPEED_AND_PITCH so the UI speed control stays enabled") {
-        val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { })
-        player.isCommandAvailable(Player.COMMAND_SET_SPEED_AND_PITCH) shouldBe true
-    }
+        // Note: getAvailableCommands() can't be unit-tested in this source set — it builds a
+        // Player.Commands via buildUpon(), whose FlagSet touches android.util.SparseBooleanArray,
+        // which is "not mocked" here (androidHostTest runs without Robolectric). isCommandAvailable
+        // is the primary query path the UI uses, and it IS covered below.
+        test("advertises COMMAND_SET_SPEED_AND_PITCH so the UI speed control stays enabled") {
+            val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { })
+            player.isCommandAvailable(Player.COMMAND_SET_SPEED_AND_PITCH) shouldBe true
+        }
 
-    test("isCommandAvailable still delegates for non-speed commands") {
-        val delegate = mock<Player>()
-        every { delegate.isCommandAvailable(Player.COMMAND_PLAY_PAUSE) } returns true
-        val player = SpeedAwareCastPlayer(delegate, CastRateSetter { })
-        player.isCommandAvailable(Player.COMMAND_PLAY_PAUSE) shouldBe true
-    }
+        test("isCommandAvailable still delegates for non-speed commands") {
+            val delegate = mock<Player>()
+            every { delegate.isCommandAvailable(Player.COMMAND_PLAY_PAUSE) } returns true
+            val player = SpeedAwareCastPlayer(delegate, CastRateSetter { })
+            player.isCommandAvailable(Player.COMMAND_PLAY_PAUSE) shouldBe true
+        }
 
-    test("reports DEFAULT (1.0x) before any speed is set") {
-        val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { })
-        player.playbackParameters shouldBe PlaybackParameters.DEFAULT
-    }
-})
+        test("reports DEFAULT (1.0x) before any speed is set") {
+            val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { })
+            player.playbackParameters shouldBe PlaybackParameters.DEFAULT
+        }
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayerTest.kt
@@ -1,0 +1,28 @@
+package com.calypsan.listenup.client.playback.cast
+
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpeedAwareCastPlayerTest : FunSpec({
+    test("setPlaybackParameters routes the speed to the rate setter and reports it back") {
+        var lastRate = -1.0
+        val rateSetter = CastRateSetter { rate -> lastRate = rate }
+        val player = SpeedAwareCastPlayer(mock<Player>(), rateSetter)
+
+        player.setPlaybackParameters(PlaybackParameters(1.5f))
+
+        lastRate shouldBe 1.5
+        player.playbackParameters.speed shouldBe 1.5f
+    }
+
+    test("setPlaybackSpeed also routes through the rate setter") {
+        var lastRate = -1.0
+        val player = SpeedAwareCastPlayer(mock<Player>(), CastRateSetter { lastRate = it })
+        player.setPlaybackSpeed(2.0f)
+        lastRate shouldBe 2.0
+        player.playbackParameters.speed shouldBe 2.0f
+    }
+})

--- a/sharedUI/src/androidMain/AndroidManifest.xml
+++ b/sharedUI/src/androidMain/AndroidManifest.xml
@@ -98,6 +98,11 @@
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />
 
+        <!-- Google Cast: Default Media Receiver options provider -->
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="com.calypsan.listenup.client.playback.cast.CastOptionsProvider" />
+
         <!-- Disable default WorkManager initialization so we can use custom factory -->
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -41,6 +41,7 @@ import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.PlaybackStateWriter
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.playback.SleepTimerManager
+import com.calypsan.listenup.client.playback.cast.CastPreparer
 import com.calypsan.listenup.client.sync.AndroidBackgroundSyncScheduler
 import com.calypsan.listenup.client.sync.BackgroundSyncScheduler
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -238,6 +239,9 @@ val playbackModule =
                 holder = get<MediaControllerHolder>().asControllerHolder(),
             )
         }
+
+        // Cast preparer — re-fetches signed network URLs when handing off to a Chromecast.
+        single { CastPreparer(playbackRpcFactory = get(), serverConfig = get()) }
     }
 
 /**

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.android.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.android.kt
@@ -1,18 +1,32 @@
 package com.calypsan.listenup.client.features.nowplaying.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.mediarouter.app.MediaRouteButton
 import com.google.android.gms.cast.framework.CastButtonFactory
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 
 @Composable
 actual fun CastButton(modifier: Modifier) {
+    val context = LocalContext.current
+    // Mirror CastSessionController.createOrNull's guard: on a de-Googled device (no Play Services)
+    // CastButtonFactory can reach into CastContext and throw. No Play Services → no cast button,
+    // local playback unaffected (never stranded).
+    val available =
+        remember(context) {
+            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) ==
+                ConnectionResult.SUCCESS
+        }
+    if (!available) return
     AndroidView(
         modifier = modifier,
-        factory = { context ->
-            MediaRouteButton(context).also { button ->
-                CastButtonFactory.setUpMediaRouteButton(context.applicationContext, button)
+        factory = { ctx ->
+            MediaRouteButton(ctx).also { button ->
+                CastButtonFactory.setUpMediaRouteButton(ctx.applicationContext, button)
             }
         },
     )

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.android.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.android.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.client.features.nowplaying.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.mediarouter.app.MediaRouteButton
+import com.google.android.gms.cast.framework.CastButtonFactory
+
+@Composable
+actual fun CastButton(modifier: Modifier) {
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            MediaRouteButton(context).also { button ->
+                CastButtonFactory.setUpMediaRouteButton(context.applicationContext, button)
+            }
+        },
+    )
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.os.Bundle
 import android.provider.MediaStore
+import android.widget.Toast
 import androidx.annotation.OptIn
 import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.media3.common.AudioAttributes
@@ -89,6 +90,12 @@ class PlaybackService : MediaLibraryService() {
     private var notificationProvider: AudiobookNotificationProvider? = null
     private var castSessionController: CastSessionController? = null
 
+    // True while the session player is the cast player. Main-thread only (set in the
+    // cast handoffs, read by the idle-timer guard). The PlayerListener is attached only
+    // to the local ExoPlayer, so cast play/pause never reaches it — this flag is how the
+    // idle timer learns to stand down while casting (see startIdleTimer).
+    private var casting = false
+
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var idleJob: Job? = null
     private var positionUpdateJob: Job? = null
@@ -117,6 +124,9 @@ class PlaybackService : MediaLibraryService() {
      * ExoPlayer tracks position within the current file, but we need position
      * relative to the entire book for progress tracking. The PlaybackTimeline
      * handles this translation.
+     *
+     * Reads the active session player — the local ExoPlayer normally, the cast
+     * player while casting — so position recording follows wherever audio is playing.
      *
      * @return Book-relative position in milliseconds, or 0 if unavailable
      */
@@ -279,6 +289,14 @@ class PlaybackService : MediaLibraryService() {
         val prepared = castPreparer.prepareForCast(bookId)
         if (prepared == null) {
             logger.warn { "Cast prepare failed — staying local" }
+            // Honest-over-silent: the user tapped cast and nothing audible happened.
+            Toast.makeText(this, "Couldn't start casting.", Toast.LENGTH_LONG).show()
+            return
+        }
+        // Connect→disconnect race: the session can drop while prepareForCast suspends. Re-check
+        // before committing so we never swap onto a dead cast session with no path back.
+        if (!controller.isSessionAvailable) {
+            logger.warn { "Cast session gone during prepare — staying local" }
             return
         }
         // Snapshot the currently-loaded items for queue order + on-TV metadata.
@@ -301,8 +319,10 @@ class PlaybackService : MediaLibraryService() {
                 "Cannot cast this book (uncastable=${built.droppedUncastable}, " +
                     "unmatched=${built.droppedUnmatched}) — staying local"
             }
-            // TODO(cast): surface a user-facing "can't cast this format" message — needs an AppError subtype.
-            // Staying local is itself the never-stranded fallback.
+            // Honest-over-silent: tell the user why casting didn't start. Staying local is the
+            // never-stranded fallback. (A typed AppError + snackbar is a tracked follow-up; a
+            // Toast is the v1 honest-over-silent signal.)
+            Toast.makeText(this, "This book's format can't be cast.", Toast.LENGTH_LONG).show()
             return
         }
         val mediaItems = built.tracks.map { factory.toMediaItem(it) }
@@ -311,6 +331,14 @@ class PlaybackService : MediaLibraryService() {
         val index = local.currentMediaItemIndex
         val positionInItem = local.currentPosition
 
+        // Commit to the swap. Set `casting` BEFORE pausing local, because pausing fires the
+        // local PlayerListener's onIsPlayingChanged(false) → startIdleTimer, which must stand
+        // down while casting (the cast player has no listener to ever cancel it). While casting
+        // the local player is paused, so periodic progress saves + listening-event recording
+        // pause too; the position is still persisted on disconnect via the cast-aware
+        // getBookRelativePosition(). (Tracked follow-up: drive the position job off
+        // session.player so cast time counts toward stats.)
+        casting = true
         val cast = controller.castPlayer
         cast.setMediaItems(mediaItems, index, positionInItem)
         cast.playWhenReady = wasPlaying
@@ -318,6 +346,7 @@ class PlaybackService : MediaLibraryService() {
         cast.setPlaybackSpeed(speed) // routes via SpeedAwareCastPlayer → RemoteMediaClient.setPlaybackRate
         session.player = cast
         local.playWhenReady = false // release local audio focus; keep its items loaded for fast return
+        cancelIdleTimer() // belt-and-suspenders: the `casting` guard already blocks new timers
         logger.info { "Swapped to Cast at index=$index pos=$positionInItem" }
     }
 
@@ -332,9 +361,13 @@ class PlaybackService : MediaLibraryService() {
         val index = cast.currentMediaItemIndex
         val positionInItem = cast.currentPosition
         val wasPlaying = cast.playWhenReady
+        // Known v1 limitation: the retained local player still holds the book that was loaded
+        // at hand-off. If the user changed books on the cast device mid-session, swapping back
+        // could seek the wrong book. (Tracked follow-up.)
         local.seekTo(index, positionInItem)
         local.playWhenReady = wasPlaying
         session.player = local
+        casting = false // normal idle logic resumes now that the local player drives the session
         logger.info { "Swapped back to local at index=$index pos=$positionInItem" }
         saveCurrentPosition() // existing method — persists through the normal recorder
     }
@@ -506,6 +539,13 @@ class PlaybackService : MediaLibraryService() {
         timeout: kotlin.time.Duration,
         reason: String,
     ) {
+        // Never idle-out while casting: the cast player lives inside THIS service's session,
+        // and its play/pause events never reach the local PlayerListener that would cancel the
+        // timer — so a timer started here (e.g. by the pause that hand-off triggers on the local
+        // player) would tear the cast session down after the timeout. The flag check is the
+        // robust guard because onIsPlayingChanged is posted asynchronously and could fire after
+        // a bare cancel. Covers every startIdleTimer path (pause, idle, book-finished, error).
+        if (casting) return
         idleJob?.cancel()
         idleJob =
             serviceScope.launch {
@@ -1223,8 +1263,12 @@ class PlaybackService : MediaLibraryService() {
             customCommand: SessionCommand,
             args: Bundle,
         ): ListenableFuture<SessionResult> {
+            // Route transport controls to the ACTIVE session player — the cast player while
+            // casting — so skip/chapter/speed reach the receiver, not the paused local player.
+            // Queue order is identical on both (the index-shift guard in handoffToCast ensures
+            // a 1:1 map), so the timeline's book-relative → index/offset math holds unchanged.
             val p =
-                player ?: return Futures.immediateFuture(
+                mediaLibrarySession?.player ?: player ?: return Futures.immediateFuture(
                     SessionResult(SessionResult.RESULT_ERROR_UNKNOWN),
                 )
             val chapters = playbackManager.chapters.value

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -30,6 +30,10 @@ import com.calypsan.listenup.client.composeapp.R
 import com.calypsan.listenup.client.automotive.BrowseTree
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.automotive.CustomActions
+import com.calypsan.listenup.client.playback.cast.CastMediaItemFactory
+import com.calypsan.listenup.client.playback.cast.CastPreparer
+import com.calypsan.listenup.client.playback.cast.CastSessionController
+import com.calypsan.listenup.client.playback.cast.CastSourceItem
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.error.ErrorBus
@@ -83,6 +87,7 @@ class PlaybackService : MediaLibraryService() {
     private var mediaLibrarySession: MediaLibraryService.MediaLibrarySession? = null
     private var player: ExoPlayer? = null
     private var notificationProvider: AudiobookNotificationProvider? = null
+    private var castSessionController: CastSessionController? = null
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var idleJob: Job? = null
@@ -100,6 +105,7 @@ class PlaybackService : MediaLibraryService() {
     private val browseTreeProvider: BrowseTreeProvider by inject()
     private val voiceIntentResolver: VoiceIntentResolver by inject()
     private val homeRepository: HomeRepository by inject()
+    private val castPreparer: CastPreparer by inject()
 
     // Current book ID is read from PlaybackManager (single source of truth)
     private val currentBookId: BookId?
@@ -115,7 +121,7 @@ class PlaybackService : MediaLibraryService() {
      * @return Book-relative position in milliseconds, or 0 if unavailable
      */
     private fun getBookRelativePosition(): Long {
-        val player = player ?: return 0L
+        val player = mediaLibrarySession?.player ?: player ?: return 0L
         val timeline = playbackManager.currentTimeline.value ?: return player.currentPosition
         return timeline.toBookPosition(player.currentMediaItemIndex, player.currentPosition)
     }
@@ -139,6 +145,7 @@ class PlaybackService : MediaLibraryService() {
 
         initializePlayer()
         initializeMediaSession()
+        initializeCast()
         initializeNotificationProvider()
 
         // Register callback for chapter changes to update notification
@@ -246,6 +253,90 @@ class PlaybackService : MediaLibraryService() {
         val provider = notificationProvider ?: return
         setMediaNotificationProvider(provider)
         logger.info { "Notification provider initialized" }
+    }
+
+    /**
+     * Initialize Cast if Google Play Services is present. On a de-Googled device
+     * this is a no-op — no cast button, local playback unaffected (never stranded).
+     */
+    private fun initializeCast() {
+        castSessionController =
+            CastSessionController.createOrNull(
+                context = this,
+                onConnected = { serviceScope.launch { handoffToCast() } },
+                onDisconnected = { serviceScope.launch { handoffToLocal() } },
+            )
+        if (castSessionController != null) logger.info { "Cast initialized" }
+    }
+
+    /** Local → Cast: re-fetch network URLs, build the cast queue at the current position, swap the session player. */
+    private suspend fun handoffToCast() {
+        val controller = castSessionController ?: return
+        val session = mediaLibrarySession ?: return
+        val local = player ?: return
+        val bookId = playbackManager.currentBookId.value ?: return
+
+        val prepared = castPreparer.prepareForCast(bookId)
+        if (prepared == null) {
+            logger.warn { "Cast prepare failed — staying local" }
+            return
+        }
+        // Snapshot the currently-loaded items for queue order + on-TV metadata.
+        val sourceItems =
+            (0 until local.mediaItemCount).map { i ->
+                val mi = local.getMediaItemAt(i)
+                CastSourceItem(
+                    fileId = mi.mediaId,
+                    title = mi.mediaMetadata.title?.toString(),
+                    artist = mi.mediaMetadata.artist?.toString(),
+                    albumTitle = mi.mediaMetadata.albumTitle?.toString(),
+                )
+            }
+        val factory = CastMediaItemFactory()
+        val built = factory.build(sourceItems, prepared.files, prepared.coverUrlAbsolute)
+        // Index-shift safety: only cast a complete, in-order queue. A dropped file would
+        // shift indices and resume on the wrong file — fall back to local instead.
+        if (built.tracks.size != sourceItems.size) {
+            logger.warn {
+                "Cannot cast this book (uncastable=${built.droppedUncastable}, " +
+                    "unmatched=${built.droppedUnmatched}) — staying local"
+            }
+            // TODO(cast): surface a user-facing "can't cast this format" message — needs an AppError subtype.
+            // Staying local is itself the never-stranded fallback.
+            return
+        }
+        val mediaItems = built.tracks.map { factory.toMediaItem(it) }
+        val wasPlaying = local.playWhenReady
+        val speed = local.playbackParameters.speed
+        val index = local.currentMediaItemIndex
+        val positionInItem = local.currentPosition
+
+        val cast = controller.castPlayer
+        cast.setMediaItems(mediaItems, index, positionInItem)
+        cast.playWhenReady = wasPlaying
+        cast.prepare()
+        cast.setPlaybackSpeed(speed) // routes via SpeedAwareCastPlayer → RemoteMediaClient.setPlaybackRate
+        session.player = cast
+        local.playWhenReady = false // release local audio focus; keep its items loaded for fast return
+        logger.info { "Swapped to Cast at index=$index pos=$positionInItem" }
+    }
+
+    /** Cast → Local: read cast position, seek the retained ExoPlayer there, swap back, persist progress. */
+    private fun handoffToLocal() {
+        val controller = castSessionController ?: return
+        val session = mediaLibrarySession ?: return
+        val local = player ?: return
+        // If the session isn't currently on the cast player, nothing to do (we never swapped).
+        if (session.player === local) return
+        val cast = controller.castPlayer
+        val index = cast.currentMediaItemIndex
+        val positionInItem = cast.currentPosition
+        val wasPlaying = cast.playWhenReady
+        local.seekTo(index, positionInItem)
+        local.playWhenReady = wasPlaying
+        session.player = local
+        logger.info { "Swapped back to local at index=$index pos=$positionInItem" }
+        saveCurrentPosition() // existing method — persists through the normal recorder
     }
 
     /**
@@ -368,6 +459,8 @@ class PlaybackService : MediaLibraryService() {
         // when mediaLibrarySession was never built or was already null.
         mediaLibrarySession?.release()
         mediaLibrarySession = null
+        castSessionController?.release()
+        castSessionController = null
         player?.release()
         player = null
         notificationProvider = null

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -361,11 +361,16 @@ class PlaybackService : MediaLibraryService() {
         val index = cast.currentMediaItemIndex
         val positionInItem = cast.currentPosition
         val wasPlaying = cast.playWhenReady
+        // SpeedAwareCastPlayer mirrors the live receiver rate, so a speed change made while casting
+        // is carried back to the local player — otherwise saveCurrentPosition() below persists a
+        // stale speed.
+        val speed = cast.playbackParameters.speed
         // Known v1 limitation: the retained local player still holds the book that was loaded
         // at hand-off. If the user changed books on the cast device mid-session, swapping back
         // could seek the wrong book. (Tracked follow-up.)
         local.seekTo(index, positionInItem)
         local.playWhenReady = wasPlaying
+        local.setPlaybackSpeed(speed)
         session.player = local
         casting = false // normal idle logic resumes now that the local player drives the session
         logger.info { "Swapped back to local at index=$index pos=$positionInItem" }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactory.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactory.kt
@@ -1,0 +1,92 @@
+package com.calypsan.listenup.client.playback.cast
+
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+
+/** Title/artist/album of a currently-loaded queue item, keyed by [fileId] (= MediaItem.mediaId). */
+data class CastSourceItem(
+    val fileId: String,
+    val title: String?,
+    val artist: String?,
+    val albumTitle: String?,
+)
+
+/** A file from a fresh `/playback/prepare` call: absolute network URL + format token. */
+data class CastPreparedFile(
+    val fileId: String,
+    val absoluteUrl: String,
+    val format: String,
+)
+
+/** One resolved cast track (pure data — assembled into a Media3 [MediaItem] by [CastMediaItemFactory.toMediaItem]). */
+data class CastTrack(
+    val fileId: String,
+    val uri: String,
+    val mimeType: String,
+    val title: String?,
+    val artist: String?,
+    val albumTitle: String?,
+    val artworkUri: String?,
+)
+
+/** Result of a build: the castable tracks in queue order, plus how many files were dropped as un-castable. */
+data class CastTracks(
+    val tracks: List<CastTrack>,
+    val droppedUncastable: Int,
+)
+
+/**
+ * Builds the Cast queue. Zips the currently-loaded items (stable order +
+ * on-TV metadata) with a fresh `/playback/prepare` result (network URLs +
+ * formats), matched by file id. Files whose format Cast can't decode are
+ * dropped and counted so the caller can warn/fallback. The on-TV artwork is the
+ * signed network [coverUrlAbsolute] — a Cast device can't read the phone's
+ * local `file://` cover.
+ */
+class CastMediaItemFactory {
+    fun build(
+        currentItems: List<CastSourceItem>,
+        prepared: List<CastPreparedFile>,
+        coverUrlAbsolute: String?,
+    ): CastTracks {
+        val preparedById = prepared.associateBy { it.fileId }
+        var dropped = 0
+        val tracks =
+            currentItems.mapNotNull { item ->
+                val file = preparedById[item.fileId] ?: return@mapNotNull null
+                val mime = castMimeType(file.format)
+                if (mime == null) {
+                    dropped++
+                    return@mapNotNull null
+                }
+                CastTrack(
+                    fileId = item.fileId,
+                    uri = file.absoluteUrl,
+                    mimeType = mime,
+                    title = item.title,
+                    artist = item.artist,
+                    albumTitle = item.albumTitle,
+                    artworkUri = coverUrlAbsolute,
+                )
+            }
+        return CastTracks(tracks, dropped)
+    }
+
+    /** Assembles a [CastTrack] into a Media3 [MediaItem] with an explicit MIME type (CastPlayer requires it). */
+    fun toMediaItem(track: CastTrack): MediaItem =
+        MediaItem.Builder()
+            .setMediaId(track.fileId)
+            .setUri(track.uri)
+            .setMimeType(track.mimeType)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(track.title)
+                    .setArtist(track.artist)
+                    .setAlbumTitle(track.albumTitle)
+                    .setArtworkUri(track.artworkUri?.let { Uri.parse(it) })
+                    .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
+                    .build(),
+            )
+            .build()
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactory.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactory.kt
@@ -30,19 +30,27 @@ data class CastTrack(
     val artworkUri: String?,
 )
 
-/** Result of a build: the castable tracks in queue order, plus how many files were dropped as un-castable. */
+/**
+ * Result of a build: the castable tracks in queue order, plus how many files were
+ * dropped and why. Both counts let the caller warn or fall back honestly instead of
+ * silently shipping a truncated queue to the TV.
+ */
 data class CastTracks(
     val tracks: List<CastTrack>,
     val droppedUncastable: Int,
+    val droppedUnmatched: Int,
 )
 
 /**
  * Builds the Cast queue. Zips the currently-loaded items (stable order +
  * on-TV metadata) with a fresh `/playback/prepare` result (network URLs +
- * formats), matched by file id. Files whose format Cast can't decode are
- * dropped and counted so the caller can warn/fallback. The on-TV artwork is the
- * signed network [coverUrlAbsolute] — a Cast device can't read the phone's
- * local `file://` cover.
+ * formats), matched by file id. The on-TV artwork is the signed network
+ * [coverUrlAbsolute] — a Cast device can't read the phone's local `file://` cover.
+ *
+ * A loaded item is dropped (never silently — every drop is counted) when either:
+ * - its format is one Cast can't decode → counted in [CastTracks.droppedUncastable];
+ * - no prepared file matches its id → counted in [CastTracks.droppedUnmatched]
+ *   (normally zero, because `/playback/prepare` should cover every loaded file).
  */
 class CastMediaItemFactory {
     fun build(
@@ -51,26 +59,35 @@ class CastMediaItemFactory {
         coverUrlAbsolute: String?,
     ): CastTracks {
         val preparedById = prepared.associateBy { it.fileId }
-        var dropped = 0
+        var droppedUncastable = 0
+        var droppedUnmatched = 0
         val tracks =
-            currentItems.mapNotNull { item ->
-                val file = preparedById[item.fileId] ?: return@mapNotNull null
-                val mime = castMimeType(file.format)
-                if (mime == null) {
-                    dropped++
-                    return@mapNotNull null
+            buildList {
+                for (item in currentItems) {
+                    val file = preparedById[item.fileId]
+                    if (file == null) {
+                        droppedUnmatched++
+                        continue
+                    }
+                    val mime = castMimeType(file.format)
+                    if (mime == null) {
+                        droppedUncastable++
+                        continue
+                    }
+                    add(
+                        CastTrack(
+                            fileId = item.fileId,
+                            uri = file.absoluteUrl,
+                            mimeType = mime,
+                            title = item.title,
+                            artist = item.artist,
+                            albumTitle = item.albumTitle,
+                            artworkUri = coverUrlAbsolute,
+                        ),
+                    )
                 }
-                CastTrack(
-                    fileId = item.fileId,
-                    uri = file.absoluteUrl,
-                    mimeType = mime,
-                    title = item.title,
-                    artist = item.artist,
-                    albumTitle = item.albumTitle,
-                    artworkUri = coverUrlAbsolute,
-                )
             }
-        return CastTracks(tracks, dropped)
+        return CastTracks(tracks, droppedUncastable, droppedUnmatched)
     }
 
     /** Assembles a [CastTrack] into a Media3 [MediaItem] with an explicit MIME type (CastPlayer requires it). */

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactory.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMediaItemFactory.kt
@@ -92,18 +92,19 @@ class CastMediaItemFactory {
 
     /** Assembles a [CastTrack] into a Media3 [MediaItem] with an explicit MIME type (CastPlayer requires it). */
     fun toMediaItem(track: CastTrack): MediaItem =
-        MediaItem.Builder()
+        MediaItem
+            .Builder()
             .setMediaId(track.fileId)
             .setUri(track.uri)
             .setMimeType(track.mimeType)
             .setMediaMetadata(
-                MediaMetadata.Builder()
+                MediaMetadata
+                    .Builder()
                     .setTitle(track.title)
                     .setArtist(track.artist)
                     .setAlbumTitle(track.albumTitle)
                     .setArtworkUri(track.artworkUri?.let { Uri.parse(it) })
                     .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
                     .build(),
-            )
-            .build()
+            ).build()
 }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypes.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypes.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.client.playback.cast
+
+/**
+ * Maps a stored audio [format] token (lowercase extension, e.g. `"m4b"`) to the
+ * MIME type a Cast receiver needs in the load request. Returns `null` for
+ * formats Chromecast cannot decode (WMA, AIFF) so callers can fall back to local
+ * playback rather than hand the receiver something it will reject.
+ *
+ * Cast codec support: FLAC, HE/LC-AAC (in MP4), MP3, Opus/Vorbis (in OGG/WebM),
+ * WAV (LPCM). See https://developers.google.com/cast/docs/media.
+ */
+fun castMimeType(format: String): String? =
+    when (format.lowercase()) {
+        "m4b", "m4a", "mp4", "m4p", "aac" -> "audio/mp4"
+        "mp3" -> "audio/mpeg"
+        "flac" -> "audio/flac"
+        "wav", "wave" -> "audio/wav"
+        "ogg", "oga", "opus" -> "audio/ogg"
+        "webm" -> "audio/webm"
+        else -> null
+    }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypes.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastMimeTypes.kt
@@ -11,7 +11,8 @@ package com.calypsan.listenup.client.playback.cast
  */
 fun castMimeType(format: String): String? =
     when (format.lowercase()) {
-        "m4b", "m4a", "mp4", "m4p", "aac" -> "audio/mp4"
+        "m4b", "m4a", "mp4", "m4p" -> "audio/mp4"
+        "aac" -> "audio/aac"
         "mp3" -> "audio/mpeg"
         "flac" -> "audio/flac"
         "wav", "wave" -> "audio/wav"

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastOptionsProvider.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastOptionsProvider.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.client.playback.cast
+
+import android.content.Context
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.framework.CastOptions
+import com.google.android.gms.cast.framework.OptionsProvider
+import com.google.android.gms.cast.framework.SessionProvider
+
+/**
+ * Cast framework configuration. Uses the Default Media Receiver
+ * (`CC1AD845`) — no Cast Developer Console registration, no app id to manage.
+ * Referenced by name from the manifest `OPTIONS_PROVIDER_CLASS_NAME` meta-data.
+ */
+class CastOptionsProvider : OptionsProvider {
+    override fun getCastOptions(context: Context): CastOptions =
+        CastOptions.Builder()
+            .setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
+            .build()
+
+    override fun getAdditionalSessionProviders(context: Context): List<SessionProvider>? = null
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastOptionsProvider.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastOptionsProvider.kt
@@ -13,7 +13,8 @@ import com.google.android.gms.cast.framework.SessionProvider
  */
 class CastOptionsProvider : OptionsProvider {
     override fun getCastOptions(context: Context): CastOptions =
-        CastOptions.Builder()
+        CastOptions
+            .Builder()
             .setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
             .build()
 

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparer.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparer.kt
@@ -38,7 +38,10 @@ class CastPreparer(
                     coverUrlAbsolute = data.coverUrl?.let { serverUrl + it },
                 )
             }
-            is AppResult.Failure -> null
+
+            is AppResult.Failure -> {
+                null
+            }
         }
     }
 }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparer.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastPreparer.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.client.playback.cast
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.BookId
+
+/** Network cast inputs for a book: per-file absolute URL + format, plus the absolute cover URL. */
+data class CastPrepared(
+    val files: List<CastPreparedFile>,
+    val coverUrlAbsolute: String?,
+)
+
+/**
+ * Fetches the signed **network** URLs a Cast device needs. Casting always
+ * re-prepares (even for downloaded books) because a Chromecast cannot read the
+ * phone's local `file://` paths. Returns null on any failure → the caller stays
+ * local (never stranded).
+ */
+class CastPreparer(
+    private val playbackRpcFactory: PlaybackRpcFactory,
+    private val serverConfig: ServerConfig,
+) {
+    suspend fun prepareForCast(bookId: BookId): CastPrepared? {
+        val serverUrl = serverConfig.getServerUrl()?.value ?: return null
+        return when (val result = playbackRpcFactory.playbackService().prepare(bookId)) {
+            is AppResult.Success -> {
+                val data = result.data
+                CastPrepared(
+                    files =
+                        data.audioFiles.map {
+                            CastPreparedFile(
+                                fileId = it.fileId,
+                                absoluteUrl = serverUrl + it.url,
+                                format = it.format,
+                            )
+                        },
+                    coverUrlAbsolute = data.coverUrl?.let { serverUrl + it },
+                )
+            }
+            is AppResult.Failure -> null
+        }
+    }
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastSessionController.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastSessionController.kt
@@ -33,6 +33,13 @@ class CastSessionController private constructor(
     private val onConnected: () -> Unit,
     private val onDisconnected: () -> Unit,
 ) {
+    /**
+     * Whether a Cast session is live right now. Read after a suspension (e.g. the network
+     * re-prepare) to confirm the session didn't drop in the gap before swapping onto it.
+     */
+    val isSessionAvailable: Boolean
+        get() = rawCastPlayer.isCastSessionAvailable
+
     init {
         rawCastPlayer.setSessionAvailabilityListener(
             object : SessionAvailabilityListener {

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastSessionController.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastSessionController.kt
@@ -1,0 +1,80 @@
+package com.calypsan.listenup.client.playback.cast
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.SessionAvailabilityListener
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Owns the Cast session lifecycle. Built lazily and only when Google Play
+ * Services is available — on a de-Googled device this is a no-op and the app
+ * plays locally, untouched (never stranded).
+ *
+ * The [castPlayer] (a [SpeedAwareCastPlayer] over Media3's [CastPlayer]) is the
+ * player the PlaybackService swaps into its MediaLibrarySession on connect. This
+ * class only SIGNALS transitions via [onConnected]/[onDisconnected]; the service
+ * performs the swap so the session + local ExoPlayer stay in one place.
+ */
+@OptIn(UnstableApi::class)
+class CastSessionController private constructor(
+    private val rawCastPlayer: CastPlayer,
+    val castPlayer: Player,
+) {
+    var onConnected: (() -> Unit)? = null
+    var onDisconnected: (() -> Unit)? = null
+
+    init {
+        rawCastPlayer.setSessionAvailabilityListener(
+            object : SessionAvailabilityListener {
+                override fun onCastSessionAvailable() {
+                    logger.info { "Cast session available" }
+                    onConnected?.invoke()
+                }
+
+                override fun onCastSessionUnavailable() {
+                    logger.info { "Cast session unavailable" }
+                    onDisconnected?.invoke()
+                }
+            },
+        )
+    }
+
+    fun release() {
+        rawCastPlayer.setSessionAvailabilityListener(null)
+        rawCastPlayer.release()
+    }
+
+    companion object {
+        /**
+         * Returns a controller, or null when Google Play Services / Cast is
+         * unavailable (de-Googled device) — caller then never shows a cast
+         * button and plays locally.
+         */
+        fun createOrNull(context: Context): CastSessionController? {
+            val available = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+            if (available != ConnectionResult.SUCCESS) {
+                logger.info { "Google Play Services unavailable ($available) — Cast disabled" }
+                return null
+            }
+            return runCatching {
+                val castContext = CastContext.getSharedInstance(context)
+                val castPlayer = CastPlayer(castContext)
+                val rateSetter =
+                    CastRateSetter { rate ->
+                        castContext.sessionManager.currentCastSession
+                            ?.remoteMediaClient
+                            ?.setPlaybackRate(rate)
+                    }
+                CastSessionController(castPlayer, SpeedAwareCastPlayer(castPlayer, rateSetter))
+            }.onFailure { logger.warn(it) { "Cast init failed — Cast disabled" } }.getOrNull()
+        }
+    }
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastSessionController.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/CastSessionController.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.client.playback.cast
 
 import android.content.Context
 import androidx.annotation.OptIn
-import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.RemoteCastPlayer
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -18,30 +18,32 @@ private val logger = KotlinLogging.logger {}
  * Services is available — on a de-Googled device this is a no-op and the app
  * plays locally, untouched (never stranded).
  *
- * The [castPlayer] (a [SpeedAwareCastPlayer] over Media3's [CastPlayer]) is the
- * player the PlaybackService swaps into its MediaLibrarySession on connect. This
- * class only SIGNALS transitions via [onConnected]/[onDisconnected]; the service
- * performs the swap so the session + local ExoPlayer stay in one place.
+ * The [castPlayer] (a [SpeedAwareCastPlayer] over Media3's [RemoteCastPlayer]) is
+ * the player the PlaybackService swaps into its MediaLibrarySession on connect.
+ * This class only SIGNALS transitions via the [onConnected]/[onDisconnected]
+ * callbacks supplied to [createOrNull]; the service performs the swap so the
+ * session + local ExoPlayer stay in one place. The callbacks are registered into
+ * the session-availability listener in the constructor, so no transition can fire
+ * before they're wired.
  */
 @OptIn(UnstableApi::class)
 class CastSessionController private constructor(
-    private val rawCastPlayer: CastPlayer,
+    private val rawCastPlayer: RemoteCastPlayer,
     val castPlayer: Player,
+    private val onConnected: () -> Unit,
+    private val onDisconnected: () -> Unit,
 ) {
-    var onConnected: (() -> Unit)? = null
-    var onDisconnected: (() -> Unit)? = null
-
     init {
         rawCastPlayer.setSessionAvailabilityListener(
             object : SessionAvailabilityListener {
                 override fun onCastSessionAvailable() {
                     logger.info { "Cast session available" }
-                    onConnected?.invoke()
+                    onConnected()
                 }
 
                 override fun onCastSessionUnavailable() {
                     logger.info { "Cast session unavailable" }
-                    onDisconnected?.invoke()
+                    onDisconnected()
                 }
             },
         )
@@ -56,9 +58,15 @@ class CastSessionController private constructor(
         /**
          * Returns a controller, or null when Google Play Services / Cast is
          * unavailable (de-Googled device) — caller then never shows a cast
-         * button and plays locally.
+         * button and plays locally. [onConnected]/[onDisconnected] fire on Cast
+         * session transitions; they're registered in the constructor so no
+         * transition can be missed.
          */
-        fun createOrNull(context: Context): CastSessionController? {
+        fun createOrNull(
+            context: Context,
+            onConnected: () -> Unit,
+            onDisconnected: () -> Unit,
+        ): CastSessionController? {
             val available = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
             if (available != ConnectionResult.SUCCESS) {
                 logger.info { "Google Play Services unavailable ($available) — Cast disabled" }
@@ -66,14 +74,19 @@ class CastSessionController private constructor(
             }
             return runCatching {
                 val castContext = CastContext.getSharedInstance(context)
-                val castPlayer = CastPlayer(castContext)
+                val remotePlayer = RemoteCastPlayer.Builder(context).build()
                 val rateSetter =
                     CastRateSetter { rate ->
                         castContext.sessionManager.currentCastSession
                             ?.remoteMediaClient
                             ?.setPlaybackRate(rate)
                     }
-                CastSessionController(castPlayer, SpeedAwareCastPlayer(castPlayer, rateSetter))
+                CastSessionController(
+                    rawCastPlayer = remotePlayer,
+                    castPlayer = SpeedAwareCastPlayer(remotePlayer, rateSetter),
+                    onConnected = onConnected,
+                    onDisconnected = onDisconnected,
+                )
             }.onFailure { logger.warn(it) { "Cast init failed — Cast disabled" } }.getOrNull()
         }
     }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayer.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayer.kt
@@ -1,0 +1,46 @@
+package com.calypsan.listenup.client.playback.cast
+
+import androidx.annotation.OptIn
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+
+/** Pushes a playback rate to the Cast receiver. Implemented over `RemoteMediaClient.setPlaybackRate()`. */
+fun interface CastRateSetter {
+    fun setRate(rate: Double)
+}
+
+/**
+ * Wraps Media3's [androidx.media3.cast.CastPlayer] so playback-speed changes work.
+ *
+ * `CastPlayer` declares `setPlaybackParameters` unsupported (ExoPlayer issue
+ * #6784), but the Cast Default Media Receiver honors `setPlaybackRate`. We
+ * intercept the speed command, forward it to the receiver via [rateSetter], and
+ * remember it so [getPlaybackParameters] reports the live rate — keeping the
+ * UI speed control truthful while casting.
+ */
+@OptIn(UnstableApi::class)
+class SpeedAwareCastPlayer(
+    castPlayer: Player,
+    private val rateSetter: CastRateSetter,
+) : ForwardingPlayer(castPlayer) {
+    private var current: PlaybackParameters = PlaybackParameters.DEFAULT
+
+    override fun setPlaybackParameters(playbackParameters: PlaybackParameters) {
+        current = playbackParameters
+        rateSetter.setRate(playbackParameters.speed.toDouble())
+    }
+
+    override fun setPlaybackSpeed(speed: Float) {
+        setPlaybackParameters(PlaybackParameters(speed))
+    }
+
+    override fun getPlaybackParameters(): PlaybackParameters = current
+
+    override fun isCommandAvailable(command: Int): Boolean =
+        command == Player.COMMAND_SET_SPEED_AND_PITCH || super.isCommandAvailable(command)
+
+    override fun getAvailableCommands(): Player.Commands =
+        super.getAvailableCommands().buildUpon().add(Player.COMMAND_SET_SPEED_AND_PITCH).build()
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayer.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayer.kt
@@ -25,10 +25,15 @@ class SpeedAwareCastPlayer(
     castPlayer: Player,
     private val rateSetter: CastRateSetter,
 ) : ForwardingPlayer(castPlayer) {
-    private var current: PlaybackParameters = PlaybackParameters.DEFAULT
+    /**
+     * Local mirror of the last rate we pushed — authoritative only because this app is the
+     * sole rate-writer. It is NOT synced receiver state: it starts at [PlaybackParameters.DEFAULT]
+     * and would lag a pre-existing remote rate when resuming an already-playing Cast session.
+     */
+    private var currentParameters: PlaybackParameters = PlaybackParameters.DEFAULT
 
     override fun setPlaybackParameters(playbackParameters: PlaybackParameters) {
-        current = playbackParameters
+        currentParameters = playbackParameters
         rateSetter.setRate(playbackParameters.speed.toDouble())
     }
 
@@ -36,7 +41,7 @@ class SpeedAwareCastPlayer(
         setPlaybackParameters(PlaybackParameters(speed))
     }
 
-    override fun getPlaybackParameters(): PlaybackParameters = current
+    override fun getPlaybackParameters(): PlaybackParameters = currentParameters
 
     override fun isCommandAvailable(command: Int): Boolean =
         command == Player.COMMAND_SET_SPEED_AND_PITCH || super.isCommandAvailable(command)

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayer.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/cast/SpeedAwareCastPlayer.kt
@@ -47,5 +47,9 @@ class SpeedAwareCastPlayer(
         command == Player.COMMAND_SET_SPEED_AND_PITCH || super.isCommandAvailable(command)
 
     override fun getAvailableCommands(): Player.Commands =
-        super.getAvailableCommands().buildUpon().add(Player.COMMAND_SET_SPEED_AND_PITCH).build()
+        super
+            .getAvailableCommands()
+            .buildUpon()
+            .add(Player.COMMAND_SET_SPEED_AND_PITCH)
+            .build()
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.kt
@@ -1,0 +1,15 @@
+package com.calypsan.listenup.client.features.nowplaying.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * The Cast / route-picker button for the Now Playing screen.
+ *
+ * On Android this embeds the framework `MediaRouteButton`, which handles device
+ * discovery, the chooser/controller dialogs, the connecting animation, and
+ * auto-hides when no Cast devices are on the network. On platforms without Cast
+ * (Desktop) it renders nothing.
+ */
+@Composable
+expect fun CastButton(modifier: Modifier = Modifier)

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/PlayerTopBar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/PlayerTopBar.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.filled.Book
-import androidx.compose.material.icons.filled.Cast
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -41,7 +40,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.calypsan.listenup.client.playback.NowPlayingState
 import listenup.composeapp.generated.resources.Res
-import listenup.composeapp.generated.resources.player_cast
 import listenup.composeapp.generated.resources.player_close_book
 import listenup.composeapp.generated.resources.player_collapse
 import listenup.composeapp.generated.resources.player_go_to_book
@@ -191,14 +189,8 @@ private fun WideTopBar(
             )
         }
 
-        // Cast icon button — tonal style (future feature, not yet wired).
-        IconButton(onClick = { /* cast not yet wired */ }) {
-            Icon(
-                imageVector = Icons.Default.Cast,
-                contentDescription = stringResource(Res.string.player_cast),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        // Cast / route-picker button — framework MediaRouteButton (auto-hides when no devices).
+        CastButton(modifier = Modifier.size(48.dp))
 
         overflowAnchor()
     }
@@ -240,7 +232,11 @@ private fun CompactTopBar(
             textAlign = TextAlign.Center,
         )
 
-        Box(modifier = Modifier.align(Alignment.CenterEnd)) {
+        Row(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CastButton(modifier = Modifier.size(48.dp))
             overflowAnchor()
         }
     }

--- a/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.desktop.kt
+++ b/sharedUI/src/desktopMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.desktop.kt
@@ -1,0 +1,9 @@
+package com.calypsan.listenup.client.features.nowplaying.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun CastButton(modifier: Modifier) {
+    // Cast is Android-only; render nothing on Desktop.
+}


### PR DESCRIPTION
## Android Chromecast

Adds Google Cast support to the Android client: a cast button in Now Playing → device picker → audio plays on the Cast device with cover/title/author on the TV → full transport, chapter, speed, and sleep-timer control → disconnect resumes locally from the same spot.

**iOS already had working AirPlay** (audited as part of this work — the `AVRoutePickerView` path was correct; the only "finding" there was a false alarm). This PR is **Android-only**.

### Architecture

Service-side player swap: `PlaybackService` holds the existing `ExoPlayer` plus a `RemoteCastPlayer`; a `SessionAvailabilityListener` swaps the `MediaLibrarySession`'s player on connect/disconnect, so the UI, notification, lock screen, chapter nav, and sleep timer stay agnostic. Casting always re-fetches signed **network** URLs via the existing `/playback/prepare` RPC at connect time (a downloaded book's local `file://` URIs aren't fetchable by a Cast device).

- **Server (signed cover URLs):** `CoverUrlSigner` (mirrors `AudioUrlSigner`), a header-less signature-authed `GET /api/v1/cover-cast/{id}` route mounted outside the JWT block, and a backward-compatible `coverUrl` on `PreparedPlayback` so the receiver can fetch the cover (no `Authorization` header).
- **Android cast core (`…/playback/cast/`):** `castMimeType`, `CastMediaItemFactory` (zips the loaded queue with the fresh prepare result by `fileId`, drops/counts un-castable + unmatched files), `SpeedAwareCastPlayer`, `CastPreparer`, `CastSessionController` (Play-Services-guarded), `CastOptionsProvider` (Default Media Receiver — no Cast Console registration/fee).
- **UI:** `expect`/`actual CastButton` (Android `MediaRouteButton`, Desktop no-op) wired into the Now Playing top bar in both compact and wide layouts (replacing a long-dead stub).

### Scope decisions

- **Default Media Receiver** (zero setup).
- **Speed + sleep timer** included while casting.
- Cast icon on the **full Now Playing screen only** (not the mini-player).
- **Never stranded:** no Play Services → no cast button, local playback untouched; any prepare/cast failure falls back to local.

### Testing

Full Linux-lane gate **green**: `spotlessCheck` + `detekt` clean, `:sharedLogic:jvmTest` + `:server:jvmTest` (5,205 tests, 0 failures), `:sharedUI:testAndroidHostTest` (269 tests, 0 failures), `:androidApp:assembleDebug` clean. New unit tests cover the cover signer, the cover-cast route (incl. the access gate), the prepare cover-URL minting + contract round-trip (incl. backward-compat), `castMimeType`, `CastMediaItemFactory` (order/drop/count), `SpeedAwareCastPlayer`, and `CastPreparer`.

> iOS lanes run on remote CI only (no Mac locally). This PR touches no iOS files; the one shared change is a **defaulted** `coverUrl: String?` field on the `PreparedPlayback` DTO — watch the iOS build / Swift-export-surface job, though a received DTO gaining a nullable field shouldn't break the Swift side.

### ⚠️ On-device verification still required before merge

The Cast SDK interaction (the actual `session.player` swap, `RemoteCastPlayer`/session transitions, `setPlaybackRate` routing, Toast rendering) is only verifiable on a real Cast device — there's none in the build environment. Please verify on a Chromecast / Cast-enabled TV/speaker on the same Wi-Fi:

- [ ] Cast icon appears in Now Playing **only when** a Cast device is reachable; hidden otherwise (and no empty gap in the header when hidden).
- [ ] Tap → device picker → select → audio plays on the **Cast device**; cover + title + author show on the TV.
- [ ] Play/pause, scrub, skip ±, **chapter prev/next** control the cast device.
- [ ] **Speed:** change speed while casting → receiver rate changes; then **disconnect → local resumes at that speed** (verifies the disconnect speed-restore fix).
- [ ] **Sleep timer:** short timer while casting → cast device pauses at expiry.
- [ ] **Disconnect** (picker or power off the device) → resumes locally from the same position.
- [ ] Cast a **downloaded** book → still works (re-prepare fetches network URLs).
- [ ] **Long session:** leave a cast playing untouched **> 30 min** → session survives, service not torn down (verifies the idle-timer-during-cast fix).
- [ ] Server progress: after a cast session, the persisted position matches where you stopped.
- [ ] **De-Googled / no-Play-Services** build → no cast button, local playback works (verifies the button guard).
- [ ] (If you have a WMA/AIFF book) tap cast → "can't be cast" Toast + stays local.

### Deferred follow-ups (tracked, not blockers)

- `SpeedAwareCastPlayer` + `CastRateSetter` are likely removable once on-device confirms `RemoteCastPlayer` handles speed natively (would also drop the speed-mirror drift caveat).
- No live periodic progress-save / listening-stats accrual **during** cast (position is saved on disconnect) — drive the position job off `session.player` to count cast time toward stats.
- Book-changed-mid-cast can resume the wrong position on disconnect — block book changes while casting, or re-sync the local queue before swap-back.
- Replace the can't-cast Toast with a typed `PlaybackError` + snackbar (the idiomatic error path; deferred to avoid a new `@Serializable` AppError subtype mid-feature).
- Extract a shared HMAC-signer base for `CoverUrlSigner`/`AudioUrlSigner` (currently a deliberate parallel duplication to avoid destabilizing the working audio signer).
- `m4p` → `audio/mp4` (DRM'd `.m4p` can't decode on Cast but falls back to local gracefully).

> `origin/main` advanced while this was built; a rebase onto current `main` will likely be needed before merge (standard).
