### PR TITLE
👷 ci(server): build native server.kexe for Docker release, blocking on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 #
 # Manual, per-platform release. Version comes from the VERSION file; the optional
 # `version` input bumps it (commits + tags). Android → Play internal/draft,
-# iOS → TestFlight, server → GHCR (non-blocking until #647 clears).
+# iOS → TestFlight, server → GHCR.
 
 name: Release
 
@@ -238,11 +238,13 @@ jobs:
             -allowProvisioningUpdates
 
   server:
-    name: Server → GHCR (non-blocking until #647)
-    runs-on: ubuntu-latest
+    name: Server → GHCR
+    # Pin to 24.04 so the builder's glibc matches the ubuntu:24.04 runtime image
+    # (Dockerfile.native). The dynamically-linked server.kexe would fail to start on an
+    # older-glibc base with a "GLIBC_x.y not found" error.
+    runs-on: ubuntu-24.04
     needs: set-version
     if: ${{ inputs.server }}
-    continue-on-error: true
     permissions:
       contents: read
       packages: write
@@ -252,18 +254,33 @@ jobs:
         with:
           ref: ${{ needs.set-version.outputs.sha }}
 
-      - name: Set up GraalVM 21
-        uses: graalvm/setup-graalvm@v1
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '21'
-          distribution: 'graalvm-community'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build native binary
-        run: ./gradlew :server:nativeCompile --no-configuration-cache --no-daemon
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache Konan (Kotlin/Native)
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-konan-
+
+      # Dev packages provide the libargon2.so / libsqlite3.so symlinks the K/N linker resolves
+      # via -largon2 / -lsqlite3 (against -L/usr/lib). The runtime image installs the .so.N
+      # siblings (libargon2-1, libsqlite3-0) for execution.
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev libsqlite3-dev
+
+      - name: Build native server binary (server.kexe)
+        run: ./gradlew :server:linkReleaseExecutableLinuxX64 --no-daemon
 
       - name: Stage binary for Docker
-        run: find server/build/native/nativeCompile -maxdepth 1 -type f -perm -u+x -exec cp {} server/server-binary \;
+        run: cp server/build/bin/linuxX64/releaseExecutable/server.kexe server/server-binary
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/server/Dockerfile.native
+++ b/server/Dockerfile.native
@@ -1,6 +1,11 @@
-# Runtime image for the GraalVM native server binary.
-# The binary is built on the runner by :server:nativeCompile and copied in here.
-FROM debian:stable-slim
+# Runtime image for the Kotlin/Native server binary (server.kexe), built on the runner by
+# :server:linkReleaseExecutableLinuxX64 and copied in here. Base pinned to ubuntu:24.04 to match
+# the ubuntu-24.04 builder's glibc; the binary dynamically links libargon2 + libsqlite3, so their
+# runtime shared objects are installed below.
+FROM ubuntu:24.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libargon2-1 libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
 RUN useradd -r -u 10001 listenup
 COPY server-binary /usr/local/bin/listenup-server
 RUN chmod +x /usr/local/bin/listenup-server


### PR DESCRIPTION
## What

The release pipeline's `server` job still built the server with GraalVM `:server:nativeCompile` — a task that no longer exists after the native-runtime flip (#927). A failed step skips later steps, so the job died before the Docker build and **never pushed an image**, silently, because `continue-on-error: true` masked it.

## Changes

- **`release.yml` server job** — build the real Kotlin/Native binary:
  - JDK 21 + Gradle + Konan cache + `libargon2-dev`/`libsqlite3-dev` (mirrors the existing `build-server-native` CI job)
  - `./gradlew :server:linkReleaseExecutableLinuxX64` → stage `server/build/bin/linuxX64/releaseExecutable/server.kexe`
  - then the existing GHCR login + build/push runs — native binary built **before** the image is pushed
- **Removed `continue-on-error: true`** — a native-build / Docker / GHCR-push failure now fails the run instead of being green-masked. The platform jobs are independent (`github-release` depends on `android`, not `server`), so this surfaces server breaks honestly without blocking the mobile lanes.
- **`Dockerfile.native`** — `server.kexe` dynamically links libargon2 + libsqlite3, so the runtime image installs `libargon2-1`/`libsqlite3-0`. Base moved `debian:stable-slim` → `ubuntu:24.04` and the builder pinned to `ubuntu-24.04` so link-time and runtime glibc match (avoids a `GLIBC_x.y not found` startup crash).

## Verification

The `link` + Docker path can't run on macOS/arm64 (linuxX64 cross-compile is host-disabled), so it gets its first real exercise on the Linux runner. Plan: a throwaway Release run with only the **server** box checked to smoke-test native-build → GHCR end-to-end.