### PR TITLE
🐛 fix(server): check native inotify/mDNS syscall returns and log failures

### DIFF
--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayer.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayer.linuxX64.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.server.mdns
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -36,6 +37,7 @@ import platform.posix.SO_REUSEADDR
 import platform.posix.SO_REUSEPORT
 import platform.posix.bind
 import platform.posix.close
+import platform.posix.errno
 import platform.posix.htons
 import platform.posix.in_addr
 import platform.posix.ip_mreq
@@ -45,6 +47,8 @@ import platform.posix.setsockopt
 import platform.posix.sockaddr
 import platform.posix.sockaddr_in
 import platform.posix.socket
+
+private val logger = KotlinLogging.logger {}
 
 private const val GROUP = "224.0.0.251"
 private const val PORT: UShort = 5353u
@@ -169,15 +173,18 @@ private class NativeMdnsSocket(
             dest.sin_port = htons(PORT)
             dest.sin_addr.s_addr = inet_addr(GROUP)
             payload.usePinned { pinned ->
-                sendto(
-                    fd,
-                    pinned.addressOf(0),
-                    payload.size.convert(),
-                    0,
-                    dest.ptr.reinterpret(),
-                    sizeOf<sockaddr_in>().convert(),
-                )
-                Unit
+                val sent =
+                    sendto(
+                        fd,
+                        pinned.addressOf(0),
+                        payload.size.convert(),
+                        0,
+                        dest.ptr.reinterpret(),
+                        sizeOf<sockaddr_in>().convert(),
+                    )
+                if (sent < 0) {
+                    logger.warn { "mDNS sendto failed on $interfaceName (errno=$errno) — advertisement not sent" }
+                }
             }
         }
     }

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcher.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcher.kt
@@ -142,6 +142,12 @@ internal class InotifyDirectoryWatcher(
             while (offset < bytesRead) {
                 val event = (buffer + offset)!!.reinterpret<inotify_event>().pointed
                 val nameLen = event.len.toInt()
+                if (nameLen < 0 || offset + headerSize + nameLen > bytesRead) {
+                    logger.warn {
+                        "inotify event with invalid name length ($nameLen) at offset $offset of $bytesRead bytes — dropping rest of batch"
+                    }
+                    break
+                }
                 val name =
                     if (nameLen > 0) {
                         (buffer + offset + headerSize)!!.reinterpret<ByteVar>().toKString()
@@ -225,7 +231,12 @@ internal class InotifyDirectoryWatcher(
         // the fds + thread.
         val counter = ByteArray(Long.SIZE_BYTES)
         counter[0] = 1
-        counter.usePinned { write(shutdownFd, it.addressOf(0), counter.size.convert()) }
+        val woke = counter.usePinned { write(shutdownFd, it.addressOf(0), counter.size.convert()) }
+        if (woke < 0) {
+            logger.warn {
+                "eventfd shutdown write failed (errno=$errno) — relying on Job cancellation to stop the watcher"
+            }
+        }
         loop?.cancelAndJoin()
         close(inotifyFd)
         close(shutdownFd)


### PR DESCRIPTION
## What
Three native syscall return values were ignored, so failures passed silently — mDNS could fail to advertise with no trace, and a malformed/truncated inotify batch could be mis-parsed.

## Changes (`linuxX64Main`, 2 files)
- **inotify `nameLen`** (`drainEvents`) — guard `nameLen < 0 || offset + headerSize + nameLen > bytesRead`: log + `break` (drop the rest of the malformed batch; the next `read` recovers).
- **eventfd `write`** (`close`) — capture the return; on `< 0` log a warning (shutdown is still backstopped by `loop?.cancelAndJoin()`).
- **mDNS `sendto`** (`NativeMdnsSocket.send`) — capture the return; on `< 0` log a warning with the interface name + `errno` (the next periodic advertisement retries). Replaces the old `Unit`-terminated discard.

`errno` is read on failure; `KotlinLogging` file logger added to the mDNS layer (the inotify file already had one).

## Notes
- `-Xreturn-value-checker=check` didn't catch these — cinterop syscall fns aren't `@MustUseReturnValue`-annotated.
- The failure branches need libc fault injection to hit deterministically, so no new unit test; the existing `InotifyDirectoryWatcherNativeTest` is the happy-path regression guard (confirms the `nameLen` guard doesn't reject valid events and the guarded eventfd write still wakes/closes the loop).

## Verification
`:server:linuxX64Test` → BUILD SUCCESSFUL (inotify native test passes); spotless + detekt green.

Batch-4 plan 042, finding E.