### PR TITLE
✨ Sharing Phase 1: shared deep-link core (codec, resolver, targets)

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
+++ b/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
@@ -433,6 +433,8 @@ object SwiftExportSourcePatcher {
             "com.calypsan.listenup.client.presentation.storage.DeleteConfirmation" to 2,
             "com.calypsan.listenup.client.presentation.sync.SyncIndicatorUiEvent" to 4,
             "com.calypsan.listenup.client.presentation.tagdetail.TagDetailUiState" to 4,
+            "com.calypsan.listenup.client.share.ShareResolution" to 5,
+            "com.calypsan.listenup.client.share.ShareTarget" to 2,
             "com.calypsan.listenup.api.dto.backup.BackupEvent" to 10,
             "com.calypsan.listenup.api.dto.imports.ImportEvent" to 6,
             "com.calypsan.listenup.api.error.DownloadError" to 2,

--- a/scripts/export-surface-baseline.txt
+++ b/scripts/export-surface-baseline.txt
@@ -457,7 +457,12 @@ SetupErrorType
 SetupField
 SetupUiState
 SetupViewModel
+ShareLinkCodec
+ShareLinkConstants
 SharePermission
+ShareResolution
+ShareTarget
+ShareTargetResolver
 Shelf
 ShelfBook
 ShelfBookSort

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DeepLinkManager.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DeepLinkManager.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.client.share.ShareTarget
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -69,4 +70,33 @@ class DeepLinkManager {
      * Checks if there's a pending invite without consuming it.
      */
     fun hasPendingInvite(): Boolean = pendingInvite.value != null
+
+    /**
+     * Observable flow of the pending share-link / deep-link target.
+     *
+     * The generalized successor to [pendingInvite]: both platforms' routers observe this,
+     * run it through [com.calypsan.listenup.client.share.ShareTargetResolver], and act on the
+     * resolution. Null when nothing is pending. Phase 2 migrates invite reception onto this
+     * seam and retires [pendingInvite].
+     */
+    val pendingTarget: StateFlow<ShareTarget?>
+        field = MutableStateFlow<ShareTarget?>(null)
+
+    /**
+     * Stores a pending target to be processed by navigation. Called by the reception layer
+     * after [com.calypsan.listenup.client.share.ShareLinkCodec.decode] yields a target.
+     *
+     * @param target The decoded [ShareTarget] to hold until navigation consumes it.
+     */
+    fun setPendingTarget(target: ShareTarget) {
+        pendingTarget.value = target
+    }
+
+    /** Clears the pending target after navigation has consumed it (single-fire semantics). */
+    fun consumeTarget() {
+        pendingTarget.value = null
+    }
+
+    /** Checks whether a target is pending without consuming it. */
+    fun hasPendingTarget(): Boolean = pendingTarget.value != null
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -1,5 +1,8 @@
 package com.calypsan.listenup.client.share
 
+import com.calypsan.listenup.core.BookId
+import io.ktor.http.parseQueryString
+
 /**
  * Pure, two-way translation between share-link URL strings and [ShareTarget].
  *
@@ -12,6 +15,12 @@ package com.calypsan.listenup.client.share
  * the same params in the `?query` as a fallback, in case a platform strips the fragment.
  */
 object ShareLinkCodec {
+    /**
+     * RFC 3986 §2.3 unreserved characters — safe to appear in a percent-encoded value without
+     * being escaped. All other octets (including `:` and `/`) are percent-encoded.
+     */
+    private val rfc3986UnreservedChars: Set<Char> =
+        (('a'..'z') + ('A'..'Z') + ('0'..'9') + listOf('-', '.', '_', '~')).toSet()
 
     /** Builds a shareable link for [target]. Books → the `https` `/o` form; invites → `listenup://join`. */
     fun encode(target: ShareTarget): String =
@@ -19,6 +28,19 @@ object ShareLinkCodec {
             is ShareTarget.Book -> encodeBook(target)
             is ShareTarget.Invite -> encodeInvite(target)
         }
+
+    /**
+     * Parses [raw] into a [ShareTarget], or `null` if it is not a recognised ListenUp link.
+     * Unknown entity types and foreign hosts return `null` (forward-compatible, not a crash).
+     */
+    fun decode(raw: String): ShareTarget? {
+        val url = raw.trim()
+        return when {
+            url.startsWith(ShareLinkConstants.SHARE_URL_PREFIX, ignoreCase = true) -> decodeHttpsForm(url)
+            url.startsWith("${ShareLinkConstants.CUSTOM_SCHEME}://", ignoreCase = true) -> decodeCustomScheme(url)
+            else -> null
+        }
+    }
 
     private fun encodeBook(book: ShareTarget.Book): String =
         buildString {
@@ -36,27 +58,78 @@ object ShareLinkCodec {
             append("&code=").append(invite.code.percentEncodeQueryValue())
         }
 
+    private fun decodeHttpsForm(url: String): ShareTarget? {
+        // Length-based slice is safe: the prefix matched ignore-case, so its length is unchanged.
+        val remainder = url.substring(ShareLinkConstants.SHARE_URL_PREFIX.length)
+        // The path must end at /o exactly — reject /o/something or /other.
+        if (remainder.isNotEmpty() && remainder[0] !in charArrayOf('#', '?')) return null
+        val query = remainder.substringAfter('?', "").substringBefore('#')
+        val fragment = remainder.substringAfter('#', "")
+        val params = parseQueryString(fragment.ifEmpty { query })
+        if (params["t"] != "book") return null
+        val bookId = params["b"]?.takeIf { it.isNotBlank() } ?: return null
+        return ShareTarget.Book(
+            bookId = BookId(bookId),
+            serverInstanceId = params["i"]?.takeIf { it.isNotBlank() },
+            serverUrl = params["u"]?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun decodeCustomScheme(url: String): ShareTarget? {
+        val afterScheme = url.substring("${ShareLinkConstants.CUSTOM_SCHEME}://".length)
+        val host =
+            afterScheme
+                .substringBefore('/')
+                .substringBefore('?')
+                .substringBefore('#')
+                .lowercase()
+        return when (host) {
+            "book" -> {
+                val id =
+                    afterScheme
+                        .substringAfter('/', "")
+                        .substringBefore('?')
+                        .substringBefore('#')
+                        .split('/')
+                        .firstOrNull { it.isNotBlank() }
+                        ?: return null
+                ShareTarget.Book(bookId = BookId(id), serverInstanceId = null, serverUrl = null)
+            }
+
+            "join" -> {
+                val query = afterScheme.substringAfter('?', "").substringBefore('#')
+                val params = parseQueryString(query)
+                val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
+                val code = params["code"]?.takeIf { it.isNotBlank() } ?: return null
+                ShareTarget.Invite(serverUrl = server, code = code)
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+
     /**
      * Percent-encodes this string as a query parameter value, following RFC 3986 §2.3.
      * Unreserved characters (ALPHA / DIGIT / "-" / "." / "_" / "~") are left as-is;
      * everything else — including ":" and "/" — is percent-encoded with uppercase hex digits.
      */
-    private fun String.percentEncodeQueryValue(): String = buildString {
-        for (byte in encodeToByteArray()) {
-            val ch = byte.toInt() and 0xFF
-            if (ch in 0x30..0x39 || // 0-9
-                ch in 0x41..0x5A || // A-Z
-                ch in 0x61..0x7A || // a-z
-                ch == 0x2D || // -
-                ch == 0x2E || // .
-                ch == 0x5F || // _
-                ch == 0x7E // ~
-            ) {
-                append(ch.toChar())
-            } else {
-                append('%')
-                append(ch.toString(16).uppercase().padStart(2, '0'))
+    private fun String.percentEncodeQueryValue(): String =
+        buildString {
+            for (byte in encodeToByteArray()) {
+                val ch = (byte.toInt() and 0xFF).toChar()
+                if (ch in rfc3986UnreservedChars) {
+                    append(ch)
+                } else {
+                    append('%')
+                    append(
+                        ch.code
+                            .toString(16)
+                            .uppercase()
+                            .padStart(2, '0'),
+                    )
+                }
             }
         }
-    }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.client.share
+
+/**
+ * Pure, two-way translation between share-link URL strings and [ShareTarget].
+ *
+ * [encode] is used by the Share button (Phase 2/3) to build the shareable `https` link.
+ * [decode] is used by both platforms' reception layers to parse an incoming link — the new
+ * `https://link.listenup.audio/o#…` form **and** the legacy `listenup://book/{id}` /
+ * `listenup://join?…` schemes — so the parsing lives once, in `commonMain`, not per platform.
+ *
+ * The payload rides in the URL `#fragment` (the host never receives it); [decode] also accepts
+ * the same params in the `?query` as a fallback, in case a platform strips the fragment.
+ */
+object ShareLinkCodec {
+
+    /** Builds a shareable link for [target]. Books → the `https` `/o` form; invites → `listenup://join`. */
+    fun encode(target: ShareTarget): String =
+        when (target) {
+            is ShareTarget.Book -> encodeBook(target)
+            is ShareTarget.Invite -> encodeInvite(target)
+        }
+
+    private fun encodeBook(book: ShareTarget.Book): String =
+        buildString {
+            append(ShareLinkConstants.SHARE_URL_PREFIX)
+            append("#t=book")
+            append("&b=").append(book.bookId.value.percentEncodeQueryValue())
+            book.serverInstanceId?.let { append("&i=").append(it.percentEncodeQueryValue()) }
+            book.serverUrl?.let { append("&u=").append(it.percentEncodeQueryValue()) }
+        }
+
+    private fun encodeInvite(invite: ShareTarget.Invite): String =
+        buildString {
+            append(ShareLinkConstants.CUSTOM_SCHEME).append("://join")
+            append("?server=").append(invite.serverUrl.percentEncodeQueryValue())
+            append("&code=").append(invite.code.percentEncodeQueryValue())
+        }
+
+    /**
+     * Percent-encodes this string as a query parameter value, following RFC 3986 §2.3.
+     * Unreserved characters (ALPHA / DIGIT / "-" / "." / "_" / "~") are left as-is;
+     * everything else — including ":" and "/" — is percent-encoded with uppercase hex digits.
+     */
+    private fun String.percentEncodeQueryValue(): String = buildString {
+        for (byte in encodeToByteArray()) {
+            val ch = byte.toInt() and 0xFF
+            if (ch in 0x30..0x39 || // 0-9
+                ch in 0x41..0x5A || // A-Z
+                ch in 0x61..0x7A || // a-z
+                ch == 0x2D || // -
+                ch == 0x2E || // .
+                ch == 0x5F || // _
+                ch == 0x7E // ~
+            ) {
+                append(ch.toChar())
+            } else {
+                append('%')
+                append(ch.toString(16).uppercase().padStart(2, '0'))
+            }
+        }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -84,30 +84,30 @@ object ShareLinkCodec {
                 .substringBefore('#')
                 .lowercase()
         return when (host) {
-            "book" -> {
-                val id =
-                    afterScheme
-                        .substringAfter('/', "")
-                        .substringBefore('?')
-                        .substringBefore('#')
-                        .split('/')
-                        .firstOrNull { it.isNotBlank() }
-                        ?: return null
-                ShareTarget.Book(bookId = BookId(id), serverInstanceId = null, serverUrl = null)
-            }
-
-            "join" -> {
-                val query = afterScheme.substringAfter('?', "").substringBefore('#')
-                val params = parseQueryString(query)
-                val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
-                val code = params["code"]?.takeIf { it.isNotBlank() } ?: return null
-                ShareTarget.Invite(serverUrl = server, code = code)
-            }
-
-            else -> {
-                null
-            }
+            "book" -> decodeLegacyBookScheme(afterScheme)
+            "join" -> decodeLegacyJoinScheme(afterScheme)
+            else -> null
         }
+    }
+
+    private fun decodeLegacyBookScheme(afterScheme: String): ShareTarget? {
+        val id =
+            afterScheme
+                .substringAfter('/', "")
+                .substringBefore('?')
+                .substringBefore('#')
+                .split('/')
+                .firstOrNull { it.isNotBlank() }
+                ?: return null
+        return ShareTarget.Book(bookId = BookId(id), serverInstanceId = null, serverUrl = null)
+    }
+
+    private fun decodeLegacyJoinScheme(afterScheme: String): ShareTarget? {
+        val query = afterScheme.substringAfter('?', "").substringBefore('#')
+        val params = parseQueryString(query)
+        val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
+        val code = params["code"]?.takeIf { it.isNotBlank() } ?: return null
+        return ShareTarget.Invite(serverUrl = server, code = code)
     }
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkConstants.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkConstants.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.client.share
+
+/**
+ * Compile-time constants for ListenUp share links.
+ *
+ * The share domain is **developer-owned** infrastructure — a tiny static redirector that
+ * lets a tapped link open the app or fall back to the install page. It is never a
+ * self-hosted server's address, and (because the payload rides in the URL fragment) it
+ * never learns what was shared. See `docs/superpowers/specs/2026-06-26-sharing-design.md`.
+ */
+object ShareLinkConstants {
+    /** Host of the static share-link redirector. App/Universal Links verify against this domain. */
+    const val SHARE_DOMAIN: String = "link.listenup.audio"
+
+    /** The single generalized "open" path. Book ships first; series/contributors reuse it later. */
+    const val OPEN_PATH: String = "/o"
+
+    /** The `https` prefix every shareable link starts with: `https://link.listenup.audio/o`. */
+    const val SHARE_URL_PREFIX: String = "https://$SHARE_DOMAIN$OPEN_PATH"
+
+    /** The custom scheme retained for back-compat and app-to-app links. */
+    const val CUSTOM_SCHEME: String = "listenup"
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareResolution.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareResolution.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.client.share
+
+import com.calypsan.listenup.core.BookId
+
+/**
+ * The decided outcome of a [ShareTarget] against the currently-connected server.
+ *
+ * [ShareTargetResolver.resolve] produces the instanceId-decidable outcomes — [OpenBook],
+ * [OpenInviteClaim], [WrongServer], [NotConnected]. [NoAccess] is reached **downstream**, at
+ * open time, when the connected server reports the book is not accessible: that check is
+ * server-side (`BookAccessPolicy`), so it cannot be decided by the pure resolver. The platform
+ * routing layer renders the user-facing message for each outcome (strings added in Phases 2–3).
+ */
+sealed interface ShareResolution {
+    /** The book is on the connected server — open Book Detail (fetch-on-demand if not yet synced). */
+    data class OpenBook(val bookId: BookId) : ShareResolution
+
+    /** A join link — present the invite-claim flow for [serverUrl] / [code]. */
+    data class OpenInviteClaim(val serverUrl: String, val code: String) : ShareResolution
+
+    /** The link points at a different ListenUp server than the one the user is signed in to. */
+    data class WrongServer(val serverUrl: String?) : ShareResolution
+
+    /** No server is connected — the user must sign in to the host server first. */
+    data class NotConnected(val serverUrl: String?) : ShareResolution
+
+    /** Same server, but the user is not permitted to see this book (decided at open time). */
+    data object NoAccess : ShareResolution
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareResolution.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareResolution.kt
@@ -13,16 +13,25 @@ import com.calypsan.listenup.core.BookId
  */
 sealed interface ShareResolution {
     /** The book is on the connected server — open Book Detail (fetch-on-demand if not yet synced). */
-    data class OpenBook(val bookId: BookId) : ShareResolution
+    data class OpenBook(
+        val bookId: BookId,
+    ) : ShareResolution
 
     /** A join link — present the invite-claim flow for [serverUrl] / [code]. */
-    data class OpenInviteClaim(val serverUrl: String, val code: String) : ShareResolution
+    data class OpenInviteClaim(
+        val serverUrl: String,
+        val code: String,
+    ) : ShareResolution
 
     /** The link points at a different ListenUp server than the one the user is signed in to. */
-    data class WrongServer(val serverUrl: String?) : ShareResolution
+    data class WrongServer(
+        val serverUrl: String?,
+    ) : ShareResolution
 
     /** No server is connected — the user must sign in to the host server first. */
-    data class NotConnected(val serverUrl: String?) : ShareResolution
+    data class NotConnected(
+        val serverUrl: String?,
+    ) : ShareResolution
 
     /** Same server, but the user is not permitted to see this book (decided at open time). */
     data object NoAccess : ShareResolution

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
@@ -1,0 +1,40 @@
+package com.calypsan.listenup.client.share
+
+import com.calypsan.listenup.core.BookId
+
+/**
+ * A decoded share / deep-link target — what the user is trying to open.
+ *
+ * This is the generalized model: [Book] ships first; series and contributors slot in later
+ * as new variants with no change to the codec or resolver call sites. Parity between Android
+ * and iOS comes from both platforms decoding to — and resolving — this one type.
+ */
+sealed interface ShareTarget {
+    /**
+     * A shared book.
+     *
+     * @property bookId The server-scoped book id to open.
+     * @property serverInstanceId The stable `instanceId` of the server that produced the link,
+     *   or `null` for a legacy `listenup://book/{id}` link that carried no server context
+     *   (such a link resolves against the currently-connected server).
+     * @property serverUrl The source server's URL, for display and a possible future "connect"
+     *   action — never the identity key (URLs vary LAN-vs-remote). `null` when the link carried none.
+     */
+    data class Book(
+        val bookId: BookId,
+        val serverInstanceId: String?,
+        val serverUrl: String?,
+    ) : ShareTarget
+
+    /**
+     * An invite / join claim — the existing `listenup://join` link, unified into this model.
+     *
+     * @property serverUrl The server the invite is for (persisted before lookup so a fresh
+     *   install can reach it).
+     * @property code The invite code.
+     */
+    data class Invite(
+        val serverUrl: String,
+        val code: String,
+    ) : ShareTarget
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
@@ -19,6 +19,11 @@ sealed interface ShareTarget {
      *   (such a link resolves against the currently-connected server).
      * @property serverUrl The source server's URL, for display and a possible future "connect"
      *   action — never the identity key (URLs vary LAN-vs-remote). `null` when the link carried none.
+     *
+     * Note: [serverInstanceId] and [serverUrl] are independently optional (they map to the link's
+     * separate `i` and `u` params). This app's encoder always supplies both together from a
+     * connected server; a link carrying one but not the other is representable but degenerate —
+     * the resolver treats a null [serverInstanceId] as a legacy link and ignores [serverUrl] then.
      */
     data class Book(
         val bookId: BookId,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTargetResolver.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTargetResolver.kt
@@ -1,0 +1,36 @@
+package com.calypsan.listenup.client.share
+
+/**
+ * Decides what a decoded [ShareTarget] should do, given the currently-connected server's
+ * stable `instanceId` (or `null` when no server is connected).
+ *
+ * Pure and shared so Android and iOS behave identically. It returns the instanceId-decidable
+ * outcomes; [ShareResolution.NoAccess] is **not** produced here — book access is a server-side
+ * decision reached at open time (see [ShareResolution]).
+ */
+object ShareTargetResolver {
+    /** Resolves [target] against [connectedInstanceId] (the connected server's `instanceId`, or `null`). */
+    fun resolve(
+        target: ShareTarget,
+        connectedInstanceId: String?,
+    ): ShareResolution =
+        when (target) {
+            is ShareTarget.Invite -> ShareResolution.OpenInviteClaim(target.serverUrl, target.code)
+            is ShareTarget.Book -> resolveBook(target, connectedInstanceId)
+        }
+
+    private fun resolveBook(
+        book: ShareTarget.Book,
+        connectedInstanceId: String?,
+    ): ShareResolution =
+        when {
+            connectedInstanceId == null -> ShareResolution.NotConnected(book.serverUrl)
+
+            // A legacy link carries no server context — open it against whatever server we are on.
+            book.serverInstanceId == null -> ShareResolution.OpenBook(book.bookId)
+
+            book.serverInstanceId == connectedInstanceId -> ShareResolution.OpenBook(book.bookId)
+
+            else -> ShareResolution.WrongServer(book.serverUrl)
+        }
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/DeepLinkManagerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/DeepLinkManagerTest.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.data.repository
+
+import app.cash.turbine.test
+import com.calypsan.listenup.client.share.ShareTarget
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DeepLinkManagerTest :
+    FunSpec({
+
+        test("pendingTarget starts null") {
+            DeepLinkManager().pendingTarget.value shouldBe null
+        }
+
+        test("setPendingTarget then consumeTarget drives pendingTarget and hasPendingTarget") {
+            val manager = DeepLinkManager()
+            val target = ShareTarget.Book(bookId = BookId("book-1"), serverInstanceId = "inst-1", serverUrl = null)
+
+            manager.pendingTarget.test {
+                awaitItem() shouldBe null
+
+                manager.setPendingTarget(target)
+                awaitItem() shouldBe target
+                manager.hasPendingTarget() shouldBe true
+
+                manager.consumeTarget()
+                awaitItem() shouldBe null
+                manager.hasPendingTarget() shouldBe false
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -1,0 +1,45 @@
+package com.calypsan.listenup.client.share
+
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+
+class ShareLinkCodecTest :
+    FunSpec({
+
+        test("encode produces the https /o form with the book id, instance id, and url") {
+            val url =
+                ShareLinkCodec.encode(
+                    ShareTarget.Book(
+                        bookId = BookId("book-abc"),
+                        serverInstanceId = "inst-123",
+                        serverUrl = "https://lib.example.com",
+                    ),
+                )
+
+            url shouldStartWith "https://link.listenup.audio/o#t=book"
+            url shouldContain "b=book-abc"
+            url shouldContain "i=inst-123"
+            // serverUrl is percent-encoded as a query component.
+            url shouldContain "u=https%3A%2F%2Flib.example.com"
+        }
+
+        test("encode omits i and u when the book carries no server context") {
+            val url =
+                ShareLinkCodec.encode(
+                    ShareTarget.Book(bookId = BookId("book-abc"), serverInstanceId = null, serverUrl = null),
+                )
+
+            url shouldBe "https://link.listenup.audio/o#t=book&b=book-abc"
+        }
+
+        test("encode produces the legacy listenup join form for an invite") {
+            val url = ShareLinkCodec.encode(ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "JOIN9"))
+
+            url shouldStartWith "listenup://join?"
+            url shouldContain "server=https%3A%2F%2Flib.example.com"
+            url shouldContain "code=JOIN9"
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -42,4 +42,77 @@ class ShareLinkCodecTest :
             url shouldContain "server=https%3A%2F%2Flib.example.com"
             url shouldContain "code=JOIN9"
         }
+
+        test("decode parses the https /o form from the fragment") {
+            val target =
+                ShareLinkCodec.decode(
+                    "https://link.listenup.audio/o#t=book&b=book-abc&i=inst-123&u=https%3A%2F%2Flib.example.com",
+                )
+
+            target shouldBe
+                ShareTarget.Book(
+                    bookId = BookId("book-abc"),
+                    serverInstanceId = "inst-123",
+                    serverUrl = "https://lib.example.com",
+                )
+        }
+
+        test("decode falls back to the query when the fragment is absent") {
+            val target = ShareLinkCodec.decode("https://link.listenup.audio/o?t=book&b=book-xyz&i=inst-9")
+
+            target shouldBe
+                ShareTarget.Book(bookId = BookId("book-xyz"), serverInstanceId = "inst-9", serverUrl = null)
+        }
+
+        test("encode then decode round-trips a fully-populated book") {
+            val original =
+                ShareTarget.Book(
+                    bookId = BookId("book-abc"),
+                    serverInstanceId = "inst-123",
+                    serverUrl = "https://lib.example.com:8443/listenup",
+                )
+
+            ShareLinkCodec.decode(ShareLinkCodec.encode(original)) shouldBe original
+        }
+
+        test("encode then decode round-trips an invite") {
+            val original = ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "JOIN9")
+
+            ShareLinkCodec.decode(ShareLinkCodec.encode(original)) shouldBe original
+        }
+
+        test("decode parses the legacy listenup book scheme with no server context") {
+            val target = ShareLinkCodec.decode("listenup://book/book-legacy")
+
+            target shouldBe
+                ShareTarget.Book(bookId = BookId("book-legacy"), serverInstanceId = null, serverUrl = null)
+        }
+
+        test("decode parses the legacy listenup join scheme") {
+            val target = ShareLinkCodec.decode("listenup://join?server=https%3A%2F%2Flib.example.com&code=ABC123")
+
+            target shouldBe ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "ABC123")
+        }
+
+        test("decode returns null for an https link with an unknown type") {
+            ShareLinkCodec.decode("https://link.listenup.audio/o#t=podcast&b=x") shouldBe null
+        }
+
+        test("decode returns null for an https link missing the book id") {
+            ShareLinkCodec.decode("https://link.listenup.audio/o#t=book") shouldBe null
+        }
+
+        test("decode returns null for a join link missing the code") {
+            ShareLinkCodec.decode("listenup://join?server=https%3A%2F%2Flib.example.com") shouldBe null
+        }
+
+        test("decode returns null for a foreign https host") {
+            ShareLinkCodec.decode("https://evil.example.com/o#t=book&b=x") shouldBe null
+        }
+
+        test("decode returns null for blank or unrelated input") {
+            ShareLinkCodec.decode("") shouldBe null
+            ShareLinkCodec.decode("not a url") shouldBe null
+            ShareLinkCodec.decode("https://link.listenup.audio/other") shouldBe null
+        }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -138,4 +138,14 @@ class ShareLinkCodecTest :
         test("decode returns null for a path extension on the /o route") {
             ShareLinkCodec.decode("https://link.listenup.audio/o/extra#t=book&b=x") shouldBe null
         }
+
+        test("decode trims surrounding whitespace before parsing") {
+            ShareLinkCodec.decode("  https://link.listenup.audio/o#t=book&b=book-trim\n") shouldBe
+                ShareTarget.Book(bookId = BookId("book-trim"), serverInstanceId = null, serverUrl = null)
+        }
+
+        test("decode prefers the fragment over the query when both are present") {
+            ShareLinkCodec.decode("https://link.listenup.audio/o?t=book&b=from-query#t=book&b=from-fragment") shouldBe
+                ShareTarget.Book(bookId = BookId("from-fragment"), serverInstanceId = null, serverUrl = null)
+        }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -115,4 +115,27 @@ class ShareLinkCodecTest :
             ShareLinkCodec.decode("not a url") shouldBe null
             ShareLinkCodec.decode("https://link.listenup.audio/other") shouldBe null
         }
+
+        test("encode then decode round-trips a book with a non-ASCII server URL") {
+            val original =
+                ShareTarget.Book(
+                    bookId = BookId("book-abc"),
+                    serverInstanceId = "inst-1",
+                    serverUrl = "https://bücher.example.com",
+                )
+            ShareLinkCodec.decode(ShareLinkCodec.encode(original)) shouldBe original
+        }
+
+        test("encode percent-encodes control characters with two-digit hex") {
+            // Tab (0x09) must encode to %09, not the malformed %9.
+            val url =
+                ShareLinkCodec.encode(
+                    ShareTarget.Book(bookId = BookId("book\tabc"), serverInstanceId = null, serverUrl = null),
+                )
+            url shouldContain "b=book%09abc"
+        }
+
+        test("decode returns null for a path extension on the /o route") {
+            ShareLinkCodec.decode("https://link.listenup.audio/o/extra#t=book&b=x") shouldBe null
+        }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareTargetResolverTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareTargetResolverTest.kt
@@ -1,0 +1,49 @@
+package com.calypsan.listenup.client.share
+
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ShareTargetResolverTest :
+    FunSpec({
+
+        fun book(
+            instanceId: String?,
+            url: String? = "https://lib.example.com",
+        ) = ShareTarget.Book(bookId = BookId("book-1"), serverInstanceId = instanceId, serverUrl = url)
+
+        test("an invite always resolves to OpenInviteClaim regardless of connected server") {
+            val resolution =
+                ShareTargetResolver.resolve(
+                    ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "JOIN9"),
+                    connectedInstanceId = "inst-other",
+                )
+
+            resolution shouldBe ShareResolution.OpenInviteClaim("https://lib.example.com", "JOIN9")
+        }
+
+        test("a book on the connected server resolves to OpenBook") {
+            ShareTargetResolver.resolve(book(instanceId = "inst-1"), connectedInstanceId = "inst-1") shouldBe
+                ShareResolution.OpenBook(BookId("book-1"))
+        }
+
+        test("a book on a different server resolves to WrongServer with the source url") {
+            ShareTargetResolver.resolve(book(instanceId = "inst-1"), connectedInstanceId = "inst-2") shouldBe
+                ShareResolution.WrongServer("https://lib.example.com")
+        }
+
+        test("any book resolves to NotConnected when no server is connected") {
+            ShareTargetResolver.resolve(book(instanceId = "inst-1"), connectedInstanceId = null) shouldBe
+                ShareResolution.NotConnected("https://lib.example.com")
+        }
+
+        test("a legacy book (no server context) opens against the connected server") {
+            ShareTargetResolver.resolve(book(instanceId = null, url = null), connectedInstanceId = "inst-1") shouldBe
+                ShareResolution.OpenBook(BookId("book-1"))
+        }
+
+        test("a legacy book resolves to NotConnected when no server is connected") {
+            ShareTargetResolver.resolve(book(instanceId = null, url = null), connectedInstanceId = null) shouldBe
+                ShareResolution.NotConnected(null)
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ShareLogicLivesInCommonMainRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ShareLogicLivesInCommonMainRule.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Share-link parsing and resolution are the source of Android↔iOS parity, so they must live
+ * once in `commonMain` — never re-implemented in a `:sharedLogic` platform source set. A
+ * platform-specific `ShareLinkCodec`/`ShareTargetResolver`/`ShareTarget`/`ShareResolution`/
+ * `ShareLinkConstants` would silently let the two platforms drift, so make it a build failure.
+ */
+class ShareLogicLivesInCommonMainRule :
+    FunSpec({
+
+        test("share-link target, codec, resolver, and constants live only in commonMain") {
+            val shareTypes =
+                setOf(
+                    "ShareTarget",
+                    "ShareResolution",
+                    "ShareLinkCodec",
+                    "ShareTargetResolver",
+                    "ShareLinkConstants",
+                )
+            val scope = Konsist.scopeFromProduction()
+            val offenders =
+                (scope.classes() + scope.interfaces() + scope.objects())
+                    .filter { it.name in shareTypes }
+                    .filterNot { "/commonMain/" in it.path }
+                    .map { "${it.name} @ ${it.path}" }
+
+            offenders.shouldBeEmpty()
+        }
+    })


### PR DESCRIPTION
## Summary

Phase 1 (of 4) for issue #849 **Sharing** — the pure, fully-unit-tested shared core that powers cross-platform book share links. Everything lands in `:sharedLogic` `commonMain` (new package `com.calypsan.listenup.client.share`) so Android and iOS behave identically; **no platform/UI/network code, no server changes** (those are Phases 2–4).

- **`ShareTarget`** — sealed model of a decoded link: `Book(bookId, serverInstanceId?, serverUrl?)` and `Invite(serverUrl, code)`. Generalizes to series/contributors later.
- **`ShareLinkCodec`** — pure `encode`/`decode` for the new `https://link.listenup.audio/o#t=book&b&i&u` form **and** the legacy `listenup://book/{id}` / `listenup://join` schemes. Payload rides in the `#fragment` (host never sees it); decode falls back to `?query` if a platform strips the fragment. A private RFC-3986 percent-encoder (Ktor's encoder can't satisfy both "encode `:`/`/`" and "preserve `-`").
- **`ShareResolution` + `ShareTargetResolver`** — pure `resolve(target, connectedInstanceId)` → `OpenBook` / `OpenInviteClaim` / `WrongServer` / `NotConnected`. `NoAccess` is in the vocabulary but produced downstream at open time (book access is a server-side decision).
- **`DeepLinkManager`** — gains a generalized `pendingTarget` seam beside the existing invite seam (Phase 2 migrates invites onto it and retires the old seam).
- **`ShareLogicLivesInCommonMainRule`** — Konsist rule pinning the share types to `commonMain` (parity guard).

New model types are intentionally **not `@Serializable`** (in-memory only). 28 new Kotest tests (incl. Turbine), built TDD.

## Test plan

- [x] `./gradlew spotlessCheck detekt :sharedLogic:jvmTest` → **BUILD SUCCESSFUL** (2811 tests, 0 failures); all share/DeepLinkManager/Konsist tests pass.
- [ ] **macOS only — REQUIRED before merge:** regenerate the Swift Export baseline (`scripts/export-surface-inventory.sh <Shared.swift> --update-baseline`) so the `Test (iOS)` job accepts the 5 new public types. Until then the iOS lane will flag an unreviewed export addition. This is the one pending step.

## Follow-ups (separate plans)

- **Phase 2 — Android:** App Links intent-filter + autoVerify, route reception through the shared codec, wire the existing Share button to the builder, delete the bespoke `DeepLinkParser` parsing, add UI strings.
- **Phase 3 — iOS:** URL scheme + associated-domains, `onOpenURL`/`onContinueUserActivity` reception, the missing invite-claim SwiftUI screen, a `ShareLink` button.
- **Phase 4 — Redirector:** the 3 static files + on-device App/Universal-Link verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)