### PR TITLE
📦 build(server): strip symbols from the native release binary

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.security.MessageDigest
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
@@ -47,6 +48,11 @@ kotlin {
         binaries {
             executable {
                 entryPoint = "com.calypsan.listenup.server.main"
+                // Strip the symbol/debug tables from the release binary only (debug keeps them for
+                // native debugging). `-s` passes through K/N's ld.lld; .dynsym and .eh_frame survive,
+                // so dynamic linking and stack-unwinding are intact and the binary still boots. This
+                // drops server.kexe ~33MB -> ~23MB and the distroless image ~58MB -> ~49MB.
+                if (buildType == NativeBuildType.RELEASE) linkerOpts("-s")
             }
         }
         // Provide the system library search paths for the K/N bundled ld.lld linker, which has
@@ -74,6 +80,8 @@ kotlin {
         binaries {
             executable {
                 entryPoint = "com.calypsan.listenup.server.main"
+                // Strip the release binary (see the linuxX64 note above); debug keeps its symbols.
+                if (buildType == NativeBuildType.RELEASE) linkerOpts("-s")
             }
         }
         // arm64 multiarch dir (Debian/Ubuntu aarch64), present on an arm64 host / cross-sysroot.


### PR DESCRIPTION
Scope `linkerOpts("-s")` to the RELEASE executable on both `linuxX64` and `linuxArm64`, stripping the ELF symbol table from the deployed `server.kexe`. Debug builds keep their symbols.

## Impact

| | Before | After | Δ |
|---|---|---|---|
| `server.kexe` | 33.1 MB | 23.5 MB | **−9.68 MB / −29%** |
| Distroless image | 58.3 MB | 48.6 MB | **−9.68 MB / −16.6%** |
| Idle RSS | 67.8 MiB | 50.8 MiB | **−25%** (symbol table never resident) |

Cold-start and `/healthz` are unchanged-to-faster (`Application started in 0.06 s`).

## Trade-off (tracked: #949)

`-s` removes `.symtab`+`.strtab` — the entire 9.68 MB — and kotlin-logging reads that table to name loggers on Kotlin/Native, so release-image log lines tag `[UnknownLogger]` instead of their source subsystem. No middle-ground link flag exists (`--strip-debug` saves ~42 KB; the symbol table *is* the win). Mitigated: log **messages stay descriptive** and **correlation IDs survive**, so single-request tracing still works. #949 restores per-subsystem tags via explicit named loggers.

## Verification

- `:server:linkReleaseExecutableLinuxX64` → `file server.kexe` reports **stripped**, 23.5 MB (fresh BuildID — genuinely the `-s` link, not a manual strip).
- Distroless image rebuilt via the CI steps (`Dockerfile.native`, context `server`) → 48.6 MB.
- `scripts/serve-smoke.sh lu-server:capstone` → `SMOKE OK: /healthz=200 and no V9 migration failure`.
- `spotlessCheck detekt` → `BUILD SUCCESSFUL`.

Closes the binary-size half of the lean-native-deploy line (plan 050). Benchmarks: `docs/server-capstone-2026-06-29-benchmarks.md` (non-repo).