### PR TITLE
🐛 fix(build): scope Swift Export patcher to each target's own SPM package dir

### DIFF
--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -243,7 +243,19 @@ tasks.matching { it.name.endsWith("GenerateSPMPackage") }.configureEach {
     // regenerating composes cleanly. Mirrors the always-verify gate in
     // `listenup.localization.gradle.kts`.
     outputs.upToDateWhen { false }
-    val spmPackageDir = project.layout.buildDirectory.dir("SPMPackage")
+    // Patch only THIS task's own per-target SPM package, not the shared `build/SPMPackage` parent.
+    // That dir holds one subdir per iOS target+config (`iosArm64/Debug`, `iosSimulatorArm64/Debug`, …),
+    // and `patchPackage` selects a single `Shared.swift` via `firstOrNull`. Pointing it at the parent
+    // lets an already-patched sibling target — whose sealed-enum marker makes `appendSealedEnumSupport`
+    // return 0 — trip the `count > 0` floor below. That's the intermittent "matched 0 sealed types"
+    // failure seen when a device build runs while a simulator package is already patched (or vice
+    // versa). Scoping to this task's own `<target>/<config>` dir isolates the per-target patches.
+    val packageStem = name.removeSuffix("GenerateSPMPackage") // e.g. "iosArm64Debug"
+    val configName =
+        listOf("Debug", "Release").firstOrNull(packageStem::endsWith)
+            ?: error("Unexpected GenerateSPMPackage task name '$name' — cannot derive its SPM config dir.")
+    val targetName = packageStem.removeSuffix(configName) // e.g. "iosArm64"
+    val spmPackageDir = project.layout.buildDirectory.dir("SPMPackage/$targetName/$configName")
     doLast {
         val counts =
             com.calypsan.listenup.gradle.SwiftExportSourcePatcher


### PR DESCRIPTION
## Problem

iOS builds intermittently fail during `:sharedLogic:<target>DebugGenerateSPMPackage` with:

```
Swift Export patcher: appendSealedEnumSupport matched 0 sealed types — the generated output
shape likely changed (Kotlin/Swift-Export bump).
```

Despite the message, the generated output is fine and nothing about Kotlin/Swift-Export changed.

## Root cause

`build/SPMPackage/` holds **one subdirectory per iOS target** (`iosArm64/Debug`, `iosSimulatorArm64/Debug`, …). The post-generation patcher (`SwiftExportSourcePatcher.patchPackage`) was pointed at the **shared parent** dir and selects a single `Shared.swift` via `walkTopDown().firstOrNull`.

`appendSealedEnumSupport` is idempotent — on an **already-patched** file (its marker present) it returns count `0`. So when one target's package is already patched (e.g. a prior **simulator** build) and another target generates fresh (e.g. an Android Studio **device** build), `firstOrNull` can land on the already-patched sibling, the patcher returns `0`, and the `check(sealedEnum > 0)` floor fires. Filesystem walk order makes it intermittent.

## Fix

Scope each `GenerateSPMPackage` task's patcher to **its own** `SPMPackage/<target>/<config>` dir (derived from the task name), instead of the shared parent. Per-target patches can no longer poison each other. No change to the patcher logic or its golden tests.

## Verification

- Cleared stale state, fresh device build (`xcodebuild build -destination generic/platform=iOS`):
  `Swift export patcher: {patchSource=4, camelCase=2, flatTypealias=531, sealedEnum=104, appResult=1}` → `** BUILD SUCCEEDED **`
- `spotlessCheck`, `detekt`, `:build-logic:convention:test` (patcher unit tests) all green.

Supersedes the `rm -rf sharedLogic/build/{SwiftExport,SPMPackage}` escape hatch in `client/CLAUDE.md` rule 15 for this failure mode.