### PR TITLE
📝 docs: make code comments developer-directed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ Releases are explicit and manual via the **Release** workflow (`workflow_dispatc
 - **Version** lives in the `VERSION` file at the repo root (one number line). Drive Android `versionName` from it; iOS `MARKETING_VERSION` and the server image tag follow. Build numbers are auto-derived per platform (Android `versionCode` from commit count, iOS `CURRENT_PROJECT_VERSION` from the CI run number).
 - **To bump + ship:** run the Release workflow and type the new number in the `version` input (it commits `VERSION` + tags `v<x>`). Leave it blank to re-ship the current `VERSION`.
 - **Per-platform:** the `android` / `ios` / `server` checkboxes scope a run — use them for single-platform hotfixes.
-- iOS stops at **TestFlight** (no auto-submit to App Store review). Android ships to the **Play internal/draft** track. The **server** job builds a GraalVM native image to GHCR and is **non-blocking** (`continue-on-error`) until [#647](https://github.com/ListenUpApp/ListenUp/issues/647) clears.
+- iOS stops at **TestFlight** (no auto-submit to App Store review). Android ships to the **Play internal/draft** track. The **server** job links a Kotlin/Native `server.kexe` (`:server:linkReleaseExecutableLinuxX64`), packages it into a two-stage distroless image (`server/Dockerfile.native`) that compiles a modern SQLite (≥ 3.43) in-build, and pushes it to GHCR (`ghcr.io/listenupapp/listenup-server`, tagged with the version, commit SHA, and `latest`). It is a hard gate — a failed server build fails the release.
 
 ---
 

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/LibraryAdminService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/LibraryAdminService.kt
@@ -13,8 +13,7 @@ import kotlinx.rpc.annotations.Rpc
  *
  * In the single-library model there is exactly one library; all operations target
  * it without requiring a library id. Manages the library's root folders (add,
- * remove, scan) and provides onboarding helpers ([getSetupStatus], [browseFilesystem])
- * that replace the legacy `SetupApiContract` REST surface.
+ * remove, scan) and provides onboarding helpers ([getSetupStatus], [browseFilesystem]).
  *
  * The library is server-wide (cross-user). All folder-mutating methods
  * ([addFolder], [removeFolder], [scanFolder], [scanLibrary]) and the
@@ -51,8 +50,7 @@ interface LibraryAdminService {
      * Returns the current setup status — whether the server needs onboarding
      * ([SetupStatus.needsSetup] = `true` when THE library has no folders yet).
      *
-     * Migrates the legacy `SetupApiContract.getLibraryStatus` capability into the
-     * RPC surface. Clients use this to decide whether to show the onboarding
+     * Clients use this to decide whether to show the onboarding
      * wizard on first launch.
      *
      * Open to any authenticated caller — drives onboarding before an admin exists.
@@ -69,9 +67,6 @@ interface LibraryAdminService {
      * Returns an empty list when [path] has no sub-directories. Returns
      * [com.calypsan.listenup.api.error.LibraryError.InvalidPath] when [path] does
      * not exist or is not readable.
-     *
-     * Migrates the legacy `SetupApiContract.listDirectory` capability into the
-     * RPC surface.
      *
      * Admin-only — non-admins receive [com.calypsan.listenup.api.error.AuthError.PermissionDenied].
      */

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/MetadataLookupService.kt
@@ -80,10 +80,10 @@ interface MetadataLookupService {
      * Searches Audible for contributors matching [query].
      *
      * **Currently stubs to an empty list.** Audible has no official
-     * contributor-search API; the Go reference implementation used HTML
+     * contributor-search API; the available approach is HTML
      * scraping of `www.audible.com/search?searchAuthor=`, which requires a
-     * Kotlin-first HTML parser dependency not yet added to `:server`. A later
-     * phase will land a proper implementation — either via HTML scraping or an
+     * Kotlin-first HTML parser dependency not yet added to `:server`. A proper
+     * implementation will land later — either via HTML scraping or an
      * alternative metadata source (e.g. MusicBrainz, OpenLibrary).
      *
      * The method signature is included in the contract now so client code can

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/PingService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/PingService.kt
@@ -4,10 +4,10 @@ import com.calypsan.listenup.api.result.AppResult
 import kotlinx.rpc.annotations.Rpc
 
 /**
- * Phase 0 smoke-test service.
+ * Smoke-test service.
  *
  * Exists only to prove the kotlinx.rpc pipeline (codegen → server registration →
- * client proxy → wire round-trip) works on CIO. Will be deleted in Phase 1 when
+ * client proxy → wire round-trip) works on CIO. Slated for removal once
  * real domain @Rpc services replace it.
  */
 @Rpc

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ScannerService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ScannerService.kt
@@ -9,9 +9,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.rpc.annotations.Rpc
 
 /**
- * Public scanner contract. Mounted at `/api/rpc/public` (no auth wall in
- * Phase 2; admin-gating lands when the auth surface gets a role check in
- * Phase 4).
+ * Public scanner contract. Mounted at `/api/rpc/public` (no auth wall
+ * currently; admin-gating lands when the auth surface gets a role check).
  *
  * `observeProgress()` is a server-pushed [Flow] of [RpcEvent]-wrapped [ScanEvent]s —
  * kotlinx.rpc opens a dedicated WebSocket frame stream for it. Multiple

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/ContributorUpdate.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/ContributorUpdate.kt
@@ -7,8 +7,8 @@ import kotlinx.serialization.Serializable
  * PATCH payload for [com.calypsan.listenup.api.ContributorService.updateContributor].
  *
  * Every field is nullable — `null` means "don't touch." Aliases are **not**
- * present in C1 because contributor aliases are not yet a server-side concept;
- * the C2 phase introduces the `contributor_aliases` server substrate.
+ * present because contributor aliases are not yet a server-side concept; a
+ * future `contributor_aliases` server substrate will introduce them.
  */
 @Serializable
 @SerialName("ContributorUpdate")

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/LibraryDtos.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/LibraryDtos.kt
@@ -10,8 +10,8 @@ import kotlinx.serialization.Serializable
  * Wire representation of a Library — the top-level grouping entity that owns N
  * [LibraryFolder]s and scopes a collection of audiobooks.
  *
- * Libraries are server-wide (cross-user) for now. [accessMode] and
- * [createdByUserId] are forward-staged for the Multi-user phase: they carry
+ * Libraries are server-wide (cross-user). [accessMode] and
+ * [createdByUserId] are forward-staged for multi-user support: they carry
  * default values (`SHARED` / `null`) and are not enforced until per-user
  * permission gating lands.
  *
@@ -34,13 +34,13 @@ data class Library(
     val metadataPrecedence: String,
     /**
      * Who can see this library. Defaults to [AccessMode.SHARED] (all users).
-     * Forward-staged for Multi-user phase — not enforced until permissions land.
+     * Forward-staged for multi-user support — not enforced until permissions land.
      */
     val accessMode: AccessMode,
     /**
      * The user who created this library. `null` for bootstrap-created libraries
-     * (env-var path at first boot) or pre-Multi-user libraries.
-     * Forward-staged for Multi-user phase.
+     * (env-var path at first boot) or pre-multi-user libraries.
+     * Forward-staged for multi-user support.
      */
     val createdByUserId: UserId?,
     /** Unix epoch milliseconds when this library was created. */
@@ -127,13 +127,13 @@ data class DirectoryEntry(
 /**
  * Library access mode — controls which users can see and play from a library.
  *
- * Forward-staged for the Multi-user phase: the column exists and is stored, but
+ * Forward-staged for multi-user support: the column exists and is stored, but
  * enforcement is deferred until per-user permission gating lands. All libraries
- * behave as [SHARED] regardless of the stored value until that phase.
+ * behave as [SHARED] regardless of the stored value until then.
  *
  * - [SHARED] — visible to all authenticated users (default).
  * - [PRIVATE] — visible only to the library owner ([Library.createdByUserId]).
- * - [RESTRICTED] — visible to an explicit allowlist (managed in Multi-user phase).
+ * - [RESTRICTED] — visible to an explicit allowlist (managed under multi-user support).
  */
 @Serializable
 enum class AccessMode {

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/auth/DeviceInfo.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/auth/DeviceInfo.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 /**
  * Structured device metadata a first-party client sends when it creates a session
  * (login/register/setup/invite-claim). All fields optional — third-party REST callers
- * may omit any. Trimmed from the Go/ABS DeviceInfo: no browser_* / client_build / ip_address.
+ * may omit any. Intentionally excludes browser_*, client_build, and ip_address.
  */
 @Serializable
 data class DeviceInfo(

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/preferences/UserPreferencesDtos.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/preferences/UserPreferencesDtos.kt
@@ -20,7 +20,7 @@ data class UserPreferencesDto(
 
 /**
  * Partial update for playback preferences — every field is nullable; only non-null fields are merged
- * onto the caller's stored preferences (PATCH semantics, mirroring the Go reference).
+ * onto the caller's stored preferences (PATCH semantics).
  */
 @Serializable
 @SerialName("UpdateUserPreferencesRequest")

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  * Three concerns coexist on the shape, deliberately separated:
  *
  *  1. **Resolved view** — `title`/`authors`/`narrators`/`series`/etc. The
- *     merged result of every signal source after applying ABS invariant #7
+ *     merged result of every signal source after applying source
  *     precedence. UI list rendering reads these.
  *  2. **Raw signal** — [embedded] preserves the parser's output verbatim.
  *     Fields like real `durationMs`, `chapters`, and embedded `artwork`

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/MetadataStatus.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/MetadataStatus.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  *
  * Surfaces in scan summaries so operators see "12 FLAC files detected,
  * parser not available" instead of an opaque per-file error. The
- * aggregator (Phase 3 scan-summary task) groups books by status.
+ * scan-summary aggregator groups books by status.
  *
  * `null` on [AnalyzedBook] means the parser was never invoked (e.g. no
  * audio file in the candidate at all). [Available] means the parser

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanResult.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/ScanResult.kt
@@ -27,8 +27,8 @@ sealed interface ScanScope {
 }
 
 /**
- * The aggregated output of one scan invocation. Phase 2 keeps this purely
- * in-memory — no persistence yet. Phase 4's Books domain takes this as its
+ * The aggregated output of one scan invocation. Kept purely
+ * in-memory — no persistence. The Books domain takes this as its
  * input.
  */
 @Serializable

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/TrackEntry.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/TrackEntry.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 /**
  * One audio file in playback order, with its derived position metadata.
- * Phase 2 only fills track/disc from filename or parent folder; embedded-tag
- * sources land in Phase 3 and use [TrackNumberSource.METADATA].
+ * Track/disc are currently filled from filename or parent folder only; embedded-tag
+ * sources are future work and use [TrackNumberSource.METADATA].
  *
  * [durationMs] is the track's own playable length, parsed from embedded metadata
  * for multi-file books (where it is needed to sum the book's total duration and to

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/external/abs/AbsChapter.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/external/abs/AbsChapter.kt
@@ -5,8 +5,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * One chapter as ABS encodes it in `metadata.json`. Times are in seconds.
- * Phase 2 reads but does not use these — chapter inference lands in Phase 3
- * once audiometa is ported.
+ * Currently read but not yet used — chapter inference is future work.
  */
 @Serializable
 data class AbsChapter(

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/metadata/AudibleRegion.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/metadata/AudibleRegion.kt
@@ -12,11 +12,6 @@ import kotlinx.serialization.Serializable
  *
  * Server-specific routing details (API hostname, locale cookies) live in
  * `:server`'s `AudibleRegionConfig` extension to keep the contract lean.
- *
- * Ported from Go at `server/internal/metadata/audible/types.go`. Regions match
- * exactly — no extras, no omissions. The client-side `AudibleRegion` enum
- * previously defined in `sharedLogic` presentation layer is replaced by this
- * canonical contract type.
  */
 @Serializable
 enum class AudibleRegion(

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/LibrarySyncPayload.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/LibrarySyncPayload.kt
@@ -8,8 +8,8 @@ import kotlinx.serialization.Serializable
  * zero-or-more [LibraryFolderSyncPayload] roots.
  *
  * Libraries are server-wide (cross-user) in the current single-user model.
- * `accessMode` and `createdByUserId` are forward-staged for the multi-user
- * phase; they are present on the wire today but not enforced.
+ * `accessMode` and `createdByUserId` are forward-staged for multi-user
+ * support; they are present on the wire today but not enforced.
  *
  * `metadataPrecedence` is the comma-separated source list that governs
  * which metadata source wins when multiple sources exist for the same field

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/AudioTags.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/AudioTags.kt
@@ -8,8 +8,7 @@ import kotlinx.serialization.Serializable
  *
  * Sources: ID3v2/ID3v1 frames (MP3), Vorbis comments (FLAC, Ogg, Opus),
  * MP4 `ilst` atoms (M4A, M4B). The mapping from format-specific frame/key
- * names to these fields lives in the per-format parser; see spec §8 for
- * the full mapping tables.
+ * names to these fields lives in the per-format parser.
  *
  * [custom] surfaces every unmapped tag key/value the parser saw, rather than
  * silently dropping them — a downstream phase can use them later without
@@ -41,7 +40,7 @@ data class AudioTags(
     companion object {
         /** The [custom] map key under which every format reader stores the file's
          *  comment tag (ID3v2 COMM, MP4 `©cmt`, Vorbis COMMENT). The Analyzer uses it
-         *  as the `description` fallback, matching the Go reference. */
+         *  as the `description` fallback. */
         const val COMMENT_KEY: String = "comment"
 
         /** The [custom] map key under which every format reader stores the album tag

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/ChapterSource.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/ChapterSource.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
  * Diagnostic provenance — surfaces in logs and metrics so a "wrong chapters"
  * report immediately tells you which extraction path produced them.
  *
- * Per spec §8.4, MP4 dual-emission (Nero + Apple) prefers Nero, so the
+ * When an MP4 emits both Nero and Apple chapter formats, the parser prefers Nero, so the
  * source value reflects that precedence outcome, not all sources present.
  */
 @Serializable

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/EmbeddedAudioMetadata.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/EmbeddedAudioMetadata.kt
@@ -7,12 +7,12 @@ import kotlinx.serialization.Serializable
  * Aggregate of every metadata signal extracted from a single audio file.
  *
  * Produced by `EmbeddedMetadataParser.parse(source)` (server-side); consumed by
- * the Phase 2 Analyzer as the "embedded metadata" input to its precedence-merge
- * stage (ABS invariant #7). Crosses the wire when Phase 4's Books domain
+ * the Analyzer as the "embedded metadata" input to its precedence-merge
+ * stage. Crosses the wire when the Books domain
  * returns it on RPC service signatures.
  *
  * For multi-file books, the parser is invoked on the primary audio file
- * (first by stable sort) only; per spec §3 non-goals.
+ * (first by stable sort) only.
  */
 @Serializable
 @SerialName("EmbeddedAudioMetadata")

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/SeriesEntry.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/embeddedmeta/SeriesEntry.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 /**
  * One entry in a book's series membership list.
  *
- * [sequence] is a `String?` (not `Int`) per ABS invariant #10 — series sequences
+ * [sequence] is a `String?` (not `Int`) because series sequences
  * like `"1.5"`, `"0a"`, and `"III"` are valid in the wild. Null when the series
  * membership is acknowledged but the position isn't known.
  */

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/server/rpcguard/CorrelationId.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/server/rpcguard/CorrelationId.kt
@@ -5,9 +5,9 @@ import kotlin.uuid.Uuid
 /**
  * Pulls the active request's correlation id, or null if none is propagated.
  *
- * JVM reads it from the Ktor `CallId` -> SLF4J `MDCContext` bridge (unchanged). Native reads it
+ * JVM reads it from the Ktor `CallId` -> SLF4J `MDCContext` bridge. Native reads it
  * from a [CorrelationContext] coroutine-context element; until the native Ktor pipeline installs
- * one (a later Phase-5 sub-project), native returns null and the guard falls back to
+ * one, native returns null and the guard falls back to
  * [newCorrelationId].
  */
 internal expect suspend fun currentCorrelationId(): String?

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationConfig.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationConfig.kt
@@ -64,7 +64,7 @@ internal fun Application.resolveImageHome(): Path =
 /**
  * Takes an exclusive lock on the data directory when `server.dataDirLock` is enabled (production
  * default in `application.conf`), so a second server on the same `$LISTENUP_HOME` fails fast with a
- * clear message instead of racing the scan-spool (#703 — a stale JVM whose covers get swept by a
+ * clear message instead of racing the scan-spool (a stale JVM whose covers get swept by a
  * fresh boot). Off by default in code, so the isolated test configs (which omit the key) never
  * lock. The lock is released on [ApplicationStopped]; the OS frees it anyway on process death.
  */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/AbsModels.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/AbsModels.kt
@@ -50,7 +50,7 @@ internal data class AbsProgress(
  * actual seconds, used to backfill ListeningUp listening-event history.
  *
  * [itemId] is the ABS `mediaItemId` (= `books.id` for `mediaItemType = 'book'`), so it joins to
- * [AbsItem.id] and resolves through the same Phase-2 matcher path as [AbsProgress].
+ * [AbsItem.id] and resolves through the same matcher path as [AbsProgress].
  * [startPositionSeconds]/[endPositionSeconds] are the playhead positions at session start/end.
  * [timeListeningSeconds] is ABS's authoritative actually-listened span (NOT the wall-clock duration).
  * [startedAtMs] is epoch **millis**, parsed from the ISO-8601 `createdAt` text column.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/AbsSchema.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/AbsSchema.kt
@@ -71,7 +71,7 @@ package com.calypsan.listenup.server.absimport
  *   they are real FK columns on the table. We read `userId`.
  * - **Item FK:** like `mediaProgresses`, a `mediaItemType = 'book'` session keys the item via
  *   `mediaItemId = books.id`, so [AbsModels.AbsSession.itemId] correlates against the same key the
- *   Phase-2 matcher resolves (`books.id`). Podcast sessions (`mediaItemType = 'podcastEpisode'`) are
+ *   matcher resolves (`books.id`). Podcast sessions (`mediaItemType = 'podcastEpisode'`) are
  *   excluded by the `WHERE mediaItemType = 'book'` filter.
  * - **ASSUMED — no playback-rate column:** the model defines NO `playbackRate`/`playbackSpeed`
  *   column, so the reader cannot recover the speed; it defaults to `1.0`. Flagged for verification

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImpl.kt
@@ -91,7 +91,7 @@ class AdminUserServiceImpl(
         return suspendTransaction(sql) {
             AppResult.Success(
                 // ACTIVE only: pending/denied registrations have their own surfaces and must not
-                // appear in the active roster (#624). Soft-deleted users are excluded as always.
+                // appear in the active roster. Soft-deleted users are excluded as always.
                 sql.usersQueries
                     .selectActiveLive()
                     .executeAsList()
@@ -128,7 +128,7 @@ class AdminUserServiceImpl(
         return suspendTransaction(sql) {
             AppResult.Success(
                 // ACTIVE only: search is an active-roster operation; pending/denied registrations
-                // have their own surfaces and must not leak in (#624, sibling of listUsers).
+                // have their own surfaces and must not leak in (sibling of listUsers).
                 sql.usersQueries
                     .selectActiveLive()
                     .executeAsList()

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
@@ -256,8 +256,8 @@ internal class BookMetadataApplier(
      * `MetadataLookupServiceImpl.enrichWithMoodsAndTags`) and presented to the user as toggleable
      * chips; the apply path honors that selection rather than re-scraping. A re-match swaps the old
      * set for the new — a deselected mood/tag is dropped — and an empty set removes all of that
-     * dimension's links (explicit "none" from the review). This is the #573 fix: re-matching no
-     * longer accumulates.
+     * dimension's links (explicit "none" from the review). This stops re-matching from
+     * accumulating across applies.
      *
      * Best-effort: a write error is logged and skipped so the already-committed match is never
      * rolled back. [CancellationException] is always re-raised.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookServiceImpl.kt
@@ -317,7 +317,7 @@ internal class BookServiceImpl(
         val current = repo.findById(id) ?: return bookNotFound(id)
 
         // Validate every input genre exists and is live BEFORE the relink. Unknown ids surface as
-        // BookError.InvalidInput per spec (no auto-create). One bulk read replaces the per-input
+        // BookError.InvalidInput (no auto-create). One bulk read replaces the per-input
         // findById storm; the in-order membership check keeps the first-offender (input order) error
         // byte-identical. genreRepo.findLiveIds is a suspend read, so the validation runs before
         // opening the (non-suspend) SQLDelight relink transaction.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -400,7 +400,7 @@ internal class CollectionServiceImpl(
     //
     // These are ADMIN-INTERNAL operations, deliberately NOT part of the @Rpc
     // CollectionService contract (frozen at 12 user-facing methods). They are exposed as
-    // public methods so the admin REST routes (and, eventually, the scanner) can call them.
+    // public methods so the admin REST routes (and potentially the scanner) can call them.
 
     /**
      * Resolves the library's per-library system collection of [type], creating it on first use.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -322,6 +322,6 @@ private fun AudibleContributorProfile.toMetadataContributorProfile(): MetadataCo
         deathDate = null,
         // Audible author pages expose no external website (the scrape yields only name, biography,
         // and og:image), so there is nothing to populate here — website stays a manual-only field
-        // edited on the contributor page (#616).
+        // edited on the contributor page.
         website = null,
     )

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/UserPreferencesServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/UserPreferencesServiceImpl.kt
@@ -27,7 +27,7 @@ private val SLEEP_RANGE = 1..480
  * Both operations are scoped to the authenticated principal. `getMyPreferences` returns the
  * caller's stored row or [defaults] when none exists; `updateMyPreferences` does get-or-create →
  * partial-merge (only non-null request fields) → clamp numeric values into range → persist with a
- * fresh `updated_at`. Mirrors the legacy Go preferences endpoint.
+ * fresh `updated_at`.
  *
  * Route handlers call [copyWith] to bind each request to the authenticated principal; the Koin
  * singleton carries [PrincipalProvider.None] so an un-scoped call is denied rather than running

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
@@ -367,7 +367,7 @@ class AuthServiceImpl(
 
     private fun deviceInfoOf(s: Sessions): DeviceInfo? {
         // The read path must not assume stored rows honour the current DeviceInfo
-        // invariants: legacy sessions (old Go server / pre-validation) may hold blank
+        // invariants: legacy sessions (pre-validation) may hold blank
         // or over-long fields. Sanitize before constructing so DeviceInfo.init's
         // length `require` — the correct *inbound* guard — never throws on outbound data.
         fun field(value: String?): String? = value?.takeIf { it.isNotBlank() }?.take(DEVICE_FIELD_MAX)
@@ -401,7 +401,7 @@ class AuthServiceImpl(
         now: Long,
     ): AuthUser =
         AuthUser(
-            // Phase 1 placeholder. UUIDv7 (lexicographically sortable, time-ordered) is the
+            // UUIDv4. UUIDv7 (lexicographically sortable, time-ordered) would be the
             // long-term shape — UUIDv4 is fine while ids are TEXT primary keys with no
             // timestamp-driven scan path.
             id = Uuid.random().toString(),

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/ServerSecretsConfig.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/ServerSecretsConfig.kt
@@ -13,7 +13,7 @@ import io.ktor.server.config.ApplicationConfig
  */
 fun resolveServerSecrets(config: ApplicationConfig): ServerSecrets {
     // Honour `listenup.home` (config) so secrets.properties lands under the SAME home as the DB and
-    // covers/spool — all server data stays under one directory (#703).
+    // covers/spool — all server data stays under one directory.
     val home =
         resolveListenupHome(
             configuredHome = config.propertyOrNull("listenup.home")?.getString(),

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/UserPrincipal.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/UserPrincipal.kt
@@ -10,7 +10,7 @@ import com.calypsan.listenup.api.dto.auth.UserRole
  *
  * Embedding `role` here means handlers don't need a DB hit to gate
  * admin-only operations — at the cost of a role change taking effect only
- * when the access token expires (≤15m). Acceptable tradeoff per the spec.
+ * when the access token expires (≤15m). An accepted tradeoff.
  */
 data class UserPrincipal(
     val userId: UserId,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/EmbeddedCoverCache.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/EmbeddedCoverCache.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.sync.withLock
  *
  * **Staleness caveat.** Entries are keyed by [BookId]. If a book's embedded
  * artwork changes after a rescan, the stale bytes remain cached until evicted.
- * Acceptable for Books-A — covers rarely change, and a server restart clears
+ * Acceptable here — covers rarely change, and a server restart clears
  * the cache. Keying by cover hash would close the gap but would require the
  * route to thread the hash through; revisit if cover churn becomes a concern.
  *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
@@ -22,7 +22,7 @@ internal expect fun tryLockFile(lockFile: Path): FileLockHandle?
  *
  * Two instances sharing one `$LISTENUP_HOME` — a stale JVM that wasn't fully killed plus a fresh
  * boot — race the scan-spool: the new boot's `sweepOrphans()` could delete a live scan's covers out
- * from under the other instance's persist. That is the cause of #703's spooled-cover 404s. This lock
+ * from under the other instance's persist, the cause of spooled-cover 404s. This lock
  * turns that silent corruption into an explicit, fail-fast startup error.
  *
  * Backed by a [FileLockHandle] on `<dataHome>/.lock`: the OS releases it automatically on process

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataHome.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataHome.kt
@@ -38,7 +38,7 @@ fun resolveListenupHome(
  * This single resolver is the guarantee that all server data lands under ONE directory — the DB,
  * secrets, covers, and spool can never diverge because they all resolve through here. (Previously
  * the DB and secrets read only [envHome], so a `listenup.home` config split them off from the
- * covers/spool — the bug behind #703's "data isn't where I cleared it" confusion.) Pure —
+ * covers/spool — the bug behind the "data isn't where I cleared it" confusion.) Pure —
  * callers read the config / env / system properties at the edge.
  */
 fun resolveListenupHome(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/AuthModule.kt
@@ -215,7 +215,7 @@ private fun ApplicationConfig.serverName(): String =
 private fun ApplicationConfig.resolveJdbcUrl(): String {
     val configured = propertyOrNull("database.jdbcUrl")?.getString().orEmpty()
     // Honour `listenup.home` (config) so the DB lands under the SAME home as covers/spool — not just
-    // $LISTENUP_HOME. Keeps all server data under one directory (#703).
+    // $LISTENUP_HOME. Keeps all server data under one directory.
     val home =
         resolveListenupHome(
             configuredHome = propertyOrNull("listenup.home")?.getString(),

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/SeedModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/SeedModule.kt
@@ -26,7 +26,7 @@ import org.koin.dsl.module
 /**
  * Koin module for the demo seed profile. Installed by `Application.module()` only
  * when `seed.profile = demo`. The `SeedRunner`'s seeder list is hand-assembled —
- * every future domain phase adds its `DomainSeeder` to this list.
+ * each domain adds its `DomainSeeder` to this list.
  *
  * @param hasPlaybackModule whether the `:playback` slice is active (i.e., a library
  *   path is configured). When false, [PlaybackPositionDomainSeeder],
@@ -46,8 +46,8 @@ import org.koin.dsl.module
  *   scanner, so this can be true even without a library configured.
  * @param hasGenresModule whether the `:genres` slice is active. When true,
  *   [GenreDomainSeeder] is registered to seed the default genre taxonomy (3 roots,
- *   ~70 nodes total) ported from Go's `internal/genre/defaults.go`. Like tags, the
- *   genre tree is curator-controlled and independent of the scanner.
+ *   ~70 nodes total). Like tags, the genre tree is curator-controlled and
+ *   independent of the scanner.
  * @param hasMoodsModule whether the moods slice is active. When true,
  *   [MoodDomainSeeder] is registered to seed the canonical Audible mood vocabulary
  *   (≈24 affective labels). Like genres, moods are curator-controlled dedupe anchors

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/UserPreferencesModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/UserPreferencesModule.kt
@@ -7,7 +7,7 @@ import com.calypsan.listenup.server.sync.ChangeBus
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-/** Per-user playback-preferences RPC service (issue #599). */
+/** Per-user playback-preferences RPC service. */
 fun userPreferencesModule(): Module =
     module {
         single<UserPreferencesService> {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Id3v2Reader.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp3/Id3v2Reader.kt
@@ -16,8 +16,7 @@ import com.calypsan.listenup.server.embeddedmeta.decode.TextDecoding
  * tag size (header + body) so the caller can locate the audio region.
  *
  * Returns `null` if the buffer doesn't start with the "ID3" magic. Malformed
- * frames are skipped in line with the Go reference's tolerant behaviour
- * (`/home/simonh/Code/audiometa/internal/mp3/id3v2.go`).
+ * frames are skipped rather than aborting the read — a tolerant parse.
  */
 internal data class Id3v2ReadResult(
     val tags: AudioTags,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/AtomWalker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/AtomWalker.kt
@@ -16,9 +16,8 @@ import com.calypsan.listenup.server.embeddedmeta.decode.TextDecoding
  * `stbl`, `tref`, `----`, `covr`) hold child atoms in their payload. Leaf
  * atoms hold structured payloads consumed by readers in this package.
  *
- * Ports `/home/simonh/Code/audiometa/internal/m4a/atoms.go` to Kotlin with
- * pre-buffered bytes (the file is read in full at parse time — see
- * [Mp4Parser]) so failures map to byte-slice bounds rather than IO errors.
+ * Walks atoms over pre-buffered bytes (the file is read in full at parse time —
+ * see [Mp4Parser]) so failures map to byte-slice bounds rather than IO errors.
  */
 internal data class Atom(
     val type: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ChapterExtractor.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ChapterExtractor.kt
@@ -11,17 +11,16 @@ import kotlinx.io.IOException
  *
  * - **Nero `chpl`** (`moov.udta.chpl`): a flat list of `(start-100ns, title)`
  *   entries. End times are derived as `next.startMs - 1` with the last
- *   chapter clamped to the file's `durationMs`. Layout matches the Go
- *   reference `chapters.go`: `version(1) + flags(3) + reserved(4) +
- *   count(1) + per-entry`.
+ *   chapter clamped to the file's `durationMs`. Header layout is
+ *   `version(1) + flags(3) + reserved(4) + count(1) + per-entry`.
  * - **Apple QuickTime text-track** (`tref.chap` → text-track sample table):
  *   the audio track's `tref.chap` references a chapter `trak`, whose `mdia/
  *   minf/stbl` carries `stts` (per-sample timing), `stsz` (sample sizes),
  *   `stco` / `co64` (chunk offsets). Each text sample is `length(2 BE) +
  *   UTF-8 title`. Single-chunk layouts only — multi-chunk text tracks would
- *   need `stsc` parsing, which the Go reference also defers.
+ *   need `stsc` parsing, which this extractor does not implement.
  *
- * Per spec §8.4 precedence rule, callers run [readNeroChpl] first; if it
+ * By the precedence rule, callers run [readNeroChpl] first; if it
  * yields any chapters, the Apple text-track path is skipped.
  *
  * MagicNumber suppressed: Nero `chpl` and Apple QuickTime text-track atom field
@@ -155,8 +154,8 @@ internal object Mp4ChapterExtractor {
 
         if (sampleStartsMs.isEmpty() || sampleSizes.isEmpty() || chunkOffsets.isEmpty()) return emptyList()
 
-        // Build absolute sample offsets. Single-chunk layout (the only one we
-        // emit from the DSL and the only one Go's parser handles fully):
+        // Build absolute sample offsets. Single-chunk layout (the only one the
+        // fixtures emit, and the only one this extractor handles fully):
         // sample[i] = chunk[0] + sum(sampleSize[0..i-1]).
         val sampleOffsets = LongArray(sampleSizes.size)
         if (chunkOffsets.size == 1) {
@@ -166,8 +165,8 @@ internal object Mp4ChapterExtractor {
                 cursor += sampleSizes[i]
             }
         } else {
-            // Multi-chunk fallback — assume 1:1 mapping (Go reference does
-            // the same simplification, with the same caveat).
+            // Multi-chunk fallback — assume a 1:1 mapping. A deliberate simplification
+            // with the caveat that genuinely multi-chunk text tracks would be misread.
             for (i in 0 until minOf(chunkOffsets.size, sampleSizes.size)) {
                 sampleOffsets[i] = chunkOffsets[i]
             }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4Parser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4Parser.kt
@@ -35,8 +35,6 @@ import kotlinx.io.IOException
  * - Required atom missing (`moov` or `mvhd`) →
  *   [AudioMetadataError.CorruptHeader] — the file is structurally invalid
  *   per ISO/IEC 14496-12; best surfaced rather than guessed at.
- *
- * Reference: spec §8.4 + Go `/home/simonh/Code/audiometa/internal/m4a/`.
  */
 internal class Mp4Parser : AudioFormatParser {
     override val supports: Set<AudioFormat> = setOf(AudioFormat.Mp4)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/foundation/FoundationModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/foundation/FoundationModule.kt
@@ -31,7 +31,7 @@ class FoundationDeps(
  * `KoinIsolated` and the full route graph. The production server uses
  * [com.calypsan.listenup.server.module] (jvmMain) — which additionally keeps `CallLogging`,
  * `PartialContent`, the full DI graph, and every domain route. This is the substrate those
- * verticals grow onto; the production native `main()` (Phase 5) builds on [foundationServer].
+ * verticals grow onto; the production native `main()` builds on [foundationServer].
  *
  * **RPC service registration is intentionally not done here.** The `guard(...)` decorator that every
  * RPC registration must wrap its impl in (it sanitises escaped exceptions into typed `AppError`
@@ -39,7 +39,7 @@ class FoundationDeps(
  * registration is impossible from commonMain until rpc-guard generates for native. This skeleton
  * therefore installs only the [Krpc] transport; callers register services. The native RPC smoke
  * proves the transport serves by registering an unguarded test ping via [foundationServer]'s
- * `configure` hook (test scope), and the production native `main()` (Phase 5) registers the real
+ * `configure` hook (test scope), and the production native `main()` registers the real
  * guarded services once rpc-guard is native.
  */
 fun Application.installFoundation(deps: FoundationDeps) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/foundation/NativeServer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/foundation/NativeServer.kt
@@ -7,7 +7,7 @@ import io.ktor.server.engine.embeddedServer
 /**
  * Builds an embedded CIO server running the foundation skeleton. Compiles for linuxX64 — proving the
  * CIO engine links with the full plugin stack natively — and starts a real server (no test-host
- * shim) for the native RPC smoke. The production native `main()` (Phase 5) builds on this; it is not
+ * shim) for the native RPC smoke. The production native `main()` builds on this; it is not
  * the production entrypoint yet.
  *
  * [configure] runs after [installFoundation], on the same [Application] — the seam where callers

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/media/ImageStore.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/media/ImageStore.kt
@@ -11,7 +11,7 @@ import kotlinx.io.files.SystemFileSystem
  * Reusable validate-store-serve primitive for user-uploaded images, rooted at [baseDir]
  * (e.g. `$LISTENUP_HOME/avatars`). Validates the bytes are a real JPEG/PNG/WebP by magic number
  * (not the declared content type) and enforces [maxBytes]. Files are stored as `<key>.<ext>`.
- * Designed to back avatars now and book covers later.
+ * Designed to back avatars, and built to extend to book covers.
  */
 class ImageStore(
     private val baseDir: Path,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleApi.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleApi.kt
@@ -50,8 +50,7 @@ interface AudibleApi {
      * Audible author page at `www.audible.{tld}/author/x/{asin}`.
      *
      * The official catalog API no longer returns contributor images or
-     * biographies, so web scraping is the only reliable source — mirroring
-     * Go's `GetContributorProfile` in `server/internal/metadata/audible/contributor.go`.
+     * biographies, so web scraping is the only reliable source.
      *
      * @return [AppResult.Success] with the profile (or `null` for a 404),
      *   or a typed [com.calypsan.listenup.api.error.MetadataError] on failure.
@@ -65,9 +64,8 @@ interface AudibleApi {
      * Searches Audible's contributor catalog by [name] using HTML scraping of
      * `www.audible.{tld}/search?searchAuthor={name}`.
      *
-     * The official catalog API offers no contributor-search endpoint — HTML
-     * scraping mirrors Go's `SearchContributors` in
-     * `server/internal/metadata/audible/contributor.go`.
+     * The official catalog API offers no contributor-search endpoint, so this
+     * relies on HTML scraping.
      *
      * Results are deduplicated by ASIN and ranked by name-similarity to [name].
      *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -33,9 +33,8 @@ private val logger = KotlinLogging.logger {}
  *    - decode failure → [MetadataError.Malformed]
  *    - network failure → [MetadataError.ExternalUnavailable]
  *
- * URL paths and query-parameter shapes are ported from the Go reference at
- * `server/internal/metadata/audible/`. The `response_groups` values are the
- * authoritative set from that implementation.
+ * URL paths, query-parameter shapes, and the `response_groups` values target
+ * Audible's regional `/1.0/` catalog endpoints.
  *
  * [CancellationException] is never swallowed — it is always rethrown.
  */
@@ -133,8 +132,7 @@ class AudibleClient(
      * Endpoint: `GET https://www.audible.{tld}/author/x/{asin}`
      *
      * Audible's catalog API no longer returns contributor images or biographies,
-     * so the author web page is the only reliable source — mirroring Go's
-     * `GetContributorProfile` in `server/internal/metadata/audible/contributor.go`.
+     * so the author web page is the only reliable source.
      * A placeholder name (`x`) is used in the URL because Audible redirects to
      * the canonical slug regardless.
      *
@@ -298,7 +296,7 @@ class AudibleClient(
                     )
                     // The storefront locale cookie forces the correct regional catalog and turns
                     // Audible's 503-without-cookie into a 200 (covers /pd product pages + the
-                    // contributor scrape, fixing non-US contributor lookups — #551 residual).
+                    // contributor scrape, fixing non-US contributor lookups).
                     header("Cookie", region.localeCookie())
                     queryParams.forEach { (k, v) -> parameter(k, v) }
                 }
