### PR TITLE
🐛 fix(ios): two pre-beta iOS bugs — pending-approval SSE userId + admin avatars

### DIFF
--- a/iosApp/ListenUp/Core/AuthStateObserver.swift
+++ b/iosApp/ListenUp/Core/AuthStateObserver.swift
@@ -58,7 +58,7 @@ final class AuthStateObserver {
             openRegistration = login.openRegistration
         case .pendingApproval(let pending):
             state = .pendingApproval
-            pendingApprovalUserId = pending.userId as? String ?? ""
+            pendingApprovalUserId = pending.userIdString
             pendingApprovalEmail = pending.email
         case .authenticated:
             state = .authenticated

--- a/iosApp/ListenUp/Features/Admin/Components/AdminPendingUserRow.swift
+++ b/iosApp/ListenUp/Features/Admin/Components/AdminPendingUserRow.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// One row in PENDING REGISTRATIONS: an initials avatar, name + email, and Deny / Approve
+/// One row in PENDING REGISTRATIONS: the user's avatar, name + email, and Deny / Approve
 /// actions. While either action is in flight a spinner replaces both buttons.
 struct AdminPendingUserRow: View {
     let user: AdminUserRowModel
@@ -10,8 +10,7 @@ struct AdminPendingUserRow: View {
 
     var body: some View {
         HStack(spacing: 13) {
-            ContributorAvatar(name: user.name, imagePath: nil, id: user.id, fontSize: 15)
-                .frame(width: 40, height: 40)
+            UserAvatarView(userId: user.id, fallbackName: user.name, size: 40)
             VStack(alignment: .leading, spacing: 1) {
                 Text(user.name)
                     .font(.body)

--- a/iosApp/ListenUp/Features/Admin/Components/AdminUserRow.swift
+++ b/iosApp/ListenUp/Features/Admin/Components/AdminUserRow.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// One row in the USERS list: an initials avatar, the user's name + email, their role badge,
+/// One row in the USERS list: the user's avatar, the user's name + email, their role badge,
 /// and a context-menu delete (suppressed for protected root users). A spinner replaces the
 /// trailing affordance while this user's delete is in flight.
 struct AdminUserRow: View {
@@ -10,8 +10,7 @@ struct AdminUserRow: View {
 
     var body: some View {
         HStack(spacing: 13) {
-            ContributorAvatar(name: user.name, imagePath: nil, id: user.id, fontSize: 15)
-                .frame(width: 40, height: 40)
+            UserAvatarView(userId: user.id, fallbackName: user.name, size: 40)
             VStack(alignment: .leading, spacing: 1) {
                 Text(user.name)
                     .font(.body)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/AuthState.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/AuthState.kt
@@ -38,7 +38,16 @@ sealed interface AuthState {
     data class PendingApproval(
         val userId: UserId,
         val email: String,
-    ) : AuthState
+    ) : AuthState {
+        /**
+         * The raw user id as a plain `String`.
+         *
+         * Swift Export exposes [userId] as an opaque `UserId` wrapper with no `.value` accessor,
+         * so iOS reads this instead — the same `idString` convention every other Swift-consumed
+         * domain model follows.
+         */
+        val userIdString: String get() = userId.value
+    }
 
     /** User is authenticated with a valid session. */
     data class Authenticated(

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/AuthStateTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/model/AuthStateTest.kt
@@ -1,0 +1,23 @@
+package com.calypsan.listenup.client.domain.model
+
+import com.calypsan.listenup.api.dto.auth.UserId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [AuthState] accessors that cross the Swift Export boundary.
+ *
+ * `PendingApproval.userId` is a `UserId` value class; the exported Swift wrapper has no
+ * `.value` accessor, so iOS reads [AuthState.PendingApproval.userIdString] instead — the same
+ * `idString` convention every other Swift-consumed domain model follows. Without it the iOS
+ * observer fell back to an empty id, producing a malformed `registration-status//stream` URL.
+ */
+class AuthStateTest :
+    FunSpec({
+
+        test("PendingApproval.userIdString unwraps the value class to the raw id") {
+            val pending = AuthState.PendingApproval(UserId("b4bebe72-f14f-4b71-9550-0d05e9119921"), "user@example.com")
+
+            pending.userIdString shouldBe "b4bebe72-f14f-4b71-9550-0d05e9119921"
+        }
+    })


### PR DESCRIPTION
Two independent iOS bugs found during pre-beta testing.

## 1. Registration approval never resolves (404 loop)
Testing the approval system, the pending-approval screen hammered `GET /api/v1/auth/registration-status//stream` and `.../registration-status/` — note the **empty user id** — 404ing every ~5s.

**Cause:** `AuthState.PendingApproval.userId` is a `UserId` value class. Swift Export exposes it as an opaque wrapper with **no `.value` accessor**, so `AuthStateObserver`'s `pending.userId as? String ?? ""` silently fell back to `""`. Every other Swift-consumed domain model (`User`, `BookDetail`, `Contributor`, …) already dodges this by exposing a Kotlin `idString`; `PendingApproval` was the one that didn't.

**Fix:** add `PendingApproval.userIdString` (the same `idString` convention) and read it from Swift. Covered by a new `AuthStateTest`.

## 2. Admin user list shows avatars only for the current user
The admin USERS / PENDING rows drew `ContributorAvatar(imagePath: nil)` — the *contributor-photo* component with no path — so they could only ever render initials, never a user's uploaded photo.

**Fix:** swap both rows to `UserAvatarView(userId:fallbackName:size:)`, which fetches each user's avatar via `GET /api/v1/avatars/{userId}` (serves any user; 404 → initials fallback). No contract/server change needed — the per-user endpoint already exists.

## Verification
Full local pre-push gate run on macOS:
- ✅ Lint (Kotlin: spotless + detekt; Swift: no new warnings)
- ✅ Test (JVM) — `:sharedLogic:jvmTest`
- ✅ Test (JVM) — `:server:jvmTest` except the 2 known-environmental `MulticastMdnsResponderTest` failures (multicast egress on macOS; green on CI Linux)
- ✅ Build (Android) — `:androidApp:assembleDebug`
- ✅ Build (iOS) + Test (iOS) `build-for-testing` — both compile against a freshly regenerated Swift Export framework (confirms `userIdString` is exported/consumed)