### PR TITLE
🚨 chore(server): clear compiler warnings (return-value-checker, opt-ins, redundant -X flag)

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -60,7 +60,6 @@ kotlin {
         freeCompilerArgs.addAll(
             "-Xexpect-actual-classes",
             "-Xreturn-value-checker=check",
-            "-Xexplicit-backing-fields",
             "-Xskip-prerelease-check",
         )
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImpl.kt
@@ -209,8 +209,8 @@ internal class LibraryAdminServiceImpl(
         // Admin-only: triggering a scan is a privileged server operation.
         requireAdmin()?.let { return AppResult.Failure(it) }
         val folderPage = libraryFolderRepository.pullSince(userId = null, cursor = 0L, limit = Int.MAX_VALUE)
-        folderPage.items.firstOrNull { it.id == folderId.value && it.deletedAt == null }
-            ?: return AppResult.Failure(LibraryError.FolderNotFound())
+        val folderExists = folderPage.items.any { it.id == folderId.value && it.deletedAt == null }
+        if (!folderExists) return AppResult.Failure(LibraryError.FolderNotFound())
         scanOrchestrator.scanFolder(folderId)
         return AppResult.Success(Unit)
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/Crc32.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/compression/Crc32.kt
@@ -6,6 +6,7 @@ package com.calypsan.listenup.server.compression
  * Mirrors `java.util.zip.CRC32`: feed bytes via [update]; read the running checksum from [value]
  * as a 32-bit unsigned value held in a [Long] (`0..0xFFFFFFFF`). Pure commonMain.
  */
+@OptIn(ExperimentalUnsignedTypes::class)
 class Crc32 {
     private var crc = 0xFFFFFFFFuL
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
@@ -1,7 +1,10 @@
 package com.calypsan.listenup.server.db
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+
+private val logger = KotlinLogging.logger {}
 
 /** A handle to a held [DataDirLock]; closing it releases the OS lock. */
 internal interface FileLockHandle : AutoCloseable
@@ -43,7 +46,11 @@ class DataDirLock(
     }
 
     override fun close() {
-        runCatching { handle?.close() }
+        try {
+            handle?.close()
+        } catch (e: Exception) {
+            logger.debug(e) { "ignoring data-dir lock-handle close failure" }
+        }
         handle = null
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
@@ -83,6 +83,7 @@ internal class ScanCoordinator(
     fun isScanning(): Boolean = mutex.isLocked
 
     /** True after [close] has been called. Used in tests to verify teardown. */
+    @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
     fun isChannelClosed(): Boolean = incrementalChannel.isClosedForSend
 
     suspend fun scanFull(): AppResult<ScanResult> {
@@ -109,7 +110,11 @@ internal class ScanCoordinator(
         }
         scope.launch {
             try {
-                runFullScan()
+                val result = runFullScan()
+                logger.info {
+                    "background full scan completed for library ${libraryId.value}: " +
+                        "${result.books.size} books, ${result.filesWalked} files in ${result.durationMs}ms"
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ContributorRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ContributorRepository.kt
@@ -268,7 +268,7 @@ class ContributorRepository(
         for ((name, sortName) in identities) {
             val derivedSortName = sortName ?: SortKeys.sortName(name, null)
             val key = contributorDedupKey(name, derivedSortName)
-            byKey.getOrPut(key) { name to derivedSortName }
+            if (key !in byKey) byKey[key] = name to derivedSortName
         }
 
         // One bulk SELECT for the existing rows — the bulk of the work, collapsed from N per-book reads.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
@@ -206,7 +206,8 @@ class SeriesRepository(
         // resolveOrCreate's first-casing-wins semantics for the create path.
         val byKey = LinkedHashMap<String, String>()
         for (name in names) {
-            byKey.getOrPut(normalizeForDedup(name)) { name }
+            val key = normalizeForDedup(name)
+            if (key !in byKey) byKey[key] = name
         }
 
         // One bulk SELECT for the existing rows — the bulk of the work, collapsed from N per-book reads.

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.jvm.kt
@@ -32,7 +32,15 @@ private class JvmFileLockHandle(
     private val lock: FileLock,
 ) : FileLockHandle {
     override fun close() {
-        runCatching { lock.release() }
-        runCatching { channel.close() }
+        try {
+            lock.release()
+        } catch (e: Exception) {
+            logger.debug(e) { "ignoring data-dir lock release failure" }
+        }
+        try {
+            channel.close()
+        } catch (e: Exception) {
+            logger.debug(e) { "ignoring data-dir lock channel close failure" }
+        }
     }
 }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -334,7 +334,7 @@ private suspend fun ServerSSESession.runKeepalive(intervalMillis: Long) {
 private suspend fun ServerSSESession.sendStreamError(e: Exception) {
     val cid = UUID.randomUUID().toString()
     log.error(e) { "Uncaught SSE flow exception [cid=$cid]" }
-    runCatching {
+    try {
         send(
             data =
                 contractJson.encodeToString(
@@ -350,6 +350,10 @@ private suspend fun ServerSSESession.sendStreamError(e: Exception) {
                 ),
             event = SSE_EVENT_CONTROL,
         )
+    } catch (sendError: CancellationException) {
+        throw sendError
+    } catch (sendError: Exception) {
+        log.debug(sendError) { "failed to deliver SSE stream-error event [cid=$cid]" }
     }
 }
 


### PR DESCRIPTION
Clears the pre-existing `:server` compiler warnings surfaced in the build output. No behavior change except two intentional, informative log lines (see below).

## Fixes
- **Redundant build flag** — drop `-Xexplicit-backing-fields` (stable since Kotlin 2.4, so the arg is now a warning). Kept `-Xreturn-value-checker=check`.
- **Opt-ins** — `@OptIn(ExperimentalUnsignedTypes::class)` on `Crc32` (its `ULongArray` table); `@OptIn(DelicateCoroutinesApi::class)` on `ScanCoordinator.isChannelClosed` (`isClosedForSend`).
- **`LibraryAdminServiceImpl.scanFolder`** — `firstOrNull { … } ?: return` existence guard → `any { … }` + `if (!exists) return` (result is now used, not discarded).
- **`ContributorRepository` / `SeriesRepository`** — dedup `getOrPut(key) { … }` (return discarded) → `if (key !in map) map[key] = …` (behavior-identical first-writer-wins).
- **Best-effort discards** (`-Xreturn-value-checker` flagged the discarded `runCatching` / fire-and-forget results) → `try/catch` that **logs the failure** (`logger.debug(e) { … }`), per the "honest over silent" rule rather than silently swallowing:
  - `DataDirLock` (common + jvm) lock/handle close
  - `SyncRoutes` SSE stream-error send (also now re-throws `CancellationException`)
  - `ScanCoordinator` fire-and-forget full scan now logs a one-line completion (`N books, M files in Xms`)

## Deferred (intentionally)
`MdnsSocketLayer.jvm.kt` and `RecursiveDirectoryWatcher.kt` warnings are left as-is — the upcoming mDNS and inotify-watcher native capability ports rewrite those files.

## Verification
Full Linux gate green: `:sharedLogic:jvmTest`, `:server:jvmTest`, `:server:linuxX64Test`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug`. The touched files emit no compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)