### PR TITLE
✨ feat(server): native HTTP request logging via pipeline interception

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/CallIdLogging.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/CallIdLogging.kt
@@ -3,8 +3,9 @@ package com.calypsan.listenup.server.plugins
 import io.ktor.server.application.Application
 
 /**
- * Installs request logging that binds the correlation id (from [installCallId]) into the logging
- * context. JVM-only — `ktor-server-call-logging` has no native artifact, so the native actual is a
- * no-op and the native server relies on [installCallId] plus per-route logging.
+ * Installs per-request access logging (method, path, status, duration) keyed to the correlation id
+ * from [installCallId]. The JVM actual uses Ktor's `CallLogging` plugin and binds the id into the
+ * SLF4J MDC; `ktor-server-call-logging` has no native artifact, so the native actual reproduces the
+ * essentials with a pipeline interceptor and inlines the id (native has no MDC).
  */
 expect fun Application.installCallLogging()

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/plugins/CallIdLogging.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/plugins/CallIdLogging.linuxX64.kt
@@ -1,9 +1,38 @@
 package com.calypsan.listenup.server.plugins
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import kotlin.time.TimeSource
+
+private val logger = KotlinLogging.logger {}
 
 /**
- * No-op: `ktor-server-call-logging` has no Kotlin/Native artifact. The native server keeps
- * [installCallId] (correlation ids still flow) but omits per-request access logging.
+ * Native request logging: `ktor-server-call-logging` has no Kotlin/Native artifact, so this actual
+ * reproduces its essentials by intercepting the pipeline — timing each call, then logging method,
+ * path, status, duration, and the [installCallId] correlation id (inlined because native has no SLF4J
+ * MDC). Mirrors the JVM actual's INFO access log.
  */
-actual fun Application.installCallLogging() = Unit
+actual fun Application.installCallLogging() {
+    intercept(ApplicationCallPipeline.Monitoring) {
+        val started = TimeSource.Monotonic.markNow()
+        try {
+            proceed()
+        } finally {
+            val durationMs = started.elapsedNow().inWholeMilliseconds
+            val status =
+                call.response
+                    .status()
+                    ?.value
+                    ?.toString() ?: "-"
+            val correlationId = call.callId ?: "-"
+            logger.info {
+                "${call.request.httpMethod.value} ${call.request.path()} -> $status (${durationMs}ms) [$correlationId]"
+            }
+        }
+    }
+}

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/plugins/NativeCallLoggingNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/plugins/NativeCallLoggingNativeTest.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.server.plugins
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO as ClientCIO
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EngineConnectorBuilder
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+/**
+ * Native runtime proof for the linuxX64 [installCallLogging] actual: it installs on the real CIO
+ * engine and a request flows through the logging interceptor without error, returning 200. The
+ * interceptor's emitted line is not asserted (capturing the native logging appender's stdout is not
+ * practical) — the contract under test is "installs + serves through the interceptor on native".
+ */
+class NativeCallLoggingNativeTest {
+    @Test
+    fun installsAndServesARequestThroughTheLoggingInterceptor(): Unit =
+        runBlocking {
+            val server =
+                embeddedServer(
+                    factory = CIO,
+                    configure = { connectors.add(EngineConnectorBuilder().apply { port = 0 }) },
+                ) {
+                    installCallId()
+                    installCallLogging()
+                    routing { get("/ping") { call.respondText("pong") } }
+                }
+            server.start(wait = false)
+            val client = HttpClient(ClientCIO)
+            try {
+                val port =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
+                val response = client.get("http://127.0.0.1:$port/ping")
+                response.status shouldBe HttpStatusCode.OK
+            } finally {
+                client.close()
+                server.stop(0, 0)
+            }
+        }
+}


### PR DESCRIPTION
## What
The native runtime emitted **no HTTP access logs** — `installCallLogging` was a no-op on linuxX64 because `ktor-server-call-logging` has no Kotlin/Native artifact (it's a JVM-only dependency, so it can't move to commonMain).

## Change
- `CallIdLogging.linuxX64.kt` — the actual now installs a pipeline interceptor on `ApplicationCallPipeline.Monitoring` (the same idiom as the existing `MaintenanceGate`). It times each call with `TimeSource.Monotonic`, and in a `finally` logs at INFO via `KotlinLogging`: `METHOD path -> status (Nms) [correlationId]`. The correlation id is inlined from `call.callId` (native has no SLF4J MDC). `try/finally` guarantees the line even if a handler throws.
- `NativeCallLoggingNativeTest` — boots `embeddedServer(CIO)` with `installCallId()` + `installCallLogging()` + a route, hits it with a real CIO client, asserts the interceptor installs + serves (capturing the native log appender's stdout isn't practical — scope per the plan).
- commonMain `CallIdLogging.kt` — KDoc updated (dropped the now-false "native is a no-op" line); `expect` signature unchanged.

## Verification
`:server:linuxX64Test :server:jvmTest` → BUILD SUCCESSFUL (incl. the new native test; `NativeServerBootTest` still green). spotless + detekt green against post-038 native coverage.

Batch-4 plan 041, finding D.