### PR TITLE
🐛 fix(server): attribute each scanned book to its own library folder

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/dto/scanner/AnalyzedBook.kt
@@ -62,6 +62,16 @@ data class AnalyzedBook(
      */
     val hasScanWarning: Boolean = false,
     val documents: List<AnalyzedDocument> = emptyList(),
+    /**
+     * Absolute filesystem root of the library folder this book was walked from — the anchor
+     * [candidate].rootRelPath is relative to. The persister resolves the book's `folder_id` and
+     * reads its cover from THIS root, so a multi-folder library attributes every book to its own
+     * folder (resolving one folder for the whole scan misplaces every non-primary-folder book,
+     * which then fails to serve — a 404). `null` on books produced before folder attribution;
+     * the persister falls back to the scan's primary root for those.
+     */
+    @SerialName("folderRootPath")
+    val folderRootPath: String? = null,
 )
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scanner/Scanner.kt
@@ -105,6 +105,10 @@ internal class Scanner(
         var totalFileCount = 0
         var totalCandidateCount = 0
         val folderRoots = mutableListOf<Path>()
+        // The ORIGINAL configured root-path string per folder — stamped onto each book below so the
+        // persister resolves folder_id by an exact library_folders.root_path match (a Path round-trip
+        // could differ). Parallel to [folderRoots].
+        val folderRootPaths = mutableListOf<String>()
         val candidatesPerFolder = mutableListOf<List<CandidateBook>>()
 
         for (folder in library.folders) {
@@ -115,6 +119,7 @@ internal class Scanner(
             totalFileCount += files.size
             totalCandidateCount += candidates.size
             folderRoots += folderRoot
+            folderRootPaths += rootPath
             candidatesPerFolder += candidates
         }
 
@@ -165,7 +170,9 @@ internal class Scanner(
                     folderRoots[i],
                     previousByPath,
                 )
-            allBooks += pass.books
+            // Stamp every book in this pass (fresh AND fingerprint-cache reuses) with its owning
+            // folder's root so the persister attributes it to the correct library_folders row.
+            allBooks += pass.books.map { it.copy(folderRootPath = folderRootPaths[i]) }
             allErrors += pass.errors
             authorsMatched += pass.authorsMatched
             totalDurationMs += pass.totalDurationMs
@@ -244,13 +251,13 @@ internal class Scanner(
             library.folders.firstOrNull { folder ->
                 folder.rootPath?.let { bookRoot.isUnder(Path(it)) } ?: false
             }
-        val folderRoot =
-            owningFolder?.rootPath?.let { Path(it) }
-                ?: library.folders
-                    .firstOrNull()
-                    ?.rootPath
-                    ?.let { Path(it) }
-                ?: bookRoot
+        // The ORIGINAL configured root-path string (exact library_folders.root_path) this subtree
+        // belongs to — stamped onto each book so the persister resolves the right folder_id.
+        val folderRootPath =
+            owningFolder?.rootPath
+                ?: library.folders.firstOrNull()?.rootPath
+                ?: bookRoot.toString()
+        val folderRoot = Path(folderRootPath)
 
         val walker = Walker()
         val rawFiles = walker.walk(bookRoot).toList()
@@ -279,7 +286,8 @@ internal class Scanner(
         // the untouched books are preserved via previousUntouched below.
         val previousByPath = lastResult?.books.orEmpty().associateBy { it.candidate.rootRelPath }
         val pass = collectAnalyzed(analyzer, candidates, correlationId, rebasedFiles.size, folderRoot, previousByPath)
-        val books = pass.books
+        // Stamp each book with its owning folder's root so the persister attributes it correctly.
+        val books = pass.books.map { it.copy(folderRootPath = folderRootPath) }
         val errors = pass.errors
 
         val (previousAffected, previousUntouched) =

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -113,10 +113,6 @@ class BookPersister internal constructor(
     internal suspend fun persist(result: ScanResult) {
         try {
             val libraryId = libraryRegistry.currentLibrary()
-            // Resolve the folder whose root_path matches the scan result's rootPath.
-            // Falls back to a sentinel folderId so a misconfigured folder doesn't
-            // block persistence; the TODO below tracks proper error surfacing.
-            val folderId = resolveFolderId(result.rootPath)
 
             // Suppress the per-book firehose PUBLISH for any BULK persist so the lossy live tail
             // (ChangeBus replay=256, DROP_OLDEST) never carries the burst — otherwise it overflows
@@ -132,9 +128,9 @@ class BookPersister internal constructor(
             try {
                 counts =
                     if (suppressFirehose) {
-                        withContext(FirehoseSuppressed) { persistAll(result, libraryId, folderId) }
+                        withContext(FirehoseSuppressed) { persistAll(result, libraryId) }
                     } else {
-                        persistAll(result, libraryId, folderId)
+                        persistAll(result, libraryId)
                     }
             } catch (e: OutOfMemoryError) {
                 // OOM means the JVM heap is compromised. We still emit Completed with the partial
@@ -182,7 +178,6 @@ class BookPersister internal constructor(
     private suspend fun persistAll(
         result: ScanResult,
         libraryId: LibraryId,
-        folderId: FolderId,
     ): PersistCounts {
         // Build the seen-paths set cheaply from the scan result — no DB, no per-book work.
         // This represents every rootRelPath present on disk at scan time.
@@ -198,9 +193,11 @@ class BookPersister internal constructor(
         fun coverBearing(change: AnalyzedBook): AnalyzedBook =
             coverBearingByPath[change.candidate.rootRelPath] ?: change
 
-        // Use the scan result's rootPath for filesystem cover reads — aligned
-        // with Analyzer's own path resolution (Analyzer.kt: rootPath.resolve(relPath)).
-        val scanRoot = Path(result.rootPath)
+        // Each book carries the absolute root of the folder it was walked from. A book's folder_id
+        // and its cover both resolve against THIS root — not the scan's primary rootPath — so a
+        // multi-folder library attributes every book to its own folder. Resolving one folder for the
+        // whole scan misplaced every non-primary-folder book, whose audio/cover then 404'd.
+        fun folderRootOf(book: AnalyzedBook): String = book.folderRootPath ?: result.rootPath
         // Resolve the library's system collection ONCE per scan: ALL_BOOKS when the inbox gate
         // is off (non-held), INBOX when it is on (held). The two cases are mutually exclusive —
         // a held book must never join ALL_BOOKS or it becomes visible to all members. A resolution
@@ -209,6 +206,9 @@ class BookPersister internal constructor(
         val systemCollectionId = resolveSystemCollectionId(libraryId)
         var persisted = 0
         var failed = 0
+        // Running failed count from folder groups already fully processed — the per-group callback adds
+        // its own in-flight failures on top for live progress ticks.
+        var failedBase = 0
 
         // Persistence is a visible phase, not a silent gap. The bar binds to booksAnalyzed/booksTotal
         // and hits 100% the instant ANALYZING ends; without these events the client would freeze at
@@ -240,7 +240,7 @@ class BookPersister internal constructor(
         val coversByBook =
             buildMap {
                 for (book in changedBooks) {
-                    extractPendingCover(book, scanRoot)?.let { put(book.candidate.rootRelPath, it) }
+                    extractPendingCover(book, Path(folderRootOf(book)))?.let { put(book.candidate.rootRelPath, it) }
                 }
             }
 
@@ -264,26 +264,39 @@ class BookPersister internal constructor(
         // Initial tick at 0 so the UI leaves the 100%-analyze state the moment persistence begins.
         if (toPersist > 0) emitPersistProgress(0)
 
-        // Batched persist: identity/genre/cover resolution + bulk existence in a suspend prepare phase,
-        // then chunked write transactions (O(chunks), not O(books)). The progress callback fires per
-        // chunk; we throttle emission to ~PERSIST_PROGRESS_TICKS ticks for a large library.
-        val persistResult =
-            ingest.resolveOrInsertAll(
-                libraryId = libraryId,
-                folderId = folderId,
-                books = changedBooks,
-                coversByBook = coversByBook,
-                systemCollectionId = systemCollectionId,
-                identityMaps = identityMaps,
-            ) { processed, failedSoFar ->
-                failed = failedSoFar
-                if (processed - lastTickAt >= persistProgressStride || processed == toPersist) {
-                    lastTickAt = processed
-                    emitPersistProgress(processed)
+        // Resolve every distinct owning-folder root to its FolderId ONCE (fallback sentinel per root
+        // handled by resolveFolderId).
+        val folderIdByRoot: Map<String, FolderId> =
+            changedBooks.mapTo(mutableSetOf(), ::folderRootOf).associateWith { resolveFolderId(it) }
+
+        // Batched persist, folder group by folder group so each book lands under the folder it was
+        // walked from. Within a group it is the same chunked O(chunks) write. Progress and counts
+        // accumulate across groups so the PERSISTING bar and the Completed summary stay whole-scan.
+        // (An OutOfMemoryError throws PersistAbortedByOom out of the group, carrying its own partial
+        // counts, so this accumulation only needs to be correct on the normal path.)
+        var processedBase = 0
+        for ((folderRoot, group) in changedBooks.groupBy(::folderRootOf)) {
+            val groupResult =
+                ingest.resolveOrInsertAll(
+                    libraryId = libraryId,
+                    folderId = folderIdByRoot.getValue(folderRoot),
+                    books = group,
+                    coversByBook = coversByBook,
+                    systemCollectionId = systemCollectionId,
+                    identityMaps = identityMaps,
+                ) { processedInGroup, failedInGroup ->
+                    val processedTotal = processedBase + processedInGroup
+                    failed = failedBase + failedInGroup
+                    if (processedTotal - lastTickAt >= persistProgressStride || processedTotal == toPersist) {
+                        lastTickAt = processedTotal
+                        emitPersistProgress(processedTotal)
+                    }
                 }
-            }
-        persisted = persistResult.persisted
-        failed = persistResult.failed
+            persisted += groupResult.persisted
+            failedBase += groupResult.failed
+            processedBase += group.size
+        }
+        failed = failedBase
 
         // Incremental Removed changes tombstone the book at their path immediately so deletions reflow
         // without waiting for the next Full scan. Idempotent: a no-op when the book is already deleted

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.domain.embeddedmeta.EmbeddedArtwork
 import com.calypsan.listenup.server.api.CollectionAccessPolicy
@@ -46,6 +47,65 @@ import kotlinx.coroutines.test.runTest
 
 class BookPersisterTest :
     FunSpec({
+
+        test("multi-folder scan persists each book under the folderId of ITS OWN folder") {
+            withSqlDatabase {
+                runTest {
+                    // One library, two folders at distinct roots. Each book carries the root it was
+                    // walked from; the persister must resolve folder_id per book from that root — not
+                    // one folder for the whole scan (the bug that 404'd every non-primary-folder book).
+                    val now = 0L
+                    sql.librariesQueries.insert(
+                        id = "lib",
+                        name = "L",
+                        metadata_precedence = "embedded",
+                        access_mode = "shared",
+                        created_by_user_id = null,
+                        created_at = now,
+                        revision = 0L,
+                        updated_at = now,
+                        deleted_at = null,
+                        client_op_id = null,
+                    )
+                    sql.libraryFoldersQueries.insert(
+                        id = "folder-a",
+                        library_id = "lib",
+                        root_path = "/mnt/A",
+                        created_at = now,
+                        revision = 0L,
+                        updated_at = now,
+                        deleted_at = null,
+                        client_op_id = null,
+                    )
+                    sql.libraryFoldersQueries.insert(
+                        id = "folder-b",
+                        library_id = "lib",
+                        root_path = "/mnt/B",
+                        created_at = now,
+                        revision = 0L,
+                        updated_at = now,
+                        deleted_at = null,
+                        client_op_id = null,
+                    )
+
+                    val fake = FakeBookIngest()
+                    val persister = persister(fake, scope = this)
+
+                    val bookA = analyzedBook("Book A").copy(folderRootPath = "/mnt/A")
+                    val bookB = analyzedBook("Book B").copy(folderRootPath = "/mnt/B")
+                    persister.persist(
+                        scanResult(
+                            books = listOf(bookA, bookB),
+                            changes = listOf(ChangeEventDto.Added(bookA), ChangeEventDto.Added(bookB)),
+                            scope = ScanScope.Full,
+                        ),
+                    )
+
+                    fake.folderIdByPath["Book A"] shouldBe FolderId("folder-a")
+                    fake.folderIdByPath["Book B"] shouldBe FolderId("folder-b")
+                }
+            }
+        }
 
         test("persists changed books from ScanResult.changes") {
             withSqlDatabase {
@@ -602,6 +662,9 @@ private class FakeBookIngest(
     /** The [AnalyzedBook.cover] each [resolveOrInsert] saw, keyed by rootRelPath. */
     val coverByPath = mutableMapOf<String, CoverSource?>()
 
+    /** The [com.calypsan.listenup.core.FolderId] each [resolveOrInsert] saw, keyed by rootRelPath. */
+    val folderIdByPath = mutableMapOf<String, com.calypsan.listenup.core.FolderId>()
+
     /** seenPaths sets passed to each [softDeleteAbsentByPaths] call. */
     val softDeleteAbsentByPathsCalls = mutableListOf<Set<String>>()
 
@@ -634,6 +697,7 @@ private class FakeBookIngest(
         suppressionObserved += currentCoroutineContext()[FirehoseSuppressed.Key] != null
         val path = analyzed.candidate.rootRelPath
         coverByPath[path] = analyzed.cover
+        folderIdByPath[path] = folderId
         if (path in oomForRootRelPath) {
             throw OutOfMemoryError("simulated OOM for $path")
         }


### PR DESCRIPTION
## Bug
In a multi-folder library, playing a book from any folder other than the first crashed the player: the server returned **404** for the audio stream (`Audio file not found`), and the book's cover was missing.

## Root cause (confirmed against a live DB)
Every book was attributed to the **first** library folder. `Scanner.runFullScan` walks each folder with its own root (so each book's `rootRelPath` is correct *for its folder*) but aggregates all books into one `ScanResult` stamped with `rootPath = primaryRootPath`; `BookPersister` then resolved a single `folder_id` from that and wrote it onto **every** book. Books outside the primary folder resolved to `<primaryRoot>/<relPath>` — a nonexistent path → 404 on audio, and cover extraction read from the wrong root.

## Fix
Each `AnalyzedBook` now carries its owning `folderRootPath` (stamped per folder pass in `runFullScan`/`runIncremental`). `BookPersister` resolves `folder_id` and reads covers **per book**, grouping the batched persist by folder so each book lands under the folder it was walked from.

## Follow-up (out of scope)
The scan pipeline still keys books by `rootRelPath` alone (Differ, fingerprint cache, cover map, tombstone sweep), which would collide if two folders shared a relative path. Deferred.

## Verification
`:server:jvmTest` green including a new multi-folder persister test; existing scanner/persister tests unchanged; native compile green; DTO Konsist (`:sharedLogic:jvmTest`) green.