### PR TITLE
✨ feat(server): native multipart/form-data parser (replaces the 501 stub)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartFormData.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartFormData.kt
@@ -1,0 +1,229 @@
+package com.calypsan.listenup.server.io
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readRemaining
+import kotlinx.io.Sink
+import kotlinx.io.readByteArray
+
+/** The request body was not well-formed multipart/form-data (missing boundary, truncated, …). */
+internal class MalformedMultipartException(
+    message: String,
+) : RuntimeException(message)
+
+/** The captured file part exceeded the caller's size limit before its boundary was reached. */
+internal class MultipartPartTooLargeException(
+    val limit: Long,
+) : RuntimeException("Multipart file part exceeded the $limit-byte limit.")
+
+private const val DEFAULT_BUFFER_BYTES = 64 * 1024
+private val CRLF = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte())
+
+/**
+ * Streams the first file part of a `multipart/form-data` body (RFC 7578) on [channel] to the sink from
+ * [openSink], up to [formFieldLimit] bytes. Parts before the first file part (and everything after it)
+ * are read and discarded. [openSink] is invoked exactly once — lazily, only when a file part is found —
+ * so no destination is created for a body that carries no file. Returns true when a file part streamed.
+ *
+ * Hand-rolled because the Kotlin/Native Ktor CIO server cannot parse multipart through Ktor's transform
+ * ([KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)) — only that transform is broken, so the
+ * native actual reads the raw body channel (which works on every engine) and this decodes the wire
+ * format directly. It is platform-agnostic Kotlin over a [ByteReadChannel], so the JVM test suite
+ * exercises every branch. The body never lands in memory: each part streams through a small fixed
+ * buffer, holding back only the last `delimiter.size - 1` bytes per fill so a boundary that straddles
+ * two reads is still detected.
+ *
+ * @param boundary the `boundary` parameter from the request's `Content-Type` header.
+ * @throws MalformedMultipartException if the body is truncated or not valid multipart/form-data.
+ * @throws MultipartPartTooLargeException if the file part exceeds [formFieldLimit].
+ */
+internal suspend fun streamFirstFilePart(
+    channel: ByteReadChannel,
+    boundary: String,
+    formFieldLimit: Long,
+    bufferCapacity: Int = DEFAULT_BUFFER_BYTES,
+    openSink: () -> Sink,
+): Boolean {
+    val reader = MultipartBodyReader(channel, boundary, bufferCapacity)
+    reader.skipToFirstBoundary()
+    while (true) {
+        when (reader.readBoundaryTrailer()) {
+            BoundaryTrailer.End -> return false
+            BoundaryTrailer.More -> Unit
+        }
+        val isFilePart = reader.readHeaderBlock().any(::isFilePartDisposition)
+        if (isFilePart) {
+            openSink().use { sink -> reader.streamPartBodyTo(sink, formFieldLimit) }
+            return true
+        }
+        reader.streamPartBodyTo(sink = null, limit = Long.MAX_VALUE)
+    }
+}
+
+/** A part is a file part when its Content-Disposition carries a `filename` parameter (mirrors Ktor). */
+private fun isFilePartDisposition(headerLine: String): Boolean {
+    val lower = headerLine.lowercase()
+    return lower.startsWith("content-disposition:") &&
+        (lower.contains("filename=") || lower.contains("filename*="))
+}
+
+private enum class BoundaryTrailer { More, End }
+
+/**
+ * Buffered, holdback-aware reader over a [ByteReadChannel] for one multipart body. All positions are
+ * indices into [buf]; [fill] compacts and refills from the channel, growing the buffer only if a
+ * single delimiter cannot fit (so a pathological boundary never deadlocks the scan).
+ */
+private class MultipartBodyReader(
+    private val channel: ByteReadChannel,
+    boundary: String,
+    capacity: Int,
+) {
+    // Inter-part delimiter is CRLF + "--boundary"; the very first boundary has no leading CRLF.
+    private val dashBoundary = "--$boundary".encodeToByteArray()
+    private val delimiter = CRLF + dashBoundary
+
+    private var buf = ByteArray(maxOf(capacity, delimiter.size * 2 + 2))
+    private var pos = 0
+    private var limit = 0
+    private var eof = false
+
+    /** Discards the preamble and consumes the opening `--boundary`. */
+    suspend fun skipToFirstBoundary() {
+        while (true) {
+            val idx = indexOf(dashBoundary, pos)
+            if (idx >= 0) {
+                pos = idx + dashBoundary.size
+                return
+            }
+            // Keep the last (dashBoundary.size - 1) bytes — they may begin the boundary in the next fill.
+            pos = safeEnd(dashBoundary.size)
+            if (!fill()) throw MalformedMultipartException("No multipart boundary found in body.")
+        }
+    }
+
+    /** Reads the two bytes after a boundary: `--` ends the multipart, CRLF introduces the next part. */
+    suspend fun readBoundaryTrailer(): BoundaryTrailer {
+        ensure(2)
+        if (buf[pos] == '-'.code.toByte() && buf[pos + 1] == '-'.code.toByte()) {
+            pos += 2
+            return BoundaryTrailer.End
+        }
+        // Tolerate optional transport padding (spaces/tabs) before the CRLF.
+        while (buf[pos] == ' '.code.toByte() || buf[pos] == '\t'.code.toByte()) {
+            pos++
+            ensure(1)
+        }
+        ensure(2)
+        if (buf[pos] != '\r'.code.toByte() || buf[pos + 1] != '\n'.code.toByte()) {
+            throw MalformedMultipartException("Malformed boundary terminator.")
+        }
+        pos += 2
+        return BoundaryTrailer.More
+    }
+
+    /** Reads part headers up to (and consuming) the blank line that ends the header block. */
+    suspend fun readHeaderBlock(): List<String> {
+        val headers = mutableListOf<String>()
+        while (true) {
+            val line = readLine()
+            if (line.isEmpty()) return headers
+            headers += line
+        }
+    }
+
+    /**
+     * Streams the current part's body to [sink] (or discards it when null) until the next delimiter,
+     * which it consumes. Enforces [limit] on bytes emitted to a non-null sink.
+     */
+    suspend fun streamPartBodyTo(
+        sink: Sink?,
+        limit: Long,
+    ) {
+        var emitted = 0L
+        while (true) {
+            val idx = indexOf(delimiter, pos)
+            if (idx >= 0) {
+                emitted = emit(sink, pos, idx - pos, emitted, limit)
+                pos = idx + delimiter.size
+                return
+            }
+            val end = safeEnd(delimiter.size)
+            if (end > pos) {
+                emitted = emit(sink, pos, end - pos, emitted, limit)
+                pos = end
+            }
+            if (!fill()) throw MalformedMultipartException("Multipart body ended before its boundary.")
+        }
+    }
+
+    private fun emit(
+        sink: Sink?,
+        offset: Int,
+        count: Int,
+        emitted: Long,
+        limit: Long,
+    ): Long {
+        if (sink == null || count == 0) return emitted
+        val total = emitted + count
+        if (total > limit) throw MultipartPartTooLargeException(limit)
+        sink.write(buf, offset, offset + count)
+        return total
+    }
+
+    private suspend fun readLine(): String {
+        while (true) {
+            val idx = indexOf(CRLF, pos)
+            if (idx >= 0) {
+                val line = buf.decodeToString(pos, idx)
+                pos = idx + CRLF.size
+                return line
+            }
+            if (!fill()) throw MalformedMultipartException("Multipart header line was not terminated.")
+        }
+    }
+
+    /** Index of [pattern] in `buf[from until limit]`, or -1. Patterns here are short (a boundary). */
+    private fun indexOf(
+        pattern: ByteArray,
+        from: Int,
+    ): Int {
+        val last = limit - pattern.size
+        var i = maxOf(from, 0)
+        while (i <= last) {
+            var j = 0
+            while (j < pattern.size && buf[i + j] == pattern[j]) j++
+            if (j == pattern.size) return i
+            i++
+        }
+        return -1
+    }
+
+    /** The largest index up to which bytes are safe to consume without splitting a [keep]-byte token. */
+    private fun safeEnd(keep: Int): Int = if (limit - pos > keep - 1) limit - (keep - 1) else pos
+
+    /** Ensures at least [n] bytes are buffered, or throws if the channel ends first. */
+    private suspend fun ensure(n: Int) {
+        while (limit - pos < n) {
+            if (!fill()) throw MalformedMultipartException("Multipart body ended unexpectedly.")
+        }
+    }
+
+    /** Compacts consumed bytes, then reads one more chunk. Returns false at end of channel. */
+    private suspend fun fill(): Boolean {
+        if (pos > 0) {
+            buf.copyInto(buf, 0, pos, limit)
+            limit -= pos
+            pos = 0
+        }
+        if (limit == buf.size) buf = buf.copyOf(buf.size * 2)
+        if (eof) return false
+        val chunk = channel.readRemaining((buf.size - limit).toLong()).readByteArray()
+        if (chunk.isEmpty()) {
+            eof = true
+            return false
+        }
+        chunk.copyInto(buf, limit)
+        limit += chunk.size
+        return true
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.kt
@@ -10,20 +10,13 @@ import kotlinx.io.files.Path
  * (Ktor's 50 MiB default rejects large library backups before they can be staged). [dest] is
  * overwritten; its parent directory must exist.
  *
- * Platform note: the JVM runtime streams the upload. Kotlin/Native's Ktor CIO server cannot parse
- * multipart bodies (JetBrains [KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)), so the
- * native actual throws [MultipartUploadUnsupported], which [installAppErrorStatusPages] surfaces as
- * `501 Not Implemented`. The native server is a compile/boot target; the JVM runtime serves uploads.
+ * Platform note: the JVM runtime delegates to Ktor's `receiveMultipart`. Kotlin/Native's Ktor CIO
+ * server cannot parse multipart through that transform (JetBrains
+ * [KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)), so the native actual reads the raw
+ * body channel and decodes the wire format itself via [streamFirstFilePart]. Both runtimes serve
+ * uploads with identical behaviour.
  */
 internal expect suspend fun ApplicationCall.streamFirstFilePartTo(
     dest: Path,
     formFieldLimit: Long,
 ): Boolean
-
-/**
- * Signals that a multipart upload was attempted on the Kotlin/Native server runtime, whose Ktor CIO
- * engine cannot parse multipart bodies (KTOR-7361). Thrown by the native [streamFirstFilePartTo]
- * actual and surfaced as `501 Not Implemented` by [installAppErrorStatusPages].
- */
-internal class MultipartUploadUnsupported :
-    UnsupportedOperationException("Multipart upload is not supported on the native server runtime.")

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -29,7 +29,8 @@ import com.calypsan.listenup.api.error.TagError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.server.io.MultipartUploadUnsupported
+import com.calypsan.listenup.server.io.MalformedMultipartException
+import com.calypsan.listenup.server.io.MultipartPartTooLargeException
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -53,12 +54,19 @@ private val logger = KotlinLogging.logger("AppErrorStatusPages")
  */
 fun Application.installAppErrorStatusPages() {
     install(StatusPages) {
-        // The native server runtime can't parse multipart (KTOR-7361) — surface an upload attempt as
-        // a precise 501 rather than letting it fall through to a generic 500. JVM never throws this.
-        exception<MultipartUploadUnsupported> { call, _ ->
+        // A malformed multipart upload (truncated body, missing boundary) is a client error, not a
+        // server fault — surface 400 rather than letting it fall through to a generic 500.
+        exception<MalformedMultipartException> { call, _ ->
             call.respond(
-                HttpStatusCode.NotImplemented,
-                mapOf("error" to "not_implemented", "reason" to "multipart_upload_unsupported_on_native"),
+                HttpStatusCode.BadRequest,
+                mapOf("error" to "bad_request", "reason" to "malformed_multipart"),
+            )
+        }
+        // An upload past the configured size cap is 413 Payload Too Large, not a 500.
+        exception<MultipartPartTooLargeException> { call, _ ->
+            call.respond(
+                HttpStatusCode.PayloadTooLarge,
+                mapOf("error" to "payload_too_large", "reason" to "multipart_part_too_large"),
             )
         }
         exception<Throwable> { call, ex ->

--- a/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/MultipartFormDataTest.kt
+++ b/server/src/commonTest/kotlin/com/calypsan/listenup/server/io/MultipartFormDataTest.kt
@@ -1,0 +1,173 @@
+package com.calypsan.listenup.server.io
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlin.random.Random
+
+/**
+ * Exercises the hand-rolled multipart parser against crafted bodies. Runs on the JVM test runner
+ * (Kotest), so every branch — boundary straddling, near-boundary body bytes, size limits — is covered
+ * fast; the native runtime reuses the identical code through `streamFirstFilePartTo`'s native actual.
+ */
+class MultipartFormDataTest :
+    FunSpec({
+
+        test("extracts a single file part byte-for-byte") {
+            val body = "The Way of Kings, chapter one.".encodeToByteArray()
+            val multipart = buildMultipart(BOUNDARY, listOf(filePart("backup", "lib.zip", body)))
+
+            extractFilePart(multipart) shouldBe body
+        }
+
+        test("skips form fields before the file part") {
+            val body = byteArrayOf(9, 8, 7, 6, 5)
+            val multipart =
+                buildMultipart(
+                    BOUNDARY,
+                    listOf(
+                        fieldPart("kind", "library".encodeToByteArray()),
+                        fieldPart("overwrite", "true".encodeToByteArray()),
+                        filePart("backup", "lib.zip", body),
+                    ),
+                )
+
+            extractFilePart(multipart) shouldBe body
+        }
+
+        test("captures the first file part and ignores later parts") {
+            val first = "first".encodeToByteArray()
+            val multipart =
+                buildMultipart(
+                    BOUNDARY,
+                    listOf(
+                        filePart("a", "first.bin", first),
+                        filePart("b", "second.bin", "second".encodeToByteArray()),
+                    ),
+                )
+
+            extractFilePart(multipart) shouldBe first
+        }
+
+        test("returns false and never opens a sink when there is no file part") {
+            val multipart =
+                buildMultipart(BOUNDARY, listOf(fieldPart("kind", "library".encodeToByteArray())))
+            var sinkOpened = false
+
+            val found =
+                streamFirstFilePart(ByteReadChannel(multipart), BOUNDARY, LIMIT) {
+                    sinkOpened = true
+                    Buffer()
+                }
+
+            found.shouldBeFalse()
+            sinkOpened.shouldBeFalse()
+        }
+
+        test("handles an empty file part") {
+            val multipart = buildMultipart(BOUNDARY, listOf(filePart("backup", "empty.zip", ByteArray(0))))
+
+            extractFilePart(multipart) shouldBe ByteArray(0)
+        }
+
+        test("is not fooled by near-boundary byte sequences inside the body") {
+            // Contains "\r\n--BOUNDAR" (one char short) and "z--BOUNDARY" (no leading CRLF) — neither is
+            // the real "\r\n--BOUNDARY" delimiter, so the whole payload must survive intact.
+            val body = "abc\r\n--BOUNDAR\r\nxyz--BOUNDARY-tail".encodeToByteArray()
+            val multipart = buildMultipart(BOUNDARY, listOf(filePart("backup", "tricky.bin", body)))
+
+            extractFilePart(multipart) shouldBe body
+        }
+
+        test("enforces the size limit on the file part") {
+            val body = ByteArray(1_000) { it.toByte() }
+            val multipart = buildMultipart(BOUNDARY, listOf(filePart("backup", "big.zip", body)))
+
+            shouldThrow<MultipartPartTooLargeException> {
+                streamFirstFilePart(ByteReadChannel(multipart), BOUNDARY, formFieldLimit = 999) { Buffer() }
+            }
+        }
+
+        test("accepts a file part exactly at the size limit") {
+            val body = ByteArray(1_000) { it.toByte() }
+            val multipart = buildMultipart(BOUNDARY, listOf(filePart("backup", "exact.zip", body)))
+
+            extractFilePart(multipart, limit = 1_000) shouldBe body
+        }
+
+        test("throws on a body with no boundary at all") {
+            shouldThrow<MalformedMultipartException> {
+                streamFirstFilePart(ByteReadChannel("not multipart".encodeToByteArray()), BOUNDARY, LIMIT) {
+                    Buffer()
+                }
+            }
+        }
+
+        // Tiny buffer capacities force the boundary and headers to straddle fills, stressing the
+        // holdback scanner that a 64 KiB production buffer would never exercise.
+        listOf(13, 17, 31, 64, 257).forEach { capacity ->
+            test("round-trips a large random body with a $capacity-byte buffer") {
+                val body = Random(capacity.toLong()).nextBytes(20_000)
+                val multipart = buildMultipart(BOUNDARY, listOf(filePart("backup", "rand.bin", body)))
+
+                extractFilePart(multipart, capacity = capacity) shouldBe body
+            }
+        }
+    })
+
+private const val BOUNDARY = "BOUNDARY"
+private const val LIMIT = 1L shl 30
+
+private suspend fun extractFilePart(
+    multipart: ByteArray,
+    limit: Long = LIMIT,
+    capacity: Int = 64 * 1024,
+): ByteArray {
+    val captured = Buffer()
+    val found =
+        streamFirstFilePart(ByteReadChannel(multipart), BOUNDARY, limit, capacity) { captured }
+    check(found) { "expected a file part" }
+    return captured.readByteArray()
+}
+
+private class CraftedPart(
+    val headers: List<String>,
+    val body: ByteArray,
+)
+
+private fun filePart(
+    name: String,
+    filename: String,
+    body: ByteArray,
+) = CraftedPart(
+    listOf(
+        "Content-Disposition: form-data; name=\"$name\"; filename=\"$filename\"",
+        "Content-Type: application/octet-stream",
+    ),
+    body,
+)
+
+private fun fieldPart(
+    name: String,
+    body: ByteArray,
+) = CraftedPart(listOf("Content-Disposition: form-data; name=\"$name\""), body)
+
+private fun buildMultipart(
+    boundary: String,
+    parts: List<CraftedPart>,
+): ByteArray {
+    val out = Buffer()
+    for (part in parts) {
+        out.write("--$boundary\r\n".encodeToByteArray())
+        for (header in part.headers) out.write("$header\r\n".encodeToByteArray())
+        out.write("\r\n".encodeToByteArray())
+        out.write(part.body)
+        out.write("\r\n".encodeToByteArray())
+    }
+    out.write("--$boundary--\r\n".encodeToByteArray())
+    return out.readByteArray()
+}

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/MultipartUpload.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/io/MultipartUpload.linuxX64.kt
@@ -1,14 +1,26 @@
 package com.calypsan.listenup.server.io
 
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.contentType
+import io.ktor.server.request.receiveChannel
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 /**
- * The Kotlin/Native Ktor CIO server cannot parse multipart request bodies (KTOR-7361), so it cannot
- * stream an upload. Fails loudly with [MultipartUploadUnsupported] (→ `501 Not Implemented`) rather
- * than silently dropping the body; uploads are served by the JVM runtime, which has a real actual.
+ * The Kotlin/Native Ktor CIO server cannot use Ktor's `receiveMultipart` transform (KTOR-7361), but
+ * the raw body channel works on every engine — so this reads it and decodes multipart/form-data with
+ * [streamFirstFilePart], streaming the first file part straight to [dest]. Behaviour matches the JVM
+ * actual.
  */
 internal actual suspend fun ApplicationCall.streamFirstFilePartTo(
     dest: Path,
     formFieldLimit: Long,
-): Boolean = throw MultipartUploadUnsupported()
+): Boolean {
+    val boundary =
+        request.contentType().parameter("boundary")
+            ?: throw MalformedMultipartException("multipart/form-data request is missing a boundary parameter.")
+    return streamFirstFilePart(receiveChannel(), boundary, formFieldLimit) {
+        SystemFileSystem.sink(dest).buffered()
+    }
+}

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
@@ -1,7 +1,5 @@
 package com.calypsan.listenup.server.io
 
-import com.calypsan.listenup.api.contractJson
-import com.calypsan.listenup.server.plugins.installAppErrorStatusPages
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO as ClientCIO
@@ -9,41 +7,41 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.call
-import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
 import kotlin.test.Test
 
 /**
- * Native counterpart to the JVM upload-route tests: the Kotlin/Native Ktor CIO server cannot parse
- * multipart (KTOR-7361), so [streamFirstFilePartTo]'s native actual throws [MultipartUploadUnsupported],
- * which [installAppErrorStatusPages] surfaces as a precise `501 Not Implemented` rather than an opaque
- * transform error. This proves the upload routes fail honestly on the native runtime (the JVM runtime
- * serves uploads — that path is covered by `BackupRoutesTest` / `ImportRoutesTest`).
+ * Proves the Kotlin/Native runtime serves multipart uploads at parity with the JVM. Ktor's CIO server
+ * cannot use `receiveMultipart` (KTOR-7361), so [streamFirstFilePartTo]'s native actual reads the raw
+ * body channel and decodes the wire format with [streamFirstFilePart] (whose every branch is covered
+ * by `MultipartFormDataTest` on the JVM runner). This drives a real `embeddedServer(CIO)` over an
+ * ephemeral port and asserts the uploaded file lands on disk byte-for-byte.
  *
- * Drives a real `embeddedServer(CIO)` over an ephemeral port; `kotlin.test.@Test` + `runBlocking` and a
- * `Unit` body so the K/N runner discovers it.
+ * `kotlin.test.@Test` + `runBlocking` and a `Unit` body so the K/N runner discovers it; the upload
+ * target is a CWD-relative path because the native test runner has no usable temp directory.
  */
 class MultipartUploadNativeTest {
     @Test
-    fun nativeMultipartUploadRespondsNotImplemented(): Unit =
+    fun nativeServerStreamsTheFirstFilePartToDisk(): Unit =
         runBlocking {
-            val dest = Path("lu-native-multipart-test.bin")
+            val dest = Path("lu-native-multipart-upload-test.bin")
+            val payload = ByteArray(50_000) { (it * 7).toByte() }
             val server =
                 embeddedServer(CIO, port = 0) {
-                    install(ContentNegotiation) { json(contractJson) }
-                    installAppErrorStatusPages()
                     routing {
                         post("/upload") {
                             val received = call.streamFirstFilePartTo(dest, formFieldLimit = 1L shl 20)
@@ -65,20 +63,23 @@ class MultipartUploadNativeTest {
                             MultiPartFormDataContent(
                                 formData {
                                     append(
-                                        "file",
-                                        "x".encodeToByteArray(),
+                                        "backup",
+                                        payload,
                                         Headers.build {
-                                            append(HttpHeaders.ContentDisposition, "filename=\"x.bin\"")
+                                            append(HttpHeaders.ContentDisposition, "filename=\"lib.zip\"")
                                         },
                                     )
                                 },
                             ),
                         )
                     }
-                response.status shouldBe HttpStatusCode.NotImplemented
+                response.status shouldBe HttpStatusCode.OK
+                response.bodyAsText() shouldBe "received"
+                SystemFileSystem.source(dest).buffered().use { it.readByteArray() } shouldBe payload
             } finally {
                 client.close()
                 server.stop(0, 0)
+                SystemFileSystem.delete(dest, mustExist = false)
             }
         }
 }


### PR DESCRIPTION
## What

Reverses #913's native **501 stub** with a real, hand-rolled `multipart/form-data` parser, so the Kotlin/Native server runtime serves uploads (backup restore, ABS import, cover upload) at parity with the JVM. Part of the Phase 5 "everything native, full parity with JVM" arc.

## Why a hand-rolled parser

Ktor's CIO **server** can't parse multipart through its `receiveMultipart` transform on native ([KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)). But only that higher-level transform is broken — a de-risking spike confirmed `call.receiveChannel()` (the raw body) round-trips a 200 KB POST body byte-for-byte on a real native CIO server. So the native actual reads the raw channel and decodes the wire format itself.

## How

- The `streamFirstFilePartTo` `expect/actual` seam stays. **JVM keeps Ktor's `receiveMultipart`** (production-proven — untouched). The **native actual** now parses: it pulls `boundary` from the Content-Type header and feeds `receiveChannel()` to the new parser.
- New commonMain `io/MultipartFormData.kt` — `streamFirstFilePart(channel, boundary, limit, …, openSink)`: a buffered hold-back scanner over `ByteReadChannel`. It streams each part through a small fixed buffer (the body never lands in memory), holding back only the last `delimiter.size - 1` bytes per fill so a boundary that straddles two reads is still found. A part is a file part iff its Content-Disposition has `filename=`; the sink is opened lazily, only when the first file part is found (no destination created for a fileless body).
- The dead `MultipartUploadUnsupported` + its `501` status-pages branch are removed. The parser's `MalformedMultipartException` → **400** and `MultipartPartTooLargeException` → **413** replace it (more correct than the old fall-through-to-500 would have been).

## Tests

- **`MultipartFormDataTest`** (commonTest → runs on the JVM Kotest runner, 14 cases): single file part; skips form fields before the file; first-of-many; no-file-part → `false` and the sink is never opened; empty part; **near-boundary body bytes** (`\r\n--BOUNDAR`, `z--BOUNDARY`) not mis-split; size-limit throws; exact-limit accepted; no-boundary throws; and **5 random-body round-trips at tiny buffer capacities (13/17/31/64/257)** to stress the straddling scanner a 64 KiB production buffer never would.
- **`MultipartUploadNativeTest`** (linuxX64Test) flipped from asserting 501 to driving a real `embeddedServer(CIO)` and asserting a 50 KB uploaded file lands on disk byte-for-byte.
- Full gate green: `:sharedLogic:jvmTest`, `:server:jvmTest`, `:server:linuxX64Test`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug`.