### PR TITLE
🔗 fix(deeplinks): route invite links via https universal-link form, remove listenup:// scheme

### DIFF
--- a/iosApp/ListenUp/Core/DeepLinkRouter.swift
+++ b/iosApp/ListenUp/Core/DeepLinkRouter.swift
@@ -33,7 +33,7 @@ final class DeepLinkRouter {
 
     deinit { bridge.cancelAll() }
 
-    /// Decode an incoming URL (custom scheme or universal link) and stash it on the shared
+    /// Decode an incoming universal-link URL and stash it on the shared
     /// seam; the `pendingTarget` binding above drives `resolve`.
     func receive(url: URL) {
         guard let target = ShareLinkCodec.shared.decode(raw: url.absoluteString) else { return }

--- a/iosApp/ListenUp/Info.plist
+++ b/iosApp/ListenUp/Info.plist
@@ -23,16 +23,5 @@
 	</array>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string>com.calypsan.listenup.client.ios</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>listenup</string>
-			</array>
-		</dict>
-	</array>
 </dict>
 </plist>

--- a/iosApp/ListenUp/ListenUpApp.swift
+++ b/iosApp/ListenUp/ListenUpApp.swift
@@ -40,9 +40,6 @@ private struct RootView: View {
             .environment(currentUser)
             .environment(hapticsSettings)
             .environment(deepLinkRouter)
-            .onOpenURL { url in
-                deepLinkRouter.receive(url: url)
-            }
             .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
                 if let url = activity.webpageURL { deepLinkRouter.receive(url: url) }
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -1,15 +1,16 @@
 package com.calypsan.listenup.client.share
 
 import com.calypsan.listenup.core.BookId
+import io.ktor.http.Parameters
 import io.ktor.http.parseQueryString
 
 /**
  * Pure, two-way translation between share-link URL strings and [ShareTarget].
  *
- * [encode] is used by the Share button (Phase 2/3) to build the shareable `https` link.
- * [decode] is used by both platforms' reception layers to parse an incoming link — the new
- * `https://link.listenup.audio/o#…` form **and** the legacy `listenup://book/{id}` /
- * `listenup://join?…` schemes — so the parsing lives once, in `commonMain`, not per platform.
+ * Every shareable link is the `https://link.listenup.audio/o#…` universal-link form — one shape
+ * for books and invites alike, so a tapped link opens the app (or falls back to the install page)
+ * on both platforms. [encode] builds it; [decode] parses it, living once in `commonMain` rather
+ * than per platform.
  *
  * The payload rides in the URL `#fragment` (the host never receives it); [decode] also accepts
  * the same params in the `?query` as a fallback, in case a platform strips the fragment.
@@ -22,13 +23,7 @@ object ShareLinkCodec {
     private val rfc3986UnreservedChars: Set<Char> =
         (('a'..'z') + ('A'..'Z') + ('0'..'9') + listOf('-', '.', '_', '~')).toSet()
 
-    /**
-     * Builds a shareable link for [target]. Both books and invites use the `https`
-     * universal-link `/o#…` form (`t=book` / `t=invite`) so the link is a real, tappable
-     * Universal Link / App Link that opens the app via the `link.listenup.audio` associated
-     * domain. The legacy `listenup://book/{id}` / `listenup://join?…` custom schemes are still
-     * accepted by [decode] for links shared before this change.
-     */
+    /** Builds the `https` `/o` universal-link for [target] — `t=book` for books, `t=invite` for invites. */
     fun encode(target: ShareTarget): String =
         when (target) {
             is ShareTarget.Book -> encodeBook(target)
@@ -37,15 +32,12 @@ object ShareLinkCodec {
 
     /**
      * Parses [raw] into a [ShareTarget], or `null` if it is not a recognised ListenUp link.
-     * Unknown entity types and foreign hosts return `null` (forward-compatible, not a crash).
+     * Foreign hosts and unknown entity types return `null` (forward-compatible, not a crash).
      */
     fun decode(raw: String): ShareTarget? {
         val url = raw.trim()
-        return when {
-            url.startsWith(ShareLinkConstants.SHARE_URL_PREFIX, ignoreCase = true) -> decodeHttpsForm(url)
-            url.startsWith("${ShareLinkConstants.CUSTOM_SCHEME}://", ignoreCase = true) -> decodeCustomScheme(url)
-            else -> null
-        }
+        if (!url.startsWith(ShareLinkConstants.SHARE_URL_PREFIX, ignoreCase = true)) return null
+        return decodeHttpsForm(url)
     }
 
     private fun encodeBook(book: ShareTarget.Book): String =
@@ -74,57 +66,22 @@ object ShareLinkCodec {
         val fragment = remainder.substringAfter('#', "")
         val params = parseQueryString(fragment.ifEmpty { query })
         return when (params["t"]) {
-            "book" -> {
-                val bookId = params["b"]?.takeIf { it.isNotBlank() } ?: return null
-                ShareTarget.Book(
-                    bookId = BookId(bookId),
-                    serverInstanceId = params["i"]?.takeIf { it.isNotBlank() },
-                    serverUrl = params["u"]?.takeIf { it.isNotBlank() },
-                )
-            }
-
-            "invite" -> {
-                val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
-                val code = params["code"]?.takeIf { it.isNotBlank() } ?: return null
-                ShareTarget.Invite(serverUrl = server, code = code)
-            }
-
-            else -> {
-                null
-            }
-        }
-    }
-
-    private fun decodeCustomScheme(url: String): ShareTarget? {
-        val afterScheme = url.substring("${ShareLinkConstants.CUSTOM_SCHEME}://".length)
-        val host =
-            afterScheme
-                .substringBefore('/')
-                .substringBefore('?')
-                .substringBefore('#')
-                .lowercase()
-        return when (host) {
-            "book" -> decodeLegacyBookScheme(afterScheme)
-            "join" -> decodeLegacyJoinScheme(afterScheme)
+            "book" -> decodeBookParams(params)
+            "invite" -> decodeInviteParams(params)
             else -> null
         }
     }
 
-    private fun decodeLegacyBookScheme(afterScheme: String): ShareTarget? {
-        val id =
-            afterScheme
-                .substringAfter('/', "")
-                .substringBefore('?')
-                .substringBefore('#')
-                .split('/')
-                .firstOrNull { it.isNotBlank() }
-                ?: return null
-        return ShareTarget.Book(bookId = BookId(id), serverInstanceId = null, serverUrl = null)
+    private fun decodeBookParams(params: Parameters): ShareTarget? {
+        val bookId = params["b"]?.takeIf { it.isNotBlank() } ?: return null
+        return ShareTarget.Book(
+            bookId = BookId(bookId),
+            serverInstanceId = params["i"]?.takeIf { it.isNotBlank() },
+            serverUrl = params["u"]?.takeIf { it.isNotBlank() },
+        )
     }
 
-    private fun decodeLegacyJoinScheme(afterScheme: String): ShareTarget? {
-        val query = afterScheme.substringAfter('?', "").substringBefore('#')
-        val params = parseQueryString(query)
+    private fun decodeInviteParams(params: Parameters): ShareTarget? {
         val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
         val code = params["code"]?.takeIf { it.isNotBlank() } ?: return null
         return ShareTarget.Invite(serverUrl = server, code = code)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkConstants.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkConstants.kt
@@ -17,7 +17,4 @@ object ShareLinkConstants {
 
     /** The `https` prefix every shareable link starts with: `https://link.listenup.audio/o`. */
     const val SHARE_URL_PREFIX: String = "https://$SHARE_DOMAIN$OPEN_PATH"
-
-    /** The custom scheme retained for back-compat and app-to-app links. */
-    const val CUSTOM_SCHEME: String = "listenup"
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
@@ -15,15 +15,15 @@ sealed interface ShareTarget {
      *
      * @property bookId The server-scoped book id to open.
      * @property serverInstanceId The stable `instanceId` of the server that produced the link,
-     *   or `null` for a legacy `listenup://book/{id}` link that carried no server context
-     *   (such a link resolves against the currently-connected server).
+     *   or `null` when the link carried no server context (it then resolves against the
+     *   currently-connected server).
      * @property serverUrl The source server's URL, for display and a possible future "connect"
      *   action — never the identity key (URLs vary LAN-vs-remote). `null` when the link carried none.
      *
      * Note: [serverInstanceId] and [serverUrl] are independently optional (they map to the link's
      * separate `i` and `u` params). This app's encoder always supplies both together from a
      * connected server; a link carrying one but not the other is representable but degenerate —
-     * the resolver treats a null [serverInstanceId] as a legacy link and ignores [serverUrl] then.
+     * the resolver treats a null [serverInstanceId] as a context-free link and ignores [serverUrl] then.
      */
     data class Book(
         val bookId: BookId,
@@ -32,7 +32,7 @@ sealed interface ShareTarget {
     ) : ShareTarget
 
     /**
-     * An invite / join claim — the existing `listenup://join` link, unified into this model.
+     * An invite / join claim.
      *
      * @property serverUrl The server the invite is for (persisted before lookup so a fresh
      *   install can reach it).

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -35,7 +35,7 @@ class ShareLinkCodecTest :
             url shouldBe "https://link.listenup.audio/o#t=book&b=book-abc"
         }
 
-        test("encode produces the https /o universal-link form for an invite") {
+        test("encode produces the https /o form for an invite") {
             val url = ShareLinkCodec.encode(ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "JOIN9"))
 
             url shouldStartWith "https://link.listenup.audio/o#t=invite"
@@ -55,20 +55,6 @@ class ShareLinkCodecTest :
                     serverInstanceId = "inst-123",
                     serverUrl = "https://lib.example.com",
                 )
-        }
-
-        test("decode parses the https /o invite form from the fragment") {
-            val target =
-                ShareLinkCodec.decode(
-                    "https://link.listenup.audio/o#t=invite&server=https%3A%2F%2Flib.example.com&code=JOIN9",
-                )
-
-            target shouldBe ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "JOIN9")
-        }
-
-        test("decode returns null for an https invite form missing the code") {
-            ShareLinkCodec.decode("https://link.listenup.audio/o#t=invite&server=https%3A%2F%2Flib.example.com") shouldBe
-                null
         }
 
         test("decode falls back to the query when the fragment is absent") {
@@ -95,17 +81,23 @@ class ShareLinkCodecTest :
             ShareLinkCodec.decode(ShareLinkCodec.encode(original)) shouldBe original
         }
 
-        test("decode parses the legacy listenup book scheme with no server context") {
-            val target = ShareLinkCodec.decode("listenup://book/book-legacy")
+        test("decode parses the https /o form for an invite") {
+            val target =
+                ShareLinkCodec.decode(
+                    "https://link.listenup.audio/o#t=invite&server=http%3A%2F%2F192.168.86.24%3A8080&code=ejOvmuYJBGyMDb2DoLgtsg",
+                )
 
             target shouldBe
-                ShareTarget.Book(bookId = BookId("book-legacy"), serverInstanceId = null, serverUrl = null)
+                ShareTarget.Invite(serverUrl = "http://192.168.86.24:8080", code = "ejOvmuYJBGyMDb2DoLgtsg")
         }
 
-        test("decode parses the legacy listenup join scheme") {
-            val target = ShareLinkCodec.decode("listenup://join?server=https%3A%2F%2Flib.example.com&code=ABC123")
+        test("decode returns null for an https invite missing the code") {
+            ShareLinkCodec.decode("https://link.listenup.audio/o#t=invite&server=https%3A%2F%2Flib.example.com") shouldBe null
+        }
 
-            target shouldBe ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "ABC123")
+        test("decode returns null for the removed listenup:// custom scheme") {
+            ShareLinkCodec.decode("listenup://join?server=https%3A%2F%2Flib.example.com&code=ABC123") shouldBe null
+            ShareLinkCodec.decode("listenup://book/book-legacy") shouldBe null
         }
 
         test("decode returns null for an https link with an unknown type") {
@@ -114,10 +106,6 @@ class ShareLinkCodecTest :
 
         test("decode returns null for an https link missing the book id") {
             ShareLinkCodec.decode("https://link.listenup.audio/o#t=book") shouldBe null
-        }
-
-        test("decode returns null for a join link missing the code") {
-            ShareLinkCodec.decode("listenup://join?server=https%3A%2F%2Flib.example.com") shouldBe null
         }
 
         test("decode returns null for a foreign https host") {

--- a/sharedUI/src/androidMain/AndroidManifest.xml
+++ b/sharedUI/src/androidMain/AndroidManifest.xml
@@ -58,23 +58,7 @@
 
 
 
-            <!-- Deep link: listenup://join?server=...&code=... -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="listenup" android:host="join" />
-            </intent-filter>
-
-            <!-- Deep link: listenup://book/{bookId} -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="listenup" android:host="book" />
-            </intent-filter>
-
-            <!-- App Link: https://link.listenup.audio/o#... (autoVerify needs assetlinks.json — Phase 4) -->
+            <!-- App Link: https://link.listenup.audio/o#... (books and invites), verified via assetlinks.json -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -52,8 +52,7 @@ private val logger = KotlinLogging.logger {}
  * - Disconnects realtime sync when app goes to background (saves battery)
  * - Auto-reconnects on app resume
  *
- * Handles deep links for invite URLs:
- * - listenup://join?server=...&code=... (custom scheme)
+ * Handles share / deep links via the https App Link (https://link.listenup.audio/o#...).
  *
  * This ensures real-time updates when actively using the app
  * while preserving battery life in the background.
@@ -120,13 +119,13 @@ class MainActivity : ComponentActivity() {
      * Parses and stores deep link or shortcut action for navigation layer to consume.
      *
      * Handles:
-     * - Invite deep links (listenup://join)
+     * - Share / deep links (https App Links: book + invite)
      * - App shortcut actions (RESUME, PLAY_BOOK, SEARCH, SLEEP_TIMER)
      */
     private fun handleIntent(intent: Intent?) {
         if (intent == null) return
 
-        // Share / deep links (https App Links + legacy listenup:// scheme) — parsed once, in commonMain.
+        // Share / deep links (https App Links) — parsed once, in commonMain.
         if (intent.action == Intent.ACTION_VIEW) {
             intent.data?.toString()?.let { raw ->
                 ShareLinkCodec.decode(raw)?.let { target ->


### PR DESCRIPTION
## What

Invite deep links (`https://link.listenup.audio/o#t=invite&server=…&code=…`) now decode and route to the invite-claim / registration flow with the server pre-filled. Previously they fell through to the **server-connect page**, because `ShareLinkCodec.decodeHttpsForm` only handled `t=book` and returned `null` for `t=invite`.

While fixing it, standardized **all** share links on the single `https://link.listenup.audio/o#…` universal-link form and removed the legacy `listenup://` custom scheme end-to-end:

- `encodeInvite` now emits the `…/o#t=invite` form (was `listenup://join`), matching `encodeBook`
- deleted the custom-scheme decoders (`decodeCustomScheme` / `decodeLegacyBookScheme` / `decodeLegacyJoinScheme`) and the `CUSTOM_SCHEME` constant
- Android: dropped both `listenup://` intent-filters (kept the verified https App Link)
- iOS: removed `CFBundleURLTypes` and the now-dead `.onOpenURL` handler (universal links arrive via `onContinueUserActivity`)
- de-legacied KDoc / comments in `ShareTarget`, `MainActivity`, `DeepLinkRouter`

## Why

`decodeHttpsForm` only knew `t=book`, so a tapped invite universal link decoded to `null` → no pending target → the app showed its default unauthenticated screen (server-connect). A custom `listenup://` scheme also can't function as a tappable universal link, so keeping two link shapes was drift waiting to happen. One form now: books and invites alike.

This is pre-release; no `listenup://` links exist in the wild, so the scheme is removed outright (nuke-and-pave, no compat shim).

## Tests

`ShareLinkCodecTest` extended (19 passing locally) — adds the real-world invite link as a regression case and a `listenup://` → `null` rejection test; flipped the invite-encode assertion to the https form.

## CI note

Full local gate (Konsist/Android/iOS) couldn't run on the dev machine — local `.worktrees/` checkouts blow the Konsist scan's heap, an artifact CI doesn't have. Relying on CI for the authoritative Lint/Test/Build lanes.
