### PR TITLE
🐳 fix(server): distroless named-volume deploys + honest data-dir errors

### DIFF
--- a/server/Dockerfile.native
+++ b/server/Dockerfile.native
@@ -17,6 +17,9 @@ RUN curl -fsSL -o amalg.zip "$SQLITE_AMALGAMATION_URL" \
         -shared -o /build/libsqlite3.so.0 sqlite3.c \
     && cat sqlite3.h | grep -m1 '#define SQLITE_VERSION ' \
     && awk '/#define SQLITE_VERSION_NUMBER/ { if ($3 < 3043000) { print "SQLite too old: " $3; exit 1 } }' sqlite3.h
+# An empty /data to seed the runtime image's data dir — the distroless base has no shell, so the dir is
+# created here and COPY --chown'd into the final stage below.
+RUN mkdir -p /data
 
 FROM gcr.io/distroless/cc-debian12:nonroot
 # libcrypt.so.1 is NOT in distroless/cc (Debian split it out of glibc into libcrypt1); the binary links
@@ -25,5 +28,13 @@ COPY --from=libs /build/libsqlite3.so.0                     /usr/lib/x86_64-linu
 COPY --from=libs /usr/lib/x86_64-linux-gnu/libargon2.so.1   /usr/lib/x86_64-linux-gnu/
 COPY --from=libs /usr/lib/x86_64-linux-gnu/libcrypt.so.1    /usr/lib/x86_64-linux-gnu/
 COPY server-binary /usr/local/bin/listenup-server
+# The server runs as nonroot (uid 65532, from the distroless base) and writes its DB, secrets, and
+# extracted covers under /data. Ship /data pre-created and owned by 65532 so a fresh Docker *named
+# volume* inherits that ownership (Docker seeds a new volume from the image mountpoint's owner/perms),
+# letting the server write on first boot. Without it, a named-volume run fails: the nonroot process
+# can't create /data/.lock, which the data-dir lock then misreports as "another server is running".
+# (Bind mounts still need a host-side `chown 65532` or `--user`; that's inherent to bind mounts.)
+COPY --from=libs --chown=65532:65532 /data /data
+VOLUME /data
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/listenup-server"]

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.linux.kt
@@ -3,6 +3,7 @@
 package com.calypsan.listenup.server.db
 
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
 import kotlinx.io.files.Path
 import platform.linux.LOCK_EX
 import platform.linux.LOCK_NB
@@ -13,11 +14,20 @@ import platform.posix.O_WRONLY
 import platform.posix.S_IRUSR
 import platform.posix.S_IWUSR
 import platform.posix.close
+import platform.posix.errno
 import platform.posix.open
+import platform.posix.strerror
 
 internal actual fun tryLockFile(lockFile: Path): FileLockHandle? {
     val fd = open(lockFile.toString(), O_CREAT or O_WRONLY, (S_IRUSR or S_IWUSR).toUInt())
-    if (fd < 0) return null
+    if (fd < 0) {
+        // open() never fails because the lock is *held* — that's only knowable from flock() below.
+        // A negative fd means the lock file can't be opened/created at all (typically EACCES on a
+        // data dir the nonroot server can't write). Surface it, rather than returning null, which the
+        // caller would otherwise misreport as "another server is already using the data directory".
+        val err = errno
+        error("cannot open data-dir lock file $lockFile: ${strerror(err)?.toKString() ?: "errno=$err"}")
+    }
     if (flock(fd, LOCK_EX or LOCK_NB) != 0) {
         close(fd) // another open file description holds it (cross-process OR same-process second open)
         return null

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/DataDirLockPermissionNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/db/DataDirLockPermissionNativeTest.kt
@@ -1,0 +1,44 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.calypsan.listenup.server.db
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.io.files.Path
+import platform.posix.S_IRUSR
+import platform.posix.S_IXUSR
+import platform.posix.geteuid
+import platform.posix.getpid
+import platform.posix.mkdir
+import platform.posix.rmdir
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+/**
+ * Native proof that an *unwritable* data dir surfaces as a clear permission error — not the misleading
+ * "another server is already using the data directory", which is reserved for a genuine `flock`
+ * conflict. Regression guard for the distroless nonroot named-volume boot failure: a fresh root-owned
+ * volume left the nonroot server unable to create `<dataHome>/.lock`, and `tryLockFile` reported that
+ * `open()` failure as a lock conflict.
+ */
+class DataDirLockPermissionNativeTest {
+    @Test
+    fun openFailureOnUnwritableDirThrowsPermissionErrorNotLockConflict() {
+        // root bypasses directory permission bits — open() would succeed, so the test proves nothing.
+        // CI typically runs as root (container), where this is skipped; it validates locally as non-root.
+        if (geteuid() == 0u) return
+
+        val dir = "/tmp/lu-lock-perm-${getpid()}"
+        rmdir(dir) // defensive: clear a leftover from a previously-crashed run
+        mkdir(dir, (S_IRUSR or S_IXUSR).toUInt()) // r-x------ : created without write permission
+        try {
+            val failure =
+                assertFailsWith<IllegalStateException> {
+                    DataDirLock.forDataHome(Path(dir)).tryAcquire()
+                }
+            assertContains(failure.message ?: "", "cannot open data-dir lock file")
+        } finally {
+            rmdir(dir)
+        }
+    }
+}


### PR DESCRIPTION
Surfaced by the native-server capstone run: the distroless image (`gcr.io/distroless/cc-debian12:nonroot`, uid 65532) never creates or owns `/data`, so the most common self-host setup — a Docker **named volume** — **fails to boot on first run**, and the failure is *misreported* as a lock conflict.

## 1. Named-volume boot failure (the real bug) — `Dockerfile.native`
A fresh named volume is seeded `root:root`, so the nonroot server can't write `/data` (DB, secrets, covers). Fix: create `/data` in the builder stage and `COPY --chown=65532:65532` it into the runtime image (+ `VOLUME /data`). Docker then seeds a fresh named volume from the image mountpoint's ownership, so the server can write on first boot.

- **Before:** `docker run -v lu_data:/data … ` → boot fails.
- **After (verified):** named volume → `/healthz` 200, DB written `65532:65532`, secrets at `/data/secrets.properties`.
- Bind mounts still need a host-side `chown 65532` or `--user` — inherent to bind mounts, not fixable in the image.

## 2. Misleading error (the diagnostic fix) — `DataDirLock.linux.kt`
On the unwritable dir, the native `tryLockFile` `open()` failed (EACCES) and returned `null` — indistinguishable from "lock held" — so the caller printed *"Another ListenUp server is already using the data directory."* `open()` can never mean "held" (only `flock` detects that), so it now throws a clear `cannot open data-dir lock file …: Permission denied`. (JVM already threw `AccessDeniedException` here; this brings native in line.)

New regression test `DataDirLockPermissionNativeTest` (linuxX64) creates an unwritable dir and asserts the clear error — guarded to skip under root (CI), validated locally as non-root.

## Verification
- Patched image: fresh named-volume boot → **HEALTHY**, `/data` files owned `65532:65532`.
- Full gate green: `:sharedLogic:jvmTest :server:jvmTest :server:linuxX64Test spotlessCheck detekt :androidApp:assembleDebug` → `BUILD SUCCESSFUL`. New native test ran (not skipped) and passed.