### PR TITLE
🐛 fix(books): preserve a contributor's per-book alias (creditedAs) through book edits

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
@@ -216,6 +216,7 @@ internal fun BookWithContributors.toDetail(
                 BookContributor(
                     id = entity.id.value,
                     name = creditedAsByContributorId[entity.id] ?: entity.name,
+                    creditedAs = creditedAsByContributorId[entity.id],
                     roles = rolesByContributorId[entity.id] ?: emptyList(),
                 )
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BookContributor.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/BookContributor.kt
@@ -5,9 +5,15 @@ package com.calypsan.listenup.client.domain.model
  *
  * Contains only the contributor's identity and their roles for the book (e.g., author, narrator).
  * For full contributor details (biography, image, etc.), see the [Contributor] domain model.
+ *
+ * [name] is the display string for this book — it already resolves to [creditedAs] when a per-book
+ * alias is set, falling back to the canonical contributor name otherwise. [creditedAs] preserves the
+ * raw per-book alias (or `null` when the book credits the contributor under their canonical name) so
+ * the load → edit → save round-trip can carry it back to the server unchanged.
  */
 data class BookContributor(
     val id: String,
     val name: String,
+    val creditedAs: String? = null,
     val roles: List<String> = emptyList(),
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/EditableTypes.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/EditableTypes.kt
@@ -12,11 +12,16 @@ typealias ContributorRole = com.calypsan.listenup.api.dto.ContributorRole
  *
  * Domain model representing a contributor that can be modified.
  * Used by [BookEditData] and related use cases.
+ *
+ * [creditedAs] preserves the per-book alias loaded from the book↔contributor join so an unedited
+ * contributor is saved back under the same credited name instead of reverting to its canonical name.
+ * `null` means the book credits the contributor under their canonical name.
  */
 data class EditableContributor(
     val id: String? = null, // null for newly added contributors
     val name: String,
     val roles: Set<ContributorRole>,
+    val creditedAs: String? = null,
 )
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/book/LoadBookForEditUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/book/LoadBookForEditUseCase.kt
@@ -185,6 +185,7 @@ open class LoadBookForEditUseCase(
                     contributor.roles
                         .mapNotNull { ContributorRole.fromApiValue(it) }
                         .toSet(),
+                creditedAs = contributor.creditedAs,
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/book/UpdateBookUseCase.kt
@@ -171,6 +171,7 @@ open class UpdateBookUseCase(
                         id = editable.id?.let { ContributorId(it) },
                         name = editable.name,
                         role = role.apiValue,
+                        creditedAs = editable.creditedAs,
                         position = index,
                     )
                 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/ContributorCreditedAsRoundTripTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/domain/usecase/book/ContributorCreditedAsRoundTripTest.kt
@@ -1,0 +1,139 @@
+package com.calypsan.listenup.client.domain.usecase.book
+
+import com.calypsan.listenup.api.dto.BookContributorInput
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.TestData
+import com.calypsan.listenup.client.domain.model.BookContributor
+import com.calypsan.listenup.client.domain.model.BookUpdateRequest
+import com.calypsan.listenup.client.domain.model.ContributorRole
+import com.calypsan.listenup.client.domain.model.EditableContributor
+import com.calypsan.listenup.client.domain.repository.BookEditRepository
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.GenreRepository
+import com.calypsan.listenup.client.domain.repository.ImageRepository
+import com.calypsan.listenup.client.domain.repository.ImageStagingRepository
+import com.calypsan.listenup.client.domain.repository.MoodRepository
+import com.calypsan.listenup.client.domain.repository.TagRepository
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression test for the per-book alias (`creditedAs`) round-trip through book editing.
+ *
+ * An author credited under an alias (e.g. the canonical "Stephen King" credited as
+ * "Richard Bachman" on a specific book) stores that alias in `credited_as` on the
+ * book↔contributor join. Editing the book's contributors and saving used to revert the
+ * alias back to the canonical name because the client UPDATE path dropped it: the
+ * load → edit → save round-trip never carried `creditedAs` from the loaded book into the
+ * [BookContributorInput] sent to the server.
+ *
+ * This test drives the real [LoadBookForEditUseCase] then [UpdateBookUseCase] and asserts
+ * the unedited aliased contributor is saved back with its alias preserved, not nulled.
+ */
+class ContributorCreditedAsRoundTripTest :
+    FunSpec({
+
+        test("loading then saving preserves an unedited contributor's per-book alias (creditedAs)") {
+            runTest {
+                // Given — a book whose author is credited under an alias. The display name already
+                // resolves to the alias; creditedAs holds the raw per-book alias the server stored.
+                val aliasedAuthor =
+                    BookContributor(
+                        id = "c1",
+                        name = "Richard Bachman",
+                        creditedAs = "Richard Bachman",
+                        roles = listOf("Author"),
+                    )
+                val book = TestData.bookDetail(id = "book-1", allContributors = listOf(aliasedAuthor))
+
+                val bookRepository: BookRepository = mock()
+                val genreRepository: GenreRepository = mock()
+                val tagRepository: TagRepository = mock()
+                val moodRepository: MoodRepository = mock()
+                everySuspend { bookRepository.getBookDetail("book-1") } returns book
+                everySuspend { genreRepository.getAll() } returns emptyList()
+                everySuspend { genreRepository.getGenresForBook(any()) } returns emptyList()
+                every { tagRepository.observeAllTags() } returns flowOf(emptyList())
+                every { tagRepository.observeTagsForBook(any()) } returns flowOf(emptyList())
+                every { moodRepository.observeAllMoods() } returns flowOf(emptyList())
+                every { moodRepository.observeMoodsForBook(any()) } returns flowOf(emptyList())
+
+                val loadUseCase =
+                    LoadBookForEditUseCase(
+                        bookRepository = bookRepository,
+                        genreRepository = genreRepository,
+                        tagRepository = tagRepository,
+                        moodRepository = moodRepository,
+                    )
+
+                // When — load the book for editing.
+                val loaded = loadUseCase("book-1").shouldBeInstanceOf<AppResult.Success<*>>()
+                val editData = loaded.data as com.calypsan.listenup.client.domain.model.BookEditData
+
+                // The loaded editable contributor must carry the alias forward.
+                val loadedAuthor = editData.contributors.single { it.id == "c1" }
+                loadedAuthor.creditedAs shouldBe "Richard Bachman"
+
+                // Capture the wire inputs the update path produces.
+                var capturedInputs: List<BookContributorInput>? = null
+                val bookEditRepository: BookEditRepository = mock()
+                val imageRepository: ImageRepository = mock()
+                val imageStagingRepository: ImageStagingRepository = mock()
+                everySuspend { bookEditRepository.updateBook(any(), any()) } returns AppResult.Success(Unit)
+                everySuspend { bookEditRepository.setBookContributors(any(), any()) } calls
+                    { (_: BookId, inputs: List<BookContributorInput>) ->
+                        capturedInputs = inputs
+                        AppResult.Success(Unit)
+                    }
+
+                val updateUseCase =
+                    UpdateBookUseCase(
+                        bookEditRepository = bookEditRepository,
+                        tagRepository = tagRepository,
+                        moodRepository = moodRepository,
+                        imageRepository = imageRepository,
+                        imageStagingRepository = imageStagingRepository,
+                    )
+
+                // The aliased author is left UNCHANGED; the user merely adds a narrator, which forces
+                // the full setBookContributors rewrite the bug lives in.
+                val addedNarrator =
+                    EditableContributor(
+                        id = "c2",
+                        name = "Frank Muller",
+                        roles = setOf(ContributorRole.NARRATOR),
+                    )
+                val original = editData
+                val current =
+                    BookUpdateRequest(
+                        bookId = editData.bookId,
+                        metadata = editData.metadata,
+                        contributors = editData.contributors + addedNarrator,
+                        series = editData.series,
+                        genres = editData.genres,
+                        tags = editData.tags,
+                        moods = editData.moods,
+                        pendingCover = null,
+                    )
+
+                // When — save.
+                updateUseCase(current, original).shouldBeInstanceOf<AppResult.Success<*>>()
+
+                // Then — the unedited aliased author's per-book alias survives the round-trip.
+                val inputs = capturedInputs.shouldNotBeNull()
+                val authorInput = inputs.single { it.id?.value == "c1" }
+                authorInput.creditedAs shouldBe "Richard Bachman"
+            }
+        }
+    })


### PR DESCRIPTION
From the pre-beta bug-bash. A contributor's per-book alias (`credited_as` on the book↔contributor join) reverted to the canonical name on any book save: `UpdateBookUseCase.updateContributors()` rebuilt `BookContributorInput` without `creditedAs`, so the server wrote null. Fix: carry `creditedAs` through `EditableContributor` → domain `BookContributor` → `BookEntityMapper` → Load/Update use cases, with a jvmTest.

⚠️ Touches the exported `BookContributor` type → the iOS `Test (iOS)` check will be RED until the Swift export baseline (`scripts/export-surface-baseline.txt`) is regenerated on a Mac. Will follow up.