### PR TITLE
♻️ refactor(server): single-source config defaults shared by native + application.conf

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ServerConfigDefaults.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ServerConfigDefaults.kt
@@ -1,0 +1,48 @@
+package com.calypsan.listenup.server
+
+/**
+ * One server configuration knob: its [key], its [default] value, and the optional [envVar] that
+ * overrides it. The single source of truth for the server's configuration defaults — shared by the
+ * Kotlin/Native [defaultServerConfig] (which builds the config in code, HOCON being JVM-only) and the
+ * JVM runtime's `jvmMain/resources/application.conf`. `ServerConfigDefaultsContractTest` (jvmTest)
+ * fails the build if `application.conf` ever drifts from this list.
+ */
+internal data class ServerConfigDefault(
+    val key: String,
+    val default: String,
+    val envVar: String?,
+)
+
+/**
+ * The canonical server configuration defaults. Adding or changing a knob here is the *only* place a
+ * default lives; `application.conf` must mirror it (pinned by the contract test) and the native config
+ * is built straight from it.
+ */
+internal val SERVER_CONFIG_DEFAULTS: List<ServerConfigDefault> =
+    listOf(
+        ServerConfigDefault("ktor.deployment.port", "8080", "PORT"),
+        ServerConfigDefault("app.serverName", "ListenUp", "LISTENUP_SERVER_NAME"),
+        ServerConfigDefault("database.jdbcUrl", "", null),
+        // Placeholder secrets: the resolver treats these exact defaults as "unset" and generates real
+        // secrets under $LISTENUP_HOME/secrets.properties on first boot.
+        ServerConfigDefault(
+            "auth.refreshPepper",
+            "test-pepper-change-in-production-this-must-be-32-bytes-or-more",
+            "LISTENUP_REFRESH_PEPPER",
+        ),
+        ServerConfigDefault(
+            "jwt.secret",
+            "test-jwt-secret-change-in-production-at-least-32-bytes-please",
+            "LISTENUP_JWT_SECRET",
+        ),
+        ServerConfigDefault("jwt.issuer", "listenup", null),
+        ServerConfigDefault("jwt.audience", "listenup-client", null),
+        ServerConfigDefault("registration.policy", "APPROVAL_QUEUE", "LISTENUP_REGISTRATION_POLICY"),
+        ServerConfigDefault("scanner.libraryPath", "", "LISTENUP_LIBRARY_PATH"),
+        ServerConfigDefault("scanner.metadataPrecedence", "", "LISTENUP_METADATA_PRECEDENCE"),
+        ServerConfigDefault("scanner.embeddedCoverCacheSize", "1000", "LISTENUP_EMBEDDED_COVER_CACHE_SIZE"),
+        ServerConfigDefault("seed.profile", "", "LISTENUP_SEED_PROFILE"),
+        ServerConfigDefault("server.dataDirLock", "true", "LISTENUP_DATA_DIR_LOCK"),
+        ServerConfigDefault("scan.rescanOnStartup", "true", "LISTENUP_SCAN_RESCAN_ON_STARTUP"),
+        ServerConfigDefault("scan.periodicRescanInterval", "6h", "LISTENUP_SCAN_PERIODIC_RESCAN_INTERVAL"),
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/ServerConfigDefaultsContractTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/ServerConfigDefaultsContractTest.kt
@@ -1,0 +1,31 @@
+package com.calypsan.listenup.server
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigResolveOptions
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the JVM runtime's `application.conf` to the shared [SERVER_CONFIG_DEFAULTS] so the two config
+ * sources can never drift: the native runtime builds its config from the list, the JVM runtime reads
+ * the HOCON file, and this test fails the build if a default in one is changed without the other.
+ *
+ * Substitutions are resolved with the process environment OFF, so each `${?ENV}` override falls back to
+ * its in-file default — making the comparison deterministic regardless of the CI environment.
+ */
+class ServerConfigDefaultsContractTest :
+    FunSpec({
+        val applicationConf =
+            ConfigFactory
+                .parseResources("application.conf")
+                .resolve(ConfigResolveOptions.defaults().setUseSystemEnvironment(false))
+
+        test("application.conf default matches ServerConfigDefaults for every key") {
+            SERVER_CONFIG_DEFAULTS.forEach { entry ->
+                withClue("config key '${entry.key}'") {
+                    applicationConf.getValue(entry.key).unwrapped().toString() shouldBe entry.default
+                }
+            }
+        }
+    })

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/DefaultServerConfig.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/DefaultServerConfig.kt
@@ -5,31 +5,16 @@ import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.config.MapApplicationConfig
 
 /**
- * Builds the server configuration for the Kotlin/Native runtime from environment variables. HOCON is
- * JVM-only, so Kotlin/Native cannot load `application.conf`; this reproduces the same knobs — every
- * default and `${?ENV_VAR}` override — in code. **Keep in sync with `jvmMain/resources/application.conf`.**
- *
- * The `jwt.secret` / `auth.refreshPepper` defaults are the same placeholders as `application.conf`:
- * the secret resolver treats them as "unset" and generates + persists real secrets under
- * `$LISTENUP_HOME/secrets.properties` on first boot.
+ * Builds the server configuration for the Kotlin/Native runtime. HOCON is JVM-only, so Kotlin/Native
+ * cannot load `application.conf`; instead the config is assembled in code from the shared
+ * [SERVER_CONFIG_DEFAULTS] — each knob's env-var override wins, falling back to its default. The
+ * canonical defaults live in one place (`ServerConfigDefaults`); `application.conf` mirrors them and is
+ * pinned by `ServerConfigDefaultsContractTest`.
  */
-internal fun defaultServerConfig(): ApplicationConfig =
-    MapApplicationConfig(
-        "ktor.deployment.port" to (readEnv("PORT") ?: "8080"),
-        "app.serverName" to (readEnv("LISTENUP_SERVER_NAME") ?: "ListenUp"),
-        "database.jdbcUrl" to "",
-        "auth.refreshPepper" to
-            (readEnv("LISTENUP_REFRESH_PEPPER") ?: "test-pepper-change-in-production-this-must-be-32-bytes-or-more"),
-        "jwt.secret" to
-            (readEnv("LISTENUP_JWT_SECRET") ?: "test-jwt-secret-change-in-production-at-least-32-bytes-please"),
-        "jwt.issuer" to "listenup",
-        "jwt.audience" to "listenup-client",
-        "registration.policy" to (readEnv("LISTENUP_REGISTRATION_POLICY") ?: "APPROVAL_QUEUE"),
-        "scanner.libraryPath" to (readEnv("LISTENUP_LIBRARY_PATH") ?: ""),
-        "scanner.metadataPrecedence" to (readEnv("LISTENUP_METADATA_PRECEDENCE") ?: ""),
-        "scanner.embeddedCoverCacheSize" to (readEnv("LISTENUP_EMBEDDED_COVER_CACHE_SIZE") ?: "1000"),
-        "seed.profile" to (readEnv("LISTENUP_SEED_PROFILE") ?: ""),
-        "server.dataDirLock" to (readEnv("LISTENUP_DATA_DIR_LOCK") ?: "true"),
-        "scan.rescanOnStartup" to (readEnv("LISTENUP_SCAN_RESCAN_ON_STARTUP") ?: "true"),
-        "scan.periodicRescanInterval" to (readEnv("LISTENUP_SCAN_PERIODIC_RESCAN_INTERVAL") ?: "6h"),
-    )
+internal fun defaultServerConfig(): ApplicationConfig {
+    val values =
+        SERVER_CONFIG_DEFAULTS
+            .map { entry -> entry.key to (entry.envVar?.let(::readEnv) ?: entry.default) }
+            .toTypedArray()
+    return MapApplicationConfig(*values)
+}


### PR DESCRIPTION
## What

After the native flip, the server had **two sources of truth for its config defaults**: `application.conf` (HOCON, the JVM runtime) and `DefaultServerConfig.kt` (code, the native runtime, since HOCON is JVM-only). They could silently drift. This unifies them.

## How

- New commonMain **`SERVER_CONFIG_DEFAULTS`** — the canonical list of `(key, default, envVar)` for every config knob. One place to add or change a default.
- `defaultServerConfig()` (native) now builds the config straight from that list — env override wins, default otherwise.
- New jvmTest **`ServerConfigDefaultsContractTest`** parses `application.conf` (with process-env resolution off, for determinism) and asserts every entry matches. If `application.conf` and the shared list ever disagree, the build fails.

`application.conf` stays the JVM runtime's loader (unchanged), but it's now *pinned* to the shared list rather than a free-floating duplicate.

## Tests

- `ServerConfigDefaultsContractTest` passes (the two are in sync today).
- The native boot test (from #927) still exercises the rebuilt `defaultServerConfig()`.
- Full gate green: `:sharedLogic:jvmTest`, `:server:jvmTest`, `:server:linuxX64Test`, `spotlessCheck`, `detekt`, `:androidApp:assembleDebug`.