### PR TITLE
✅ test(server): native parity tests for PasswordHasher, SqlAdminConnection, mDNS

### DIFF
--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/auth/PasswordHasherNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/auth/PasswordHasherNativeTest.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.server.auth
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+/**
+ * Native parity proof for [PasswordHasher] — the libargon2-cinterop actual. The cross-impl vector test
+ * (below) is the real anti-drift guard: it pins a PHC string PRODUCED BY THE JVM actual (password4j) and
+ * asserts the NATIVE [PasswordHasher.verify] accepts it. If the libargon2 marshalling or PHC parsing ever
+ * drifts from password4j's encoding, native verify returns false and existing users can no longer log in
+ * on the native server — this test fails first.
+ */
+class PasswordHasherNativeTest {
+    @Test
+    fun nativeHashVerifyRoundTrips(): Unit =
+        runBlocking {
+            val hasher = PasswordHasher()
+            val phc = hasher.hash("native-round-trip-password")
+            phc shouldStartWith "$" + "argon2id"
+            hasher.verify("native-round-trip-password", phc) shouldBe true
+            hasher.verify("wrong-password!!", phc) shouldBe false
+        }
+
+    @Test
+    fun nativeVerifyAcceptsAJvmProducedHash(): Unit =
+        runBlocking {
+            // VECTOR PROVENANCE: produced by the JVM actual (password4j) from `plaintext` below, via the
+            // plan's Step 3 generation procedure. Do NOT hand-edit. If the Argon2 parameters ever change,
+            // regenerate it from the JVM impl — a hand-written value defeats the anti-drift purpose.
+            val plaintext = "listenup-native-parity-vector"
+            val jvmProducedHash =
+                "\$argon2id\$v=19\$m=65536,t=3,p=4\$9j3C+x1TtkZNN1++COnYDQ\$x2M9twfkhkgdGh8DmhzTs4P2tKulagocBE6BDiontW4"
+            PasswordHasher().verify(plaintext, jvmProducedHash) shouldBe true
+        }
+}

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/SqlAdminConnectionNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/SqlAdminConnectionNativeTest.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.server.db
+
+import io.kotest.matchers.shouldBe
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlin.random.Random
+import kotlin.test.Test
+
+/**
+ * Native parity proof for the SQLite admin-connection seam ([openAdminConnection] → libsqlite3 cinterop).
+ * Exercises the real native path used by migrations / VACUUM / external-DB reads: open a read-write
+ * connection on a fresh file, run DDL + DML via [SqlAdminConnection.execute], read it back via the bound
+ * [SqlAdminConnection.query], and assert the round-trip survives the cinterop marshalling.
+ */
+class SqlAdminConnectionNativeTest {
+    @Test
+    fun executesDdlAndQueriesItBackOverTheNativeDriver() {
+        // Temp dir is unusable in the linuxX64 test runner — use a working-directory-relative file.
+        val dbName = "lu-admin-native-test-${Random.nextInt(1, Int.MAX_VALUE).toString(HEX_RADIX)}.db"
+        try {
+            openAdminConnection(dbName, readOnly = false).use { conn ->
+                conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+                conn.execute("INSERT INTO t (id, name) VALUES (1, 'kaladin')")
+                conn.execute("INSERT INTO t (id, name) VALUES (2, 'shallan')")
+                val names =
+                    conn.query(
+                        sql = "SELECT name FROM t WHERE name = ?",
+                        bind = { bindString(1, "shallan") },
+                        map = { row -> row.getString("name") },
+                    )
+                names shouldBe listOf("shallan")
+            }
+        } finally {
+            // journal_mode=WAL (set for read-write) leaves -wal / -shm sidecars; remove all three.
+            for (suffix in listOf("", "-wal", "-shm")) {
+                SystemFileSystem.delete(Path(dbName + suffix), mustExist = false)
+            }
+        }
+    }
+
+    private companion object {
+        const val HEX_RADIX = 16
+    }
+}

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayerNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayerNativeTest.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.server.mdns
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+/**
+ * Native construction/teardown proof for the mDNS POSIX socket layer ([openMdnsSockets] → getifaddrs /
+ * socket / setsockopt / IP_ADD_MEMBERSHIP cinterop). Enumerates interfaces, opens one multicast socket
+ * per usable IPv4 interface, validates each socket's shape, then leaves the group and closes the fd.
+ *
+ * Scope boundary: full multicast send/receive is NOT exercised — a CI runner's network namespace may have
+ * no multicast-capable interface (the returned list is then legitimately empty) and outbound multicast is
+ * unreliable in sandboxes. This test proves the enumeration + bind + join + teardown syscall path runs
+ * cleanly and releases its file descriptors; it does not assert a datagram round-trip.
+ */
+class MdnsSocketLayerNativeTest {
+    @Test
+    fun opensAndClosesMulticastSocketsWithoutCrashing() {
+        // May be empty on a runner with no usable interface — a valid outcome (advertise-disabled).
+        val sockets = openMdnsSockets()
+        try {
+            for (socket in sockets) {
+                socket.ipv4.size shouldBe IPV4_BYTES
+                (socket.interfaceName.isNotBlank()) shouldBe true
+            }
+        } finally {
+            sockets.forEach { it.leaveAndClose() }
+        }
+    }
+
+    private companion object {
+        const val IPV4_BYTES = 4
+    }
+}


### PR DESCRIPTION
## What
The native runtime had effectively one E2E test (`/healthz` boot smoke). This adds parity tests for the highest-risk native cinterop seams — most importantly an **anti-drift guard** for password hashing.

## New tests (3 files, all `linuxX64Test`, `kotlin.test.@Test` + `runBlocking`)
- **PasswordHasherNativeTest** — native hash→verify round-trip (incl. wrong-password rejection) + the **cross-impl vector**: native `verify()` against a real Argon2id PHC string produced by the JVM/password4j actual. If the libargon2 cinterop marshalling ever drifts from the JVM impl, this fails — catching the silent "native auth-hashes become unverifiable" class before users hit it.
- **SqlAdminConnectionNativeTest** — DDL + DML + bound-`?`-param round-trip over the libsqlite3 cinterop (with `-wal`/`-shm` cleanup).
- **MdnsSocketLayerNativeTest** — open/validate/teardown of the POSIX multicast socket layer (construct/teardown scope; no datagram round-trip).

## Notes
- Zero production-code changes — diff is the 3 new test files only. The JVM hash vector was generated via a throwaway emit-test that was fully reverted before commit.
- `:server:linuxX64Test`: **BUILD SUCCESSFUL**, 24 tests (20→24), 0 failures. spotless + detekt green.

Batch-4 plan 043, finding F. Depends on #932 (plan 039) to actually run these in CI.