### PR TITLE
✨ feat: Library Settings admin screen — editable scan folders (Android + iOS)

### DIFF
--- a/iosApp/ListenUp/Core/Dependencies.swift
+++ b/iosApp/ListenUp/Core/Dependencies.swift
@@ -119,6 +119,7 @@ final class Dependencies {
     func createAdminViewModel() -> AdminViewModel { KoinHelper.shared.getAdminViewModel() }
     func createAdminInboxViewModel() -> AdminInboxViewModel { KoinHelper.shared.getAdminInboxViewModel() }
     func createAdminSettingsViewModel() -> AdminSettingsViewModel { KoinHelper.shared.getAdminSettingsViewModel() }
+    func createLibrarySettingsViewModel() -> LibrarySettingsViewModel { KoinHelper.shared.getLibrarySettingsViewModel() }
     func createCreateInviteViewModel() -> CreateInviteViewModel { KoinHelper.shared.getCreateInviteViewModel() }
     func createABSImportHubViewModel() -> ABSImportHubViewModel { KoinHelper.shared.getABSImportHubViewModel() }
     func createImportFlowViewModel() -> ImportFlowViewModel { KoinHelper.shared.getImportFlowViewModel() }

--- a/iosApp/ListenUp/Features/Admin/AdminView.swift
+++ b/iosApp/ListenUp/Features/Admin/AdminView.swift
@@ -264,6 +264,16 @@ struct AdminView: View {
         VStack(alignment: .leading, spacing: 0) {
             AdminSectionHeader(String(localized: "admin.management"))
             VStack(spacing: 0) {
+                NavigationLink(value: LibrarySettingsDestination()) {
+                    NavigationActionRow(
+                        systemImage: "externaldrive.fill",
+                        tint: .luTint,
+                        title: String(localized: "admin.library_settings"),
+                        subtitle: String(localized: "admin.library_settings_subtitle")
+                    )
+                }
+                .buttonStyle(.plain)
+                rowSeparator
                 NavigationActionRow(
                     systemImage: "person.2.fill",
                     tint: .luTint,

--- a/iosApp/ListenUp/Features/Admin/LibrarySettings/LibrarySettingsObserver.swift
+++ b/iosApp/ListenUp/Features/Admin/LibrarySettings/LibrarySettingsObserver.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Shared
+
+/// Observes `LibrarySettingsViewModel` — flattens the sealed `LibrarySettingsUiState`
+/// into a SwiftUI-native `LibrarySettingsPhase` (`loading` / `ready` / `error`) and maps the
+/// bridged Kotlin folder + directory lists into native value types at this boundary, so the
+/// view never feeds a Swift-Export-bridged object into a `ForEach` (iosApp rule 8).
+///
+/// Errors are mapped once here (per iosApp rule 10): the terminal `Error` case becomes an
+/// `error(String)` phase, and the transient `Ready.error` becomes `Ready.transientError`.
+///
+/// Thin over `FlowBridge`, mirroring `AdminObserver` / `LibrarySetupViewModelWrapper`.
+@Observable
+@MainActor
+final class LibrarySettingsObserver {
+    // MARK: - State
+
+    private(set) var phase: LibrarySettingsPhase = .loading
+
+    // MARK: - Dependencies
+
+    /// Optional so the bridge-free test initializer can drive `apply` without a live KMP VM;
+    /// production always wires it. Action methods are safe no-ops when nil.
+    private let viewModel: LibrarySettingsViewModel?
+    private let bridge = FlowBridge()
+
+    // MARK: - Init
+
+    init(viewModel: LibrarySettingsViewModel) {
+        self.viewModel = viewModel
+        bridge.bind(viewModel.state) { [weak self] in self?.apply($0) }
+    }
+
+    /// Bridge-free initializer for observer-level unit tests. Skips flow binding so the
+    /// stateful mapping (`apply`) can be driven directly without a live KMP ViewModel.
+    init() {
+        self.viewModel = nil
+    }
+
+    deinit { bridge.cancelAll() }   // cancelAll() is nonisolated-safe; see FlowBridge.
+
+    // MARK: - Actions
+
+    func addFolder(_ path: String) { viewModel?.addScanPath(path: path) }
+    func removeFolder(id: String) { viewModel?.removeFolder(folderId: id) }
+    func rescan() { viewModel?.triggerScan() }
+    func showFolderBrowser(_ show: Bool) { viewModel?.setShowFolderBrowser(show: show) }
+    func openBrowserDirectory(_ path: String) { viewModel?.loadBrowserDirectory(path: path) }
+    func browserNavigateUp() { viewModel?.browserNavigateUp() }
+    func clearError() { viewModel?.clearError() }
+
+    // MARK: - State mapping
+
+    /// Internal (not private) so observer-level tests can drive the mapping directly.
+    func apply(_ state: LibrarySettingsUiState) {
+        switch onEnum(of: state) {
+        case .loading:
+            phase = .loading
+        case .ready(let ready):
+            phase = .ready(LibrarySettingsReadyModel(from: ready))
+        case .error(let error):
+            phase = .error(error.error.message)
+        case .unknown:
+            Log.error("Unexpected LibrarySettingsUiState case")
+            phase = .loading
+        }
+    }
+}
+
+// MARK: - Phase
+
+/// Flattened library-settings state for a SwiftUI `switch`.
+enum LibrarySettingsPhase {
+    case loading
+    case ready(LibrarySettingsReadyModel)
+    case error(String)
+}
+
+// MARK: - Ready model
+
+/// The fully-flattened `Ready` snapshot the screen renders. All bridged Kotlin lists are
+/// mapped to native value types here so the view's `ForEach`es never touch a bridged object.
+struct LibrarySettingsReadyModel: Equatable {
+    let folders: [LibraryFolderRowModel]
+    /// The last live folder can't be removed (a library must keep at least one scan path).
+    let canRemoveFolders: Bool
+    let isSaving: Bool
+    let isScanning: Bool
+    /// A transient mutation failure, surfaced as a dismissible alert.
+    let transientError: String?
+
+    // Folder browser overlay
+    let showFolderBrowser: Bool
+    let isBrowserLoading: Bool
+    let browserPath: String
+    let browserParent: String?
+    let browserEntries: [BrowserEntryModel]
+    let browserIsRoot: Bool
+
+    init(from ready: LibrarySettingsUiStateReady) {
+        self.folders = ready.library.folders.map(LibraryFolderRowModel.init(from:))
+        self.canRemoveFolders = ready.library.folders.count > 1
+        self.isSaving = ready.isSaving
+        self.isScanning = ready.isScanning
+        self.transientError = ready.error?.message
+        self.showFolderBrowser = ready.showFolderBrowser
+        self.isBrowserLoading = ready.isBrowserLoading
+        self.browserPath = ready.browserPath
+        self.browserParent = ready.browserParent
+        self.browserEntries = ready.browserEntries.map(BrowserEntryModel.init(from:))
+        self.browserIsRoot = ready.browserIsRoot
+    }
+}
+
+// MARK: - Row models
+
+/// One library scan folder, flattened for SwiftUI display.
+struct LibraryFolderRowModel: Identifiable, Equatable {
+    let id: String
+    /// The folder's root path, falling back to its id when the server redacted the path.
+    /// (Non-admins never reach this screen, so in practice this is always the real path.)
+    let displayPath: String
+
+    init(from folder: LibraryFolderRef) {
+        self.id = folder.id
+        self.displayPath = folder.rootPath ?? folder.id
+    }
+
+    init(id: String, displayPath: String) {
+        self.id = id
+        self.displayPath = displayPath
+    }
+}
+
+/// One server-side directory in the folder browser, flattened for SwiftUI display.
+struct BrowserEntryModel: Identifiable, Equatable {
+    var id: String { path }
+    let name: String
+    let path: String
+
+    init(from entry: DirectoryEntryResponse) {
+        self.name = entry.name
+        self.path = entry.path
+    }
+
+    init(name: String, path: String) {
+        self.name = name
+        self.path = path
+    }
+}

--- a/iosApp/ListenUp/Features/Admin/LibrarySettings/LibrarySettingsView.swift
+++ b/iosApp/ListenUp/Features/Admin/LibrarySettings/LibrarySettingsView.swift
@@ -1,0 +1,329 @@
+import SwiftUI
+import Shared
+
+/// Library Settings — the admin surface for managing the single library's scan folders and
+/// triggering a rescan. Reached from Administration › Management.
+///
+/// Mirrors `AdminView`'s structure: grouped `.fieldCard()` sections under `AdminSectionHeader`
+/// overlines, built on the native design system. The shared `LibrarySettingsViewModel` is
+/// bridged through `LibrarySettingsObserver`, which flattens its state into native value types.
+struct LibrarySettingsView: View {
+    @Environment(\.dependencies) private var deps
+
+    @State private var observer: LibrarySettingsObserver?
+    @State private var pendingRemove: LibraryFolderRowModel?
+
+    var body: some View {
+        Group {
+            if let observer {
+                content(observer)
+            } else {
+                LoadingStateView()
+            }
+        }
+        .background(Color.luSurface)
+        .navigationTitle(String(localized: "admin.library_settings"))
+        .navigationBarTitleDisplayMode(.large)
+        .onAppear {
+            if observer == nil {
+                observer = LibrarySettingsObserver(viewModel: deps.createLibrarySettingsViewModel())
+            }
+        }
+    }
+
+    // MARK: - Phase routing
+
+    @ViewBuilder
+    private func content(_ observer: LibrarySettingsObserver) -> some View {
+        switch observer.phase {
+        case .loading:
+            LoadingStateView()
+        case .error(let message):
+            ContentUnavailableView(
+                String(localized: "common.something_went_wrong"),
+                systemImage: "exclamationmark.triangle",
+                description: Text(message)
+            )
+        case .ready(let model):
+            ready(model, observer: observer)
+        }
+    }
+
+    // MARK: - Ready
+
+    private func ready(_ model: LibrarySettingsReadyModel, observer: LibrarySettingsObserver) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                scanPathsSection(model, observer: observer)
+                rescanSection(model, observer: observer)
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 20)
+            // Reading-width cap so the form stays comfortable on iPad / wide Split View
+            // instead of stretching a phone layout across the full width.
+            .frame(maxWidth: 640, alignment: .leading)
+            .frame(maxWidth: .infinity)
+        }
+        .sheet(isPresented: browserBinding(observer)) {
+            FolderBrowserSheet(observer: observer)
+        }
+        .alert(
+            String(localized: "admin.remove_scan_path"),
+            isPresented: removeBinding,
+            presenting: pendingRemove
+        ) { folder in
+            Button(String(localized: "common.remove"), role: .destructive) {
+                observer.removeFolder(id: folder.id)
+                pendingRemove = nil
+            }
+            Button(String(localized: "common.cancel"), role: .cancel) { pendingRemove = nil }
+        } message: { folder in
+            Text(String(format: String(localized: "admin.remove_path_from_library_scan"), folder.displayPath))
+        }
+        .alert(
+            String(localized: "common.something_went_wrong"),
+            isPresented: transientErrorBinding(model, observer: observer),
+            presenting: model.transientError
+        ) { _ in
+            Button(String(localized: "common.ok"), role: .cancel) { observer.clearError() }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    // MARK: - Scan paths
+
+    private func scanPathsSection(_ model: LibrarySettingsReadyModel, observer: LibrarySettingsObserver) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            AdminSectionHeader(String(localized: "admin.scan_paths"))
+            VStack(spacing: 0) {
+                ForEach(model.folders) { folder in
+                    folderRow(folder, model: model)
+                    rowSeparator
+                }
+                addFolderRow(model, observer: observer)
+            }
+            .fieldCard()
+        }
+    }
+
+    private func folderRow(_ folder: LibraryFolderRowModel, model: LibrarySettingsReadyModel) -> some View {
+        HStack(spacing: 13) {
+            IconTile(systemImage: "folder.fill", tint: .luTint)
+            Text(folder.displayPath)
+                .font(.callout.monospaced())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.head)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if model.canRemoveFolders && !model.isSaving {
+                Button {
+                    pendingRemove = folder
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "admin.remove_path"))
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+    }
+
+    private func addFolderRow(_ model: LibrarySettingsReadyModel, observer: LibrarySettingsObserver) -> some View {
+        Button {
+            observer.showFolderBrowser(true)
+        } label: {
+            HStack(spacing: 13) {
+                IconTile(systemImage: "plus", tint: .luTint)
+                Text(String(localized: "admin.add_folder"))
+                    .font(.body)
+                    .foregroundStyle(Color.luTint)
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(model.isSaving)
+    }
+
+    // MARK: - Rescan
+
+    private func rescanSection(_ model: LibrarySettingsReadyModel, observer: LibrarySettingsObserver) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            AdminSectionHeader(String(localized: "admin.scanning"))
+            Button {
+                observer.rescan()
+            } label: {
+                HStack(spacing: 13) {
+                    IconTile(systemImage: "arrow.clockwise", tint: .luTint)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(String(localized: "admin.rescan_library"))
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                        Text(String(localized: "admin.scan_all_paths_for_new"))
+                            .font(.footnote)
+                            .foregroundStyle(Color.luLabel2)
+                            .multilineTextAlignment(.leading)
+                    }
+                    Spacer(minLength: 12)
+                    if model.isScanning {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 11)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(model.isScanning)
+            .fieldCard()
+        }
+    }
+
+    // MARK: - Shared chrome
+
+    private var rowSeparator: some View {
+        Rectangle()
+            .fill(Color.luSeparator)
+            .frame(height: 0.5)
+            .padding(.leading, 61)
+    }
+
+    // MARK: - Bindings
+
+    private func browserBinding(_ observer: LibrarySettingsObserver) -> Binding<Bool> {
+        Binding(
+            get: {
+                if case .ready(let model) = observer.phase { return model.showFolderBrowser }
+                return false
+            },
+            set: { presenting in if !presenting { observer.showFolderBrowser(false) } }
+        )
+    }
+
+    private var removeBinding: Binding<Bool> {
+        Binding(
+            get: { pendingRemove != nil },
+            set: { presenting in if !presenting { pendingRemove = nil } }
+        )
+    }
+
+    private func transientErrorBinding(
+        _ model: LibrarySettingsReadyModel,
+        observer: LibrarySettingsObserver
+    ) -> Binding<Bool> {
+        Binding(
+            get: { model.transientError != nil },
+            set: { presenting in if !presenting { observer.clearError() } }
+        )
+    }
+}
+
+// MARK: - Folder browser sheet
+
+/// A modal server-filesystem browser for adding a scan folder. Reads live browser state from
+/// the observer (so drilling in/out re-renders), then adds the current directory as a scan path.
+private struct FolderBrowserSheet: View {
+    let observer: LibrarySettingsObserver
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if case .ready(let model) = observer.phase {
+                    browser(model)
+                } else {
+                    LoadingStateView()
+                }
+            }
+            .background(Color.luSurface)
+            .navigationTitle(String(localized: "admin.select_folder"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "common.cancel")) { observer.showFolderBrowser(false) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func browser(_ model: LibrarySettingsReadyModel) -> some View {
+        VStack(spacing: 0) {
+            pathBar(model)
+            addThisFolderButton(model)
+            Divider()
+            if model.isBrowserLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else {
+                List(model.browserEntries) { entry in
+                    Button {
+                        observer.openBrowserDirectory(entry.path)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "folder")
+                                .foregroundStyle(.secondary)
+                            Text(entry.name)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    private func pathBar(_ model: LibrarySettingsReadyModel) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "folder")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Text(model.browserPath)
+                .font(.callout.monospaced())
+                .lineLimit(1)
+                .truncationMode(.head)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if !model.browserIsRoot {
+                Button {
+                    observer.browserNavigateUp()
+                } label: {
+                    Label(String(localized: "common.back"), systemImage: "arrow.up")
+                        .font(.footnote.weight(.semibold))
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.luTint)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func addThisFolderButton(_ model: LibrarySettingsReadyModel) -> some View {
+        Button {
+            observer.addFolder(model.browserPath)
+        } label: {
+            Label(String(localized: "admin.add_this_folder"), systemImage: "plus.circle.fill")
+                .font(.body.weight(.medium))
+                .foregroundStyle(Color.luTint)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(model.isSaving)
+    }
+}

--- a/iosApp/ListenUp/Features/Main/MainTabView.swift
+++ b/iosApp/ListenUp/Features/Main/MainTabView.swift
@@ -236,6 +236,9 @@ private extension View {
             .navigationDestination(for: AdminCollectionDetailDestination.self) { destination in
                 AdminCollectionDetailView(collectionId: destination.collectionId)
             }
+            .navigationDestination(for: LibrarySettingsDestination.self) { _ in
+                LibrarySettingsView()
+            }
     }
 }
 

--- a/iosApp/ListenUp/Navigation/Destinations.swift
+++ b/iosApp/ListenUp/Navigation/Destinations.swift
@@ -121,3 +121,7 @@ struct AdminCollectionsDestination: Hashable {}
 struct AdminCollectionDetailDestination: Hashable {
     let collectionId: String
 }
+
+/// The Library Settings screen (admin / root users only), reached from Administration ›
+/// Management. Manages the single library's scan folders and triggers a rescan.
+struct LibrarySettingsDestination: Hashable {}

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -861,6 +861,26 @@
         }
       }
     },
+    "admin.library_settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library Settings"
+          }
+        }
+      }
+    },
+    "admin.library_settings_subtitle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage scan folders and rescan your library"
+          }
+        }
+      }
+    },
     "admin.link_copied": {
       "localizations": {
         "en": {

--- a/iosApp/ListenUpTests/Admin/LibrarySettingsObserverTests.swift
+++ b/iosApp/ListenUpTests/Admin/LibrarySettingsObserverTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Shared
+@testable import ListenUp
+
+/// The value-type mappings the `LibrarySettingsObserver` performs at its boundary — the
+/// guard against feeding Swift-Export-bridged Kotlin objects into a `ForEach` (iosApp rule 8).
+/// Mirrors `DirectoryItemMappingTests` (the established native-mapping test style).
+@Suite("LibrarySettings folder row mapping")
+@MainActor
+struct LibraryFolderRowModelTests {
+    @Test func mapsIdAndRootPath() {
+        let model = LibraryFolderRowModel(from: LibraryFolderRef(id: "f1", rootPath: "/media/books"))
+        #expect(model.id == "f1")
+        #expect(model.displayPath == "/media/books")
+    }
+
+    @Test func fallsBackToIdWhenPathRedacted() {
+        let model = LibraryFolderRowModel(from: LibraryFolderRef(id: "f2", rootPath: nil))
+        #expect(model.id == "f2")
+        #expect(model.displayPath == "f2")
+    }
+}
+
+@Suite("LibrarySettings browser entry mapping")
+@MainActor
+struct BrowserEntryModelTests {
+    @Test func mapsNamePathAndId() {
+        let model = BrowserEntryModel(from: DirectoryEntryResponse(name: "Books", path: "/media/books"))
+        #expect(model.name == "Books")
+        #expect(model.path == "/media/books")
+        // id is derived from path so SwiftUI diffs entries by their absolute path.
+        #expect(model.id == "/media/books")
+    }
+}

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -962,6 +962,8 @@
     "invite_expires_in": "Invite expires in",
     "invite_preview": "Invite preview",
     "invite_someone": "Invite Someone",
+    "library_settings": "Library Settings",
+    "library_settings_subtitle": "Manage scan folders and rescan your library",
     "link_copied": "Link copied!",
     "listening_history": "Listening history",
     "management": "Management",

--- a/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
+++ b/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
@@ -33,6 +33,7 @@ import com.calypsan.listenup.client.presentation.admin.AdminCollectionDetailView
 import com.calypsan.listenup.client.presentation.admin.AdminCollectionsViewModel
 import com.calypsan.listenup.client.presentation.admin.AdminInboxViewModel
 import com.calypsan.listenup.client.presentation.admin.AdminSettingsViewModel
+import com.calypsan.listenup.client.presentation.admin.LibrarySettingsViewModel
 import com.calypsan.listenup.client.presentation.admin.AdminViewModel
 import com.calypsan.listenup.client.presentation.admin.CreateInviteViewModel
 import com.calypsan.listenup.client.presentation.admin.imports.ImportFlowViewModel
@@ -218,6 +219,8 @@ object KoinHelper {
     fun getAdminViewModel(): AdminViewModel = resolve(AdminViewModel::class)
 
     fun getAdminSettingsViewModel(): AdminSettingsViewModel = resolve(AdminSettingsViewModel::class)
+
+    fun getLibrarySettingsViewModel(): LibrarySettingsViewModel = resolve(LibrarySettingsViewModel::class)
 
     fun getCreateInviteViewModel(): CreateInviteViewModel = resolve(CreateInviteViewModel::class)
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/admin/ManagementSectionTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/features/admin/ManagementSectionTest.kt
@@ -1,0 +1,76 @@
+package com.calypsan.listenup.client.features.admin
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies the admin Management section surfaces a Library Settings tile and that
+ * tapping it routes to the navigation callback. This is the hub entry point that
+ * makes the (previously unreachable) [LibrarySettingsScreen] reachable.
+ *
+ * JUnit4 + Robolectric — the canonical shape for Compose UI tests in this module
+ * (a `createComposeRule()` rule requires JUnit4). `@Config(sdk = [35])` pins
+ * Robolectric to the highest SDK its release ships, and supplies the real Android
+ * resource environment so `stringResource` resolves the packaged English strings
+ * (per [com.calypsan.listenup.client.presentation.error.AppErrorLocalizationTest]).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ManagementSectionTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `library settings tile is shown`() {
+        composeRule.setContent {
+            MaterialTheme {
+                ManagementSection(
+                    onInviteClick = {},
+                    onCollectionsClick = {},
+                    onCategoriesClick = {},
+                    onBackupClick = {},
+                    onInboxClick = {},
+                    onLibrarySettingsClick = {},
+                    inboxEnabled = false,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(LIBRARY_SETTINGS_TITLE).assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the library settings tile invokes its callback`() {
+        var clicked = false
+        composeRule.setContent {
+            MaterialTheme {
+                ManagementSection(
+                    onInviteClick = {},
+                    onCollectionsClick = {},
+                    onCategoriesClick = {},
+                    onBackupClick = {},
+                    onInboxClick = {},
+                    onLibrarySettingsClick = { clicked = true },
+                    inboxEnabled = false,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(LIBRARY_SETTINGS_TITLE).performClick()
+
+        clicked shouldBe true
+    }
+
+    private companion object {
+        const val LIBRARY_SETTINGS_TITLE = "Library Settings"
+    }
+}

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/AdminEntries.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/AdminEntries.kt
@@ -66,6 +66,9 @@ internal fun EntryProviderScope<NavKey>.adminEntries(backStack: NavBackStack<Nav
             onInboxClick = {
                 backStack.add(AdminInbox)
             },
+            onLibrarySettingsClick = {
+                backStack.add(AdminLibrarySettings)
+            },
             onUserClick = { userId ->
                 backStack.add(AdminUserDetail(userId))
             },

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="admin_invite_expires_in">Invite expires in</string>
     <string name="admin_invite_preview">Invite preview</string>
     <string name="admin_invite_someone">Invite Someone</string>
+    <string name="admin_library_settings">Library Settings</string>
+    <string name="admin_library_settings_subtitle">Manage scan folders and rescan your library</string>
     <string name="admin_link_copied">Link copied!</string>
     <string name="admin_listening_history">Listening history</string>
     <string name="admin_management">Management</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.HowToReg
 import androidx.compose.material.icons.outlined.Inbox
@@ -92,6 +93,8 @@ import listenup.composeapp.generated.resources.admin_copy_link
 import listenup.composeapp.generated.resources.admin_create_backups_and_restore_server
 import listenup.composeapp.generated.resources.admin_deny_registration
 import listenup.composeapp.generated.resources.admin_invite_someone
+import listenup.composeapp.generated.resources.admin_library_settings
+import listenup.composeapp.generated.resources.admin_library_settings_subtitle
 import listenup.composeapp.generated.resources.admin_link_copied
 import listenup.composeapp.generated.resources.admin_management
 import listenup.composeapp.generated.resources.admin_no_pending_registrations
@@ -142,6 +145,7 @@ fun AdminScreen(
     onCategoriesClick: () -> Unit = {},
     onBackupClick: () -> Unit = {},
     onInboxClick: () -> Unit = {},
+    onLibrarySettingsClick: () -> Unit = {},
     onUserClick: (String) -> Unit = {},
     serverName: String = "",
     onServerNameChange: (String) -> Unit = {},
@@ -226,6 +230,7 @@ fun AdminScreen(
                     onCategoriesClick = onCategoriesClick,
                     onBackupClick = onBackupClick,
                     onInboxClick = onInboxClick,
+                    onLibrarySettingsClick = onLibrarySettingsClick,
                     serverName = serverName,
                     onServerNameChange = onServerNameChange,
                     remoteUrl = remoteUrl,
@@ -325,6 +330,7 @@ private fun AdminContent(
     onCategoriesClick: () -> Unit,
     onBackupClick: () -> Unit,
     onInboxClick: () -> Unit,
+    onLibrarySettingsClick: () -> Unit,
     serverName: String,
     onServerNameChange: (String) -> Unit,
     remoteUrl: String,
@@ -353,6 +359,7 @@ private fun AdminContent(
             onCategoriesClick = onCategoriesClick,
             onBackupClick = onBackupClick,
             onInboxClick = onInboxClick,
+            onLibrarySettingsClick = onLibrarySettingsClick,
             serverName = serverName,
             onServerNameChange = onServerNameChange,
             remoteUrl = remoteUrl,
@@ -401,6 +408,7 @@ private fun AdminContent(
                     onCategoriesClick = onCategoriesClick,
                     onBackupClick = onBackupClick,
                     onInboxClick = onInboxClick,
+                    onLibrarySettingsClick = onLibrarySettingsClick,
                     inboxEnabled = inboxEnabled,
                 )
             }
@@ -425,6 +433,7 @@ private fun AdminTwoPaneContent(
     onCategoriesClick: () -> Unit,
     onBackupClick: () -> Unit,
     onInboxClick: () -> Unit,
+    onLibrarySettingsClick: () -> Unit,
     serverName: String,
     onServerNameChange: (String) -> Unit,
     remoteUrl: String,
@@ -479,6 +488,7 @@ private fun AdminTwoPaneContent(
                     onCategoriesClick = onCategoriesClick,
                     onBackupClick = onBackupClick,
                     onInboxClick = onInboxClick,
+                    onLibrarySettingsClick = onLibrarySettingsClick,
                     inboxEnabled = inboxEnabled,
                 )
             }
@@ -908,12 +918,13 @@ private fun InviteRow(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun ManagementSection(
+internal fun ManagementSection(
     onInviteClick: () -> Unit,
     onCollectionsClick: () -> Unit,
     onCategoriesClick: () -> Unit,
     onBackupClick: () -> Unit,
     onInboxClick: () -> Unit,
+    onLibrarySettingsClick: () -> Unit,
     inboxEnabled: Boolean,
 ) {
     val colors = MaterialTheme.colorScheme
@@ -924,6 +935,15 @@ private fun ManagementSection(
             fontWeight = FontWeight.Bold,
             color = colors.onSurface,
             modifier = Modifier.padding(start = 4.dp, bottom = 4.dp),
+        )
+        ActionTile(
+            title = stringResource(Res.string.admin_library_settings),
+            subtitle = stringResource(Res.string.admin_library_settings_subtitle),
+            icon = Icons.Outlined.FolderOpen,
+            onClick = onLibrarySettingsClick,
+            containerColor = colors.secondaryContainer,
+            badgeColor = colors.secondary,
+            badgeContentColor = colors.onSecondary,
         )
         if (inboxEnabled) {
             ActionTile(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/LibrarySettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/LibrarySettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,10 +17,10 @@ import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BasicAlertDialog
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -44,8 +43,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.calypsan.listenup.client.design.components.ColorBlockHero
 import com.calypsan.listenup.client.design.components.FullScreenLoadingIndicator
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicatorSmall
+import com.calypsan.listenup.client.design.components.SectionGroup
+import com.calypsan.listenup.client.design.components.SettingRow
 import com.calypsan.listenup.client.domain.model.LibraryFolderRef
 import com.calypsan.listenup.client.presentation.admin.LibrarySettingsUiState
 import com.calypsan.listenup.client.presentation.admin.LibrarySettingsViewModel
@@ -54,6 +56,7 @@ import com.calypsan.listenup.client.presentation.error.localizedString
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.admin_add_folder
 import listenup.composeapp.generated.resources.admin_add_this_folder
+import listenup.composeapp.generated.resources.admin_library_settings
 import listenup.composeapp.generated.resources.admin_remove_path
 import listenup.composeapp.generated.resources.admin_remove_path_from_library_scan
 import listenup.composeapp.generated.resources.admin_remove_scan_path
@@ -93,18 +96,13 @@ fun LibrarySettingsScreen(
         }
     }
 
-    val topBarTitle = "Library Settings"
-
     ListenUpScaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(
-                title = { Text(topBarTitle) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Outlined.ArrowBack, "Back")
-                    }
-                },
+            ColorBlockHero(
+                title = stringResource(Res.string.admin_library_settings),
+                badgeIcon = Icons.Outlined.FolderOpen,
+                onBack = onBackClick,
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -167,64 +165,6 @@ private fun LibrarySettingsContent(
     modifier: Modifier = Modifier,
 ) {
     val library = state.library
-
-    LazyColumn(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp),
-    ) {
-        // Scan paths section
-        item {
-            Text(
-                text = stringResource(Res.string.admin_scan_paths),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
-            )
-        }
-
-        item {
-            ScanPathsCard(
-                folders = library.folders,
-                isSaving = state.isSaving,
-                onRemoveFolder = onRemoveFolder,
-                onAddFolder = onAddFolder,
-            )
-        }
-
-        // Rescan section
-        item {
-            Spacer(modifier = Modifier.height(24.dp))
-            Text(
-                text = stringResource(Res.string.admin_scanning),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(bottom = 8.dp),
-            )
-        }
-
-        item {
-            RescanCard(
-                isScanning = state.isScanning,
-                onTriggerScan = onTriggerScan,
-            )
-        }
-
-        item {
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-    }
-}
-
-@Composable
-private fun ScanPathsCard(
-    folders: List<LibraryFolderRef>,
-    isSaving: Boolean,
-    onRemoveFolder: (String) -> Unit,
-    onAddFolder: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
     var folderToRemove by remember { mutableStateOf<LibraryFolderRef?>(null) }
 
     // Confirm removal dialog
@@ -251,123 +191,68 @@ private fun ScanPathsCard(
         )
     }
 
-    ElevatedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors =
-            CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            ),
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            folders.forEachIndexed { index, folder ->
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Folder,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = folder.rootPath ?: folder.id,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.weight(1f),
-                    )
-                    if (folders.size > 1 && !isSaving) {
-                        IconButton(onClick = { folderToRemove = folder }) {
-                            Icon(
-                                imageVector = Icons.Outlined.Close,
-                                contentDescription = stringResource(Res.string.admin_remove_path),
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        }
-                    }
-                }
-                if (index < folders.lastIndex) {
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                    )
-                }
-            }
-
-            HorizontalDivider(
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-            )
-
-            // Add folder button
-            Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .clickable(enabled = !isSaving, onClick = onAddFolder)
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+        item {
+            SectionGroup(
+                label = stringResource(Res.string.admin_scan_paths),
+                icon = Icons.Outlined.Folder,
+                accent = MaterialTheme.colorScheme.secondary,
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Add,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = stringResource(Res.string.admin_add_folder),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                library.folders.forEachIndexed { index, folder ->
+                    val canRemove = library.folders.size > 1 && !state.isSaving
+                    SettingRow(
+                        title = folder.rootPath ?: folder.id,
+                        icon = Icons.Outlined.Folder,
+                        accent = MaterialTheme.colorScheme.secondary,
+                        showDivider = index > 0,
+                        trailing =
+                            if (canRemove) {
+                                {
+                                    IconButton(onClick = { folderToRemove = folder }) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Close,
+                                            contentDescription = stringResource(Res.string.admin_remove_path),
+                                            tint = MaterialTheme.colorScheme.error,
+                                        )
+                                    }
+                                }
+                            } else {
+                                null
+                            },
+                    )
+                }
+                SettingRow(
+                    title = stringResource(Res.string.admin_add_folder),
+                    icon = Icons.Outlined.Add,
+                    accent = MaterialTheme.colorScheme.primary,
+                    showDivider = true,
+                    onClick = if (state.isSaving) null else onAddFolder,
                 )
             }
         }
-    }
-}
 
-@Composable
-private fun RescanCard(
-    isScanning: Boolean,
-    onTriggerScan: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    ElevatedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        colors =
-            CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            ),
-    ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clickable(enabled = !isScanning, onClick = onTriggerScan)
-                    .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.Refresh,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(Res.string.admin_rescan_library),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.primary,
+        item {
+            SectionGroup(
+                label = stringResource(Res.string.admin_scanning),
+                icon = Icons.Outlined.Refresh,
+                accent = MaterialTheme.colorScheme.primary,
+            ) {
+                SettingRow(
+                    title = stringResource(Res.string.admin_rescan_library),
+                    subtitle = stringResource(Res.string.admin_scan_all_paths_for_new),
+                    icon = Icons.Outlined.Refresh,
+                    onClick = if (state.isScanning) null else onTriggerScan,
+                    trailing =
+                        if (state.isScanning) {
+                            { ListenUpLoadingIndicatorSmall() }
+                        } else {
+                            null
+                        },
                 )
-                Text(
-                    text = stringResource(Res.string.admin_scan_all_paths_for_new),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            if (isScanning) {
-                ListenUpLoadingIndicatorSmall()
             }
         }
     }


### PR DESCRIPTION
## What

Adds an **Admin → Library Settings** surface for managing a library's scan folders (add / remove / browse the server filesystem) and triggering a rescan — on **both** Android/Compose and iOS.

The backend + shared `LibrarySettingsViewModel` already existed; this PR surfaces it. On Android the screen was built but **unreachable** (no nav entry); on iOS it didn't exist at all.

## Android / Compose
- New **"Library Settings"** tile in the admin hub's Management section, wired to push the (previously orphaned) `AdminLibrarySettings` route.
- Rebuilt `LibrarySettingsScreen` to the sibling design language — `ColorBlockHero` header + accent-headed `SectionGroup`/`SettingRow` cards (was a plain `TopAppBar` + ad-hoc `ElevatedCard`s). Behavior unchanged.

## iOS (new screen)
- `LibrarySettingsObserver` bridges the shared VM, mapping folders/browser entries to **native value types** at the boundary (no bridged Kotlin objects in `ForEach`).
- `LibrarySettingsView` — scan-paths card (add/remove + confirm), rescan card, folder-browser sheet, in the Liquid-Glass/HIG language.
- DI seam (`KoinHelper.getLibrarySettingsViewModel` + `Dependencies.createLibrarySettingsViewModel`), `LibrarySettingsDestination` + registration, and the hub row in `AdminView`.

## Strings
Added to the canonical `sharedLogic/.../strings/en.json`, regenerating both the Android `strings.xml` and the iOS `Localizable.xcstrings`.

## Tests
- **Android**: `ManagementSectionTest` (TDD — tile renders + tap fires nav callback).
- **iOS**: 3 Swift Testing mapping tests for the observer's value-type bridging.

## Verification (local, CI-equivalent)
- ✅ `:sharedUI:testAndroidHostTest`, `:sharedLogic:jvmTest`
- ✅ `spotlessCheck`, `detekt`, `verifyStrings`, SwiftLint
- ✅ `:androidApp:assembleDebug`
- ✅ iOS app build + tests, `check-no-appresult-await`, export-surface baseline match
- ⚠️ `:server:jvmTest` — 2 `MulticastMdnsResponderTest` failures, pre-existing Mac-environmental mDNS flakes (server module untouched here)

## Scope notes
This covers **add/remove** folders. In-place **rename** (re-pointing books via the ABS-matcher logic) is a deliberate follow-up, not included here.