### PR TITLE
🐛 fix(shared): quiet the expected "server not configured" startup noise

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
+import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -60,6 +61,13 @@ internal object ErrorMapper {
             }
 
             is IOException -> {
+                TransportError.NetworkUnavailable(debugInfo = exception.message)
+            }
+
+            // "No server configured yet" is an expected pre-connection state (fresh / signed-out
+            // install), not a fault — type it as a transport-unavailable so the boundary folds it
+            // quietly instead of surfacing a generic InternalError "server error".
+            is ServerUrlNotConfiguredException -> {
                 TransportError.NetworkUnavailable(debugInfo = exception.message)
             }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ActivityRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ActivityRpcFactory.kt
@@ -77,7 +77,7 @@ internal open class KtorActivityRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminSettingsRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminSettingsRpcFactory.kt
@@ -76,7 +76,7 @@ internal open class KtorAdminSettingsRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminUserRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AdminUserRpcFactory.kt
@@ -76,7 +76,7 @@ internal open class KtorAdminUserRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AuthRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/AuthRpcFactory.kt
@@ -100,7 +100,7 @@ internal class KtorAuthRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BackupRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BackupRpcFactory.kt
@@ -77,7 +77,7 @@ internal open class KtorBackupRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BookRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BookRpcFactory.kt
@@ -81,7 +81,7 @@ internal class KtorBookRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
@@ -79,7 +79,7 @@ internal open class KtorCollectionRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ContributorRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ContributorRpcFactory.kt
@@ -81,7 +81,7 @@ internal class KtorContributorRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/GenreRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/GenreRpcFactory.kt
@@ -77,7 +77,7 @@ internal class KtorGenreRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ImportRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ImportRpcFactory.kt
@@ -77,7 +77,7 @@ internal open class KtorImportRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/InviteRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/InviteRpcFactory.kt
@@ -96,7 +96,7 @@ internal open class KtorInviteRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/LibraryAdminRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/LibraryAdminRpcFactory.kt
@@ -83,7 +83,7 @@ internal open class KtorLibraryAdminRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/MetadataLookupRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/MetadataLookupRpcFactory.kt
@@ -83,7 +83,7 @@ internal open class KtorMetadataLookupRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/MoodRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/MoodRpcFactory.kt
@@ -77,7 +77,7 @@ internal open class KtorMoodRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
@@ -80,7 +80,7 @@ internal class KtorPlaybackRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ProfileRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ProfileRpcFactory.kt
@@ -79,7 +79,7 @@ internal open class KtorProfileRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ScannerRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ScannerRpcFactory.kt
@@ -71,7 +71,7 @@ internal open class KtorScannerRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SeriesRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SeriesRpcFactory.kt
@@ -81,7 +81,7 @@ internal class KtorSeriesRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ServerUrlNotConfiguredException.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ServerUrlNotConfiguredException.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.client.data.remote
+
+/**
+ * Thrown when a server RPC/HTTP call is attempted before a server URL has been configured.
+ *
+ * This is an *expected* state, not a bug: on a fresh or signed-out install, background work
+ * (preference sync, instance/server-info fetches) can fire before the user has connected to a
+ * server. Making it a typed signal — rather than a stringly `error("Server URL not configured …")`
+ * [IllegalStateException] — lets the boundary fold it into a quiet "not connected yet" path:
+ * [com.calypsan.listenup.client.core.error.ErrorMapper] maps it to
+ * [com.calypsan.listenup.api.error.TransportError.NetworkUnavailable], and callers log it at
+ * `debug` instead of dumping a stacktrace for a non-failure.
+ *
+ * Extends [IllegalStateException] so existing catch-all transport boundaries keep treating it as a
+ * thrown transport error; only the few sites that care about the not-connected case test for the
+ * type.
+ */
+internal class ServerUrlNotConfiguredException :
+    IllegalStateException("Server URL not configured — cannot open a server connection")

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
@@ -77,7 +77,7 @@ internal open class KtorShelfRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SocialRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SocialRpcFactory.kt
@@ -77,7 +77,7 @@ internal open class KtorSocialRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TagRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/TagRpcFactory.kt
@@ -79,7 +79,7 @@ internal open class KtorTagRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/UserPreferencesRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/UserPreferencesRpcFactory.kt
@@ -75,7 +75,7 @@ internal open class KtorUserPreferencesRpcFactory(
     private suspend fun rpcBaseUrl(): String {
         val httpUrl =
             serverConfig.getActiveUrl()?.value
-                ?: error("Server URL not configured — cannot open RPC connection")
+                ?: throw ServerUrlNotConfiguredException()
         return toWebSocketScheme(httpUrl)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.result.map
 import com.calypsan.listenup.client.core.error.ErrorMapper
 import com.calypsan.listenup.client.data.local.db.UserPreferencesDao
 import com.calypsan.listenup.client.data.local.db.UserPreferencesEntity
+import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
 import com.calypsan.listenup.client.data.remote.UserPreferencesRpcFactory
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.UserPreferences
@@ -134,6 +135,12 @@ internal class UserPreferencesRepositoryImpl(
             block()
         } catch (e: CancellationException) {
             throw e
+        } catch (e: ServerUrlNotConfiguredException) {
+            // Expected before the user connects to a server (fresh / signed-out install) — fold it
+            // quietly. Logging it as a warning with a stacktrace would imply a fault where there is
+            // none; ErrorMapper types it as a transient NetworkUnavailable.
+            logger.debug { "User-preferences RPC skipped — no server configured yet" }
+            AppResult.Failure(ErrorMapper.map(e))
         } catch (e: Throwable) {
             logger.warn(e) { "User-preferences RPC failed" }
             AppResult.Failure(ErrorMapper.map(e))

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/core/error/ErrorMapperTest.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.client.checkIs
+import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -145,6 +146,18 @@ class ErrorMapperTest :
             val error = ErrorMapper.map(exception)
 
             checkIs<InternalError>(error)
+        }
+
+        // ========== ServerUrlNotConfiguredException → TransportError.NetworkUnavailable ==========
+
+        test("map ServerUrlNotConfiguredException returns NetworkUnavailable, not InternalError") {
+            // "No server configured yet" is an expected pre-connection state, not a bug — it must
+            // map to a typed transport error (matching InstanceRepositoryImpl's precedent) so the
+            // boundary can fold it quietly instead of surfacing a generic "server error".
+            val error = ErrorMapper.map(ServerUrlNotConfiguredException())
+
+            val networkUnavailable = error.shouldBeInstanceOf<TransportError.NetworkUnavailable>()
+            (networkUnavailable.debugInfo?.contains("Server URL not configured") == true) shouldBe true
         }
 
         test("map NullPointerException returns InternalError") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
@@ -107,6 +107,10 @@ private fun com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration.contai
             !line.contains("throw e") && // cancellation rethrow: throw e
             !line.contains("throw cause") && // cancellation rethrow: throw cause
             !line.contains("throw NotImplementedError(") && // placeholder
-            !line.contains("throw EnvelopeMismatchException(") // protocol contract guard
+            !line.contains("throw EnvelopeMismatchException(") && // protocol contract guard
+            // not-connected guard: RPC-proxy factories throw this typed exception when no server
+            // URL is configured (an expected pre-connection state). ErrorMapper folds it to a
+            // transient NetworkUnavailable; it is a configuration guard, not a swallowed failure.
+            !line.contains("throw ServerUrlNotConfiguredException(")
     }
 }


