### PR TITLE
⚡️ perf(server): batch-resolve contributors/series/genres on book edit

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
@@ -31,6 +31,8 @@ import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.BookWriteExtras
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.SeriesRepository
+import com.calypsan.listenup.server.services.contributorDedupKey
+import com.calypsan.listenup.server.services.normalizeForDedup
 import kotlinx.coroutines.withContext
 
 private const val MAX_SEARCH_LIMIT = 200
@@ -191,21 +193,24 @@ internal class BookServiceImpl(
         val current =
             repo.findById(id)
                 ?: return bookNotFound(id)
+        val sorted = contributors.sortedBy { it.position }
+        // Resolve every id-less contributor in ONE bulk SELECT (creating the missing rows through the
+        // same resolveOrCreate the scanner uses), then look each input's id up by its dedup key —
+        // identical ids, order, duplicate-collapse, and sync events to the prior per-item path.
+        val resolvedByKey = contributorRepo.resolveOrCreateAll(sorted.filter { it.id == null }.map { it.name to null })
         val resolved =
-            contributors
-                .sortedBy { it.position }
-                .map { input ->
-                    val resolvedId =
-                        input.id?.value
-                            ?: contributorRepo.resolveOrCreate(input.name, sortName = null).value
-                    BookContributorPayload(
-                        id = resolvedId,
-                        name = input.name,
-                        sortName = null,
-                        role = input.role,
-                        creditedAs = input.creditedAs,
-                    )
-                }
+            sorted.map { input ->
+                val resolvedId =
+                    input.id?.value
+                        ?: resolvedByKey.getValue(contributorDedupKey(input.name, null)).value
+                BookContributorPayload(
+                    id = resolvedId,
+                    name = input.name,
+                    sortName = null,
+                    role = input.role,
+                    creditedAs = input.creditedAs,
+                )
+            }
         return when (val upsertResult = repo.upsert(current.copy(contributors = resolved))) {
             is AppResult.Success -> AppResult.Success(Unit)
             is AppResult.Failure -> AppResult.Failure(upsertResult.error)
@@ -272,19 +277,21 @@ internal class BookServiceImpl(
         val current =
             repo.findById(id)
                 ?: return bookNotFound(id)
+        val sorted = series.sortedWith(compareBy(nullsLast()) { it.position })
+        // Resolve every id-less series in ONE bulk SELECT, then look each input's id up by its
+        // normalized key — identical ids, order, and sync events to the prior per-item path.
+        val resolvedByKey = seriesRepo.resolveOrCreateAll(sorted.filter { it.id == null }.map { it.name })
         val resolved =
-            series
-                .sortedWith(compareBy(nullsLast()) { it.position })
-                .map { input ->
-                    val resolvedId =
-                        input.id?.value
-                            ?: seriesRepo.resolveOrCreate(input.name).value
-                    BookSeriesPayload(
-                        id = resolvedId,
-                        name = input.name,
-                        sequence = input.position?.toString(),
-                    )
-                }
+            sorted.map { input ->
+                val resolvedId =
+                    input.id?.value
+                        ?: resolvedByKey.getValue(normalizeForDedup(input.name)).value
+                BookSeriesPayload(
+                    id = resolvedId,
+                    name = input.name,
+                    sequence = input.position?.toString(),
+                )
+            }
         return when (val upsertResult = repo.upsert(current.copy(series = resolved))) {
             is AppResult.Success -> AppResult.Success(Unit)
             is AppResult.Failure -> AppResult.Failure(upsertResult.error)
@@ -310,11 +317,13 @@ internal class BookServiceImpl(
         val current = repo.findById(id) ?: return bookNotFound(id)
 
         // Validate every input genre exists and is live BEFORE the relink. Unknown ids surface as
-        // BookError.InvalidInput per spec (no auto-create). genreRepo.findById is a suspend read,
-        // so the validation runs before opening the (non-suspend) SQLDelight relink transaction.
+        // BookError.InvalidInput per spec (no auto-create). One bulk read replaces the per-input
+        // findById storm; the in-order membership check keeps the first-offender (input order) error
+        // byte-identical. genreRepo.findLiveIds is a suspend read, so the validation runs before
+        // opening the (non-suspend) SQLDelight relink transaction.
+        val liveIds = genreRepo.findLiveIds(genres.map { it.genreId.value })
         for (input in genres) {
-            val genre = genreRepo.findById(input.genreId.value)
-            if (genre == null || genre.deletedAt != null) {
+            if (input.genreId.value !in liveIds) {
                 return AppResult.Failure(BookError.InvalidInput(debugInfo = "unknownGenre=${input.genreId.value}"))
             }
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreRepository.kt
@@ -140,6 +140,19 @@ class GenreRepository(
     /** Reads a genre by raw id outside substrate orchestration — test/diagnostic + service use. */
     suspend fun findById(idStr: String): GenreSyncPayload? = suspendTransaction(db) { readPayload(idStr) }
 
+    /** Returns the subset of [ids] that are live (non-tombstoned) genres, in one query. */
+    suspend fun findLiveIds(ids: Collection<String>): Set<String> =
+        if (ids.isEmpty()) {
+            emptySet()
+        } else {
+            suspendTransaction(db) {
+                db.genresQueries
+                    .selectLiveIdsByIds(ids.distinct())
+                    .executeAsList()
+                    .toSet()
+            }
+        }
+
     /**
      * Returns the live (non-tombstoned) genre with the given [slug], or null if absent.
      * Tombstoned rows are excluded — slug uniqueness is enforced only among live rows

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Genres.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Genres.sq
@@ -43,6 +43,11 @@ CREATE INDEX idx_genres_revision ON genres(revision);
 selectById:
 SELECT * FROM genres WHERE id = :id;
 
+-- Ids of the LIVE (non-tombstoned) genres among :ids — one query for the
+-- setBookGenres batch validation. A deleted OR unknown id simply won't appear.
+selectLiveIdsByIds:
+SELECT id FROM genres WHERE id IN :ids AND deleted_at IS NULL;
+
 insert:
 INSERT INTO genres (
     id, name, slug, path, parent_id, depth, sort_order, color, description,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetContributorsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetContributorsTest.kt
@@ -310,6 +310,132 @@ class BookServiceImplSetContributorsTest :
                 }
             }
         }
+
+        test("setBookContributors collapses duplicate id-less names to one created row, two payload entries") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                val bus = ChangeBus()
+                val syncRegistry = SyncRegistry()
+                val contributorRepo = ContributorRepository(db.sql, bus, syncRegistry)
+                val seriesRepo = SeriesRepository(db.sql, bus, syncRegistry)
+                val genreRepo = GenreRepository(db.sql, bus, syncRegistry)
+                val repo =
+                    BookRepository(
+                        db = db.sql,
+                        driver = db.driver,
+                        bus = bus,
+                        registry = syncRegistry,
+                        contributorRepository = contributorRepo,
+                        seriesRepository = seriesRepo,
+                        genreRepository = genreRepo,
+                    )
+                val service =
+                    BookServiceImpl(
+                        repo = repo,
+                        contributorRepo = contributorRepo,
+                        seriesRepo = seriesRepo,
+                        coverStorage = CoverStorage(),
+                        sql = db.sql,
+                        genreRepo = genreRepo,
+                        accessPolicy = BookAccessPolicy(db.sql, db.driver),
+                        permissionPolicy = UserPermissionPolicy(db.sql),
+                        principal = PrincipalProvider { UserPrincipal(UserId("test-admin"), SessionId("s"), UserRole.ROOT) },
+                    )
+                runTest {
+                    val existing = contributorRepo.resolveOrCreate("Brandon Sanderson", sortName = null)
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings"))
+                    val preCount = contributorRepo.listLiveIds().size
+
+                    val result =
+                        service.setBookContributors(
+                            BookId("b1"),
+                            listOf(
+                                BookContributorInput(id = null, name = "Tolkien", role = "author", position = 0),
+                                BookContributorInput(id = null, name = "Tolkien", role = "narrator", position = 1),
+                                BookContributorInput(id = existing, name = "Brandon Sanderson", role = "editor", position = 2),
+                            ),
+                        )
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    // Two "Tolkien" inputs share one dedup key → exactly ONE new row created.
+                    contributorRepo.listLiveIds().size shouldBe preCount + 1
+
+                    val updated = repo.findById(BookId("b1"))!!
+                    updated.contributors shouldHaveSize 3
+                    // Both "Tolkien" payloads resolve to the SAME id, order follows position, roles preserved.
+                    updated.contributors[0].id shouldBe updated.contributors[1].id
+                    updated.contributors[0].role shouldBe "author"
+                    updated.contributors[1].role shouldBe "narrator"
+                    updated.contributors[2].id shouldBe existing.value
+                    updated.contributors[2].role shouldBe "editor"
+                }
+            }
+        }
+
+        test("setBookContributors with mixed existing-by-id + multiple new-by-name preserves order and ids") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                val bus = ChangeBus()
+                val syncRegistry = SyncRegistry()
+                val contributorRepo = ContributorRepository(db.sql, bus, syncRegistry)
+                val seriesRepo = SeriesRepository(db.sql, bus, syncRegistry)
+                val genreRepo = GenreRepository(db.sql, bus, syncRegistry)
+                val repo =
+                    BookRepository(
+                        db = db.sql,
+                        driver = db.driver,
+                        bus = bus,
+                        registry = syncRegistry,
+                        contributorRepository = contributorRepo,
+                        seriesRepository = seriesRepo,
+                        genreRepository = genreRepo,
+                    )
+                val service =
+                    BookServiceImpl(
+                        repo = repo,
+                        contributorRepo = contributorRepo,
+                        seriesRepo = seriesRepo,
+                        coverStorage = CoverStorage(),
+                        sql = db.sql,
+                        genreRepo = genreRepo,
+                        accessPolicy = BookAccessPolicy(db.sql, db.driver),
+                        permissionPolicy = UserPermissionPolicy(db.sql),
+                        principal = PrincipalProvider { UserPrincipal(UserId("test-admin"), SessionId("s"), UserRole.ROOT) },
+                    )
+                runTest {
+                    val existing = contributorRepo.resolveOrCreate("Brandon Sanderson", sortName = null)
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings"))
+                    val preCount = contributorRepo.listLiveIds().size
+
+                    val result =
+                        service.setBookContributors(
+                            BookId("b1"),
+                            listOf(
+                                BookContributorInput(id = existing, name = "Brandon Sanderson", role = "author", position = 0),
+                                BookContributorInput(id = null, name = "New Narrator One", role = "narrator", position = 1),
+                                BookContributorInput(id = null, name = "New Narrator Two", role = "narrator", position = 2),
+                            ),
+                        )
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    // Two distinct new names → exactly TWO new rows created via the batch path.
+                    contributorRepo.listLiveIds().size shouldBe preCount + 2
+
+                    val updated = repo.findById(BookId("b1"))!!
+                    updated.contributors shouldHaveSize 3
+                    updated.contributors[0].id shouldBe existing.value
+                    updated.contributors[0].name shouldBe "Brandon Sanderson"
+                    updated.contributors[1].name shouldBe "New Narrator One"
+                    updated.contributors[2].name shouldBe "New Narrator Two"
+                    // Each new name resolves to its own distinct id.
+                    (updated.contributors[1].id == updated.contributors[2].id) shouldBe false
+                }
+            }
+        }
     })
 
 private fun bookFixture(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetGenresTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetGenresTest.kt
@@ -30,6 +30,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
@@ -140,6 +141,30 @@ class BookServiceImplSetGenresTest :
                         )
                     result.shouldBeInstanceOf<AppResult.Failure>()
                     result.error.shouldBeInstanceOf<BookError.InvalidInput>()
+                }
+            }
+        }
+
+        test("setBookGenres names the first unknown genreId in input order") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                seedGenre("g-fant", name = "Fantasy", slug = "fantasy", path = "/fantasy")
+                seedGenre("g-hist", name = "History", slug = "history", path = "/history")
+                runTest {
+                    val service = makeService(this@withSqlDatabase)
+                    val result =
+                        service.setBookGenres(
+                            BookId("book1"),
+                            listOf(
+                                BookGenreInput(GenreId("g-fant")),
+                                BookGenreInput(GenreId("missing")),
+                                BookGenreInput(GenreId("g-hist")),
+                            ),
+                        )
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+                    val error = result.error.shouldBeInstanceOf<BookError.InvalidInput>()
+                    (error.debugInfo ?: "") shouldContain "unknownGenre=missing"
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetSeriesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetSeriesTest.kt
@@ -300,6 +300,71 @@ class BookServiceImplSetSeriesTest :
                 }
             }
         }
+
+        test("setBookSeries collapses duplicate id-less names to one created row, two payload entries") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                val bus = ChangeBus()
+                val syncRegistry = SyncRegistry()
+                val contributorRepo = ContributorRepository(db.sql, bus, syncRegistry)
+                val seriesRepo = SeriesRepository(db.sql, bus, syncRegistry)
+                val genreRepo = GenreRepository(db.sql, bus, syncRegistry)
+                val repo =
+                    BookRepository(
+                        db = db.sql,
+                        driver = db.driver,
+                        bus = bus,
+                        registry = syncRegistry,
+                        contributorRepository = contributorRepo,
+                        seriesRepository = seriesRepo,
+                        genreRepository = genreRepo,
+                    )
+                val service =
+                    BookServiceImpl(
+                        repo = repo,
+                        contributorRepo = contributorRepo,
+                        seriesRepo = seriesRepo,
+                        coverStorage = CoverStorage(),
+                        sql = db.sql,
+                        genreRepo = genreRepo,
+                        accessPolicy = BookAccessPolicy(db.sql, db.driver),
+                        permissionPolicy = UserPermissionPolicy(db.sql),
+                        principal = PrincipalProvider { UserPrincipal(UserId("test-admin"), SessionId("s"), UserRole.ROOT) },
+                    )
+                runTest {
+                    val existing = seriesRepo.resolveOrCreate("The Cosmere")
+                    repo.upsert(bookFixture(id = "b1", title = "The Way of Kings"))
+                    val preCount = seriesRepo.listLiveIds().size
+
+                    val result =
+                        service.setBookSeries(
+                            BookId("b1"),
+                            listOf(
+                                BookSeriesInput(id = null, name = "Mistborn", position = 1.0),
+                                BookSeriesInput(id = null, name = "Mistborn", position = 2.0),
+                                BookSeriesInput(id = existing, name = "The Cosmere", position = 3.0),
+                            ),
+                        )
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    // Two "Mistborn" inputs share one normalized key → exactly ONE new row created.
+                    seriesRepo.listLiveIds().size shouldBe preCount + 1
+
+                    // The book_series junction PK is (book_id, series_id), and replaceSeries
+                    // distinctBy { it.id } — so the two same-id "Mistborn" memberships collapse
+                    // to one, keeping the first (sequence "1.0", ordinal 0). Cosmere follows.
+                    val updated = repo.findById(BookId("b1"))!!
+                    updated.series shouldHaveSize 2
+                    updated.series[0].name shouldBe "Mistborn"
+                    updated.series[0].sequence shouldBe "1.0"
+                    updated.series[1].id shouldBe existing.value
+                    updated.series[1].name shouldBe "The Cosmere"
+                    updated.series[1].sequence shouldBe "3.0"
+                }
+            }
+        }
     })
 
 private fun bookFixture(


### PR DESCRIPTION
## What
The book-edit path resolved related entities one row at a time: `setBookContributors` / `setBookSeries` called `resolveOrCreate` per item, and `setBookGenres` called `findById` per genre — an N+1 query storm on each edit.

## Change (commonMain)
- **Contributors / Series** — resolve all id-less inputs in ONE `resolveOrCreateAll`, then map each input to its id via the **same dedup key** the per-item path used (`contributorDedupKey` / `normalizeForDedup`). `getValue` makes any key drift fail loudly.
- **Genres** — replace the per-input `findById` loop with one `findLiveIds` bulk read (new `selectLiveIdsByIds` SQLDelight query + `GenreRepository.findLiveIds`) + an in-order membership check, keeping the first-unknown-genre error byte-identical.

Ids, ordering, duplicate-collapse, and emitted sync events are unchanged — this is the edit path (low frequency), so honest impact is MED.

## Tests
4 new characterization cases across the real `BookServiceImplSet{Contributors,Series,Genres}Test` harnesses (duplicate-name collapse, mixed existing-by-id + new-by-name order/id preservation, first-unknown-genre-in-input-order). They pass on **both** the pre-edit baseline and the post-edit code — proving behavior equivalence. (One test assumption was corrected via baseline-first TDD: the series junction already collapses duplicate `series_id` memberships; production behavior unchanged.)

## Verification
`:server:jvmTest` + `:server:compileKotlinLinuxX64` → BUILD SUCCESSFUL; spotless + detekt green (incl. post-038 commonMain coverage).

Batch-4 plan 045, finding H.