### PR TITLE
🐳 build(server): two-stage distroless native image (~58 MB, −48%)

### DIFF
--- a/server/Dockerfile.native
+++ b/server/Dockerfile.native
@@ -1,14 +1,29 @@
-# Runtime image for the Kotlin/Native server binary (server.kexe), built on the runner by
-# :server:linkReleaseExecutableLinuxX64 and copied in here. Base pinned to ubuntu:24.04 to match
-# the ubuntu-24.04 builder's glibc; the binary dynamically links libargon2 + libsqlite3, so their
-# runtime shared objects are installed below.
-FROM ubuntu:24.04
+# Two-stage runtime image for the Kotlin/Native server.kexe.
+# We COMPILE a modern SQLite (>= 3.43, FTS5+JSON1) inside a debian:12 builder so the server's SQLite is
+# pinned and links the same glibc (2.36) the distroless base provides — NOT the base's 3.40.1, which is
+# too old for migration V9's contentless_delete=1 (added in SQLite 3.43.0). Static-linking is not an
+# option (K/N can't link host-built .a archives; no musl target) — see docs/plans/050 §5.
+FROM debian:12-slim AS libs
+ARG SQLITE_AMALGAMATION_URL=https://www.sqlite.org/2024/sqlite-amalgamation-3450000.zip
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libargon2-1 libsqlite3-0 \
+    && apt-get install -y --no-install-recommends \
+        gcc libc6-dev ca-certificates curl unzip libargon2-1 \
     && rm -rf /var/lib/apt/lists/*
-RUN useradd -r -u 10001 listenup
+WORKDIR /build
+RUN curl -fsSL -o amalg.zip "$SQLITE_AMALGAMATION_URL" \
+    && unzip -q amalg.zip \
+    && cd sqlite-amalgamation-* \
+    && gcc -O2 -fPIC -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_JSON1 \
+        -shared -o /build/libsqlite3.so.0 sqlite3.c \
+    && cat sqlite3.h | grep -m1 '#define SQLITE_VERSION ' \
+    && awk '/#define SQLITE_VERSION_NUMBER/ { if ($3 < 3043000) { print "SQLite too old: " $3; exit 1 } }' sqlite3.h
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+# libcrypt.so.1 is NOT in distroless/cc (Debian split it out of glibc into libcrypt1); the binary links
+# crypt(3). libsqlite3.so.0 is our self-built modern build. libargon2.so.1 is debian's.
+COPY --from=libs /build/libsqlite3.so.0                     /usr/lib/x86_64-linux-gnu/
+COPY --from=libs /usr/lib/x86_64-linux-gnu/libargon2.so.1   /usr/lib/x86_64-linux-gnu/
+COPY --from=libs /usr/lib/x86_64-linux-gnu/libcrypt.so.1    /usr/lib/x86_64-linux-gnu/
 COPY server-binary /usr/local/bin/listenup-server
-RUN chmod +x /usr/local/bin/listenup-server
-USER 10001
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/listenup-server"]

--- a/server/scripts/serve-smoke.sh
+++ b/server/scripts/serve-smoke.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Boots the given image and proves the server reaches a healthy /healthz — which transitively proves
+# migration V9 (FTS5 contentless_delete, SQLite >= 3.43) applied, since migrations run at boot before
+# /healthz serves. A too-old SQLite dies at V9 and /healthz never returns 200.
+# Usage: serve-smoke.sh <image-ref> [docker-run-platform-flag]
+set -euo pipefail
+IMAGE="${1:?usage: serve-smoke.sh <image> [--platform linux/arm64]}"
+PLATFORM_FLAG="${2:-}"
+NAME="lu-smoke-$$"
+HOST_PORT=18080
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# --tmpfs /data gives a world-writable dir so the non-root (uid 65532) server can mkdir LISTENUP_HOME.
+docker run -d --name "$NAME" $PLATFORM_FLAG \
+    --tmpfs /data \
+    -e LISTENUP_HOME=/data \
+    -e PORT=8080 \
+    -p "${HOST_PORT}:8080" \
+    "$IMAGE" >/dev/null
+
+ok=""
+for _ in $(seq 1 60); do
+    if curl -fsS "http://localhost:${HOST_PORT}/healthz" 2>/dev/null | grep -q '"status":"ok"'; then
+        ok=1; break
+    fi
+    sleep 2
+done
+
+echo "----- container logs -----"
+docker logs "$NAME" 2>&1 | tail -40
+
+if [ -z "$ok" ]; then
+    echo "SMOKE FAILED: /healthz never returned 200 within 120s" >&2
+    exit 1
+fi
+# Defensive: assert migration V9 did not fail (the exact failure 050 §4 documented).
+if docker logs "$NAME" 2>&1 | grep -qiE 'contentless_delete|Migration V9.*fail'; then
+    echo "SMOKE FAILED: migration V9 error in logs (SQLite too old?)" >&2
+    exit 1
+fi
+echo "SMOKE OK: /healthz=200 and no V9 migration failure"


### PR DESCRIPTION
## What
Replace the `ubuntu:24.04` single-stage server image with a lean two-stage distroless build. **Measured: 58.3 MB vs ~113 MB (−48.4%)**, smaller attack surface (no shell, no apt).

## How (the non-obvious part)
- **`debian:12-slim` builder compiles SQLite 3.45** (FTS5+JSON1) to `libsqlite3.so.0`, with a `≥ 3.43` version assert. This is required, not cosmetic: migration V9 (FTS5 `contentless_delete=1`) needs SQLite ≥ 3.43, but distroless-debian12 ships **3.40.1**, and copying ubuntu's 3.45 `.so` fails on glibc skew (needs 2.38 > distroless 2.36). So SQLite is **compiled in-build**, never copied from a distro.
- **Runtime = `gcr.io/distroless/cc-debian12:nonroot`** copying the self-built `libsqlite3.so.0` + `libargon2.so.1` + `libcrypt.so.1` (the last is split out of glibc on Debian and absent from distroless/cc).
- **Static-linking is off the table** (K/N can't link host-built `.a` archives; no musl target — see spike 050).
- New `server/scripts/serve-smoke.sh` — boots the container and proves migration V9 applies (not just `/healthz`, which would miss a SQLite-version failure).

## Verification
`docker build` → image boots, `GET /healthz → 200`, no V9/`contentless_delete` failure in logs (migrations run at boot before `/healthz` serves). `:server:linkReleaseExecutableLinuxX64` green.

Batch-4 plan **053 Phase A** (follow-up to spikes 049+050). Phase B (arm64) + Phase C (multi-arch CI) are separate PRs.