### PR TITLE
fix(server): survive-strip logger names — kill [UnknownLogger] in the native release (#949)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/Application.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/Application.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.SupervisorJob
 import org.koin.ktor.ext.get as koinGet
 import org.koin.ktor.ext.inject
 
-internal val logger = KotlinLogging.logger {}
+internal val logger = KotlinLogging.logger("com.calypsan.listenup.server.Application")
 
 internal const val SEED_PROFILE_DEMO = "demo"
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
@@ -18,11 +18,11 @@ import com.calypsan.listenup.server.services.PublicProfileMaintainer
 import com.calypsan.listenup.server.services.UserStatsBackfillService
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.FirehoseSuppressed
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ImportApplier>()
 
 /**
  * The apply stage of an ABS import: writes the staged listening progress into ListenUp through

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookMetadataApplier.kt
@@ -22,10 +22,10 @@ import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.GenreHierarchyFromLadder
 import com.calypsan.listenup.server.services.SeriesRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<BookMetadataApplier>()
 
 /**
  * Applies a chosen Audible match to an existing book aggregate, honoring a per-field

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorMetadataApplier.kt
@@ -10,11 +10,11 @@ import com.calypsan.listenup.server.io.hashBytesSha256
 import com.calypsan.listenup.server.metadata.audible.AudibleContributorProfile
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.MetadataService
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.io.files.Path
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ContributorMetadataApplier>()
 
 /**
  * Applies Audible contributor metadata to an existing contributor row.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorServiceImpl.kt
@@ -16,10 +16,10 @@ import com.calypsan.listenup.server.db.sqldelight.suspendTransaction as sqlTrans
 import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.sync.BookSearchReindexer
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ContributorServiceImpl>()
 
 /**
  * Thin [ContributorService] implementation.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/DefaultAllBooksGrantIssuer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/DefaultAllBooksGrantIssuer.kt
@@ -6,12 +6,12 @@ import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.services.LibraryRegistry
 import com.calypsan.listenup.server.sync.CollectionGrantRepository
 import com.calypsan.listenup.server.sync.CollectionRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<DefaultAllBooksGrantIssuer>()
 
 /**
  * Best-effort collaborator that grants the per-library ALL_BOOKS system collection to a new

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/GenreServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/GenreServiceImpl.kt
@@ -22,10 +22,10 @@ import com.calypsan.listenup.server.services.GenreRepository
 import com.calypsan.listenup.server.services.GenreSlug
 import com.calypsan.listenup.server.sync.BookSearchReindexer
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.uuid.Uuid
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<GenreServiceImpl>()
 
 private const val MIN_BROWSE_LIMIT = 1
 private const val MAX_BROWSE_LIMIT = 1000

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/LibraryAdminServiceImpl.kt
@@ -22,13 +22,13 @@ import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.LibraryFolderRepository
 import com.calypsan.listenup.server.services.LibraryRegistry
 import com.calypsan.listenup.server.services.LibraryRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<LibraryAdminServiceImpl>()
 
 /**
  * Server-side implementation of [LibraryAdminService].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -34,10 +34,10 @@ import com.calypsan.listenup.server.services.GenreRepository
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.services.MetadataService
 import com.calypsan.listenup.server.services.SeriesRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<MetadataLookupServiceImpl>()
 
 /**
  * Server-side implementation of [MetadataLookupService].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/PlaybackServiceImpl.kt
@@ -22,11 +22,11 @@ import com.calypsan.listenup.server.services.ListeningEventRepository
 import com.calypsan.listenup.server.services.PlaybackPositionRepository
 import com.calypsan.listenup.server.services.UserStatsRepository
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import io.ktor.http.encodeURLParameter
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<PlaybackServiceImpl>()
 
 /**
  * [PlaybackService] implementation. Combines signed audio URLs from

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/SeriesServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/SeriesServiceImpl.kt
@@ -17,9 +17,9 @@ import com.calypsan.listenup.server.services.BookRepository
 import com.calypsan.listenup.server.services.SeriesRepository
 import com.calypsan.listenup.server.sync.BookSearchReindexer
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<SeriesServiceImpl>()
 
 /**
  * Thin [SeriesService] implementation.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/AuthServiceImpl.kt
@@ -30,13 +30,13 @@ import com.calypsan.listenup.server.services.ActivityRecorder
 import com.calypsan.listenup.server.services.PublicProfileMaintainer
 import com.calypsan.listenup.server.settings.ServerSettingsRepository
 import com.calypsan.listenup.server.sync.ShelfRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 import kotlin.time.ExperimentalTime
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<AuthServiceImpl>()
 
 /**
  * The contract implementation. Pure domain logic — Ktor types are deliberately

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/ServerSecrets.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/auth/ServerSecrets.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.auth
 import com.calypsan.listenup.server.io.createTempFileIn
 import com.calypsan.listenup.server.io.restrictFileToOwner
 import dev.whyoleg.cryptography.random.CryptographyRandom
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -61,7 +61,7 @@ internal fun resolveSecret(
     return if (configValue == committedDefault) store.getOrGenerate(storeKey) else configValue
 }
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ServerSecrets>()
 
 private const val SECRETS_FILENAME = "secrets.properties"
 private const val SECRET_BYTE_LENGTH = 48

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/RestoreOrchestrator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/RestoreOrchestrator.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.server.db.DatabaseHandle
 import com.calypsan.listenup.server.io.copyDirectoryRecursively
 import com.calypsan.listenup.server.io.deleteRecursively
 import com.calypsan.listenup.server.io.fileIoDispatcher
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<RestoreOrchestrator>()
 
 /**
  * Orchestrates a live in-process restore: validate → drain → safety-copy → extract → close pool

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/CoverResponder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/CoverResponder.kt
@@ -6,7 +6,7 @@ import com.calypsan.listenup.server.embeddedmeta.EmbeddedMetadataParser
 import com.calypsan.listenup.server.io.fileIoDispatcher
 import com.calypsan.listenup.server.io.readBytes
 import com.calypsan.listenup.server.services.BookRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<CoverResponder>()
 
 /**
  * Serves a book's cover image bytes for `GET /api/v1/books/{id}/cover`.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/CoverStorage.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/CoverStorage.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.cover
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<CoverStorage>()
 
 /**
  * Filesystem-side counterpart to the cover-state column on `books`: the only

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/ManagedCoverFiles.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/cover/ManagedCoverFiles.kt
@@ -5,13 +5,13 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.io.fileIoDispatcher
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ManagedCoverFiles>()
 
 /**
  * The result of storing a scanned cover to the managed cover store.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.db
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<DataDirLock>()
 
 /** A handle to a held [DataDirLock]; closing it releases the OS lock. */
 internal interface FileLockHandle : AutoCloseable

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ScannerModule.kt
@@ -35,7 +35,7 @@ import kotlinx.io.files.Path
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-private val logger = KotlinLogging.logger {}
+private val logger = KotlinLogging.logger("com.calypsan.listenup.server.di.ScannerModule")
 
 /**
  * Koin module for the scanner slice. Wires:

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/logging/LoggerFor.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/logging/LoggerFor.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.server.logging
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * Creates a [KLogger] named after [T]'s fully-qualified class name, resolved at compile time.
+ *
+ * Unlike `KotlinLogging.logger {}` — which derives the name from the enclosing symbol at runtime —
+ * this reads the reified type's name from compile-time type info (on Kotlin/Native, RTTI in
+ * `.rodata`). That survives `-s` symbol stripping on the native release binary, so release logs keep
+ * their per-subsystem tag instead of collapsing to `[UnknownLogger]` (issue #949).
+ *
+ * The fully-qualified name also keeps the JVM per-package level overrides
+ * (`LISTENUP_LOG_LEVEL_<pkg>`, matched by `startsWith`) working; the formatters shorten it to the
+ * simple class name for display.
+ */
+internal inline fun <reified T : Any> loggerFor(): KLogger =
+    KotlinLogging.logger(T::class.qualifiedName ?: T::class.simpleName ?: "UnknownLogger")

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/mdns/MdnsRefreshOnServerInfoChange.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/mdns/MdnsRefreshOnServerInfoChange.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
-private val log = KotlinLogging.logger("mdns.MdnsRefreshOnServerInfoChange")
+private val log = KotlinLogging.logger("com.calypsan.listenup.server.mdns.MdnsRefreshOnServerInfoChange")
 
 /**
  * Re-announce mDNS whenever the server's identity changes. The admin "update server settings" path

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/mdns/MdnsTxt.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/mdns/MdnsTxt.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.mdns
 import com.calypsan.listenup.server.api.ServerIdentity
 import io.github.oshai.kotlinlogging.KotlinLogging
 
-private val log = KotlinLogging.logger("mdns.MdnsTxt")
+private val log = KotlinLogging.logger("com.calypsan.listenup.server.mdns.MdnsTxt")
 
 /** RFC 6763 §6.1: each `key=value` TXT string is limited to 255 octets. */
 private const val MAX_TXT_OCTETS = 255

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/mdns/MulticastMdnsResponder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/mdns/MulticastMdnsResponder.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.server.mdns
 
 import com.calypsan.listenup.core.IODispatcher
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -12,7 +12,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private val log = KotlinLogging.logger("mdns.MulticastMdnsResponder")
+private val log = loggerFor<MulticastMdnsResponder>()
 
 /**
  * Advertise-only mDNS responder over the platform [MdnsSocketLayer] seam (java.net on JVM, POSIX on

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -4,7 +4,7 @@ import com.calypsan.listenup.api.error.MetadataError
 import com.calypsan.listenup.api.metadata.AudibleRegion
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -16,7 +16,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<AudibleClient>()
 
 /**
  * Ktor-backed HTTP adapter for the Audible catalog API.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/itunes/ITunesClient.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.metadata.itunes
 import com.calypsan.listenup.api.error.MetadataError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ITunesClient>()
 
 /**
  * Ktor-backed adapter for the iTunes Search API. Used **only** for cover art —

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/provider/AudibleMetadataProvider.kt
@@ -14,9 +14,9 @@ import com.calypsan.listenup.server.metadata.audible.AudibleSearchResult
 import com.calypsan.listenup.server.metadata.audible.AudibleSeriesEntry
 import com.calypsan.listenup.server.metadata.audible.SearchParams
 import com.calypsan.listenup.server.services.MetadataService
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<AudibleMetadataProvider>()
 
 /**
  * [MetadataProvider] backed by Audible via [MetadataService] (which adds TTL caching +

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/plugins/AppErrorStatusPages.kt
@@ -41,7 +41,7 @@ import io.ktor.server.response.respond
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 
-private val logger = KotlinLogging.logger("AppErrorStatusPages")
+private val logger = KotlinLogging.logger("com.calypsan.listenup.server.plugins.AppErrorStatusPages")
 
 /**
  * Surfaces unexpected throwables — genuine bugs, framework errors, OOM —

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/RouteResponses.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/RouteResponses.kt
@@ -11,7 +11,7 @@ import io.ktor.server.plugins.callid.callId
 import io.ktor.server.request.uri
 import io.ktor.server.response.respond
 
-private val logger = KotlinLogging.logger {}
+private val logger = KotlinLogging.logger("com.calypsan.listenup.server.routes.RouteResponses")
 
 /**
  * Renders an [AppResult] as the canonical wire response: `Success → 200`, `Failure →` the

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/CoverSpool.kt
@@ -7,12 +7,12 @@ import com.calypsan.listenup.server.io.hashBytesSha256
 import com.calypsan.listenup.server.io.readBytes
 import com.calypsan.listenup.server.io.statFile
 import com.calypsan.listenup.server.io.writeBytes
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<CoverSpool>()
 
 /**
  * Scan-scoped on-disk staging for embedded cover bytes, so the scanner never holds all of a

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/RescanScheduler.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/RescanScheduler.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.server.scanner
 
 import com.calypsan.listenup.core.LibraryId
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -10,7 +10,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<RescanScheduler>()
 
 /**
  * Never-Stranded backstop: periodically full-rescans the registered library so

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanCoordinator.kt
@@ -4,7 +4,7 @@ import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.error.ScanError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.LibraryId
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.atomicfu.locks.SynchronizedObject
@@ -15,7 +15,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ScanCoordinator>()
 
 /**
  * Single-flight coordinator for the library's full scans and incremental re-analysis.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/ScanOrchestrator.kt
@@ -8,7 +8,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.server.io.isUnder
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.files.Path
@@ -24,7 +24,7 @@ internal interface ScannerResultPort {
     fun lastResult(): ScanResult?
 }
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ScanOrchestrator>()
 
 /**
  * Top-level orchestrator that manages the single [Scanner] + [ScanCoordinator] bundle

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -25,7 +25,7 @@ import com.calypsan.listenup.server.scanner.pipeline.Differ
 import com.calypsan.listenup.server.scanner.pipeline.Grouper
 import com.calypsan.listenup.server.scanner.pipeline.Walker
 import com.calypsan.listenup.server.scanner.sidecar.SidecarParser
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import com.calypsan.listenup.server.io.isUnder
 import com.calypsan.listenup.server.io.relativeTo
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,7 +37,7 @@ import kotlin.uuid.Uuid
 import kotlin.concurrent.Volatile
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<Scanner>()
 
 /** Minimum interval between throttled ANALYZING [ScanEvent.Progress] emissions. */
 private const val PROGRESS_THROTTLE_MS = 200L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReader.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/metadata/AbsMetadataReader.kt
@@ -4,7 +4,7 @@ import com.calypsan.listenup.api.dto.scanner.SeriesEntry
 import com.calypsan.listenup.api.external.abs.AbsMetadata
 import com.calypsan.listenup.server.io.fileIoDispatcher
 import com.calypsan.listenup.server.io.readText
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<AbsMetadataReader>()
 
 /**
  * Reads ABS-authored `metadata.json` sidecar files. Two-step parse:

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Analyzer.kt
@@ -31,14 +31,14 @@ import com.calypsan.listenup.server.scanner.metadata.MetadataPrecedenceSource
 import com.calypsan.listenup.server.scanner.document.DocumentCollector
 import com.calypsan.listenup.server.scanner.sidecar.SidecarMetadata
 import com.calypsan.listenup.server.scanner.sidecar.SidecarParser
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.io.files.Path
 import com.calypsan.listenup.domain.embeddedmeta.SeriesEntry as EmbeddedSeriesEntry
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<Analyzer>()
 
 /**
  * Stage 3 of the scanner pipeline: turns each [CandidateBook] into an

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Differ.kt
@@ -3,11 +3,11 @@ package com.calypsan.listenup.server.scanner.pipeline
 import com.calypsan.listenup.api.dto.scanner.AnalyzedBook
 import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
 import com.calypsan.listenup.api.dto.scanner.FileType
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<Differ>()
 
 /**
  * Stage 4 of the scanner pipeline: emits a [ChangeEventDto] per book that

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Walker.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/pipeline/Walker.kt
@@ -7,7 +7,7 @@ import com.calypsan.listenup.server.io.relativeTo
 import com.calypsan.listenup.server.io.statFile
 import com.calypsan.listenup.server.scanner.inference.FileTypeRules
 import com.calypsan.listenup.server.scanner.inference.SkipRules
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -15,7 +15,7 @@ import kotlinx.io.IOException
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<Walker>()
 
 /**
  * Stage 1 of the scanner pipeline: enumerates every file beneath a library

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/DescTxtParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/DescTxtParser.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.scanner.sidecar
 
 import com.calypsan.listenup.server.io.readText
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<DescTxtParser>()
 
 /**
  * Parses a `desc.txt` sidecar — the entire file is the book description.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/NfoParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/NfoParser.kt
@@ -7,10 +7,10 @@ import com.calypsan.listenup.server.scanner.sidecar.xml.directText
 import com.calypsan.listenup.server.scanner.sidecar.xml.firstText
 import com.calypsan.listenup.server.scanner.sidecar.xml.getElementsByTagName
 import com.calypsan.listenup.server.scanner.sidecar.xml.parseXml
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<NfoParser>()
 
 /**
  * Parses Kodi/Plex-style `.nfo` XML metadata sidecars.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/OpfParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/OpfParser.kt
@@ -8,10 +8,10 @@ import com.calypsan.listenup.server.scanner.sidecar.xml.getAttribute
 import com.calypsan.listenup.server.scanner.sidecar.xml.getElementsByTagName
 import com.calypsan.listenup.server.scanner.sidecar.xml.parseXml
 import com.calypsan.listenup.server.scanner.sidecar.xml.textContent
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<OpfParser>()
 
 /**
  * Captures a leading four-digit year — either a bare year (`2014`) or the year

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/ReaderTxtParser.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/sidecar/ReaderTxtParser.kt
@@ -1,10 +1,10 @@
 package com.calypsan.listenup.server.scanner.sidecar
 
 import com.calypsan.listenup.server.io.readText
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ReaderTxtParser>()
 
 /**
  * Parses a `reader.txt` sidecar — one narrator name per line.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/FolderWatcher.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.scanner.watcher
 import com.calypsan.listenup.server.io.isSymlink
 import com.calypsan.listenup.server.scanner.inference.MultiDiscPattern
 import com.calypsan.listenup.server.scanner.inference.SkipRules
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<FolderWatcher>()
 
 /**
  * Watches a library tree for filesystem changes and emits the

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/WatcherSupervisor.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/watcher/WatcherSupervisor.kt
@@ -4,12 +4,12 @@ import com.calypsan.listenup.api.dto.LibraryFolderRef
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.server.scanner.WatcherSupervisorPort
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.files.Path
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<WatcherSupervisor>()
 
 /**
  * Manages the lifecycle of [FolderWatcher] instances — one per registered

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/ActiveSessionCleanupTask.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/ActiveSessionCleanupTask.kt
@@ -5,7 +5,7 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -15,7 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ActiveSessionCleanupTask>()
 
 /**
  * Periodic sweep that hard-deletes stale `active_sessions` rows.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/ExpiredSessionCleanupTask.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/ExpiredSessionCleanupTask.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.scheduler
 
 import com.calypsan.listenup.server.auth.SessionService
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -12,7 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ExpiredSessionCleanupTask>()
 
 /**
  * Periodic sweep that hard-deletes session rows whose `expires_at` timestamp is

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/MetadataCacheCleanupTask.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/MetadataCacheCleanupTask.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.server.scheduler
 
 import com.calypsan.listenup.server.services.MetadataCacheRepository
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -12,7 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<MetadataCacheCleanupTask>()
 
 /**
  * Periodic sweep that hard-deletes expired rows from the metadata cache table.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/OrphanImageCleanupTask.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/OrphanImageCleanupTask.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.server.scheduler
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.SeriesRepository
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlinx.coroutines.CoroutineScope
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<OrphanImageCleanupTask>()
 
 /**
  * Periodic sweep that removes `.jpg` image files under `{imageHome}/contributors/`

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ActiveSessionSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ActiveSessionSeeder.kt
@@ -3,9 +3,9 @@ package com.calypsan.listenup.server.seed
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.services.ActiveSessionRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ActiveSessionSeeder>()
 
 /** How many demo books to seed live presence sessions for (at most). */
 private const val DEMO_SESSION_COUNT = 2L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ActivitySeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ActivitySeeder.kt
@@ -4,9 +4,9 @@ import com.calypsan.listenup.api.dto.activity.ActivityType
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.services.ActivityRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ActivitySeeder>()
 
 /**
  * Seeds a couple of social-activity rows for the [UserDomainSeeder.DEMO_EMAIL] account, so a fresh

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/CollectionDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/CollectionDomainSeeder.kt
@@ -6,11 +6,11 @@ import com.calypsan.listenup.server.api.CollectionServiceImpl
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.CollectionRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.uuid.Uuid
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<CollectionDomainSeeder>()
 
 /** Display name of the single demo collection seeded for the demo profile. */
 private const val DEMO_COLLECTION_NAME = "Favourites"

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ContributorEnrichmentSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ContributorEnrichmentSeeder.kt
@@ -4,9 +4,9 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.contributorDedupKey
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ContributorEnrichmentSeeder>()
 
 /**
  * Adds biography, sort name, and website enrichment to the demo contributors

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/GenreDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/GenreDomainSeeder.kt
@@ -3,11 +3,11 @@ package com.calypsan.listenup.server.seed
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.GenreSyncPayload
 import com.calypsan.listenup.server.services.GenreRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<GenreDomainSeeder>()
 
 /**
  * Seeded genre node — the curator-controlled default taxonomy.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/InviteDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/InviteDomainSeeder.kt
@@ -10,9 +10,9 @@ import com.calypsan.listenup.server.auth.UserPrincipal
 import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<InviteDomainSeeder>()
 
 /**
  * Seeds the demo profile's invite surface — one unclaimed, pending invite so a

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ListeningEventDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ListeningEventDomainSeeder.kt
@@ -5,11 +5,11 @@ import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.services.ListeningEventRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ListeningEventDomainSeeder>()
 
 /** How many demo books to seed listening events for (at most). */
 private const val DEMO_BOOK_COUNT = 3L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/MoodDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/MoodDomainSeeder.kt
@@ -5,11 +5,11 @@ import com.calypsan.listenup.api.sync.Mood
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.MoodRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<MoodDomainSeeder>()
 
 /**
  * A seeded mood — the canonical Audible affective vocabulary. The slug is the

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/PlaybackPositionDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/PlaybackPositionDomainSeeder.kt
@@ -4,10 +4,10 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.services.PlaybackPositionRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<PlaybackPositionDomainSeeder>()
 
 /** Spacing between the seeded positions' `lastPlayedAt` timestamps. */
 private const val ONE_HOUR_MS = 60 * 60 * 1000L

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/PublicProfileDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/PublicProfileDomainSeeder.kt
@@ -3,9 +3,9 @@ package com.calypsan.listenup.server.seed
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.services.PublicProfileMaintainer
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<PublicProfileDomainSeeder>()
 
 /**
  * Refreshes the `public_profiles` projection for every seeded user so the dev

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/SeedRunner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/SeedRunner.kt
@@ -1,8 +1,8 @@
 package com.calypsan.listenup.server.seed
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<SeedRunner>()
 
 /**
  * Runs the registered [DomainSeeder]s in ascending [DomainSeeder.order]. Each seeder

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ShelfDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/ShelfDomainSeeder.kt
@@ -5,11 +5,11 @@ import com.calypsan.listenup.api.sync.ShelfSyncPayload
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.ShelfRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.uuid.Uuid
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<ShelfDomainSeeder>()
 
 /**
  * Seeds the demo profile's shelves for each demo user.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/TagDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/TagDomainSeeder.kt
@@ -5,11 +5,11 @@ import com.calypsan.listenup.api.sync.Tag
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.TagRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.uuid.Uuid
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<TagDomainSeeder>()
 
 /**
  * Default tags seeded for the demo profile:

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/UserDomainSeeder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/seed/UserDomainSeeder.kt
@@ -5,9 +5,9 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.auth.AuthServiceImpl
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<UserDomainSeeder>()
 
 /**
  * Seeds the demo profile's users — known accounts so a developer running the demo

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ActivityRecorder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ActivityRecorder.kt
@@ -3,9 +3,9 @@ package com.calypsan.listenup.server.services
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ActivityRecorder>()
 
 /**
  * Records a social activity and fires the broadcast [SyncControl.ActivityChanged] nudge so every

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookFinder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookFinder.kt
@@ -11,9 +11,9 @@ import com.calypsan.listenup.server.sync.SqlFragment
 import com.calypsan.listenup.server.sync.bindRaw
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<BookFinder>()
 
 /** SQLite caps a statement at 999 bound parameters; chunk `IN (…)` lists below it with headroom. */
 private const val SQLITE_IN_CHUNK = 900

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookIngestPort.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookIngestPort.kt
@@ -9,10 +9,10 @@ import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.core.SeriesId
 import com.calypsan.listenup.server.cover.PendingCover
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<BookIngestPort>()
 
 /**
  * The narrow slice of [BookRepository] that [BookPersister] depends on.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -21,7 +21,7 @@ import com.calypsan.listenup.server.scanner.CoverSpool
 import com.calypsan.listenup.server.scanner.toSummary
 import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import com.calypsan.listenup.server.io.readBytes
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<BookPersister>()
 
 /**
  * Cap the number of PERSISTING progress ticks emitted per scan, independent of library size: the

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -36,7 +36,7 @@ import com.calypsan.listenup.server.sync.SyncableSubstrateQueries
 import com.calypsan.listenup.server.sync.accessFilteredDigest
 import com.calypsan.listenup.server.sync.selectIdRevAccessFiltered
 import app.cash.sqldelight.db.SqlDriver
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 import kotlin.uuid.Uuid
 import kotlin.time.Clock
@@ -45,7 +45,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<BookRepository>()
 
 /**
  * Books per chunked write transaction in [BookRepository.resolveOrInsertAll]. Each chunk is one

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/CoverSearchService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/CoverSearchService.kt
@@ -8,13 +8,13 @@ import com.calypsan.listenup.api.metadata.AudibleRegion
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.metadata.provider.CoverProvider
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<CoverSearchService>()
 
 /** A book's title + primary author, used to query the cover catalogs. */
 data class BookSummary(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/MetadataService.kt
@@ -16,13 +16,13 @@ import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<MetadataService>()
 
 /**
  * Orchestrator for external metadata lookups. Wraps [AudibleApi] + [ITunesApi]

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PendingGenrePromotion.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PendingGenrePromotion.kt
@@ -3,9 +3,9 @@ package com.calypsan.listenup.server.services
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<PendingGenrePromotion>()
 
 /**
  * One-time, idempotent migration of the legacy `pending_book_genres` backlog into

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PublicProfileMaintainer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PublicProfileMaintainer.kt
@@ -5,10 +5,10 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.sync.PublicProfileRepository
 import com.calypsan.listenup.server.util.runCatchingCancellable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<PublicProfileMaintainer>()
 
 /** Days in the longest rolling window the projection tracks. */
 private const val YEAR_WINDOW_DAYS = 365

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/ChangeBus.kt
@@ -2,13 +2,13 @@ package com.calypsan.listenup.server.sync
 
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncEvent
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<ChangeBus>()
 
 private const val LIVE_TAIL_BUFFER = 256
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -10,7 +10,7 @@ import app.cash.sqldelight.TransactionCallbacks
 import app.cash.sqldelight.TransactionWithReturn
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import com.calypsan.listenup.server.io.hashBytesSha256
 import kotlin.time.Clock
 import kotlinx.coroutines.currentCoroutineContext
@@ -22,7 +22,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 
-private val log = KotlinLogging.logger {}
+private val log = loggerFor<SqlSyncableRepository<*, *>>()
 
 /**
  * SQLDelight twin of [SyncableRepository] — the abstract base every syncable

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.ktor.ext.inject
 
-private val log = KotlinLogging.logger("rpc.SyncFirehose")
+private val log = KotlinLogging.logger("com.calypsan.listenup.server.sync.SyncFirehose")
 
 // SSE `event:` line for out-of-band SyncControl frames (CursorStale, StreamError).
 // Distinct from the per-domain `event: <domainName>` lines used for SyncEvent payloads.

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/db/DataDirLock.jvm.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.server.db
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.io.files.Path
 import java.nio.channels.FileChannel
 import java.nio.channels.FileLock
@@ -8,7 +8,7 @@ import java.nio.channels.OverlappingFileLockException
 import java.nio.file.StandardOpenOption
 import java.nio.file.Path as NioPath
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<JvmFileLockHandle>()
 
 internal actual fun tryLockFile(lockFile: Path): FileLockHandle? {
     val channel =

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/FilePermissions.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/FilePermissions.jvm.kt
@@ -6,7 +6,7 @@ import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.Path as NioPath
 
-private val logger = KotlinLogging.logger {}
+private val logger = KotlinLogging.logger("com.calypsan.listenup.server.io.FilePermissions")
 
 internal actual fun restrictFileToOwner(path: Path) {
     runCatching {

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLogger.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/ListenUpLogger.kt
@@ -24,7 +24,7 @@ import org.slf4j.helpers.MessageFormatter
  * - **TRACE** — verbose payload dumps (rare).
  *
  * Always carry the correlation id (propagated via MDC) and key entity ids (bookId/userId/scanId) in the message.
- * New code obtains loggers via `io.github.oshai.kotlinlogging.KotlinLogging.logger {}`, never `org.slf4j` directly.
+ * New code obtains loggers via `com.calypsan.listenup.server.logging.loggerFor`, never `org.slf4j` directly.
  * Never log tokens, password hashes, secrets, or user content.
  */
 class ListenUpLogger(

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/PlainFormatter.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/logging/PlainFormatter.kt
@@ -13,7 +13,8 @@ private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:
  * Pattern: `yyyy-MM-dd HH:mm:ss.SSS [thread] LEVEL [correlationId] logger - message`
  * Followed by `\tat class.method(file:line)` lines if a throwable is present.
  *
- * Logger name is trimmed to at most 36 characters (rightmost), matching logback's `%logger{36}`.
+ * Logger name is rendered as its final dotted segment (the simple class name), e.g.
+ * `com.calypsan.listenup.server.scanner.ScanOrchestrator` -> `ScanOrchestrator`.
  */
 internal fun formatPlain(
     level: Level,
@@ -24,7 +25,7 @@ internal fun formatPlain(
     val timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER)
     val thread = Thread.currentThread().name
     val correlationId = MDC.get("correlationId") ?: ""
-    val shortName = if (loggerName.length > 36) loggerName.takeLast(36) else loggerName
+    val shortName = loggerName.substringAfterLast('.')
 
     val sb = StringBuilder()
     sb.append(timestamp)

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/watcher/RecursiveDirectoryWatcher.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/scanner/watcher/RecursiveDirectoryWatcher.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.server.scanner.watcher
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -25,7 +25,7 @@ import java.nio.file.WatchKey
 import java.nio.file.WatchService
 import java.util.concurrent.ConcurrentHashMap
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<RecursiveDirectoryWatcher>()
 
 /**
  * JVM-native recursive directory watcher over [java.nio.file.WatchService].

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/seed/SeedLibraryGenerator.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/seed/SeedLibraryGenerator.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.server.seed
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.add
@@ -13,7 +13,7 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 import kotlin.math.abs
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<SeedLibraryGenerator>()
 
 private val prettyJson = Json { prettyPrint = true }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/KonsistTextUtils.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/KonsistTextUtils.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.server.konsist
+
+/**
+ * Strips line (`// …`) and block (`/* … */`) comments from Kotlin source text so a Konsist rule
+ * that text-matches a forbidden token (a banned disk-write call, a symbol-derived logger) can't
+ * false-fail on a commented-out occurrence or a KDoc mention.
+ *
+ * Shared by [SidecarParsersAreReadOnly] and [NoSymbolDerivedLoggerNamesRule] — one copy so the two
+ * guards can't drift apart.
+ */
+internal fun stripComments(source: String): String =
+    source
+        .replace(Regex("""//[^\n]*"""), "")
+        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/NoSymbolDerivedLoggerNamesRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/NoSymbolDerivedLoggerNamesRule.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.server.konsist
 import com.lemonappdev.konsist.api.Konsist
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThan
 
 /**
  * Guard for issue #949: the native release binary is stripped (`-s`), erasing the symbol table that
@@ -19,15 +20,20 @@ class NoSymbolDerivedLoggerNamesRule :
         val namedLogger = Regex("""KotlinLogging\.logger\s*\(\s*"([^"]+)"""")
 
         test("no server logger uses the symbol-derived KotlinLogging.logger {} form") {
-            val offenders =
+            val serverFiles =
                 Konsist
                     .scopeFromProduction()
                     .files
                     .filter { serverProduction.containsMatchIn(it.path) }
-                    .filter { file ->
-                        val strippedText = stripComments(file.text)
-                        emptyLambdaLogger.containsMatchIn(strippedText)
-                    }.map { it.path }
+
+            // Guard against a vacuous pass: a future scope misconfiguration that matches no server
+            // production files must fail loudly, not silently report zero offenders.
+            serverFiles.size shouldBeGreaterThan 0
+
+            val offenders =
+                serverFiles
+                    .filter { file -> emptyLambdaLogger.containsMatchIn(stripComments(file.text)) }
+                    .map { it.path }
 
             offenders.shouldBeEmpty()
         }
@@ -50,8 +56,3 @@ class NoSymbolDerivedLoggerNamesRule :
             offenders.shouldBeEmpty()
         }
     })
-
-private fun stripComments(source: String): String =
-    source
-        .replace(Regex("""//[^\n]*"""), "")
-        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/NoSymbolDerivedLoggerNamesRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/NoSymbolDerivedLoggerNamesRule.kt
@@ -1,0 +1,57 @@
+package com.calypsan.listenup.server.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Guard for issue #949: the native release binary is stripped (`-s`), erasing the symbol table that
+ * kotlin-logging's `KotlinLogging.logger {}` reads to derive names — so every release log line
+ * collapses to `[UnknownLogger]`. Every `:server` logger must use an explicit, strip-safe name:
+ * `loggerFor<T>()` or `KotlinLogging.logger("<fully.qualified.name>")`. The empty-lambda form is
+ * banned across all server production source sets, and string names must be fully-qualified so the
+ * JVM `LISTENUP_LOG_LEVEL_<pkg>` overrides keep matching.
+ */
+class NoSymbolDerivedLoggerNamesRule :
+    FunSpec({
+        val serverProduction = Regex("/server/src/(commonMain|jvmMain|linuxMain)/")
+        val emptyLambdaLogger = Regex("""KotlinLogging\.logger\s*(\(\s*)?\{""")
+        val namedLogger = Regex("""KotlinLogging\.logger\s*\(\s*"([^"]+)"""")
+
+        test("no server logger uses the symbol-derived KotlinLogging.logger {} form") {
+            val offenders =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .filter { serverProduction.containsMatchIn(it.path) }
+                    .filter { file ->
+                        val strippedText = stripComments(file.text)
+                        emptyLambdaLogger.containsMatchIn(strippedText)
+                    }.map { it.path }
+
+            offenders.shouldBeEmpty()
+        }
+
+        test("explicitly-named server loggers use a fully-qualified name") {
+            val offenders =
+                Konsist
+                    .scopeFromProduction()
+                    .files
+                    .filter { serverProduction.containsMatchIn(it.path) }
+                    .flatMap { file ->
+                        val strippedText = stripComments(file.text)
+                        namedLogger
+                            .findAll(strippedText)
+                            .map { file to it.groupValues[1] }
+                            .toList()
+                    }.filterNot { (_, name) -> name.startsWith("com.calypsan.listenup.server") }
+                    .map { (file, name) -> "${file.path}: \"$name\"" }
+
+            offenders.shouldBeEmpty()
+        }
+    })
+
+private fun stripComments(source: String): String =
+    source
+        .replace(Regex("""//[^\n]*"""), "")
+        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/SidecarParsersAreReadOnly.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/SidecarParsersAreReadOnly.kt
@@ -75,8 +75,3 @@ class SidecarParsersAreReadOnly :
             offenders.shouldBeEmpty()
         }
     })
-
-private fun stripComments(source: String): String =
-    source
-        .replace(Regex("""//[^\n]*"""), "")
-        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/logging/LoggerForTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/logging/LoggerForTest.kt
@@ -1,0 +1,14 @@
+package com.calypsan.listenup.server.logging
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private class SampleSubsystem
+
+class LoggerForTest :
+    FunSpec({
+        test("loggerFor derives the fully-qualified class name") {
+            loggerFor<SampleSubsystem>().name shouldBe
+                "com.calypsan.listenup.server.logging.SampleSubsystem"
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/logging/PlainFormatterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/logging/PlainFormatterTest.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.server.logging
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.slf4j.event.Level
+
+class PlainFormatterTest :
+    FunSpec({
+        test("formatPlain renders only the simple class name, not the package") {
+            val out =
+                formatPlain(
+                    level = Level.INFO,
+                    loggerName = "com.calypsan.listenup.server.scanner.ScanOrchestrator",
+                    message = "started",
+                    throwable = null,
+                )
+
+            out shouldContain " ScanOrchestrator - started"
+            out shouldNotContain "com.calypsan"
+        }
+    })

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/NativeMain.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/NativeMain.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.server
 
 import com.calypsan.listenup.server.io.readEnv
+import com.calypsan.listenup.server.logging.installNativeLogFormatting
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EngineConnectorBuilder
 import io.ktor.server.engine.applicationEnvironment
@@ -15,6 +16,7 @@ private const val DEFAULT_PORT = 8080
  * engine and blocks until shutdown.
  */
 fun main() {
+    installNativeLogFormatting()
     val port = readEnv("PORT")?.toIntOrNull() ?: DEFAULT_PORT
     embeddedServer(
         factory = CIO,

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/logging/NativeLogFormatting.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/logging/NativeLogFormatting.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.server.logging
+
+import io.github.oshai.kotlinlogging.DefaultMessageFormatter
+import io.github.oshai.kotlinlogging.Formatter
+import io.github.oshai.kotlinlogging.KLoggingEvent
+import io.github.oshai.kotlinlogging.KotlinLoggingConfiguration
+
+/**
+ * kotlin-logging [Formatter] for the native build that renders the logger name as its final dotted
+ * segment (the simple class name), mirroring the JVM `PlainFormatter`. The stored name stays
+ * fully-qualified; only the displayed tag is shortened, e.g.
+ * `com.calypsan.listenup.server.scanner.ScanOrchestrator` -> `[ScanOrchestrator]`.
+ */
+private object ShortLoggerNameFormatter : Formatter {
+    private val delegate = DefaultMessageFormatter(includePrefix = true)
+
+    override fun formatMessage(loggingEvent: KLoggingEvent): String =
+        delegate.formatMessage(
+            loggingEvent.copy(loggerName = loggingEvent.loggerName.substringAfterLast('.')),
+        )
+}
+
+/**
+ * Installs [ShortLoggerNameFormatter] as the active native kotlin-logging formatter. Call once at
+ * process startup, before any logging.
+ */
+internal fun installNativeLogFormatting() {
+    KotlinLoggingConfiguration.direct.formatter = ShortLoggerNameFormatter
+}

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayer.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/mdns/MdnsSocketLayer.linux.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.server.mdns
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -48,7 +48,7 @@ import platform.posix.sockaddr
 import platform.posix.sockaddr_in
 import platform.posix.socket
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<NativeMdnsSocket>()
 
 private const val GROUP = "224.0.0.251"
 private const val PORT: UShort = 5353u

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/plugins/CallIdLogging.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/plugins/CallIdLogging.linux.kt
@@ -9,7 +9,7 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import kotlin.time.TimeSource
 
-private val logger = KotlinLogging.logger {}
+private val logger = KotlinLogging.logger("com.calypsan.listenup.server.plugins.CallIdLogging")
 
 /**
  * Native request logging: `ktor-server-call-logging` has no Kotlin/Native artifact, so this actual

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcher.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcher.kt
@@ -1,6 +1,6 @@
 package com.calypsan.listenup.server.scanner.watcher
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.calypsan.listenup.server.logging.loggerFor
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.cinterop.ByteVar
@@ -54,7 +54,7 @@ import platform.posix.pollfd
 import platform.posix.read
 import platform.posix.write
 
-private val logger = KotlinLogging.logger {}
+private val logger = loggerFor<InotifyDirectoryWatcher>()
 
 /** inotify mask we register per directory — the create/modify/delete + rename pair the JVM WatchService surfaces. */
 private val WATCH_MASK: UInt = (IN_CREATE or IN_MODIFY or IN_DELETE or IN_MOVED_TO or IN_MOVED_FROM).toUInt()


### PR DESCRIPTION
Closes #949.

## Problem

The native release image strips `server.kexe` (`linkerOpts("-s")`), which erases the ELF symbol table that kotlin-logging reads to derive `KotlinLogging.logger {}` names on Kotlin/Native. Result: **every log line in the shipped release was tagged `[UnknownLogger]`** instead of its subsystem.

## Fix

Give every logger an explicit, strip-safe name, and shorten only the *display*:

- **`loggerFor<T>()` helper** (commonMain) — derives the fully-qualified name from the reified type at compile time (embedded in `.rodata`, which survives `-s`). Used at the class-anchored call sites.
- **Explicit `KotlinLogging.logger("<FQCN>")` literals** for the handful of class-less files (e.g. `Application`, route/plugin/mdns helpers).
- **Display shortened to the simple class name** (`[ScanOrchestrator]`) on both paths: JVM `PlainFormatter` (`substringAfterLast('.')`) and a new native `ShortLoggerNameFormatter` installed at `NativeMain` startup. The **stored** name stays fully-qualified, so the JVM per-package `LISTENUP_LOG_LEVEL_<pkg>` overrides keep working; `JsonFormatter` keeps the full FQCN for log aggregators.
- **Normalized 6 previously short-named loggers** (`"mdns.MdnsTxt"` → `"com.calypsan.listenup.server.mdns.MdnsTxt"`, etc.) — a correctness fix too, since short names couldn't be targeted by the `startsWith`-based level overrides.
- **Konsist guard** `NoSymbolDerivedLoggerNamesRule` bans the empty-lambda form and requires FQCN string names across all server source sets, so this can't regress.

All 74 call sites migrated (67 commonMain + 4 jvmMain + 3 linuxMain), plus the 6 normalizations.

## Acceptance (the stripped release binary)

Built `:server:linkReleaseExecutableLinuxX64` (`file` confirms *stripped*) and booted it — **zero `[UnknownLogger]`**, real subsystem tags throughout:

```
INFO: [ServerSecrets] Generated and persisted a new server secret ...
INFO: [RescanScheduler] periodic rescan enabled every 6h
INFO: [ScanOrchestrator] Library registered: id=... name='Library' folders=0
INFO: [MulticastMdnsResponder] mDNS advertisement started: _listenup._tcp.local port=8099 ...
INFO: [Application] See You Space Cowboy...
```

The exact line from the issue (`periodic rescan enabled every 6h`) now reads `[RescanScheduler]`.

## Verification

- `:server:jvmTest` + `spotlessKotlinCheck` + `detekt` — green
- `:sharedLogic:jvmTest` — green
- Konsist guard `NoSymbolDerivedLoggerNamesRule` — green
- JVM `PlainFormatter` + `loggerFor` unit tests — green
- Stripped native `server.kexe` boot — 0 `[UnknownLogger]` (above)

## Follow-up (not in scope)

`sharedLogic/` and `contract/` still have ~165 `KotlinLogging.logger {}` sites. They're JVM-only (clients aren't stripped), so they're correct today and intentionally excluded by the guard's `/server/src/` filter. If a native client target is ever added, they'd regress silently — worth a follow-up issue then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)