### PR TITLE
📝 docs: make CLAUDE.md self-contained, drop dangling doc references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 You are not here to write code. You are here to make a dent in the universe.
 
-Before anything else, read `../docs/SOUL.md`. It is the why. Everything technical follows from it.
+The *why* behind every technical rule below — internalize it before you write code. Everything technical follows from it.
 
 **ListenUp is glass.** You should look through it, not at it. The moment the user notices the app, it has failed. When playback stutters, when progress is lost, when the UI lies about what's happening — that's a promise broken. The person using this app chose to self-host because they believe their library and their experience should be truly theirs. We respect that investment by building something worthy of it.
 
-Then read `../docs/architecture/target-architecture.md` (the rubric — 13 sections, 61 rules, each source-cited) and `../docs/architecture/restoration-roadmap.md` (the sequencing guide). Understand the target. Every technical decision you make should either move the codebase closer to the rubric or hold the line where it already complies. When you're about to make a non-obvious choice, check the rubric first — if a rule exists for it, follow the rule; if you disagree with the rule, say so and cite your source.
+The canonical engineering rules are inlined below under **Key Rubric Rules (Quick Reference)** and **Error Architecture**. Understand the target. Every technical decision you make should either move the codebase closer to those rules or hold the line where it already complies. When you're about to make a non-obvious choice, check the rules first — if one exists for it, follow it; if you disagree with a rule, say so and cite your source.
 
 The SOUL's principles are not separate from the technical rules. They ARE the technical rules:
 - **"Honest over silent"** → the Error Model rule: re-throw `CancellationException`, never swallow exceptions, surface errors with `AppResult<T>` — because software that lies by omission is the deepest failure.
@@ -68,13 +68,9 @@ Before touching anything, read the surrounding code. Understand the patterns, th
 
 ### The Architecture Audit
 
-This codebase has been through a comprehensive architecture audit (2026-04-11). The audit produced:
+This codebase has been through a comprehensive architecture audit (2026-04-11). Its durable output is inlined below: the **Key Rubric Rules (Quick Reference)** and **Error Architecture** sections are the target the codebase is being restored toward.
 
-- **`../docs/architecture/target-architecture.md`** — the durable rubric. 13 sections, 61 rules. Check this before making changes.
-- **`../docs/architecture/findings/`** — per-subsystem findings. Historical record of drift at audit time.
-- **`../docs/architecture/restoration-roadmap.md`** — 9 prioritised workstreams. Each becomes its own spec → plan → execute cycle.
-
-**The rubric is the target.** If you're about to write code that violates a rubric rule, stop. Either follow the rule or present a source-cited argument for why the rule should be updated.
+**The inlined rules are the target.** If you're about to write code that violates one, stop. Either follow the rule or present a source-cited argument for why the rule should be updated.
 
 ---
 
@@ -183,7 +179,7 @@ Strict Kotlin everywhere. Types are not a formality — they are the first layer
 
 ### Key Rubric Rules (Quick Reference)
 
-These are the rules most likely to affect day-to-day work. The full rubric is in `target-architecture.md`.
+These are the rules most likely to affect day-to-day work.
 
 - **`AppResult<T>`** is the single result type for every fallible suspend function. See *Error Architecture* below.
 - **Always re-throw `CancellationException`** in catch blocks. `SyncManager` and `SearchRepositoryImpl` are the compliance references.
@@ -196,7 +192,7 @@ These are the rules most likely to affect day-to-day work. The full rubric is in
 
 ### Error Architecture
 
-Full philosophy in the parent `CLAUDE.md`. Day-to-day rules:
+Day-to-day rules:
 
 - **Fallible suspend functions return `AppResult<T>`** (`shared/.../client/core/AppResult.kt`). Not `Result<T>`, not `throw`. A small set of un-migrated APIs still throws; those files are tracked in `NoThrowsInDataLayerRule`'s `RESIDUAL_THROWS_ALLOWLIST` and migrate opportunistically as the in-place rewrite re-touches each domain.
 - **Data-layer APIs use `apiCall { ... }` / `apiCallUnit { ... }`** (in `data/remote/ApiCallHelper.kt`) at the request boundary. The Ktor plugin (`installListenUpErrorHandling`, `expectSuccess = true`) raises `ResponseException` on non-2xx; `apiCall` catches it via `suspendRunCatching` and routes through `ErrorMapper` to a typed `AppResult.Failure`. API method bodies are just request shape + a `.map { it.toDomain() }` transform on success.

