### PR TITLE
🐛 fix(shared): route to admin setup on relaunch when the server still needs setup

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStore.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStore.kt
@@ -116,12 +116,19 @@ internal class AuthSessionStore(
             )
         }
 
-        return DomainAuthState.NeedsLogin(openRegistration = getCachedOpenRegistration())
+        // Honour the last-known setupRequired so a relaunch on a server that still has no admin routes
+        // to setup, not to login — offline, from the value cached by [checkServerStatus]. A stale "true"
+        // self-corrects: SetupViewModel re-runs checkServerStatus on entry.
+        return if (getCachedSetupRequired()) {
+            DomainAuthState.NeedsSetup
+        } else {
+            DomainAuthState.NeedsLogin(openRegistration = getCachedOpenRegistration())
+        }
     }
 
     /**
      * Hit the server's instance endpoint to learn whether setup is required.
-     * Caches `openRegistration` for offline-first state derivation. On network
+     * Caches `setupRequired` + `openRegistration` for offline-first state derivation. On network
      * failure we stay in NeedsLogin — never blow away the URL automatically.
      */
     override suspend fun checkServerStatus(): DomainAuthState {
@@ -134,6 +141,7 @@ internal class AuthSessionStore(
                 logger.info { "checkServerStatus: getServerInfo succeeded (${startMark.elapsedNow()})" }
                 val openRegistration = result.data.registrationPolicy != RegistrationPolicy.CLOSED
                 secureStorage.save(KEY_OPEN_REGISTRATION, openRegistration.toString())
+                secureStorage.save(KEY_SETUP_REQUIRED, result.data.setupRequired.toString())
 
                 val newState =
                     if (result.data.setupRequired) {
@@ -156,6 +164,9 @@ internal class AuthSessionStore(
 
     private suspend fun getCachedOpenRegistration(): Boolean =
         secureStorage.read(KEY_OPEN_REGISTRATION)?.toBooleanStrictOrNull() ?: false
+
+    private suspend fun getCachedSetupRequired(): Boolean =
+        secureStorage.read(KEY_SETUP_REQUIRED)?.toBooleanStrictOrNull() ?: false
 
     override suspend fun refreshOpenRegistration() {
         val currentState = authState.value
@@ -212,6 +223,7 @@ internal class AuthSessionStore(
         const val KEY_SESSION_ID = "session_id"
         const val KEY_USER_ID = "user_id"
         const val KEY_OPEN_REGISTRATION = "open_registration"
+        const val KEY_SETUP_REQUIRED = "setup_required"
         const val KEY_PENDING_USER_ID = "pending_user_id"
         const val KEY_PENDING_EMAIL = "pending_email"
     }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AuthSessionStoreTest.kt
@@ -237,6 +237,7 @@ class AuthSessionStoreTest :
                 everySuspend { storage.read("session_id") } returns null
                 everySuspend { storage.read("pending_user_id") } returns null
                 everySuspend { storage.read("open_registration") } returns null
+                everySuspend { storage.read("setup_required") } returns null
                 val store = createStore(storage = storage, serverConfig = serverConfig)
 
                 store.initializeAuthState()
@@ -255,6 +256,28 @@ class AuthSessionStoreTest :
                 val store = createStore(storage = storage, instanceRepository = instanceRepository)
 
                 store.checkServerStatus()
+
+                store.authState.value.shouldBeInstanceOf<AuthState.NeedsSetup>()
+            }
+        }
+
+        test("initializeAuthState returns NeedsSetup when setup was required on the last server check") {
+            runTest {
+                // Regression: a relaunch runs the offline deriveAuthState (no network), which must honour
+                // the cached setupRequired flag. Otherwise a fresh server (no admin yet) resolves to the
+                // Login screen, whose "Create Account" leads to the approval-gated request flow with no
+                // path back to admin setup — a fresh-server dead-end.
+                val storage = createMockStorage()
+                val serverConfig = createMockServerConfig()
+                everySuspend { serverConfig.getServerUrl() } returns ServerUrl("http://test:8088")
+                everySuspend { storage.read("access_token") } returns null
+                everySuspend { storage.read("user_id") } returns null
+                everySuspend { storage.read("session_id") } returns null
+                everySuspend { storage.read("pending_user_id") } returns null
+                everySuspend { storage.read("setup_required") } returns "true"
+                val store = createStore(storage = storage, serverConfig = serverConfig)
+
+                store.initializeAuthState()
 
                 store.authState.value.shouldBeInstanceOf<AuthState.NeedsSetup>()
             }


### PR DESCRIPTION
## What

On a fresh server (no admin yet), **relaunching the app dropped you on the Sign In screen instead of the first-run admin-setup screen** — and Sign In's "Create Account" leads to the approval-gated Request Account flow, which on a server with no admin is a dead-end (no one can approve the request). Found while bringing up the native server end-to-end.

## Root cause

Two paths derive auth state:
- `checkServerStatus()` (the connect flow, makes a network call) reads `setupRequired` from the instance endpoint and routes to `NeedsSetup`.
- `deriveAuthState()` (offline-first, runs on **every launch** via `initializeAuthState`) returns `NeedsLogin` for a configured-server/no-token state **without consulting `setupRequired`**.

So the setup state was only honored on the initial connect, never on relaunch.

## Fix

Cache `setupRequired` exactly the way `openRegistration` is already cached: `checkServerStatus` persists it, and `deriveAuthState` returns `NeedsSetup` when it's cached-true. A stale `true` self-corrects — `SetupViewModel` re-runs `checkServerStatus` on entry, which refreshes the flag (and would route to `NeedsLogin` once an admin exists). The JVM/native runtimes and the rest of the flow are untouched.

## Tests

- New regression test: `initializeAuthState` returns `NeedsSetup` when `setupRequired` was cached (TDD — confirmed it fails on the old code, passes with the fix).
- Updated the existing "lands on NeedsLogin" test to stub the new key.
- Full gate green: `:sharedLogic:jvmTest`, `:server:jvmTest`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug`.