### PR TITLE
♻️ refactor(server): drop dead @OptIn + re-throw CancellationException on shutdown

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -394,13 +394,28 @@ private fun Application.installGracefulShutdown(applicationScope: CoroutineScope
     val watcherSupervisor = koinGet<WatcherSupervisorPort>()
     val databaseHandle = koinGet<DatabaseHandle>()
     monitor.subscribe(ApplicationStopped) {
+        // Best-effort, sequential shutdown (real stop + every testApplication teardown). Each step
+        // re-throws CancellationException via logShutdownFailure (honest-over-silent) — see its doc.
         runCatching { runBlocking { watcherSupervisor.unmountAll() } }
-            .onFailure { logger.warn(it) { "watcher unmount on shutdown failed" } }
+            .onFailure { logShutdownFailure(it, "watcher unmount on shutdown failed") }
         runCatching { applicationScope.cancel("application stopped") }
-            .onFailure { logger.warn(it) { "background-scope cancel on shutdown failed" } }
+            .onFailure { logShutdownFailure(it, "background-scope cancel on shutdown failed") }
         runCatching { databaseHandle.close() }
-            .onFailure { logger.warn(it) { "db pool close on shutdown failed" } }
+            .onFailure { logShutdownFailure(it, "db pool close on shutdown failed") }
     }
+}
+
+/**
+ * Logs a best-effort shutdown-step failure, but re-throws `CancellationException` (honest-over-silent).
+ * A cancellation reaching the synchronous [ApplicationStopped] callback means the process/test is being
+ * torn down, so aborting the remaining best-effort steps is correct.
+ */
+private fun logShutdownFailure(
+    throwable: Throwable,
+    message: String,
+) {
+    if (throwable is kotlinx.coroutines.CancellationException) throw throwable
+    logger.warn(throwable) { message }
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/RefreshTokenHasher.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/RefreshTokenHasher.kt
@@ -26,7 +26,6 @@ class RefreshTokenHasher(
             .decodeFromByteArrayBlocking(HMAC.Key.Format.RAW, pepper.copyOf())
 
     /** Returns lowercase hex of the HMAC-SHA-256 digest (64 chars). */
-    @OptIn(ExperimentalStdlibApi::class)
     fun hash(token: String): String =
         key
             .signatureGenerator()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/BackupArchiveCompatTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/BackupArchiveCompatTest.kt
@@ -14,7 +14,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
-@OptIn(ExperimentalStdlibApi::class)
 class BackupArchiveCompatTest :
     FunSpec({
 


### PR DESCRIPTION
## What
Two small correctness/modernity cleanups (the 2 surviving items of the audit's cleanup bundle; the other two findings were verified not-an-issue):

1. **Dead `@OptIn(ExperimentalStdlibApi)` removed** in `RefreshTokenHasher.kt` + `BackupArchiveCompatTest.kt` — `.toHexString()` is stable in Kotlin 2.4.0.
2. **`installGracefulShutdown` now re-throws `CancellationException`** before logging in all 3 shutdown `onFailure` blocks (the honest-over-silent rule — never swallow cancellation).

## Note on shape
The literal 3-inline-`throw` form tripped detekt's `ThrowsCount` (max 2/function) — which now lints `:server` commonMain after #934. Since `@file:Suppress` is banned, the repeated "re-throw cancellation else log" idiom is consolidated into one private `logShutdownFailure(throwable, message)` helper. Behavior is identical (CancellationException re-thrown; other throwables logged via the same 3 messages, same order, same best-effort semantics) and it's DRY.

## Verification
`./gradlew detekt spotlessCheck :server:jvmTest` (against the current Gradle-9.6.1 main) → BUILD SUCCESSFUL; the shutdown path runs cleanly in every `testApplication` teardown. `:server:compileKotlinLinuxX64` green (commonMain still compiles native).

Batch-4 plan 048, findings: obsolete `@OptIn` + swallowed `CancellationException`. (`upsertFromAnalyzed`'s param list is deferred to plan 047's decomposition.)