### PR TITLE
👷 ci(server): run :server:linuxX64Test in the native job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
 
   # ── Build ────────────────────────────────────────────────────────────────────
   build-server-native:
-    name: Build (server linuxX64)
+    name: Build & Test (server linuxX64)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Gate behind lint + JVM tests so a broken compile can't land on a passing test run.
@@ -231,11 +231,14 @@ jobs:
           key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-konan-
 
-      - name: Install libargon2 headers (for the native cinterop)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev
+      - name: Install native link dependencies (libargon2 + libsqlite3)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev libsqlite3-dev
 
       - name: Compile :server linuxX64
         run: ./gradlew :server:compileKotlinLinuxX64 --no-daemon
+
+      - name: Run :server linuxX64 tests
+        run: ./gradlew :server:linuxX64Test --no-daemon
 
   build-android:
     name: Build (Android)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -49,11 +49,12 @@ kotlin {
                 entryPoint = "com.calypsan.listenup.server.main"
             }
         }
-        // Provide the system library search path for the K/N bundled ld.lld linker. On Arch
-        // Linux libraries live in /usr/lib; the bundled ld.lld has no default sysroot and won't
-        // find libsqlite3/libargon2 without this. On Debian/Ubuntu the same path also resolves
-        // (multiarch .so is at /usr/lib/x86_64-linux-gnu but /usr/lib contains symlinks).
-        binaries.all { linkerOpts("-L/usr/lib") }
+        // Provide the system library search paths for the K/N bundled ld.lld linker, which has
+        // no default sysroot and won't find libsqlite3/libargon2 without them. /usr/lib covers
+        // distros that put the .so there directly (e.g. Arch); /usr/lib/x86_64-linux-gnu is the
+        // Debian/Ubuntu multiarch location where apt's -dev packages install it. A non-existent
+        // -L dir is harmless — the linker ignores it.
+        binaries.all { linkerOpts("-L/usr/lib", "-L/usr/lib/x86_64-linux-gnu") }
     }
 
     // Mirror the `listenup.jvm` convention plugin: apply the project-wide compiler-args triple


### PR DESCRIPTION
## What
Wire the native test suite into CI. The `build-server-native` job previously only *compiled* `:server:compileKotlinLinuxX64` — the flip's `NativeServerBootTest` + the `linuxX64Test` suite never ran on a PR, so native-only regressions could land green.

## Changes (`.github/workflows/ci.yml`, `build-server-native` job only)
- Add a `Run :server linuxX64 tests` step (`./gradlew :server:linuxX64Test`) after the compile step.
- Add `libsqlite3-dev` to the apt step — the native **test** executable links libsqlite3 (SQLiter + the server's sqlite3 cinterop) where the compile-only step only needed `libargon2-dev`.
- Rename the job display to `Build & Test (server linuxX64)`.

## Verification
`:server:linuxX64Test` run locally: **BUILD SUCCESSFUL**, 20 tests / 10 suites, 0 failures (incl. `NativeServerBootTest`).

Batch-4 audit plan 038–052 (`docs/plans/038…`), finding B. Dependency: unblocks plan 043 (native parity tests) actually running in CI.