### PR TITLE
🐛 fix: WebSocket keepalive on RPC transport so dead sockets surface as errors, not hangs

### DIFF
--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -137,6 +137,7 @@ import io.ktor.server.plugins.partialcontent.PartialContent
 import io.ktor.server.resources.Resources
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
+import io.ktor.server.websocket.WebSockets
 import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -153,6 +154,10 @@ import java.nio.file.Path
 import kotlinx.io.files.Path as DataDirPath
 
 private val logger = KotlinLogging.logger {}
+
+/** RPC WebSocket keepalive (ms): server pings every [WS_PING_PERIOD_MS]; closes if no pong within [WS_PING_TIMEOUT_MS]. */
+private const val WS_PING_PERIOD_MS = 15_000L
+private const val WS_PING_TIMEOUT_MS = 15_000L
 
 private const val SEED_PROFILE_DEMO = "demo"
 
@@ -252,6 +257,14 @@ private fun Application.installCorePlugins() {
     install(ContentNegotiation) { json(contractJson) }
     install(Resources)
     install(SSE)
+    // Keepalive for the kotlinx.rpc WebSockets: server-side pings detect a dead/half-open client
+    // socket and close the session, so a stalled RPC call is torn down rather than left hanging.
+    // Mirrors the client-side ping in ApiClientFactory. Must precede install(Krpc), which transports
+    // its sessions over these WebSockets.
+    install(WebSockets) {
+        pingPeriodMillis = WS_PING_PERIOD_MS
+        timeoutMillis = WS_PING_TIMEOUT_MS
+    }
     install(Krpc)
     install(PartialContent)
     install(AutoHeadResponse)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -15,6 +15,7 @@ import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.client.call.HttpClientCall
@@ -32,6 +33,9 @@ import io.ktor.client.plugins.plugin
 import kotlin.coroutines.cancellation.CancellationException
 
 private const val SERVER_URL_NOT_CONFIGURED_MESSAGE = "Server URL not configured"
+
+/** Ping interval (ms) for RPC WebSockets — detects a dead/half-open socket so calls can't hang forever. */
+private const val WS_PING_INTERVAL_MS = 15_000L
 private val logger = KotlinLogging.logger {}
 
 /**
@@ -253,6 +257,14 @@ internal class KtorApiClientFactory(
                     requestTimeoutMillis = 30_000
                     connectTimeoutMillis = 10_000
                     socketTimeoutMillis = 30_000
+                }
+
+                // Keepalive for the kotlinx.rpc WebSockets (installKrpc opens its sessions over this
+                // base client). Without pings, a half-open / "black-hole" socket is never detected and
+                // an in-flight RPC call awaits its response forever — the contributor-merge hang. A
+                // periodic ping fails the dead session so the call surfaces an error instead of spinning.
+                install(WebSockets) {
+                    pingIntervalMillis = WS_PING_INTERVAL_MS
                 }
 
                 // Retry idempotent requests on 5xx responses and transient IO failures.


### PR DESCRIPTION
The systemic fix for the contributor-merge "indefinite spinner" hang (root-caused after #899's per-call mitigation).

## Root cause (recap)
An RPC call over the shared kotlinx.rpc WebSocket can **stall forever on a half-open / "black-hole" socket**: kotlinx.rpc 0.11.x doesn't propagate the dead connection, `HttpTimeout` doesn't cover a post-upgrade WS stall, and **there was no WebSocket keepalive on either side** to detect it. The server finishes the work and writes the response into the dead socket (lost); the client awaits it indefinitely with no error. `InstanceRpcFactory` was already hardened against this exact "black-hole socket" case with timeouts; every other RPC factory shares one engine and had no such guard. (It can't reproduce in `testApplication` — the in-memory transport never half-opens.)

## This change — keepalive (the systemic fix)
- **Client** (`ApiClientFactory`): `install(WebSockets) { pingIntervalMillis = 15_000 }` on the base client that every RPC factory layers `installKrpc` over — so all RPC WebSockets ping.
- **Server** (`Application.installCorePlugins`): `install(WebSockets) { pingPeriodMillis = 15_000; timeoutMillis = 15_000 }` before `install(Krpc)`.

With pings, a dead/half-open socket is detected within ~15–30s and the session is closed, so a stalled call surfaces an error (which existing retry/`AppResult.Failure` handling + #899's merge timeout turn into recovery) instead of spinning forever. Keepalive is duration-independent, so it does **not** break legitimately long RPCs (`scanFull`, `createBackup`/`restoreBackup`, `import.apply`) or the `observeProgress()` `Flow` streams — which a blanket per-call timeout would have.

## Scope / why not a blanket per-call timeout
We deliberately did **not** add a uniform per-call timeout: it would kill the long-running calls and can't wrap the progress streams. Per-call timeouts stay targeted (merge via #899, instance-verify). Keepalive is the safe systemic layer.

## Verification
- `:server:jvmTest` RPC round-trip tests (`BookServiceRpcTest`, `InstanceServiceRpcTest`) pass — the `WebSockets`+`Krpc` install coexists and RPC is unbroken.
- `:androidApp:assembleDebug` + `spotlessCheck`/`detekt` green.
- **Limitation:** the ping *firing* can't be exercised in `testApplication` (in-memory transport); the config is standard Ktor and verified non-breaking. Real-socket validation is on-device.

## Follow-up
The underlying kotlinx.rpc non-propagation is tracked upstream; the catalog already pins `0.11.0-grpc-188` chasing a krpc fix — bump when it lands. Ping values (15s) are conservative; tune if battery/traffic on mobile warrants.