### PR TITLE
🐛 fix(server): scanner surfaces 'no recognized audio' skips cleanly, not as a stacktrace

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.server.scanner.metadata.AbsMetadataReader
 import com.calypsan.listenup.server.scanner.metadata.MetadataPrecedence
 import com.calypsan.listenup.server.scanner.pipeline.Analyzer
 import com.calypsan.listenup.server.scanner.pipeline.BookAnalysisFailure
+import com.calypsan.listenup.server.scanner.pipeline.NoRecognizedAudio
 import com.calypsan.listenup.server.scanner.pipeline.Differ
 import com.calypsan.listenup.server.scanner.pipeline.Grouper
 import com.calypsan.listenup.server.scanner.pipeline.Walker
@@ -402,7 +403,15 @@ internal class Scanner(
                     while (recent.size > RECENT_BOOKS_CAP) recent.removeFirst()
                 }.onFailure { t ->
                     val relPath = (t as? BookAnalysisFailure)?.rootRelPath ?: errorRoot.toString()
-                    logger.warn(t) { "analyze failed: path=$relPath library=${library.id.value}" }
+                    // A folder with no recognized audio is an expected skip (not a book), not a
+                    // fault — log it as a calm, actionable one-liner without a stacktrace. Genuine
+                    // analysis faults keep the full throwable so they stay diagnosable.
+                    val skip = (t as? BookAnalysisFailure)?.cause as? NoRecognizedAudio
+                    if (skip != null) {
+                        logger.warn { "skipped: path=$relPath library=${library.id.value} — ${skip.message}" }
+                    } else {
+                        logger.warn(t) { "analyze failed: path=$relPath library=${library.id.value}" }
+                    }
                     errors += toScanError(t, errorRoot)
                 }
             val now = clock()

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -105,8 +105,11 @@ internal class Analyzer(
             // Tiered book rule: a candidate that yields no playable track is not a
             // book — it's skipped, not ingested. Surfaces as a Result.failure so the
             // caller records it in ScanResult.errors and never in ScanResult.books.
+            // A typed skip (carrying the candidate's file names) lets the scanner log an
+            // actionable one-liner — a misnamed file like `Open Heavensm4b` (dropped dot) is
+            // far more common here than a genuinely empty folder — without a noisy stacktrace.
             if (tracks.isEmpty()) {
-                error("candidate has no audio tracks")
+                throw NoRecognizedAudio(candidate.files.map { it.name })
             }
             val primaryAudio = tracks.firstOrNull()?.file
             val (embedded, embeddedStatus) = parseEmbedded(primaryAudio)
@@ -685,6 +688,33 @@ private val NATURAL_TRACK_ORDER =
         { it.trackNumber ?: Int.MAX_VALUE },
         { it.file.name },
     )
+
+/**
+ * A candidate that contains files but none recognized as audio. It is *not* a book, so it is
+ * skipped (an expected outcome, not a fault). [files] are the candidate's file names — usually a
+ * single misnamed file (e.g. `Open Heavensm4b` with the extension dot dropped) — so the scanner can
+ * log an actionable one-liner instead of a stacktrace. The composed [message] is reused verbatim as
+ * the resulting `ScanError`'s detail.
+ */
+internal class NoRecognizedAudio(
+    val files: List<String>,
+) : Exception(message(files)) {
+    private companion object {
+        private const val MAX_LISTED = 5
+
+        fun message(files: List<String>): String {
+            val found =
+                if (files.isEmpty()) {
+                    ""
+                } else {
+                    val shown = files.take(MAX_LISTED).joinToString()
+                    val more = if (files.size > MAX_LISTED) ", …" else ""
+                    " (found: $shown$more)"
+                }
+            return "no recognized audio files$found — check the file extension"
+        }
+    }
+}
 
 /**
  * Wraps any per-book analysis failure with the candidate's `rootRelPath` so

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/pipeline/AnalyzerTest.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -602,6 +603,33 @@ class AnalyzerTest :
 
                     book.series shouldBe listOf(SeriesEntry(name = "The Stormlight Archive", sequence = "2"))
                 }
+            }
+        }
+
+        test("a candidate whose files include no recognized audio is skipped with an actionable, typed failure") {
+            val root = Files.createTempDirectory("no-audio-candidate")
+            runTest {
+                val analyzer = Analyzer(Path(root.toString()), metadataReader, embeddedParser)
+                // Mirrors a real report: 'Open Heavens.m4b' with the dot dropped, so the file has no
+                // recognized extension → classified UNKNOWN, never AUDIO. The folder yields zero
+                // playable tracks and is skipped (it is not a book).
+                val candidate =
+                    candidateOf(
+                        "Bill Johnson/Open Heavens",
+                        files = listOf(fileEntry("Bill Johnson/Open Heavens/Open Heavensm4b", FileType.UNKNOWN)),
+                    )
+
+                val result = analyzer.analyze(flowOf(candidate)).toList().single()
+
+                result.isFailure shouldBe true
+                val failure = result.exceptionOrNull().shouldBeInstanceOf<BookAnalysisFailure>()
+                failure.rootRelPath shouldBe "Bill Johnson/Open Heavens"
+                // A typed skip (not a bare IllegalStateException) naming the unrecognized file, so the
+                // scanner can log it without a stacktrace and the operator can fix the extension.
+                val skip = failure.cause.shouldBeInstanceOf<NoRecognizedAudio>()
+                skip.files shouldContainExactly listOf("Open Heavensm4b")
+                failure.message.shouldNotBeNull()
+                failure.message!!.contains("check the file extension") shouldBe true
             }
         }
     })


### PR DESCRIPTION
A library scan logged a full WARN stacktrace for a folder that simply had no recognized audio:

```
WARN Scanner - analyze failed: path=Bill Johnson/Open Heavens ...
BookAnalysisFailure: candidate has no audio tracks
```

## What was really happening
That folder contains one 419 MB file named `Open Heavensm4b` — **the extension dot is missing** (should be `Open Heavens.m4b`). `FileTypeRules` classifies audio by extension, so the file is `UNKNOWN`, the candidate yields zero tracks, and the analyzer correctly skips it as "not a book" (by design).

The problem was how that benign skip surfaced: a generic `error("candidate has no audio tracks")` → `BookAnalysisFailure` → **WARN with a full stacktrace**, indistinguishable from a real analysis fault. A genuinely misnamed audiobook was effectively dropped with an alarming, non-actionable log.

## Change (server-only)
- New typed `NoRecognizedAudio` skip carrying the candidate's file names; the analyzer throws it instead of a bare `error(...)`.
- The scanner distinguishes it from real faults and logs a calm, **actionable** one-liner with no stacktrace, e.g.:
  `skipped: path=Bill Johnson/Open Heavens — no recognized audio files (found: Open Heavensm4b) — check the file extension`
- Genuine analysis faults keep the full throwable + stacktrace.
- It's still recorded in `ScanResult.errors` (visible to the operator); the `ScanError` detail reuses the same actionable message. No contract/UI change.

## Tests
- `AnalyzerTest`: new case — a candidate with files but no recognized audio fails with a typed `NoRecognizedAudio` naming the unrecognized file and an actionable message.
- Verified locally: `AnalyzerTest` + `ScannerEndToEndTest` + `spotlessCheck detekt` all green.

Note: the immediate fix for the reported book is to rename `Open Heavensm4b` → `Open Heavens.m4b`; it imports on the next scan.