### PR TITLE
🚨 fix(quality): unbreak native detekt on main (unnecessary parens in mDNS test)

### DIFF
--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayerNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayerNativeTest.kt
@@ -21,7 +21,7 @@ class MdnsSocketLayerNativeTest {
         try {
             for (socket in sockets) {
                 socket.ipv4.size shouldBe IPV4_BYTES
-                (socket.interfaceName.isNotBlank()) shouldBe true
+                socket.interfaceName.isNotBlank() shouldBe true
             }
         } finally {
             sockets.forEach { it.leaveAndClose() }


### PR DESCRIPTION
## Why main is red
A merge interaction between two PRs that were each green in isolation:
- **#933** (043, native parity tests) added `MdnsSocketLayerNativeTest.kt`, which contains `(socket.interfaceName.isNotBlank()) shouldBe true` — an `UnnecessaryParentheses` violation. When #933's CI ran, main didn't yet have native detekt coverage, so it slipped through.
- **#934** (038) added `server/src/linuxX64Test` to detekt's `source.setFrom`. When #934's CI ran, main didn't yet contain #933's test file.

Both merged → `origin/main` now has the file **and** the coverage → `./gradlew detekt` fails. This fails the **Lint job on every open/new PR** (#932 already merged green before the interaction; #935 and #936 went red on it).

## Fix
Remove the unnecessary parentheses (one line). `./gradlew detekt` → BUILD SUCCESSFUL; spotless green.

**Merge this first** — it unblocks the Lint job for #935, #936, and the rest of the Batch-4 PRs.