### PR TITLE
🐛 fix(ios): never await AppResult suspends from Swift (bridge-trap class fix) + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,10 @@ jobs:
         if: always()
         run: bash scripts/export-surface-inventory.sh
 
+      - name: No AppResult await from Swift (gate)
+        if: always()
+        run: bash scripts/check-no-appresult-await.sh
+
   # ── Build ────────────────────────────────────────────────────────────────────
   build-server-native:
     name: Build (server linuxX64)

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/result/AppResult.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/result/AppResult.kt
@@ -146,3 +146,20 @@ inline fun <T> AppResult<T>.recover(recovery: (AppError) -> T): AppResult<T> =
         is AppResult.Success -> this
         is AppResult.Failure -> AppResult.Success(recovery(error))
     }
+
+/**
+ * The success value, or `null` on failure — folding the [AppResult] entirely in Kotlin.
+ *
+ * Canonical way to consume an [AppResult] from a context that must not see the `AppResult` type —
+ * notably the Swift Export boundary: `await`-ing an `AppResult`-returning suspend from Swift traps
+ * (`as! any AppResult` cast failure). Unwrap in Kotlin via a `*OrNull` accessor and hand Swift the
+ * plain value. [onFailure] receives the typed [AppError] so the caller can log it.
+ */
+inline fun <T> AppResult<T>.valueOrNull(onFailure: (AppError) -> Unit = {}): T? =
+    when (this) {
+        is AppResult.Success -> data
+        is AppResult.Failure -> {
+            onFailure(error)
+            null
+        }
+    }

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/result/AppResult.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/result/AppResult.kt
@@ -157,7 +157,10 @@ inline fun <T> AppResult<T>.recover(recovery: (AppError) -> T): AppResult<T> =
  */
 inline fun <T> AppResult<T>.valueOrNull(onFailure: (AppError) -> Unit = {}): T? =
     when (this) {
-        is AppResult.Success -> data
+        is AppResult.Success -> {
+            data
+        }
+
         is AppResult.Failure -> {
             onFailure(error)
             null

--- a/iosApp/CLAUDE.md
+++ b/iosApp/CLAUDE.md
@@ -72,6 +72,13 @@ before any non-trivial iOS work.
      `SearchRow`, `RoleSectionRow`, `EditableRelation`. If the observer still needs the raw Kotlin
      object (e.g. for an id→object lookup on a remove/tap action), keep it as private observer
      state, off the diff path — never in the `ForEach`.
+   - **Never `await` an `AppResult`-returning Kotlin suspend from Swift.** It traps in the Swift Export
+     bridge (`__createProtocolWrapper(...) as! any AppResult` cast failure → frozen UI). Consume
+     `AppResult` in Kotlin and expose a plain-typed `*OrNull` accessor (see `AppResult.valueOrNull` +
+     the `getInstanceOrNull`/`getResumeBookOrNull`/`downloadBookOrNull`/`ensureLocalPathOrNull`
+     precedents); Swift `await`s the plain optional. Enforced by `scripts/check-no-appresult-await.sh`
+     in the `Test (iOS)` CI job. (Plain-typed suspends — `String?`, domain types, `Flow`,
+     fire-and-forget `Unit` — are fine.)
 9. **Native, type-safe navigation.** `NavigationStack` + value-typed routes; sheets,
    `presentationDetents`, and inspectors over ported screens.
 10. **Errors the iOS way.** The shared typed `AppError` crosses the boundary, but iOS maps

--- a/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
@@ -182,8 +182,7 @@ final class BookDetailObserver {
         Task {
             if (try? await downloadService.downloadBookOrNull(bookId: book.id)) == nil {
                 // Failure was folded + logged in Kotlin; surface a generic message (no AppResult here).
-                downloadError = String(localized: "book_detail.download_failed",
-                                       defaultValue: "Couldn't start the download. Please try again.")
+                downloadError = String(localized: "book.detail_download_failed")
                 Log.error("downloadBook failed for \(book.idString)")
             }
         }

--- a/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
@@ -180,34 +180,13 @@ final class BookDetailObserver {
         guard let book else { return }
         downloadError = nil
         Task {
-            do {
-                let result = try await downloadService.downloadBook(bookId: book.id)
-                // `AppResult<Unit>` erases its generic to `any AppResult` over Swift Export. Fold it via
-                // the generated typed accessor — both branches compiler-forced.
-                switch appResultCase(result) {
-                case .failure(let failure):
-                    downloadError = failure.error.message
-                case .success:
-                    break
-                case .unknown:
-                    Log.error("downloadBook returned an unexpected AppResult case for \(book.idString)")
-                }
-            } catch {
-                // A *thrown* error (vs. the typed `.failure` above) is unexpected — surface
-                // it instead of the old `try?` that silently dropped it and left the button
-                // looking idle. Cancellation (the view went away) is intentionally silent.
-                if let message = Self.downloadThrowMessage(for: error) {
-                    Log.error("Download failed for \(book.idString)", error: error)
-                    downloadError = message
-                }
+            if (try? await downloadService.downloadBookOrNull(bookId: book.id)) == nil {
+                // Failure was folded + logged in Kotlin; surface a generic message (no AppResult here).
+                downloadError = String(localized: "book_detail.download_failed",
+                                       defaultValue: "Couldn't start the download. Please try again.")
+                Log.error("downloadBook failed for \(book.idString)")
             }
         }
-    }
-
-    /// Maps a *thrown* download error to a user-facing message, or `nil` when the throw
-    /// is mere cancellation (the user navigated away) and nothing should surface.
-    nonisolated static func downloadThrowMessage(for error: Error) -> String? {
-        error is CancellationError ? nil : String(localized: "common.something_went_wrong")
     }
 
     func cancelDownload() {
@@ -349,23 +328,18 @@ final class BookDetailObserver {
     }
 
     private func buildShareURL(bookId: String) async {
-        guard let result = try? await Dependencies.shared.instanceRepository.getInstance(forceRefresh: false) else { return }
-        switch appResultCase(result) {
-        case .success(let success):
-            guard let instance = success.data as? Instance else { return }
-            let baseUrl = instance.remoteUrl ?? instance.localUrl
-            let trimmed = baseUrl.map { $0.hasSuffix("/") ? String($0.dropLast()) : $0 }
-            let raw = ShareLinkCodec.shared.encode(
-                target: ShareTargetBook(
-                    bookId: BookId(value: bookId),
-                    serverInstanceId: instance.id.value,
-                    serverUrl: trimmed
-                )
+        guard let instance = try? await Dependencies.shared.instanceRepository.getInstanceOrNull(forceRefresh: false)
+        else { return }
+        let baseUrl = instance.remoteUrl ?? instance.localUrl
+        let trimmed = baseUrl.map { $0.hasSuffix("/") ? String($0.dropLast()) : $0 }
+        let raw = ShareLinkCodec.shared.encode(
+            target: ShareTargetBook(
+                bookId: BookId(value: bookId),
+                serverInstanceId: instance.id.value,
+                serverUrl: trimmed
             )
-            shareURL = URL(string: raw)
-        case .failure, .unknown:
-            break
-        }
+        )
+        shareURL = URL(string: raw)
     }
 
     private func observeDownloadStatus(bookId: String) {

--- a/iosApp/ListenUp/Features/Intents/LastPlayedBookProvider.swift
+++ b/iosApp/ListenUp/Features/Intents/LastPlayedBookProvider.swift
@@ -10,23 +10,8 @@ import ListenUpActivityKit
 struct LastPlayedBookProvider: LastPlayedBookProviding {
 
     func mostRecentBookId() async -> String? {
-        // `getContinueListening` is a suspend `AppResult<List<ContinueListeningBook>>`;
-        // Swift Export exposes it as `async throws` with the generic erased to `any AppResult`.
-        // A thrown error (infra fault) or a typed `.failure` both mean "nothing to resume" —
-        // never stranded: the intent surfaces a spoken "nothing to resume" message.
-        guard let result = try? await Dependencies.shared.homeRepository.getContinueListening(limit: 1) else {
-            return nil
-        }
-        switch appResultCase(result) {
-        case .success(let success):
-            let books = success.data as? [ContinueListeningBook]
-            return books?.first?.bookId
-        case .failure(let failure):
-            Log.error("getContinueListening failed while resolving resume: \(failure.error.message)")
-            return nil
-        case .unknown:
-            Log.error("getContinueListening returned an unexpected AppResult case")
-            return nil
-        }
+        // iOS-safe accessor: AppResult is folded in Kotlin (never awaited across the bridge).
+        // nil (failure or nothing to resume) → the intent speaks "nothing to resume". Never stranded.
+        (try? await Dependencies.shared.homeRepository.getResumeBookOrNull())?.bookId
     }
 }

--- a/iosApp/ListenUp/Features/Intents/LastPlayedBookProvider.swift
+++ b/iosApp/ListenUp/Features/Intents/LastPlayedBookProvider.swift
@@ -2,9 +2,10 @@ import ListenUpActivityKit
 @preconcurrency import Shared
 
 /// The app's `LastPlayedBookProviding` implementation — reads
-/// `HomeRepository.getContinueListening(1)`, the same offline-first "Continue
-/// Listening" source the Home screen renders. The top item is, by definition,
-/// "resume my book"; its `bookId` feeds `ResumePlaybackIntent`.
+/// `HomeRepository.getResumeBookOrNull()`, the same offline-first "Continue
+/// Listening" source the Home screen renders (it fetches a window and takes the
+/// first). The top item is, by definition, "resume my book"; its `bookId` feeds
+/// `ResumePlaybackIntent`.
 /// Registered with `AppDependencyManager` at launch (see `ListenUpApp`).
 @MainActor
 struct LastPlayedBookProvider: LastPlayedBookProviding {

--- a/iosApp/ListenUp/Features/Player/KotlinPlaybackSeam.swift
+++ b/iosApp/ListenUp/Features/Player/KotlinPlaybackSeam.swift
@@ -189,24 +189,8 @@ struct KotlinBookDocumentProviding: BookDocumentProviding {
     }
 
     func ensureLocalPath(bookId: String, docId: String) async -> String? {
-        // The Kotlin suspend fun is exposed as `async throws`; failures via AppResult
-        // come back as `.failure`, not as thrown exceptions. Drop thrown errors (infra faults).
-        guard let result = try? await repository.ensureLocal(bookId: BookId(value: bookId), docId: docId) else {
-            return nil
-        }
-        // `AppResult<String>` erases its generic to `any AppResult` over Swift Export. Fold it via the
-        // generated typed accessor (both branches compiler-forced); the success `data` is type-erased
-        // to `any _KotlinBridgeable?` and the payload here is a Kotlin String.
-        switch appResultCase(result) {
-        case .success(let success):
-            return success.data as? String
-        case .failure(let failure):
-            // A typed `.failure` is no longer silently dropped — surface why the PDF won't localize.
-            Log.error("ensureLocal failed for \(docId): \(failure.error.message)")
-            return nil
-        case .unknown:
-            Log.error("ensureLocal returned an unexpected AppResult case for \(docId)")
-            return nil
-        }
+        // iOS-safe accessor: AppResult is folded in Kotlin. A failure (or thrown infra fault) → nil.
+        // `try?` already flattens the bridged `String?` to a single optional, so no `?? nil` is needed.
+        try? await repository.ensureLocalPathOrNull(bookId: BookId(value: bookId), docId: docId)
     }
 }

--- a/iosApp/ListenUp/Features/Player/KotlinPlaybackSeam.swift
+++ b/iosApp/ListenUp/Features/Player/KotlinPlaybackSeam.swift
@@ -164,7 +164,7 @@ struct KotlinBookCoverProviding: BookCoverProviding {
 }
 
 /// Adapts `DocumentRepository` to `BookDocumentProviding`. Takes the first emission from
-/// `observeDocuments` (a one-shot read) and calls `ensureLocal` to download on demand.
+/// `observeDocuments` (a one-shot read) and calls `ensureLocalPathOrNull` to download on demand.
 struct KotlinBookDocumentProviding: BookDocumentProviding {
     let repository: DocumentRepository
 

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -2611,6 +2611,16 @@
         }
       }
     },
+    "book.detail_download_failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't start the download. Please try again."
+          }
+        }
+      }
+    },
     "book.detail_downloaded": {
       "localizations": {
         "en": {

--- a/iosApp/ListenUpTests/BookDetailObserverTests.swift
+++ b/iosApp/ListenUpTests/BookDetailObserverTests.swift
@@ -15,25 +15,6 @@ struct BookDetailObserverTests {
     }
 }
 
-/// The download path used to swallow thrown errors with `try?`, so a failure left the
-/// button looking idle. The fix surfaces non-cancellation throws and stays silent on
-/// cancellation; this pins that decision (the observer itself needs live KMP `Ready`
-/// state to construct, so the decision is verified at its pure seam).
-@Suite("Download throw handling")
-struct DownloadThrowMessageTests {
-    private struct Boom: Error {}
-
-    @Test func cancellationSurfacesNothing() {
-        #expect(BookDetailObserver.downloadThrowMessage(for: CancellationError()) == nil)
-    }
-
-    @Test func realErrorSurfacesAMessage() {
-        let message = BookDetailObserver.downloadThrowMessage(for: Boom())
-        #expect(message != nil)
-        #expect(message?.isEmpty == false)
-    }
-}
-
 @Suite("Cast helpers")
 struct CastHelpersTests {
     private func member(_ name: String, _ roles: [String]) -> CastMember {

--- a/iosApp/ListenUpTests/SeriesDetailObserverTests.swift
+++ b/iosApp/ListenUpTests/SeriesDetailObserverTests.swift
@@ -14,8 +14,8 @@ struct SeriesDetailObserverTests {
 /// Pins the Series-detail CTA label. The regression: a never-started series still has a
 /// `resumeTarget` (the first book), so the label showed "Continue" even though nothing had
 /// been played. The label now reads "Start …" until the user has any progress. The observer
-/// needs live KMP state to construct, so — per the established pattern
-/// (e.g. `BookDetailObserver.downloadThrowMessage`) — the decision is pinned at its pure seam.
+/// needs live KMP state to construct, so — per the established pattern — the decision is
+/// pinned at its pure seam (`SeriesDetailObserver.continueLabel`).
 @Suite("SeriesDetail Continue CTA")
 struct SeriesDetailContinueLabelTests {
     @Test func emptySeriesStartsListening() {

--- a/scripts/check-no-appresult-await.sh
+++ b/scripts/check-no-appresult-await.sh
@@ -9,7 +9,11 @@
 #     an AppResult and a non-AppResult overload is skipped (grep can't disambiguate it);
 #   * matches only an `await` whose direct receiver chain reaches `.<fn>(` — so enum-case
 #     comparisons and nested `await otherFn { … .fn() }` don't false-trigger.
-# Residual gap (accepted): a real trap on an overloaded name slips through. bash 3.2-safe (no mapfile).
+# Residual gap (accepted): a real trap on an overloaded name slips through. Live examples today —
+#   `prepare` (PlaybackPreparer→PreparedPlayback? vs PlaybackService→AppResult) and
+#   `resumeIncompleteDownloads` (DownloadService→Unit vs DownloadRepository→AppResult) — are safe
+#   only because Swift targets the non-AppResult variant; awaiting the AppResult overload would pass.
+# bash 3.2-safe (no mapfile).
 #
 # Usage: check-no-appresult-await.sh [path-to-Shared.swift]   (auto-discovers if omitted)
 set -uo pipefail

--- a/scripts/check-no-appresult-await.sh
+++ b/scripts/check-no-appresult-await.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Fails if any iOS Swift code `await`s a Kotlin suspend returning AppResult across the Swift Export
+# bridge — that traps at runtime (`__createProtocolWrapper(...) as! any AppResult` cast failure →
+# frozen UI). Fix: use a Kotlin-side plain-typed `*OrNull` accessor (unwrap AppResult in Kotlin).
+# See iosApp/CLAUDE.md.
+#
+# Heuristic (static, name-based) with two false-positive guards:
+#   * only watches names that are *uniquely* AppResult-returning in Shared.swift — a name with both
+#     an AppResult and a non-AppResult overload is skipped (grep can't disambiguate it);
+#   * matches only an `await` whose direct receiver chain reaches `.<fn>(` — so enum-case
+#     comparisons and nested `await otherFn { … .fn() }` don't false-trigger.
+# Residual gap (accepted): a real trap on an overloaded name slips through. bash 3.2-safe (no mapfile).
+#
+# Usage: check-no-appresult-await.sh [path-to-Shared.swift]   (auto-discovers if omitted)
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SHARED="${1:-}"
+if [[ -z "$SHARED" || ! -f "$SHARED" ]]; then
+  SHARED="$(find "$REPO_ROOT/sharedLogic/build" -name 'Shared.swift' -path '*SPMPackage*' 2>/dev/null | head -1)"
+  [[ -z "$SHARED" ]] && SHARED="$(find "$REPO_ROOT/sharedLogic/build" -name 'Shared.swift' 2>/dev/null | head -1)"
+fi
+if [[ -z "$SHARED" || ! -f "$SHARED" ]]; then
+  echo "check-no-appresult-await: Shared.swift not found (run after a Swift Export build on macOS)." >&2
+  exit 2
+fi
+
+# Names of exported funcs that are UNIQUELY AppResult-returning (every `public func NAME(...)`
+# returns `any …api.result.AppResult`; drop any name with a non-AppResult overload).
+watch="$(perl -0777 -ne '
+  my %ar; my %other;
+  while (/public func ([A-Za-z_]\w*)\s*\(([^{]*?)\{/sg) {
+    my ($n,$sig) = ($1,$2);
+    if ($sig =~ /->\s*any\s+[\w.]*api\.result\.AppResult\b/s) { $ar{$n}=1 } else { $other{$n}=1 }
+  }
+  for (sort keys %ar) { print "$_\n" unless $other{$_} }
+' "$SHARED")"
+
+if [[ -z "$watch" ]]; then
+  echo "check-no-appresult-await: no uniquely-AppResult exported funcs found; nothing to guard."
+  exit 0
+fi
+
+count="$(printf '%s\n' "$watch" | grep -c .)"
+hits=0
+while IFS= read -r fn; do
+  [[ -z "$fn" ]] && continue
+  while IFS= read -r line; do
+    echo "VIOLATION: $line"
+    hits=1
+  done < <(grep -rnE "(try[?]?[[:space:]]+)?await[[:space:]]+[A-Za-z0-9_.()?]*[.]${fn}[(]" "$REPO_ROOT/iosApp" --include='*.swift' 2>/dev/null)
+done <<< "$watch"
+
+if [[ "$hits" -eq 1 ]]; then
+  cat >&2 <<'MSG'
+
+✗ iOS Swift must not `await` an AppResult-returning Kotlin suspend — it traps in the Swift Export
+  bridge (`as! any AppResult` cast failure → frozen UI). Add/use a Kotlin-side plain-typed `*OrNull`
+  accessor (unwrap AppResult in Kotlin). See iosApp/CLAUDE.md.
+MSG
+  exit 1
+fi
+echo "check-no-appresult-await: clean (${count} uniquely-AppResult fns, 0 awaited from Swift)."
+exit 0

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DocumentRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DocumentRepository.kt
@@ -76,5 +76,5 @@ interface DocumentRepository {
         ensureLocal(
             bookId,
             docId,
-        ).valueOrNull { documentRepositoryLogger.warn { "ensureLocalPathOrNull: ${it.message}" } }
+        ).valueOrNull { documentRepositoryLogger.warn { "ensureLocalPathOrNull: ${it.debugInfo ?: it.message}" } }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DocumentRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DocumentRepository.kt
@@ -3,9 +3,13 @@
 package com.calypsan.listenup.client.domain.repository
 
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.valueOrNull
 import com.calypsan.listenup.client.domain.model.BookDocument
 import com.calypsan.listenup.core.BookId
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
+
+private val documentRepositoryLogger = KotlinLogging.logger {}
 
 /**
  * Repository for accessing supplementary book documents (PDFs, ebooks, etc.).
@@ -60,4 +64,17 @@ interface DocumentRepository {
         bookId: BookId,
         docId: String,
     ): AppResult<String>
+
+    /**
+     * iOS-safe accessor: the local document path or `null` on failure (folded in Kotlin). Use from
+     * Swift — never `await` the `AppResult`-returning [ensureLocal] (Swift Export bridge trap).
+     */
+    suspend fun ensureLocalPathOrNull(
+        bookId: BookId,
+        docId: String,
+    ): String? =
+        ensureLocal(
+            bookId,
+            docId,
+        ).valueOrNull { documentRepositoryLogger.warn { "ensureLocalPathOrNull: ${it.message}" } }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/HomeRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/HomeRepository.kt
@@ -3,9 +3,13 @@
 package com.calypsan.listenup.client.domain.repository
 
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.valueOrNull
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
 import com.calypsan.listenup.client.domain.model.ContinueListeningItem
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
+
+private val homeRepositoryLogger = KotlinLogging.logger {}
 
 /**
  * Repository contract for home screen data operations.
@@ -23,6 +27,15 @@ interface HomeRepository {
      * @return Result containing list of ContinueListeningBook on success
      */
     suspend fun getContinueListening(limit: Int = 10): AppResult<List<ContinueListeningBook>>
+
+    /**
+     * iOS-safe accessor: the most-recent "continue listening" book, or `null`. Use from Swift —
+     * never `await` the `AppResult`-returning [getContinueListening] (Swift Export bridge trap).
+     */
+    suspend fun getResumeBookOrNull(): ContinueListeningBook? =
+        getContinueListening(limit = 1)
+            .valueOrNull { homeRepositoryLogger.warn { "getResumeBookOrNull: ${it.message}" } }
+            ?.firstOrNull()
 
     /**
      * Observe continue listening books from local database.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/HomeRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/HomeRepository.kt
@@ -33,8 +33,8 @@ interface HomeRepository {
      * never `await` the `AppResult`-returning [getContinueListening] (Swift Export bridge trap).
      */
     suspend fun getResumeBookOrNull(): ContinueListeningBook? =
-        getContinueListening(limit = 1)
-            .valueOrNull { homeRepositoryLogger.warn { "getResumeBookOrNull: ${it.message}" } }
+        getContinueListening(limit = 5)
+            .valueOrNull { homeRepositoryLogger.warn { "getResumeBookOrNull: ${it.debugInfo ?: it.message}" } }
             ?.firstOrNull()
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
@@ -57,7 +57,9 @@ interface InstanceRepository {
      * never `await` the `AppResult`-returning [getInstance] (Swift Export bridge trap). Android/server use [getInstance].
      */
     suspend fun getInstanceOrNull(forceRefresh: Boolean = false): Instance? =
-        getInstance(forceRefresh).valueOrNull { instanceRepositoryLogger.warn { "getInstanceOrNull: ${it.message}" } }
+        getInstance(forceRefresh).valueOrNull {
+            instanceRepositoryLogger.warn { "getInstanceOrNull: ${it.debugInfo ?: it.message}" }
+        }
 
     /**
      * Verifies a server URL is a valid ListenUp instance before authentication.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
@@ -4,7 +4,11 @@ package com.calypsan.listenup.client.domain.repository
 
 import com.calypsan.listenup.api.dto.ServerInfo
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.valueOrNull
 import com.calypsan.listenup.client.domain.model.Instance
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val instanceRepositoryLogger = KotlinLogging.logger {}
 
 /**
  * Result of server verification: the server's [ServerInfo] and the URL that
@@ -47,6 +51,13 @@ interface InstanceRepository {
      * GET surface exists. New code should prefer [getServerInfo].
      */
     suspend fun getInstance(forceRefresh: Boolean = false): AppResult<Instance>
+
+    /**
+     * iOS-safe accessor: the [Instance] or `null` on failure (folded in Kotlin). Use from Swift —
+     * never `await` the `AppResult`-returning [getInstance] (Swift Export bridge trap). Android/server use [getInstance].
+     */
+    suspend fun getInstanceOrNull(forceRefresh: Boolean = false): Instance? =
+        getInstance(forceRefresh).valueOrNull { instanceRepositoryLogger.warn { "getInstanceOrNull: ${it.message}" } }
 
     /**
      * Verifies a server URL is a valid ListenUp instance before authentication.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -51,7 +51,9 @@ interface DownloadService {
      * Swift — never `await` the `AppResult`-returning [downloadBook] (Swift Export bridge trap).
      */
     suspend fun downloadBookOrNull(bookId: BookId): DownloadOutcome? =
-        downloadBook(bookId).valueOrNull { downloadServiceLogger.warn { "downloadBookOrNull: ${it.message}" } }
+        downloadBook(
+            bookId,
+        ).valueOrNull { downloadServiceLogger.warn { "downloadBookOrNull: ${it.debugInfo ?: it.message}" } }
 
     /**
      * Cancel active download for a book.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -1,10 +1,14 @@
 package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.valueOrNull
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
+
+private val downloadServiceLogger = KotlinLogging.logger {}
 
 /**
  * Interface for download operations needed by PlaybackManager.
@@ -41,6 +45,13 @@ interface DownloadService {
      * for unexpected errors (book not found, missing audio metadata, etc.).
      */
     suspend fun downloadBook(bookId: BookId): AppResult<DownloadOutcome>
+
+    /**
+     * iOS-safe accessor: the [DownloadOutcome] or `null` on failure (folded in Kotlin). Use from
+     * Swift — never `await` the `AppResult`-returning [downloadBook] (Swift Export bridge trap).
+     */
+    suspend fun downloadBookOrNull(bookId: BookId): DownloadOutcome? =
+        downloadBook(bookId).valueOrNull { downloadServiceLogger.warn { "downloadBookOrNull: ${it.message}" } }
 
     /**
      * Cancel active download for a book.

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -270,6 +270,7 @@
     "detail_discard_progress": "Discard Progress",
     "detail_download": "Download",
     "detail_download_book": "Download book",
+    "detail_download_failed": "Couldn't start the download. Please try again.",
     "detail_downloaded": "Downloaded",
     "detail_edit_book": "Edit Book",
     "detail_find_metadata": "Find Metadata",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/AppResultValueOrNullTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/AppResultValueOrNullTest.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.client.core
+
+import com.calypsan.listenup.api.error.AppError
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.valueOrNull
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class AppResultValueOrNullTest :
+    FunSpec({
+        test("Success returns its data and does not invoke onFailure") {
+            var failureSeen = false
+            AppResult.Success(42).valueOrNull { failureSeen = true } shouldBe 42
+            failureSeen shouldBe false
+        }
+
+        test("Failure returns null and invokes onFailure with the typed error") {
+            val err: AppError = TransportError.NetworkUnavailable(debugInfo = "x")
+            var seen: AppError? = null
+            AppResult.Failure(err).valueOrNull { seen = it }.shouldBeNull()
+            seen shouldBe err
+        }
+    })

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -262,6 +262,7 @@ One beautiful library.</string>
     <string name="book_detail_done">Done</string>
     <string name="book_detail_download">Download</string>
     <string name="book_detail_download_book">Download book</string>
+    <string name="book_detail_download_failed">Couldn\'t start the download. Please try again.</string>
     <string name="book_detail_downloaded">Downloaded</string>
     <string name="book_detail_edit_book">Edit Book</string>
     <string name="book_detail_error_title">Couldn’t load this book</string>


### PR DESCRIPTION
## Summary

Eliminates — and structurally prevents — the iOS crash class behind the post-scan Home freeze (PR #896 fixed one instance; this fixes the rest and guards against recurrence).

**Root cause:** `await`-ing a Kotlin `suspend` that returns the generic `AppResult<T>` from Swift traps in the experimental Swift Export bridge — `__createProtocolWrapper(...) as! any AppResult` (`Swift runtime failure: type cast failed`, on a background dispatch queue → frozen UI). Awaiting a *plain-typed* suspend is fine.

**Approach:** keep `AppResult` (the canonical error model) entirely in Kotlin and hand Swift plain types.

- **`AppResult.valueOrNull(onFailure)`** — a pure, Kotest-tested fold (`contract`).
- **Four `*OrNull` repo accessors** (interface default methods) that fold `AppResult` in Kotlin and log `debugInfo`: `getInstanceOrNull`, `getResumeBookOrNull`, `downloadBookOrNull`, `ensureLocalPathOrNull`. The existing `AppResult` methods are untouched (Android/server keep them).
- **Four iOS call sites converted** to the plain accessors (`buildShareURL`, `mostRecentBookId`, `ensureLocalPath`, `downloadBook`) — no `await` of `AppResult`, no `appResultCase`. Orphaned `downloadThrowMessage` + its test removed; the download-failed string routed through the `en.json` localization pipeline (`book.detail_download_failed`).
- **CI guard** `scripts/check-no-appresult-await.sh` (bash-3.2-safe; uniqueness filter + tight `await` pattern) wired into the `Test (iOS)` job — fails if any iOS Swift `await`s an `AppResult`-returning exported function. Runs clean today (147 uniquely-AppResult fns, 0 awaits) and self-test-proven to flag a planted violation.
- **`iosApp/CLAUDE.md`** documents the invariant.

The whole-implementation review independently verified the invariant holds across *all* of `iosApp/` (every Swift `await` resolves to a non-AppResult variant).

## Known gaps / follow-ups (out of scope)
- The guard skips *overloaded* names it can't disambiguate by grep (`prepare`, `resumeIncompleteDownloads` are live examples — safe today because Swift targets the non-AppResult overload; documented in the script header).
- Pre-existing: `DownloadButton.swift` references non-resolving `book_detail.download*` catalog keys — separate bug, not touched here.

## Test plan
- [x] Kotlin: `:sharedLogic:jvmTest` (incl. `AppResultValueOrNullTest`) + spotless/detekt green
- [x] Localization: `verifyStrings` green (en.json → strings.xml + Localizable.xcstrings in sync)
- [x] iOS: build + test + swiftlint green (also validated Swift Export *does* export the Kotlin interface default methods)
- [x] Guard: clean on bash 5.3 and `/bin/bash` 3.2; self-test flags a planted violation
- [ ] Device smoke (recommended): share a book, Siri "resume", start a download, open a PDF — none freeze