### PR TITLE
🐛 fix(shared): make book edits offline-first (cache + queue, no ServerConnectError)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositoryImpl.kt
@@ -1,13 +1,18 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.BookContributorInput
 import com.calypsan.listenup.api.dto.BookGenreInput
 import com.calypsan.listenup.api.dto.BookSeriesInput
 import com.calypsan.listenup.api.dto.BookUpdate
 import com.calypsan.listenup.api.dto.ChapterInput
 import com.calypsan.listenup.api.result.AppResult as WireAppResult
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.BookRpcFactory
 import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.BookEditRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
@@ -19,24 +24,63 @@ import kotlinx.coroutines.CancellationException
 private val logger = KotlinLogging.logger {}
 
 /**
- * Pure RPC dispatcher for book edits.
+ * Offline-first book editor.
  *
- * No optimistic Room writes — the SSE echo from the server is the single write
- * path back into Room. This keeps state consistent across devices and matches
- * the Tags / playback-positions write pattern.
+ * [updateBook] writes the patch into Room immediately and enqueues a durable
+ * pending op (the same outbox the playback-position writes use), so an edit made
+ * offline persists and replays on reconnect rather than failing with a
+ * [com.calypsan.listenup.api.error.ServerConnectError]. The authoritative state
+ * still arrives via the SSE sync engine and reconciles through
+ * [com.calypsan.listenup.client.data.sync.handlers.BookSyncDomainHandler].
  *
- * Wire [WireAppResult] values returned by the RPC service are converted to the
- * client-layer [AppResult] at this boundary, following the same pattern as
- * [TagRepositoryImpl].
+ * The remaining methods stay pure RPC dispatchers — the SSE echo from the server
+ * is their single write path back into Room. Wire [WireAppResult] values returned
+ * by the RPC service are converted to the client-layer [AppResult] at this
+ * boundary, following the same pattern as [TagRepositoryImpl].
  */
 internal class BookEditRepositoryImpl(
     private val bookRpcFactory: BookRpcFactory,
     private val collectionRpcFactory: CollectionRpcFactory,
+    private val bookDao: BookDao,
+    private val pendingQueue: PendingOperationQueue,
+    private val transactionRunner: TransactionRunner,
+    private val authSession: AuthSession,
 ) : BookEditRepository {
     override suspend fun updateBook(
         id: BookId,
         patch: BookUpdate,
-    ): AppResult<Unit> = rpcCallUnit { bookRpcFactory.bookService().updateBook(id, patch) }
+    ): AppResult<Unit> {
+        val ownerUserId =
+            authSession.getUserId()
+                ?: return AppResult.Failure(ErrorMapper.map(IllegalStateException("No signed-in user")))
+        transactionRunner.atomically {
+            bookDao.getById(id)?.let { existing ->
+                bookDao.upsert(
+                    existing.copy(
+                        title = patch.title ?: existing.title,
+                        sortTitle = patch.sortTitle ?: existing.sortTitle,
+                        subtitle = patch.subtitle ?: existing.subtitle,
+                        description = patch.description ?: existing.description,
+                        publisher = patch.publisher ?: existing.publisher,
+                        publishYear = patch.publishYear ?: existing.publishYear,
+                        language = patch.language ?: existing.language,
+                        isbn = patch.isbn ?: existing.isbn,
+                        asin = patch.asin ?: existing.asin,
+                        abridged = patch.abridged ?: existing.abridged,
+                        // revision + updatedAt deliberately untouched; addedAt handled server-side.
+                    ),
+                )
+            }
+        }
+        pendingQueue.enqueue(
+            domainName = "books",
+            entityId = id.value,
+            opType = "update",
+            payload = contractJson.encodeToString(BookUpdate.serializer(), patch),
+            ownerUserId = ownerUserId,
+        )
+        return AppResult.Success(Unit)
+    }
 
     override suspend fun setBookContributors(
         id: BookId,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/BookUpdateOpSender.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/BookUpdateOpSender.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.BookUpdate
+import com.calypsan.listenup.api.result.AppResult as WireAppResult
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.BookRpcFactory
+import com.calypsan.listenup.core.BookId
+
+/**
+ * Pushes a queued book edit to the server via
+ * [com.calypsan.listenup.api.BookService.updateBook].
+ *
+ * The PATCH semantics are idempotent — every non-null field replaces the current
+ * value — so the pending-operation queue may safely re-fire on retry. The
+ * authoritative state returns via the SSE sync engine and reconciles through
+ * [com.calypsan.listenup.client.data.sync.handlers.BookSyncDomainHandler]; the
+ * sender therefore discards the (Unit) success payload.
+ *
+ * The [PendingOperation.payload] is a JSON-encoded [BookUpdate]. The sender
+ * decodes it at dispatch time (not enqueue time) so the queue row is the single
+ * durable representation of the pending write.
+ */
+internal class BookUpdateOpSender(
+    private val rpcFactory: BookRpcFactory,
+) : PendingOperationSender {
+    override suspend fun send(op: PendingOperation): AppResult<Unit> {
+        val patch = contractJson.decodeFromString(BookUpdate.serializer(), op.payload)
+        return when (val result = rpcFactory.bookService().updateBook(BookId(op.entityId), patch)) {
+            is WireAppResult.Success -> AppResult.Success(Unit)
+            is WireAppResult.Failure -> AppResult.Failure(result.error)
+        }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/BookModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/BookModule.kt
@@ -88,11 +88,16 @@ internal val bookModule: Module =
             )
         } binds arrayOf(BookIngestPort::class)
 
-        // BookEditRepository — pure RPC dispatcher; SSE echoes write back into Room.
+        // BookEditRepository — offline-first updateBook (Room + outbox queue); the
+        // remaining edits stay RPC-only with SSE echoes writing back into Room.
         single<BookEditRepository> {
             BookEditRepositoryImpl(
                 bookRpcFactory = get(),
                 collectionRpcFactory = get(),
+                bookDao = get(),
+                pendingQueue = get(),
+                transactionRunner = get(),
+                authSession = get(),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncRenovationModule.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.connection.ConnectionCoordinator
 import com.calypsan.listenup.client.data.connection.ReconnectionSupervisor
 import com.calypsan.listenup.client.data.sync.ACTIVITY_PRIME_LIMIT
 import com.calypsan.listenup.client.data.sync.ActivityRefreshSignal
+import com.calypsan.listenup.client.data.sync.BookUpdateOpSender
 import com.calypsan.listenup.client.data.sync.CatchUp
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
 import com.calypsan.listenup.client.data.sync.DomainDigestClient
@@ -108,6 +109,7 @@ internal val clientSyncRenovationModule =
                     mapOf(
                         "playback_positions" to PlaybackPositionOpSender(rpcFactory = get()),
                         "listening_events" to ListeningEventOpSender(rpcFactory = get()),
+                        "books" to BookUpdateOpSender(rpcFactory = get()),
                     ),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookEditRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookEditRepository.kt
@@ -13,9 +13,9 @@ import com.calypsan.listenup.core.BookId
 /**
  * Client-side write surface for book editing.
  *
- * All methods dispatch via [com.calypsan.listenup.api.BookService] over RPC.
- * Authoritative state arrives back via the SSE sync engine; this interface
- * makes no optimistic Room writes.
+ * [updateBook] is offline-first; the remaining methods dispatch via
+ * [com.calypsan.listenup.api.BookService] over RPC, with authoritative state
+ * arriving back via the SSE sync engine (no optimistic Room writes).
  *
  * Wire-side DTOs ([BookUpdate], [BookContributorInput], [BookSeriesInput])
  * are passed through unchanged — the contract is the source of truth.
@@ -24,9 +24,10 @@ interface BookEditRepository {
     /**
      * Applies the PATCH payload [patch] to the book identified by [id].
      *
-     * Every non-null field on [patch] replaces the current value; null fields
-     * leave existing state untouched. The server emits an SSE event with the
-     * updated payload on success; clients update Room reactively.
+     * Offline-first: every non-null field is written to Room immediately and a
+     * durable pending op is enqueued, so the edit survives and replays on
+     * reconnect rather than failing offline. The authoritative state still
+     * arrives via the SSE sync engine and reconciles the optimistic write.
      */
     suspend fun updateBook(
         id: BookId,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositorySetChaptersTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositorySetChaptersTest.kt
@@ -3,8 +3,14 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.BookService
 import com.calypsan.listenup.api.dto.ChapterInput
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.data.local.db.PendingOperationV2Dao
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.BookRpcFactory
 import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.data.sync.PendingOperationSender
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.core.BookId
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -24,7 +30,19 @@ class BookEditRepositorySetChaptersTest :
                 val chapters = listOf(ChapterInput(id = "c1", title = "A", startTime = 0, duration = 1000))
                 everySuspend { service.setBookChapters(BookId("b1"), chapters) } returns AppResult.Success(Unit)
 
-                val repo = BookEditRepositoryImpl(rpcFactory, mock<CollectionRpcFactory>(MockMode.autoUnit))
+                val repo =
+                    BookEditRepositoryImpl(
+                        bookRpcFactory = rpcFactory,
+                        collectionRpcFactory = mock<CollectionRpcFactory>(MockMode.autoUnit),
+                        bookDao = mock<BookDao>(MockMode.autoUnit),
+                        pendingQueue =
+                            PendingOperationQueue(
+                                dao = mock<PendingOperationV2Dao>(MockMode.autoUnit),
+                                sender = PendingOperationSender { AppResult.Success(Unit) },
+                            ),
+                        transactionRunner = mock<TransactionRunner>(MockMode.autoUnit),
+                        authSession = mock<AuthSession>(MockMode.autoUnit),
+                    )
                 repo.setBookChapters(BookId("b1"), chapters)
 
                 verifySuspend { service.setBookChapters(BookId("b1"), chapters) }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositoryOfflineTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookEditRepositoryOfflineTest.kt
@@ -1,0 +1,76 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.dto.BookUpdate
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.remote.BookRpcFactory
+import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.data.sync.PendingOperationSender
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.Timestamp
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+class BookEditRepositoryOfflineTest :
+    FunSpec({
+        test("offline book edit persists to Room and enqueues a pending op without ServerConnectError") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val bookId = BookId("book1")
+                db.bookDao().upsert(
+                    BookEntity(
+                        id = bookId,
+                        libraryId = LibraryId("lib1"),
+                        folderId = FolderId("folder1"),
+                        title = "Old Title",
+                        totalDuration = 0L,
+                        createdAt = Timestamp(0L),
+                        updatedAt = Timestamp(0L),
+                    ),
+                )
+
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                    )
+                val txRunner =
+                    object : TransactionRunner {
+                        override suspend fun <R> atomically(block: suspend () -> R): R = block()
+                    }
+                val authSession: AuthSession = mock()
+                everySuspend { authSession.getUserId() } returns "u1"
+
+                val repo =
+                    BookEditRepositoryImpl(
+                        bookRpcFactory = mock<BookRpcFactory>(),
+                        collectionRpcFactory = mock<CollectionRpcFactory>(),
+                        bookDao = db.bookDao(),
+                        pendingQueue = queue,
+                        transactionRunner = txRunner,
+                        authSession = authSession,
+                    )
+
+                val result = repo.updateBook(bookId, BookUpdate(title = "New Title"))
+
+                result shouldBe AppResult.Success(Unit)
+                db.bookDao().getById(bookId)?.title shouldBe "New Title"
+                db
+                    .pendingOperationV2Dao()
+                    .nextDispatchable(maxAttempts = 5)
+                    .firstOrNull()
+                    ?.domainName shouldBe "books"
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookUpdateOpSenderTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookUpdateOpSenderTest.kt
@@ -1,0 +1,73 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.BookService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.BookUpdate
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.result.AppResult as WireAppResult
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.BookRpcFactory
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+
+class BookUpdateOpSenderTest :
+    FunSpec({
+
+        test("decodes BookUpdate and calls updateBook; returns Success on RPC success") {
+            runTest {
+                val patch = BookUpdate(title = "New Title")
+                val payload = contractJson.encodeToString(BookUpdate.serializer(), patch)
+
+                val service: BookService = mock()
+                everySuspend { service.updateBook(any(), any()) } returns WireAppResult.Success(Unit)
+
+                val rpcFactory: BookRpcFactory = mock()
+                everySuspend { rpcFactory.bookService() } returns service
+
+                val result = BookUpdateOpSender(rpcFactory).send(fakeOp(payload))
+
+                result shouldBe AppResult.Success(Unit)
+                verifySuspend(exactly(1)) { service.updateBook(BookId("book1"), patch) }
+            }
+        }
+
+        test("propagates a WireAppResult.Failure as AppResult.Failure") {
+            runTest {
+                val patch = BookUpdate(title = "New Title")
+                val payload = contractJson.encodeToString(BookUpdate.serializer(), patch)
+
+                val expectedError = SyncError.PushFailed()
+                val service: BookService = mock()
+                everySuspend { service.updateBook(any(), any()) } returns WireAppResult.Failure(expectedError)
+
+                val rpcFactory: BookRpcFactory = mock()
+                everySuspend { rpcFactory.bookService() } returns service
+
+                val result = BookUpdateOpSender(rpcFactory).send(fakeOp(payload))
+
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error shouldBe expectedError
+            }
+        }
+    })
+
+private fun fakeOp(payload: String): PendingOperation =
+    PendingOperation(
+        clientOpId = "op-1",
+        domainName = "books",
+        entityId = "book1",
+        opType = "update",
+        payload = payload,
+        enqueuedAt = 1_000L,
+        failureCount = 0,
+        ownerUserId = "user-1",
+    )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.data.repository.BookEditRepositoryImpl
 import com.calypsan.listenup.client.data.repository.ContributorEditRepositoryImpl
 import com.calypsan.listenup.client.data.repository.GenreRepositoryImpl
 import com.calypsan.listenup.client.data.repository.SeriesEditRepositoryImpl
+import com.calypsan.listenup.client.data.sync.BookUpdateOpSender
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
 import com.calypsan.listenup.client.data.sync.DomainDigestClient
 import com.calypsan.listenup.client.data.sync.DomainPendingOperationSender
@@ -375,11 +376,7 @@ internal fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.
                 // matches the existing SSE/REST clients above.
                 installKrpc()
             }
-        val bookEditRepository: BookEditRepository =
-            BookEditRepositoryImpl(
-                bookRpcFactory = TestBookRpcFactory(testClient),
-                collectionRpcFactory = TestCollectionRpcFactory(testClient),
-            )
+        val testBookRpcFactory = TestBookRpcFactory(testClient)
         val contributorEditRepository: ContributorEditRepository =
             ContributorEditRepositoryImpl(contributorRpcFactory = TestContributorRpcFactory(testClient))
         val seriesEditRepository: SeriesEditRepository =
@@ -413,8 +410,22 @@ internal fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.
                             mapOf(
                                 "playback_positions" to playbackSender,
                                 "listening_events" to listeningEventSender,
+                                "books" to BookUpdateOpSender(testBookRpcFactory),
                             ),
                         ),
+                )
+
+            // Offline-first book edits write to client Room and enqueue a "books" op;
+            // the engine drains it through the BookUpdateOpSender above to the in-process
+            // server, whose SSE echo reconciles client Room via BookSyncDomainHandler.
+            val bookEditRepository: BookEditRepository =
+                BookEditRepositoryImpl(
+                    bookRpcFactory = testBookRpcFactory,
+                    collectionRpcFactory = TestCollectionRpcFactory(testClient),
+                    bookDao = clientDb.bookDao(),
+                    pendingQueue = queue,
+                    transactionRunner = RoomTransactionRunner(clientDb),
+                    authSession = FakeAuthSession(),
                 )
 
             val catchUp =


### PR DESCRIPTION
## Problem

Editing a book while offline threw a `ServerConnectError` and **lost the edit**. `BookEditRepositoryImpl.updateBook` was a pure RPC dispatch — server-first by design (its KDoc: *"the SSE echo is the single write path"*) — so with no connection the edit never reached Room and nothing was queued.

## Fix

Make book edits offline-first by reusing the **existing** pending-operation queue (the same outbox playback uses) — no new infrastructure, no server or `:contract` changes:

1. **Optimistic Room write** — apply the patch's non-null fields to the `BookEntity` inside `transactionRunner.atomically { }`, leaving `revision`/`updatedAt` untouched (server stays authoritative).
2. **Durable enqueue** — `pendingQueue.enqueue("books", bookId, "update", json(BookUpdate), userId)`.
3. **Return `Success` immediately** — instant UI, online or offline.
4. **Replay on reconnect** — new `BookUpdateOpSender` decodes the patch and calls `BookService.updateBook`; the existing `BookSyncDomainHandler` reconciles the SSE echo.

Edits made offline now persist and sync when the connection returns.

## Tests (TDD)

- `BookEditRepositoryOfflineTest` — an offline edit returns `Success`, updates Room, and enqueues a `"books"` op (no `ServerConnectError`). This is the regression test for the reported bug.
- `BookUpdateOpSenderTest` — decodes the payload, calls the RPC, maps `Success`/`Failure`.
- The in-process `BookEditE2ETest` harness was updated to wire the new sender + repo deps, so it now exercises the full offline round-trip (Room write → enqueue → drain → server → SSE echo → reconcile).

## Verification

`:sharedLogic:jvmTest` · `spotlessCheck` · `detekt` — all green.

## Scope / follow-on

This PR ships the **books** slice (the reported bug). The same uniform pattern is planned for **series edit, contributor edit, profile name/tagline, and user preferences** (closing a preferences push gap), with online-only actions (merge/unmerge/delete, admin, password, avatar) kept online but messaged honestly. Those slices are specced and planned and will follow as separate work.