### PR TITLE
🐛 fix(server): use the Curl engine for outbound metadata HTTPS on native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,8 +231,8 @@ jobs:
           key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-konan-
 
-      - name: Install native link dependencies (libargon2 + libsqlite3)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev libsqlite3-dev
+      - name: Install native link dependencies (libargon2 + libsqlite3 + libcurl)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev libsqlite3-dev libcurl4-openssl-dev
 
       - name: Compile :server linuxX64
         run: ./gradlew :server:compileKotlinLinuxX64 --no-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,11 +270,11 @@ jobs:
           key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-konan-
 
-      # Dev packages provide the libargon2.so / libsqlite3.so symlinks the K/N linker resolves
-      # via -largon2 / -lsqlite3 (against -L/usr/lib). The runtime image installs the .so.N
-      # siblings (libargon2-1, libsqlite3-0) for execution.
+      # Dev packages provide the libargon2.so / libsqlite3.so / libcurl.so symlinks the K/N linker
+      # resolves via -largon2 / -lsqlite3 / -lcurl (against -L/usr/lib). The runtime image installs the
+      # .so.N siblings (libargon2-1, libsqlite3-0, libcurl4) for execution.
       - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev libsqlite3-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libargon2-dev libsqlite3-dev libcurl4-openssl-dev
 
       - name: Build native server binary (server.kexe)
         run: ./gradlew :server:linkReleaseExecutableLinuxX64 --no-daemon

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,6 +124,7 @@ androidx-window = { module = "androidx.window:window", version.ref = "androidx-w
 # Ktor
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-curl = { module = "io.ktor:ktor-client-curl", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/server/Dockerfile.native
+++ b/server/Dockerfile.native
@@ -7,7 +7,7 @@ FROM debian:12-slim AS libs
 ARG SQLITE_AMALGAMATION_URL=https://www.sqlite.org/2024/sqlite-amalgamation-3450000.zip
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        gcc libc6-dev ca-certificates curl unzip libargon2-1 \
+        gcc libc6-dev ca-certificates curl unzip libargon2-1 libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
 RUN curl -fsSL -o amalg.zip "$SQLITE_AMALGAMATION_URL" \
@@ -20,6 +20,15 @@ RUN curl -fsSL -o amalg.zip "$SQLITE_AMALGAMATION_URL" \
 # An empty /data to seed the runtime image's data dir — the distroless base has no shell, so the dir is
 # created here and COPY --chown'd into the final stage below.
 RUN mkdir -p /data
+# Stage libcurl + its full transitive .so closure for the Kotlin/Native Curl HTTP engine (metadata
+# outbound HTTPS). distroless/cc ships none of these. `ldd` resolves the complete recursive closure;
+# exclude the glibc/libgcc/libstdc++ core libs the distroless/cc base already provides.
+RUN mkdir -p /curl-deps \
+    && cp -L /usr/lib/x86_64-linux-gnu/libcurl.so.4 /curl-deps/ \
+    && ldd /usr/lib/x86_64-linux-gnu/libcurl.so.4 \
+        | awk '/=> \// { print $3 }' \
+        | grep -vE '/(libc|libm|libdl|libpthread|librt|libgcc_s|libstdc\+\+)\.so' \
+        | while read -r lib; do cp -L "$lib" /curl-deps/; done
 
 FROM gcr.io/distroless/cc-debian12:nonroot
 # libcrypt.so.1 is NOT in distroless/cc (Debian split it out of glibc into libcrypt1); the binary links
@@ -27,6 +36,11 @@ FROM gcr.io/distroless/cc-debian12:nonroot
 COPY --from=libs /build/libsqlite3.so.0                     /usr/lib/x86_64-linux-gnu/
 COPY --from=libs /usr/lib/x86_64-linux-gnu/libargon2.so.1   /usr/lib/x86_64-linux-gnu/
 COPY --from=libs /usr/lib/x86_64-linux-gnu/libcrypt.so.1    /usr/lib/x86_64-linux-gnu/
+# CA trust store + libcurl and its transitive closure, for the Kotlin/Native Curl HTTP engine the
+# metadata slice uses for outbound HTTPS (Audible/iTunes). distroless/cc ships neither; CIO's native TLS
+# is unsupported, so metadata lookups need libcurl + a CA bundle present at runtime.
+COPY --from=libs /curl-deps/                                /usr/lib/x86_64-linux-gnu/
+COPY --from=libs /etc/ssl/certs/ca-certificates.crt        /etc/ssl/certs/ca-certificates.crt
 COPY server-binary /usr/local/bin/listenup-server
 # The server runs as nonroot (uid 65532, from the distroless base) and writes its DB, secrets, and
 # extracted covers under /data. Ship /data pre-created and owned by 65532 so a fresh Docker *named

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -168,10 +168,10 @@ kotlin {
                 // koin-core and koin-ktor (the install(Koin) plugin) both publish linuxX64 variants.
                 implementation(libs.koin.core)
                 implementation(libs.koin.ktor)
-                // Ktor HTTP client (CIO engine) — the metadata slice's Audible/iTunes/image client.
-                // KMP: linuxX64 variants exist; MetadataModule moved to commonMain (Phase 5-4c).
+                // Ktor HTTP client — the metadata slice's Audible/iTunes/image client. The engine is a
+                // per-platform seam (metadataHttpClient): CIO on jvmMain, Curl on linuxMain, because
+                // Ktor CIO's TLS is unsupported for outbound HTTPS on Kotlin/Native (Phase 5-4c).
                 implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.cio)
                 implementation(libs.ktor.client.content.negotiation)
             }
         }
