### PR TITLE
🐛 fix(shared): put share-link payload in ?query so iOS Universal Links deliver it

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InviteMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InviteMapper.kt
@@ -18,7 +18,7 @@ internal fun InviteDto.toInviteInfo(serverUrl: String): InviteInfo =
         expiresAt = expiresAt.toString(),
         claimedAt = claimedAt?.toString(),
         // The shared, copyable invite link is a Universal Link / App Link via the deep-link codec
-        // (https://link.listenup.audio/o#t=invite&server=…&code=…) — NOT the old "$serverUrl/invite/$code"
+        // (https://link.listenup.audio/o?t=invite&server=…&code=…) — NOT the old "$serverUrl/invite/$code"
         // plain-server URL, which the server has no route for (it 404s) and which never deep-linked.
         url = ShareLinkCodec.encode(ShareTarget.Invite(serverUrl = serverUrl, code = code)),
         createdAt = createdAt.toString(),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -7,13 +7,15 @@ import io.ktor.http.parseQueryString
 /**
  * Pure, two-way translation between share-link URL strings and [ShareTarget].
  *
- * Every shareable link is the `https://link.listenup.audio/o#…` universal-link form — one shape
+ * Every shareable link is the `https://link.listenup.audio/o?…` universal-link form — one shape
  * for books and invites alike, so a tapped link opens the app (or falls back to the install page)
  * on both platforms. [encode] builds it; [decode] parses it, living once in `commonMain` rather
  * than per platform.
  *
- * The payload rides in the URL `#fragment` (the host never receives it); [decode] also accepts
- * the same params in the `?query` as a fallback, in case a platform strips the fragment.
+ * The payload rides in the URL `?query`: iOS Universal Links do not reliably deliver the URL
+ * `#fragment` to the app (`NSUserActivity.webpageURL` drops it), and the redirector's `/o`→`/o/`
+ * 308 strands a fragment too — a query survives both. [decode] still accepts the legacy `#fragment`
+ * form so links shared before this change keep working when they arrive intact (e.g. on Android).
  */
 object ShareLinkCodec {
     /**
@@ -43,7 +45,7 @@ object ShareLinkCodec {
     private fun encodeBook(book: ShareTarget.Book): String =
         buildString {
             append(ShareLinkConstants.SHARE_URL_PREFIX)
-            append("#t=book")
+            append("?t=book")
             append("&b=").append(book.bookId.value.percentEncodeQueryValue())
             book.serverInstanceId?.let { append("&i=").append(it.percentEncodeQueryValue()) }
             book.serverUrl?.let { append("&u=").append(it.percentEncodeQueryValue()) }
@@ -52,7 +54,7 @@ object ShareLinkCodec {
     private fun encodeInvite(invite: ShareTarget.Invite): String =
         buildString {
             append(ShareLinkConstants.SHARE_URL_PREFIX)
-            append("#t=invite")
+            append("?t=invite")
             append("&server=").append(invite.serverUrl.percentEncodeQueryValue())
             append("&code=").append(invite.code.percentEncodeQueryValue())
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplInviteTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplInviteTest.kt
@@ -151,7 +151,7 @@ class AdminRepositoryImplInviteTest :
             info.id shouldBe "inv1"
             info.code shouldBe "abc123"
             info.name shouldBe "Ada"
-            info.url shouldBe "https://link.listenup.audio/o#t=invite&server=https%3A%2F%2Fsrv.example&code=abc123"
+            info.url shouldBe "https://link.listenup.audio/o?t=invite&server=https%3A%2F%2Fsrv.example&code=abc123"
             info.claimedAt shouldBe null
         }
 
@@ -191,7 +191,7 @@ class AdminRepositoryImplInviteTest :
             val info = (result as AppResult.Success).data
             info.email shouldBe "ada@example.com"
             info.role shouldBe "ADMIN"
-            info.url shouldBe "https://link.listenup.audio/o#t=invite&server=https%3A%2F%2Fsrv.example&code=code-abc"
+            info.url shouldBe "https://link.listenup.audio/o?t=invite&server=https%3A%2F%2Fsrv.example&code=code-abc"
         }
 
         test("createInvite maps the lowercase 'member' role token to UserRole.MEMBER (least privilege)") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.core.BookId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 
 class ShareLinkCodecTest :
@@ -19,7 +20,7 @@ class ShareLinkCodecTest :
                     ),
                 )
 
-            url shouldStartWith "https://link.listenup.audio/o#t=book"
+            url shouldStartWith "https://link.listenup.audio/o?t=book"
             url shouldContain "b=book-abc"
             url shouldContain "i=inst-123"
             // serverUrl is percent-encoded as a query component.
@@ -32,15 +33,26 @@ class ShareLinkCodecTest :
                     ShareTarget.Book(bookId = BookId("book-abc"), serverInstanceId = null, serverUrl = null),
                 )
 
-            url shouldBe "https://link.listenup.audio/o#t=book&b=book-abc"
+            url shouldBe "https://link.listenup.audio/o?t=book&b=book-abc"
         }
 
         test("encode produces the https /o form for an invite") {
             val url = ShareLinkCodec.encode(ShareTarget.Invite(serverUrl = "https://lib.example.com", code = "JOIN9"))
 
-            url shouldStartWith "https://link.listenup.audio/o#t=invite"
+            url shouldStartWith "https://link.listenup.audio/o?t=invite"
             url shouldContain "server=https%3A%2F%2Flib.example.com"
             url shouldContain "code=JOIN9"
+        }
+
+        test("encode puts the invite payload in the query, not the fragment, so it survives iOS Universal Link delivery") {
+            val invite = ShareTarget.Invite(serverUrl = "http://192.168.86.24:8080", code = "JOIN9")
+            val url = ShareLinkCodec.encode(invite)
+
+            // iOS Universal Links (NSUserActivity.webpageURL) drop the #fragment; the payload must ride in ?query.
+            url shouldContain "?t=invite"
+            url shouldNotContain "#"
+            // Simulate a delivery that strips everything from '#' onward: the invite still decodes.
+            ShareLinkCodec.decode(url.substringBefore("#")) shouldBe invite
         }
 
         test("decode parses the https /o form from the fragment") {

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -52,7 +52,7 @@ private val logger = KotlinLogging.logger {}
  * - Disconnects realtime sync when app goes to background (saves battery)
  * - Auto-reconnects on app resume
  *
- * Handles share / deep links via the https App Link (https://link.listenup.audio/o#...).
+ * Handles share / deep links via the https App Link (https://link.listenup.audio/o?...).
  *
  * This ensures real-time updates when actively using the app
  * while preserving battery life in the background.
@@ -128,7 +128,8 @@ class MainActivity : ComponentActivity() {
         // Share / deep links (https App Links) — parsed once, in commonMain.
         if (intent.action == Intent.ACTION_VIEW) {
             intent.data?.toString()?.let { raw ->
-                ShareLinkCodec.decode(raw)?.let { target ->
+                val target = ShareLinkCodec.decode(raw)
+                if (target != null) {
                     logger.debug {
                         when (target) {
                             is ShareTarget.Book -> "Received book share link: bookId=${target.bookId.value}"
@@ -138,6 +139,10 @@ class MainActivity : ComponentActivity() {
                     deepLinkManager.setPendingTarget(target)
                     return
                 }
+                // Diagnosability: an App-Link VIEW reached our host but did not decode to a share
+                // target (e.g. a stripped/malformed link). Log it so one logcat pinpoints the failure
+                // instead of the previous silent fall-through to auth routing.
+                logger.warn { "ACTION_VIEW did not decode to a share target: data=$raw" }
             }
         }
 


### PR DESCRIPTION
Fixes the invite-link bug that resisted four prior attempts — because it's **iOS-specific and none of the earlier fixes touched iOS delivery.**

**Root cause (diagnosed + emulator-verified):** invite/book links were generated **fragment-only** (`…/o#t=invite&server=…&code=…`). iOS Universal Links do **not** reliably deliver the URL `#fragment` to the app (`NSUserActivity.webpageURL` drops it), and the redirector's `/o`→`/o/` 308 strands a fragment too (curl-confirmed: it *preserves* query strings but fragments never reach the server). So on iOS the payload is lost → `ShareLinkCodec.decode` returns null → `DeepLinkRouter` silently no-ops → `RootView` falls through to `.needsServerUrl` → the server-setup screen.

**Why this is the whole fix (no iOS-Swift change needed):** the decoder already has a query fallback (`fragment.ifEmpty { query }`, with the comment *"in case a platform strips the fragment"*) — dead code until now because nothing generated the query form. The iOS router already forwards the full URL verbatim, and AASA + entitlements are correct. So moving generation to `?query` fixes iOS end-to-end. Queries survive iOS Universal Links AND the 308 (both confirmed).

**Change:** `ShareLinkCodec.encodeInvite`/`encodeBook` now emit `?t=…` instead of `#t=…`. Decoder unchanged (already handles both; legacy `#fragment` links still decode for backward compat).

**Diagnosability (defense-in-depth):** `MainActivity.handleIntent` now logs a WARN when an `ACTION_VIEW` to our host fails to decode (was a silent fall-through — *the* reason four fixes flew blind).

**Verified on an Android emulator (resizable AVD):**
- Android *receiving* (the untested "other direction") already worked — both fragment and query forms → "Join a library" screen.
- New build: query-form invite → join screen ✓; stripped link → the new decode-null WARN fires ✓.
- Unit: encode→query, round-trips, survives fragment-strip (new regression test), legacy fragment still decodes; `AdminRepositoryImplInviteTest` updated; `:androidApp:assembleDebug` + spotless + detekt green.

**⚠️ Needs one iOS confirmation** (only iOS can verify UL delivery): build on the Mac, tap a query-form invite on an iPhone/simulator → should land on the join screen. See the handoff doc.