### PR TITLE
🐛 fix(server): decode avatar upload multipart on the native server (KTOR-7361)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.kt
@@ -20,3 +20,20 @@ internal expect suspend fun ApplicationCall.streamFirstFilePartTo(
     dest: Path,
     formFieldLimit: Long,
 ): Boolean
+
+/**
+ * Receives a multipart request and returns the bytes of the first file part, or null when no file part
+ * is present. Non-file parts and any parts after the first are released and ignored. [formFieldLimit]
+ * caps the accepted size; a file part larger than it raises [MultipartPartTooLargeException] before it
+ * fully lands in memory. For small uploads (avatars) that must be buffered for magic-number validation
+ * — large streaming uploads use [streamFirstFilePartTo] instead.
+ *
+ * Platform note: the JVM runtime delegates to Ktor's `receiveMultipart`. Kotlin/Native's Ktor CIO
+ * server cannot parse multipart through that transform (JetBrains
+ * [KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)), so the native actual reads the raw
+ * body channel and decodes the wire format itself via [streamFirstFilePart]. Both runtimes serve
+ * uploads with identical behaviour.
+ *
+ * @throws MultipartPartTooLargeException if the file part exceeds [formFieldLimit].
+ */
+internal expect suspend fun ApplicationCall.receiveFirstFilePartBytes(formFieldLimit: Long): ByteArray?

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ProfileRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ProfileRoutes.kt
@@ -2,23 +2,21 @@ package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import com.calypsan.listenup.server.io.MultipartPartTooLargeException
+import com.calypsan.listenup.server.io.readBytes
+import com.calypsan.listenup.server.io.receiveFirstFilePartBytes
 import com.calypsan.listenup.server.media.ImageStore
 import com.calypsan.listenup.server.plugins.userPrincipalOrNull
 import com.calypsan.listenup.server.services.PublicProfileMaintainer
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.PartData
-import io.ktor.http.content.forEachPart
-import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import com.calypsan.listenup.server.io.readBytes
-import io.ktor.utils.io.toByteArray
 import kotlin.time.Clock
 import kotlinx.io.files.SystemFileSystem
 
@@ -45,27 +43,17 @@ fun Route.profileRoutes(
         val principal = call.userPrincipalOrNull() ?: return@post call.respond(HttpStatusCode.Unauthorized)
         val userId = principal.userId.value
 
-        var bytes: ByteArray? = null
-        var declared = ContentType.Application.OctetStream.toString()
-        var oversized = false
-        call.receiveMultipart().forEachPart { part ->
-            if (part is PartData.FileItem && bytes == null) {
-                val declaredLength = part.headers[HttpHeaders.ContentLength]?.toLongOrNull()
-                if (declaredLength != null && declaredLength > AVATAR_MAX_BYTES) {
-                    part.release()
-                    oversized = true
-                    return@forEachPart
-                }
-                declared = part.contentType?.toString() ?: declared
-                bytes = part.provider().toByteArray()
-            }
-            part.release()
-        }
-        if (oversized) return@post call.respond(HttpStatusCode.PayloadTooLarge)
-        val data = bytes ?: return@post call.respond(HttpStatusCode.BadRequest, "missing file part")
+        val data =
+            try {
+                call.receiveFirstFilePartBytes(AVATAR_MAX_BYTES)
+            } catch (e: MultipartPartTooLargeException) {
+                return@post call.respond(HttpStatusCode.PayloadTooLarge, "image exceeds ${e.limit} bytes")
+            } ?: return@post call.respond(HttpStatusCode.BadRequest, "missing file part")
 
+        // ImageStore validates by magic number, not the declared content type — the octet-stream
+        // default only surfaces in its invalid-image error text, so no per-part content type is read.
         try {
-            imageStore.store(userId, data, declared)
+            imageStore.store(userId, data, ContentType.Application.OctetStream.toString())
         } catch (e: ImageStore.InvalidImageException) {
             return@post call.respond(HttpStatusCode.UnprocessableEntity, e.message ?: "invalid image")
         }

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.jvm.kt
@@ -6,9 +6,11 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveMultipart
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readRemaining
+import kotlinx.io.Buffer
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
 
 /** Bounded read size for streaming an upload to disk — never holds the whole body in memory. */
 private const val UPLOAD_CHUNK_BYTES: Long = 64L * 1024
@@ -26,6 +28,33 @@ internal actual suspend fun ApplicationCall.streamFirstFilePartTo(
         part.release()
     }
     return received
+}
+
+internal actual suspend fun ApplicationCall.receiveFirstFilePartBytes(formFieldLimit: Long): ByteArray? {
+    var bytes: ByteArray? = null
+    // Ktor's default formFieldLimit (50 MiB) governs the transform; our own cap is enforced by
+    // readCappedBytes so it fires deterministically as MultipartPartTooLargeException regardless of
+    // how the engine treats file-part limits (matching the native decoder's contract).
+    receiveMultipart().forEachPart { part ->
+        if (part is PartData.FileItem && bytes == null) {
+            bytes = part.provider().readCappedBytes(formFieldLimit)
+        }
+        part.release()
+    }
+    return bytes
+}
+
+/** Reads this channel fully into memory, raising [MultipartPartTooLargeException] past [limit]. */
+private suspend fun ByteReadChannel.readCappedBytes(limit: Long): ByteArray {
+    val buffer = Buffer()
+    var total = 0L
+    while (true) {
+        val chunk = readRemaining(UPLOAD_CHUNK_BYTES)
+        if (chunk.exhausted()) break
+        total += buffer.transferFrom(chunk)
+        if (total > limit) throw MultipartPartTooLargeException(limit)
+    }
+    return buffer.readByteArray()
 }
 
 /** Streams this channel to [dest] in [UPLOAD_CHUNK_BYTES] chunks, never buffering the full payload. */

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/io/MultipartUpload.linux.kt
@@ -3,9 +3,11 @@ package com.calypsan.listenup.server.io
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.contentType
 import io.ktor.server.request.receiveChannel
