### PR TITLE
🐛 fix(invite): deliver iOS universal-link invites via .onOpenURL + claim name fields

### DIFF
--- a/iosApp/ListenUp/Core/DeepLinkRouter.swift
+++ b/iosApp/ListenUp/Core/DeepLinkRouter.swift
@@ -13,7 +13,7 @@ final class DeepLinkRouter {
     /// The resolved, view-facing outcome of the current pending share-link target.
     enum Outcome: Equatable {
         case none
-        case claimInvite(serverURL: String, code: String)
+        case claimInvite(serverURL: String, code: String, remoteURL: String?)
         case openBook(id: String)
         case wrongServer
         case notConnected
@@ -58,7 +58,7 @@ final class DeepLinkRouter {
         switch onEnum(of: target) {
         case .invite(let invite):
             Log.info("DeepLink: resolved invite → presenting claim sheet")
-            outcome = .claimInvite(serverURL: invite.serverUrl, code: invite.code)
+            outcome = .claimInvite(serverURL: invite.serverUrl, code: invite.code, remoteURL: invite.remoteUrl)
         case .book(let book):
             Task { @MainActor [weak self] in await self?.resolveBook(book) }
         case .unknown:

--- a/iosApp/ListenUp/Core/DeepLinkRouter.swift
+++ b/iosApp/ListenUp/Core/DeepLinkRouter.swift
@@ -36,7 +36,14 @@ final class DeepLinkRouter {
     /// Decode an incoming universal-link URL and stash it on the shared
     /// seam; the `pendingTarget` binding above drives `resolve`.
     func receive(url: URL) {
-        guard let target = ShareLinkCodec.shared.decode(raw: url.absoluteString) else { return }
+        // Redact the query when logging — it carries the invite `code` (a bearer secret)
+        // and the server URL. Host + path (`link.listenup.audio/o`) is enough to trace delivery.
+        let safe = "\(url.host ?? "?")\(url.path)"
+        guard let target = ShareLinkCodec.shared.decode(raw: url.absoluteString) else {
+            Log.error("DeepLink: decode returned nil for \(safe)")
+            return
+        }
+        Log.info("DeepLink: decoded a share target from \(safe)")
         deepLinkManager.setPendingTarget(target: target)
     }
 
@@ -50,6 +57,7 @@ final class DeepLinkRouter {
         guard let target else { outcome = .none; return }
         switch onEnum(of: target) {
         case .invite(let invite):
+            Log.info("DeepLink: resolved invite → presenting claim sheet")
             outcome = .claimInvite(serverURL: invite.serverUrl, code: invite.code)
         case .book(let book):
             Task { @MainActor [weak self] in await self?.resolveBook(book) }

--- a/iosApp/ListenUp/Features/ClaimInvite/ClaimInviteView.swift
+++ b/iosApp/ListenUp/Features/ClaimInvite/ClaimInviteView.swift
@@ -11,13 +11,14 @@ struct ClaimInviteView: View {
     // MARK: - Configuration
 
     let onDismiss: () -> Void
-    private let deepLinkSeed: (serverURL: String, code: String)?
+    private let deepLinkSeed: (serverURL: String, code: String, remoteURL: String?)?
 
     // MARK: - State
 
     @State private var wrapper: ClaimInviteViewModelWrapper
     @State private var code = ""
-    @State private var displayName = ""
+    @State private var firstName = ""
+    @State private var lastName = ""
     @State private var password = ""
     @State private var didStart = false
 
@@ -31,9 +32,9 @@ struct ClaimInviteView: View {
         ))
     }
 
-    init(deepLinkServerURL: String, deepLinkCode: String, onDismiss: @escaping () -> Void) {
+    init(deepLinkServerURL: String, deepLinkCode: String, deepLinkRemoteURL: String?, onDismiss: @escaping () -> Void) {
         self.onDismiss = onDismiss
-        self.deepLinkSeed = (deepLinkServerURL, deepLinkCode)
+        self.deepLinkSeed = (deepLinkServerURL, deepLinkCode, deepLinkRemoteURL)
         _wrapper = State(initialValue: ClaimInviteViewModelWrapper(
             viewModel: Dependencies.shared.claimInviteViewModel
         ))
@@ -58,7 +59,7 @@ struct ClaimInviteView: View {
             if let seed = deepLinkSeed, !didStart {
                 didStart = true
                 Log.info("ClaimInviteView appeared from deep link — starting lookup")
-                wrapper.start(serverURL: seed.serverURL, code: seed.code)
+                wrapper.start(serverURL: seed.serverURL, code: seed.code, remoteURL: seed.remoteURL)
             }
         }
     }
@@ -118,11 +119,19 @@ struct ClaimInviteView: View {
                 AuthLargeHeader(title: String(localized: "invite.set_password_title"))
                 AuthFieldGroup {
                     AppTextField(
-                        placeholder: String(localized: "common.display_name"),
-                        text: $displayName,
+                        placeholder: String(localized: "auth.first_name"),
+                        text: $firstName,
                         icon: "person",
                         isLast: false,
-                        textContentType: .name,
+                        textContentType: .givenName,
+                        autocapitalization: .words
+                    )
+                    AppTextField(
+                        placeholder: String(localized: "auth.last_name"),
+                        text: $lastName,
+                        icon: "person",
+                        isLast: false,
+                        textContentType: .familyName,
                         autocapitalization: .words
                     )
                     AppTextField(
@@ -137,17 +146,9 @@ struct ClaimInviteView: View {
                     title: String(localized: "invite.get_started"),
                     isLoading: false
                 ) {
-                    wrapper.claim(
-                        password: password,
-                        displayName: displayName.isEmpty ? nil : displayName
-                    )
+                    wrapper.claim(password: password, firstName: firstName, lastName: lastName)
                 }
-                .disabled(password.isEmpty)
-            }
-            .onAppear {
-                if displayName.isEmpty {
-                    displayName = preview.displayName
-                }
+                .disabled(firstName.isEmpty || lastName.isEmpty || password.isEmpty)
             }
         }
     }

--- a/iosApp/ListenUp/Features/ClaimInvite/ClaimInviteView.swift
+++ b/iosApp/ListenUp/Features/ClaimInvite/ClaimInviteView.swift
@@ -57,6 +57,7 @@ struct ClaimInviteView: View {
         .onAppear {
             if let seed = deepLinkSeed, !didStart {
                 didStart = true
+                Log.info("ClaimInviteView appeared from deep link — starting lookup")
                 wrapper.start(serverURL: seed.serverURL, code: seed.code)
             }
         }

--- a/iosApp/ListenUp/Features/ClaimInvite/ClaimInviteViewModelWrapper.swift
+++ b/iosApp/ListenUp/Features/ClaimInvite/ClaimInviteViewModelWrapper.swift
@@ -32,12 +32,12 @@ final class ClaimInviteViewModelWrapper {
         viewModel.onCodeEntered(code: code.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
-    func start(serverURL: String?, code: String) {
-        viewModel.start(serverUrl: serverURL, code: code)
+    func start(serverURL: String?, code: String, remoteURL: String?) {
+        viewModel.start(serverUrl: serverURL, code: code, remoteUrl: remoteURL)
     }
 
-    func claim(password: String, displayName: String?) {
-        viewModel.onClaimSubmit(password: password, displayName: displayName)
+    func claim(password: String, firstName: String, lastName: String) {
+        viewModel.onClaimSubmit(password: password, firstName: firstName, lastName: lastName)
     }
 
     // MARK: - State mapping

--- a/iosApp/ListenUp/ListenUpApp.swift
+++ b/iosApp/ListenUp/ListenUpApp.swift
@@ -40,7 +40,16 @@ private struct RootView: View {
             .environment(currentUser)
             .environment(hapticsSettings)
             .environment(deepLinkRouter)
+            // Universal links: `.onOpenURL` is the reliable SwiftUI App-lifecycle delivery path
+            // (cold launch *and* while running). `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)`
+            // does not fire for universal links under the SwiftUI lifecycle — kept only as a
+            // belt-and-suspenders and to confirm delivery in logs.
+            .onOpenURL { url in
+                Log.info("onOpenURL fired: \(url.host ?? "?")\(url.path)")
+                deepLinkRouter.receive(url: url)
+            }
             .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                Log.info("onContinueUserActivity fired: \(activity.webpageURL?.host ?? "nil")")
                 if let url = activity.webpageURL { deepLinkRouter.receive(url: url) }
             }
             .sheet(isPresented: invitePresented) {

--- a/iosApp/ListenUp/ListenUpApp.swift
+++ b/iosApp/ListenUp/ListenUpApp.swift
@@ -53,8 +53,8 @@ private struct RootView: View {
                 if let url = activity.webpageURL { deepLinkRouter.receive(url: url) }
             }
             .sheet(isPresented: invitePresented) {
-                if case .claimInvite(let serverURL, let code) = deepLinkRouter.outcome {
-                    ClaimInviteView(deepLinkServerURL: serverURL, deepLinkCode: code) {
+                if case .claimInvite(let serverURL, let code, let remoteURL) = deepLinkRouter.outcome {
+                    ClaimInviteView(deepLinkServerURL: serverURL, deepLinkCode: code, deepLinkRemoteURL: remoteURL) {
                         deepLinkRouter.consume()
                     }
                 }

--- a/iosApp/ListenUpTests/DeepLinkRouterTests.swift
+++ b/iosApp/ListenUpTests/DeepLinkRouterTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @preconcurrency import Shared
 @testable import ListenUp
@@ -21,5 +22,23 @@ struct DeepLinkRouterTests {
         await awaitUntil { router.outcome == .claimInvite(serverURL: "https://lib.example.com", code: "JOIN9") }
 
         #expect(router.outcome == .claimInvite(serverURL: "https://lib.example.com", code: "JOIN9"))
+    }
+
+    /// Covers the full `receive(url:)` → `ShareLinkCodec.decode` → `pendingTarget` → resolve seam
+    /// that a delivery modifier (`.onOpenURL`) feeds — the end-to-end path the prior invite fixes
+    /// never exercised. URL is the real universal-link shape (query payload per #971) with a
+    /// synthetic code, incl. a percent-encoded cleartext-LAN `server` and a non-standard port.
+    @Test func receiveDecodesUniversalLinkIntoClaimInvite() async throws {
+        let manager = DeepLinkManager()
+        let router = DeepLinkRouter(deepLinkManager: manager)
+
+        let url = URL(
+            string: "https://link.listenup.audio/o?t=invite&server=http%3A%2F%2F192.168.86.250%3A8080&code=TESTINVITECODE"
+        )!
+        router.receive(url: url)
+
+        await awaitUntil { router.outcome == .claimInvite(serverURL: "http://192.168.86.250:8080", code: "TESTINVITECODE") }
+
+        #expect(router.outcome == .claimInvite(serverURL: "http://192.168.86.250:8080", code: "TESTINVITECODE"))
     }
 }

--- a/iosApp/ListenUpTests/DeepLinkRouterTests.swift
+++ b/iosApp/ListenUpTests/DeepLinkRouterTests.swift
@@ -15,13 +15,13 @@ struct DeepLinkRouterTests {
         let manager = DeepLinkManager()
         let router = DeepLinkRouter(deepLinkManager: manager)
 
-        manager.setPendingTarget(target: ShareTargetInvite(serverUrl: "https://lib.example.com", code: "JOIN9"))
+        manager.setPendingTarget(target: ShareTargetInvite(serverUrl: "https://lib.example.com", code: "JOIN9", remoteUrl: nil))
         // FlowBridge delivers the StateFlow emission asynchronously (Kotlin collector → MainActor
         // hop). Poll for the resolved outcome rather than racing a fixed sleep — a saturated CI
         // scheduler can blow past a 100 ms window, which is exactly what flaked here.
-        await awaitUntil { router.outcome == .claimInvite(serverURL: "https://lib.example.com", code: "JOIN9") }
+        await awaitUntil { router.outcome == .claimInvite(serverURL: "https://lib.example.com", code: "JOIN9", remoteURL: nil) }
 
-        #expect(router.outcome == .claimInvite(serverURL: "https://lib.example.com", code: "JOIN9"))
+        #expect(router.outcome == .claimInvite(serverURL: "https://lib.example.com", code: "JOIN9", remoteURL: nil))
     }
 
     /// Covers the full `receive(url:)` → `ShareLinkCodec.decode` → `pendingTarget` → resolve seam
@@ -37,8 +37,28 @@ struct DeepLinkRouterTests {
         )!
         router.receive(url: url)
 
-        await awaitUntil { router.outcome == .claimInvite(serverURL: "http://192.168.86.250:8080", code: "TESTINVITECODE") }
+        await awaitUntil { router.outcome == .claimInvite(serverURL: "http://192.168.86.250:8080", code: "TESTINVITECODE", remoteURL: nil) }
 
-        #expect(router.outcome == .claimInvite(serverURL: "http://192.168.86.250:8080", code: "TESTINVITECODE"))
+        #expect(router.outcome == .claimInvite(serverURL: "http://192.168.86.250:8080", code: "TESTINVITECODE", remoteURL: nil))
+    }
+
+    /// A link that carries an optional `remote=` (WAN) URL surfaces it on the outcome, so the claim
+    /// flow can fall back to it when the invitee is off the local network.
+    @Test func receiveCarriesTheRemoteURLFromTheLink() async throws {
+        let manager = DeepLinkManager()
+        let router = DeepLinkRouter(deepLinkManager: manager)
+
+        let url = URL(
+            string: "https://link.listenup.audio/o?t=invite&server=http%3A%2F%2F192.168.1.5%3A8080&code=JOIN9&remote=https%3A%2F%2Flib.example.com"
+        )!
+        router.receive(url: url)
+
+        let expected = DeepLinkRouter.Outcome.claimInvite(
+            serverURL: "http://192.168.1.5:8080",
+            code: "JOIN9",
+            remoteURL: "https://lib.example.com"
+        )
+        await awaitUntil { router.outcome == expected }
+        #expect(router.outcome == expected)
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -167,7 +167,8 @@ internal class AdminRepositoryImpl(
     override suspend fun getInvites(): AppResult<List<InviteInfo>> =
         catching("getInvites") {
             val serverUrl = serverConfig.getActiveUrl()?.value.orEmpty()
-            inviteRpc.adminService().listInvites().map { list -> list.map { it.toInviteInfo(serverUrl) } }
+            val remoteUrl = inviteRemoteUrl(serverUrl)
+            inviteRpc.adminService().listInvites().map { list -> list.map { it.toInviteInfo(serverUrl, remoteUrl) } }
         }
 
     override suspend fun createInvite(
@@ -187,8 +188,16 @@ internal class AdminRepositoryImpl(
                     displayName = email.substringBefore('@'),
                     role = role.toInviteRole(),
                     expiresInDays = expiresInDays,
-                ).map { it.toInviteInfo(serverUrl) }
+                ).map { it.toInviteInfo(serverUrl, inviteRemoteUrl(serverUrl)) }
         }
+
+    /**
+     * The operator-set remote (WAN) URL to embed alongside the local [serverUrl] in an invite link,
+     * so an invitee off the local network can still connect. `null` when unset or identical to the
+     * local URL (no point carrying a duplicate). The claim flow tries local first, then this.
+     */
+    private suspend fun inviteRemoteUrl(serverUrl: String): String? =
+        serverConfig.getRemoteUrl()?.value?.takeIf { it.isNotBlank() && it != serverUrl }
 
     override suspend fun deleteInvite(inviteId: String): AppResult<Unit> =
         catching("deleteInvite") { inviteRpc.adminService().revokeInvite(InviteId(inviteId)) }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InviteMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InviteMapper.kt
@@ -6,9 +6,15 @@ import com.calypsan.listenup.client.domain.model.InviteInfo
 import com.calypsan.listenup.client.share.ShareLinkCodec
 import com.calypsan.listenup.client.share.ShareTarget
 
-internal fun InviteSummary.toInviteInfo(serverUrl: String): InviteInfo = invite.toInviteInfo(serverUrl)
+internal fun InviteSummary.toInviteInfo(
+    serverUrl: String,
+    remoteUrl: String?,
+): InviteInfo = invite.toInviteInfo(serverUrl, remoteUrl)
 
-internal fun InviteDto.toInviteInfo(serverUrl: String): InviteInfo =
+internal fun InviteDto.toInviteInfo(
+    serverUrl: String,
+    remoteUrl: String?,
+): InviteInfo =
     InviteInfo(
         id = id.value,
         code = code,
@@ -20,6 +26,7 @@ internal fun InviteDto.toInviteInfo(serverUrl: String): InviteInfo =
         // The shared, copyable invite link is a Universal Link / App Link via the deep-link codec
         // (https://link.listenup.audio/o?t=invite&server=…&code=…) — NOT the old "$serverUrl/invite/$code"
         // plain-server URL, which the server has no route for (it 404s) and which never deep-linked.
-        url = ShareLinkCodec.encode(ShareTarget.Invite(serverUrl = serverUrl, code = code)),
+        // [remoteUrl] rides along when set so an off-LAN invitee can still connect.
+        url = ShareLinkCodec.encode(ShareTarget.Invite(serverUrl = serverUrl, code = code, remoteUrl = remoteUrl)),
         createdAt = createdAt.toString(),
     )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -86,6 +86,7 @@ internal val authPresentationModule =
             com.calypsan.listenup.client.presentation.invite.ClaimInviteViewModel(
                 repository = get(),
                 serverConfig = get(),
+                instanceRepository = get(),
             )
         }
         // LibrarySetupViewModel for initial library configuration

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/invite/ClaimInviteViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/invite/ClaimInviteViewModel.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.presentation.invite
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.InviteRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.core.ServerUrl
@@ -23,6 +24,7 @@ import kotlinx.coroutines.launch
 class ClaimInviteViewModel(
     private val repository: InviteRepository,
     private val serverConfig: ServerConfig,
+    private val instanceRepository: InstanceRepository,
 ) : ViewModel() {
     val state: StateFlow<ClaimInviteUiState>
         field = MutableStateFlow<ClaimInviteUiState>(ClaimInviteUiState.Idle)
@@ -30,24 +32,32 @@ class ClaimInviteViewModel(
     private var code: String? = null
 
     /**
-     * Entry point for the deep-link claim path: persist the server URL the link
-     * carries, then look up the invite — in that order, on one coroutine.
+     * Entry point for the deep-link claim path: pick a reachable server URL from the link, persist
+     * it, then look up the invite — in that order, on one coroutine.
      *
-     * The single launch is load-bearing. The RPC factory resolves its base URL
-     * from [ServerConfig], so on a fresh install the lookup must not run until
-     * [ServerConfig.setServerUrl] has completed; sequencing both on one coroutine
-     * makes the set-before-lookup order deterministic. A null [serverUrl] is the
-     * manual-entry path, where the user already selected a server via Connect, so
-     * the set step is skipped and we go straight to lookup.
+     * The link carries the admin's local [serverUrl] and, when the server advertises one, a
+     * [remoteUrl] (WAN). We probe the local URL first and fall back to the remote, so an invitee off
+     * the LAN still connects — the same Never-Stranded reachability probe
+     * ([InstanceRepository.findReachableUrl]) that `ServerSelectViewModel` uses. If neither probes as
+     * reachable we still persist the local URL so the lookup surfaces a real connection error.
+     *
+     * The single launch is load-bearing. The RPC factory resolves its base URL from [ServerConfig],
+     * so on a fresh install the lookup must not run until [ServerConfig.setServerUrl] has completed;
+     * sequencing the probe, the set, and the lookup on one coroutine keeps that order deterministic.
+     * A null [serverUrl] is the manual-entry path, where the user already selected a server via
+     * Connect, so the set step is skipped and we go straight to lookup.
      */
     fun start(
         serverUrl: String?,
         code: String,
+        remoteUrl: String? = null,
     ) {
         this.code = code
         viewModelScope.launch {
-            if (serverUrl != null) {
-                serverConfig.setServerUrl(ServerUrl(serverUrl))
+            val candidates = listOfNotNull(serverUrl, remoteUrl).distinct()
+            if (candidates.isNotEmpty()) {
+                val reachable = instanceRepository.findReachableUrl(candidates) ?: candidates.first()
+                serverConfig.setServerUrl(ServerUrl(reachable))
             }
             lookUp(code)
         }
@@ -69,11 +79,19 @@ class ClaimInviteViewModel(
             }
     }
 
+    /**
+     * Claim the invite. The UI collects the user's name as separate first/last fields
+     * (matching registration); they are joined here into the single `displayName` the
+     * contract carries — the one place the combination lives, so both platforms stay in
+     * step. Blank names collapse to `null`, letting the server fall back to the invite's name.
+     */
     fun onClaimSubmit(
         password: String,
-        displayName: String? = null,
+        firstName: String,
+        lastName: String,
     ) {
         val code = code ?: return
+        val displayName = "${firstName.trim()} ${lastName.trim()}".trim().ifBlank { null }
         viewModelScope.launch {
             state.value = ClaimInviteUiState.Submitting
             state.value =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareLinkCodec.kt
@@ -57,6 +57,10 @@ object ShareLinkCodec {
             append("?t=invite")
             append("&server=").append(invite.serverUrl.percentEncodeQueryValue())
             append("&code=").append(invite.code.percentEncodeQueryValue())
+            // Optional remote (WAN) URL so an off-LAN invitee can still connect; older links omit it.
+            invite.remoteUrl?.takeIf { it.isNotBlank() }?.let {
+                append("&remote=").append(it.percentEncodeQueryValue())
+            }
         }
 
     private fun decodeHttpsForm(url: String): ShareTarget? {
@@ -88,7 +92,11 @@ object ShareLinkCodec {
     private fun decodeInviteParams(params: Parameters): ShareTarget? {
         val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
         val code = params["code"]?.takeIf { it.isNotBlank() } ?: return null
-        return ShareTarget.Invite(serverUrl = server, code = code)
+        return ShareTarget.Invite(
+            serverUrl = server,
+            code = code,
+            remoteUrl = params["remote"]?.takeIf { it.isNotBlank() },
+        )
     }
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/share/ShareTarget.kt
@@ -34,12 +34,16 @@ sealed interface ShareTarget {
     /**
      * An invite / join claim.
      *
-     * @property serverUrl The server the invite is for (persisted before lookup so a fresh
-     *   install can reach it).
+     * @property serverUrl The server the invite is for — the admin's local/active URL, persisted
+     *   before lookup so a fresh install can reach it.
      * @property code The invite code.
+     * @property remoteUrl The server's operator-set remote (WAN) URL when configured, so an invitee
+     *   off the local network can still connect; `null` when the server advertises none. The claim
+     *   flow tries [serverUrl] first and falls back to [remoteUrl].
      */
     data class Invite(
         val serverUrl: String,
         val code: String,
+        val remoteUrl: String? = null,
     ) : ShareTarget
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/invite/ClaimInviteViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/invite/ClaimInviteViewModelTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.api.dto.invite.InvitePreview
 import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
 import com.calypsan.listenup.client.domain.repository.InviteRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.core.ServerUrl
@@ -21,6 +22,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
@@ -76,7 +78,7 @@ class ClaimInviteViewModelTest :
 
         test("initial state is Idle") {
             val repo = mock<InviteRepository>()
-            val vm = ClaimInviteViewModel(repo, mock())
+            val vm = ClaimInviteViewModel(repo, mock(), mock())
 
             vm.state.value.shouldBeInstanceOf<ClaimInviteUiState.Idle>()
         }
@@ -85,7 +87,7 @@ class ClaimInviteViewModelTest :
             runTest(testDispatcher) {
                 val repo = mock<InviteRepository>()
                 everySuspend { repo.lookupInvite(any()) } returns AppResult.Success(fakePreview())
-                val vm = ClaimInviteViewModel(repo, mock())
+                val vm = ClaimInviteViewModel(repo, mock(), mock())
 
                 vm.state.test {
                     awaitItem().shouldBeInstanceOf<ClaimInviteUiState.Idle>()
@@ -103,7 +105,7 @@ class ClaimInviteViewModelTest :
                 val repo = mock<InviteRepository>()
                 everySuspend { repo.lookupInvite(any()) } returns
                     AppResult.Failure(InternalError(correlationId = "corr-1"))
-                val vm = ClaimInviteViewModel(repo, mock())
+                val vm = ClaimInviteViewModel(repo, mock(), mock())
 
                 vm.onCodeEntered(INVITE_CODE)
                 testDispatcher.scheduler.advanceUntilIdle()
@@ -119,18 +121,35 @@ class ClaimInviteViewModelTest :
                 everySuspend { repo.lookupInvite(any()) } returns AppResult.Success(fakePreview())
                 everySuspend { repo.claimInvite(any(), any(), any()) } returns
                     AppResult.Success(fakeSession())
-                val vm = ClaimInviteViewModel(repo, mock())
+                val vm = ClaimInviteViewModel(repo, mock(), mock())
 
                 vm.onCodeEntered(INVITE_CODE)
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 vm.state.test {
                     awaitItem().shouldBeInstanceOf<ClaimInviteUiState.Preview>()
-                    vm.onClaimSubmit("password123", "Alice")
+                    vm.onClaimSubmit("password123", "Alice", "Anderson")
                     awaitItem().shouldBeInstanceOf<ClaimInviteUiState.Submitting>()
                     awaitItem().shouldBeInstanceOf<ClaimInviteUiState.Claimed>()
                     cancelAndIgnoreRemainingEvents()
                 }
+            }
+        }
+
+        test("onClaimSubmit joins the first and last name into a single display name") {
+            runTest(testDispatcher) {
+                val repo = mock<InviteRepository>()
+                everySuspend { repo.lookupInvite(any()) } returns AppResult.Success(fakePreview())
+                everySuspend { repo.claimInvite(any(), any(), any()) } returns
+                    AppResult.Success(fakeSession())
+                val vm = ClaimInviteViewModel(repo, mock(), mock())
+
+                vm.onCodeEntered(INVITE_CODE)
+                testDispatcher.scheduler.advanceUntilIdle()
+                vm.onClaimSubmit("password123", " Alice ", " Anderson ")
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                verifySuspend { repo.claimInvite(INVITE_CODE, "password123", "Alice Anderson") }
             }
         }
 
@@ -140,11 +159,11 @@ class ClaimInviteViewModelTest :
                 everySuspend { repo.lookupInvite(any()) } returns AppResult.Success(fakePreview())
                 everySuspend { repo.claimInvite(any(), any(), any()) } returns
                     AppResult.Failure(AuthError.InvalidCredentials())
-                val vm = ClaimInviteViewModel(repo, mock())
+                val vm = ClaimInviteViewModel(repo, mock(), mock())
 
                 vm.onCodeEntered(INVITE_CODE)
                 testDispatcher.scheduler.advanceUntilIdle()
-                vm.onClaimSubmit("password123", null)
+                vm.onClaimSubmit("password123", "", "")
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 val error = vm.state.value.shouldBeInstanceOf<ClaimInviteUiState.Error>()
@@ -155,9 +174,9 @@ class ClaimInviteViewModelTest :
         test("onClaimSubmit before a code is known is a no-op") {
             runTest(testDispatcher) {
                 val repo = mock<InviteRepository>()
-                val vm = ClaimInviteViewModel(repo, mock())
+                val vm = ClaimInviteViewModel(repo, mock(), mock())
 
-                vm.onClaimSubmit("password123", null)
+                vm.onClaimSubmit("password123", "", "")
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 vm.state.value.shouldBeInstanceOf<ClaimInviteUiState.Idle>()
@@ -185,7 +204,11 @@ class ClaimInviteViewModelTest :
                                 AppResult.Success(fakePreview())
                             }
                     }
-                val vm = ClaimInviteViewModel(repo, serverConfig)
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { findReachableUrl(any()) } returns "https://example.com"
+                    }
+                val vm = ClaimInviteViewModel(repo, serverConfig, instanceRepository)
 
                 vm.start(serverUrl = "https://example.com", code = INVITE_CODE)
                 testDispatcher.scheduler.advanceUntilIdle()
@@ -213,12 +236,45 @@ class ClaimInviteViewModelTest :
                                 AppResult.Success(fakePreview())
                             }
                     }
-                val vm = ClaimInviteViewModel(repo, serverConfig)
+                val vm = ClaimInviteViewModel(repo, serverConfig, mock())
 
                 vm.start(serverUrl = null, code = INVITE_CODE)
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 events shouldBe listOf("lookupInvite")
+                vm.state.value.shouldBeInstanceOf<ClaimInviteUiState.Preview>()
+            }
+        }
+
+        // Off-LAN invitee: the link's local URL is unreachable, so the reachability probe picks the
+        // remote (WAN) URL and that is what gets persisted before lookup. Local is offered first.
+        test("start persists the reachable URL from the link, falling back local → remote") {
+            runTest(testDispatcher) {
+                val serverConfig =
+                    mock<ServerConfig> {
+                        everySuspend { setServerUrl(any()) } returns Unit
+                    }
+                val instanceRepository =
+                    mock<InstanceRepository> {
+                        everySuspend { findReachableUrl(any()) } returns "https://remote.example.com"
+                    }
+                val repo =
+                    mock<InviteRepository> {
+                        everySuspend { lookupInvite(any()) } returns AppResult.Success(fakePreview())
+                    }
+                val vm = ClaimInviteViewModel(repo, serverConfig, instanceRepository)
+
+                vm.start(
+                    serverUrl = "http://192.168.1.5:8080",
+                    code = INVITE_CODE,
+                    remoteUrl = "https://remote.example.com",
+                )
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                verifySuspend {
+                    instanceRepository.findReachableUrl(listOf("http://192.168.1.5:8080", "https://remote.example.com"))
+                }
+                verifySuspend { serverConfig.setServerUrl(ServerUrl("https://remote.example.com")) }
                 vm.state.value.shouldBeInstanceOf<ClaimInviteUiState.Preview>()
             }
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/share/ShareLinkCodecTest.kt
@@ -93,6 +93,40 @@ class ShareLinkCodecTest :
             ShareLinkCodec.decode(ShareLinkCodec.encode(original)) shouldBe original
         }
 
+        test("encode carries the optional remote URL so an off-LAN invitee can connect") {
+            val url =
+                ShareLinkCodec.encode(
+                    ShareTarget.Invite(
+                        serverUrl = "http://192.168.1.5:8080",
+                        code = "JOIN9",
+                        remoteUrl = "https://lib.example.com",
+                    ),
+                )
+
+            url shouldContain "server=http%3A%2F%2F192.168.1.5%3A8080"
+            url shouldContain "remote=https%3A%2F%2Flib.example.com"
+        }
+
+        test("encode then decode round-trips an invite that carries a remote URL") {
+            val original =
+                ShareTarget.Invite(
+                    serverUrl = "http://192.168.1.5:8080",
+                    code = "JOIN9",
+                    remoteUrl = "https://lib.example.com",
+                )
+
+            ShareLinkCodec.decode(ShareLinkCodec.encode(original)) shouldBe original
+        }
+
+        test("decode of a link with no remote param yields a null remoteUrl (backward compatible)") {
+            val target =
+                ShareLinkCodec.decode(
+                    "https://link.listenup.audio/o?t=invite&server=http%3A%2F%2F192.168.1.5%3A8080&code=JOIN9",
+                )
+
+            target shouldBe ShareTarget.Invite(serverUrl = "http://192.168.1.5:8080", code = "JOIN9", remoteUrl = null)
+        }
+
         test("decode parses the https /o form for an invite") {
             val target =
                 ShareLinkCodec.decode(

--- a/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -140,6 +140,7 @@ fun ListenUpNavigation(
         JoinNavigation(
             serverUrl = invite.serverUrl,
             inviteCode = invite.code,
+            remoteUrl = invite.remoteUrl,
             onComplete = { deepLinkManager.consumeTarget() },
             onCancel = { deepLinkManager.consumeTarget() },
         )
@@ -233,6 +234,7 @@ private fun PendingApprovalNavigation(
 private fun JoinNavigation(
     serverUrl: String,
     inviteCode: String,
+    remoteUrl: String?,
     onComplete: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -241,6 +243,7 @@ private fun JoinNavigation(
         onCancel = onCancel,
         initialCode = inviteCode,
         serverUrl = serverUrl,
+        remoteUrl = remoteUrl,
     )
 }
 

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/invite/JoinScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/invite/JoinScreen.kt
@@ -75,16 +75,18 @@ fun JoinScreen(
     modifier: Modifier = Modifier,
     initialCode: String? = null,
     serverUrl: String? = null,
+    remoteUrl: String? = null,
     viewModel: ClaimInviteViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     // Deep-link entry contract: when a code arrives with the link, hand it to the
-    // ViewModel's start() so the server URL is persisted before the lookup fires,
-    // landing the user on Preview rather than an empty field.
-    LaunchedEffect(initialCode, serverUrl) {
+    // ViewModel's start() so a reachable server URL is persisted before the lookup fires,
+    // landing the user on Preview rather than an empty field. The link's optional remote
+    // URL rides along so an off-LAN invitee still connects (local-first, remote fallback).
+    LaunchedEffect(initialCode, serverUrl, remoteUrl) {
         if (!initialCode.isNullOrBlank()) {
-            viewModel.start(serverUrl = serverUrl, code = initialCode)
+            viewModel.start(serverUrl = serverUrl, code = initialCode, remoteUrl = remoteUrl)
         }
     }
 
@@ -166,7 +168,7 @@ private fun CodeEntryStep(
 @Composable
 private fun ClaimStep(
     preview: InvitePreview,
-    onClaim: (password: String, displayName: String?) -> Unit,
+    onClaim: (password: String, firstName: String, lastName: String) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -182,7 +184,8 @@ private fun ClaimStep(
     }
 
     var password by remember { mutableStateOf("") }
-    var displayName by remember { mutableStateOf(preview.displayName) }
+    var firstName by remember { mutableStateOf("") }
+    var lastName by remember { mutableStateOf("") }
     val focusManager = LocalFocusManager.current
 
     AuthScaffold(
@@ -195,9 +198,18 @@ private fun ClaimStep(
         InvitePreviewCard(preview)
 
         ListenUpTextField(
-            value = displayName,
-            onValueChange = { displayName = it },
-            label = "Display name",
+            value = firstName,
+            onValueChange = { firstName = it },
+            label = "First name",
+            leadingIcon = Icons.Outlined.Person,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
+        )
+
+        ListenUpTextField(
+            value = lastName,
+            onValueChange = { lastName = it },
+            label = "Last name",
             leadingIcon = Icons.Outlined.Person,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
@@ -215,15 +227,16 @@ private fun ClaimStep(
                 KeyboardActions(
                     onDone = {
                         focusManager.clearFocus()
-                        onClaim(password, displayName.ifBlank { null })
+                        onClaim(password, firstName, lastName)
                     },
                 ),
         )
 
         ListenUpButton(
-            onClick = { onClaim(password, displayName.ifBlank { null }) },
+            onClick = { onClaim(password, firstName, lastName) },
             text = "Get started",
             leadingIcon = Icons.AutoMirrored.Outlined.Login,
+            enabled = firstName.isNotBlank() && lastName.isNotBlank() && password.isNotBlank(),
         )
     }
 }


### PR DESCRIPTION
## Why

Invite links opened on iOS got stuck on the Server Select screen instead of routing into the claim flow. Root cause: SwiftUI's `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)` never fires for universal links in either warm- or cold-launch — the delivery hook that used to catch them (`.onOpenURL`) was removed in #921. Infrastructure and the AASA file were fine all along.

## What

- **iOS delivery fix** — re-add `.onOpenURL` so universal links are received again (warm + cold launch). Device-verified. (`ListenUpApp.swift`, `DeepLinkRouter.swift`, `DeepLinkRouterTests.swift`)
- **Claim name fields** — the claim-invite flow now collects first/last name, threaded through `ClaimInviteViewModel`, `JoinScreen`, and the iOS `ClaimInvite` views. (`ClaimInviteViewModel.kt`, `JoinScreen.kt`, `ClaimInviteView.swift`, wrapper)
- **Remote-URL link fallback** — `ShareLinkCodec` / `ShareTarget` gain a remote-URL fallback so links still resolve when the primary path doesn't apply. (`ShareLinkCodec.kt`, `ShareTarget.kt`, `AdminRepositoryImpl.kt`, `InviteMapper.kt`)

## Testing

- `ClaimInviteViewModelTest`, `ShareLinkCodecTest`, `DeepLinkRouterTests` updated/added.
- iOS delivery path verified on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)