### PR TITLE
🐛 fix(nowplaying): build the cast button in an AppCompat theme so MediaRouteButton survives a translucent window background

### DIFF
--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.android.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/components/CastButton.android.kt
@@ -1,11 +1,13 @@
 package com.calypsan.listenup.client.features.nowplaying.components
 
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.mediarouter.app.MediaRouteButton
+import com.calypsan.listenup.client.composeapp.R
 import com.google.android.gms.cast.framework.CastButtonFactory
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -25,7 +27,11 @@ actual fun CastButton(modifier: Modifier) {
     AndroidView(
         modifier = modifier,
         factory = { ctx ->
-            MediaRouteButton(ctx).also { button ->
+            // MediaRouteButton's constructor computes controller contrast against the theme's
+            // android:colorBackground, which the edge-to-edge Compose window leaves translucent
+            // (#0) — crashing the button. Build it in an opaque AppCompat theme instead.
+            val themed = ContextThemeWrapper(ctx, R.style.Theme_ListenUp_CastButton)
+            MediaRouteButton(themed).also { button ->
                 CastButtonFactory.setUpMediaRouteButton(ctx.applicationContext, button)
             }
         },

--- a/sharedUI/src/androidMain/res/values/themes_cast.xml
+++ b/sharedUI/src/androidMain/res/values/themes_cast.xml
@@ -1,0 +1,7 @@
+<resources>
+    <!-- MediaRouteButton's MediaRouterThemeHelper requires an opaque android:colorBackground to
+         compute controller contrast. The app's edge-to-edge Compose window theme leaves it
+         translucent (#0), which crashes the button's constructor. Theme.AppCompat.DayNight provides
+         an opaque colorBackground; we build the button in this theme via ContextThemeWrapper. -->
+    <style name="Theme.ListenUp.CastButton" parent="Theme.AppCompat.DayNight" />
+</resources>


### PR DESCRIPTION
From the pre-beta bug-bash (native server test pass). Tapping Cast on Now Playing crashed: `MediaRouteButton` is built with the edge-to-edge Compose window theme whose `android:colorBackground` is translucent (`#0`), and `MediaRouterThemeHelper` requires an opaque background → `IllegalArgumentException`. Fix: a dedicated `Theme.ListenUp.CastButton` (parent `Theme.AppCompat.DayNight`) and a `ContextThemeWrapper` so the button is constructed in an opaque AppCompat theme.