### PR TITLE
✨ feat(client): let the user escape a stalled "Building your library" scan

### DIFF
--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -9771,6 +9771,16 @@
         }
       }
     },
+    "library_scan.continue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        }
+      }
+    },
     "library_scan.eta": {
       "localizations": {
         "en": {
@@ -9797,6 +9807,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "Building your library, %1$d percent complete"
+          }
+        }
+      }
+    },
+    "library_scan.stalled_message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is taking longer than expected. You can continue to your library now — the rest will keep appearing as it syncs."
+          }
+        }
+      }
+    },
+    "library_scan.stalled_settings_hint": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can re-run the scan anytime from Settings."
           }
         }
       }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -15,12 +15,17 @@ import com.calypsan.listenup.client.domain.repository.ProfileRepository
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -52,6 +57,15 @@ data class AppStartupState(
      * a resolved "go to shell" one.
      */
     val checkResolved: Boolean = false,
+    /**
+     * True once the user taps "Continue" on a stalled "Building your library" screen. Latches the
+     * readiness gate to [LibraryReadiness.Ready] so the shell mounts on the partial library that
+     * incremental sync has already landed in Room — the never-stranded escape from a server scan
+     * that can't complete. Process-lived, mirroring the sync layer's initial-scan latch: a fresh
+     * launch or a re-auth starts `false`, and once latched the populating gate never re-shows this
+     * session.
+     */
+    val populatingDismissed: Boolean = false,
 )
 
 /**
@@ -95,7 +109,10 @@ class AppStartupViewModel(
      *
      * `Eagerly`, not `WhileSubscribed`, so [LibraryReadiness] is live for the whole ViewModel
      * lifetime — the splash gate and lifecycle hooks read state without an active UI subscription.
+     * The Eagerly collector also keeps the populating stall watchdog ([flatMapLatest] below) ticking
+     * regardless of UI subscription, so a stall is detected even between recompositions.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     val readiness: StateFlow<LibraryReadiness> =
         combine(
             state,
@@ -104,10 +121,32 @@ class AppStartupViewModel(
         ) { s, scanning, progress ->
             when {
                 !s.checkResolved || s.isChecking -> LibraryReadiness.Checking
+
                 s.setupCheckFailed -> LibraryReadiness.CheckFailed
+
                 s.needsLibrarySetup -> LibraryReadiness.NeedsSetup
-                scanning -> LibraryReadiness.Populating(progress)
+
+                // Once the user has escaped a stalled populate, the latch wins over a still-true
+                // scan signal so the shell stays mounted on the partial library.
+                scanning && !s.populatingDismissed -> LibraryReadiness.Populating(progress)
+
                 else -> LibraryReadiness.Ready
+            }
+        }.flatMapLatest { readiness ->
+            // Stall watchdog, only for the populating gate. Emit the live state immediately, then —
+            // if no fresh upstream value (advancing progress, a cleared scan, a dismiss) arrives
+            // within POPULATING_STALL_TIMEOUT_MS — re-emit it as `stalled`. flatMapLatest cancels and
+            // restarts this inner flow on every upstream change, so each progress tick resets the
+            // timer: a healthy slow scan keeps advancing and never reaches the stalled emission;
+            // only a quiet, stuck scan does.
+            if (readiness is LibraryReadiness.Populating) {
+                flow {
+                    emit(readiness)
+                    delay(POPULATING_STALL_TIMEOUT_MS)
+                    emit(readiness.copy(stalled = true))
+                }
+            } else {
+                flowOf(readiness)
             }
         }.stateIn(
             scope = viewModelScope,
@@ -118,6 +157,13 @@ class AppStartupViewModel(
     companion object {
         /** Apps backgrounded longer than this will re-run the library-setup check on resume. */
         const val BACKGROUND_THRESHOLD_MS = 30 * 60 * 1000L // 30 minutes