@@ -182,6 +182,10 @@ kotlin {
                 // Shared by both Linux arches; both publish linuxArm64 + linuxX64 variants.
                 implementation(libs.sqldelight.driver.native)
                 implementation(libs.cryptography.provider.openssl3.prebuilt)
+                // Ktor Curl client engine (libcurl) — the metadata slice's outbound HTTPS on native.
+                // CIO's TLS is unsupported on Kotlin/Native. Publishes linuxX64 + linuxArm64 variants;
+                // links the system libcurl (shipped into the runtime image — see Dockerfile.native).
+                implementation(libs.ktor.client.curl)
             }
         }
 
@@ -192,6 +196,9 @@ kotlin {
                 // (moved there for the native HTTP foundation). JVM-only Ktor plugins below:
                 implementation(libs.ktor.server.call.logging)
                 implementation(libs.ktor.server.auto.head.response)
+
+                // Ktor CIO client engine — the JVM metadata client (metadataHttpClient.jvm.kt).
+                implementation(libs.ktor.client.cio)
 
                 // Persistence
                 implementation(libs.sqlite.jdbc)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/MetadataHttpClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/MetadataHttpClient.kt
@@ -1,0 +1,17 @@
+package com.calypsan.listenup.server.di
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+
+/**
+ * Builds the dedicated metadata [HttpClient] for outbound third-party API calls (Audible / iTunes /
+ * image downloads), applying [configure] on top of the per-platform HTTP engine.
+ *
+ * The engine is a native seam because outbound HTTPS differs by target:
+ *  - **JVM** uses the CIO engine.
+ *  - **Kotlin/Native (Linux)** uses the Curl engine (libcurl). Ktor's CIO engine does not support
+ *    outbound TLS on Kotlin/Native, so every HTTPS request to Audible/iTunes threw and was mapped to
+ *    `ExternalUnavailable`. The Curl engine delegates TLS to libcurl, which the native runtime image
+ *    ships alongside a CA trust store.
+ */
+internal expect fun metadataHttpClient(configure: HttpClientConfig<*>.() -> Unit): HttpClient

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/MetadataModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/MetadataModule.kt
@@ -35,7 +35,6 @@ import com.calypsan.listenup.server.sync.BookTagRepository
 import com.calypsan.listenup.server.sync.TagRepository
 import kotlin.time.Clock
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.io.files.Path
@@ -77,7 +76,7 @@ private const val METADATA_HTTP_CLIENT = "metadataHttpClient"
 fun metadataModule(imageHome: Path): Module =
     module {
         single(named(METADATA_HTTP_CLIENT)) {
-            HttpClient(CIO) {
+            metadataHttpClient {
                 install(ContentNegotiation) {
                     json(
                         Json {

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/MetadataHttpClient.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/di/MetadataHttpClient.jvm.kt
@@ -1,0 +1,9 @@
+package com.calypsan.listenup.server.di
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.cio.CIO
+
+/** JVM metadata client: the CIO engine, whose TLS is fully supported on the JVM. */
+internal actual fun metadataHttpClient(configure: HttpClientConfig<*>.() -> Unit): HttpClient =
+    HttpClient(CIO, configure)

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/di/MetadataHttpClient.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/di/MetadataHttpClient.linux.kt
@@ -1,0 +1,15 @@
+package com.calypsan.listenup.server.di
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.curl.Curl
+
+/**
+ * Kotlin/Native (Linux) metadata client: the Curl engine (libcurl). Ktor's CIO engine does not support
+ * outbound TLS on Kotlin/Native, so HTTPS calls to Audible/iTunes failed and were mapped to
+ * `ExternalUnavailable`. Curl delegates TLS to libcurl, which the native runtime image ships alongside a
+ * CA trust store. Both linuxX64 and linuxArm64 share this actual (the `ktor-client-curl` artifact and
+ * libcurl are available on both arches).
+ */
+internal actual fun metadataHttpClient(configure: HttpClientConfig<*>.() -> Unit): HttpClient =
+    HttpClient(Curl, configure)

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/metadata/MetadataHttpClientNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/metadata/MetadataHttpClientNativeTest.kt
@@ -1,9 +1,8 @@
 package com.calypsan.listenup.server.metadata
 
+import com.calypsan.listenup.server.di.metadataHttpClient
 import io.kotest.matchers.shouldBe
-import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.cio.CIO as ClientCIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.json
@@ -22,11 +21,12 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 /**
- * Native capability proof for the metadata HTTP client: `MetadataModule` wires an
- * `HttpClient(CIO)` with ContentNegotiation to call Audible/iTunes. This pins that a Kotlin/Native
- * CIO client can perform a GET **and deserialize a JSON body via ContentNegotiation** — the exact
- * path the scrapers rely on (an earlier multipart test proved client request/response but not the
- * client-side JSON ContentNegotiation seam).
+ * Native capability proof for the metadata HTTP client seam (`metadataHttpClient`): on Kotlin/Native
+ * it builds a Curl-engine client (libcurl) with ContentNegotiation — the engine `MetadataModule`
+ * wires for the Audible/iTunes scrapers (CIO's TLS is unsupported on K/N). This pins that the native
+ * metadata client can perform a GET **and deserialize a JSON body via ContentNegotiation** — the exact
+ * path the scrapers rely on. Real outbound HTTPS is verified manually via `runNative` (CI has no
+ * outbound network), so this exercises the request + JSON-deserialize seam over loopback HTTP.
  *
  * `kotlin.test.@Test` + `runBlocking`, `Unit` body, real `embeddedServer(CIO)` over an ephemeral port.
  */
@@ -54,7 +54,7 @@ class MetadataHttpClientNativeTest {
                 }
             server.start(wait = false)
             val client =
-                HttpClient(ClientCIO) {
+                metadataHttpClient {
                     install(ClientContentNegotiation) { json(lenientJson) }
                 }
             try {


### PR DESCRIPTION
From the pre-beta bug-bash. All metadata searches failed on the native server ("Couldn't reach the external metadata service").

**Root cause:** `MetadataModule` built `HttpClient(CIO)` in `commonMain`. Ktor's CIO engine does not support outbound TLS on Kotlin/Native, so every HTTPS call to Audible/iTunes/image hosts threw and was mapped to `MetadataError.ExternalUnavailable`. Native outbound HTTPS was never exercised — the existing native test was loopback-CIO-only (HTTP, no TLS), which is exactly how this slipped through.

**Fix — per-platform engine seam:**
- New `internal expect fun metadataHttpClient(configure)` → **CIO actual on jvmMain**, **Curl actual on linuxMain** (`ktor-client-curl`, libcurl). `MetadataModule` builds the client via the seam. `ktor-client-cio` moves commonMain→jvmMain; `ktor-client-curl` added to the catalog + linuxMain.
- **Docker (`Dockerfile.native`):** the distroless runtime stage now ships `ca-certificates.crt` + `libcurl.so.4` and its full `ldd` closure (the lean base had neither).
- **CI:** `release.yml` + `ci.yml` install `libcurl4-openssl-dev` so the K/N linker resolves `-lcurl`.

**Test:** consolidated the duplicate/misleading native test to drive the real `metadataHttpClient` (Curl) seam over a loopback GET + JSON-deserialize round-trip. Real outbound HTTPS is verified manually via `runNative` (CI has no outbound network).

Verified locally: `:server:jvmTest` + `:server:linuxX64Test` (native compile + link + run) + spotless + detekt → BUILD SUCCESSFUL.