--- a/iosApp/CLAUDE.md
+++ b/iosApp/CLAUDE.md
@@ -2,9 +2,8 @@
 
 Operational rules for building the native iOS client. These **override** any
 Android-shaped assumption inherited from the root `CLAUDE.md` when working under
-`iosApp/`. The *why* behind each rule, plus the shared/native boundary diagram, lives in
-[`docs/superpowers/ios-principles.md`](../../docs/superpowers/ios-principles.md) — read it
-before any non-trivial iOS work.
+`iosApp/`. The *why* behind each rule, and the shared/native boundary, are described
+inline below.
 
 > **Mental model:** iOS is its own app. It shares ListenUp's *brain* (domain, data, sync,
 > contract) and builds its own *body* (presentation + UI) the way Apple intends. We
@@ -13,9 +12,8 @@ before any non-trivial iOS work.
 ## Philosophy & parity
 
 1. **Parity with Android is a guide, not a requirement.** Implement what makes sense for
-   iOS; add where it helps, remove or fold where the platforms diverge. The
-   [iOS↔Android parity ledger](../../docs/superpowers/ios-android-parity-ledger.md) tracks
-   the gap — it informs priorities, it does not mandate 1:1 coverage.
+   iOS; add where it helps, remove or fold where the platforms diverge. Parity informs
+   priorities — it does not mandate 1:1 coverage.
 2. **Each platform is built the best, most idiomatic way for itself.** A first-class native
    experience outranks code-sharing. Sharing is the means, not the goal.
 3. **Reference Android for implementation clues only** — never look, structure, or
@@ -44,7 +42,7 @@ before any non-trivial iOS work.
    or per-platform files, and prefer organizing reusable native code so it could move into a
    Swift package/framework target consumed by `iosApp`, a future `macApp`, and `watchApp`.
    Don't build macOS/watchOS UI yet — just don't bake in assumptions that block it.
-5. **The local DB is the single source of truth (non-negotiable, from SOUL.md).** iOS reads
+5. **The local DB is the single source of truth (non-negotiable).** iOS reads
    the shared offline-first store, never the network directly. "Build it like an iOS app"
    governs presentation — it is never license to fork a parallel native networking/cache path.
 6. **Diverge in presentation, converge in contract.** If an iOS need reveals a missing
@@ -121,7 +119,7 @@ before any non-trivial iOS work.
     `.font(.system(size:))` is allowed **only** for a decorative glyph in a fixed-size container
     (a badge circle, an SF Symbol sized to its frame) and must carry a one-line
     `// decorative fixed size` comment. The conversion is a phased rollout, one area per slice —
-    `LicensesView` is the reference precedent; see `plans/README.md` for remaining areas.
+    `LicensesView` is the reference precedent.
 
 ## Media & process
 


### PR DESCRIPTION
## What
The CLAUDE.md files instructed readers to "first read" several docs that **don't exist** (`docs/SOUL.md`, `docs/architecture/target-architecture.md`, `…/restoration-roadmap.md`, `…/findings/`, `docs/superpowers/ios-*.md`). This makes each CLAUDE.md self-contained — a developer can follow it with no other file open.

## Changes (pointer surgery — no substantive content removed)
- **`client/CLAUDE.md`** — the "read SOUL.md / read the 61-rule rubric" pointers now reference the **inlined** *Key Rubric Rules (Quick Reference)* + *Error Architecture* sections (which already carry the load-bearing rules); the dead architecture-doc bullets are collapsed into the durable instruction.
- **`iosApp/CLAUDE.md`** — drops the missing `ios-principles.md` + parity-ledger pointers (the standalone statements remain); "from SOUL.md" → "(non-negotiable)".
- **`sharedUI/CLAUDE.md`** — unchanged (had no dangling refs).

A parent project file (`/home/simonh/Code/listenup/CLAUDE.md`) is **outside any git repo**, so its two stale pointers were fixed in place and are **not** part of this PR.

## Verify
`grep -nE 'SOUL\.md|docs/architecture|target-architecture|restoration-roadmap|ios-principles|parity-ledger'` → 0 matches across all CLAUDE.md files; every surviving `.md` reference resolves to a file that exists.

Batch-4 plan 052 (user-directed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)