+
+        /**
+         * How long the "Building your library" gate may go without scan progress advancing before it
+         * is marked stalled and offers the never-stranded "Continue" escape. A healthy scan advances
+         * progress far more often than this; only a stuck or crashed server scan reaches it.
+         */
+        const val POPULATING_STALL_TIMEOUT_MS = 45_000L
     }
 
     init {
@@ -189,6 +235,17 @@ class AppStartupViewModel(
                 setupCheckFailed = false,
                 checkResolved = true,
             )
+    }
+
+    /**
+     * Escape the "Building your library" gate when the initial scan has stalled (see
+     * [LibraryReadiness.Populating.stalled]). Latches [AppStartupState.populatingDismissed] so
+     * [readiness] computes [LibraryReadiness.Ready] and the shell mounts on the partial library
+     * already in Room — books still scanning keep appearing as incremental sync lands them, and the
+     * user can re-run the scan from Settings whenever they like. Never re-shows the gate this session.
+     */
+    fun onContinueToPartialLibrary() {
+        state.value = state.value.copy(populatingDismissed = true)
     }
 
     /** Re-run the library-setup check after a transient failure (the retry the nav layer offers). */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadiness.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadiness.kt
@@ -28,9 +28,15 @@ sealed interface LibraryReadiness {
      * the server is still scanning or the client is still importing the scanned books (see
      * `applyScanEvent`). Show the dedicated populating screen and do NOT mount the shell. [progress]
      * is the live scan progress when available, null during the indeterminate "finishing up" import.
+     *
+     * [stalled] is the never-stranded escape hatch: it latches `true` once scan progress has gone
+     * quiet for `AppStartupViewModel.POPULATING_STALL_TIMEOUT_MS` (a crashed/stuck server scan that
+     * can never complete), so the screen can offer "Continue" into the partial library. A healthy
+     * scan keeps advancing progress and never trips it.
      */
     data class Populating(
         val progress: ScanProgressState?,
+        val stalled: Boolean = false,
     ) : LibraryReadiness
 
     /** A populated library is queryable in Room. Mount the shell. */

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -1343,7 +1343,10 @@
     "books": "Books",
     "authors": "Authors",
     "hours": "Hours",
-    "progress_a11y": "Building your library, %1$d percent complete"
+    "progress_a11y": "Building your library, %1$d percent complete",
+    "stalled_message": "This is taking longer than expected. You can continue to your library now — the rest will keep appearing as it syncs.",
+    "continue": "Continue",
+    "stalled_settings_hint": "You can re-run the scan anytime from Settings."
   },
   "genre": {
     "browse_title": "Browse by Genre",

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadinessTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadinessTest.kt
@@ -24,11 +24,14 @@ import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 
@@ -99,6 +102,24 @@ class LibraryReadinessTest :
             return sync
         }
 
+        fun progressState(current: Int = 0) =
+            ScanProgressState(
+                phase = "analyzing",
+                current = current,
+                total = current,
+                added = 0,
+                updated = 0,
+                removed = 0,
+            )
+
+        // Admin whose library is already set up; the gate is then driven purely by the scan signal.
+        fun setUpAdminService(): LibraryAdminService {
+            val service = mock<LibraryAdminService>()
+            everySuspend { service.getSetupStatus() } returns
+                AppResult.Success(SetupStatus(needsSetup = false))
+            return service
+        }
+
         val authenticated = AuthState.Authenticated(UserId("user-001"), SessionId("session-001"))
 
         test("fresh admin: Checking -> NeedsSetup -> Populating -> Ready") {
@@ -127,14 +148,16 @@ class LibraryReadinessTest :
                     awaitItem() shouldBe LibraryReadiness.NeedsSetup
 
                     // Wizard done + the initial scan begins: needs-setup clears while scanning is up.
+                    // runCurrent (not advanceUntilIdle) so virtual time doesn't leap past the
+                    // populating stall watchdog and spuriously mark the gate stalled.
                     scanning.value = true
                     vm.onLibrarySetupComplete()
-                    advanceUntilIdle()
+                    runCurrent()
                     awaitItem() shouldBe LibraryReadiness.Populating(null)
 
                     // Server scan + client import settle → shell is safe to mount.
                     scanning.value = false
-                    advanceUntilIdle()
+                    runCurrent()
                     awaitItem() shouldBe LibraryReadiness.Ready
                 }
             }
@@ -183,6 +206,105 @@ class LibraryReadinessTest :
                     advanceUntilIdle()
                     awaitItem() shouldBe LibraryReadiness.CheckFailed
                 }
