### PR TITLE
✨ feat(server): file-upload routes → commonMain (native, Phase 5-3c)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.io
+
+import io.ktor.server.application.ApplicationCall
+import kotlinx.io.files.Path
+
+/**
+ * Receives a multipart request and streams the first file part to [dest] chunk by chunk, so a
+ * multi-GiB upload never lands in memory. Returns true when a file part was present; non-file parts
+ * and any parts after the first are released and ignored. [formFieldLimit] caps the accepted size
+ * (Ktor's 50 MiB default rejects large library backups before they can be staged). [dest] is
+ * overwritten; its parent directory must exist.
+ *
+ * Platform note: the JVM runtime streams the upload. Kotlin/Native's Ktor CIO server cannot parse
+ * multipart bodies (JetBrains [KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)), so the
+ * native actual throws [MultipartUploadUnsupported], which [installAppErrorStatusPages] surfaces as
+ * `501 Not Implemented`. The native server is a compile/boot target; the JVM runtime serves uploads.
+ */
+internal expect suspend fun ApplicationCall.streamFirstFilePartTo(
+    dest: Path,
+    formFieldLimit: Long,
+): Boolean
+
+/**
+ * Signals that a multipart upload was attempted on the Kotlin/Native server runtime, whose Ktor CIO
+ * engine cannot parse multipart bodies (KTOR-7361). Thrown by the native [streamFirstFilePartTo]
+ * actual and surfaced as `501 Not Implemented` by [installAppErrorStatusPages].
+ */
+internal class MultipartUploadUnsupported :
+    UnsupportedOperationException("Multipart upload is not supported on the native server runtime.")

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -29,6 +29,7 @@ import com.calypsan.listenup.api.error.TagError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.io.MultipartUploadUnsupported
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -52,6 +53,14 @@ private val logger = KotlinLogging.logger("AppErrorStatusPages")
  */
 fun Application.installAppErrorStatusPages() {
     install(StatusPages) {
+        // The native server runtime can't parse multipart (KTOR-7361) — surface an upload attempt as
+        // a precise 501 rather than letting it fall through to a generic 500. JVM never throws this.
+        exception<MultipartUploadUnsupported> { call, _ ->
+            call.respond(
+                HttpStatusCode.NotImplemented,
+                mapOf("error" to "not_implemented", "reason" to "multipart_upload_unsupported_on_native"),
+            )
+        }
         exception<Throwable> { call, ex ->
             // Cancellation must always re-raise — never swallow it.
             if (ex is CancellationException) throw ex

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/BackupRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/BackupRoutes.kt
@@ -10,35 +10,33 @@ import com.calypsan.listenup.core.BackupId
 import com.calypsan.listenup.server.backup.BackupArchive
 import com.calypsan.listenup.server.backup.BackupManifest
 import com.calypsan.listenup.server.backup.BackupPaths
-import com.calypsan.listenup.server.plugins.toHttpStatus
+import com.calypsan.listenup.server.io.createTempFileIn
 import com.calypsan.listenup.server.io.respondSeekable
+import com.calypsan.listenup.server.io.streamFirstFilePartTo
+import com.calypsan.listenup.server.plugins.toHttpStatus
 import com.calypsan.listenup.server.plugins.userPrincipalOrNull
 import com.calypsan.listenup.server.plugins.withCorrelationId
 import io.ktor.http.ContentDisposition
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.PartData
-import io.ktor.http.content.forEachPart
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.plugins.callid.callId
-import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import io.ktor.utils.io.jvm.javaio.copyTo
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import kotlinx.coroutines.CancellationException
-import kotlinx.io.files.Path as IoPath
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlin.time.Instant
 
 /**
  * Max accepted size for an uploaded `.listenup.zip` backup. Legitimate backups for large libraries
  * can exceed 50 MiB; this route streams the file straight to a temp file (never buffered in
- * memory), so a generous cap is safe. Ktor's default [formFieldLimit] is 50 MiB (52_428_800 bytes),
+ * memory), so a generous cap is safe. Ktor's default `formFieldLimit` is 50 MiB (52_428_800 bytes),
  * which would reject valid large restores before they could be staged. Mirrors [ImportRoutes]'
  * cap for consistency — both upload endpoints accept the same ceiling.
  */
@@ -66,7 +64,7 @@ private const val MAX_BACKUP_RESTORE_BYTES: Long = 5L * 1024 * 1024 * 1024 // 5 
  *  - The id for the uploaded archive is derived from the manifest's [BackupManifest.createdAt]
  *    timestamp — never from a client-supplied filename — preventing path traversal.
  *  - Upload is streamed directly to a temp file; the body is never buffered into a [ByteArray].
- *  - Download uses Ktor's [respondFile] (file-channel streaming), not `Files.readAllBytes`.
+ *  - Download uses [respondSeekable] (file-channel streaming), not a full read into memory.
  */
 fun Route.backupRoutes(
     paths: BackupPaths,
@@ -83,7 +81,7 @@ fun Route.backupRoutes(
         }
 
         val archivePath = paths.archiveFor(rawId)
-        if (!java.io.File(archivePath.toString()).isFile) {
+        if (SystemFileSystem.metadataOrNull(archivePath)?.isRegularFile != true) {
             return@get call.respondBareAppError(BackupError.BackupNotFound())
         }
 
@@ -106,7 +104,7 @@ fun Route.backupRoutes(
 /**
  * Streams the multipart body to a temp file, validates it, then moves it into [BackupPaths.backupsDir].
  * The temp file is always cleaned up in a `finally` block; on success it has already been moved so
- * [Files.deleteIfExists] is a no-op.
+ * the delete is a no-op.
  */
 private suspend fun ApplicationCall.handleUpload(
     paths: BackupPaths,
@@ -114,44 +112,29 @@ private suspend fun ApplicationCall.handleUpload(
 ) {
     paths.ensureDirs()
     // Stream the upload to a temp file — never buffer multi-hundred-MB backups into memory.
-    val tmpFile =
-        Files.createTempFile(
-            java.nio.file.Path
-                .of(paths.tmpDir.toString()),
-            "upload-",
-            ".listenup.zip",
-        )
+    val tmpFile = createTempFileIn(paths.tmpDir, "upload-", ".listenup.zip")
     try {
-        var received = false
-        receiveMultipart(formFieldLimit = MAX_BACKUP_RESTORE_BYTES).forEachPart { part ->
-            if (part is PartData.FileItem && !received) {
-                received = true
-                Files.newOutputStream(tmpFile).use { out ->
-                    part.provider().copyTo(out)
-                }
-            }
-            part.release()
-        }
-
-        if (!received) {
+        if (!streamFirstFilePartTo(tmpFile, MAX_BACKUP_RESTORE_BYTES)) {
             respond(HttpStatusCode.BadRequest, "missing file part")
             return
         }
 
         // Validate before staging — a corrupt archive must never land in backupsDir.
-        val manifest = validateUpload(archive, IoPath(tmpFile.toString())) ?: return
+        val manifest = validateUpload(archive, tmpFile) ?: return
 
         // Derive a filesystem-safe id from the manifest timestamp — never from the
         // client-supplied filename — to prevent path traversal.
         val safeId = deriveSafeId(manifest)
-        val destFile = java.io.File(paths.archiveFor(safeId).toString())
-        Files.move(tmpFile, destFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        val destPath = paths.archiveFor(safeId)
+        // Mirror REPLACE_EXISTING: drop any prior archive with this id before the atomic rename.
+        SystemFileSystem.delete(destPath, mustExist = false)
+        SystemFileSystem.atomicMove(tmpFile, destPath)
 
         val summary =
             BackupSummary(
                 id = BackupId(safeId),
                 createdAt = manifest.createdAt,
-                sizeBytes = destFile.length(),
+                sizeBytes = SystemFileSystem.metadataOrNull(destPath)?.size ?: 0L,
                 includesImages = manifest.includesImages,
                 schemaVersion = manifest.schemaVersion,
                 appVersion = manifest.appVersion,
@@ -161,8 +144,8 @@ private suspend fun ApplicationCall.handleUpload(
         respond(HttpStatusCode.OK, summary)
     } finally {
         // Clean up the temp file on any failure path; on success it has already been
-        // moved to dest so deleteIfExists is a no-op there.
-        Files.deleteIfExists(tmpFile)
+        // moved to dest so the delete is a no-op there.
+        SystemFileSystem.delete(tmpFile, mustExist = false)
     }
 }
 
@@ -173,7 +156,7 @@ private suspend fun ApplicationCall.handleUpload(
  */
 private suspend fun ApplicationCall.validateUpload(
     archive: BackupArchive,
-    tmpFile: IoPath,
+    tmpFile: Path,
 ): BackupManifest? =
     try {
         archive.validate(tmpFile)
@@ -204,10 +187,7 @@ private fun String.isSafeBackupId(): Boolean {
  * Using the manifest timestamp (not the client-supplied filename) prevents path traversal.
  */
 private fun deriveSafeId(manifest: BackupManifest): String {
-    val iso =
-        java.time.Instant
-            .ofEpochMilli(manifest.createdAt)
-            .toString()
+    val iso = Instant.fromEpochMilliseconds(manifest.createdAt).toString()
     // ':' is invalid in filenames on some filesystems; replace to match local backup id format.
     return "backup-${iso.replace(':', '-')}"
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ImportRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ImportRoutes.kt
@@ -10,36 +10,37 @@ import com.calypsan.listenup.api.error.ImportError
 import com.calypsan.listenup.core.ImportId
 import com.calypsan.listenup.server.absimport.AbsSchema
 import com.calypsan.listenup.server.absimport.ImportPaths
+import com.calypsan.listenup.server.compression.zip.ZipReader
+import com.calypsan.listenup.server.io.createTempFileIn
+import com.calypsan.listenup.server.io.deleteRecursively
+import com.calypsan.listenup.server.io.isUnder
+import com.calypsan.listenup.server.io.streamFirstFilePartTo
+import com.calypsan.listenup.server.io.writeText
 import com.calypsan.listenup.server.plugins.toHttpStatus
 import com.calypsan.listenup.server.plugins.userPrincipalOrNull
 import com.calypsan.listenup.server.plugins.withCorrelationId
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.PartData
-import io.ktor.http.content.forEachPart
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.plugins.callid.callId
-import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
-import io.ktor.utils.io.jvm.javaio.copyTo
 import kotlinx.coroutines.CancellationException
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlinx.io.files.Path as IoPath
-import java.util.UUID
-import java.util.zip.ZipInputStream
-import kotlin.io.path.outputStream
-import kotlin.io.path.writeText
 import kotlin.time.Clock
+import kotlin.uuid.Uuid
 
 /**
  * Max accepted size for an uploaded `.audiobookshelf` backup. ABS backups for large libraries
  * routinely reach hundreds of MB; this endpoint is admin-only and streams the file straight to a
- * temp file (never buffered in memory), so a generous cap is safe. Ktor's default [formFieldLimit]
+ * temp file (never buffered in memory), so a generous cap is safe. Ktor's default `formFieldLimit`
  * is 50 MiB (52_428_800 bytes), which rejected real backups before they could be streamed.
  */
 private const val MAX_BACKUP_UPLOAD_BYTES: Long = 5L * 1024 * 1024 * 1024 // 5 GiB
@@ -89,32 +90,21 @@ private suspend fun ApplicationCall.handleImportUpload(
 ) {
     paths.ensureDirs()
     // Stream the upload to a temp file — never buffer a multi-hundred-MB ABS backup into memory.
-    val tmpZip = Files.createTempFile(paths.tmpDir.toNio(), "abs-upload-", ".audiobookshelf")
+    val tmpZip = createTempFileIn(paths.tmpDir, "abs-upload-", ".audiobookshelf")
     try {
-        var received = false
-        receiveMultipart(formFieldLimit = MAX_BACKUP_UPLOAD_BYTES).forEachPart { part ->
-            if (part is PartData.FileItem && !received) {
-                received = true
-                tmpZip.outputStream().use { out -> part.provider().copyTo(out) }
-            }
-            part.release()
-        }
-
-        if (!received) {
+        if (!streamFirstFilePartTo(tmpZip, MAX_BACKUP_UPLOAD_BYTES)) {
             respondImportAppError(ImportError.UploadFailed(debugInfo = "missing file part"))
             return
         }
 
         // Server-minted id — never from the client filename — so it is always a safe path segment.
-        val importId = "abs-${UUID.randomUUID()}"
-        val importDir = paths.dirFor(importId).toNio()
-        Files.createDirectories(importDir)
+        val importId = "abs-${Uuid.random()}"
+        val importDir = paths.dirFor(importId)
+        SystemFileSystem.createDirectories(importDir)
         try {
-            extractAbsDatabase(tmpZip, importDir, paths.absDbFor(importId).toNio())
+            extractAbsDatabase(tmpZip, importDir, paths.absDbFor(importId))
             val createdAt = clock.now().toEpochMilliseconds()
-            paths.metaFor(importId).toNio().writeText(
-                metaJson.encodeToString(UploadMeta(createdAt = createdAt)),
-            )
+            paths.metaFor(importId).writeText(metaJson.encodeToString(UploadMeta(createdAt = createdAt)))
             respond(
                 HttpStatusCode.OK,
                 ImportSummary(
@@ -126,17 +116,17 @@ private suspend fun ApplicationCall.handleImportUpload(
                 ),
             )
         } catch (e: AbsDatabaseMissingException) {
-            importDir.toFile().deleteRecursively()
+            deleteRecursively(importDir)
             respondImportAppError(ImportError.UploadFailed(debugInfo = e.message))
         } catch (e: CancellationException) {
-            importDir.toFile().deleteRecursively()
+            deleteRecursively(importDir)
             throw e
         } catch (e: Exception) {
-            importDir.toFile().deleteRecursively()
+            deleteRecursively(importDir)
             respondImportAppError(ImportError.UploadFailed(debugInfo = e.message))
         }
     } finally {
-        Files.deleteIfExists(tmpZip)
+        SystemFileSystem.delete(tmpZip, mustExist = false)
     }
 }
 
@@ -146,9 +136,8 @@ private class AbsDatabaseMissingException :
 
 /**
  * Extracts exactly the `absdatabase.sqlite` entry from [zip] to [dest]. Zip-slip-safe: only the
- * entry whose name matches [AbsSchema.DB_FILENAME] (by its final path segment) is written, and only
- * to [dest], which is already resolved under [importDir]. Throws [AbsDatabaseMissingException] when
- * no matching entry is present.
+ * entry whose leaf name matches [AbsSchema.DB_FILENAME] is written, and only to [dest], which is
+ * asserted to live under [importDir]. Throws [AbsDatabaseMissingException] when no entry matches.
  */
 private fun extractAbsDatabase(
     zip: Path,
@@ -156,39 +145,34 @@ private fun extractAbsDatabase(
     dest: Path,
 ) {
     // dest is server-derived under importDir; assert the invariant defensively before any write.
-    require(dest.toAbsolutePath().normalize().startsWith(importDir.toAbsolutePath().normalize())) {
-        "extraction target escapes the import directory"
-    }
+    require(dest.isUnder(importDir)) { "extraction target escapes the import directory" }
     val extracted =
-        Files.newInputStream(zip).use { rawIn ->
-            ZipInputStream(rawIn).use { zin -> zin.extractAbsDbEntryTo(dest) }
+        ZipReader(zip).use { reader ->
+            // Match on the leaf name (not the full entry path) so arbitrary nested paths are ignored
+            // and only [dest] is ever written — the zip-slip guard.
+            val entry =
+                reader.entries().firstOrNull { e ->
+                    !e.name.endsWith('/') && e.name.leafName() == AbsSchema.DB_FILENAME
+                }
+            if (entry == null) {
+                false
+            } else {
+                reader.openEntry(entry).use { source ->
+                    SystemFileSystem.sink(dest).buffered().use { it.transferFrom(source) }
+                }
+                true
+            }
         }
     if (!extracted) throw AbsDatabaseMissingException()
 }
 
-/**
- * Scans this zip stream and copies the first entry whose leaf name is [AbsSchema.DB_FILENAME] to
- * [dest], returning true if one was found. Matching on the leaf name (not the full entry path) is
- * the zip-slip guard: arbitrary nested paths are ignored and only [dest] is ever written.
- */
-private fun ZipInputStream.extractAbsDbEntryTo(dest: Path): Boolean {
-    var entry = nextEntry
-    while (entry != null) {
-        val leaf = entry.name.substringAfterLast('/').substringAfterLast('\\')
-        if (!entry.isDirectory && leaf == AbsSchema.DB_FILENAME) {
-            dest.outputStream().use { out -> copyTo(out) }
-            closeEntry()
-            return true
-        }
-        closeEntry()
-        entry = nextEntry
-    }
-    return false
-}
+/** The final path segment of a zip entry name (slash- or backslash-separated). */
+private fun String.leafName(): String = substringAfterLast('/').substringAfterLast('\\')
 
 private val metaJson = Json { ignoreUnknownKeys = true }
 
 @Serializable
+@SerialName("UploadMeta")
 private data class UploadMeta(
     val createdAt: Long,
 )
@@ -199,6 +183,3 @@ private suspend fun ApplicationCall.respondImportAppError(error: AppError) {
     val typed = error.withCorrelationId(callId)
     respond(typed.toHttpStatus(), typed)
 }
-
-/** Bridges a kotlinx-io path (from [ImportPaths]) to the java.nio path this route's zip/IO code uses. */
-private fun IoPath.toNio(): Path = Path.of(toString())

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/MetadataImageRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/MetadataImageRoutes.kt
@@ -10,8 +10,7 @@ import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import java.nio.file.Path
-import kotlinx.io.files.Path as IoPath
+import kotlinx.io.files.Path
 
 /**
  * Routes that serve contributor photos and series cover images from local
@@ -34,8 +33,7 @@ fun Route.metadataImageRoutes(
         val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
         val contributor = contributorRepository.findById(id) ?: return@get call.respond(HttpStatusCode.NotFound)
         val relPath = contributor.imagePath ?: return@get call.respond(HttpStatusCode.NotFound)
-        val absolute = resolveSandboxed(imageHome, relPath) ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val path = IoPath(absolute.toString())
+        val path = resolveSandboxed(imageHome, relPath) ?: return@get call.respond(HttpStatusCode.BadRequest)
         call.respondSeekable(path, ContentType.defaultForFilePath(path.name))
     }
 
@@ -43,8 +41,7 @@ fun Route.metadataImageRoutes(
         val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
         val series = seriesRepository.findById(id) ?: return@get call.respond(HttpStatusCode.NotFound)
         val relPath = series.coverPath ?: return@get call.respond(HttpStatusCode.NotFound)
-        val absolute = resolveSandboxed(imageHome, relPath) ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val path = IoPath(absolute.toString())
+        val path = resolveSandboxed(imageHome, relPath) ?: return@get call.respond(HttpStatusCode.BadRequest)
         call.respondSeekable(path, ContentType.defaultForFilePath(path.name))
     }
 }
@@ -58,5 +55,5 @@ private fun resolveSandboxed(
     relativePath: String,
 ): Path? {
     if (relativePath.startsWith("/") || "../" in relativePath || relativePath == "..") return null
-    return base.resolve(relativePath).normalize()
+    return Path(base, relativePath)
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -515,7 +515,7 @@ private fun Application.installAppRoutes(homeDir: Path) {
             playbackRoutes(playbackService)
             playbackProgressRoutes(playbackProgressService, bookAccessPolicy)
             adminRoutes(backfillService, searchReindexService)
-            metadataImageRoutes(contributorRepository, seriesRepository, homeDir)
+            metadataImageRoutes(contributorRepository, seriesRepository, DataDirPath(homeDir.toString()))
             metadataRoutes(metadataLookupService)
             searchRoutes(searchService)
             tagRoutes(tagService, bookAccessPolicy)

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.jvm.kt
@@ -1,0 +1,40 @@
+package com.calypsan.listenup.server.io
+
+import io.ktor.http.content.PartData
+import io.ktor.http.content.forEachPart
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveMultipart
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readRemaining
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+/** Bounded read size for streaming an upload to disk — never holds the whole body in memory. */
+private const val UPLOAD_CHUNK_BYTES: Long = 64L * 1024
+
+internal actual suspend fun ApplicationCall.streamFirstFilePartTo(
+    dest: Path,
+    formFieldLimit: Long,
+): Boolean {
+    var received = false
+    receiveMultipart(formFieldLimit = formFieldLimit).forEachPart { part ->
+        if (part is PartData.FileItem && !received) {
+            received = true
+            part.provider().writeTo(dest)
+        }
+        part.release()
+    }
+    return received
+}
+
+/** Streams this channel to [dest] in [UPLOAD_CHUNK_BYTES] chunks, never buffering the full payload. */
+private suspend fun ByteReadChannel.writeTo(dest: Path) {
+    SystemFileSystem.sink(dest).buffered().use { sink ->
+        while (true) {
+            val chunk = readRemaining(UPLOAD_CHUNK_BYTES)
+            if (chunk.exhausted()) break
+            sink.transferFrom(chunk)
+        }
+    }
+}

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/MultipartUpload.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/MultipartUpload.linuxX64.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.server.io
+
+import io.ktor.server.application.ApplicationCall
+import kotlinx.io.files.Path
+
+/**
+ * The Kotlin/Native Ktor CIO server cannot parse multipart request bodies (KTOR-7361), so it cannot
+ * stream an upload. Fails loudly with [MultipartUploadUnsupported] (→ `501 Not Implemented`) rather
+ * than silently dropping the body; uploads are served by the JVM runtime, which has a real actual.
+ */
+internal actual suspend fun ApplicationCall.streamFirstFilePartTo(
+    dest: Path,
+    formFieldLimit: Long,
+): Boolean = throw MultipartUploadUnsupported()

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
@@ -1,0 +1,84 @@
+package com.calypsan.listenup.server.io
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.server.plugins.installAppErrorStatusPages
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO as ClientCIO
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import kotlin.test.Test
+
+/**
+ * Native counterpart to the JVM upload-route tests: the Kotlin/Native Ktor CIO server cannot parse
+ * multipart (KTOR-7361), so [streamFirstFilePartTo]'s native actual throws [MultipartUploadUnsupported],
+ * which [installAppErrorStatusPages] surfaces as a precise `501 Not Implemented` rather than an opaque
+ * transform error. This proves the upload routes fail honestly on the native runtime (the JVM runtime
+ * serves uploads — that path is covered by `BackupRoutesTest` / `ImportRoutesTest`).
+ *
+ * Drives a real `embeddedServer(CIO)` over an ephemeral port; `kotlin.test.@Test` + `runBlocking` and a
+ * `Unit` body so the K/N runner discovers it.
+ */
+class MultipartUploadNativeTest {
+    @Test
+    fun nativeMultipartUploadRespondsNotImplemented(): Unit =
+        runBlocking {
+            val dest = Path("lu-native-multipart-test.bin")
+            val server =
+                embeddedServer(CIO, port = 0) {
+                    install(ContentNegotiation) { json(contractJson) }
+                    installAppErrorStatusPages()
+                    routing {
+                        post("/upload") {
+                            val received = call.streamFirstFilePartTo(dest, formFieldLimit = 1L shl 20)
+                            call.respondText(if (received) "received" else "empty")
+                        }
+                    }
+                }
+            server.start(wait = false)
+            val client = HttpClient(ClientCIO)
+            try {
+                val port =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
+                val response =
+                    client.post("http://127.0.0.1:$port/upload") {
+                        setBody(
+                            MultiPartFormDataContent(
+                                formData {
+                                    append(
+                                        "file",
+                                        "x".encodeToByteArray(),
+                                        Headers.build {
+                                            append(HttpHeaders.ContentDisposition, "filename=\"x.bin\"")
+                                        },
+                                    )
+                                },
+                            ),
+                        )
+                    }
+                response.status shouldBe HttpStatusCode.NotImplemented
+            } finally {
+                client.close()
+                server.stop(0, 0)
+            }
+        }
+}


### PR DESCRIPTION
Moves the last three jvmMain route handlers — `BackupRoutes`, `ImportRoutes`, `MetadataImageRoutes` — to commonMain so `:server` compiles and serves them on linuxX64. This is the final routes increment before P5-4 (DI) and the P5-5 native `main()` flip.

## Seams ported
- `java.nio.file.Files` / `java.io.File` / `StandardCopyOption` → `kotlinx.io.SystemFileSystem` + the existing commonMain `io/` helpers (`createTempFileIn`, `deleteRecursively`, `isUnder`).
- `java.util.zip.ZipInputStream` → the native `ZipReader` (#831) for the zip-slip-safe `absdatabase.sqlite` extraction.
- `java.util.UUID` → `kotlin.uuid.Uuid`; `java.time.Instant` → `kotlin.time.Instant` (matches `BackupServiceImpl`'s local backup-id format).
- `java.nio.file.Path` image-home param → `kotlinx.io.files.Path`.

## The native multipart gap (KTOR-7361)
The Kotlin/Native Ktor CIO server **cannot parse `receiveMultipart()`** — it throws `CannotTransformContentToTypeException` ([KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)), confirmed against a real `embeddedServer(CIO)` (not just `testApplication`). The two upload routes depend on it.

Handled via an `expect`/`actual` seam on the new `streamFirstFilePartTo` helper:
- **JVM actual** streams the first file part to disk in 64 KiB chunks (never buffers the body).
- **Native actual** throws `MultipartUploadUnsupported`, which `installAppErrorStatusPages` surfaces as a clean **`501 Not Implemented`**.

The JVM runtime stays the production upload runtime; native compiles + boots (the Phase 5 goal) and fails uploads honestly rather than silently.

## Tests
- Existing `BackupRoutesTest` (7), `ImportRoutesTest` (4), `MetadataImageRoutesTest` (13) pass unchanged against the ported code (full upload → validate → move → download, ZIP extraction, path-traversal, range requests).
- New `MultipartUploadNativeTest` (linuxX64Test) drives a real native CIO server and asserts the honest `501`.
- Full Linux gate green: `:sharedLogic:jvmTest`, `:server:jvmTest`, `:server:linuxX64Test`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)