### PR DESCRIPTION
## Problem

On a fresh / signed-out install, background work (user-preference sync, instance & server-info fetches) fires **before** the user has connected to a server. The RPC-proxy factories signalled "no server URL" with a stringly `error("Server URL not configured — cannot open RPC connection")` (a bare `IllegalStateException`), and `UserPreferencesRepositoryImpl` logged it via `logger.warn(e) { … }` — dumping a **full stacktrace for an expected, non-failure state**, plus `ErrorMapper` misclassified it as a generic `InternalError` ("Something went wrong on the server").

A stacktrace for a normal pre-connection state is exactly the "software that lies" the error philosophy warns against. (Notably `InstanceRepositoryImpl` already did it right — typed `TransportError.NetworkUnavailable`.)

## Fix

- New typed `ServerUrlNotConfiguredException` (in `data/remote`) replaces the 22 factories' stringly `error(...)` — so the not-connected case is a **typed signal**, not an anonymous ISE callers can't distinguish without substring-matching (which the error rules forbid).
- `ErrorMapper` maps it centrally to `TransportError.NetworkUnavailable` — fixing the misleading "server error" classification **everywhere at once** (matches the existing `InstanceRepositoryImpl` precedent).
- `UserPreferencesRepositoryImpl.rpcCall` folds the not-connected case quietly at `debug` (no stacktrace); real failures still log at `warn`.
- `NoThrowsInDataLayerRule` gains an allow-pattern for this typed configuration guard, alongside the existing `EnvelopeMismatchException` guard.

## Tests (TDD)

- `ErrorMapperTest`: `map(ServerUrlNotConfiguredException())` → `NetworkUnavailable` (written red → green).
- Full `:sharedLogic:jvmTest`, `spotlessCheck`, `detekt` green (incl. the Konsist no-throws rule).

Behaviour is unchanged — the app still proceeds to onboarding; only the startup log noise and error classification are corrected.