+            }
+        }
+
+        // ===================== Never-stranded stall escape =====================
+
+        // A scan that goes quiet for the whole timeout must flip the gate to `stalled` so the
+        // populating screen can offer the "Continue" escape. State is read off the Eagerly-shared
+        // StateFlow with explicit clock control, so the not-yet/just-crossed boundary is exact.
+        test("populating gate stalls once scan progress is quiet for the timeout") {
+            runTest(dispatcher) {
+                val scanning = MutableStateFlow(true)
+                val vm =
+                    AppStartupViewModel(
+                        userRepoReturning(adminUser()),
+                        adminFactory(setUpAdminService()),
+                        authSession(MutableStateFlow(authenticated)),
+                        profileRepo(),
+                        syncRepo(scanning),
+                    )
+
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Populating(null)
+
+                // Just shy of the timeout: still not stalled.
+                advanceTimeBy(AppStartupViewModel.POPULATING_STALL_TIMEOUT_MS - 1)
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Populating(null, stalled = false)
+
+                // Crossing the timeout latches stalled.
+                advanceTimeBy(1)
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Populating(null, stalled = true)
+            }
+        }
+
+        // A healthy-but-slow scan keeps advancing progress; each advance must reset the watchdog, so
+        // the gate never trips even though far more than one timeout's worth of time elapses overall.
+        test("advancing scan progress keeps resetting the stall watchdog") {
+            runTest(dispatcher) {
+                val scanning = MutableStateFlow(true)
+                val progress = MutableStateFlow<ScanProgressState?>(progressState(current = 0))
+                val vm =
+                    AppStartupViewModel(
+                        userRepoReturning(adminUser()),
+                        adminFactory(setUpAdminService()),
+                        authSession(MutableStateFlow(authenticated)),
+                        profileRepo(),
+                        syncRepo(scanning, progress),
+                    )
+
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Populating(progressState(0))
+
+                repeat(4) { tick ->
+                    // Nearly a full timeout passes, then progress advances — resetting the timer.
+                    advanceTimeBy(AppStartupViewModel.POPULATING_STALL_TIMEOUT_MS - 1_000)
+                    runCurrent()
+                    vm.readiness.value
+                        .shouldBeInstanceOf<LibraryReadiness.Populating>()
+                        .stalled shouldBe false
+                    progress.value = progressState(current = tick + 1)
+                    runCurrent()
+                }
+
+                vm.readiness.value
+                    .shouldBeInstanceOf<LibraryReadiness.Populating>()
+                    .stalled shouldBe false
+            }
+        }
+
+        // Tapping Continue latches readiness to Ready even though the server scan signal is still up,
+        // and the latch holds — the populating gate never re-shows for the rest of the session.
+        test("Continue latches readiness to Ready and the latch holds while the scan keeps running") {
+            runTest(dispatcher) {
+                val scanning = MutableStateFlow(true)
+                val vm =
+                    AppStartupViewModel(
+                        userRepoReturning(adminUser()),
+                        adminFactory(setUpAdminService()),
+                        authSession(MutableStateFlow(authenticated)),
+                        profileRepo(),
+                        syncRepo(scanning),
+                    )
+
+                runCurrent()
+                advanceTimeBy(AppStartupViewModel.POPULATING_STALL_TIMEOUT_MS)
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Populating(null, stalled = true)
+
+                // Continue → Ready, despite the scan still running underneath.
+                vm.onContinueToPartialLibrary()
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Ready
+                scanning.value shouldBe true
+
+                // Latch holds: more time passes, scan still up — never re-shows the gate.
+                advanceTimeBy(AppStartupViewModel.POPULATING_STALL_TIMEOUT_MS * 2)
+                runCurrent()
+                vm.readiness.value shouldBe LibraryReadiness.Ready
             }
         }
     })

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -730,6 +730,7 @@ private fun authenticatedNavEntries(
         nowPlayingViewModel = nowPlayingViewModel,
         readiness = readiness,
         onSignOut = onSignOut,
+        onContinueToPartialLibrary = startupViewModel::onContinueToPartialLibrary,
     )
     librarySetupEntry(backStack, startupViewModel, scope, syncRepository)
     bookEntries(backStack)

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/ShellEntry.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/entries/ShellEntry.kt
@@ -35,6 +35,7 @@ internal fun EntryProviderScope<NavKey>.shellEntry(
     nowPlayingViewModel: NowPlayingViewModel,
     readiness: () -> LibraryReadiness,
     onSignOut: () -> Unit,
+    onContinueToPartialLibrary: () -> Unit,
 ) {
     entry<Shell> {
         // Read the hoisted state INSIDE the entry content (not as a captured parameter) so the
@@ -50,7 +51,11 @@ internal fun EntryProviderScope<NavKey>.shellEntry(
         // the heap → OOM). Populating spans the server scan AND the client import, so
         // when it clears the books are already in Room (see applyScanEvent).
         (readinessState as? LibraryReadiness.Populating)?.let { populating ->
-            LibraryScanScreen(scanProgress = populating.progress)
+            LibraryScanScreen(
+                scanProgress = populating.progress,
+                stalled = populating.stalled,
+                onContinue = onContinueToPartialLibrary,
+            )
             return@entry
         }
 

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -978,9 +978,12 @@ One beautiful library.</string>
     <string name="library_your_audiobooks_will_appear_here">Your audiobooks will appear here once the scan is complete</string>
     <string name="library_scan_authors">Authors</string>
     <string name="library_scan_books">Books</string>
+    <string name="library_scan_continue">Continue</string>
     <string name="library_scan_eta">about %1$d min left</string>
     <string name="library_scan_hours">Hours</string>
     <string name="library_scan_progress_a11y">Building your library, %1$d percent complete</string>
+    <string name="library_scan_stalled_message">This is taking longer than expected. You can continue to your library now — the rest will keep appearing as it syncs.</string>
+    <string name="library_scan_stalled_settings_hint">You can re-run the scan anytime from Settings.</string>
     <string name="library_scan_subtitle_analyzing">Analyzing %1$d of %2$d files — your shelves are filling in.</string>
     <string name="library_scan_subtitle_finishing">Finishing up — almost there.</string>
     <string name="library_scan_subtitle_persisting">Saving your library — almost done.</string>

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/LibraryScanScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/setup/scan/LibraryScanScreen.kt
@@ -37,11 +37,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.calypsan.listenup.client.design.TwoPaneMinWidth
+import com.calypsan.listenup.client.design.components.ListenUpButton
 import com.calypsan.listenup.client.domain.model.ScanProgressState
 import com.calypsan.listenup.client.domain.model.etaMinutes
 import com.calypsan.listenup.client.features.auth.components.BrandMark
 import com.calypsan.listenup.client.features.setup.components.SetupHeroBlob
 import listenup.composeapp.generated.resources.Res
+import listenup.composeapp.generated.resources.library_scan_continue
+import listenup.composeapp.generated.resources.library_scan_stalled_message
+import listenup.composeapp.generated.resources.library_scan_stalled_settings_hint
 import listenup.composeapp.generated.resources.library_setup_building_title
 import listenup.composeapp.generated.resources.scan_building_subtitle
 import listenup.composeapp.generated.resources.scan_files_total
@@ -61,18 +65,24 @@ private const val ETA_TICK_MS = 1_000L
  * [com.calypsan.listenup.client.features.setup.LibrarySetupScreen]. Drives live progress, ETA and
  * matched-book stats off [scanProgress]; renders the loader + headline alone when it's null (the
  * brief "finishing up" tail after the scan's Completed event clears granular progress).
+ *
+ * When [stalled] is true the scan has gone quiet long enough to be considered stuck, so a
+ * never-stranded escape is shown: an [onContinue] action to enter the partial library now, plus a
+ * hint that the scan can be re-run from Settings.
  */
 @Composable
 fun LibraryScanScreen(
     scanProgress: ScanProgressState?,
     modifier: Modifier = Modifier,
+    stalled: Boolean = false,
+    onContinue: () -> Unit = {},
 ) {
     Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
         BoxWithConstraints {
             if (maxWidth >= TwoPaneMinWidth) {
-                DesktopLayout(progress = scanProgress)
+                DesktopLayout(progress = scanProgress, stalled = stalled, onContinue = onContinue)
             } else {
-                PhoneLayout(progress = scanProgress)
+                PhoneLayout(progress = scanProgress, stalled = stalled, onContinue = onContinue)
             }
         }
     }
@@ -81,7 +91,11 @@ fun LibraryScanScreen(
 // ──────────────────────────── PHONE ────────────────────────────
 
 @Composable
-private fun PhoneLayout(progress: ScanProgressState?) {
+private fun PhoneLayout(
+    progress: ScanProgressState?,
+    stalled: Boolean,
+    onContinue: () -> Unit,
+) {
     Column(
         modifier =
             Modifier
@@ -92,14 +106,18 @@ private fun PhoneLayout(progress: ScanProgressState?) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        ScanBody(progress = progress, wide = false)
+        ScanBody(progress = progress, wide = false, stalled = stalled, onContinue = onContinue)
     }
 }
 
 // ──────────────────────────── DESKTOP ────────────────────────────
 
 @Composable
-private fun DesktopLayout(progress: ScanProgressState?) {
+private fun DesktopLayout(
+    progress: ScanProgressState?,
+    stalled: Boolean,
+    onContinue: () -> Unit,
+) {
     Row(modifier = Modifier.fillMaxSize()) {
         BoxWithConstraints(modifier = Modifier.fillMaxHeight()) {
             val brandWidth = (maxWidth * 0.42f).coerceIn(360.dp, 560.dp)
@@ -147,7 +165,7 @@ private fun DesktopLayout(progress: ScanProgressState?) {
                     .padding(48.dp),
             contentAlignment = Alignment.Center,
         ) {
-            ScanBody(progress = progress, wide = true)
+            ScanBody(progress = progress, wide = true, stalled = stalled, onContinue = onContinue)
         }
     }
 }
@@ -159,6 +177,8 @@ private fun DesktopLayout(progress: ScanProgressState?) {
 private fun ScanBody(
     progress: ScanProgressState?,
     wide: Boolean,
+    stalled: Boolean,
+    onContinue: () -> Unit,
 ) {
     Column(
         modifier = Modifier.widthIn(max = if (wide) 500.dp else 360.dp),
@@ -184,6 +204,43 @@ private fun ScanBody(
             Spacer(Modifier.height(26.dp))
             ScanStatsBlock(progress = progress, wide = wide)
         }
+        if (stalled) {
+            Spacer(Modifier.height(30.dp))
+            StalledEscape(onContinue = onContinue)
+        }
+    }
+}
+
+/**
+ * Never-stranded escape shown when the scan has stalled: an honest message, a primary "Continue"
+ * into the partial library, and a hint pointing at the existing manual rescan in Settings.
+ */
+@Composable
+private fun StalledEscape(onContinue: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(Res.string.library_scan_stalled_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(max = 360.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        ListenUpButton(
+            text = stringResource(Res.string.library_scan_continue),
+            onClick = onContinue,
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = stringResource(Res.string.library_scan_stalled_settings_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(max = 360.dp),
+        )
     }
 }
 


### PR DESCRIPTION
Never-stranded escape from the first-run gate when a server scan stalls (e.g. an OOM crash that can't complete). Today `LibraryReadiness.Populating` only flips to `Ready` once the scanned library is queryable in Room — so a stalled scan strands the user on "Building your library" forever. This adds the missing exit (mirroring the existing `CheckFailed` "don't strand them" precedent).

## How it works
- **Stall detection** — `AppStartupViewModel` wraps the readiness flow in `flatMapLatest`: the `Populating` state emits immediately, then after `POPULATING_STALL_TIMEOUT_MS = 45s` re-emits with `stalled = true`. Because `flatMapLatest` restarts on every upstream change, each scan-progress advance resets the timer — a healthy slow scan keeps advancing and never trips it; only a quiet/stuck scan reaches the stalled emission.
- **`LibraryReadiness.Populating`** gains `stalled: Boolean = false`.
- **Escape UI** — when stalled, the scan screen shows "This is taking longer than expected — continue to your library now" with a **Continue** button and a hint pointing to the existing **Settings → rescan** (`AdminRepository.triggerScan`, no reimplementation). Tapping `onContinueToPartialLibrary()` latches `populatingDismissed` so readiness computes `Ready` and the shell mounts on the partial library that incremental sync already landed; books still scanning keep appearing.

## Tests
`AppStartupViewModel`/`LibraryReadiness`: stalls after the timeout; advancing progress keeps resetting the watchdog (never stalls); Continue latches `Ready` and holds while the scan keeps running.

## Gate
`:sharedLogic:jvmTest :androidApp:assembleDebug spotlessCheck detekt` → **BUILD SUCCESSFUL**. New strings generated from the `en.json` source.

## iOS
Compose (Android/Desktop) escape UI + the shared stall logic land here; the change is additive (new property with a default) so iOS compiles and the shared logic benefits it, but the **SwiftUI "Continue" button parity is a follow-up** (this repo's usual Compose-first → iOS-parity cadence). No new public type name → no Swift-export baseline change expected.