### PR TITLE
🐛 fix(ios): contributor photos sync in real time

### DIFF
--- a/iosApp/ListenUp/DesignSystem/Components/AuthenticatedImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/AuthenticatedImageRequest.swift
@@ -17,20 +17,31 @@ enum AuthenticatedImageRequest {
         targetPixels > 0 ? [ImageProcessors.Resize(width: targetPixels, unit: .pixels)] : []
     }
 
-    /// A Nuke request for a durable local file path.
-    static func localFile(_ path: String, processors: [any ImageProcessing]) -> ImageRequest {
-        ImageRequest(url: URL(fileURLWithPath: path), processors: processors)
+    /// A Nuke request for a durable local file path. `cacheKey`, when supplied, overrides Nuke's
+    /// URL-derived cache key so a content change at a stable path still busts the cache.
+    static func localFile(
+        _ path: String,
+        processors: [any ImageProcessing],
+        cacheKey: String? = nil
+    ) -> ImageRequest {
+        let userInfo: [ImageRequest.UserInfoKey: Any]? = cacheKey.map { [.imageIdKey: $0] }
+        return ImageRequest(url: URL(fileURLWithPath: path), processors: processors, userInfo: userInfo)
     }
 
     /// A Nuke request for an authenticated server URL: attaches `Authorization: Bearer` but keys the
-    /// cache on the URL (Nuke's default) so a cached image survives token rotation and never
-    /// re-downloads just because the access token rotated.
+    /// cache on `cacheKey` when supplied (else the URL, Nuke's default) so a cached image survives
+    /// token rotation and never re-downloads just because the access token rotated.
     @MainActor
-    static func authenticated(url: URL, processors: [any ImageProcessing]) async -> ImageRequest {
+    static func authenticated(
+        url: URL,
+        processors: [any ImageProcessing],
+        cacheKey: String? = nil
+    ) async -> ImageRequest {
         var urlRequest = URLRequest(url: url)
         if let token = try? await KoinHelper.shared.accessToken() {
             urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        return ImageRequest(urlRequest: urlRequest, processors: processors)
+        let userInfo: [ImageRequest.UserInfoKey: Any]? = cacheKey.map { [.imageIdKey: $0] }
+        return ImageRequest(urlRequest: urlRequest, processors: processors, userInfo: userInfo)
     }
 }

--- a/iosApp/ListenUp/DesignSystem/Components/ContributorAvatar.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ContributorAvatar.swift
@@ -94,7 +94,7 @@ struct ContributorAvatar: View {
             // Streamed contributor photo, layered over the BlurHash/initials placeholder. Nuke
             // owns the off-main decode + caching (scroll-safe, like the cover grid).
             if streamsContributorPhoto {
-                ContributorPhotoLayer(contributorId: id)
+                ContributorPhotoLayer(contributorId: id, imagePath: imagePath)
                     .clipShape(Circle())
             }
         }
@@ -144,6 +144,9 @@ struct ContributorAvatar: View {
 /// so the BlurHash/initials placeholder shows through.
 private struct ContributorPhotoLayer: View {
     let contributorId: String
+    /// The contributor's content-addressed image path. Folded into the cache key and the task id so
+    /// a sync-driven photo change (new path) busts the cached image instead of serving the stale one.
+    let imagePath: String?
 
     @Environment(\.displayScale) private var displayScale
     @State private var request: ImageRequest?
@@ -164,11 +167,12 @@ private struct ContributorPhotoLayer: View {
                 targetMaxPixels = pixels
             }
         }
-        // Cancelled when the row scrolls away; re-resolves only when id/size change.
-        .task(id: TaskKey(contributorId: contributorId, targetPixels: targetMaxPixels)) {
+        // Cancelled when the row scrolls away; re-resolves when id/imagePath/size change.
+        .task(id: TaskKey(contributorId: contributorId, imagePath: imagePath, targetPixels: targetMaxPixels)) {
             guard targetMaxPixels > 0 else { return }
             request = await ContributorImageRequest.contributor(
                 contributorId: contributorId,
+                imagePath: imagePath,
                 targetPixels: targetMaxPixels
             )
         }
@@ -177,6 +181,7 @@ private struct ContributorPhotoLayer: View {
     /// Identity for the request-building task: any change re-resolves the photo source.
     private struct TaskKey: Equatable {
         let contributorId: String
+        let imagePath: String?
         let targetPixels: CGFloat
     }
 }

--- a/iosApp/ListenUp/DesignSystem/Components/ContributorAvatar.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ContributorAvatar.swift
@@ -145,7 +145,9 @@ struct ContributorAvatar: View {
 private struct ContributorPhotoLayer: View {
     let contributorId: String
     /// The contributor's content-addressed image path. Folded into the cache key and the task id so
-    /// a sync-driven photo change (new path) busts the cached image instead of serving the stale one.
+    /// a sync-driven photo change (new path) re-resolves and busts the cached image. On the
+    /// local-file branch the disk copy is dropped upstream by `ContributorSyncDomainHandler` when
+    /// `imagePath` changes, so the stale file is gone before this re-resolves.
     let imagePath: String?
 
     @Environment(\.displayScale) private var displayScale

--- a/iosApp/ListenUp/DesignSystem/Components/ContributorImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ContributorImageRequest.swift
@@ -32,6 +32,15 @@ enum ContributorImageRequest {
         return await AuthenticatedImageRequest.authenticated(url: url, processors: processors)
     }
 
+    /// The content-addressed Nuke cache key for a contributor photo. Folding the server's
+    /// content-addressed `imagePath` (`contributors/{sha}.jpg`) into the key means a re-scraped
+    /// photo (new path) busts the cached image instead of serving the stale one — mirroring the
+    /// Compose `contributorCacheKey` and `BookCoverImage`'s `coverHash` handling. Pure, so it's
+    /// unit-tested. `nil` imagePath falls back to a stable per-id key.
+    static func cacheKey(contributorId: String, imagePath: String?) -> String {
+        "\(contributorId):\(imagePath ?? "contributor")"
+    }
+
     /// The authenticated contributor-photo endpoint for a server base URL. Pure, so the endpoint
     /// shape is unit-tested. Returns nil for a blank base.
     static func photoURL(base: String, contributorId: String) -> URL? {

--- a/iosApp/ListenUp/DesignSystem/Components/ContributorImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ContributorImageRequest.swift
@@ -40,8 +40,8 @@ enum ContributorImageRequest {
     /// The content-addressed Nuke cache key for a contributor photo. Folding the server's
     /// content-addressed `imagePath` (`contributors/{sha}.jpg`) into the key means a re-scraped
     /// photo (new path) busts the cached image instead of serving the stale one — mirroring the
-    /// Compose `contributorCacheKey` and `BookCoverImage`'s `coverHash` handling. Pure, so it's
-    /// unit-tested. `nil` imagePath falls back to a stable per-id key.
+    /// Compose `contributorCacheKey`. Pure, so it's unit-tested. `nil` imagePath falls back to a
+    /// stable per-id key.
     static func cacheKey(contributorId: String, imagePath: String?) -> String {
         "\(contributorId):\(imagePath ?? "contributor")"
     }

--- a/iosApp/ListenUp/DesignSystem/Components/ContributorImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/ContributorImageRequest.swift
@@ -10,15 +10,20 @@ import Nuke
 /// Nuke's evictable cache. Mirrors `CoverImageRequest` and the Compose `ContributorCoverImage`.
 enum ContributorImageRequest {
     @MainActor
-    static func contributor(contributorId: String, targetPixels: CGFloat) async -> ImageRequest? {
+    static func contributor(
+        contributorId: String,
+        imagePath: String?,
+        targetPixels: CGFloat
+    ) async -> ImageRequest? {
         let processors = AuthenticatedImageRequest.processors(targetPixels: targetPixels)
+        let key = cacheKey(contributorId: contributorId, imagePath: imagePath)
 
         let repository = KoinHelper.shared.getImageRepository()
 
         // Offline fast path: a previously cached photo on disk.
         if repository.contributorImageExists(contributorId: contributorId) {
             let path = repository.getContributorImagePath(contributorId: contributorId)
-            return AuthenticatedImageRequest.localFile(path, processors: processors)
+            return AuthenticatedImageRequest.localFile(path, processors: processors, cacheKey: key)
         }
 
         // No durable file yet — persist this streamed photo on disk for offline use (fire-and-forget,
@@ -29,7 +34,7 @@ enum ContributorImageRequest {
               let url = photoURL(base: base, contributorId: contributorId)
         else { return nil }
 
-        return await AuthenticatedImageRequest.authenticated(url: url, processors: processors)
+        return await AuthenticatedImageRequest.authenticated(url: url, processors: processors, cacheKey: key)
     }
 
     /// The content-addressed Nuke cache key for a contributor photo. Folding the server's

--- a/iosApp/ListenUp/Features/Library/Components/PersonRow.swift
+++ b/iosApp/ListenUp/Features/Library/Components/PersonRow.swift
@@ -21,7 +21,7 @@ struct PersonRow: View {
             HStack(spacing: 14) {
                 ContributorAvatar(
                     name: name,
-                    imagePath: nil,
+                    imagePath: contributor.imagePath,
                     blurHash: contributor.imageBlurHash,
                     id: contributor.id,
                     fontSize: 16,

--- a/iosApp/ListenUp/Features/Library/ContributorRow.swift
+++ b/iosApp/ListenUp/Features/Library/ContributorRow.swift
@@ -5,19 +5,21 @@ import Shared
 ///
 /// **Why (performance — see `BookRow`).** `PersonRow` re-read 5+ bridged properties of the Kotlin
 /// `ContributorWithBookCount` on every diff; over a whole-library list with an alphabet scrubber that
-/// re-bridging hangs the main thread. Snapshot once at the observer boundary. The avatar still streams
-/// the server photo — `PersonRow` passes `id` to `ContributorAvatar(streamsContributorPhoto: true)`,
-/// which resolves the durable path from the id, so `imagePath` isn't needed here.
+/// re-bridging hangs the main thread. Snapshot once at the observer boundary. `imagePath` is the
+/// contributor's content-addressed photo path — `PersonRow` passes it to
+/// `ContributorAvatar(streamsContributorPhoto: true)` so a sync-driven photo change busts the cache.
 struct ContributorRow: Identifiable, Equatable, Hashable {
     let id: String
     let name: String
     let bookCount: Int
+    let imagePath: String?
     let imageBlurHash: String?
 
-    init(id: String, name: String, bookCount: Int, imageBlurHash: String?) {
+    init(id: String, name: String, bookCount: Int, imagePath: String?, imageBlurHash: String?) {
         self.id = id
         self.name = name
         self.bookCount = bookCount
+        self.imagePath = imagePath
         self.imageBlurHash = imageBlurHash
     }
 
@@ -26,6 +28,7 @@ struct ContributorRow: Identifiable, Equatable, Hashable {
         self.id = contributor.contributor.idString
         self.name = contributor.contributor.name
         self.bookCount = Int(contributor.bookCount)
+        self.imagePath = contributor.contributor.imagePath
         self.imageBlurHash = contributor.contributor.imageBlurHash
     }
 }

--- a/iosApp/ListenUpTests/AuthenticatedImageRequestTests.swift
+++ b/iosApp/ListenUpTests/AuthenticatedImageRequestTests.swift
@@ -23,4 +23,16 @@ struct AuthenticatedImageRequestTests {
         let request = AuthenticatedImageRequest.localFile("/var/covers/book-1.jpg", processors: [])
         #expect(request.url == URL(fileURLWithPath: "/var/covers/book-1.jpg"))
     }
+
+    @Test func localFileRequestCarriesOverrideCacheKey() {
+        let request = AuthenticatedImageRequest.localFile(
+            "/var/contributors/c-1.jpg", processors: [], cacheKey: "c-1:contributors/aaa.jpg"
+        )
+        #expect(request.userInfo[.imageIdKey] as? String == "c-1:contributors/aaa.jpg")
+    }
+
+    @Test func localFileRequestWithoutCacheKeyLeavesDefault() {
+        let request = AuthenticatedImageRequest.localFile("/var/covers/book-1.jpg", processors: [])
+        #expect(request.userInfo[.imageIdKey] == nil)
+    }
 }

--- a/iosApp/ListenUpTests/ContributorImageRequestTests.swift
+++ b/iosApp/ListenUpTests/ContributorImageRequestTests.swift
@@ -13,4 +13,23 @@ struct ContributorImageRequestTests {
     @Test func blankBaseYieldsNil() {
         #expect(ContributorImageRequest.photoURL(base: "", contributorId: "contrib-42") == nil)
     }
+
+    @Test func cacheKeyFoldsImagePath() {
+        #expect(
+            ContributorImageRequest.cacheKey(contributorId: "c-1", imagePath: "contributors/aaa.jpg")
+                == "c-1:contributors/aaa.jpg"
+        )
+    }
+
+    @Test func cacheKeyChangesWhenImagePathChanges() {
+        let before = ContributorImageRequest.cacheKey(contributorId: "c-1", imagePath: "contributors/aaa.jpg")
+        let after = ContributorImageRequest.cacheKey(contributorId: "c-1", imagePath: "contributors/bbb.jpg")
+        #expect(before != after)
+    }
+
+    @Test func cacheKeyStableWhenImagePathNil() {
+        #expect(
+            ContributorImageRequest.cacheKey(contributorId: "c-1", imagePath: nil) == "c-1:contributor"
+        )
+    }
 }

--- a/iosApp/ListenUpTests/ContributorRowTests.swift
+++ b/iosApp/ListenUpTests/ContributorRowTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import ListenUp
+
+/// Pins that `ContributorRow` carries `imagePath` as part of its value identity, so a sync-driven
+/// photo change re-renders `PersonRow` and busts the avatar cache. (`init(_:)` from the bridged
+/// `ContributorWithBookCount` needs live KMP state — pinned at the pure memberwise seam, per the
+/// `SeriesDetailObserver` convention.)
+@Suite("ContributorRow")
+struct ContributorRowTests {
+    @Test func differentImagePathProducesDifferentRow() {
+        let before = ContributorRow(
+            id: "c-1", name: "Brandon Sanderson", bookCount: 12,
+            imagePath: "contributors/aaa.jpg", imageBlurHash: nil
+        )
+        let after = ContributorRow(
+            id: "c-1", name: "Brandon Sanderson", bookCount: 12,
+            imagePath: "contributors/bbb.jpg", imageBlurHash: nil
+        )
+        #expect(before != after)
+    }
+}

--- a/iosApp/ListenUpTests/SeriesContributorSectioningTests.swift
+++ b/iosApp/ListenUpTests/SeriesContributorSectioningTests.swift
@@ -11,7 +11,7 @@ struct SeriesContributorSectioningTests {
     }
 
     private func person(_ id: String, _ name: String) -> ContributorRow {
-        ContributorRow(id: id, name: name, bookCount: 1, imageBlurHash: nil)
+        ContributorRow(id: id, name: name, bookCount: 1, imagePath: nil, imageBlurHash: nil)
     }
 
     // MARK: - Series alphabet index

--- a/iosApp/ListenUpTests/SeriesCoverDeckTests.swift
+++ b/iosApp/ListenUpTests/SeriesCoverDeckTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import ListenUp
+
+/// Series imagery on iOS is a `CoverStack` of member-book covers — there is no dedicated series
+/// cover. This pins that a member book's cover change flows into the deck's diff value (`CoverArt`),
+/// so the series UI re-renders and `BookCoverImage` busts the cover cache (its `TaskKey` already
+/// includes `coverPath`). Guards against a future refactor that drops `coverPath` from `CoverArt`.
+@Suite("Series cover deck")
+struct SeriesCoverDeckTests {
+    @Test func coverArtCapturesMemberBookCoverPath() {
+        let book = BookRow(
+            id: "book-1", title: "The Way of Kings", authorNames: "Brandon Sanderson",
+            hasDocuments: false, coverPath: "/covers/book-1.jpg", coverBlurHash: nil
+        )
+        #expect(CoverArt(book: book).coverPath == "/covers/book-1.jpg")
+    }
+
+    @Test func memberCoverChangeProducesDifferentCoverArt() {
+        let before = BookRow(
+            id: "book-1", title: "T", authorNames: "A",
+            hasDocuments: false, coverPath: "/covers/book-1.jpg", coverBlurHash: nil
+        )
+        let after = BookRow(
+            id: "book-1", title: "T", authorNames: "A",
+            hasDocuments: false, coverPath: "/covers/book-1-v2.jpg", coverBlurHash: nil
+        )
+        #expect(CoverArt(book: before) != CoverArt(book: after))
+    }
+}


### PR DESCRIPTION
## Summary

Contributor avatars on iOS now refresh in real time when the server changes a contributor's photo (metadata re-scrape or `PATCH /contributors/{id}`).

The Kotlin server already emits `contributor.updated` over the sync firehose with a content-addressed `imagePath`, and the shared layer already writes it to Room and deletes the stale local file. iOS just wasn't reacting: `ContributorPhotoLayer` keyed its `.task` on `(contributorId, targetPixels)` only, and the Nuke cache keyed on a stable-per-id URL/path — so a content change never busted. This folds the content-addressed `imagePath` into **both** the Nuke cache key (`userInfo[.imageIdKey]`) and the `.task` identity, mirroring what Compose's `ContributorCoverImage` already does.

- Pure `ContributorImageRequest.cacheKey(contributorId:imagePath:)` — byte-for-byte parity with Compose's `contributorCacheKey`.
- `AuthenticatedImageRequest.localFile/authenticated` gain an optional `cacheKey` (defaults `nil`, so book covers are untouched).
- `ContributorImageRequest.contributor(imagePath:)` threads the key into both the local-file and server branches.
- `ContributorPhotoLayer` carries `imagePath` in its `TaskKey`; `ContributorRow` snapshots it at the observer boundary; `PersonRow` passes it through (was hardcoded `nil`).
- **Series:** no production change — iOS draws series as a `CoverStack` of member-book covers, which already bust on `coverPath`. Added a guard test to lock that in.

Scope: iOS only. Compose/Android already handles this (the `imagePath` cache key) and the server already emits the events.

## Test Plan
- [x] TDD: `ContributorImageRequest` cacheKey (3 cases), `AuthenticatedImageRequest` cacheKey→`userInfo[.imageIdKey]` (2 cases), `ContributorRow` imagePath identity, series cover-deck guard (2 cases)
- [x] Full iOS suite green (`** TEST SUCCEEDED **`)
- [x] SwiftLint clean on changed files
- [ ] Manual smoke against the Kotlin server: change a contributor's photo server-side; confirm the avatar updates within ~1s on the Library Contributors tab and the contributor detail hero without restarting