### PR TITLE
🐛 fix(client): invite create — map role token to UserRole, drop invitee name

### DIFF
--- a/iosApp/ListenUp/Features/Admin/CreateInviteObserver.swift
+++ b/iosApp/ListenUp/Features/Admin/CreateInviteObserver.swift
@@ -33,9 +33,8 @@ final class CreateInviteObserver {
 
     // MARK: - Actions
 
-    func createInvite(name: String, email: String, role: InviteRole, expiresInDays: Int) {
+    func createInvite(email: String, role: InviteRole, expiresInDays: Int) {
         viewModel.createInvite(
-            name: name,
             email: email,
             role: role.wireValue,
             expiresInDays: Int32(expiresInDays)
@@ -138,12 +137,10 @@ enum InviteRole: CaseIterable, Identifiable {
 /// Which form field a validation failure highlights. A native mirror of the shared
 /// `CreateInviteField` (which doesn't bridge as a clean Swift enum for view code).
 enum InviteField: Equatable {
-    case name
     case email
 
     init(from field: CreateInviteField) {
         switch field {
-        case .name: self = .name
         case .email: self = .email
         }
     }

--- a/iosApp/ListenUp/Features/Admin/CreateInviteView.swift
+++ b/iosApp/ListenUp/Features/Admin/CreateInviteView.swift
@@ -19,7 +19,6 @@ struct CreateInviteView: View {
     let viewModel: CreateInviteViewModel
     @State private var observer: CreateInviteObserver?
 
-    @State private var name = ""
     @State private var email = ""
     @State private var role: InviteRole = .member
     @State private var expiresInDays = 7
@@ -82,15 +81,6 @@ struct CreateInviteView: View {
         VStack(alignment: .leading, spacing: 0) {
             AdminSectionHeader(String(localized: "admin.whos_joining"))
             VStack(spacing: 0) {
-                AppTextField(
-                    placeholder: String(localized: "common.name"),
-                    text: $name,
-                    label: String(localized: "common.name"),
-                    icon: "person",
-                    error: validationField == .name ? String(localized: "admin.name_is_required") : nil,
-                    isLast: false,
-                    autocapitalization: .words
-                )
                 AppTextField(
                     placeholder: String(localized: "common.email"),
                     text: $email,
@@ -177,11 +167,10 @@ struct CreateInviteView: View {
     // MARK: - Actions
 
     private func submit(observer: CreateInviteObserver) {
-        observer.createInvite(name: name, email: email, role: role, expiresInDays: expiresInDays)
+        observer.createInvite(email: email, role: role, expiresInDays: expiresInDays)
     }
 
     private func resetForm() {
-        name = ""
         email = ""
         role = .member
         expiresInDays = 7

--- a/iosApp/ListenUpTests/AdminObserverTests.swift
+++ b/iosApp/ListenUpTests/AdminObserverTests.swift
@@ -47,10 +47,7 @@ struct AdminObserverTests {
 
     // MARK: - Validation field routing
 
-    @Test func validationErrorRoutesToNamedField() {
-        let nameFailure = InviteFailure(from: CreateInviteErrorTypeValidationError(field: .name))
-        #expect(nameFailure == .validation(.name))
-
+    @Test func validationErrorRoutesToEmailField() {
         let emailFailure = InviteFailure(from: CreateInviteErrorTypeValidationError(field: .email))
         #expect(emailFailure == .validation(.email))
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -171,7 +171,6 @@ internal class AdminRepositoryImpl(
         }
 
     override suspend fun createInvite(
-        name: String,
         email: String,
         role: String,
         expiresInDays: Int,
@@ -182,8 +181,11 @@ internal class AdminRepositoryImpl(
                 .adminService()
                 .createInvite(
                     email = email,
-                    displayName = name,
-                    role = UserRole.valueOf(role),
+                    // The admin no longer names the invitee — they choose a display name when they
+                    // claim. The email's local part is a non-blank placeholder that satisfies the
+                    // server's display_name invariant until the claimer overrides it.
+                    displayName = email.substringBefore('@'),
+                    role = role.toInviteRole(),
                     expiresInDays = expiresInDays,
                 ).map { it.toInviteInfo(serverUrl) }
         }
@@ -276,6 +278,16 @@ internal class AdminRepositoryImpl(
 // ═══════════════════════════════════════════════════════════════════════════
 // CONVERSION FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Maps the create-invite form's role token to the wire [UserRole].
+ *
+ * The form emits lowercase strings (`"member"`/`"admin"`); a case-insensitive match avoids the
+ * `IllegalArgumentException` that `UserRole.valueOf("member")` raised (it requires the exact enum
+ * names). Anything that isn't an explicit admin grant falls back to the least-privileged MEMBER.
+ */
+private fun String.toInviteRole(): UserRole =
+    if (trim().equals("admin", ignoreCase = true)) UserRole.ADMIN else UserRole.MEMBER
 
 /**
  * Convert the contract [ContractLibrary] (returned by [com.calypsan.listenup.api.LibraryAdminService])

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AdminRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AdminRepository.kt
@@ -105,14 +105,15 @@ interface AdminRepository {
     /**
      * Create a new invite code.
      *
-     * @param name Display name for the invite
+     * The invitee names their own account when they claim the invite, so no display name is
+     * collected here — the admin only supplies the email the invite is bound to.
+     *
      * @param email Email to restrict the invite to
      * @param role Role to assign to users who use this invite
      * @param expiresInDays Number of days until the invite expires
      * @return [AppResult] carrying the created invite, or a failure.
      */
     suspend fun createInvite(
-        name: String,
         email: String,
         role: String = "member",
         expiresInDays: Int = 7,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/admin/CreateInviteUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/admin/CreateInviteUseCase.kt
@@ -8,30 +8,24 @@ import com.calypsan.listenup.client.domain.repository.AdminRepository
 /**
  * Creates a new invite code.
  *
- * Validates that name is not blank and email is valid before creating.
+ * Validates that the email is well-formed before creating. No display name is collected — the
+ * invitee names their own account when they claim the invite.
  */
 open class CreateInviteUseCase(
     private val adminRepository: AdminRepository,
 ) {
     open suspend operator fun invoke(
-        name: String,
         email: String,
         role: String = "member",
         expiresInDays: Int = 7,
     ): AppResult<InviteInfo> {
-        val trimmedName = name.trim()
         val trimmedEmail = email.trim()
-
-        if (trimmedName.isBlank()) {
-            return validationError("Name is required")
-        }
 
         if (!isValidEmail(trimmedEmail)) {
             return validationError("Invalid email address")
         }
 
         return adminRepository.createInvite(
-            name = trimmedName,
             email = trimmedEmail,
             role = role,
             expiresInDays = expiresInDays,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModel.kt
@@ -26,7 +26,6 @@ class CreateInviteViewModel(
         field = MutableStateFlow<CreateInviteUiState>(CreateInviteUiState.Ready())
 
     fun createInvite(
-        name: String,
         email: String,
         role: String,
         expiresInDays: Int,
@@ -34,7 +33,7 @@ class CreateInviteViewModel(
         viewModelScope.launch {
             updateReady { it.copy(status = CreateInviteStatus.Submitting) }
 
-            when (val result = createInviteUseCase(name, email, role, expiresInDays)) {
+            when (val result = createInviteUseCase(email, role, expiresInDays)) {
                 is AppResult.Success -> {
                     updateReady { it.copy(status = CreateInviteStatus.Success(result.data)) }
                 }
@@ -81,18 +80,10 @@ class CreateInviteViewModel(
     private fun classifyError(error: AppError): CreateInviteErrorType =
         when (error) {
             is ValidationError -> {
-                when {
-                    error.message.contains("Name is required", ignoreCase = true) -> {
-                        CreateInviteErrorType.ValidationError(CreateInviteField.NAME)
-                    }
-
-                    error.message.contains("Invalid email", ignoreCase = true) -> {
-                        CreateInviteErrorType.ValidationError(CreateInviteField.EMAIL)
-                    }
-
-                    else -> {
-                        CreateInviteErrorType.ServerError(error.message)
-                    }
+                if (error.message.contains("Invalid email", ignoreCase = true)) {
+                    CreateInviteErrorType.ValidationError(CreateInviteField.EMAIL)
+                } else {
+                    CreateInviteErrorType.ServerError(error.message)
                 }
             }
 
@@ -179,6 +170,5 @@ sealed interface CreateInviteErrorType {
 
 /** Form field highlighted by [CreateInviteErrorType.ValidationError]. */
 enum class CreateInviteField {
-    NAME,
     EMAIL,
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplInviteTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplInviteTest.kt
@@ -172,25 +172,38 @@ class AdminRepositoryImplInviteTest :
             info.claimedAt shouldBe "5000000"
         }
 
-        test("createInvite calls RPC with correct args and maps InviteDto to InviteInfo") {
+        // Regression: the create-invite form emits lowercase role tokens ("member"/"admin"). The
+        // previous `UserRole.valueOf(role)` threw IllegalArgumentException on those (it expects the
+        // exact enum names), surfacing to the admin as "Something went wrong on the server".
+        test("createInvite maps the lowercase 'admin' role token to UserRole.ADMIN") {
             val service = FakeInviteService()
             val repo = buildRepo(service)
 
-            val result = repo.createInvite(name = "Ada", email = "ada@x", role = "ADMIN", expiresInDays = 7)
+            val result = repo.createInvite(email = "ada@example.com", role = "admin", expiresInDays = 7)
 
             (result is AppResult.Success) shouldBe true
-            // Verify args forwarded to RPC
             service.createdInvites.size shouldBe 1
             val (email, displayName, role) = service.createdInvites.first()
-            email shouldBe "ada@x"
-            displayName shouldBe "Ada"
+            email shouldBe "ada@example.com"
             role shouldBe UserRole.ADMIN
-            // Verify returned domain model
+            // The admin no longer names the invitee — display name defaults to the email's local part.
+            displayName shouldBe "ada"
             val info = (result as AppResult.Success).data
-            info.name shouldBe "Ada"
-            info.email shouldBe "ada@x"
+            info.email shouldBe "ada@example.com"
             info.role shouldBe "ADMIN"
             info.url shouldBe "https://srv.example/invite/code-abc"
+        }
+
+        test("createInvite maps the lowercase 'member' role token to UserRole.MEMBER (least privilege)") {
+            val service = FakeInviteService()
+            val repo = buildRepo(service)
+
+            val result = repo.createInvite(email = "pat@example.com", role = "member", expiresInDays = 7)
+
+            (result is AppResult.Success) shouldBe true
+            val (_, displayName, role) = service.createdInvites.first()
+            role shouldBe UserRole.MEMBER
+            displayName shouldBe "pat"
         }
 
         test("deleteInvite calls revokeInvite with wrapped InviteId") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModelTest.kt
@@ -56,41 +56,19 @@ class CreateInviteViewModelTest :
             }
         }
 
-        test("createInvite validates empty name") {
-            runTest {
-                val createInviteUseCase: CreateInviteUseCase = mock()
-                // Body-level message convention: ViewModel routes by string-matching
-                // failure.message, so pass a typed AppError whose body-level message
-                // matches the relevant branch ("Name is required").
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
-                    AppResult.Failure(
-                        com.calypsan.listenup.api.error
-                            .ValidationError(message = "Name is required"),
-                    )
-                val viewModel = CreateInviteViewModel(createInviteUseCase)
-
-                viewModel.createInvite(name = "", email = "test@example.com", role = "user", expiresInDays = 7)
-                advanceUntilIdle()
-
-                val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
-                val status = ready.status.shouldBeInstanceOf<CreateInviteStatus.Error>()
-                val errorType = status.type.shouldBeInstanceOf<CreateInviteErrorType.ValidationError>()
-                errorType.field shouldBe CreateInviteField.NAME
-            }
-        }
-
         test("createInvite validates invalid email") {
             runTest {
                 val createInviteUseCase: CreateInviteUseCase = mock()
-                // Body-level message convention: see empty-name test for explanation.
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                // The VM sub-classifies a ValidationError by its body-level message; "Invalid email"
+                // routes to the EMAIL field highlight.
+                everySuspend { createInviteUseCase(any(), any(), any()) } returns
                     AppResult.Failure(
                         com.calypsan.listenup.api.error
                             .ValidationError(message = "Invalid email"),
                     )
                 val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-                viewModel.createInvite(name = "Test User", email = "invalid-email", role = "user", expiresInDays = 7)
+                viewModel.createInvite(email = "invalid-email", role = "user", expiresInDays = 7)
                 advanceUntilIdle()
 
                 val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
@@ -104,10 +82,10 @@ class CreateInviteViewModelTest :
             runTest {
                 val createInviteUseCase: CreateInviteUseCase = mock()
                 val invite = createInviteInfo()
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns AppResult.Success(invite)
+                everySuspend { createInviteUseCase(any(), any(), any()) } returns AppResult.Success(invite)
                 val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-                viewModel.createInvite(name = "New User", email = "new@example.com", role = "user", expiresInDays = 7)
+                viewModel.createInvite(email = "new@example.com", role = "user", expiresInDays = 7)
                 advanceUntilIdle()
 
                 val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
@@ -121,14 +99,14 @@ class CreateInviteViewModelTest :
                 val createInviteUseCase: CreateInviteUseCase = mock()
                 // Server returns 409 Conflict for duplicate email — ViewModel routes
                 // TransportError.Server4xx(409) → EmailInUse via type-pattern matching.
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                everySuspend { createInviteUseCase(any(), any(), any()) } returns
                     AppResult.Failure(
                         com.calypsan.listenup.api.error.TransportError
                             .Server4xx(statusCode = 409),
                     )
                 val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-                viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
+                viewModel.createInvite(email = "test@example.com", role = "user", expiresInDays = 7)
                 advanceUntilIdle()
 
                 val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
@@ -144,14 +122,14 @@ class CreateInviteViewModelTest :
                 // body-level message ("No internet connection. Check your network.")
                 // contains both "network" and "connection", which the VM's branch
                 // looks for.
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                everySuspend { createInviteUseCase(any(), any(), any()) } returns
                     AppResult.Failure(
                         com.calypsan.listenup.api.error.TransportError
                             .NetworkUnavailable(),
                     )
                 val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-                viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
+                viewModel.createInvite(email = "test@example.com", role = "user", expiresInDays = 7)
                 advanceUntilIdle()
 
                 val ready = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
@@ -163,11 +141,11 @@ class CreateInviteViewModelTest :
         test("clearError resets to Idle") {
             runTest {
                 val createInviteUseCase: CreateInviteUseCase = mock()
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns
+                everySuspend { createInviteUseCase(any(), any(), any()) } returns
                     Failure(RuntimeException("Name is required"))
                 val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-                viewModel.createInvite(name = "", email = "test@example.com", role = "user", expiresInDays = 7)
+                viewModel.createInvite(email = "test@example.com", role = "user", expiresInDays = 7)
                 advanceUntilIdle()
                 val readyAfterError = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
                 checkIs<CreateInviteStatus.Error>(readyAfterError.status)
@@ -182,10 +160,10 @@ class CreateInviteViewModelTest :
         test("reset returns to initial state") {
             runTest {
                 val createInviteUseCase: CreateInviteUseCase = mock()
-                everySuspend { createInviteUseCase(any(), any(), any(), any()) } returns AppResult.Success(createInviteInfo())
+                everySuspend { createInviteUseCase(any(), any(), any()) } returns AppResult.Success(createInviteInfo())
                 val viewModel = CreateInviteViewModel(createInviteUseCase)
 
-                viewModel.createInvite(name = "Test", email = "test@example.com", role = "user", expiresInDays = 7)
+                viewModel.createInvite(email = "test@example.com", role = "user", expiresInDays = 7)
                 advanceUntilIdle()
                 val readyAfterSuccess = viewModel.state.value.shouldBeInstanceOf<CreateInviteUiState.Ready>()
                 checkIs<CreateInviteStatus.Success>(readyAfterSuccess.status)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/imports/ImportFlowViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/imports/ImportFlowViewModelTest.kt
@@ -1046,7 +1046,6 @@ private class FakeAdminRepository(
     override suspend fun getInvites(): AppResult<List<InviteInfo>> = AppResult.Success(emptyList())
 
     override suspend fun createInvite(
-        name: String,
         email: String,
         role: String,
         expiresInDays: Int,
@@ -1055,7 +1054,7 @@ private class FakeAdminRepository(
             InviteInfo(
                 id = "inv-1",
                 code = "CODE",
-                name = name,
+                name = email.substringBefore('@'),
                 email = email,
                 role = role,
                 expiresAt = "",

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/CreateInviteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/CreateInviteScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Send
-import androidx.compose.material.icons.outlined.Badge
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Headphones
 import androidx.compose.material.icons.outlined.Mail
@@ -47,7 +46,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
@@ -90,7 +88,6 @@ import listenup.composeapp.generated.resources.admin_name_is_invited
 import listenup.composeapp.generated.resources.admin_whos_joining
 import listenup.composeapp.generated.resources.common_admin
 import listenup.composeapp.generated.resources.common_copy
-import listenup.composeapp.generated.resources.common_display_name
 import listenup.composeapp.generated.resources.common_done
 import listenup.composeapp.generated.resources.common_email_address
 import listenup.composeapp.generated.resources.common_member
@@ -218,10 +215,9 @@ fun CreateInviteScreen(
 @Composable
 private fun CreateInviteForm(
     status: CreateInviteStatus,
-    onSubmit: (String, String, String, Int) -> Unit,
+    onSubmit: (String, String, Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var name by remember { mutableStateOf("") }
     var email by remember { mutableStateOf("") }
     var role by remember { mutableStateOf(ROLE_MEMBER) }
     var expiresInDays by remember { mutableIntStateOf(7) }
@@ -241,13 +237,11 @@ private fun CreateInviteForm(
     val sections: @Composable () -> Unit = {
         Column(verticalArrangement = Arrangement.spacedBy(28.dp)) {
             WhosJoiningSection(
-                name = name,
-                onNameChange = { name = it },
                 email = email,
                 onEmailChange = { email = it },
                 isSubmitting = isSubmitting,
                 validationField = validationField,
-                onSubmit = { onSubmit(name, email, role, expiresInDays) },
+                onSubmit = { onSubmit(email, role, expiresInDays) },
             )
             AccessLevelSection(
                 role = role,
@@ -263,7 +257,7 @@ private fun CreateInviteForm(
 
     val submitButton: @Composable () -> Unit = {
         ListenUpButton(
-            onClick = { onSubmit(name, email, role, expiresInDays) },
+            onClick = { onSubmit(email, role, expiresInDays) },
             text = stringResource(Res.string.admin_create_invite),
             leadingIcon = Icons.AutoMirrored.Outlined.Send,
             enabled = !isSubmitting,
@@ -303,8 +297,6 @@ private fun CreateInviteForm(
 
 @Composable
 private fun WhosJoiningSection(
-    name: String,
-    onNameChange: (String) -> Unit,
     email: String,
     onEmailChange: (String) -> Unit,
     isSubmitting: Boolean,
@@ -317,19 +309,6 @@ private fun WhosJoiningSection(
             label = stringResource(Res.string.admin_whos_joining),
             icon = Icons.Outlined.PersonAdd,
             accent = MaterialTheme.colorScheme.primary,
-        )
-        ListenUpTextField(
-            value = name,
-            onValueChange = onNameChange,
-            label = stringResource(Res.string.common_display_name),
-            leadingIcon = Icons.Outlined.Badge,
-            enabled = !isSubmitting,
-            isError = validationField == CreateInviteField.NAME,
-            supportingText =
-                if (validationField == CreateInviteField.NAME) "Name is required" else "The person's display name",
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Next),
-            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
-            modifier = Modifier.fillMaxWidth(),
         )
         ListenUpTextField(
             value = email,


### PR DESCRIPTION
Fixes the admin **Create invite** flow on iOS + Android.

## Bug 1 — "Something Went Wrong on the Server" when creating an invite
The admin form emits lowercase role tokens (`"member"`/`"admin"`), but `AdminRepositoryImpl.createInvite` called `UserRole.valueOf(role)`. `UserRole` is `{ROOT, ADMIN, MEMBER}` with no `@SerialName`, so `valueOf("member")` threw `IllegalArgumentException` **client-side, before any RPC call**. `catching {}` wrapped it into `AppResult.Failure(InternalError())`, whose user-facing message is literally "Something went wrong on the server." — so it looked like a 500 even though the server was never hit (server logs were empty; the real stack was in logcat).

Fix: a case-insensitive `String.toInviteRole()` mapping to `UserRole`, defaulting to least-privileged `MEMBER`.

## Bug 2 — invite display name was inconsistent
Registration captures first + last name, but the invite flow used a single free-text "Display name" field (admin-set, pre-filled on the claim page). The admin form is now **email-only** (plus role + expiry) — the invitee names their own account when they claim. The invite's display name is derived from the email's local part at the repository boundary, so the **contract, server, and migrations are untouched**.

## Scope
- **shared:** `AdminRepository` / `CreateInviteUseCase` / `CreateInviteViewModel` / `CreateInviteField` (drop `NAME`); `AdminRepositoryImpl` (role mapping + email-derived display name)
- **Android:** `CreateInviteScreen` (remove name field)
- **iOS:** `CreateInviteView` / `CreateInviteObserver` / `AdminObserverTests` (remove name field + `.name` case)

## Tests
- `AdminRepositoryImplInviteTest`: regression — lowercase `"admin"`→`ADMIN`, `"member"`→`MEMBER`; display name derived from email.
- `CreateInviteViewModelTest` / `ImportFlowViewModelTest`: updated to the email-only signature.
- Verified locally on Linux: `:androidApp:assembleDebug`, the three affected test classes, and `spotlessCheck detekt` all green. iOS build/tests are CI-verified (no local Mac).