### PR TITLE
🐛 fix(ios): stop the post-scan Home freeze (avatar AppResult-bridge trap)

### DIFF
--- a/iosApp/ListenUp/DesignSystem/Components/UserAvatarView.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/UserAvatarView.swift
@@ -12,6 +12,7 @@ struct UserAvatarView: View {
     private let userId: String?
     private let fallbackName: String
     private let avatarColorHex: String?
+    private let hasImageAvatar: Bool
     private let size: CGFloat
 
     /// Render from a known Kotlin `User`. Used by toolbars / profile screens.
@@ -19,20 +20,30 @@ struct UserAvatarView: View {
         self.userId = user?.idString
         self.fallbackName = user?.displayName ?? ""
         self.avatarColorHex = user?.avatarColor
+        self.hasImageAvatar = user?.hasImageAvatar ?? false
         self.size = size
     }
 
     /// Render from primitives — for list rows that carry only the user's id (per iOS rule 8,
     /// we never put a bridged Kotlin `User` in a `ForEach`). Resolves the picture by `userId`,
-    /// falling back to initials derived from `fallbackName`.
-    init(userId: String, fallbackName: String, avatarColor: String? = nil, size: CGFloat = 36) {
+    /// falling back to initials derived from `fallbackName`. `hasImageAvatar` defaults to `true`
+    /// because list rows can't cheaply know the avatar type; a 404 negative-caches in the shared
+    /// downloader, so an auto-avatar user just falls back to initials after one cheap miss.
+    init(
+        userId: String,
+        fallbackName: String,
+        avatarColor: String? = nil,
+        hasImageAvatar: Bool = true,
+        size: CGFloat = 36
+    ) {
         self.userId = userId
         self.fallbackName = fallbackName
         self.avatarColorHex = avatarColor
+        self.hasImageAvatar = hasImageAvatar
         self.size = size
     }
 
-    /// The user's image avatar, read off the main thread by [loadAvatar] — downloading + persisting
+    /// The user's image avatar, read off the main thread by [loadAvatar] — fire-and-forget caching
     /// it on first appearance so it renders now and survives offline. Until it lands (or for an
     /// auto/initials avatar), the initials fallback shows.
     @State private var avatarImage: UIImage?
@@ -52,7 +63,7 @@ struct UserAvatarView: View {
             }
         }
         .task(id: userId) {
-            guard let userId else {
+            guard let userId, hasImageAvatar else {
                 avatarImage = nil
                 return
             }
@@ -60,16 +71,24 @@ struct UserAvatarView: View {
         }
     }
 
-    /// `nonisolated async` ⇒ the download, disk read, and decode run off the main actor. Persists
-    /// the image avatar to the durable store on first appearance (no-op once cached) and loads it;
-    /// returns nil if no avatar is available. `downloadUserAvatar` saves on success.
+    /// `nonisolated async` ⇒ disk read + decode run off the main actor. Does NOT await the bridged
+    /// `downloadUserAvatar` suspend (that AppResult suspend-bridge deadlocks under the post-scan
+    /// concurrent fan-out). Instead fire-and-forgets `ensureUserAvatarCached` (the cover/contributor/
+    /// Compose pattern) and briefly polls for the downloaded file to land.
     private nonisolated static func loadAvatar(userId: String) async -> UIImage? {
         let repository = Dependencies.shared.imageRepository
-        if !repository.userAvatarExists(userId: userId) {
-            _ = try? await repository.downloadUserAvatar(userId: userId, forceRefresh: false)
+        if repository.userAvatarExists(userId: userId) {
+            return UIImage(contentsOfFile: repository.getUserAvatarPath(userId: userId))
         }
-        guard repository.userAvatarExists(userId: userId) else { return nil }
-        return UIImage(contentsOfFile: repository.getUserAvatarPath(userId: userId))
+        repository.ensureUserAvatarCached(userId: userId)
+        for _ in 0..<8 {
+            try? await Task.sleep(for: .milliseconds(250))
+            if Task.isCancelled { return nil }
+            if repository.userAvatarExists(userId: userId) {
+                return UIImage(contentsOfFile: repository.getUserAvatarPath(userId: userId))
+            }
+        }
+        return nil
     }
 
     // MARK: - Private Views

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
@@ -33,15 +33,28 @@ internal class ImageDownloader(
     // Per-userId serialization so a post-scan fan-out of concurrent avatar requests
     // collapses to a single network fetch + save instead of stampeding the server
     // (and deadlocking the iOS AppResult suspend bridge).
+    // Both collections grow unbounded but are bounded by distinct users seen this session —
+    // acceptable for the small self-hosted userbase.
     private val avatarDownloadMutexes = mutableMapOf<String, Mutex>()
     private val avatarDownloadMutexesGuard = Mutex()
 
     // Session negative cache: a 404 means the user has no image avatar, so repeated
-    // triggers must not keep re-hitting the server.
+    // triggers must not keep re-hitting the server. Distinct users run concurrently on the
+    // multi-threaded appScope, so every access is guarded (the per-user mutex only serializes
+    // the same userId).
     private val avatarsKnownMissing = mutableSetOf<String>()
 
     private suspend fun avatarMutexFor(userId: String): Mutex =
         avatarDownloadMutexesGuard.withLock { avatarDownloadMutexes.getOrPut(userId) { Mutex() } }
+
+    private suspend fun markAvatarMissing(userId: String) =
+        avatarDownloadMutexesGuard.withLock { avatarsKnownMissing.add(userId) }
+
+    private suspend fun clearAvatarMissing(userId: String) =
+        avatarDownloadMutexesGuard.withLock { avatarsKnownMissing.remove(userId) }
+
+    private suspend fun isAvatarKnownMissing(userId: String): Boolean =
+        avatarDownloadMutexesGuard.withLock { avatarsKnownMissing.contains(userId) }
 
     /**
      * Delete a book's cover from local storage.
@@ -289,7 +302,7 @@ internal class ImageDownloader(
         avatarMutexFor(userId).withLock {
             // A forced refresh clears any prior negative-cache verdict and the stale file.
             if (forceRefresh) {
-                avatarsKnownMissing.remove(userId)
+                clearAvatarMissing(userId)
                 if (imageStorage.userAvatarExists(userId)) {
                     // Best-effort cleanup before re-download; the fresh file overwrites a failed delete anyway.
                     val _ = imageStorage.deleteUserAvatar(userId)
@@ -304,7 +317,7 @@ internal class ImageDownloader(
             }
 
             // Negative cache: the server already told us this user has no avatar this session.
-            if (!forceRefresh && userId in avatarsKnownMissing) {
+            if (!forceRefresh && isAvatarKnownMissing(userId)) {
                 logger.info { "Avatar known missing for user $userId, skipping download" }
                 return@withLock AppResult.Success(false)
             }
@@ -315,7 +328,7 @@ internal class ImageDownloader(
             val downloadResult = imageApi.downloadUserAvatar(userId)
             if (downloadResult is AppResult.Failure) {
                 // 404 is expected for users without custom avatars - don't log as error
-                avatarsKnownMissing.add(userId)
+                markAvatarMissing(userId)
                 logger.info { "Avatar not available for user $userId: ${downloadResult.message}" }
                 return@withLock AppResult.Success(false)
             }
@@ -331,7 +344,7 @@ internal class ImageDownloader(
                 return@withLock saveResult
             }
 
-            avatarsKnownMissing.remove(userId)
+            clearAvatarMissing(userId)
             logger.info { "Successfully downloaded and saved avatar for user $userId" }
             AppResult.Success(true)
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
@@ -6,6 +6,8 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.ImageApiContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private val logger = KotlinLogging.logger {}
 
@@ -28,6 +30,19 @@ internal class ImageDownloader(
     private val imageApi: ImageApiContract,
     private val imageStorage: ImageStorage,
 ) : ImageDownloaderContract {
+    // Per-userId serialization so a post-scan fan-out of concurrent avatar requests
+    // collapses to a single network fetch + save instead of stampeding the server
+    // (and deadlocking the iOS AppResult suspend bridge).
+    private val avatarDownloadMutexes = mutableMapOf<String, Mutex>()
+    private val avatarDownloadMutexesGuard = Mutex()
+
+    // Session negative cache: a 404 means the user has no image avatar, so repeated
+    // triggers must not keep re-hitting the server.
+    private val avatarsKnownMissing = mutableSetOf<String>()
+
+    private suspend fun avatarMutexFor(userId: String): Mutex =
+        avatarDownloadMutexesGuard.withLock { avatarDownloadMutexes.getOrPut(userId) { Mutex() } }
+
     /**
      * Delete a book's cover from local storage.
      *
@@ -270,44 +285,56 @@ internal class ImageDownloader(
     override suspend fun downloadUserAvatar(
         userId: String,
         forceRefresh: Boolean,
-    ): AppResult<Boolean> {
-        // Skip if already exists locally (unless forcing refresh)
-        if (!forceRefresh && imageStorage.userAvatarExists(userId)) {
-            logger.info { "Avatar already exists locally for user $userId" }
-            return AppResult.Success(false)
+    ): AppResult<Boolean> =
+        avatarMutexFor(userId).withLock {
+            // A forced refresh clears any prior negative-cache verdict and the stale file.
+            if (forceRefresh) {
+                avatarsKnownMissing.remove(userId)
+                if (imageStorage.userAvatarExists(userId)) {
+                    // Best-effort cleanup before re-download; the fresh file overwrites a failed delete anyway.
+                    val _ = imageStorage.deleteUserAvatar(userId)
+                    logger.info { "Deleted old avatar for user $userId before refresh" }
+                }
+            }
+
+            // Re-check inside the lock: a coalesced earlier caller may have just saved the file.
+            if (!forceRefresh && imageStorage.userAvatarExists(userId)) {
+                logger.info { "Avatar already exists locally for user $userId" }
+                return@withLock AppResult.Success(false)
+            }
+
+            // Negative cache: the server already told us this user has no avatar this session.
+            if (!forceRefresh && userId in avatarsKnownMissing) {
+                logger.info { "Avatar known missing for user $userId, skipping download" }
+                return@withLock AppResult.Success(false)
+            }
+
+            logger.info { "Downloading avatar for user $userId..." }
+
+            // Download from server
+            val downloadResult = imageApi.downloadUserAvatar(userId)
+            if (downloadResult is AppResult.Failure) {
+                // 404 is expected for users without custom avatars - don't log as error
+                avatarsKnownMissing.add(userId)
+                logger.info { "Avatar not available for user $userId: ${downloadResult.message}" }
+                return@withLock AppResult.Success(false)
+            }
+
+            // Save to local storage
+            val imageBytes = (downloadResult as AppResult.Success).data
+            logger.info { "Downloaded ${imageBytes.size} bytes for user $userId, saving..." }
+
+            val saveResult = imageStorage.saveUserAvatar(userId, imageBytes)
+
+            if (saveResult is AppResult.Failure) {
+                logger.error { "Failed to save avatar for user $userId: ${saveResult.message}" }
+                return@withLock saveResult
+            }
+
+            avatarsKnownMissing.remove(userId)
+            logger.info { "Successfully downloaded and saved avatar for user $userId" }
+            AppResult.Success(true)
         }
-
-        // Delete existing if force refresh
-        if (forceRefresh && imageStorage.userAvatarExists(userId)) {
-            // Best-effort cleanup before re-download; the fresh file overwrites a failed delete anyway.
-            val _ = imageStorage.deleteUserAvatar(userId)
-            logger.info { "Deleted old avatar for user $userId before refresh" }
-        }
-
-        logger.info { "Downloading avatar for user $userId..." }
-
-        // Download from server
-        val downloadResult = imageApi.downloadUserAvatar(userId)
-        if (downloadResult is AppResult.Failure) {
-            // 404 is expected for users without custom avatars - don't log as error
-            logger.info { "Avatar not available for user $userId: ${downloadResult.message}" }
-            return AppResult.Success(false)
-        }
-
-        // Save to local storage
-        val imageBytes = (downloadResult as AppResult.Success).data
-        logger.info { "Downloaded ${imageBytes.size} bytes for user $userId, saving..." }
-
-        val saveResult = imageStorage.saveUserAvatar(userId, imageBytes)
-
-        if (saveResult is AppResult.Failure) {
-            logger.error { "Failed to save avatar for user $userId: ${saveResult.message}" }
-            return saveResult
-        }
-
-        logger.info { "Successfully downloaded and saved avatar for user $userId" }
-        return AppResult.Success(true)
-    }
 
     /**
      * Get the local file path for a user's avatar image.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.data.remote.ImageApiContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -14,6 +15,10 @@ import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -149,6 +154,82 @@ class ImageDownloaderTest :
 
                 // Then - API should not be called
                 // (verify by not stubbing API - if called, test would fail)
+            }
+        }
+
+        // ========== User Avatar Dedup + Negative-Cache Tests ==========
+
+        test("concurrent downloadUserAvatar calls coalesce into a single download + save") {
+            runTest {
+                // Given - the API call is gated in-flight so the second caller must arrive
+                // while the first is still running: the exact post-scan fan-out race.
+                val fixture = createFixture()
+                val userId = "user-1"
+                val gate = CompletableDeferred<Unit>()
+                var apiCalls = 0
+                var saveCalls = 0
+                // Stateful exists: false until the first caller saves, then true so the
+                // coalesced second caller short-circuits instead of re-downloading.
+                var avatarSaved = false
+                every { fixture.imageStorage.userAvatarExists(userId) } calls { avatarSaved }
+                everySuspend { fixture.imageApi.downloadUserAvatar(userId) } calls {
+                    apiCalls++
+                    gate.await()
+                    AppResult.Success(ByteArray(10))
+                }
+                everySuspend { fixture.imageStorage.saveUserAvatar(userId, any()) } calls {
+                    saveCalls++
+                    avatarSaved = true
+                    AppResult.Success(Unit)
+                }
+                val imageDownloader = fixture.build()
+
+                // When - launch both, let them reach their suspension points, then release.
+                val first = launch { imageDownloader.downloadUserAvatar(userId, forceRefresh = false) }
+                val second = launch { imageDownloader.downloadUserAvatar(userId, forceRefresh = false) }
+                runCurrent()
+                gate.complete(Unit)
+                joinAll(first, second)
+
+                // Then - the network + save happened exactly once.
+                apiCalls shouldBe 1
+                saveCalls shouldBe 1
+            }
+        }
+
+        test("downloadUserAvatar negative-caches a 404 and skips re-hitting the server") {
+            runTest {
+                // Given - the server has no avatar for this user (404 → Failure).
+                val fixture = createFixture()
+                val userId = "user-1"
+                var apiCalls = 0
+                every { fixture.imageStorage.userAvatarExists(userId) } returns false
+                everySuspend { fixture.imageStorage.deleteUserAvatar(userId) } returns AppResult.Success(Unit)
+                everySuspend { fixture.imageApi.downloadUserAvatar(userId) } calls {
+                    apiCalls++
+                    Failure(Exception("Not found"))
+                }
+                val imageDownloader = fixture.build()
+
+                // When - first call hits the server and negative-caches the miss.
+                val firstResult = imageDownloader.downloadUserAvatar(userId, forceRefresh = false)
+
+                // Then - non-fatal success(false), one network call.
+                firstResult.shouldBeInstanceOf<AppResult.Success<Boolean>>().data shouldBe false
+                apiCalls shouldBe 1
+
+                // When - a second call for the same user.
+                val secondResult = imageDownloader.downloadUserAvatar(userId, forceRefresh = false)
+
+                // Then - the negative cache short-circuits: no second network call.
+                secondResult.shouldBeInstanceOf<AppResult.Success<Boolean>>().data shouldBe false
+                apiCalls shouldBe 1
+
+                // When - forceRefresh bypasses the negative cache.
+                imageDownloader.downloadUserAvatar(userId, forceRefresh = true)
+
+                // Then - the server is hit again.
+                apiCalls shouldBe 2
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
@@ -204,7 +204,6 @@ class ImageDownloaderTest :
                 val userId = "user-1"
                 var apiCalls = 0
                 every { fixture.imageStorage.userAvatarExists(userId) } returns false
-                everySuspend { fixture.imageStorage.deleteUserAvatar(userId) } returns AppResult.Success(Unit)
                 everySuspend { fixture.imageApi.downloadUserAvatar(userId) } calls {
                     apiCalls++
                     Failure(Exception("Not found"))


### PR DESCRIPTION
## Summary

Fixes the iOS app freezing on the Home screen right after a library scan.

**Real mechanism (confirmed by the runtime stack — *not* a deadlock):** `UserAvatarView` `await`ed the bridged `suspend fun downloadUserAvatar(): AppResult<Boolean>` directly from the view. Delivering a **generic** `AppResult<T>` back to Swift across the experimental Swift Export bridge traps on `__createProtocolWrapper(externalRCRef:) as! any AppResult` (`Swift runtime failure: type cast failed`, on a `DarwinGlobalQueueDispatcher` worker thread → the UI appears frozen). The repeated `Downloading avatar…/404` was a secondary symptom (the toolbar avatar for an *auto-avatar* user has no server image).

**Fix — align iOS avatars with the cover/contributor/Compose pattern:**
- `UserAvatarView` no longer `await`s `downloadUserAvatar`. It fire-and-forgets `ensureUserAvatarCached` (which runs the download *inside Kotlin* — the `AppResult` is consumed in Kotlin and **never crosses the trapping bridge**) and loads the local file, with a bounded off-main poll for the first-download case.
- Gates on `User.hasImageAvatar` — auto-avatar users skip the download path entirely (instant initials, no 404).
- Shared `ImageDownloader.downloadUserAvatar`: per-`userId` mutex dedup (concurrent calls coalesce to one fetch) + session negative-cache of 404s, with the negative-cache set guarded against cross-user races. Hygiene for the Kotlin-side callers (sync `queueAvatarForceRefresh`, profile self-heal).

## Known follow-up (separate, by design)
This is one of **four** Swift `await` sites of `AppResult`-returning suspends — the same latent trap also exists at `BookDetailObserver.getInstance`, `LastPlayedBookProvider.getContinueListening`, and `KotlinPlaybackSeam.ensureLocal`. A systemic fix (keep `AppResult`-returning suspends off the Swift-callable surface + a build-time export guard so it can't recur) will be designed and shipped separately. This PR unblocks the user-facing crash.

## Test plan
- [x] Kotlin TDD (dedup + negative-cache): `:sharedLogic:jvmTest` green (red→green)
- [x] iOS build + full test suite + SwiftLint clean on touched files
- [x] Kotlin lint (spotless/detekt) green
- [ ] **Device verify (the real proof):** merge, clean build, re-scan into Home → no freeze, no avatar 404 spam