### PR TITLE
✅ test(server): pin RpcRoutes jvm/native actuals byte-identical (drift-guard)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.kt
@@ -49,5 +49,13 @@ internal inline fun <reified T : Any> KrpcRoute.registerScoped(crossinline scope
  * via `AppResult<T>` returns; the guard catches anything that *escapes* a
  * service (bugs, infra faults), logs it server-side with the correlation id,
  * and returns a sanitized `InternalError`. Stacktraces never cross the wire.
+ *
+ * **Why `expect`/`actual` and not a single commonMain body:** the `guard` dispatcher and the
+ * `<Service>Guarded` decorators are KSP-generated PER-TARGET into `:contract`'s jvm + linuxX64
+ * compilations (see `contract/build.gradle.kts` `kspJvm`/`kspLinuxX64`), deliberately kept out of
+ * `:contract` commonMain to avoid forcing Apple actuals + Swift-export pollution. `guard(...)` is
+ * therefore NOT resolvable from `:server` commonMain, so the body must live in each per-target
+ * `actual`. The jvm and linuxX64 actuals are byte-identical and pinned that way by
+ * `RpcRoutesActualsParityTest`; edit them together.
  */
 expect fun Route.rpcRoutes(services: RpcServices)

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt
@@ -59,6 +59,8 @@ import kotlinx.rpc.krpc.serialization.json.json
 import kotlinx.rpc.registerService
 
 actual fun Route.rpcRoutes(services: RpcServices) {
+    // MUST stay byte-identical to the sibling actual (jvm ↔ linuxX64). See RpcRoutes.kt KDoc and
+    // RpcRoutesActualsParityTest. guard(...) is generated per-target, so the body can't move to commonMain.
     publicRpc(services)
     authenticate(JWT_PROVIDER) { authedRpc(services) }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/RpcRoutesActualsParityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/RpcRoutesActualsParityTest.kt
@@ -1,0 +1,34 @@
+package com.calypsan.listenup.server.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+/**
+ * Pins `RpcRoutes.jvm.kt` and `RpcRoutes.linuxX64.kt` byte-identical. They are per-target `actual`s only
+ * because the KSP-generated `guard(...)` is commonMain-invisible (generated per-target into :contract);
+ * see RpcRoutes.kt. Nothing else forces them to match, so this guard catches silent drift between the
+ * JVM and native RPC mounts. If you intentionally change one, change the other identically.
+ */
+class RpcRoutesActualsParityTest :
+    FunSpec({
+        test("RpcRoutes jvm and linuxX64 actuals are byte-identical") {
+            val jvmFile =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .first {
+                        it.path.endsWith(
+                            "/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt",
+                        )
+                    }
+            val jvmText = File(jvmFile.path).readText()
+            val nativePath =
+                jvmFile.path
+                    .replace("/jvmMain/", "/linuxX64Main/")
+                    .replace("RpcRoutes.jvm.kt", "RpcRoutes.linuxX64.kt")
+            val nativeText = File(nativePath).readText()
+            nativeText shouldBe jvmText
+        }
+    })

--- a/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.linuxX64.kt
+++ b/server/src/linuxX64Main/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.linuxX64.kt
@@ -59,6 +59,8 @@ import kotlinx.rpc.krpc.serialization.json.json
 import kotlinx.rpc.registerService
 
 actual fun Route.rpcRoutes(services: RpcServices) {
+    // MUST stay byte-identical to the sibling actual (jvm ↔ linuxX64). See RpcRoutes.kt KDoc and
+    // RpcRoutesActualsParityTest. guard(...) is generated per-target, so the body can't move to commonMain.
     publicRpc(services)
     authenticate(JWT_PROVIDER) { authedRpc(services) }
 }


### PR DESCRIPTION
## What
`RpcRoutes.jvm.kt` and `RpcRoutes.linuxX64.kt` are byte-identical 124-line actuals — but they **can't** be hoisted to commonMain: the `guard()`/`<Service>Guarded` decorators they call are KSP-generated **per-target** into `:contract`'s jvm + linuxX64 compilations (kept out of commonMain to avoid Apple actuals / Swift-export pollution), so `guard(...)` is invisible from commonMain. The honest fix for the duplication is a drift-guard, not a hoist.

## Change
- A Kotest test (`RpcRoutesActualsParityTest`, `:server:jvmTest`) that reads both actuals and asserts they're byte-identical — so any future edit to one that isn't mirrored to the other fails the build.
- Explanatory KDoc on the `expect` + a 2-line comment in each actual documenting why the per-target split is mandatory.

## Verification
The test passes; **proven to guard** — perturbing the native file (one trailing blank line) makes it `BUILD FAILED` with an assertion error; reverted to byte-identity. `:server:jvmTest --tests "*RpcRoutesActualsParityTest*"` + spotless + detekt → BUILD SUCCESSFUL.

Batch-4 plan 044, finding G (reframed: pin, don't hoist).