### PR TITLE
🔧 chore(build): enable cinterop commonization for shared linuxMain

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,12 @@ kotlin.daemon.jvmargs=-Xmx6144M
 # The :server linuxX64 test/run tasks can't execute on a macOS host (cross-compile target).
 # They still build on Linux/CI; this silences the "Native task ... is disabled" config noise.
 kotlin.native.ignoreDisabledTargets=true
+# The shared :server linuxMain source set (parent of linuxX64Main + linuxArm64Main) uses the
+# libargon2 + sqlite3 cinterops, which both linux targets declare identically. Commonization
+# generates a single target-agnostic view of those C APIs for the shared set, so it resolves in
+# the IDE / shared-metadata compile instead of showing unresolved references. Per-target Gradle
+# compilation worked without it; this fixes the shared-source-set view and silences the warning.
+kotlin.mpp.enableCInteropCommonization=true
 
 #Gradle
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8


### PR DESCRIPTION
## What

Adds `kotlin.mpp.enableCInteropCommonization=true` to `gradle.properties`.

## Why

The `linuxArm64` work introduced a shared `linuxMain` source set (parent of `linuxX64Main` + `linuxArm64Main`) that uses the `libargon2` + `sqlite3` cinterops, which both linux targets declare identically. Without commonization, those C APIs resolve only in the leaf source sets — so per-target Gradle compilation works (CI is green), but the **IDE / shared-metadata view** of `linuxMain` can't resolve them, showing unresolved references and the "CInterop Commonization Disabled" warning.

Commonization generates a single target-agnostic view of the (identical) cinterops for the shared set, fixing the IDE experience and silencing the warning. It's the JetBrains-recommended setting for this exact hierarchical-cinterop layout, and low-risk here since both targets use the same `.def` files.

## Verification

- `:server:commonizeCInterop` → `BUILD SUCCESSFUL` locally.
- Configuring `:server` no longer emits the commonization warning.
- (Full linux native compile runs on CI's linux/arm runners.)