### PR TITLE
🐛 fix(shared): accept the trailing-slash /o/ form in ShareLinkCodec deep-link decode

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -60,10 +60,12 @@ object ShareLinkCodec {
     private fun decodeHttpsForm(url: String): ShareTarget? {
         // Length-based slice is safe: the prefix matched ignore-case, so its length is unchanged.
         val remainder = url.substring(ShareLinkConstants.SHARE_URL_PREFIX.length)
-        // The path must end at /o exactly — reject /o/something or /other.
-        if (remainder.isNotEmpty() && remainder[0] !in charArrayOf('#', '?')) return null
-        val query = remainder.substringAfter('?', "").substringBefore('#')
-        val fragment = remainder.substringAfter('#', "")
+        // A single trailing slash is equivalent to no slash (redirectors/bots hand us both forms);
+        // beyond that the path must end at /o exactly — reject /o/something or /other.
+        val afterOptionalSlash = remainder.removePrefix("/")
+        if (afterOptionalSlash.isNotEmpty() && afterOptionalSlash[0] !in charArrayOf('#', '?')) return null
+        val query = afterOptionalSlash.substringAfter('?', "").substringBefore('#')
+        val fragment = afterOptionalSlash.substringAfter('#', "")
         val params = parseQueryString(fragment.ifEmpty { query })
         return when (params["t"]) {
             "book" -> decodeBookParams(params)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -91,6 +91,16 @@ class ShareLinkCodecTest :
                 ShareTarget.Invite(serverUrl = "http://192.168.86.24:8080", code = "ejOvmuYJBGyMDb2DoLgtsg")
         }
 
+        test("decode parses the https /o/ form (trailing slash) for an invite") {
+            val target =
+                ShareLinkCodec.decode(
+                    "https://link.listenup.audio/o/#t=invite&server=http%3A%2F%2F192.168.86.24%3A8080&code=ejOvmuYJBGyMDb2DoLgtsg",
+                )
+
+            target shouldBe
+                ShareTarget.Invite(serverUrl = "http://192.168.86.24:8080", code = "ejOvmuYJBGyMDb2DoLgtsg")
+        }
+
         test("decode returns null for an https invite missing the code") {
             ShareLinkCodec.decode("https://link.listenup.audio/o#t=invite&server=https%3A%2F%2Flib.example.com") shouldBe null
         }


### PR DESCRIPTION
From the pre-beta bug-bash. Tapping an invite link opened the app to the server-select screen instead of the join screen. `ShareLinkCodec.decodeHttpsForm` was stricter than the manifest's `pathPrefix="/o"` and rejected the trailing-slash form `/o/`; the live redirector 308-redirects `/o` → `/o/`, and link-unfurl/safe-link rewriters hand the app the `/o/#…` form, which decoded to null → `pendingTarget` stayed null → fell through to server-select. Fix: strip one optional leading slash (`removePrefix("/")`); `/o/extra` stays correctly rejected. Shared codec, so iOS is fixed too. TDD red→green, 20/20.