+import kotlinx.io.Buffer
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
 
 /**
  * The Kotlin/Native Ktor CIO server cannot use Ktor's `receiveMultipart` transform (KTOR-7361), but
@@ -23,4 +25,18 @@ internal actual suspend fun ApplicationCall.streamFirstFilePartTo(
     return streamFirstFilePart(receiveChannel(), boundary, formFieldLimit) {
         SystemFileSystem.sink(dest).buffered()
     }
+}
+
+/**
+ * In-memory sibling of [streamFirstFilePartTo] for uploads that must be buffered for validation
+ * (avatars). Decodes the raw body channel with [streamFirstFilePart] into a [Buffer] — the CIO
+ * server's `receiveMultipart` transform is unavailable on Kotlin/Native (KTOR-7361).
+ */
+internal actual suspend fun ApplicationCall.receiveFirstFilePartBytes(formFieldLimit: Long): ByteArray? {
+    val boundary =
+        request.contentType().parameter("boundary")
+            ?: throw MalformedMultipartException("multipart/form-data request is missing a boundary parameter.")
+    val buffer = Buffer()
+    val received = streamFirstFilePart(receiveChannel(), boundary, formFieldLimit) { buffer }
+    return if (received) buffer.readByteArray() else null
 }

--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/io/MultipartUploadNativeTest.kt
@@ -35,6 +35,11 @@ import kotlin.test.Test
  * target is a CWD-relative path because the native test runner has no usable temp directory.
  */
 class MultipartUploadNativeTest {
+    private companion object {
+        const val RECEIVED = "received"
+        const val EMPTY = "empty"
+    }
+
     @Test
     fun nativeServerStreamsTheFirstFilePartToDisk(): Unit =
         runBlocking {
@@ -45,7 +50,7 @@ class MultipartUploadNativeTest {
                     routing {
                         post("/upload") {
                             val received = call.streamFirstFilePartTo(dest, formFieldLimit = 1L shl 20)
-                            call.respondText(if (received) "received" else "empty")
+                            call.respondText(if (received) RECEIVED else EMPTY)
                         }
                     }
                 }
@@ -74,12 +79,62 @@ class MultipartUploadNativeTest {
                         )
                     }
                 response.status shouldBe HttpStatusCode.OK
-                response.bodyAsText() shouldBe "received"
+                response.bodyAsText() shouldBe RECEIVED
                 SystemFileSystem.source(dest).buffered().use { it.readByteArray() } shouldBe payload
             } finally {
                 client.close()
                 server.stop(0, 0)
                 SystemFileSystem.delete(dest, mustExist = false)
+            }
+        }
+
+    @Test
+    fun nativeServerReadsTheFirstFilePartIntoMemory(): Unit =
+        runBlocking {
+            // The avatar route needs the first file part's bytes in memory (magic-number validation),
+            // not a stream to disk. The Kotlin/Native CIO server can't use `receiveMultipart`
+            // (KTOR-7361), so this exercises the raw-channel path over a real embeddedServer(CIO).
+            val payload = ByteArray(40_000) { (it * 13).toByte() }
+            var received: ByteArray? = null
+            val server =
+                embeddedServer(CIO, port = 0) {
+                    routing {
+                        post("/avatar") {
+                            received = call.receiveFirstFilePartBytes(formFieldLimit = 1L shl 20)
+                            call.respondText(if (received != null) RECEIVED else EMPTY)
+                        }
+                    }
+                }
+            server.start(wait = false)
+            val client = HttpClient(ClientCIO)
+            try {
+                val port =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
+                val response =
+                    client.post("http://127.0.0.1:$port/avatar") {
+                        setBody(
+                            MultiPartFormDataContent(
+                                formData {
+                                    append(
+                                        "file",
+                                        payload,
+                                        Headers.build {
+                                            append(HttpHeaders.ContentDisposition, "filename=\"avatar.png\"")
+                                        },
+                                    )
+                                },
+                            ),
+                        )
+                    }
+                response.status shouldBe HttpStatusCode.OK
+                response.bodyAsText() shouldBe RECEIVED
+                received shouldBe payload
+            } finally {
+                client.close()
+                server.stop(0, 0)
             }
         }
 }


### PR DESCRIPTION
## Bug
Uploading an avatar failed with `Cannot transform this request's content to io.ktor.http.content.MultiPartData` on the native server.

## Root cause
`POST /api/v1/profile/avatar` called `call.receiveMultipart()` directly. Kotlin/Native's Ktor CIO server can't run that transform ([KTOR-7361](https://youtrack.jetbrains.com/issue/KTOR-7361)) — the exact error the production (native) server threw. Backup/import routes already route around this via the `streamFirstFilePartTo` expect/actual (raw-body decoder); the avatar route was never migrated.

## Fix
Added an in-memory sibling `receiveFirstFilePartBytes(formFieldLimit)`:
- JVM actual → Ktor `receiveMultipart` + a size cap (`MultipartPartTooLargeException`).
- Native actual → decodes the raw body via the existing shared `streamFirstFilePart` into a `Buffer`.

`ImageStore` validates by magic number (not the declared content type), so the route only needs the first file part's bytes. Oversize → 413, missing part → 400, bad image → 422 (unchanged).

## Verification
- New native test drives a real `embeddedServer(CIO)` and asserts the bytes round-trip.
- JVM `ProfileRoutesTest` (204/413/422/401) + decoder tests green; detekt + spotless clean.