### PR TITLE
🐛 fix(contract): cache SecureStorage reads to stop the Keystore operation-pruning storm

### DIFF
--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -58,11 +58,11 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotest.framework.engine)
             implementation(libs.kotest.assertions.core)
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         jvmTest.dependencies {
             implementation(libs.kotest.runner.junit5) // JVM-only runner; engine + assertions inherited from commonTest
-            implementation(libs.kotlinx.coroutines.test)
             // logback-classic instead of slf4j-simple: the rpcguard helpers use MDC
             // (via kotlinx-coroutines-slf4j) which requires a backend that supports
             // Mapped Diagnostic Context. slf4j-simple always returns null for MDC.get().

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/core/CachingSecureStorage.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/core/CachingSecureStorage.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.core
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A [SecureStorage] decorator that keeps an in-memory cache of decrypted values.
+ *
+ * **Why this exists.** On Android, [read] decrypts via the hardware-backed Android Keystore, which
+ * has a small pool of concurrent operation slots. Screens such as the contributors page issue a
+ * burst of concurrent `server_url` / `active_url` reads through the API client factory; without
+ * coalescing, each one is a fresh `Cipher.doFinal`. The burst exhausts the slot pool, the Keystore
+ * **prunes** in-flight operations, and the pruned ops surface as `IllegalBlockSizeException` — log
+ * spam at best, a spurious "value unavailable" null at worst.
+ *
+ * This decorator fixes that structurally: the [Mutex] both **caches** the result (so repeat reads
+ * never touch the Keystore) and **serializes** the underlying decrypt (so the slot pool can never
+ * be flooded, even on the very first concurrent miss). Concurrent misses for the same key collapse
+ * into a single delegate read; everyone else returns the cached plaintext.
+ *
+ * **Security is unchanged.** The cache holds secrets that are already resident in process memory
+ * the moment they are decrypted for use — it changes nothing about at-rest encryption, which the
+ * platform delegate still owns. Values live only for the process lifetime and are dropped on
+ * [delete] / [clear]; the delegate remains the source of truth on disk.
+ *
+ * @param delegate the platform [SecureStorage] that performs the real encrypted I/O.
+ */
+class CachingSecureStorage(
+    private val delegate: SecureStorage,
+) : SecureStorage {
+    private val cache = mutableMapOf<String, String>()
+    private val mutex = Mutex()
+
+    override suspend fun save(
+        key: String,
+        value: String,
+    ) {
+        delegate.save(key, value)
+        mutex.withLock { cache[key] = value }
+    }
+
+    override suspend fun read(key: String): String? =
+        mutex.withLock {
+            cache[key] ?: delegate.read(key)?.also { cache[key] = it }
+        }
+
+    override suspend fun delete(key: String) {
+        delegate.delete(key)
+        mutex.withLock { cache.remove(key) }
+    }
+
+    override suspend fun clear() {
+        delegate.clear()
+        mutex.withLock { cache.clear() }
+    }
+}

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/core/CachingSecureStorageTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/core/CachingSecureStorageTest.kt
@@ -1,0 +1,105 @@
+package com.calypsan.listenup.core
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+
+/**
+ * In-memory fake that counts how often each key is read from the delegate, so tests can prove
+ * the cache coalesces and absorbs reads. [read] yields before returning so concurrent callers
+ * actually interleave — a missing cache or missing lock would show up as multiple delegate reads.
+ */
+private class CountingSecureStorage : SecureStorage {
+    val store = mutableMapOf<String, String>()
+    val readCounts = mutableMapOf<String, Int>()
+
+    override suspend fun save(
+        key: String,
+        value: String,
+    ) {
+        store[key] = value
+    }
+
+    override suspend fun read(key: String): String? {
+        readCounts[key] = (readCounts[key] ?: 0) + 1
+        yield()
+        return store[key]
+    }
+
+    override suspend fun delete(key: String) {
+        store.remove(key)
+    }
+
+    override suspend fun clear() {
+        store.clear()
+    }
+}
+
+class CachingSecureStorageTest :
+    FunSpec({
+
+        test("concurrent misses coalesce into a single delegate read") {
+            runTest {
+                val delegate = CountingSecureStorage().apply { store["k"] = "v" }
+                val caching = CachingSecureStorage(delegate)
+
+                val jobs = List(100) { launch { caching.read("k") } }
+                jobs.joinAll()
+
+                delegate.readCounts["k"] shouldBe 1
+            }
+        }
+
+        test("a second read is served from cache without consulting the delegate") {
+            runTest {
+                val delegate = CountingSecureStorage().apply { store["k"] = "v" }
+                val caching = CachingSecureStorage(delegate)
+
+                caching.read("k") shouldBe "v"
+                caching.read("k") shouldBe "v"
+
+                delegate.readCounts["k"] shouldBe 1
+            }
+        }
+
+        test("save is write-through — a later read returns the new value with no delegate read") {
+            runTest {
+                val delegate = CountingSecureStorage().apply { store["k"] = "v1" }
+                val caching = CachingSecureStorage(delegate)
+
+                caching.read("k") shouldBe "v1"
+                caching.save("k", "v2")
+                caching.read("k") shouldBe "v2"
+
+                delegate.store["k"] shouldBe "v2"
+                delegate.readCounts["k"] shouldBe 1
+            }
+        }
+
+        test("delete invalidates the cache so the delegate is consulted again") {
+            runTest {
+                val delegate = CountingSecureStorage().apply { store["k"] = "v" }
+                val caching = CachingSecureStorage(delegate)
+
+                caching.read("k") shouldBe "v"
+                caching.delete("k")
+                caching.read("k") shouldBe null
+
+                delegate.readCounts["k"] shouldBe 2
+            }
+        }
+
+        test("a null delegate read is not cached as a permanent miss") {
+            runTest {
+                val delegate = CountingSecureStorage()
+                val caching = CachingSecureStorage(delegate)
+
+                caching.read("k") shouldBe null
+                caching.save("k", "v")
+                caching.read("k") shouldBe "v"
+            }
+        }
+    })

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/StorageModule.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/StorageModule.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.di
 
 import android.content.Context
 import com.calypsan.listenup.core.AndroidSecureStorage
+import com.calypsan.listenup.core.CachingSecureStorage
 import com.calypsan.listenup.core.SecureStorage
 import com.calypsan.listenup.client.data.local.images.AndroidStoragePaths
 import com.calypsan.listenup.client.data.local.images.CommonImageStorage
@@ -20,7 +21,7 @@ internal actual val platformStorageModule: Module =
     module {
         single<SecureStorage> {
             val context: Context = get()
-            AndroidSecureStorage(context)
+            CachingSecureStorage(AndroidSecureStorage(context))
         }
 
         single<StoragePaths> {

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/di/StorageModule.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/di/StorageModule.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.core.AppleSecureStorage
+import com.calypsan.listenup.core.CachingSecureStorage
 import com.calypsan.listenup.core.SecureStorage
 import com.calypsan.listenup.client.data.local.images.CommonImageStorage
 import com.calypsan.listenup.client.data.local.images.AppleStoragePaths
@@ -18,7 +19,7 @@ import org.koin.dsl.module
 internal actual val platformStorageModule: Module =
     module {
         single<SecureStorage> {
-            AppleSecureStorage()
+            CachingSecureStorage(AppleSecureStorage())
         }
 
         single<StoragePaths> {

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/Koin.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/Koin.jvm.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.core.CachingSecureStorage
 import com.calypsan.listenup.core.JvmSecureStorage
 import com.calypsan.listenup.core.SecureStorage
 import com.calypsan.listenup.core.ServerUrl
@@ -115,7 +116,7 @@ internal actual val platformStorageModule: Module =
 
         single<SecureStorage> {
             val storagePaths: JvmStoragePaths = get()
-            JvmSecureStorage(storagePaths.getSecureStoragePath())
+            CachingSecureStorage(JvmSecureStorage(storagePaths.getSecureStoragePath()))
         }
 
         single<ImageStorage> {


### PR DESCRIPTION
From the pre-beta bug-bash. The contributors page storms concurrent `server_url`/`active_url` reads; `AndroidSecureStorage.read()` does a fresh Keystore decrypt per call with no cache, so the Keystore prunes in-flight operations (`outcome: Pruned` → `IllegalBlockSizeException`) and the log fills with errors. Fix: a `CachingSecureStorage` decorator (mutex-coalesced read-through cache) in `:contract` commonMain, wrapped in DI, with a Kotest test.