@@ -362,14 +360,12 @@ class AudibleClient(
 
         /**
          * Standard response_groups for product requests.
-         * Matches Go's `responseGroups()` in `client.go`.
          */
         const val RESPONSE_GROUPS =
             "contributors,product_desc,product_attrs,product_extended_attrs,media,rating,series,category_ladders"
 
         /**
          * Image size variants to request.
-         * Matches Go's `imageSizes()` in `client.go`.
          */
         const val IMAGE_SIZES = "500,1024"
     }
@@ -387,8 +383,6 @@ class AudibleClient(
  * non-Kotlin-native dependency. The patterns are robust to Audible's typical
  * minification and attribute ordering because they target unique class names
  * and meta-tag attributes rather than tag structure.
- *
- * Ported from Go's `parseContributorProfile` in `contributor.go`.
  */
 internal fun parseContributorProfile(
     html: String,
@@ -401,7 +395,7 @@ internal fun parseContributorProfile(
     val biography = extractElementText(html, "bc-expander-content") ?: ""
 
     // Image: prefer og:image meta tag; fall back to author-image-outline img src. The
-    // author-image-outline thumbnail is a tiny 120px rendition — upsize it (#615).
+    // author-image-outline thumbnail is a tiny 120px rendition — upsize it.
     val imageUrl =
         upsizeAmazonImage(
             extractOgImage(html)?.takeUnless { it.contains(PLACEHOLDER_IMAGE_FRAGMENT) }
@@ -420,7 +414,7 @@ private const val AUTHOR_IMAGE_TARGET_PX = 600
  * Rewrites an Amazon image URL's size operator to request a larger rendition. Audible's
  * `author-image-outline` photo is served as a 120px thumbnail (e.g.
  * `…/{id}.__01_SX120_CR0,0,120,120__.jpg`); Amazon's image server honours a `._SX{n}_` operator,
- * so this swaps whichever operator block is present for `._SX600_` to fetch a sharp avatar (#615).
+ * so this swaps whichever operator block is present for `._SX600_` to fetch a sharp avatar.
  * Non-Amazon URLs (and URLs with no operator block) are returned unchanged.
  */
 private fun upsizeAmazonImage(url: String): String {
@@ -485,15 +479,13 @@ private fun extractImgSrc(
  *
  * Uses regex extraction matching the approach in [parseContributorProfile]:
  * no full HTML parser to avoid a non-Kotlin-native dependency.
- *
- * Ported from Go's `parseContributorSearch` in `contributor.go`.
  */
 internal fun parseContributorSearch(html: String): List<AudibleContributorProfile> {
     // Author links are `href="/author/{slug}/{ASIN}?{tracking}"` — Audible always appends tracking
     // query params (ref, pf_rd_*, plink, …) after the ASIN. The pattern must therefore tolerate
     // anything up to the closing quote after the ASIN; requiring a quote *immediately* after it
-    // (the previous behaviour) matched nothing, so every contributor search returned empty (#551).
-    // The anchor's inner text is the contributor name. Mirrors Go's `parseContributorSearch`.
+    // (the previous behaviour) matched nothing, so every contributor search returned empty.
+    // The anchor's inner text is the contributor name.
     val anchorPattern =
         Regex(
             """href="/author/[^/]+/([A-Z0-9]+)[^"]*"[^>]*>(.*?)</a>""",
@@ -562,9 +554,8 @@ private fun RawProduct.toBook(): AudibleBook {
 }
 
 /**
- * Separates contributors by role. Go's API sometimes places narrators in the
+ * Separates contributors by role. Audible's API sometimes places narrators in the
  * `authors` array with `role = "narrator"`, so both arrays must be inspected.
- * Mirrors Go's `separateContributorsByRole` in `client.go`.
  */
 private fun separateContributors(
     rawAuthors: List<RawContributor>,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleRateLimiter.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleRateLimiter.kt
@@ -14,17 +14,11 @@ import kotlin.time.Instant
  *
  * Maintains an independent token bucket per [AudibleRegion] — a US call does
  * not consume a UK token and vice versa. Each region allows one request per
- * [perRegionInterval], matching the Go reference's `defaultRPS = 1.0` (with
- * Go's burst-of-3 folded into the design: the first call is always free, the
- * delay only applies to rapid successive calls).
+ * [perRegionInterval] (a default of 1 request/sec): the first call to a region
+ * is always free, and the delay only applies to rapid successive calls.
  *
  * [await] is cooperative: it uses [delay] rather than blocking, so cancellation
  * propagates immediately through the waiting period.
- *
- * Ported from Go's `internal/ratelimit.KeyedRateLimiter`. The Go version uses
- * `golang.org/x/time/rate` (token bucket, 1 rps, burst 3). This Kotlin version
- * matches the steady-state behaviour: 1 request per second per region, with the
- * first call per region always returning immediately.
  */
 open class AudibleRateLimiter(
     /** Minimum gap between successive calls to the same region. */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleRegionConfig.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleRegionConfig.kt
@@ -27,8 +27,7 @@ internal val AudibleRegion.apiHost: String
 
 /**
  * The Audible website host for this region, used for web-scraping endpoints
- * such as the contributor author page (`/author/x/{asin}`). Ported from Go's
- * `Region.WebHost()` in `server/internal/metadata/audible/types.go`.
+ * such as the contributor author page (`/author/x/{asin}`).
  */
 internal val AudibleRegion.webHost: String
     get() =
@@ -51,10 +50,7 @@ internal val AudibleRegion.webHost: String
  * Audible's website (`/pd/{ASIN}` product pages, the author page, and the
  * author-search page) returns **HTTP 503** without a storefront locale cookie
  * and **HTTP 200** with one. Sending the right cookie both unblocks product-tag
- * scraping and fixes the non-US contributor lookup (issue #551 residual).
- *
- * Ported from Go's `Region.localeCookie()` in
- * `server/internal/metadata/audible/types.go` — values match exactly.
+ * scraping and fixes the non-US contributor lookup.
  */
 internal fun AudibleRegion.localeCookie(): String =
     when (this) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleTypes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleTypes.kt
@@ -19,8 +19,7 @@ import kotlinx.serialization.json.floatOrNull
 /**
  * Handles Audible API fields that may arrive as either a JSON number (`4.8`) or a
  * JSON string (`"4.8"`). The rating's `display_average_rating` sub-field is the
- * observed trigger; Go's reference uses a custom `UnmarshalJSON` for the same
- * reason (see `client.go` → `FlexibleFloat32`).
+ * observed trigger.
  */
 @Serializable(with = FlexibleFloat32Serializer::class)
 @JvmInline
@@ -57,7 +56,7 @@ internal object FlexibleFloat32Serializer : KSerializer<FlexibleFloat32> {
 // ─── Search params ────────────────────────────────────────────────────────────
 
 /**
- * Parameters for an Audible catalog search. Mirrors Go's `SearchParams`.
+ * Parameters for an Audible catalog search.
  *
  * Any combination of fields may be set; at least one should be non-null for a
  * meaningful response.
@@ -77,9 +76,8 @@ data class SearchParams(
 }
 
 // ─── Raw API response types ───────────────────────────────────────────────────
-// These types mirror the Audible JSON wire format exactly. Field names match
-// the Go `rawProduct`, `rawContributor`, `rawSeries`, `rawRating`, and
-// `rawChapterInfo` structs in `client.go`.
+// These types mirror the Audible JSON wire format exactly: the raw product,
+// contributor, series, rating, and chapter-info shapes returned by the catalog API.
 
 /** A contributor (author or narrator) reference as returned in product listings. */
 @Serializable
@@ -294,8 +292,7 @@ data class AudibleChapter(
  *
  * Unlike book metadata (which uses the catalog JSON API), contributor data is
  * fetched by scraping `www.audible.{tld}/author/x/{asin}` — Audible's official
- * API no longer returns contributor images or biographies. Ported from Go's
- * `ContributorProfile` in `server/internal/metadata/audible/types.go`.
+ * API no longer returns contributor images or biographies.
  *
  * `@Serializable` so [com.calypsan.listenup.server.services.MetadataService]
  * can cache this value as JSON in `MetadataCacheRepository`.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/ProductTag.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/ProductTag.kt
@@ -25,7 +25,7 @@ data class ProductTag(
  * `(type, name)` because the same tag repeats across impression blocks, and
  * preserve first-seen order.
  *
- * **Query-param tolerant** (mirrors [parseContributorSearch] / #551): Audible
+ * **Query-param tolerant** (mirrors [parseContributorSearch]): Audible
  * appends `?ref=…` tracking params after the `adbl_rec_tag_{id}` segment, so the
  * pattern tolerates anything up to the closing quote rather than requiring it
  * immediately after the id. The marker `adbl_rec_tag` distinguishes these

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
@@ -21,14 +21,12 @@ private val log = KotlinLogging.logger {}
  * series, chapters). iTunes is used here because its artwork resolution is
  * typically higher than Audible's (up to 7000×7000, vs Audible's 500px cap).
  *
- * The URL transformation and matching heuristic are ported directly from
- * Go's implementation at `server/internal/metadata/itunes/cover.go` and
- * `search.go`. Key deviations from Go's full surface:
+ * Key scope limits of this iTunes client:
  * - No `SearchAudiobooks` — only [findCover] is exposed; chapter/metadata
  *   lookups are Audible's domain.
- * - No image-dimension probing — Go's `GetImageDimensions` is not ported
- *   because we request the maximum-size URL and trust iTunes to serve the
- *   actual maximum; probing would require an extra HTTP round-trip per cover.
+ * - No image-dimension probing — we request the maximum-size URL and trust
+ *   iTunes to serve the actual maximum; probing would require an extra HTTP
+ *   round-trip per cover.
  * - No rate limiter — the caller is responsible for pacing; the client itself
  *   is stateless so tests can inject a `MockEngine` without timing concerns.
  *
@@ -140,19 +138,18 @@ class ITunesClient(
     /**
      * Pick the best match from [results].
      *
-     * Strategy (ported from Go's `SearchAudiobooks` filter + ordering):
+     * Strategy:
      * 1. Filter to real audiobook entries: `wrapperType == "audiobook"` OR
-     *    `collectionType == "Audiobook"` (Go applies this filter after fetching).
+     *    `collectionType == "Audiobook"` (applied after fetching).
      * 2. Among filtered candidates, prefer the first whose [ITunesSearchResult.collectionName]
      *    or [ITunesSearchResult.artistName] contains [title]/[author] respectively
-     *    (case-insensitive substring match — equivalent to Go combining title+author
-     *    into a single query and relying on iTunes relevance ordering).
+     *    (case-insensitive substring match, relying on iTunes relevance ordering).
      * 3. Fall back to the first filtered result (iTunes' own relevance ranking).
      * 4. If no audiobook-typed result exists at all, fall back to the first raw result.
      *
-     * Go does not implement a separate fuzzy scorer; it relies on iTunes relevance
-     * ordering. The substring check here is an improvement that avoids picking a
-     * clearly wrong result when multiple candidates are returned.
+     * The substring check is a deliberate addition on top of iTunes' relevance
+     * ordering: it avoids picking a clearly wrong result when multiple candidates
+     * are returned.
      */
     private fun pickBest(
         results: List<ITunesSearchResult>,
@@ -182,16 +179,10 @@ class ITunesClient(
      * serves the actual maximum available size (typically 2400×2400 or 3000×3000;
      * requesting 7000×7000 never overshoots, it just gets the max).
      *
-     * Pattern: `Regex("/\\d+x\\d+bb\\.jpg$")`, identical to Go's `sizePattern`
-     * in `cover.go`:
+     * Pattern: `Regex("/\\d+x\\d+bb\\.jpg$")` — replace the matched size segment
+     * with the maximum-size segment.
      *
-     *     var sizePattern = regexp.MustCompile(`/\d+x\d+bb\.jpg$`)
-     *     func MaxCoverURL(url string) string {
-     *         return sizePattern.ReplaceAllString(url, "/"+MaxCoverSize)
-     *     }
-     *
-     * [artworkUrl60] is used as a fallback when [artworkUrl100] is absent,
-     * matching Go's selection logic (`artworkURL := r.ArtworkURL100; if artworkURL == "" { artworkURL = r.ArtworkURL60 }`).
+     * [artworkUrl60] is used as a fallback when [artworkUrl100] is absent.
      */
     private fun toCoverHit(result: ITunesSearchResult): ITunesCoverHit {
         val sourceId = result.collectionId?.toString() ?: ""
@@ -213,9 +204,6 @@ class ITunesClient(
          * Matches iTunes artwork size fragments like `/100x100bb.jpg`, `/60x60bb.jpg`,
          * `/200x200bb.jpg`, etc. Anchored to end-of-string so partial paths are not
          * accidentally replaced.
-         *
-         * Identical to Go's `sizePattern` in `cover.go`:
-         *     regexp.MustCompile(`/\d+x\d+bb\.jpg$`)
          */
         val SIZE_PATTERN = Regex("""/\d+x\d+bb\.jpg$""")
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesTypes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesTypes.kt
@@ -19,8 +19,8 @@ internal data class ITunesSearchResponse(
  * A single match from the iTunes Search API.
  *
  * The [wrapperType] and [collectionType] fields are used to filter to real
- * audiobook entries (Go's SearchAudiobooks filters out non-audiobook wrapper
- * types). [artworkUrl100] is transformed to the maximum-resolution variant by
+ * audiobook entries, dropping non-audiobook wrapper types. [artworkUrl100] is
+ * transformed to the maximum-resolution variant by
  * [ITunesClient.toCoverHit]; [artworkUrl60] is used as a fallback if 100px is
  * absent.
  */
@@ -43,7 +43,7 @@ internal data class ITunesSearchResult(
  * [coverUrl] is the original 100×100 thumbnail URL from iTunes (kept for
  * reference and low-bandwidth contexts). [maxSizeUrl] is the high-resolution
  * variant — typically up to 7000×7000, with iTunes serving the actual maximum
- * available size — derived by URL substitution per Go's cover.go pattern.
+ * available size — derived by URL substitution.
  */
 data class ITunesCoverHit(
     val coverUrl: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/RateLimiting.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/RateLimiting.kt
@@ -23,9 +23,9 @@ object RateLimitBuckets {
 }
 
 /**
- * Phase 1 in-memory rate limiting keyed by remote host. Acceptable for the
- * self-hosted threat model — distributed/cluster-aware limits would be a
- * later concern if we ever leave the single-process deployment.
+ * In-memory rate limiting keyed by remote host. Acceptable for the
+ * self-hosted threat model — distributed/cluster-aware limits would only
+ * matter beyond the single-process deployment.
  */
 fun Application.installRateLimiting() {
     install(RateLimit) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/BookRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/BookRoutes.kt
@@ -106,7 +106,7 @@ internal fun Route.bookRoutes(
         call.respondGatedCover(res.id, accessPolicy, coverResponder)
     }
 
-    // The KMP/mobile client downloads covers from /api/v1/covers/{bookId} (the Go-era URL).
+    // The KMP/mobile client downloads covers from /api/v1/covers/{bookId}.
     // Serve the same access-gated bytes there: the books-nested route alone left every client
     // cover request 404'ing, so covers never rendered.
     routingGet("/api/v1/covers/{id}") {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
@@ -90,7 +90,7 @@ class CoverSpool(
      * least [ORPHAN_GRACE_MS]. A live scan's dir is modified on every cover write, so it stays far
      * under this window; recently-modified dirs are therefore left alone. This stops a fresh boot's
      * sweep from deleting a **concurrent** instance's in-flight scan dir out from under its persist
-     * (the cause of the spooled-cover 404s in #703 when a stale JVM still shares this data dir).
+     * (the cause of spooled-cover 404s when a stale JVM still shares this data dir).
      * Never throws.
      */
     fun sweepOrphans() {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
@@ -37,11 +37,10 @@ private val logger = KotlinLogging.logger {}
  * already pending will not be enqueued twice. A worker coroutine launched
  * by the constructor drains the queue, taking the mutex for each item.
  *
- * **Plan deviation:** the plan literal sketched `Channel.CONFLATED` for the
- * incremental queue. That collapses *all* traffic globally — when two
- * distinct book roots fire in quick succession the second clobbers the
- * first. We use an atomicfu-synchronized set for per-path dedup with an
- * unbounded queue, which gives the test-stated semantics ("100 triggers
+ * **Why not `Channel.CONFLATED`?** A conflated channel collapses *all* traffic
+ * globally — when two distinct book roots fire in quick succession the second
+ * clobbers the first. Instead, an atomicfu-synchronized set does per-path dedup
+ * over an unbounded queue, which gives the wanted semantics ("100 triggers
  * for the same path collapse to ≤ 1") *without* dropping events for
  * unrelated paths.
  *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -303,7 +303,7 @@ internal class Scanner(
         // Build the artwork-bearing result for BookPersister (so covers get written to disk).
         val incrementalResult =
             lastResult?.copy(
-                // Stamp THIS scan's id — never inherit lastResult's. Inheriting it (#703) made the
+                // Stamp THIS scan's id — never inherit lastResult's. Inheriting it made the
                 // incremental spool to its real correlationId but clear/report the previous full
                 // scan's, leaking the live spool dir and mis-keying ScanEvent.Completed.
                 correlationId = correlationId,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/inference/AbsTitleParser.kt
@@ -28,10 +28,10 @@ internal data class ParsedTitle(
  * decomposes cleanly without regex collisions.
  *
  * **Compatibility note on narrator splitting.** ABS uses `parseNameString`
- * which understands `&`, ` and `, `;`, and `Last, First` formats. Phase 2
+ * which understands `&`, ` and `, `;`, and `Last, First` formats. This parser
  * splits on the simple separators (`,`, `;`, `&`, ` and `) and trims;
- * full ABS parity for `Last, First` recombination is deferred to Phase 4
- * when name normalization gets a real implementation. For the typical
+ * full ABS parity for `Last, First` recombination is not yet implemented,
+ * pending a real name-normalization pass. For the typical
  * `{Michael Kramer; Kate Reading}` form, the simple split is correct.
  */
 internal object AbsTitleParser {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/inference/TrackInference.kt
@@ -26,9 +26,9 @@ internal data class TrackInfo(
  *
  * Track number is the first 1–4 digit run remaining in the filename after
  * stripping any matched disc prefix. Strict heuristic: ABS additionally
- * strips title/author/series/year text before this match, but Phase 2
- * skips that — embedded-tag-driven track inference is the right fix and
- * lands in Phase 3 (`TrackNumberSource.METADATA`).
+ * strips title/author/series/year text before this match, but this parser
+ * skips that — embedded-tag-driven track inference (`TrackNumberSource.METADATA`)
+ * is the better fix.
  */
 internal object TrackInference {
     private val discInFilename = Regex("""\b(disc|cd) ?(\d{1,2})\b""", RegexOption.IGNORE_CASE)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/AbridgedTitle.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/AbridgedTitle.kt
@@ -8,7 +8,7 @@ private val SUFFIX_ABRIDGED = Regex("""\s*[-:]\s*abridged\s*""", RegexOption.IGN
 /**
  * Detects an `(Abridged)`/`(Unabridged)` (or ` - / : abridged`) indicator in [title],
  * strips it, and returns `(cleanedTitle, isAbridged)`. Defaults to unabridged (most
- * audiobooks are). Ports Go's `scanner/analyzer.go parseAbridgedFromTitle`.
+ * audiobooks are).
  */
 fun parseAbridgedFromTitle(title: String): Pair<String, Boolean> {
     val lower = title.lowercase()

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -414,8 +414,7 @@ internal class Analyzer(
      * Chapter precedence:
      *   metadata.json (non-empty) → embedded (non-empty) → synthesized (multi-file) → empty.
      *
-     * Spec §3 of `2026-05-07-phase-4-multifile-chapter-synthesis-design.md`. The
-     * sidecar wins when present so user-curated chapter titles in ABS survive
+     * The sidecar wins when present so user-curated chapter titles in ABS survive
      * a rescan. Synthesis activates only when no higher source exists AND the
      * book is multi-file.
      *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesis.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/ChapterSynthesis.kt
@@ -15,8 +15,6 @@ import com.calypsan.listenup.domain.embeddedmeta.EmbeddedAudioMetadata
  *   - Required first number (1–3 digits)
  *   - Optional middle section: separator + optional word + second number
  *   - Optional trailing separator (zero or more, so bare numbers at end-of-stem match)
- *
- * Source: spec §5.1 of `2026-05-07-phase-4-multifile-chapter-synthesis-design.md`.
  */
 private val FILENAME_PREFIX_REGEX =
     Regex(
@@ -76,8 +74,6 @@ internal fun cleanFilename(name: String): String =
  * (`perTrackMetadata[track]` is null or `durationMs == 0`) produces a
  * zero-length chapter at the current cumulative position; subsequent
  * tracks' boundaries are unaffected by the failure.
- *
- * Source: spec §6 of `2026-05-07-phase-4-multifile-chapter-synthesis-design.md`.
  */
 internal fun synthesizeChapters(
     tracks: List<TrackEntry>,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/ContributorParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/ContributorParser.kt
@@ -11,9 +11,9 @@ data class ParsedContributor(
 /**
  * Splits a raw author/narrator metadata string into individual contributors with roles.
  *
- * A synthesis of two references: name-splitting + `Last, First` normalization from
- * Audiobookshelf's `parseNameString.js`, and ` - Role` suffix extraction from the Go
- * scanner's `roleMap`. Splits on the explicit person separators `;` / `&` / ` and `;
+ * A synthesis of two approaches: name-splitting + `Last, First` normalization from
+ * Audiobookshelf's `parseNameString.js`, plus ` - Role` suffix extraction via a
+ * role map. Splits on the explicit person separators `;` / `&` / ` and `;
  * within a segment a single comma is treated as `Last, First`. When no explicit
  * separator is present, a comma list is disambiguated by Audiobookshelf's rule: if the
  * first comma chunk is a bare surname (no space) the chunks are alternating `Last, First`

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/HtmlToMarkdown.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/HtmlToMarkdown.kt
@@ -2,8 +2,8 @@ package com.calypsan.listenup.server.scanner.pipeline
 
 /**
  * Minimal, dependency-free HTML→Markdown for scanned book descriptions. Audiobook
- * descriptions are simple prose; this handles the tag set Go's `scanner/html.go` guards
- * for (`p br div span b i strong em a ul ol li h1-6 blockquote`) + common entities.
+ * descriptions are simple prose; this handles the tag set
+ * (`p br div span b i strong em a ul ol li h1-6 blockquote`) + common entities.
  * Plain-text input (no detected HTML) is returned verbatim. Emphasis tags left unclosed
  * by malformed markup still convert (their span runs to end of input). Any failure falls
  * back to entity-decoded, tag-stripped text — never throws, never returns markup.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/LanguageNormalizer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/LanguageNormalizer.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.scanner.pipeline
 
 /**
  * Normalizes a raw language string to a lowercase ISO 639-1 code, or `null`
- * when unrecognized. Port of the Go scanner's `normalize.LanguageCode`.
+ * when unrecognized.
  *
  * Handles ISO 639-1 ("en"), ISO 639-2 incl. bibliographic alternates
  * ("eng"/"ger" -> "en"/"de"), locale codes ("en-US"/"en_GB" -> "en"), and

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/SidecarParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/SidecarParser.kt
@@ -5,7 +5,7 @@ import kotlinx.io.files.Path
 /**
  * Reads a metadata sidecar file into [SidecarMetadata]. Sidecars are read-only
  * enrichment inputs — a parser MUST NOT write to disk. (The Konsist rule
- * `SidecarParsersAreReadOnly`, added later in Books-A, enforces this.)
+ * `SidecarParsersAreReadOnly` enforces this.)
  *
  * A parser declares the filenames and/or extensions it handles. The
  * [com.calypsan.listenup.server.scanner.pipeline.Analyzer] routes each

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/StableSizeDebouncer.kt
@@ -22,7 +22,7 @@ import kotlin.time.Duration.Companion.seconds
  * Rather than special-case per OS, we layer this debouncer on every
  * platform: the file is "stable" when its size and mtime don't change
  * for [settle] consecutive duration. A 2 s settle with 500 ms polling is
- * the spec default — fast enough for human latency, slow enough to handle
+ * the default — fast enough for human latency, slow enough to handle
  * an SMB share's chattier events.
  *
  * Returns `false` if the file is deleted (or moved away) during the wait,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/GenreDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/GenreDomainSeeder.kt
@@ -10,8 +10,7 @@ import kotlin.uuid.Uuid
 private val logger = KotlinLogging.logger {}
 
 /**
- * Seeded genre node — the curator-controlled default taxonomy. Mirrors Go's
- * `internal/genre/defaults.go` (`GenreSeed`) verbatim.
+ * Seeded genre node — the curator-controlled default taxonomy.
  */
 private data class GenreSeed(
     val name: String,
@@ -20,8 +19,7 @@ private data class GenreSeed(
 )
 
 /**
- * Default genre tree — ported verbatim from
- * `/Users/simon/Code/listenup/server/internal/genre/defaults.go::DefaultGenres`.
+ * Default genre tree.
  *
  * Three top-level roots: Fiction, Non-Fiction, Children's & Young Adult. Mostly
  * two levels deep; a few branches reach depth 3.
@@ -210,8 +208,7 @@ private val DEFAULT_GENRES: List<GenreSeed> =
     )
 
 /**
- * Seeds the default Genre taxonomy on a fresh installation. Mirrors Go's
- * `internal/genre/defaults.go` tree verbatim. Writes through
+ * Seeds the default Genre taxonomy on a fresh installation. Writes through
  * [GenreRepository.upsert] — the real domain write path — so every seeded row is
  * indistinguishable from a curator creation. Idempotent: when any live genre
  * already exists, [isAlreadySeeded] returns `true` and [seed] is skipped, so a

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/AnalyzedBookMapper.kt
@@ -44,7 +44,7 @@ import kotlin.time.Clock
  * `bitrate`/`sampleRate`/`channels` come from `embedded.audioStream`; secondary
  * files leave them null (multi-file per-track audio metadata is a non-goal).
  *
- * `cover` is left null — cover hashing is a later task; the substrate-owned
+ * `cover` is left null — cover hashing is handled separately; the substrate-owned
  * `revision` / `updatedAt` / `createdAt` placeholders are overwritten by
  * `upsert`.
  *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -107,7 +107,7 @@ private class PreparedBatch(
  * pass after the book write commits (see [upsertFromAnalyzed]) — never nested inside the
  * SQLDelight book transaction — so a single writer never contends for the SQLite write lock.
  *
- * The system-collection membership (#680 pure-union model) is the one exception: a genuinely-new
+ * The system-collection membership (pure-union model) is the one exception: a genuinely-new
  * book's `collection_books` row — ALL_BOOKS for a non-held library, INBOX for a held one — is
  * written ATOMICALLY inside the SQLDelight book transaction ([writeSystemMembership]), because a
  * separate post-commit write left a narrow REST-catch-up window where a member could pull a held
@@ -391,7 +391,7 @@ class BookRepository(
                 deleted_at = null,
                 client_op_id = clientOpId,
             )
-            // Atomic system-collection membership (#680 pure-union model). When the scan path stashed
+            // Atomic system-collection membership (pure-union model). When the scan path stashed
             // a system collection id (genuinely-new book — ALL_BOOKS for a non-held library, INBOX for
             // a held one), write the book→collection `collection_books` membership in THIS same
             // SQLDelight transaction, so the book is collected the instant it exists. The two cases are
@@ -1255,7 +1255,7 @@ class BookRepository(
 
     /**
      * Writes the `(systemCollectionId, bookId)` membership into `collection_books` inside the
-     * open SQLDelight book transaction, atomically with the book insert (#680 pure-union model).
+     * open SQLDelight book transaction, atomically with the book insert (pure-union model).
      *
      * [systemCollectionId] is exactly one of the library's two system collections, resolved upstream
      * by [com.calypsan.listenup.server.services.BookPersister.resolveSystemCollectionId]: ALL_BOOKS

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookWriteExtras.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookWriteExtras.kt
@@ -18,7 +18,7 @@ import com.calypsan.listenup.server.db.sqldelight.currentTransactionLocal
 class BookWriteExtras(
     val managedCover: StoredCoverInfo? = null,
     /**
-     * The library's target system collection id (#680 pure-union model), set only when a
+     * The library's target system collection id (pure-union membership model), set only when a
      * genuinely-new book must be auto-assigned to a system collection: ALL_BOOKS when the inbox
      * gate is off (immediately member-visible via the default grant), or INBOX when on
      * (quarantined, admin-only). The two are mutually exclusive — a held book joins INBOX only.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreNormalizer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreNormalizer.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.services
 import com.calypsan.listenup.api.result.AppResult
 
 /**
- * Built-in genre normalization — ports Go's `internal/genre/aliases.go`.
+ * Built-in genre normalization.
  *
  * Resolves a raw scanner genre string to canonical taxonomy slug(s) via a baked-in
  * alias map (Audible's category taxonomy + common variations). This is the AUTO path;

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreSlug.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/GenreSlug.kt
@@ -19,13 +19,10 @@ import com.calypsan.listenup.server.sync.foldDiacritics
  * 6. Empty result → [GenreError.InvalidInput].
  * 7. Length > 100 → [GenreError.InvalidInput].
  *
- * Mirrors [com.calypsan.listenup.server.sync.TagSlug]. Diverges from Go's
- * `internal/genre/slug.go`, which has no `& → and` substitution. The Go-era
- * `defaults.go` authors canonical slugs such as `"sword-and-sorcery"` that
- * only this pipeline reproduces — the Go `Slugify()` was inconsistent with
- * its own seeded taxonomy. The Kotlin port resolves the inconsistency by
- * adopting TagSlug's rule, so `aliases.go` raw strings map to the same
- * canonical slugs at scanner time.
+ * Mirrors [com.calypsan.listenup.server.sync.TagSlug]. The `& → and` substitution
+ * is what produces canonical slugs such as `"sword-and-sorcery"`; adopting
+ * TagSlug's rule keeps raw alias strings mapping to the same canonical slugs at
+ * scanner time.
  */
 object GenreSlug {
     private const val MAX_SLUG_LENGTH = 100

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
@@ -31,10 +31,10 @@ private val log = KotlinLogging.logger {}
  * or the region matches the default, no fallback is attempted — otherwise the
  * default region is retried as a last resort.
  *
- * Cache TTLs ported from Go's `server/internal/store/sqlite/metadata.go`:
- * - search results: 24 h (`searchCacheDuration = 24 * time.Hour`)
- * - book metadata: 7 days (`bookCacheDuration = 7 * 24 * time.Hour`)
- * - chapters: 30 days (`chapterCacheDuration = 30 * 24 * time.Hour`)
+ * Cache TTLs:
+ * - search results: 24 h
+ * - book metadata: 7 days
+ * - chapters: 30 days
  *
  * Cache keys are scoped by region inside [MetadataCacheRepository] via the
  * `"${region.code}:${cacheKey}"` stored-key formula — callers provide only the
@@ -56,8 +56,7 @@ internal class MetadataService(
      * result for [SEARCH_TTL].
      *
      * Pass [refresh] = `true` to bypass the cache and force a fresh fetch.
-     * Only keyword-based searches are cached (matching Go's `cacheKey := params.Keywords`
-     * branch); searches with no keywords skip the cache entirely.
+     * Only keyword-based searches are cached; searches with no keywords skip the cache entirely.
      */
     suspend fun search(
         region: AudibleRegion,
@@ -83,8 +82,7 @@ internal class MetadataService(
      *
      * Tries [defaultRegion] first. If results are non-empty, returns them with
      * the default region. If empty (or [defaultRegion] is US and results are
-     * still empty), falls back to [AudibleRegion.US]. Mirrors Go's
-     * `SearchWithFallback` in `service/metadata.go`.
+     * still empty), falls back to [AudibleRegion.US].
      */
     suspend fun searchWithFallback(params: SearchParams): AppResult<List<AudibleSearchResult>> {
         val primaryResult = search(defaultRegion, params)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PendingGenrePromotion.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PendingGenrePromotion.kt
@@ -11,9 +11,9 @@ private val logger = KotlinLogging.logger {}
  * One-time, idempotent migration of the legacy `pending_book_genres` backlog into
  * live genres.
  *
- * Earlier phases stopped *writing* the pending queue (scan/apply now auto-create
+ * The scan/apply paths no longer *write* the pending queue (they auto-create
  * live genres directly), but a user's existing library still carries rows from
- * before the change. This promotion drains that backlog so the current library
+ * before that change. This promotion drains that backlog so the current library
  * lights up without a curator having to map every string by hand.
  *
  * For each book with pending rows it resolves every raw string through
@@ -27,8 +27,8 @@ private val logger = KotlinLogging.logger {}
  * `insertIfAbsent`, so re-running never duplicates links.
  *
  * Runs once on boot after migrations + genre seeding. Does NOT drop the
- * `pending_book_genres` table — that's a later cleanup phase; this only drains
- * its rows.
+ * `pending_book_genres` table — dropping it is a separate cleanup; this only
+ * drains its rows.
  */
 internal class PendingGenrePromotion(
     private val db: ListenUpDatabase,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserTimeZone.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserTimeZone.kt
@@ -10,7 +10,7 @@ import kotlinx.datetime.TimeZone
  * Defaults to [TimeZone.UTC] when the user has no row or when the stored timezone name is malformed,
  * so stats day-math callers never handle these edge cases. The per-user home timezone
  * (device-reported via login + live events; never imports) is the single consistent frame for all
- * server day-boundary math — streaks and the leaderboard. See #532.
+ * server day-boundary math — streaks and the leaderboard.
  */
 internal suspend fun ListenUpDatabase.homeTimeZone(userId: String): TimeZone {
     val name =

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexer.kt
@@ -18,8 +18,8 @@ import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
  * source tables, then uses the FTS5 `DELETE` + re-insert idiom required by
  * `contentless_delete=1` tables.
  *
- * **Why service-layer and not a SQL trigger?** The spec chose application-layer
- * reindexing for testability and decoupling — a trigger cannot join across
+ * **Why service-layer and not a SQL trigger?** Application-layer reindexing
+ * wins on testability and decoupling — a trigger cannot join across
  * `book_tags → tags → book_search_map` cleanly, whereas this class does it in
  * readable, testable Kotlin.
  */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionGrantRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionGrantRepository.kt
@@ -23,8 +23,8 @@ private const val PRINCIPAL_TYPE_USER = "USER"
  * `granted_by_user_id`), but the wire is unchanged: a USER-principal grant maps to a
  * [CollectionShareSyncPayload] (`sharedWithUserId` / `sharedByUserId`) over sync, and the
  * `domainName` stays `"collection_shares"`. [readPayload] / [writePayload] adapt between the
- * two — `principalType` is always `"USER"` on write. The wire/client rename to "grant" is
- * deferred to the phase that introduces GROUP principals.
+ * two — `principalType` is always `"USER"` on write. The wire/client rename to "grant"
+ * waits until GROUP principals are introduced.
  *
  * Permission is stored as a lowercase TEXT column (`"read"` / `"write"`); on read a corrupt or
  * unknown value defaults to [SharePermission.Read] (least-privilege).

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/AbsBackupReaderTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/AbsBackupReaderTest.kt
@@ -43,7 +43,7 @@ class AbsBackupReaderTest :
                 inProgress.currentTimeSeconds shouldBe 1234.0
                 // duration 5000s → progress ≈ 0.2468
                 inProgress.progress shouldBe 1234.0 / 5000.0
-                // Real ABS offset form "2022-01-17 04:33:12.000 +00:00" → epoch millis (#537/#532).
+                // Real ABS offset form "2022-01-17 04:33:12.000 +00:00" → epoch millis.
                 inProgress.lastUpdateMs shouldBe 1_642_393_992_000L
             }
         }
@@ -82,7 +82,7 @@ class AbsBackupReaderTest :
         }
 
         test("real ABS offset timestamps survive to true epochs, not 1970 (the #532 stats path)") {
-            // Bug #532: imported listening stats stayed empty because session/progress timestamps in
+            // Regression: imported listening stats stayed empty because session/progress timestamps in
             // ABS's "2024-06-12 02:48:10.063 +00:00" form parsed to 0L → every listening_event landed
             // in 1970, outside the weekly window, with all streak dates collapsed onto one day. Guard
             // both the session (startedAt → stats minutes/streaks) and progress (sort key) paths.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/AbsTestFixtures.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/AbsTestFixtures.kt
@@ -170,7 +170,7 @@ private fun java.sql.Connection.insertAbsRows() {
                     1234.0,
                     5000.0,
                     finished = false,
-                    // Real Sequelize-SQLite offset form (#537/#532) — same instant as the clean ISO-Z form.
+                    // Real Sequelize-SQLite offset form — same instant as the clean ISO-Z form.
                     "2022-01-17 04:33:12.000 +00:00",
                 ),
                 ProgressRow(
@@ -215,7 +215,7 @@ private fun java.sql.Connection.insertAbsSessions() {
                 startTime = 100.0,
                 currentTime = 3700.0,
                 timeListening = 3600,
-                // The real Sequelize-on-SQLite DATE form ABS writes (#537/#532): same instant as
+                // The real Sequelize-on-SQLite DATE form ABS writes: same instant as
                 // 2022-01-17T04:33:12.000Z, but the offset spelling collapsed to 1970 in the old parser.
                 startedAt = "2022-01-17 04:33:12.000 +00:00",
                 device = "Pixel 8",

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/AbsTimestampParseTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/AbsTimestampParseTest.kt
@@ -12,7 +12,7 @@ import kotlin.time.Instant
  * The regression that motivated this: Sequelize-on-SQLite writes `DataTypes.DATE` columns as
  * `2024-06-12 02:48:10.063 +00:00` — space-separated, with a millisecond fraction and an explicit
  * ` +00:00` offset. The old parser fell through every branch on that form and returned 0L, so every
- * imported listening position got `lastPlayedAt = 0` and Continue Listening lost its ordering (#537).
+ * imported listening position got `lastPlayedAt = 0` and Continue Listening lost its ordering.
  */
 class AbsTimestampParseTest :
     FunSpec({

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AdminUserServiceImplTest.kt
@@ -349,7 +349,7 @@ class AdminUserServiceImplTest :
                 runTest {
                     val svc = makeAdminUserService(db).actAs("root1", UserRole.ROOT)
                     // Search is an active-roster operation — pending/denied have their own surfaces
-                    // and must not leak in (#624, sibling of the listUsers filter).
+                    // and must not leak in (sibling of the listUsers filter).
                     val ids = svc.searchUsers("alice").shouldSucceed().map { it.id.value }
                     ids shouldContain "activeAlice"
                     ids shouldNotContain "pendingAlice"

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetGenresTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BookServiceImplSetGenresTest.kt
@@ -36,7 +36,7 @@ import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
 
 /**
- * Integration tests for [BookServiceImpl.setBookGenres]. Covers the spec Path 2
+ * Integration tests for [BookServiceImpl.setBookGenres]. Covers the
  * contract: 200-input cap, BookError.NotFound for unknown book, BookError.InvalidInput
  * for unknown or tombstoned genreIds (NO auto-create), atomic replace semantics, and
  * re-upsert side-effect.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/GenreServiceImplUnmappedTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/GenreServiceImplUnmappedTest.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.test.runTest
 
 /**
  * Integration tests for [GenreServiceImpl.listUnmappedStrings] and
- * [GenreServiceImpl.mapUnmappedToGenre]. Covers the spec Path 3 flow end-to-end:
+ * [GenreServiceImpl.mapUnmappedToGenre]. Covers the full flow end-to-end:
  * curator picks a raw string from the unmapped queue, binds it to a target
  * genre, alias is recorded, every affected book gets a junction row, pending
  * entries are cleared, and affected books are re-upserted so their

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataApplyEnrichmentTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataApplyEnrichmentTest.kt
@@ -108,7 +108,7 @@ private val ENRICH_SELECTION =
  *    `book_tags`; a value the user deselected is never written.
  *  - **Empty selection:** a selection with no moods/tags removes all of the book's moods/tags
  *    (explicit "none"), but the match still succeeds (the text metadata commits regardless).
- *  - **Reconciling re-match (#573):** re-applying with a second selection replaces the first —
+ *  - **Reconciling re-match:** re-applying with a second selection replaces the first —
  *    a deselected mood/tag is dropped, only the new selection survives.
  *
  * Drives [BookMetadataApplier] directly (rather than through [MetadataLookupServiceImpl]) so the
@@ -160,7 +160,7 @@ class MetadataApplyEnrichmentTest :
             }
         }
 
-        // #573: re-matching now RECONCILES moods/tropes to the new selection (replace, not add).
+        // Re-matching RECONCILES moods/tropes to the new selection (replace, not add).
         // A deselected mood/tag from the first apply is dropped; only the second selection survives.
         test("re-matching reconciles moods/tropes to the new selection instead of accumulating (#573)") {
             withSqlDatabase {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/db/DataDirLockTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/db/DataDirLockTest.kt
@@ -7,7 +7,7 @@ import kotlinx.io.files.Path
 
 /**
  * Pins [DataDirLock] — the single-instance guard that stops two servers from sharing one data home
- * and racing the scan-spool (#703).
+ * and racing the scan-spool.
  */
 class DataDirLockTest :
     FunSpec({

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndFixture.kt
@@ -39,7 +39,7 @@ import java.nio.file.Files
  * | `ServerConfig`         | [TestServerConfig] returning the embedded URL            |
  * | `InstanceRepository`   | [StubInstanceRepository] — auth flow doesn't read it     |
  * | `UserRepository` /     | Not bound — `LoginUseCase` / `LogoutUseCase` aren't      |
- * | `PlaybackManager`      | resolved by F12; tests call `AuthRepository` direct      |
+ * | `PlaybackManager`      | resolved here; tests call `AuthRepository` direct        |
  *
  * The test exercises the full client→server round-trip, including kotlinx.rpc
  * serialization, JWT signing, refresh-token rotation, and Exposed/SQLite
@@ -124,8 +124,8 @@ internal class AuthEndToEndFixture private constructor(
                 // jvmMain) — the type is internal to :sharedLogic so it can't be bound from here.
                 // `UserRepository` and `PlaybackManager` are only needed by
                 // `LoginUseCase` / `LogoutUseCase` (factory bindings in
-                // `clientAuthModule`). F12 calls `AuthRepository` directly and
-                // never resolves the use cases, so omitting these bindings
+                // `clientAuthModule`). These tests call `AuthRepository` directly and
+                // never resolve the use cases, so omitting these bindings
                 // keeps the test surface minimal.
             }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/AuthEndToEndTest.kt
@@ -44,7 +44,7 @@ class AuthEndToEndTest :
             )
 
         // Setup + persist tokens to AuthSession. AuthRepository.setup itself doesn't
-        // persist (that's SetupUseCase's job in production); the F12 fixture exercises
+        // persist (that's SetupUseCase's job in production); this end-to-end fixture exercises
         // the repo directly, so this helper plays the use case's role.
         suspend fun bootstrap(fix: AuthEndToEndFixture): com.calypsan.listenup.api.dto.auth.AuthSession {
             val session =

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/StubInstanceRepository.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/StubInstanceRepository.kt
@@ -8,7 +8,7 @@ import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.VerifiedServer
 
 /**
- * Stub [InstanceRepository] for the F12 fixture — `AuthSessionStore` reads it
+ * Stub [InstanceRepository] for the auth end-to-end fixture — `AuthSessionStore` reads it
  * during `checkServerStatus()` and `initializeAuthState()`, but those paths
  * are never exercised by the auth round-trip we test here. A failing stub is
  * enough; if a future test needs the instance check, replace this with a real

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/TestServerConfig.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/e2e/TestServerConfig.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.asStateFlow
  *
  * Production [ServerConfig] is `SettingsRepositoryImpl` reading from
  * `SecureStorage` plus mDNS rediscovery. None of that machinery is relevant
- * to F12, which is exercising the contract round-trip across a real wire.
+ * to these end-to-end tests, which exercise the contract round-trip across a real wire.
  */
 internal class TestServerConfig(
     private val baseUrl: String,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/fixtures/BuildMp3File.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/fixtures/BuildMp3File.kt
@@ -218,8 +218,7 @@ internal class Mp3Builder internal constructor() {
  * | 2     | Original        | `0`                                         |
  * | 1..0  | Emphasis        | `0b00`                                      |
  *
- * Ported from `/home/simonh/Code/audiometa/internal/mp3/technical.go` (the
- * reverse direction — that file decodes; this one encodes).
+ * This is the encode direction — the inverse of the frame-header decoder.
  */
 internal fun mpegFrameHeader(
     bitrate: Int,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/fixtures/BuildMp4File.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/fixtures/BuildMp4File.kt
@@ -10,9 +10,7 @@ import kotlinx.io.readByteArray
  * [com.calypsan.listenup.server.embeddedmeta.format.mp4.Mp4Parser] tests and
  * the property-test generators that exercise the parser on randomised inputs.
  *
- * The encoded byte layout matches the Go reference at
- * `/home/simonh/Code/audiometa/internal/m4a/`. In particular, the Nero `chpl`
- * encoding follows the Go variant: `version(1) + flags(3) + reserved(4) +
+ * The Nero `chpl` encoding is `version(1) + flags(3) + reserved(4) +
  * count(1) + per-chapter (start-100ns(8) + title-len(1) + title-utf8)`.
  *
  * Coverage:
@@ -262,7 +260,7 @@ internal class MoovBuilder internal constructor() {
         // to ftyp size. The cleanest solution is to make Mp4Builder do the
         // patching after assembling all top-level atoms.
         //
-        // For now, encode moov with chunk offsets pre-set assuming a
+        // Instead, encode moov with chunk offsets pre-set assuming a
         // canonical 24-byte ftyp (size 24 = ftyp header 8 + brand 4 + minor
         // 4 + 2 compat brands × 4 = 24). The default ftyp() emits exactly 24.
         // Tests using non-default ftyp lengths must use Nero chapters
@@ -440,8 +438,7 @@ internal class UdtaBuilder internal constructor() {
     }
 
     /**
-     * Emit a Nero `chpl` chapter list. Layout matches the Go reference
-     * (`/home/simonh/Code/audiometa/internal/m4a/chapters_test.go`):
+     * Emit a Nero `chpl` chapter list. Layout is
      * `version(1) + flags(3) + reserved(4) + count(1)` then per chapter
      * `start-100ns(8) + title-len(1) + title-utf8`.
      */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserPropertyTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/embeddedmeta/format/mp4/Mp4ParserPropertyTest.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.runBlocking
  * Generators are intentionally narrow — only inputs that round-trip cleanly
  * through the encoder/decoder pair are covered. ASCII-only text avoids
  * trailing-space ambiguity (the parser strips trailing ASCII spaces from
- * tag values per the Go reference's convention) and keeps the focus on
+ * tag values) and keeps the focus on
  * parser-side bugs.
  */
 class Mp4ParserPropertyTest :

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClientTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClientTest.kt
@@ -275,7 +275,7 @@ class AudibleClientTest :
                 val profile = (result as AppResult.Success<AudibleContributorProfile?>).data
                 profile.shouldNotBeNull()
                 profile.name shouldBe "Brandon Sanderson"
-                // The 120px thumbnail src is upsized to a 600px rendition (#615).
+                // The 120px thumbnail src is upsized to a 600px rendition.
                 profile.imageUrl shouldBe
                     "https://images-na.ssl-images-amazon.com/images/S/amzn-author-media-prod/" +
                     "o1ehbft4gejvtoskr22jt89eit._SX600_.jpg"
@@ -568,8 +568,8 @@ private val CONTRIBUTOR_PAGE_WITH_OG_IMAGE =
     """.trimIndent()
 
 /**
- * Author page HTML mirroring the REAL Audible structure (verified against a live author page,
- * #615): there is **no** `og:image` meta tag — the photo lives only in the
+ * Author page HTML mirroring the REAL Audible structure (verified against a live author page):
+ * there is **no** `og:image` meta tag — the photo lives only in the
  * `author-image-outline` `<img>`, whose `src` carries Amazon size params (commas) and is followed
  * by an `onerror` attribute. Guards that the `author-image-outline` fallback (not just the
  * synthetic og:image fixture) extracts a real photo URL.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/audible/ParseContributorSearchTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/metadata/audible/ParseContributorSearchTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [parseContributorSearch] — extracts the contributor hits from an Audible
  * search-by-author page (`/search?searchAuthor=...`).
  *
- * Fixtures mirror the real anchor shape rather than full page snapshots. The key case is #551:
+ * Fixtures mirror the real anchor shape rather than full page snapshots. The key case:
  * Audible appends tracking query params (`?ref=…`, `pf_rd_*`, …) after the ASIN, which the previous
  * regex (requiring a quote immediately after the ASIN) failed to match, making every search empty.
  */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/plugins/MaintenanceGateTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/plugins/MaintenanceGateTest.kt
@@ -40,7 +40,7 @@ class MaintenanceGateTest :
                 // The wire format is {"type":"BackupError.RestoreInProgress",...}; the
                 // BACKUP_RESTORE_IN_PROGRESS value is the `code` constant but is a body
                 // property not a constructor param, so the @SerialName discriminator is
-                // what the plan's assertion should match.
+                // what this test asserts against.
                 state.enter()
                 val blocked = client.get("/ping")
                 blocked.status shouldBe HttpStatusCode.ServiceUnavailable

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/AdminUserServiceRpcTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/AdminUserServiceRpcTest.kt
@@ -35,7 +35,7 @@ import kotlinx.rpc.withService
  * End-to-end reachability test for [AdminUserService.listUsers] over the authed kotlinx.rpc
  * surface — the exact path the Android admin screen drives (`AdminRepositoryImpl` → RPC proxy).
  *
- * Regression for #619: with a PENDING_APPROVAL applicant present, the admin page showed
+ * Regression: with a PENDING_APPROVAL applicant present, the admin page showed
  * "Something Went Wrong on the Server" and the pending list never appeared. The REST surface
  * serializes a pending [User] fine; this test exercises the RPC transport specifically.
  */
@@ -91,7 +91,7 @@ class AdminUserServiceRpcTest :
                         }.withService<AdminUserService>()
 
                 val users = service.listUsers().shouldBeInstanceOf<AppResult.Success<List<User>>>().data
-                // #624: the active roster excludes a pending applicant (it belongs only in the
+                // The active roster excludes a pending applicant (it belongs only in the
                 // pending section); the root admin (ACTIVE) is present. Serialization round-trips
                 // cleanly over RPC either way.
                 users.any { it.id.value == pendingId } shouldBe false

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverRouteTest.kt
@@ -299,7 +299,7 @@ class BookCoverRouteTest :
             }
         }
 
-        // ── The mobile-client cover URL: GET /api/v1/covers/{id} (Go-parity alias) ──
+        // ── The mobile-client cover URL: GET /api/v1/covers/{id} ──
         // The KMP client downloads covers from /api/v1/covers/{bookId}; the Kotlin server
         // only had /api/v1/books/{id}/cover, so every client cover request 404'd and covers
         // never rendered. This alias serves the same access-gated bytes at the client's URL.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverUploadRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/BookCoverUploadRouteTest.kt
@@ -94,7 +94,7 @@ class BookCoverUploadRouteTest :
                         }
                     uploadResponse.status shouldBe HttpStatusCode.NoContent
 
-                    // Cover is now served at the Go-era client URL.
+                    // Cover is now served at the client cover URL.
                     val serveResponse =
                         client.get("/api/v1/covers/b1") {
                             bearerAuth(token)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutesTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/RegistrationStatusRoutesTest.kt
@@ -98,7 +98,7 @@ class RegistrationStatusRoutesTest :
         }
 
         test("registration-status stream reports approved on connect when the decision was already made") {
-            // Regression for #623: the registrant's SSE wasn't live at the instant the admin
+            // Regression: the registrant's SSE wasn't live at the instant the admin
             // approved (replay=0 broadcaster → the live push was dropped). On a fresh connect
             // / reconnect / "check status", the stream must report the PERSISTED status, not an
             // eternal "pending". Otherwise the iOS Awaiting screen never advances.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/rpcguard/RpcGuardEndToEndTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/rpcguard/RpcGuardEndToEndTest.kt
@@ -35,7 +35,7 @@ import kotlinx.rpc.withService
  * connects via WebSocket, and the test asserts that the client receives a typed
  * [InternalError] — never a raw stacktrace.
  *
- * This is the load-bearing security test for the rpc-exception-guard phase.
+ * This is the load-bearing security test for the RPC exception guard.
  * If it passes, stacktraces structurally cannot cross the wire for any service
  * wrapped by [guard].
  */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/AudioLibraryFixture.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/AudioLibraryFixture.kt
@@ -9,9 +9,9 @@ import kotlin.io.path.writeText
 /**
  * A test-only DSL for assembling synthetic audiobook libraries on disk.
  *
- * Phase 2 doesn't read audio file content, so audio "tracks" are zero-byte
- * placeholders with the correct extension. Phase 3 will add a separate
- * fixture that emits real test audio for the audiometa port.
+ * The scan path under test doesn't read audio file content, so audio "tracks" are
+ * zero-byte placeholders with the correct extension. A separate fixture emits real
+ * test audio for the audio-metadata parser tests.
  *
  * Usage:
  * ```

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScanSummaryAggregationTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScanSummaryAggregationTest.kt
@@ -19,7 +19,7 @@ import io.kotest.matchers.shouldBe
 /**
  * Pins the [ScanResultSummary] aggregator and human-readable log formatter
  * against deliberate combinations of [MetadataStatus]. The aggregator is
- * the single point where Phase 3 scan summaries are computed; the
+ * the single point where scan summaries are computed; the
  * formatter is the single point where they're rendered for operators.
  */
 class ScanSummaryAggregationTest :

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerEmbeddedmetaIntegrationTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerEmbeddedmetaIntegrationTest.kt
@@ -30,7 +30,7 @@ import java.nio.file.Path
 
 /**
  * End-to-end integration coverage: real audio bytes through Walker →
- * Grouper → Analyzer → Differ, exercising the full Phase 3b enrichment
+ * Grouper → Analyzer → Differ, exercising the full enrichment
  * pipeline.
  *
  * Three deliberate book fixtures probe distinct contracts:

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndTest.kt
@@ -18,8 +18,8 @@ import kotlinx.coroutines.delay
  * server, real DI graph, real Walker → Grouper → Analyzer → Differ pipeline,
  * real REST + Resources surface. The contract boundary is exercised in full.
  *
- * Following Phase 1's F12 pattern: NO test-only overrides on the production
- * graph — failures here mean the production wiring is broken.
+ * NO test-only overrides on the production graph — failures here mean the
+ * production wiring is broken.
  *
  * Coverage:
  *  - A triggered scan picks up every book in the library
@@ -40,7 +40,7 @@ import kotlinx.coroutines.delay
  * These cases run in Kotest's plain test scope — NOT `runTest`. They make
  * real socket I/O against a real embedded server, so virtual time is the
  * wrong tool: Ktor 3.5.0's `HttpTimeout` plugin launches its timeout coroutine
- * in the *caller's* context (KTOR issue #4720 fix), so under `runTest` the
+ * in the *caller's* context (a Ktor coroutine-context behavior), so under `runTest` the
  * request-timeout's `delay` rides the auto-advancing virtual clock and fires
  * instantly — before the real network round-trip can complete. Real I/O tests
  * use real time; `AuthEndToEndTest` is the reference. The polling helper

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerTest.kt
@@ -313,7 +313,7 @@ class ScannerTest :
 
                     scanner.runIncremental(Path(fixture.root.resolve("Author/Title").toString())) // scan-2
 
-                    // Bug #703: `lastResult?.copy(...)` inherited the prior full scan's correlationId,
+                    // Regression: `lastResult?.copy(...)` inherited the prior full scan's correlationId,
                     // so the incremental spooled to scan-2 but cleared/reported scan-1 — leaking the
                     // real spool dir and mis-keying ScanEvent.Completed.
                     withClue("incremental result must carry its own correlationId (scan-2), not inherit scan-1") {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/sidecar/SidecarMergeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/sidecar/SidecarMergeTest.kt
@@ -26,7 +26,7 @@ import kotlinx.io.files.Path as IoPath
 
 /**
  * Exercises the sidecar precedence tier through the real [Analyzer] path with
- * a fake [SidecarParser]. The plan's `mergeWithPrecedence` method is a fiction
+ * a fake [SidecarParser]. There is no single `mergeWithPrecedence` method
  * — the Analyzer composes via per-field `pick*` chains, so these tests assert
  * the resolved [com.calypsan.listenup.api.dto.scanner.AnalyzedBook] fields.
  *

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/seed/GenreDomainSeederTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/seed/GenreDomainSeederTest.kt
@@ -150,7 +150,7 @@ class GenreDomainSeederTest :
                             .filter { it.id in children }
                             .map { it.slug }
                             .toSet()
-                    // From defaults.go — 10 sub-genres under Fantasy.
+                    // The default taxonomy has 10 sub-genres under Fantasy.
                     childSlugs.size shouldBe 10
                     childSlugs shouldContain "epic-fantasy"
                     childSlugs shouldContain "urban-fantasy"

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/GenreSlugNormalizeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/GenreSlugNormalizeTest.kt
@@ -10,10 +10,9 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  * Unit tests for [GenreSlug.normalize].
  *
  * Mirrors `TagSlug` semantics: NFKD diacritic strip → lowercase → `&` → ` and `
- * → non-alphanum runs → `-` → collapse + trim. The Go reference in
- * `internal/genre/slug.go` differs (no `& → and` substitution); we deliberately
- * adopt the TagSlug rule because `defaults.go` authors canonical slugs such as
- * `"sword-and-sorcery"` that only this pipeline reproduces.
+ * → non-alphanum runs → `-` → collapse + trim. The `& → and` substitution is
+ * deliberate: it produces canonical slugs such as `"sword-and-sorcery"` that no
+ * other pipeline reproduces.
  */
 class GenreSlugNormalizeTest :
     FunSpec({

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncFoundationE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncFoundationE2ETest.kt
@@ -26,7 +26,7 @@ class SyncFoundationE2ETest :
 
         test("end-to-end lifecycle: SSE connect → write → receive → reconnect → REST catch-up") {
             withTestApplication {
-                // ---- Phase 1: Connect SSE, write, assert receive ----
+                // ---- Step 1: Connect SSE, write, assert receive ----
                 var firstReceivedRevision: Long = 0
 
                 client.sse("/api/v1/sync/events") {
@@ -41,10 +41,10 @@ class SyncFoundationE2ETest :
                     }
                 }
 
-                // ---- Phase 2: Write while disconnected ----
+                // ---- Step 2: Write while disconnected ----
                 tagRepo.upsert(Tag("t2", "beta", "beta", 0, 0))
 
-                // ---- Phase 3: Reconnect with Last-Event-Id, verify replay + live tail ----
+                // ---- Step 3: Reconnect with Last-Event-Id, verify replay + live tail ----
                 // With replay=256, reconnecting with Last-Event-Id=1 delivers t2 (missed while
                 // disconnected) from the replay cache, then t3 live. This is the desired catch-up
                 // behavior — the client doesn't need REST for events still in the bus buffer.
@@ -64,19 +64,19 @@ class SyncFoundationE2ETest :
                     }
                 }
 
-                // ---- Phase 4: Verify domain-list discovery ----
+                // ---- Step 4: Verify domain-list discovery ----
                 val list: DomainList = client.get("/api/v1/sync/domains").body()
                 list.domains shouldBe listOf("tags")
 
-                // ---- Phase 5: Verify digest ----
+                // ---- Step 5: Verify digest ----
                 val digest: DomainDigest = client.get("/api/v1/sync/tags/digest?cursor=999").body()
                 digest.count shouldBe 3 // t1, t2, t3
 
-                // ---- Phase 6: REST catch-up returns all rows ----
+                // ---- Step 6: REST catch-up returns all rows ----
                 val page: Page<Tag> = client.get("/api/v1/sync/tags?since=0").body()
                 page.items shouldHaveSize 3
 
-                // ---- Phase 7: Soft-delete a row, assert tombstone in catch-up ----
+                // ---- Step 7: Soft-delete a row, assert tombstone in catch-up ----
                 tagRepo.softDelete("t1")
                 val pageAfterDelete: Page<Tag> = client.get("/api/v1/sync/tags?since=0").body()
                 val t1 = pageAfterDelete.items.first { it.id == "t1" }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncRegistryPerKoinTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncRegistryPerKoinTest.kt
@@ -14,10 +14,10 @@ import org.koin.dsl.module
 /**
  * Pins the per-Koin scoping of [SyncRegistry] — two independent Koin containers
  * must yield independent registries, so parallel `withTestApplication { }` blocks
- * (and Books-A's cross-domain Tags+Books tests) can't trample each other's
+ * (and cross-domain Tags+Books tests) can't trample each other's
  * registrations.
  *
- * Before this task, [SyncRoutes] was a process-wide `internal object` holding a
+ * Previously, [SyncRoutes] was a process-wide `internal object` holding a
  * static `ConcurrentHashMap`. The second `register("tags", …)` in a JVM run
  * would silently overwrite the first — invisible under serial test execution,
  * flaky under `kotest.parallelism > 1`. This test would have caught it.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncRoutesStreamErrorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncRoutesStreamErrorTest.kt
@@ -42,7 +42,7 @@ import org.sqlite.SQLiteConfig
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
 
 /**
- * Pins the spec §189 invariant: when the SSE firehose's emit pipeline throws,
+ * Pins the invariant: when the SSE firehose's emit pipeline throws,
  * the server emits a `SyncControl.StreamError(InternalError(correlationId, cause))`
  * frame where `cause` is the THROWABLE'S CLASS NAME only — never a full
  * stacktrace, package path, or `Caused by:` chain.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SystemCollectionSyncExclusionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SystemCollectionSyncExclusionTest.kt
@@ -23,8 +23,7 @@ import kotlinx.coroutines.test.runTest
 private const val PULL_LIMIT = 100
 
 /**
- * Fragment-materialisation tests for the system-collection exclusion rules introduced in
- * Collections Phase 2b-i.
+ * Fragment-materialisation tests for the system-collection exclusion rules.
  *
  * System collections (`ALL_BOOKS`, `INBOX`) are server-managed substrate and must never
  * appear in a member's COLLECTION-domain sync payload. A book that lives in `ALL_BOOKS`

--- a/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.delay
  * `io.kotest.provided.ProjectConfig` on the server test classpath — distinct from the `:sharedLogic`
  * config, which is not on this module's classpath).
  *
- * The server suite boots an in-process Ktor server + a real SQLite DB per spec. On the contended
+ * The server suite boots an in-process Ktor server + a real SQLite DB. On the contended
  * 2-core CI runner a few timing-sensitive specs intermittently stall or fail in ways that never
  * reproduce on a fast local box — historically the `Test (JVM)` job's recurring hang. Two guards,
  * mirroring the proven `:sharedLogic` config:

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/sqldelight/IoDispatcher.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/sqldelight/IoDispatcher.linux.kt
@@ -6,6 +6,6 @@ import kotlinx.coroutines.Dispatchers
 // Dispatchers.IO is internal on Kotlin/Native in kotlinx-coroutines 1.11.0 — no public IO-pool
 // equivalent is exposed on native. Dispatchers.Default is a real multi-threaded pool on native
 // (unlike the single-threaded legacy native model), so it is a safe dispatch site for the
-// synchronous SQLiter driver calls inside suspendTransaction. Revisit during the native-core
-// phase if a dedicated IO pool becomes public in a future coroutines release.
+// synchronous SQLiter driver calls inside suspendTransaction. Revisit if a dedicated IO pool
+// becomes public in a future coroutines release.
 internal actual val sqlIoDispatcher: CoroutineDispatcher = Dispatchers.Default

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/sqldelight/RetryableSqliteError.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/sqldelight/RetryableSqliteError.linux.kt
@@ -3,8 +3,8 @@ package com.calypsan.listenup.server.db.sqldelight
 /**
  * Native actual: SQLiter surfaces busy/locked as an exception whose message carries the SQLite text.
  * Match on the message across the cause chain (no SQLiter type import needed, so this always compiles
- * on Linux). The native server runs under low write-concurrency for now; tighten to a typed match
- * if a busy-snapshot storm is ever observed natively.
+ * on Linux). The native server runs under low write-concurrency, so a string match suffices; tighten
+ * to a typed match if a busy-snapshot storm is ever observed natively.
  */
 actual fun Throwable.isRetryableSqliteError(): Boolean {
     var cause: Throwable? = this

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/NativeServerBootTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/NativeServerBootTest.kt
@@ -20,7 +20,7 @@ import platform.posix.setenv
 import kotlin.test.Test
 
 /**
- * The Phase-5 flip proof: boots the REAL [Application.module] on a Kotlin/Native `embeddedServer(CIO)`
+ * Boots the REAL [Application.module] on a Kotlin/Native `embeddedServer(CIO)`
  * and serves `GET /healthz`. A successful boot exercises the entire native stack at once — the native
  * SQLite driver (schema migrations), native crypto (the auto-generated JWT/refresh secrets), file I/O
  * (`$LISTENUP_HOME/secrets.properties`), the full Koin graph, and the request pipeline — so this is

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/SystemEnvNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/SystemEnvNativeTest.kt
@@ -6,7 +6,7 @@ import platform.posix.setenv
 import kotlin.test.Test
 
 /**
- * Native proof for the [readEnv] / [userHomeDir] / [hostname] env seam (Phase 5 capability port): the
+ * Native proof for the [readEnv] / [userHomeDir] / [hostname] env seam: the
  * linuxX64 actuals read the process environment via `platform.posix.getenv` and the host name via
  * `gethostname`. Round-trips a value set with `setenv`, confirms an unset name reads as null, and proves
  * the host-name actual returns a sane, NUL-stripped string.

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/metadata/MetadataHttpClientNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/metadata/MetadataHttpClientNativeTest.kt
@@ -22,10 +22,10 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 /**
- * Native capability proof for the metadata HTTP client (Phase 5-4c): `MetadataModule` wires an
+ * Native capability proof for the metadata HTTP client: `MetadataModule` wires an
  * `HttpClient(CIO)` with ContentNegotiation to call Audible/iTunes. This pins that a Kotlin/Native
  * CIO client can perform a GET **and deserialize a JSON body via ContentNegotiation** — the exact
- * path the scrapers rely on (#913's multipart test proved client request/response but not the
+ * path the scrapers rely on (an earlier multipart test proved client request/response but not the
  * client-side JSON ContentNegotiation seam).
  *
  * `kotlin.test.@Test` + `runBlocking`, `Unit` body, real `embeddedServer(CIO)` over an ephemeral port.

--- a/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
+++ b/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
@@ -51,9 +51,9 @@ class KoinModuleVerifyTest :
     FunSpec({
         // Verify voiceModule — the voice intent resolver and its four repository dependencies.
         //
-        // Narrow module; the extraTypes list is correspondingly small. Covered as step 1 of
-        // the Finding 12 D4 expansion ("every leaf module is verified"). PresentationModule
-        // verification is deferred to W3, which rewrites the DI layout (Finding 02 R1) and
+        // Narrow module; the extraTypes list is correspondingly small. Part of the
+        // "every leaf module is verified" expansion. PresentationModule
+        // verification is deferred until the DI layout is rewritten, which
         // would immediately invalidate any extraTypes enumerated today.
         test("verifyVoiceModule") {
             voiceModule.verify(
@@ -67,9 +67,8 @@ class KoinModuleVerifyTest :
             )
         }
 
-        // Verify [playbackPresentationModule] — single shared playback VM bound as `single`
-        // per W7 Phase E2.2.3 consolidation. Closes drift #33 ("playbackPresentationModule
-        // not covered by module.verify()").
+        // Verify [playbackPresentationModule] — the single shared playback VM is bound as `single`.
+        // This module was previously not covered by module.verify().
         //
         // `extraTypes` enumerates cross-module dependencies that other Koin modules satisfy.
         test("verifyPlaybackPresentationModule") {

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/download/DownloadManager.kt
@@ -142,7 +142,7 @@ class DownloadManager internal constructor(
             }
 
         // Persistence Rule 1: insert is transactional. resumeIncompleteDownloads is the
-        // documented recovery path for crash-between-commit-and-enqueue (Finding 08 D9).
+        // documented recovery path for crash-between-commit-and-enqueue.
         transactionRunner.atomically {
             downloadDao.insertAll(entities)
         }
@@ -194,7 +194,7 @@ class DownloadManager internal constructor(
     override suspend fun cancelDownload(bookId: BookId) {
         // Await WorkManager cancellation completion before updating DB state. Closes the race
         // where a worker's final updateProgress write lands after cancelAllWorkByTag returns
-        // but before the state update fires (Finding 08 D10).
+        // but before the state update fires.
         workManager.cancelAllWorkByTag(bookTag(bookId)).await()
         downloadRepository
             .cancelForBook(bookId)
@@ -211,7 +211,7 @@ class DownloadManager internal constructor(
         // Cancel any active downloads first
         // Await WorkManager cancellation completion before deleting files. Closes the race
         // where a worker's final updateProgress write lands after cancelAllWorkByTag returns
-        // but before the deletion fires (Finding 08 D10).
+        // but before the deletion fires.
         workManager.cancelAllWorkByTag(bookTag(bookId)).await()
 
         // Delete files from disk

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -62,18 +62,15 @@ private const val BYTES_PER_MEGABYTE = 1_000_000
 /**
  * iOS implementation of [DownloadService] using NSURLSession background downloads.
  *
- * **W10 carveout (W8 Phase B):** this class still writes directly to
+ * **Direct-DAO carveout:** this class still writes directly to
  * [com.calypsan.listenup.client.data.local.db.DownloadDao] via the `downloadDao` constructor
- * parameter — Sync Engine Rule 5 violation, deferred to W10. The Android side migrated to inject
- * [com.calypsan.listenup.client.domain.repository.DownloadRepository] in W8 Phase B, but iOS is
- * part of W10 (iOS Player Adoption) which owns the iOS migration onto shared Kotlin VMs and
- * shared repositories. See `docs/superpowers/specs/2026-05-01-w8-handoff-design.md` § Phase B
- * "AppleDownloadService keeps its current DAO writes" and § Out of scope ("iOS download adoption
- * — deferred to W10").
+ * parameter — a Sync Engine Rule 5 violation, not yet migrated. The Android side already injects
+ * [com.calypsan.listenup.client.domain.repository.DownloadRepository]; the iOS migration onto
+ * shared Kotlin VMs and shared repositories is still pending.
  *
- * For Phase B specifically, this class's interface compliance was updated:
- * - [downloadBook] returns [com.calypsan.listenup.api.result.AppResult]<[com.calypsan.listenup.client.domain.model.DownloadOutcome]> instead of the legacy `DownloadResult`.
- * - [observeBookStatus] aggregates via the new sealed [com.calypsan.listenup.client.domain.model.BookDownloadStatus] hierarchy.
+ * This class's interface complies with [DownloadService] as follows:
+ * - [downloadBook] returns [com.calypsan.listenup.api.result.AppResult]<[com.calypsan.listenup.client.domain.model.DownloadOutcome]>.
+ * - [observeBookStatus] aggregates via the sealed [com.calypsan.listenup.client.domain.model.BookDownloadStatus] hierarchy.
  *
  * The internal DAO writes remain untouched.
  *
@@ -83,7 +80,7 @@ private const val BYTES_PER_MEGABYTE = 1_000_000
  * codec the server can serve (AAC, MP3, FLAC, ALAC, Opus), so negotiation is unnecessary — the
  * download URL points directly at the original file. **If a future server adds a codec iOS does
  * not natively support, this class requires codec negotiation matching the Android worker's
- * pattern.** Closes Finding 08 D6 (principled asymmetry, not silent omission).
+ * pattern.** This is a principled asymmetry, not a silent omission.
  */
 @OptIn(ExperimentalTime::class)
 class AppleDownloadService internal constructor(
@@ -377,11 +374,11 @@ class AppleDownloadService internal constructor(
                 .mapValues { (bookId, files) -> aggregateBookDownloadStatus(bookId, files) }
         }
 
-    // Inline copy of DownloadManager.aggregateStatus until Task 8 moves the canonical version
-    // into DownloadRepository. iOS keeps its own copy through W10 (deferred carveout per W8 design).
+    // Inline copy of DownloadManager.aggregateStatus; the canonical version has not yet
+    // moved into DownloadRepository, and iOS keeps its own copy.
     // Known parity gap with Android's aggregator: does NOT filter DownloadState.CANCELLED from
-    // activeDownloads. This gap now reaches the interface via observeAllStatuses (W8 Phase E D11) —
-    // when a cross-book consumer arrives before W10 closes this carveout, fix here first or it
+    // activeDownloads. This gap now reaches the interface via observeAllStatuses —
+    // when a cross-book consumer arrives, fix here first or it
     // will mis-report aggregate status on iOS.
     private fun aggregateBookDownloadStatus(
         bookId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
@@ -36,7 +36,7 @@ internal object ErrorMapper {
                 when {
                     // 401 means the session is stale/invalid — type it as an auth error at the
                     // boundary so the global auth-failure observer drives the app back to login
-                    // instead of looping a generic "server error" snackbar (issue #640). 403
+                    // instead of looping a generic "server error" snackbar. 403
                     // (authenticated-but-forbidden) stays a plain 4xx — it is not a session failure.
                     status == HttpStatusCode.Unauthorized.value -> {
                         AuthError.SessionExpired(debugInfo = exception.message)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserver.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserver.kt
@@ -14,7 +14,7 @@ private val logger = KotlinLogging.logger {}
 /**
  * Watches the app-wide [ErrorBus] and turns a session-invalidating [AuthError]
  * into a soft logout, so a stale/invalid session lands the user on the login
- * screen instead of looping a generic error snackbar (issue #640).
+ * screen instead of looping a generic error snackbar.
  *
  * This is the single, transport-agnostic place that reacts to auth failure:
  * a 401 from any surface (REST, RPC, SSE) is typed as an [AuthError] at the

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
@@ -110,9 +110,9 @@ internal interface ActivityDao {
      * Joins `user_profiles` (for display data) with `activities` (for recent stats).
      * Users with no recent activity show 0 values.
      *
-     * TODO(P2-leaderboard): The P2 `user_stats` table now holds per-user materialized
+     * TODO: The `user_stats` table now holds per-user materialized
      *  stats; this query should be updated to join `user_stats` for all-time stats and
-     *  `user_profiles` for profile data once the P2 sync domain handler lands.
+     *  `user_profiles` for profile data once the stats sync domain handler lands.
      *
      * @param sinceMs Epoch milliseconds - only include activities since this time
      * @return Flow emitting list of user stats

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
@@ -29,7 +29,7 @@ import com.calypsan.listenup.client.domain.repository.ImageStorage
  * ## Children
  *
  * This mapper handles the book root row only. Chapter, contributor, and series rows are
- * the responsibility of `BookSyncDomainHandler` (Task 27).
+ * the responsibility of `BookSyncDomainHandler`.
  */
 internal class BookEntityMapper {
     /**
@@ -188,7 +188,7 @@ internal fun BookWithContributors.toListItem(
  * Convert BookWithContributors to domain BookDetail for the detail screen.
  *
  * Computes [BookDetail.allContributors] via dedup-and-role-aggregation — same
- * algorithm as the (deleted in Task 12) private mapper in BookRepositoryImpl.
+ * algorithm as the now-deleted private mapper in BookRepositoryImpl.
  * Genres, tags, and moods are loaded externally and passed through.
  */
 internal fun BookWithContributors.toDetail(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseTransactions.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseTransactions.kt
@@ -5,7 +5,7 @@ import androidx.room.useWriterConnection
 
 /**
  * Runs a series of DAO writes inside a single SQLite write transaction so they either all
- * commit or all roll back (Finding 05 D2 of the architecture audit).
+ * commit or all roll back.
  *
  * Every call site that issues more than one DAO write for a single logical operation —
  * pullers, sync event processors, multi-entity edit repositories, library reset — must

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.Flow
  * [tz] is the IANA timezone name recorded at the time of the event (e.g.
  * `"Europe/London"`); it drives streak day-boundary math on both client and server.
  *
- * Carries the P2 sync substrate ([revision], [deletedAt]) for bidirectional
+ * Carries the sync substrate ([revision], [deletedAt]) for bidirectional
  * reconciliation with the server.
  */
 @Entity(
@@ -308,7 +308,7 @@ internal interface ListeningEventDao {
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /**
-     * Observe every live event's [endedAt] for [userId], oldest-first (#532). Drives the
+     * Observe every live event's [endedAt] for [userId], oldest-first. Drives the
      * client-side streak computation — the week window isn't enough because the longest streak
      * spans all history. A list of longs is cheap; only distinct calendar days matter downstream.
      *
@@ -318,7 +318,7 @@ internal interface ListeningEventDao {
     fun observeEndedAt(userId: String): Flow<List<Long>>
 
     /**
-     * One-time repair (#532): re-stamp rows poisoned with a blank userId (written during a startup
+     * One-time repair: re-stamp rows poisoned with a blank userId (written during a startup
      * catch-up before auth resolved) with the now-known signed-in [userId]. Idempotent — a no-op
      * once no blank rows remain. Returns the number of rows updated.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
@@ -122,7 +122,7 @@ internal interface PlaybackPositionDao {
      * Reactive counterpart to [getRecentPositions] — emits the [limit] most recently
      * started, unfinished positions whenever any position row changes, pushing the
      * sort and the limit to SQL so Home's Continue Listening shelf never has to pull
-     * every position to the client just to take the top N (Finding 09).
+     * every position to the client just to take the top N.
      *
      * Excludes positions with `positionMs = 0` (unstarted) AND `isFinished = true`
      * (already done) — the client-side duration-based filter handles the in-flight

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Relations.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Relations.kt
@@ -354,7 +354,7 @@ internal data class BookMoodEntity(
  *
  * Ordering semantics: aliases have no intrinsic order — DAO queries sort
  * alphabetically via `COLLATE NOCASE` for stable display across merges and
- * syncs. See Finding 05 D3 in the architecture audit.
+ * syncs.
  *
  * @property contributorId Foreign key to the contributor
  * @property alias Single alias name (stored as typed — dedup is case-insensitive

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchFtsEntities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchFtsEntities.kt
@@ -13,8 +13,7 @@ package com.calypsan.listenup.client.data.local.db
  * ranking and the FTS5 tokenizer pipeline we currently depend on in SearchDao.
  *
  * Revisit when Room 3.x ships a stable release — at that point these data
- * classes fold into @Fts5 @Entity declarations and the Callback disappears
- * (restoration-roadmap W4.4 deferred item).
+ * classes fold into @Fts5 @Entity declarations and the Callback disappears.
  *
  * Why standalone tables (not external content)?
  * - Simpler sync: delete all + reinsert during sync

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
@@ -123,7 +123,7 @@ internal class ValueClassConverters {
  * Stores enums by their declared `name` instead of their ordinal index — ordinal
  * storage silently corrupts data when an enum constant is inserted, reordered,
  * or removed, since previously-written rows then map to the wrong case.
- * Storing by name is resilient to reorderings (Finding 05 D3) and makes the
+ * Storing by name is resilient to reorderings and makes the
  * SQLite column human-readable in ad-hoc inspection. `valueOf` throws on an
  * unknown value, which is what we want: the app refuses to interpret a state
  * it no longer understands rather than silently remap it.
@@ -172,7 +172,7 @@ internal class CoverDownloadStatusConverter {
 /**
  * Round-trips a small `List<String>` as a JSON array using [appJson].
  *
- * Replaces the deleted `StringListConverter` (Finding 05 D3): the old split-on-`|||`
+ * Replaces the deleted `StringListConverter`: the old split-on-`|||`
  * approach silently corrupted any entry that happened to contain the literal
  * delimiter. JSON has no such collision surface and is human-readable in ad-hoc
  * database inspection.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserStatsDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserStatsDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Data Access Object for [UserStatsEntity] operations.
  *
- * Manages per-user materialized stats, synced from the server via the P2 stats
+ * Manages per-user materialized stats, synced from the server via the stats
  * sync domain. The primary key is the user ID (`id`).
  */
 @Dao

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/documents/DocumentStorage.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/documents/DocumentStorage.kt
@@ -66,7 +66,7 @@ internal interface DocumentStorage {
      * re-fetch. Runs on [IODispatcher].
      *
      * Used to garbage-collect orphaned cache files when a book's document UUIDs rotate on
-     * rescan (issue #699).
+     * rescan.
      *
      * @param bookId Owning book identifier.
      * @param docId Server document UUID whose cached file should be removed.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration17To18.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration17To18.kt
@@ -5,7 +5,7 @@ import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.execSQL
 
 /**
- * Room schema migration v17 → v18 — Playback-P1 syncable-domain landing.
+ * Room schema migration v17 → v18 — syncable-domain landing.
  *
  * `playback_positions` becomes a first-class syncable domain. The table gains
  * `revision` (monotonic server revision) and `deletedAt` (epoch-ms tombstone).

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration18To19.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration18To19.kt
@@ -5,18 +5,18 @@ import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.execSQL
 
 /**
- * Room schema migration v18 → v19 — Playback-P2 stats domain landing.
+ * Room schema migration v18 → v19 — stats domain landing.
  *
  * Changes:
- * - `listening_events` — rebuilt with the P2 shape: drops the old leaderboard-era
+ * - `listening_events` — rebuilt with the new shape: drops the old leaderboard-era
  *   columns (`deviceId`, `syncState`, `source`, `createdAt`) and replaces them with
  *   the sync-substrate columns (`userId`, `tz`, `deviceLabel`, `revision`, `deletedAt`).
  *   Index set also changes to composite `(userId, endedAt)` / `(userId, revision)` /
  *   `(userId, bookId)`. Existing rows are discarded (pre-launch; no production data at risk).
- * - `user_stats` — rebuilt with the P2 stats shape: drops the old leaderboard-cache
+ * - `user_stats` — rebuilt with the new stats shape: drops the old leaderboard-cache
  *   columns (`userId`, `displayName`, `avatarColor`, `avatarType`, `avatarValue`,
  *   `totalTimeMs`, `totalBooks`, `currentStreak`, `updatedAt`) and replaces with the
- *   materialized P2 stats columns mirroring `UserStatsSyncPayload`. Existing rows discarded.
+ *   materialized stats columns mirroring `UserStatsSyncPayload`. Existing rows discarded.
  * - `tentative_span` — new local-only crash-recovery table (not synced).
  *
  * Both table rebuilds use DROP + CREATE rather than ALTER TABLE because the column sets

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration30To31.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration30To31.kt
@@ -5,7 +5,7 @@ import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.execSQL
 
 /**
- * v30 → v31: rename the activities cache column `createdAt` → `occurredAt` (#548) so the feed
+ * v30 → v31: rename the activities cache column `createdAt` → `occurredAt` so the feed
  * orders/displays by the real event time. Renames in place to preserve cached rows.
  */
 internal val MIGRATION_30_31: Migration =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ActivityRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ActivityRpcFactory.kt
@@ -37,7 +37,7 @@ internal interface ActivityRpcFactory {
  * (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format, two
- * transports. Token rotation is a known phase-1-auth deferral, shared across every RPC factory.
+ * transports. Token rotation is not yet implemented; the same gap exists in every RPC factory.
  */
 internal open class KtorActivityRpcFactory(
     private val apiClientFactory: ApiClientFactory,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiContracts.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiContracts.kt
@@ -693,7 +693,7 @@ internal data class SeriesEditResponse(
  * Contract interface for user-profile API operations.
  *
  * Retains only the `getCurrentUser` endpoint. The `getBookReaders` and
- * `getUserReadingHistory` endpoints were removed in P3: the Readers section
+ * `getUserReadingHistory` endpoints were removed: the Readers section
  * now sources its data from the [com.calypsan.listenup.api.SocialService] RPC
  * (ACL-filtered server-side, refreshed on presence pings), with no REST fallback.
  */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BackupRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BackupRpcFactory.kt
@@ -37,7 +37,7 @@ internal interface BackupRpcFactory {
  * (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format, two transports.
- * Token rotation is a known phase-1-auth deferral — shared across every RPC factory.
+ * Token rotation is not yet implemented — the same gap exists in every RPC factory.
  */
 internal open class KtorBackupRpcFactory(
     private val apiClientFactory: ApiClientFactory,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
@@ -38,7 +38,7 @@ internal interface CollectionRpcFactory {
  * client is recycled (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format,
- * two transports. Token rotation is a known phase-1-auth deferral, shared across
+ * two transports. Token rotation is not yet implemented; the same gap exists in
  * every RPC factory.
  */
 internal open class KtorCollectionRpcFactory(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/HttpClientErrorHandling.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/HttpClientErrorHandling.kt
@@ -12,7 +12,7 @@ import io.ktor.client.HttpClientConfig
  * it through [com.calypsan.listenup.client.core.error.ErrorMapper] to produce an
  * `AppResult.Failure(typedError)`.
  *
- * (Finding 01 D6 / rubric rule "Ktor clients must enable `expectSuccess = true`.")
+ * (Ktor clients must enable `expectSuccess = true`.)
  */
 internal fun HttpClientConfig<*>.installListenUpErrorHandling() {
     expectSuccess = true

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ImportRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ImportRpcFactory.kt
@@ -37,7 +37,7 @@ internal interface ImportRpcFactory {
  * (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format, two transports.
- * Token rotation is a known phase-1-auth deferral — shared across every RPC factory.
+ * Token rotation is not yet implemented — the same gap exists in every RPC factory.
  */
 internal open class KtorImportRpcFactory(
     private val apiClientFactory: ApiClientFactory,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/LibraryAdminRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/LibraryAdminRpcFactory.kt
@@ -42,7 +42,7 @@ interface LibraryAdminRpcFactory {
  *
  * Wire serialization is the contract-layer [contractJson] — one wire format, two transports.
  *
- * Token rotation is a known phase-1-auth deferral — same across every RPC factory
+ * Token rotation is not yet implemented — the same gap exists in every RPC factory
  * in the codebase. Not solved here.
  */
 internal open class KtorLibraryAdminRpcFactory(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/MetadataLookupRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/MetadataLookupRpcFactory.kt
@@ -42,7 +42,7 @@ internal interface MetadataLookupRpcFactory {
  * Wire serialization is the contract-layer [contractJson] — one wire format, two
  * transports.
  *
- * Token rotation is a known phase-1-auth deferral — same across every RPC factory
+ * Token rotation is not yet implemented — the same gap exists in every RPC factory
  * in the codebase. Not solved here.
  */
 internal open class KtorMetadataLookupRpcFactory(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
@@ -13,7 +13,7 @@ import kotlinx.rpc.withService
 
 /**
  * Supplies the [PlaybackService] kotlinx.rpc proxy that backs playback preparation
- * and position recording (the Playback-P1 client write path).
+ * and position recording (the client write path).
  *
  * An interface so repositories depend on a seam that fakes/mocks in tests —
  * [KtorPlaybackRpcFactory] is the production implementation over WebSocket RPC.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ProfileRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ProfileRpcFactory.kt
@@ -38,7 +38,7 @@ internal interface ProfileRpcFactory {
  * client is recycled (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format,
- * two transports. Token rotation is a known phase-1-auth deferral, shared across
+ * two transports. Token rotation is not yet implemented; the same gap exists in
  * every RPC factory.
  */
 internal open class KtorProfileRpcFactory(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SessionApi.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SessionApi.kt
@@ -13,7 +13,7 @@ private val logger = KotlinLogging.logger {}
 /**
  * API client for user-profile operations.
  *
- * `getBookReaders` and `getUserReadingHistory` were removed in P3: the Readers
+ * `getBookReaders` and `getUserReadingHistory` were removed: the Readers
  * section now sources its data from the [com.calypsan.listenup.api.SocialService] RPC
  * (ACL-filtered server-side, refreshed on presence pings), with no REST fallback.
  *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
@@ -37,7 +37,7 @@ internal interface ShelfRpcFactory {
  * (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format, two
- * transports. Token rotation is a known phase-1-auth deferral, shared across every RPC factory.
+ * transports. Token rotation is not yet implemented; the same gap exists in every RPC factory.
  */
 internal open class KtorShelfRpcFactory(
     private val apiClientFactory: ApiClientFactory,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SocialRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SocialRpcFactory.kt
@@ -37,7 +37,7 @@ internal interface SocialRpcFactory {
  * (server URL changed, manual reset).
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format, two
- * transports. Token rotation is a known phase-1-auth deferral, shared across every RPC factory.
+ * transports. Token rotation is not yet implemented; the same gap exists in every RPC factory.
  */
 internal open class KtorSocialRpcFactory(
     private val apiClientFactory: ApiClientFactory,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TagRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TagRpcFactory.kt
@@ -39,7 +39,7 @@ internal interface TagRpcFactory {
  *
  * Wire serialization uses the contract-layer [contractJson] — one wire format, two transports.
  *
- * Token rotation is a known phase-1-auth deferral — same across every RPC factory.
+ * Token rotation is not yet implemented — the same gap exists in every RPC factory.
  */
 internal open class KtorTagRpcFactory(
     private val apiClientFactory: ApiClientFactory,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/api/ListenUpApi.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/api/ListenUpApi.kt
@@ -88,7 +88,6 @@ internal class ListenUpApi(
             // HTTP logging. Authorization is always sanitised — the bearer token is
             // sensitive and must never appear in logs, even in debug builds. Verbosity
             // drops in release builds so production log sinks don't receive header dumps.
-            // See Finding 04 D6.
             install(Logging) {
                 logger =
                     object : Logger {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/Mappers.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/Mappers.kt
@@ -35,7 +35,7 @@ internal fun BookResponse.toEntity(): BookEntity =
         sortTitle = sortTitle,
         subtitle = subtitle,
         // coverHash intentionally null here: the legacy BookResponse path is superseded by the
-        // BookService RPC fetch — see the Books-A audit §5.1 (cover-pipeline unification, Books-C).
+        // BookService RPC fetch.
         coverHash = null,
         coverBlurHash = coverImage?.blurHash,
         totalDuration = totalDuration,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -153,7 +153,7 @@ internal class AdminRepositoryImpl(
             // typed failures rather than raising them). The cached kotlinx.rpc proxy is likely bound
             // to a dead/cancelled RpcClient after a reconnect to the same server — so drop the caches
             // now and the next call (or a screen re-entry) rebinds to the live connection instead of
-            // stranding the user until app restart (#619). No auto-retry: this path also wraps
+            // stranding the user until app restart. No auto-retry: this path also wraps
             // non-idempotent writes, so re-firing the same call could double-apply.
             logger.warn(e) { "admin RPC $op failed at the transport boundary; invalidating RPC caches" }
             rpcCacheInvalidator.invalidateAll()

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryImpl.kt
@@ -90,7 +90,7 @@ internal class HomeRepositoryImpl(
                         0f
                     }
 
-                // Derive finished state from position vs duration (#204, #208)
+                // Derive finished state from position vs duration
                 // A book is finished if position >= duration OR (flag set AND near-complete)
                 val effectivelyFinished =
                     book.duration > 0 && (
@@ -150,7 +150,7 @@ internal class HomeRepositoryImpl(
      * @return Flow emitting list of [ContinueListeningItem] whenever positions or books change
      */
     override fun observeContinueListening(limit: Int): Flow<List<ContinueListeningItem>> =
-        // Push the sort + limit + isFinished=0 filter to SQL (Finding 09). Room still
+        // Push the sort + limit + isFinished=0 filter to SQL. Room still
         // re-emits on any row change, so the Home shelf stays reactive without
         // pulling every position to the client.
         playbackPositionDao

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImpl.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.map
 /**
  * Room-backed implementation of [ListeningEventRepository].
  *
- * Read-only: listening-event writes are owned by the canonical P2 recording path
+ * Read-only: listening-event writes are owned by the canonical recording path
  * ([com.calypsan.listenup.client.playback.ListeningEventRecorder]). This class
  * surfaces DAO read queries as domain types.
  *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -487,9 +487,8 @@ internal class PlaybackPositionRepositoryImpl(
     }
 
     private suspend fun handleDiscardProgress(bookId: BookId) {
-        // Local-only reset. A DISCARD_PROGRESS pending-op enqueue is deferred to a
-        // follow-up phase; until then DiscardProgress flows through the legacy REST path.
-        // See docs/superpowers/followups.md — "DiscardProgress / Restart legacy REST path".
+        // Local-only reset. A DISCARD_PROGRESS pending-op enqueue is not yet implemented;
+        // until then DiscardProgress flows through the REST path.
         val existing = dao.get(bookId) ?: return // no-op if no row
         val now = currentEpochMilliseconds()
         dao.save(
@@ -505,9 +504,8 @@ internal class PlaybackPositionRepositoryImpl(
     }
 
     private suspend fun handleRestart(bookId: BookId) {
-        // Local-only reset. A RESTART_BOOK pending-op enqueue is deferred to a
-        // follow-up phase; until then Restart flows through the legacy REST path.
-        // See docs/superpowers/followups.md — "DiscardProgress / Restart legacy REST path".
+        // Local-only reset. A RESTART_BOOK pending-op enqueue is not yet implemented;
+        // until then Restart flows through the REST path.
         val existing = dao.get(bookId) ?: return // no-op if no row
         val now = currentEpochMilliseconds()
         dao.save(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -182,7 +182,7 @@ internal class SyncRepositoryImpl(
     private suspend fun startEngineForCurrentUser(): AppResult<Unit> =
         suspendRunCatching {
             val userId = authSession.getUserId() ?: return@suspendRunCatching Unit
-            // One-time repair (#532): re-stamp rows written with a blank userId during a startup
+            // One-time repair: re-stamp rows written with a blank userId during a startup
             // catch-up race (authState still Initializing when insertIfAbsent ran). Idempotent.
             listeningEventDao.reassignBlankUserId(userId).let { repaired ->
                 if (repaired > 0) logger.info { "Repaired $repaired listening_events rows with a blank userId" }
@@ -491,7 +491,7 @@ internal suspend fun applyScanEvent(
  * its contents swapped for a different book just because that book was just scanned.
  *
  * Append-only with no cap: the marquee deliberately drifts slowly and shows the front (oldest) tiles,
- * so trimming from the front would yank visible tiles out and make the strip blink/swap (#587).
+ * so trimming from the front would yank visible tiles out and make the strip blink/swap.
  * [ScanBookRef] is tiny (title + author) and a scan is bounded, so retaining all matched books is
  * negligible and the rendering `LazyRow` stays lazy.
  */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/LibraryResetHelperImpl.kt
@@ -14,8 +14,8 @@ private val logger = KotlinLogging.logger {}
  * Coordinates clearing data across multiple DAOs while preserving
  * non-library data (downloads, preferences).
  *
- * Every delete runs inside a single write transaction — Finding 05 D2 / W4.2 —
- * so a failure at any step leaves the DB untouched rather than partially wiped.
+ * Every delete runs inside a single write transaction, so a failure at any step
+ * leaves the DB untouched rather than partially wiped.
  * Because the reset spans essentially every library table, the helper depends on
  * the [ListenUpDatabase] directly instead of listing each DAO individually; the
  * semantic is "operate on the library as a whole".

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/BookSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/BookSyncDomainHandler.kt
@@ -307,7 +307,7 @@ internal class BookSyncDomainHandler(
         // Capture the rows about to be replaced so their now-orphaned cache files can be
         // collected. Document UUIDs are minted fresh on every server rescan, so a re-scan
         // rotates every id — without this GC the `{documents}/{bookId}/` cache grows without
-        // bound as `{old-uuid}.{ext}` files are stranded on disk (issue #699).
+        // bound as `{old-uuid}.{ext}` files are stranded on disk.
         val staleDocs =
             if (documentStorage == null) {
                 emptyList()

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/ListeningEventSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/ListeningEventSyncDomainHandler.kt
@@ -14,7 +14,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * Client-side sync handler for the `listening_events` domain (Playback-P2).
+ * Client-side sync handler for the `listening_events` domain.
  *
  * Applies server sync events into the Room `listening_events` table. Each row is a
  * closed, uninterrupted listening span; the domain is **append-only** — no merge
@@ -27,7 +27,7 @@ private val logger = KotlinLogging.logger {}
  * listening-event rows are not propagated to the client (the server never mutates
  * domain fields on a committed span).
  *
- * **Tombstone handling.** The server does not emit listening-event tombstones in P2,
+ * **Tombstone handling.** The server does not emit listening-event tombstones,
  * but the substrate interface requires handling them. A tombstone received via
  * [onCatchUpItem] applies a soft-delete by `id` and revision; a [SyncEvent.Deleted]
  * at the SSE level is a no-op (same reasoning as [PlaybackPositionSyncDomainHandler]'s

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/PlaybackPositionSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/PlaybackPositionSyncDomainHandler.kt
@@ -14,7 +14,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * Client-side sync handler for the `playback_positions` domain (Playback-P1).
+ * Client-side sync handler for the `playback_positions` domain.
  *
  * Applies server sync events into the Room `playback_positions` table. One row
  * per book is the client's resume point; the server is the shared authority for

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/UserStatsSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/handlers/UserStatsSyncDomainHandler.kt
@@ -13,7 +13,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * Client-side sync handler for the `user_stats` domain (Playback-P2).
+ * Client-side sync handler for the `user_stats` domain.
  *
  * Applies server sync events into the Room `user_stats` table. Each row is a
  * **server-maintained materialized view** — the server is the sole writer of
@@ -25,7 +25,7 @@ private val logger = KotlinLogging.logger {}
  * therefore unconditionally replaces the local row. There are no local-only columns
  * to preserve.
  *
- * **Tombstone handling.** The server does not emit user-stats tombstones in P2
+ * **Tombstone handling.** The server does not emit user-stats tombstones
  * (the row exists for the lifetime of the user). Tombstones received via
  * [onCatchUpItem] apply a soft-delete by `id`; [SyncEvent.Deleted] at the SSE
  * level is handled defensively with a log.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AppCoreModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/AppCoreModule.kt
@@ -52,7 +52,7 @@ internal val appCoreModule: Module =
         }
 
         // Global auth-failure watcher: a session-invalidating AuthError on the bus
-        // soft-logs-out → login (issue #640). createdAtStart so it subscribes before
+        // soft-logs-out → login. createdAtStart so it subscribes before
         // any auth error can be emitted.
         single(createdAtStart = true) {
             AuthFailureObserver(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -58,7 +58,7 @@ internal val libraryModule: Module =
             SyncApi(clientFactory = get())
         }
 
-        // UserPreferencesRpcFactory — kotlinx.rpc proxy for UserPreferencesService (#599).
+        // UserPreferencesRpcFactory — kotlinx.rpc proxy for UserPreferencesService.
         single<UserPreferencesRpcFactory> {
             KtorUserPreferencesRpcFactory(
                 apiClientFactory = get(),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
@@ -45,7 +45,7 @@ internal val listeningModule: Module =
         }
 
         // ListeningEventRepository — read-only DAO surface for stats/leaderboard.
-        // Listening-event writes are owned by the P2 canonical recording path
+        // Listening-event writes are owned by the canonical recording path
         // (ListeningEventRecorder, bound below).
         single<ListeningEventRepository> {
             ListeningEventRepositoryImpl(
@@ -63,7 +63,7 @@ internal val listeningModule: Module =
             )
         }
 
-        // Listening event recorder — span state machine for P2 listening history.
+        // Listening event recorder — span state machine for listening history.
         // Single source for the binding (previously duplicated across all four platform
         // playback modules); platform-independent because every dependency resolves via get().
         single {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/MediaModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/MediaModule.kt
@@ -75,7 +75,7 @@ internal val mediaModule: Module =
         single<ImageStagingRepository> { get<ImageRepositoryImpl>() }
 
         // DownloadRepository — read-side of download state. Per-book commands still live
-        // on DownloadService; W8 will consolidate.
+        // on DownloadService.
         single<DownloadRepository> {
             DownloadRepositoryImpl(
                 downloadDao = get(),
@@ -130,7 +130,7 @@ internal val mediaModule: Module =
         }
 
         // On-disk document cache. A single binding so both the repository (fetch + cache) and
-        // the book sync handler (orphan GC on docId rotation, issue #699) share one instance.
+        // the book sync handler (orphan GC on docId rotation) share one instance.
         single<DocumentStorage> { DocumentStorageImpl(get()) }
 
         // DocumentRepository — on-demand fetch + disk cache for supplementary book documents.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
@@ -7,8 +7,8 @@ import org.koin.dsl.module
  * Koin module providing the playback presentation layer.
  *
  * Currently exposes [NowPlayingViewModel] as the single playback VM consumed by
- * Android, Desktop, and (post-W10) iOS. Bound as `single` per the W7 Phase E2.2.2
- * decision to survive recomposition; lifecycle matches the process.
+ * Android, Desktop, and iOS. Bound as `single` to survive recomposition;
+ * lifecycle matches the process.
  *
  * `viewModelOf` is not used because it ships in `koin-compose-viewmodel`, which is not on
  * the shared classpath. The `single` scope is the same precedent as `LibraryViewModel`

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/WeeklyStats.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/WeeklyStats.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.client.domain
 /**
  * Aggregated personal listening stats for the last 7 days.
  *
- * Backed by P2's `listening_events` table (for day buckets and genre breakdown)
+ * Backed by the `listening_events` table (for day buckets and genre breakdown)
  * and `user_stats` (for server-maintained streak counters). The ViewModel reads
  * this type from [com.calypsan.listenup.client.domain.repository.StatsRepository]
  * and maps it into UI state — no further aggregation needed at presentation layer.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/leaderboard/LeaderboardSnapshot.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/leaderboard/LeaderboardSnapshot.kt
@@ -7,7 +7,7 @@ package com.calypsan.listenup.client.domain.leaderboard
  *
  * For Week/Month/Year, the [time] ranking is computed over `listening_events`
  * within the period bounds; [books] and [streak] lists are empty since per-period
- * book/streak rankings require domain-specific math beyond P3's scope. Time is
+ * book/streak rankings require domain-specific math that is out of scope here. Time is
  * the headline ranking for bounded periods.
  *
  * For AllTime, all three lists are sourced from `user_stats`.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatus.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BookDownloadStatus.kt
@@ -4,10 +4,9 @@ package com.calypsan.listenup.client.domain.model
  * Aggregated download status for a book, modeled as a sealed hierarchy so consumers
  * can exhaustively match on the variant shape without illegal-state combinations.
  *
- * Replaces the legacy flat `data class BookDownloadStatus(state: BookDownloadState, ...)` per
- * W8 Phase B (W8 handoff design § "Refactor `BookDownloadStatus` from flat data class to sealed
- * hierarchy"). Closes the rubric drift around "UI state is a per-screen sealed hierarchy, not a
- * flat data class."
+ * Replaces a legacy flat `data class BookDownloadStatus(state: BookDownloadState, ...)`,
+ * following the rule that state is modeled as a sealed hierarchy rather than a
+ * flat data class.
  */
 sealed interface BookDownloadStatus {
     val bookId: String

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/DownloadOutcome.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/DownloadOutcome.kt
@@ -7,8 +7,8 @@ package com.calypsan.listenup.client.domain.model
  * Failures use [com.calypsan.listenup.api.result.AppResult.Failure] with a
  * [com.calypsan.listenup.api.error.DownloadError].
  *
- * Replaces the legacy `DownloadResult` sealed type per W8 Phase B
- * (W8 handoff design § "Migrate `DownloadResult` → `AppResult<DownloadOutcome>`").
+ * Replaces the legacy `DownloadResult` sealed type — fallible downloads now return
+ * `AppResult<DownloadOutcome>`.
  */
 sealed interface DownloadOutcome {
     /** New download enqueued (one or more files queued for fetch). */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ListeningEventRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ListeningEventRepository.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
  * [com.calypsan.listenup.client.data.local.db.ListeningEventDao] directly
  * (Stats, Leaderboard) — so those callers can migrate through this interface later.
  *
- * Listening-event writes are owned exclusively by the canonical P2 recording path
+ * Listening-event writes are owned exclusively by the canonical recording path
  * ([com.calypsan.listenup.client.playback.ListeningEventRecorder]); this interface
  * exposes no write method.
  *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackUpdate.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackUpdate.kt
@@ -15,7 +15,7 @@ data class CrossDevicePlaybackProgress(
  * cross-device SSE merges — through a single repository entry point
  * ([PlaybackPositionRepository.savePlaybackState]).
  *
- * Per Finding 09 D6, the eight player-event variants describe distinct semantic
+ * The eight player-event variants describe distinct semantic
  * intents even when their persistence shapes overlap (e.g., Position /
  * PlaybackPaused / PeriodicUpdate all save position+speed but represent
  * different events). Three additional variants (MarkComplete / DiscardProgress /

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadAudioFile.kt
@@ -52,7 +52,7 @@ private const val PROGRESS_BYTES_INTERVAL = 256 * 1024L // 256KB — emit progre
  * cancellation from failure.
  *
  * Features:
- * - Signed URL resolution via [PlaybackService.prepare] (Task 3 of the playback-fix plan)
+ * - Signed URL resolution via [PlaybackService.prepare]
  * - Resume support (Range headers)
  * - Progress updates via [setProgress] lambda
  * - Cancellation handling via [isStopped] lambda

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadFileManager.kt
@@ -16,7 +16,7 @@ expect class DownloadFileManager {
     /**
      * Get the path for a downloaded file. [isTemp]=true returns the in-progress temp path
      * (supports resume); [isTemp]=false returns the final destination path. Single function
-     * eliminates format-divergence risk between the two paths (Finding 08 D12).
+     * eliminates format-divergence risk between the two paths.
      */
     fun getAudioFilePath(
         bookId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProvider.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProvider.kt
@@ -49,7 +49,7 @@ private val PROACTIVE_CHECK_CADENCE = 5.minutes
  * bearer plugin. Both write to [AuthSession.saveAuthTokens]. When two
  * refreshes interleave, last-write-wins on the stored tokens — both will
  * observe the most recent rotation on their next read. A unified refresh
- * authority is tracked as a Phase 1 deferral.
+ * authority is not yet implemented.
  */
 class CachedAudioTokenProvider(
     private val authSession: AuthSession,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -28,7 +28,7 @@ private val logger = KotlinLogging.logger {}
 /**
  * Fraction of total duration a position must reach for an `Ended` state to count
  * as genuine completion. Guards against spurious `Ended` events on player
- * release/stop falsely marking a book finished (#204).
+ * release/stop falsely marking a book finished.
  */
 private const val BOOK_FINISHED_THRESHOLD = 0.90f
 
@@ -233,12 +233,12 @@ internal class PlaybackManagerImpl(
                         val playing = playbackState == PlaybackState.Playing
                         setPlaying(playing)
 
-                        // Drift #29 — error routing. AudioPlayer actuals emit
+                        // Error routing: AudioPlayer actuals emit
                         // PlaybackState.Error(message?) for platform-native failures;
                         // PlaybackManager turns that into PlaybackError on the public flow.
                         // (Android emits errors via [reportError] from MediaControllerHolder;
                         // setPlaybackState never carries Error on the Android path.)
-                        // Drift #28 — Playing/Paused → [reporter] (position + listening-event)
+                        // Playing/Paused → [reporter] (position + listening-event)
                         // routing lives in [setPlaybackState] so both Desktop (via this collect)
                         // and Android (via PlaybackStateWriter.setPlaybackState from
                         // MediaControllerHolder.Player.Listener) flow through one path.
@@ -258,7 +258,7 @@ internal class PlaybackManagerImpl(
                             val position = currentPositionMs.value
                             // Guard: only mark finished if position is actually near the end.
                             // Prevents false completion from spurious Ended events on player
-                            // release/stop (#204).
+                            // release/stop.
                             if (duration > 0 && position.toFloat() / duration >= BOOK_FINISHED_THRESHOLD) {
                                 reporter.onBookFinished(bookId, duration)
                             } else {
@@ -274,7 +274,7 @@ internal class PlaybackManagerImpl(
 
         // Start playback. The Playing transition is routed through progressTracker
         // by [setPlaybackState] when the collect above forwards the player's
-        // emission (drift #28); no explicit call here.
+        // emission; no explicit call here.
         player.play()
 
         logger.info { "Playback started via AudioPlayer at position ${resumePositionMs}ms, speed ${resumeSpeed}x" }
@@ -302,7 +302,7 @@ internal class PlaybackManagerImpl(
      * Update playback state (Idle/Buffering/Playing/Paused/Ended/Error). Same
      * caller scheme as [setBuffering].
      *
-     * Drift #28 — every Playing/Paused transition (whether triggered by Desktop's
+     * Every Playing/Paused transition (whether triggered by Desktop's
      * AudioPlayer state observation in [playerObservationJob] or Android's
      * [MediaControllerHolder.Player.Listener] pushing through this seam) routes
      * through [reporter] here, which persists position and (on Desktop/macOS, where a

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporter.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporter.kt
@@ -16,7 +16,7 @@ private val logger = KotlinLogging.logger {}
  *
  *  1. **Position persistence** — delegated to [ProgressTracker] (never lose the user's place).
  *  2. **Listening-event recording** — delegated to [ListeningEventRecorder], the canonical
- *     P2 span recorder that stamps events with the account user id and enqueues a server
+ *     span recorder that stamps events with the account user id and enqueues a server
  *     sync op.
  *
  * **Why this exists.** Before this seam, only Android drove [ListeningEventRecorder] (from
@@ -35,9 +35,9 @@ private val logger = KotlinLogging.logger {}
  * derive listening time from wall-clock and content from positions, both accurate regardless.
  *
  * @property progressTracker Position-persistence collaborator; always driven.
- * @property recorder Listening-event recorder; `null` on Android (see above), non-null on
+ * @property recorder Listening-event recorder; `null` on Android, non-null on
  *   iOS/Desktop/macOS. When `null`, every recording call is skipped and only [progressTracker]
- *   runs — exactly the pre-existing behaviour.
+ *   runs.
  * @property scope Scope on which the recorder's suspend calls are launched, mirroring
  *   [ProgressTracker]'s own fire-and-forget style. Recording failures are non-fatal (the
  *   recorder logs and self-heals via orphan recovery), so they never block playback.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -23,7 +23,7 @@ private val logger = KotlinLogging.logger {}
  * Coordinates position persistence and playback-session tracking.
  *
  * Position is sacred: saves immediately on every pause/seek. Listening-event
- * history is owned exclusively by the canonical P2 path
+ * history is owned exclusively by the canonical recording path
  * ([ListeningEventRecorder]) — this tracker never records listening events.
  *
  * Note on `open`: this class (and its overridable methods below) are `open`
@@ -310,7 +310,7 @@ open class ProgressTracker(
                 logger.warn { "Failed to delete download records for ${bookId.value} (non-fatal): ${e.message}" }
             }
 
-            // Mark book as complete (Issue #206)
+            // Mark book as complete
             val finishedAt = Clock.System.now().toEpochMilliseconds()
             when (
                 val r =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModel.kt
@@ -163,7 +163,7 @@ class AdminViewModel(
 
             // Every section degrades independently. A single failed fetch must never black out the
             // whole page — that strands the admin without the (independent) registration-policy
-            // control and every other section (#620). Failures surface as a sectional error banner
+            // control and every other section. Failures surface as a sectional error banner
             // on Ready, never as a full Error screen.
             val users =
                 when (usersResult) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/CreateInviteViewModel.kt
@@ -69,7 +69,7 @@ class CreateInviteViewModel(
 
     /**
      * Classify a [Failure]'s [AppError] into the UI's error type by *type*, not by
-     * substring-matching the message text. The pre-Phase-3 implementation matched on
+     * substring-matching the message text. An earlier implementation matched on
      * `result.message` substrings — that worked for the [ValidationError] cases
      * (constructor-supplied message text travels through verbatim) but silently fell
      * through for "already exists" / "conflict" (server 409 → `TransportError.Server4xx`

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -684,7 +684,7 @@ class BookDetailViewModel(
  *
  * Sealed hierarchy — [Ready] carries all book-dependent fields. Transient
  * action overlays ([isMarkingComplete], [isDiscardingProgress], [isRestarting],
- * [isAddingToShelf]) live on [Ready] in this iteration; W6 may extract them
+ * [isAddingToShelf]) live on [Ready]; they may later be extracted
  * into a private overlay type.
  */
 sealed interface BookDetailUiState {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModel.kt
@@ -43,7 +43,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * main pipeline — success emits a `NavAction.Deleted` through a nav Channel,
  * failure projects into `Ready.deleteError` for snackbar rendering.
  *
- * N+1 query on per-role book previews — tracked for W6; do not fix here.
+ * N+1 query on per-role book previews — known issue; do not fix here.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ContributorDetailViewModel(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributoredit/ContributorEditViewModel.kt
@@ -40,8 +40,8 @@ private const val STOP_TIMEOUT_MS = 5_000L
  * Lightweight projection of a contributor as a merge-target candidate.
  *
  * Used by [ContributorEditViewModel.mergeCandidates] to populate the contributor
- * merge picker dialog. [bookCount] is a placeholder (always `0`) until a
- * per-contributor book-count query lands; the dialog hides it for now.
+ * merge picker dialog. [bookCount] is a placeholder (always `0`) — there is no
+ * per-contributor book-count query yet, so the dialog hides it.
  */
 data class ContributorCandidate(
     val id: ContributorId,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -57,7 +57,7 @@ private val logger = KotlinLogging.logger {}
  *
  * All command-side operations route through [PlaybackController].
  *
- * Lifecycle: Bound as a Koin `single` (per W7 Phase E2.2.2) — survives recomposition
+ * Lifecycle: Bound as a Koin `single` — survives recomposition
  * and lives for the process lifetime. `init { playbackController.acquire() }` establishes
  * the MediaController connection on first resolution and holds it for the process;
  * `onCleared` never fires, so a matching `release()` would be dead code. The

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/seriesedit/SeriesEditViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/seriesedit/SeriesEditViewModel.kt
@@ -38,8 +38,8 @@ private const val STOP_TIMEOUT_MS = 5_000L
  * Lightweight projection of a series as a merge-target candidate.
  *
  * Used by [SeriesEditViewModel.mergeCandidates] to populate the series merge
- * picker dialog. [bookCount] is a placeholder (always `0`) until a per-series
- * book-count query lands; the dialog hides it for now.
+ * picker dialog. [bookCount] is a placeholder (always `0`) — there is no per-series
+ * book-count query yet, so the dialog hides it.
  */
 data class SeriesCandidate(
     val id: SeriesId,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkConstants.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkConstants.kt
@@ -6,7 +6,7 @@ package com.calypsan.listenup.client.share
  * The share domain is **developer-owned** infrastructure — a tiny static redirector that
  * lets a tapped link open the app or fall back to the install page. It is never a
  * self-hosted server's address, and (because the payload rides in the URL fragment) it
- * never learns what was shared. See `docs/superpowers/specs/2026-06-26-sharing-design.md`.
+ * never learns what was shared.
  */
 object ShareLinkConstants {
     /** Host of the static share-link redirector. App/Universal Links verify against this domain. */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/BookUpdateContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/BookUpdateContractTest.kt
@@ -12,7 +12,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Round-trips every Books-C1 patch DTO through [contractJson]. Catches field-name drift,
+ * Round-trips every book patch DTO through [contractJson]. Catches field-name drift,
  * `init`-block validation regressions, and default-value handling before any pipeline code runs.
  */
 class BookUpdateContractTest :

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/ScannerDtoContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/ScannerDtoContractTest.kt
@@ -23,7 +23,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.encodeToString
 
 /**
- * Round-trip every Phase 2 scanner DTO + sealed variant through `contractJson`.
+ * Round-trip every scanner DTO + sealed variant through `contractJson`.
  * This is the contract regression net — any drift in polymorphic discriminator
  * or default-value handling fails here before any pipeline code runs.
  */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/error/AudioMetadataErrorWireRoundTripTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/error/AudioMetadataErrorWireRoundTripTest.kt
@@ -11,8 +11,7 @@ import io.kotest.matchers.shouldBe
  *
  * `AppError` is a sealed interface; kotlinx.serialization auto-resolves
  * its subtypes from the sealed hierarchy, so no explicit module
- * registration is required (refinement spec §1 — and Task 53 in the plan
- * collapses to this test once the sealed-hierarchy assertion holds).
+ * registration is required.
  */
 class AudioMetadataErrorWireRoundTripTest :
     FunSpec({

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/SeriesSequenceTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/SeriesSequenceTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Mirrors the Go GetRandomBooks series-starter heuristic: standalones, blanks,
+ * The series-starter heuristic: standalones, blanks,
  * prequels (0 / 0.5), and "1"-family sequences are starters; "2"+ are mid-series.
  */
 class SeriesSequenceTest :

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.SerializationException
 /**
  * Tests for ErrorMapper.
  *
- * Covers the unified-AppError contract introduced in Task 13: the mapper produces
+ * Covers the unified-AppError contract: the mapper produces
  * `api.error.AppError` subtypes (`TransportError.*`, `ValidationError`, `InternalError`)
  * with body-level `message`/`code`/`isRetryable` constants per subtype and per-instance
  * detail in `debugInfo`.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserverTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/auth/AuthFailureObserverTest.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.test.runTest
 /**
  * Tests for [AuthFailureObserver] — the single place that converts a
  * session-invalidating [AuthError] surfaced on the [ErrorBus] into a soft logout,
- * driving navigation back to the login screen (issue #640).
+ * driving navigation back to the login screen.
  *
  * The observer collects a hot [kotlinx.coroutines.flow.SharedFlow], so the collector
  * is launched on an [UnconfinedTestDispatcher] — it subscribes eagerly, before the

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/AuthEndpointPredicateTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/AuthEndpointPredicateTest.kt
@@ -7,9 +7,9 @@ import io.ktor.client.request.url
 
 /**
  * Pins [isAuthEndpoint] semantics: `encodedPath.startsWith(AUTH_PATH_PREFIX)` rather than
- * the substring match the pre-W2b.4 code used. The substring form would false-positive on
+ * the substring match the earlier code used. The substring form would false-positive on
  * any URL containing `/auth/` anywhere, including legitimate API paths like
- * `/api/v1/books/by-author/123`. See Finding 04 D2.
+ * `/api/v1/books/by-author/123`.
  */
 class AuthEndpointPredicateTest :
     FunSpec({

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpRetryPolicyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/HttpRetryPolicyTest.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.test.runTest
 /**
  * Verifies the retry policy installed by [ApiClientFactory]'s authenticated client:
  * idempotent requests retry on 5xx and transient IO failures; non-idempotent methods never
- * retry. See Finding 04 D3 and rubric rule "HttpRequestRetry is installed on authenticated
+ * retry: "HttpRequestRetry is installed on authenticated
  * clients with idempotent-only semantics."
  *
  * After [installListenUpErrorHandling] was shrunk to `expectSuccess = true` only, non-2xx

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/ImageApiTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/ImageApiTest.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.test.runTest
  * Endpoint contract tests for [ImageApi].
  *
  * The live Kotlin server serves contributor photos at `GET /api/v1/contributors/{id}/photo`
- * (see `MetadataImageRoutes`). It never had the legacy Go server's `/image` route, so a request
+ * (see `MetadataImageRoutes`). There is no `/image` route, so a request
  * to `/image` 404s and contributor-image caching silently fails. This pins the path so the drift
  * can't return.
  */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryImplTest.kt
@@ -447,7 +447,7 @@ class ContributorRepositoryImplTest :
                 val result = repository.observeByBookId("book-42").first()
 
                 // Then — aliases come from the junction table and are not covered by this path;
-                // task 8 removes the entity field entirely. Scope this test to the non-alias fields.
+                // the entity field will be removed entirely. Scope this test to the non-alias fields.
                 result.size shouldBe 1
                 result[0].id.value shouldBe "contrib-1"
                 result[0].name shouldBe "Kate Reading"

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/FakeDownloadRepository.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.flow.update
 /**
  * In-memory fake implementing [DownloadRepository] for seam-level tests.
  *
- * Per project memory `feedback_fakes_for_seams.md` — validated test pattern is hand-rolled fakes
- * implementing the seam interface. State lives in a [MutableStateFlow] so observers see updates.
+ * The validated test pattern is hand-rolled fakes implementing the seam interface.
+ * State lives in a [MutableStateFlow] so observers see updates.
  *
  * Optional [enqueueFailure] lambda lets tests inject failure for [enqueueForBook] (returns the
  * lambda's value when set; `AppResult.Success(DownloadOutcome.Started)` when null).

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryObserveTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryObserveTest.kt
@@ -28,7 +28,7 @@ import kotlin.time.ExperimentalTime
  * Kotest FunSpec tests for [HomeRepositoryImpl.observeContinueListening].
  *
  * Covers the new [ContinueListeningItem]-typed Flow that replaced the old
- * [ContinueListeningBook]-typed implementation in CL-B Task 5:
+ * [ContinueListeningBook]-typed implementation:
  *
  *  A) Defense-in-depth: isFinished=true books are excluded even at low progress
  *  B) No undercount: books at high progress but isFinished=false are included

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ProfileEditRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ProfileEditRepositoryImplTest.kt
@@ -223,7 +223,7 @@ class ProfileEditRepositoryImplTest :
         // ── Avatar upload (REST multipart, not RPC) ──────────────────────────────────────
 
         /*
-         * Regression guard for #592: the server returns 204 No Content on a successful avatar
+         * Regression guard: the server returns 204 No Content on a successful avatar
          * upload. The original avatarUploaderOf called `.body<ApiResponse<Unit>>()` on the
          * response, which tried to deserialize an empty body as JSON and threw, causing the
          * upload to report failure even though the server had accepted the image.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SeriesRepositoryImplTest.kt
@@ -724,7 +724,7 @@ class SeriesRepositoryImplTest :
             }
         }
 
-        // ========== observeAllWithBooks Tests (drift #16 closure) ==========
+        // ========== observeAllWithBooks Tests ==========
 
         test("observeAllWithBooks returns empty list when no series exist") {
             runTest {
@@ -804,7 +804,7 @@ class SeriesRepositoryImplTest :
             }
         }
 
-        // ========== observeSeriesWithBooks Tests (drift #16 closure) ==========
+        // ========== observeSeriesWithBooks Tests ==========
 
         test("observeSeriesWithBooks returns null when series relation is null") {
             runTest {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryScanProgressTest.kt
@@ -221,7 +221,7 @@ class SyncRepositoryScanProgressTest :
             }
         }
 
-        // #587: the marquee shows the front (oldest) tiles and deliberately falls behind; dropping
+        // The marquee shows the front (oldest) tiles and deliberately falls behind; dropping
         // from the front to honour a cap yanked visible tiles out, causing the blink/swap. Accumulation
         // is now pure append-only — every matched book is retained, in order.
         test("recentBooks accumulation is append-only — nothing is dropped from the front") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadCancelFlowTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/download/DownloadCancelFlowTest.kt
@@ -9,8 +9,8 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 
 /**
- * Seam-level tests for [FakeDownloadRepository.cancelForBook]. Per project memory
- * `feedback_fakes_for_seams.md`: hand-rolled fakes, not mocks.
+ * Seam-level tests for [FakeDownloadRepository.cancelForBook]. Uses hand-rolled
+ * fakes, not mocks.
  *
  * Scope: the fake mirrors
  * [com.calypsan.listenup.client.data.repository.DownloadRepositoryImpl] behavior; production tests

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminViewModelTest.kt
@@ -329,7 +329,7 @@ class AdminViewModelTest :
                     )
                 advanceUntilIdle()
 
-                // #620: a users-load failure must NOT black out the page. It degrades to Ready —
+                // A users-load failure must NOT black out the page. It degrades to Ready —
                 // policy loaded, users empty, and the failure surfaced honestly — so the
                 // (independent) registration-policy control stays reachable.
                 val ready = viewModel.state.value.shouldBeInstanceOf<AdminUiState.Ready>()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/browsegenre/BrowseGenreViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/browsegenre/BrowseGenreViewModelTest.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.test.setMain
 /**
  * Tests for BrowseGenreViewModel.
  *
- * Backfill characterization tests for the screen shipped in PR #329. Covers:
+ * Backfill characterization tests for the screen. Covers:
  * - Initial Loading before observeAll emits
  * - Ready carries the observed genre tree
  * - selectGenre loads books via browseBooks(includeDescendants = current flag)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -47,13 +47,13 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 
 /**
- * Integration tests for the consolidated [NowPlayingViewModel] (W7 Phase E2.2.3).
+ * Integration tests for the consolidated [NowPlayingViewModel].
  *
- * Coverage scope (B targeted, 3 tests for Task 2):
+ * Coverage scope (B targeted, 3 tests):
  * - playBook flow (3): happy path with activate-before-seam ordering; offline error;
  *   generic prepare-null error.
  *
- * Uses [FakePlaybackManager] for the seam (W7 Phase E2.2.4 Task 1B) per the rubric's
+ * Uses [FakePlaybackManager] for the seam, following the
  * "fakes for seams" rule. The other deps are Mokkery-mocked as interfaces;
  * [SleepTimerManager] is a closed concrete class so a real instance is constructed
  * with a test-scoped [CoroutineScope] (its scope is unused by these tests since
@@ -170,14 +170,14 @@ class NowPlayingViewModelTest :
             Dispatchers.resetMain()
         }
 
-        // ========== lifecycle (W7 Phase E2.2.2 regression) ==========
+        // ========== lifecycle regression ==========
 
         test("init acquires the PlaybackController so MediaController connects") {
             val fixture = TestFixture()
 
             fixture.newVm()
 
-            // The W7 Phase E2.2.2 refactor mistakenly removed acquire/release from the
+            // A refactor mistakenly removed acquire/release from the
             // VM under the assumption that Koin-singleton lifetime obviated the call.
             // It does not — only acquire() triggers MediaControllerHolder.connect().
             // Without this call, every in-app playback command is a silent no-op.
@@ -367,7 +367,7 @@ class NowPlayingViewModelTest :
             runTest(testDispatcher) {
                 // Production [NowPlayingViewModel.seekToChapter] uses chapters.getOrNull(index)
                 // and returns when null — so out-of-range indices are a no-op (NOT clamped).
-                // This deviates from the Task 3 skeleton's "clamp to last/first" expectation;
+                // This deviates from an earlier "clamp to last/first" expectation;
                 // the test asserts production behavior.
                 val fixture = TestFixture()
                 every { fixture.playbackController.seekTo(any()) } returns Unit

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/MainDispatcherRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/MainDispatcherRule.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.test.setMain
  * ```
  *
  * Replaces the identical `Dispatchers.setMain` / `Dispatchers.resetMain` pair that currently
- * appears in every VM test file — see Finding 12 D8.
+ * appears in every VM test file.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/di/KoinTestRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/di/KoinTestRule.kt
@@ -22,7 +22,7 @@ import org.koin.core.module.Module
  * ```
  *
  * Source: Koin testing guide — https://insert-koin.io/docs/reference/koin-test/testing.
- * See Finding 12 D5 for the motivation (every VM test manually constructs dependencies).
+ * Motivation: every VM test manually constructs dependencies.
  */
 class KoinTestRule(
     private val modules: List<Module>,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeAuthSession.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeAuthSession.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Minimal [AuthSession] test fake.
  *
- * Supports two independent control points so tests can simulate the startup race that
- * caused issue #532 — [authState] still `Initializing` while [getUserId] already has the
+ * Supports two independent control points so tests can simulate the startup race where
+ * [authState] is still `Initializing` while [getUserId] already has the
  * persisted id from secure storage:
  *
  * - [authState]: the reactive state observable. Defaults to [AuthState.Authenticated] so

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackManager.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackManager.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Test fake for [PlaybackManager] — implements the interface (extracted in W7 Phase
- * E2.2.4 Task 1A) without inheritance. Tests drive backing flows directly; assertions
+ * Test fake for [PlaybackManager] — implements the interface without inheritance.
+ * Tests drive backing flows directly; assertions
  * check recorder lists.
  *
  * Mirrors the [FakeProgressTracker] pattern in spirit (rubric-aligned "fakes for

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/http/TestMockEngine.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/http/TestMockEngine.kt
@@ -26,7 +26,7 @@ import io.ktor.http.headersOf
  * ```
  *
  * Source: Ktor client testing guide — https://ktor.io/docs/client-testing.html.
- * See Finding 12 D3 for the motivation (zero MockEngine usage at audit time).
+ * Motivation: the codebase previously had no MockEngine usage.
  */
 fun testMockEngine(configure: TestMockEngineBuilder.() -> Unit): MockEngine {
     val builder = TestMockEngineBuilder()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/core/AppResultTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/core/AppResultTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 /**
  * Tests for [AppResult] — the canonical result type.
  *
- * See Finding 01 D1 for motivation: the codebase previously had three parallel error
+ * Motivation: the codebase previously had three parallel error
  * models ([Result], `AsyncState`, [AppError]) with no conversion path. [AppResult] is
  * the single sealed hierarchy carrying [AppError] directly.
  */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/AppResultSurfaceIsMustUseRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/AppResultSurfaceIsMustUseRule.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 
 /**
- * Pins Phase 2c's compiler-enforced `AppResult` must-use invariant.
+ * Pins the compiler-enforced `AppResult` must-use invariant.
  *
  * Every `domain/repository/` interface file that declares an `AppResult`-returning function
  * carries `@file:MustUseReturnValues`, so the unused-return-value checker

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/CoroutineScopeInstallsExceptionHandlerRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/CoroutineScopeInstallsExceptionHandlerRule.kt
@@ -11,7 +11,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
  * `propagateExceptionFinalResort`, which **terminates the process** — so on iOS/macOS a single
  * transient failure in a fire-and-forget `launch` on an unguarded scope crashes the whole app (JVM
  * merely logs it). `appCoroutineExceptionHandler` logs the throwable and lets the app keep running.
- * The handler was added app-wide in #728, but a scope created without it silently reopens the crash
+ * The handler is installed app-wide, but a scope created without it silently reopens the crash
  * class — this rule blocks that regression (its discovery already caught the missed macOS scope).
  *
  * The check is intentionally coarse — file-level text presence — because the scope constructions live

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataLocalDbIsInternalRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DataLocalDbIsInternalRule.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 class DataLocalDbIsInternalRule :
     FunSpec({
         // Symbols that must stay public despite living in data.local.db (cross-module
-        // consumers documented in the spec's "Flip exceptions"). Empty: the flip is clean.
+        // consumers). Empty: the flip is clean.
         // `DownloadEntity` + `DownloadState` were reclaimed by internalizing the
         // `DownloadEnqueuer` seam — its sole cross-module binding (`:sharedUI` desktop's
         // no-arg `JvmDownloadEnqueuer`) moved into `:sharedLogic`'s `desktopDownloadModule`.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/EmbeddedMetaTypesInCommonMainRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/EmbeddedMetaTypesInCommonMainRule.kt
@@ -6,17 +6,17 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
 
 /**
- * Konsist guards for the embeddedmeta package boundary (refinement spec §2.1):
+ * Konsist guards for the embeddedmeta package boundary:
  *
- *  1. Every domain type that crosses the wire (Phase 4 will return these on
- *     RPC service signatures) lives in commonMain. Domain types in a
+ *  1. Every domain type that crosses the wire — RPC service signatures return
+ *     these — lives in commonMain. Domain types in a
  *     server-only source set would force a wire-shape duplicate when the
  *     books domain migrates.
  *  2. Concrete `AudioFormatParser` implementations live under
  *     `com.calypsan.listenup.server.embeddedmeta.*` so the contributor
  *     doc's add-a-format flow has one canonical home.
  *  3. Every `AudioFormatParser` declares a non-empty `supports`. The
- *     runtime contract test (Task 40a Step 2) is the real safety net for
+ *     runtime contract test is the real safety net for
  *     this — Konsist's heuristic catches the obvious `setOf()` mistake
  *     but is structurally limited.
  */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoLegacyAppErrorRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoLegacyAppErrorRule.kt
@@ -4,14 +4,14 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 
 /**
- * Konsist guard that pins the Phase 3 PR 1 deletion of the legacy
+ * Konsist guard that pins the deletion of the legacy
  * `client.core.error.AppError` hierarchy.
  *
  * The `client.core.error` package still holds infrastructure types that survived the
  * deletion ([com.calypsan.listenup.core.error.ErrorBus],
  * [com.calypsan.listenup.client.core.error.ErrorMapper]) — those imports are allowed.
- * `AppException` was also a survivor through Phase 3.5 but was deleted in Task 27d
- * (slice 18); any new import targeting it will simply fail to resolve, so it no
+ * `AppException` was also a survivor but has since been deleted; any new import
+ * targeting it will simply fail to resolve, so it no
  * longer needs an allowlist entry here. Any other reference into that package
  * would be reaching for the deleted error types (or a re-introduction of them),
  * which is the regression this rule blocks.

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
@@ -5,12 +5,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 
 /**
- * Pins the data-layer error contract delivered by Task 27d (Phase 3.5).
+ * Pins the data-layer error contract.
  *
- * After Task 27d, fallible work in `data/remote/` and `data/repository/` returns
+ * Fallible work in `data/remote/` and `data/repository/` returns
  * [com.calypsan.listenup.api.result.AppResult] rather than throwing. This rule
  * detects functions whose body contains `throw` expressions, then filters out
- * patterns that are still legitimate after the migration:
+ * patterns that are still legitimate:
  *
  * - **Cooperative cancellation rethrows** (`throw e`, `throw cause`) — the
  *   `throw e` after `catch (e: CancellationException)` pattern that every
@@ -18,16 +18,15 @@ import io.kotest.matchers.collections.shouldBeEmpty
  * - **Programmer-error contract guards** (`throw EnvelopeMismatchException(`) —
  *   the API envelope's structural canary, raised when the server has shipped a
  *   protocol-incompatible payload. This is a build-against-the-server-contract
- *   mismatch, not a runtime business error, and predates Task 27d.
- * - **Phase-D placeholders** (`throw NotImplementedError(`) — `DownloadRepositoryImpl`
- *   stubs out platform code that lands in a later phase.
+ *   mismatch, not a runtime business error.
+ * - **Placeholders** (`throw NotImplementedError(`) — `DownloadRepositoryImpl`
+ *   stubs out platform code that is not yet implemented.
  *
  * After those exclusions, any `throw` left over represents a residual data-layer
- * exception-propagation pattern that Task 27d would migrate. Several un-migrated
- * APIs and repo impls were discovered during slice 18 (slices 1–17 chose specific
- * APIs and did not enumerate the rest of the data layer). Those files appear in
- * [RESIDUAL_THROWS_ALLOWLIST] so this rule passes today while still pinning what
- * slice 18 actually delivered.
+ * exception-propagation pattern still awaiting migration to AppResult. Several
+ * un-migrated APIs and repo impls remain; those files appear in
+ * [RESIDUAL_THROWS_ALLOWLIST] so this rule passes today while still pinning the
+ * already-migrated surface.
  *
  * **The allowlist is not a discrete clean-up backlog** — the project is being
  * rewritten in place, so each entry naturally migrates to AppResult when its
@@ -43,7 +42,7 @@ class NoThrowsInDataLayerRule :
                     .functions()
                     .filter { it.path.contains("/data/remote/") }
                     // `data/remote/model/` holds DTOs + pure mappers (e.g. Instant parsing).
-                    // Those are utility functions, not API-call boundaries — Task 27d's
+                    // Those are utility functions, not API-call boundaries — the
                     // AppResult contract applies to API methods, not parser utilities.
                     .filter { !it.path.contains("/data/remote/model/") }
                     .filter { fn -> fn.containsDisallowedThrow() }
@@ -67,7 +66,7 @@ class NoThrowsInDataLayerRule :
     })
 
 /**
- * Files known to still throw post-Task-27d. The in-place rewrite will migrate
+ * Files known to still throw. The in-place rewrite will migrate
  * each entry to AppResult when its domain is re-touched; removing a file from
  * this set is the explicit signal that the migration of that area has shipped.
  *
@@ -80,7 +79,7 @@ private val RESIDUAL_THROWS_ALLOWLIST: Set<String> =
         // APIs (each typically pairs with a repo-impl below):
         "/data/remote/SearchApi.kt",
         "/data/remote/StatsApi.kt",
-        // Auth / refresh / SSE infrastructure with throwing patterns that pre-date 27d:
+        // Auth / refresh / SSE infrastructure with throwing patterns:
         "/data/remote/ApiClientFactory.kt",
         // Repo impls still in throwing style:
         "/data/repository/AuthRepositoryImpl.kt",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/OneUserAvatarComposableRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/OneUserAvatarComposableRule.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 /**
  * Only `com.calypsan.listenup.client.design.components.UserAvatar` may be
  * imported by feature code. The legacy `ProfileAvatar` and `ClickableUserAvatar`
- * composables are deleted in Playback P3 — this rule prevents their
+ * composables have been deleted — this rule prevents their
  * re-introduction.
  */
 class OneUserAvatarComposableRule :

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/UiStateIsSealedRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/UiStateIsSealedRule.kt
@@ -6,21 +6,19 @@ import io.kotest.matchers.collections.shouldBeEmpty
 /**
  * Every `*UiState` declaration in `client/presentation/` must be a sealed
  * hierarchy (sealed interface or sealed class), not a flat data class with
- * boolean flags. Pins the canonical UI-state pattern introduced in Playback P3.
+ * boolean flags. Pins the canonical UI-state pattern.
  *
  * Scope: classes/interfaces ending in `UiState` under
  * `sharedLogic/.../client/presentation/`. The check is structural:
  * `hasSealedModifier` must be true.
  *
- * Legacy exclusions: the 8 types below were present before P3 and use the flat
- * `data class` shape. They are tracked for future migration in
- * `docs/superpowers/followups.md` ("From Playback P3 — UiState sealed backlog").
- * Do NOT add P3-touched types to this list — fix the type instead.
+ * Legacy exclusions: the 8 types below use the flat `data class` shape and await
+ * migration. Do NOT add new types to this list — fix the type instead.
  */
 class UiStateIsSealedRule :
     FunSpec({
-        // Legacy non-P3 UiState types deliberately left as flat data classes; tracked for
-        // future migration. Each entry is the simple class name (without package).
+        // Legacy UiState types deliberately left as flat data classes, awaiting migration.
+        // Each entry is the simple class name (without package).
         val legacyExclusions =
             setOf(
                 "SettingsUiState",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/UserScopedRepositoryScopesByUserRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/UserScopedRepositoryScopesByUserRule.kt
@@ -33,8 +33,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
  *   naming convention must be audited manually when they are introduced.
  *
  * **Current state.**
- * As of the initial roll-out (Playback-P1 Task 6), no production per-user
- * repository exists — `PlaybackPositionRepository` arrives in Task 8. The rule
+ * No production per-user repository exists yet — `PlaybackPositionRepository`
+ * will be the first. The rule
  * passes vacuously today and fires the moment a mis-declared per-user repository
  * is added.
  */

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ViewModelUsesStateInWhileSubscribedRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ViewModelUsesStateInWhileSubscribedRule.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 /**
  * Every `*ViewModel` in `client/presentation/` that exposes a public
  * `StateFlow<*UiState>` must derive it via `.stateIn(... WhileSubscribed ...)`.
- * Pins the canonical reactive-state pattern from Playback P3.
+ * Pins the canonical reactive-state pattern.
  *
  * Implementation note: Konsist can't easily AST-match the operator chain
  * across multiple lines, so this rule does a text-level check on the file
@@ -16,10 +16,8 @@ import io.kotest.matchers.shouldBe
  * pinning the convention.
  *
  * Exclusions fall into two kinds:
- *  - Legacy backlog: ViewModels present before P3 that do not yet use `WhileSubscribed`,
- *    tracked for future migration in `docs/superpowers/followups.md`
- *    ("From Playback P3 — WhileSubscribed backlog"). Do NOT add P3-touched *reactive*
- *    ViewModels here — fix the ViewModel instead.
+ *  - Legacy backlog: older ViewModels that do not yet use `WhileSubscribed`, awaiting
+ *    migration. Do NOT add reactive ViewModels here — fix the ViewModel instead.
  *  - By-design: imperative command-pipeline ViewModels (the ABS, import, and backup admin flows)
  *    whose state is driven by user actions + progress events, not projected from an upstream
  *    flow. `stateIn(WhileSubscribed)` is the wrong tool there; a `MutableStateFlow` with
@@ -27,8 +25,8 @@ import io.kotest.matchers.shouldBe
  */
 class ViewModelUsesStateInWhileSubscribedRule :
     FunSpec({
-        // Legacy non-P3 ViewModels deliberately left without WhileSubscribed; tracked for
-        // future migration. Each entry is the simple class name (without package).
+        // Legacy ViewModels deliberately left without WhileSubscribed, awaiting migration.
+        // Each entry is the simple class name (without package).
         val legacyExclusions =
             setOf(
                 "SettingsViewModel",

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/download/JvmDownloadEnqueuer.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/download/JvmDownloadEnqueuer.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 
 /**
- * Desktop no-op enqueuer. Desktop doesn't support downloads (per W8 Phase A's Desktop hide).
+ * Desktop no-op enqueuer. Desktop doesn't support downloads.
  */
 internal class JvmDownloadEnqueuer : DownloadEnqueuer {
     override suspend fun enqueue(entity: DownloadEntity): AppResult<Unit> =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Architectural assertions for the contract boundary. These are the
- * structural invariants Phase 1 set out to make true and Phase G1 pins in CI.
+ * structural invariants of the contract boundary, pinned in CI.
  *
  * Rules:
  *  1. `@Serializable` DTOs in `com.calypsan.listenup.api..` are in commonMain
@@ -19,13 +19,13 @@ import kotlinx.serialization.Serializable
  *  3. No `:server` symbols (`com.calypsan.listenup.server..`) are imported
  *     outside the `:server` module.
  *
- * Each rule fails the build with a list of offenders. The plan also called
- * out two more rules — "every @Rpc has a matching @Resource" and "every
- * Koin leaf module has a `module.verify()` test" — both are deferred:
+ * Each rule fails the build with a list of offenders. Two further rules —
+ * "every @Rpc has a matching @Resource" and "every
+ * Koin leaf module has a `module.verify()` test" — are deferred:
  * `PingService` is a smoke-test service that deliberately has no REST mirror,
  * and `module.verify()` coverage is already enforced ad-hoc by
  * `AuthModuleVerifyTest` + `AuthModuleVerifyTest` server-side. Those rules
- * become useful once we have multiple feature modules to compare; today
+ * become useful once there are multiple feature modules to compare; today
  * they would mostly false-positive.
  */
 class ArchitectureTest :

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoLiveQueryTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoLiveQueryTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 /**
  * Pins that the live read paths exclude tombstoned (soft-deleted) books.
  *
- * Regression guard for the audit finding where [BookDao.observeAllWithContributors]
+ * Regression guard for the case where [BookDao.observeAllWithContributors]
  * (library list + series view) and the FTS feeder query returned server-deleted books,
  * despite the DAO KDoc promising `deletedAt IS NULL` filtering.
  */

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 
 /**
- * Regression coverage for the Discover "Random Unstarted" silent-filter bug (W6 Phase F, Drift #1).
+ * Regression coverage for the Discover "Random Unstarted" silent-filter bug.
  *
  * Prior to this test suite, three DAO methods silently applied a
  * `bs.sequence IN ('1', '0', '0.5')` filter, hiding every mid-series book from

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRecentlyAddedTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRecentlyAddedTest.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 
 /**
- * Regression coverage for the Discover "Recently Added" half-list bug (W6 Phase A, Bug 5).
+ * Regression coverage for the Discover "Recently Added" half-list bug.
  *
  * Prior to this fix [BookDao.observeRecentlyAddedWithAuthor] silently applied
  * a `bs.sequence IN ('1', '0', '0.5')` filter, hiding every mid-series book from

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventDaoTest.kt
@@ -174,7 +174,7 @@ class ListeningEventDaoTest :
             }
         }
 
-        // ── #532 repair ────────────────────────────────────────────────────────────────────────
+        // ── Blank-userId repair ───────────────────────────────────────────────────────────────
 
         test("reassignBlankUserId re-stamps blank rows and leaves non-blank rows untouched") {
             val db = createInMemoryTestDatabase()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDaoTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.test.runTest
 
 /**
  * Covers the reactive query surface of [PlaybackPositionDao]:
- * - [PlaybackPositionDao.observeRecentPositions] — Continue Listening shelf (W4.3)
+ * - [PlaybackPositionDao.observeRecentPositions] — Continue Listening shelf
  */
 class PlaybackPositionDaoTest :
     FunSpec({

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/migration/SchemaMigrationSmokeTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
  *
  * Proves the test plumbing works end-to-end for `ListenUpDatabase` — schema
  * export on disk, driver wiring, constructor factory — so that when the real
- * v1 → v2 migration lands in W4.4 we can assert schema equivalence without
+ * v1 → v2 migration lands, schema equivalence can be asserted without
  * scaffolding a helper from scratch. When v2 ships, replace this smoke test
  * with an actual migration-and-validate assertion.
  */
@@ -19,9 +19,9 @@ class SchemaMigrationSmokeTest :
         test("creates current schema database and opens a live connection") {
             val helper = createMigrationTestHelper()
             try {
-                // Pin to the latest exported schema — when W4.4 lands further schema
-                // changes, bump this and start asserting actual v(N-1) → v(N) migration
-                // behaviour. For now this just proves the harness can load the schema
+                // Pin to the latest exported schema — when further schema
+                // changes land, bump this and start asserting actual v(N-1) → v(N) migration
+                // behaviour. Today this just proves the harness can load the schema
                 // bundle and drive [androidx.sqlite.SQLiteConnection].
                 val connection = helper.createDatabase(version = 10)
                 connection.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").use { stmt ->

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration17To18Test.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration17To18Test.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.longs.shouldBeExactly
 import io.kotest.matchers.shouldBe
 
 /**
- * Regression test for [MIGRATION_17_18] — the Playback-P1 syncable-domain landing
+ * Regression test for [MIGRATION_17_18] — the syncable-domain landing
  * for `playback_positions`. Asserts the table gains `revision` and `deletedAt`, and
  * that an existing row survives the rebuild with `revision = 0` and `deletedAt` null.
  * All pre-existing columns (bookId, positionMs, playbackSpeed, hasCustomSpeed, updatedAt,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration18To19Test.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration18To19Test.kt
@@ -10,12 +10,12 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 
 /**
- * Regression test for [MIGRATION_18_19] — the Playback-P2 stats domain landing.
+ * Regression test for [MIGRATION_18_19] — the stats domain landing.
  *
  * Asserts:
- * - `listening_events` is rebuilt with the P2 schema (userId, tz, deviceLabel, revision,
+ * - `listening_events` is rebuilt with the new schema (userId, tz, deviceLabel, revision,
  *   deletedAt; old columns deviceId, syncState, source, createdAt are gone).
- * - `user_stats` is rebuilt with the P2 stats shape (id, totalSecondsAllTime, …, revision,
+ * - `user_stats` is rebuilt with the new stats shape (id, totalSecondsAllTime, …, revision,
  *   deletedAt; old leaderboard columns are gone).
  * - `tentative_span` is created with all expected columns.
  * - The three composite indexes on `listening_events` exist.
@@ -48,7 +48,7 @@ class Migration18To19Test :
                     )
 
                 val columns = db.columnsOf("listening_events")
-                // New P2 columns
+                // New columns
                 columns shouldContain "id"
                 columns shouldContain "userId"
                 columns shouldContain "bookId"
@@ -96,7 +96,7 @@ class Migration18To19Test :
                     )
 
                 val columns = db.columnsOf("user_stats")
-                // New P2 columns
+                // New columns
                 columns shouldContain "id"
                 columns shouldContain "totalSecondsAllTime"
                 columns shouldContain "totalSecondsLast7Days"

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration30To31Test.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration30To31Test.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 
 /**
- * Regression test for [MIGRATION_30_31] — rename `activities.createdAt` → `occurredAt` (#548).
+ * Regression test for [MIGRATION_30_31] — rename `activities.createdAt` → `occurredAt`.
  *
  * Asserts:
  * - The column `occurredAt` exists and `createdAt` is gone after migration.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.runBlocking
 
 /**
- * The load-bearing security piece (Collections-2a Task 10): on `AccessChanged`, the engine
+ * The load-bearing security piece: on `AccessChanged`, the engine
  * re-derives each access-gated domain via a TRANSIENT catch-up and prunes every locally-live
  * row no longer in the accessible set. A revoked share must actually evict the now-inaccessible
  * rows from Room.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookSyncDomainHandlerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookSyncDomainHandlerTest.kt
@@ -388,7 +388,7 @@ private fun withTestHandler(block: suspend (BookSyncDomainHandler, ListenUpDatab
 
 /**
  * Like [withTestHandler] but injects a [RecordingDocumentStorage] so document-cache GC
- * (issue #699) can be asserted. The storage is exposed to the block.
+ * can be asserted. The storage is exposed to the block.
  */
 private fun withGcHandler(
     block: suspend (BookSyncDomainHandler, ListenUpDatabase, RecordingDocumentStorage) -> Unit,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncEngineE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncEngineE2ETest.kt
@@ -28,7 +28,7 @@ private const val OPERATION_TIMEOUT_SECONDS = 30
  * StreamError surfacing is covered at the dispatcher unit-test layer
  * (`SyncEventDispatcherTest`); piping a `StreamError` frame through the live
  * SSE transport is timing-fragile and adds no extra coverage. Local-first
- * echo and CursorStale-fallback e2e paths are deferred to followups —
+ * echo and CursorStale-fallback e2e paths are deferred —
  * see `RecordingTagSyncDomainHandler` for the seam they'll plug into.
  */
 class ClientSyncEngineE2ETest :

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionSyncAndReconcileE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionSyncAndReconcileE2ETest.kt
@@ -25,8 +25,7 @@ import kotlinx.coroutines.withTimeout
 private val ROUND_TRIP_TIMEOUT = 30.seconds
 
 /**
- * Tier 3 E2E for the collection sync handlers + the `AccessChanged` reconcile/prune — the
- * Collections-2a Task 11 deliverable.
+ * Tier 3 E2E for the collection sync handlers + the `AccessChanged` reconcile/prune.
  *
  * Two roles share one in-process server (see
  * [withCollectionSyncEngineAgainstServer][com.calypsan.listenup.client.data.sync.testing.withCollectionSyncEngineAgainstServer]):

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDeleteE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDeleteE2ETest.kt
@@ -21,7 +21,7 @@ private const val BOOK_ID = "cover-delete-b1"
 private const val COVER_HASH = "seed-cover-hash-abc123"
 
 /**
- * Tier 3 e2e test for the Books-C1 cover-delete surface: a client-side call to
+ * Tier 3 e2e test for the cover-delete surface: a client-side call to
  * [com.calypsan.listenup.client.domain.repository.BookEditRepository.deleteBookCover]
  * crosses the live kotlinx.rpc transport into the in-process `:server`'s
  * `BookService`, the server nullifies the book row's cover columns and re-upserts

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/GenreReparentE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/GenreReparentE2ETest.kt
@@ -16,7 +16,7 @@ private const val ROUND_TRIP_TIMEOUT_SECONDS = 30
  * subtree node, and the client engine applies each event into Room so paths
  * and depths reflect the new parent.
  *
- * Also covers the spec acceptance criterion #5 — the `/fic` vs `/fiction`
+ * Also covers the `/fic` vs `/fiction`
  * LIKE-collision: moving a genre whose path is a prefix of another genre's path
  * must not touch the other subtree.
  */

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventSyncDomainHandlerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventSyncDomainHandlerTest.kt
@@ -131,7 +131,7 @@ class ListeningEventSyncDomainHandlerTest :
             }
         }
 
-        // ── #532 regression: getUserId() must be used, not authState snapshot ────────────────
+        // ── Regression: getUserId() must be used, not authState snapshot ────────────────
 
         test("synced event is stamped with getUserId(), not blank, while authState is Initializing") {
             // authState is still Initializing (startup race), but getUserId() has the persisted id.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SetBookCollectionsReconcileE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SetBookCollectionsReconcileE2ETest.kt
@@ -37,8 +37,8 @@ private val ROUND_TRIP_TIMEOUT = 30.seconds
 private val POLL_INTERVAL = 100.milliseconds
 
 /**
- * Tier 3 E2E — the **security proof** for the admin `setBookCollections` write path
- * (Collections-2b Task 6). Proves end-to-end that when an admin replace-sets a book's
+ * Tier 3 E2E — the **security proof** for the admin `setBookCollections` write path.
+ * Proves end-to-end that when an admin replace-sets a book's
  * collection membership, the per-user `AccessChanged` control signal flows through the
  * member's real client [SyncEngine] and reconciles their Room: a member who LOSES their
  * access path prunes the book; a member who GAINS one receives it.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientAuthRefreshTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientAuthRefreshTest.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
- * Locks in Task 8's fix that treats mid-stream 401/403 as transient rather than
+ * Locks in the fix that treats mid-stream 401/403 as transient rather than
  * terminal, so the Ktor Bearer Auth plugin can refresh the access token on the
  * next reconnect.
  *

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -256,10 +256,10 @@ internal fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.
                 driver = serverDriver,
                 genreRepo = serverRepos.genreRepo,
             )
-        // Books-C1 Task 30 needs `ContributorService` for the deleteContributor
-        // cascade test. The reindexer requires a [BookTagRepository] + [TagRepository]
+        // The deleteContributor cascade test needs `ContributorService`. The reindexer
+        // requires a [BookTagRepository] + [TagRepository]
         // pair; both are already constructed inside `buildServerRepositories` (tagRepo
-        // for the Tags-domain tests), so we just instantiate `BookTagRepository` here.
+        // for the Tags-domain tests), so only `BookTagRepository` is instantiated here.
         val bookSearchReindexer =
             BookSearchReindexer(
                 bookTagRepository = BookTagRepository(serverSqlDb, bus, syncRegistry),
@@ -274,7 +274,7 @@ internal fun withClientSyncEngineAgainstServer(block: suspend ClientEngineScope.
                 reindexer = bookSearchReindexer,
                 sqlDb = serverSqlDb,
             )
-        // Books-C2 Task 25 needs `SeriesService` for the mergeSeries e2e test.
+        // The mergeSeries e2e test needs `SeriesService`.
         val seriesService: SeriesService =
             createSeriesService(
                 seriesRepo = serverRepos.seriesRepo,
@@ -630,7 +630,7 @@ private fun registerClientSyncHandlers(
  * only seeds a `libraries` DB row — it is never read from the filesystem on the sync write
  * path — so a throwaway temp dir is sufficient.
  *
- * The P2 stats domain requires [UserStatsUpdater], which needs [UserStatsRepository] at
+ * The stats domain requires [UserStatsUpdater], which needs [UserStatsRepository] at
  * runtime (write path) and is needed by [ListeningEventRepository] at construction. The
  * `lateinit` trick from [SyncTestApplication] breaks the circular reference: the updater
  * lambda captures the `lateinit var` that is assigned immediately after construction.
@@ -680,7 +680,7 @@ private fun buildServerRepositories(
     val playbackPositionRepo =
         PlaybackPositionRepository(serverSqlDb, bus, registry, activeSessionRepo = activeSessionRepo)
 
-    // P2: break the UserStatsRepository ↔ UserStatsUpdater cycle with a lateinit, matching
+    // Break the UserStatsRepository ↔ UserStatsUpdater cycle with a lateinit, matching
     // the pattern in SyncTestApplication.
     lateinit var statsUpdater: UserStatsUpdater
     val userStatsRepo =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadAudioFileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadAudioFileTest.kt
@@ -27,7 +27,7 @@ import java.io.File
  * Seam-level tests for [resolveDownloadUrl] via [downloadAudioFile].
  *
  * Validates that the download path obtains signed URLs from [PlaybackService.prepare]
- * (Task 3 of the playback-fix plan) and that the WaitForServer path is gone.
+ * and that the WaitForServer path is gone.
  */
 class DownloadAudioFileTest :
     FunSpec({

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadCancellationTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadCancellationTest.kt
@@ -27,7 +27,7 @@ import java.io.File
  * Contract tests for [persistDownloadCancellation], the cancellation-cleanup seam extracted from
  * [DownloadWorker.doWork]'s catch block so it can be exercised without WorkManager.
  *
- * Per project memory `feedback_fakes_for_seams.md`: hand-rolled fakes, not mokkery.
+ * Uses hand-rolled fakes, not mokkery.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadCancellationTest :

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/download/DownloadWorkerLogicTest.kt
@@ -61,7 +61,7 @@ import java.io.File
  * - androidHostTest requires Robolectric / Android libs.
  * - jvmTest sees jvmMain actuals (including DownloadFileManager with StoragePaths interface).
  *
- * Per project memory `feedback_fakes_for_seams.md`: hand-rolled fakes + MockEngine, not mokkery.
+ * Uses hand-rolled fakes + MockEngine, not mokkery.
  *
  * Download URL is resolved via PlaybackService.prepare signed URLs.
  */

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -36,8 +36,8 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
 /**
- * Verifies the isBuffering and playbackState flows added in W7 Phase E2.1 Task 1,
- * and the AudioPlayer state observation wired in Task 4.
+ * Verifies the isBuffering and playbackState flows,
+ * and the AudioPlayer state observation.
  *
  * These flows serve as the receiving end for platform-specific state pushes:
  * Android's MediaControllerHolder Player.Listener and Desktop's AudioPlayer.state
@@ -353,7 +353,7 @@ class PlaybackManagerBufferingStateTest :
         }
 
         // -------------------------------------------------------------------------
-        // Drift #28 — Android arm. PlaybackStateWriter (implemented by PlaybackManager)
+        // Android arm. PlaybackStateWriter (implemented by PlaybackManager)
         // is the seam Android's MediaControllerHolder.Player.Listener pushes state
         // changes through. Verify setPlaybackState routes Playing/Paused transitions
         // to the progressTracker so VMs no longer call it directly. MediaControllerHolder

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.test.runTest
  * also drives the RPC on-demand fetch. The handler owns the atomicity guarantee (rollback behaviour
  * is exercised in [BookRepositoryImplTest]); this test confirms the delegation wiring.
  *
- * Replaced the prior `bookIngestPort.upsertWithAudioFiles` path in the #746 fix: a single decode →
+ * Replaced the prior `bookIngestPort.upsertWithAudioFiles` path: a single decode →
  * persist seam, no parallel mapping that can drift from the contract.
  */
 class PlaybackManagerFallbackFetchAtomicityTest :

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.test.runTest
  * missing. Seeds a book with NO audio files in the junction; stubs `syncApi.getBook` to return the
  * contract [BookSyncPayload] the Kotlin server actually emits; calls `prepareForPlayback`; asserts
  * the junction is populated — INCLUDING the audio-stream fields (`codecProfile`/`spatial`/`bitrate`/
- * `sampleRate`/`channels`) that #746 dropped on the stale `SingleBookResponse` path.
+ * `sampleRate`/`channels`) that were dropped on the stale `SingleBookResponse` path.
  *
  * Uses a real in-memory DB + a real [BookSyncDomainHandler] so it exercises the full decode →
  * persist path the fallback now shares with the RPC on-demand fetch.
@@ -216,7 +216,7 @@ class PlaybackManagerFallbackFetchTest :
                     rows.map { it.id } shouldBe listOf("af-1", "af-2")
                     rows.map { it.index } shouldBe listOf(0, 1)
 
-                    // ...and the audio-stream fields must survive the fallback write (the #746 fix).
+                    // ...and the audio-stream fields must survive the fallback write.
                     val first = rows.first { it.id == "af-1" }
                     first.codecProfile shouldBe "lc"
                     first.spatial shouldBe "atmos"

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.test.runTest
  *
  * No actual audio plays — this is a data-layer-to-PlaybackManager integration
  * test. The acceptance test for actual playback is a manual checkpoint on a
- * real device before push (see plan Task 9).
+ * real device before push.
  */
 class PlaybackManagerPrepareTest :
     FunSpec({

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.test.runTest
  *    via playbackPreferences.setDefaultPlaybackSpeed (was double-writing
  *    via scope.launch at PlaybackManager:471, conflating per-book and global).
  *
- * If any of these tests regress in the future, the corresponding W7 Phase A
+ * If any of these tests regress in the future, the corresponding
  * deletion was likely re-introduced. Investigate before "fixing" the test.
  */
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerTestSupport.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.Job
 
 // Shared construction helpers for PlaybackManager jvmTests.
 //
-// [ProgressTracker] is `open` (W7 Phase E2.2.3 Task 2) so seam-level tests can
+// [ProgressTracker] is `open` so seam-level tests can
 // substitute a hand-rolled [FakeProgressTracker] (see Testing rubric: "seam-level
 // tests use fakes with in-memory state, not mocks"). Tests that need real
 // session-state behaviour continue to use [buildProgressTracker] for a real

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporterTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporterTest.kt
@@ -36,7 +36,7 @@ private const val SPEED = 1.0f
 /**
  * Tests for [PlaybackProgressReporter] — the single playback-session seam for iOS/Desktop.
  *
- * Verifies the listening-event recording fan-out (the #702 fix) against an in-memory
+ * Verifies the listening-event recording fan-out against an in-memory
  * Room database: a play→pause session records exactly one row stamped with the account
  * user id and enqueues a sync op, book-finish finalizes the span, and — crucially — a
  * `null` recorder (the Android binding) records nothing, so Android never double-records.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerDoesNotRecordEventsTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerDoesNotRecordEventsTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 /**
  * Pins the contract that [ProgressTracker] does **not** record listening events.
  *
- * Listening history is owned exclusively by the canonical P2 path
+ * Listening history is owned exclusively by the canonical recording path
  * ([ListeningEventRecorder]). [ProgressTracker]'s sole responsibilities are
  * position persistence, full-playback-session tracking, and finished-marking —
  * never listening-event writes. The pre-removal tracker queued an

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailDescriptionFieldTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailDescriptionFieldTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlin.reflect.full.memberProperties
 
 /**
- * Guards #635: the iOS Book Detail rendered the whole `Ready` toString because Swift's
+ * Guards against SKIE field shadowing: the iOS Book Detail rendered the whole `Ready` toString because Swift's
  * universal `description` (CustomStringConvertible) shadows a Kotlin `description` field
  * over the SKIE bridge. The fix renamed the field to `descriptionText`. If anyone renames
  * it back to `description`, SKIE will shadow it again — so pin the names here.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/discover/LeaderboardViewModelRealRepoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/discover/LeaderboardViewModelRealRepoTest.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.test.setMain
  *
  * Distinct from the commonTest `LeaderboardViewModelTest` (which fakes the repository itself),
  * this test exercises the full stack from ViewModel → LeaderboardRepositoryImpl → DAO, proving
- * the rewired repo (Task 13) still satisfies the ViewModel contract.
+ * the rewired repo still satisfies the ViewModel contract.
  *
  * The fake DAO uses [MutableStateFlow] (not `flowOf`) to avoid the Turbine / WhileSubscribed
  * race that fires when a cold source completes before the downstream StateFlow collects.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/profile/ProfileE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/profile/ProfileE2ETest.kt
@@ -56,7 +56,7 @@ import app.cash.sqldelight.db.SqlDriver
  *
  * This validates the contract layer (serialization round-trips), the service impl
  * (update semantics, null-field-preservation), and the WrongPassword typed-error path —
- * the same coverage the Go parity ledger requires for "Update own profile".
+ * the coverage required for "Update own profile".
  *
  * Avatar upload/serve is an HTTP REST surface, not RPC; it is covered by the
  * server-side route test and intentionally excluded here.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/ListenUpMigrationTestHelper.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/ListenUpMigrationTestHelper.kt
@@ -56,7 +56,7 @@ class ListenUpMigrationTestHelper internal constructor(
  *
  * Jvm-scoped because Room 2.8's [MigrationTestHelper] only ships JVM/Android
  * and native source-set actuals; the appleMain equivalent can be added when
- * iOS/macOS migration tests are needed (see W4.5 in the restoration roadmap).
+ * iOS/macOS migration tests are needed.
  */
 fun createMigrationTestHelper(): ListenUpMigrationTestHelper {
     val schemaDirectory: Path = Paths.get("schemas").toAbsolutePath()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabase.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabase.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.Dispatchers
  * make all Room queries run on the test scheduler. This lets `advanceUntilIdle()` drain DB
  * work deterministically, eliminating races between assertions and in-flight IO continuations.
  *
- * Scope: jvmTest only. Promoted to commonTest in W4 once cross-platform migration tests
- * need the same seam — see the W1 plan's checkpoint resolution on in-memory Room placement.
+ * Scope: jvmTest only. Promote to commonTest once cross-platform migration tests
+ * need the same seam.
  *
  * Source: Room KMP testing guide — https://developer.android.com/kotlin/multiplatform/room.
  */

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabaseTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/test/db/TestDatabaseTest.kt
@@ -8,8 +8,7 @@ import kotlinx.coroutines.test.runTest
  * Verifies [createInMemoryTestDatabase] constructs a usable [com.calypsan.listenup.client.data.local.db.ListenUpDatabase]
  * backed by an in-memory SQLite, with DAOs resolvable and a basic round-trip working.
  *
- * Lives in jvmTest (not commonTest) until W4 proves out a cross-platform test-DB seam — see the
- * W1 plan's checkpoint resolution on in-memory Room placement.
+ * Lives in jvmTest (not commonTest) until a cross-platform test-DB seam is proven out.
  */
 class TestDatabaseTest :
     FunSpec({

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/core/JvmSecureStorageTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/core/JvmSecureStorageTest.kt
@@ -15,7 +15,7 @@ import java.io.File
 class JvmSecureStorageTest :
     FunSpec({
         // A fresh, empty storage file inside a per-test temp directory ([tempdir] is cleaned up
-        // by Kotest after the spec). Starting fresh mirrors the original @BeforeTest setup.
+        // by Kotest after the spec). Starting fresh gives each test isolated state.
         fun newStorageFile(): File = File(tempdir(), "test-auth.enc").apply { delete() }
 
         test("save and read round-trip works") {

--- a/sharedLogic/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/sharedLogic/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -160,6 +160,6 @@ internal val macosPlaybackModule: Module =
             )
         }
 
-        // Background sync scheduler (stub for now)
+        // Background sync scheduler (stub)
         single<BackgroundSyncScheduler> { MacosBackgroundSyncScheduler() }
     }

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/HeroNavRowTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/HeroNavRowTest.kt
@@ -18,7 +18,7 @@ import org.robolectric.annotation.Config
  * Pins [HeroNavRow]'s interactive contract: the back control fires `onBack`, and the trailing
  * `actions` slot renders.
  *
- * The status-bar inset itself (the #595 / #563 guard) is NOT asserted pixel-wise: Robolectric
+ * The status-bar inset itself is NOT asserted pixel-wise: Robolectric
  * reports zero system-bar insets, so `windowInsetsPadding(WindowInsets.statusBars)` resolves to
  * 0.dp here and a positional assertion could not distinguish inset-applied from inset-absent. The
  * inset is instead guaranteed structurally — it is baked into the component and toggled only by the

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarUiStateTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarUiStateTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.Test
 
 /**
- * Pins the profile-less avatar fallback (#625): a pending registrant has no server-side public
+ * Pins the profile-less avatar fallback: a pending registrant has no server-side public
  * profile, so without a fallback name the avatar is stuck on the loading circle. With a name we
  * render initials; without one we keep the original loading behaviour for a profile still in flight.
  *

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/PhaseABoundarySuiteTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/navigation/PhaseABoundarySuiteTest.kt
@@ -19,12 +19,12 @@ import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Phase A boundary suite. Tests that exercise the structural invariants the
- * Phase A migration must satisfy — covered incrementally as each task lands:
+ * Navigation boundary suite. Tests that exercise the structural invariants the
+ * navigation layer must satisfy:
  *
- *  - Task 4: process-death back-stack survival via `rememberNavBackStack`.
- *  - Task 5: every `NavDisplay` invocation site installs both standard entry decorators.
- *  - Task 6: per-entry ViewModel scoping (VM-per-entry + cleared-on-pop).
+ *  - process-death back-stack survival via `rememberNavBackStack`.
+ *  - every `NavDisplay` invocation site installs both standard entry decorators.
+ *  - per-entry ViewModel scoping (VM-per-entry + cleared-on-pop).
  *
  * `@Config(sdk = [35])` pins Robolectric to the highest SDK its 4.15.1 release
  * supports; the project's compileSdk = 37 outpaces Robolectric's currently-shipped

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
@@ -185,7 +185,7 @@ class AndroidPlaybackControllerTest :
                 )
 
             // Total duration = 150_000. seekTo(200_000) — past end.
-            // Drift #26 (a) fix: should return (1, 90_000L) — LAST item's durationMs, not controller.duration
+            // Should return (1, 90_000L) — LAST item's durationMs, not controller.duration
             sut.resolveQueuePosition(items, 200_000L) shouldBe (1 to 90_000L)
         }
 

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/testing/FakeNavViewModel.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/testing/FakeNavViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 
 /**
- * A fake ViewModel used by Phase A boundary tests. Records onCleared() and the
- * SavedStateHandle observed at construction time. Hand-rolled per project memory
- * feedback_fakes_for_seams.md.
+ * A fake ViewModel for boundary tests. Records onCleared() and the
+ * SavedStateHandle observed at construction time. Hand-rolled as a fake with real
+ * in-memory state rather than a mock.
  */
 class FakeNavViewModel(
     val savedStateHandle: SavedStateHandle = SavedStateHandle(),

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/testing/NavDisplayTestHarness.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/testing/NavDisplayTestHarness.kt
@@ -19,12 +19,12 @@ import org.koin.compose.KoinApplication
 import org.koin.core.module.Module
 
 /**
- * Phase A test harness. Composes a NavDisplay with both standard entry decorators
+ * Navigation boundary test harness. Composes a NavDisplay with both standard entry decorators
  * installed and exposes helpers for boundary tests.
  *
  * Designed for reuse:
- *  - Phase B extends with DeepLinkTestHarness for Intent-driven tests
- *  - Phase C extends with per-platform graph-coverage assertions
+ *  - Intent-driven (deep-link) tests extend it with DeepLinkTestHarness
+ *  - Per-platform graph-coverage assertions extend it
  *
  * Process-death survival is exercised via Compose UI-Test's [StateRestorationTester],
  * which is the canonical mechanism for emulating an Activity / process recreation
@@ -46,7 +46,7 @@ class NavDisplayTestHarness(
      * The optional [koinModule] supplies a test-scoped Koin module wrapping the
      * NavDisplay in a `KoinApplication { }`. Pass a module with a `viewModel { }`
      * binding when boundary tests need to resolve a VM via `koinViewModel()`.
-     * Reusable for Phase B/C tests.
+     * Reusable across the deep-link and graph-coverage harnesses.
      */
     fun composeBackStack(
         initialKey: NavKey,

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/design/theme/PlatformType.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/design/theme/PlatformType.kt
@@ -64,7 +64,7 @@ actual val DisplayFontFamily: FontFamily = GoogleSansDisplay
 
 /**
  * ListenUp typography — Material 3 Expressive scale on Google Sans Flex, matched to the design
- * system's weight ramp (`docs/auth-design-bundle/.../m3.css`):
+ * system's weight ramp:
  *
  *  - body **400**, title/label **600**, headline **700**, and the Expressive `*Emphasized` roles
  *    **800** for heroes, section headers, and big stat numbers.

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -338,7 +338,7 @@ private fun ServerSetupNavigation() {
                     ServerSetupScreen(
                         onServerVerified = {
                             // URL is saved, AuthState will change automatically
-                            // Pop back to select (will be replaced by auth screen)
+                            // Pop back to select; the auth screen takes over once AuthState updates
                         },
                         onBack = {
                             backStack.removeAt(backStack.lastIndex)

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -82,7 +82,7 @@ class AndroidPlaybackController(
      * - Empty list → `(0, 0)`
      * - Position within an item → `(itemIndex, bookPositionMs - item.offsetMs)`
      * - Before first item → `(0, 0)`
-     * - Past last item → `(lastIndex, lastItem.durationMs)` (Drift #26 fix: uses item duration, not controller duration)
+     * - Past last item → `(lastIndex, lastItem.durationMs)` (uses item duration, not controller duration)
      */
     internal fun resolveQueuePosition(
         items: List<PlaybackMediaItem>,
@@ -100,7 +100,7 @@ class AndroidPlaybackController(
             0 to 0L
         } else {
             // Past end → snap to last item's end
-            // Drift #26 (a) fix: use LAST item's durationMs, not controller.duration
+            // Use LAST item's durationMs, not controller.duration
             val lastIndex = items.size - 1
             lastIndex to items.last().durationMs
         }

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
@@ -27,7 +27,7 @@ private val logger = KotlinLogging.logger {}
  * Singleton holder for the MediaController connection.
  *
  * NowPlayingViewModel consumes this controller via the PlaybackController seam
- * (PlayerViewModel was deleted in W7 Phase E2.2.3). The holder also owns the
+ * (there is no longer a separate PlayerViewModel). The holder also owns the
  * Player.Listener and position polling that drive PlaybackStateWriter on Android.
  *
  * The holder manages the lifecycle through reference counting:

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandler.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandler.kt
@@ -21,7 +21,7 @@ private const val HTTP_NOT_FOUND = 404
  * 2. ALWAYS show clear, actionable error message (never silent failures)
  * 3. AUTO-RETRY network errors (transient failures are common)
  * 4. FAIL FAST on auth/404/codec errors (don't waste time retrying the impossible)
- * 5. LOG everything (debugging > user messaging in Phase 1)
+ * 5. LOG everything (debugging > user messaging)
  */
 class PlaybackErrorHandler(
     private val progressTracker: ProgressTracker,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/HeroNavRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/HeroNavRow.kt
@@ -34,7 +34,7 @@ private val HERO_NAV_BUTTON_SIZE = 48.dp
  *
  * This is the single inset-safe source of truth for the Profile / Series / Contributor
  * detail heroes — each floats edge-to-edge behind the status bar, so each must inset its
- * controls. Encapsulating the inset here makes the #595 / #563 class of bug (controls
+ * controls. Encapsulating the inset here makes the class of bug (controls
  * trapped under the status bar) unrepresentable in those screens.
  *
  * @param onBack Invoked when the back button is tapped.

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
@@ -298,7 +298,7 @@ internal fun avatarInitials(displayName: String): String =
  *
  * [fallbackName] lets a caller render initials for a user that has no cached public profile —
  * a pending registrant never gets a server-side profile row, so without this the avatar would be
- * stuck on the indefinite loading circle (#625). Active users (profile present) ignore it.
+ * stuck on the indefinite loading circle. Active users (profile present) ignore it.
  */
 internal fun userAvatarUiState(
     profile: CachedUserProfile?,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/admin/AdminScreen.kt
@@ -815,7 +815,7 @@ private fun PendingUserRow(
         subtitle = user.email,
         showDivider = showDivider,
         // A pending registrant has no server-side public profile yet, so drive initials from their
-        // name (#625) rather than the generic add-person glyph / an indefinite loading circle.
+        // name rather than the generic add-person glyph / an indefinite loading circle.
         leading = { UserAvatar(userId = user.id, size = AvatarSize.Medium, fallbackName = name) },
     ) {
         if (isApproving || isDenying) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookActionsMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookActionsMenu.kt
@@ -158,7 +158,7 @@ fun BookActionsMenu(
             onClick = onShareClick,
         )
 
-        // Delete Book (admin only, stubbed for now)
+        // Delete Book (admin only) — not yet implemented
         if (isAdmin) {
             HorizontalDivider()
 
@@ -182,7 +182,7 @@ fun BookActionsMenu(
                         leadingIconColor = MaterialTheme.colorScheme.error,
                     ),
                 onClick = onDeleteClick,
-                enabled = false, // Stubbed for now
+                enabled = false, // Not yet implemented
             )
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookDetailHero.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookDetailHero.kt
@@ -131,7 +131,7 @@ fun CompactHero(
             abridged = abridged,
             classificationColor = MaterialTheme.colorScheme.primary,
             centered = true,
-            // larger cover→classification gap than the 8dp column rhythm, per the design
+            // larger cover→classification gap than the 8dp column rhythm
             modifier = Modifier.padding(top = 16.dp),
         )
 
@@ -435,7 +435,7 @@ private fun WideHeroIdentity(
         }
 
         // Stats — Added (accent) · Duration · Year · Rating, last in the identity column and
-        // recoloured to read on the colour band, per the design.
+        // recoloured to read on the colour band.
         StatsRow(
             rating = rating,
             duration = duration,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/MetadataSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/MetadataSection.kt
@@ -59,7 +59,7 @@ fun StatsRow(
         horizontalArrangement = horizontalArrangement,
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        // Order per the design: Added (accent) → Duration → Year, with Rating last when present.
+        // Order: Added (accent) → Duration → Year, with Rating last when present.
         addedAt?.let { timestamp ->
             StatChip(
                 icon = { Icon(Icons.Default.LibraryAdd, null, Modifier.size(16.dp)) },

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -145,7 +145,7 @@ fun WideBookDetail(
             )
 
             // Identity — full-width color band: title, independent subtitle, series chips, talent,
-            // and the stat chips as the last element of the identity column (per the design).
+            // and the stat chips as the last element of the identity column.
             WideHeroBand(
                 coverPath = book.coverPath,
                 coverHash = book.coverHash,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
@@ -666,7 +666,7 @@ private fun NarrowColorHero(
                     )
                 }
                 // Website — the narrow hero previously omitted it, so a contributor's website never
-                // showed on phones even when set (#616). `ink` keeps it readable on the colour block.
+                // showed on phones even when set. `ink` keeps it readable on the colour block.
                 state.contributor.website?.takeIf { it.isNotBlank() }?.let { url ->
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
@@ -448,7 +448,7 @@ private fun LinksCardContent(
         onValueChange = { onEvent(ContributorEditUiEvent.WebsiteChanged(it)) },
         label = "Website",
         placeholder = "https://...",
-        // A URL keyboard alone still autocorrects words and injects spaces (#617); disable text
+        // A URL keyboard alone still autocorrects words and injects spaces; disable text
         // assistance so URLs are typed verbatim.
         keyboardOptions =
             KeyboardOptions(

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/AliasesSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/AliasesSection.kt
@@ -44,7 +44,7 @@ import org.jetbrains.compose.resources.stringResource
  * dispatches the unmerge RPC; the SSE event eventually removes the alias from this
  * list, which causes the parent screen to re-render.
  *
- * Per Books-C2 design: aliases are merge/unmerge-only. There is no "add alias"
+ * By design, aliases are merge/unmerge-only. There is no "add alias"
  * affordance — aliases appear only as a side effect of `mergeContributors`. The
  * [onMergeClick] button opens the merge flow; when [aliases] is empty, a hint
  * replaces the chip row so the section still reads as a field.

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/CompactNowPlaying.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/CompactNowPlaying.kt
@@ -238,7 +238,7 @@ fun CompactNowPlaying(
 
             Spacer(Modifier.height(24.dp))
 
-            // Transport — slightly smaller FAB (88 dp) per the mobile design reference.
+            // Transport — slightly smaller FAB (88 dp).
             PlayerTransport(
                 isPlaying = state.isPlaying,
                 isBuffering = state.isBuffering,


### PR DESCRIPTION
Plan 051 (the last item in the 2026-06-29 server/native audit batch): a **comment- and KDoc-only** sweep that makes every code comment developer-directed — stripping phase/PR/plan numbers and migration narrative, deleting dead/commented-out lines, and tightening "why" comments. **Zero behavioral lines change.**

Also fixes one stale factual block: the **Releasing** section of the repo-root `client/CLAUDE.md` (the server release job) — was wrongly described as GraalVM / `continue-on-error` / blocked on #647; now correctly states it links a Kotlin/Native `server.kexe` into a two-stage distroless image and is a hard gate. `grep -nE 'GraalVM|continue-on-error|#647' client/CLAUDE.md` is now clean.

**Scope:** 287 files across `server/`, `sharedLogic/`, `sharedUI/`, `contract/` (+521 / −612).

**Verification:** full local pre-push gate green —
`:sharedLogic:jvmTest :server:jvmTest :server:linuxX64Test spotlessCheck detekt :androidApp:assembleDebug` → `BUILD SUCCESSFUL`. The build gate is the safety net: a comment edit can only break the build via a lint/line-length regression, and none did.

**Review note:** plan 051 is *attended* and intended as per-module batches. A host crash mid-sweep collapsed the in-progress edits into one uncommitted blob; this PR is the recovered work as a single squashed commit. Please review the full diff as one unit rather than expecting per-module commits.