### PR TITLE
🐛 fix(shared): make the offline outbox drain completely and survive poison ops

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -67,7 +67,12 @@ internal interface PendingOperationV2Dao {
            AND failureCount <= :maxAttempts
         """,
     )
-    suspend fun deleteQueuedOps(domainName: String, entityId: String, opType: String, maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS)
+    suspend fun deleteQueuedOps(
+        domainName: String,
+        entityId: String,
+        opType: String,
+        maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS,
+    )
 
     @Query("DELETE FROM pending_operation WHERE ownerUserId != :keepUserId")
     suspend fun deleteAllExcept(keepUserId: String)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -53,6 +53,22 @@ internal interface PendingOperationV2Dao {
     @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount > :maxAttempts")
     fun observeFailureCount(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<Int>
 
+    /**
+     * Delete still-queued (within retry budget) ops for one (domain, entity, opType) slot.
+     * Backs replace-on-enqueue coalescing; terminally-failed rows (failureCount > [maxAttempts])
+     * are preserved — diagnostic state for the failed-operation surface, not superseded work.
+     */
+    @Query(
+        """
+        DELETE FROM pending_operation
+         WHERE domainName = :domainName
+           AND entityId = :entityId
+           AND opType = :opType
+           AND failureCount <= :maxAttempts
+        """,
+    )
+    suspend fun deleteQueuedOps(domainName: String, entityId: String, opType: String, maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS)
+
     @Query("DELETE FROM pending_operation WHERE ownerUserId != :keepUserId")
     suspend fun deleteAllExcept(keepUserId: String)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -43,6 +43,10 @@ internal interface PendingOperationV2Dao {
     )
     suspend fun nextDispatchable(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): List<PendingOperationV2Entity>
 
+    /** Count of ops still within retry budget — i.e. rows a future drain wave could dispatch. */
+    @Query("SELECT COUNT(*) FROM pending_operation WHERE failureCount <= :maxAttempts")
+    suspend fun countDispatchable(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Int
+
     @Query("SELECT COUNT(*) FROM pending_operation")
     fun observeQueueDepth(): Flow<Int>
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -32,8 +32,9 @@ private val logger = KotlinLogging.logger {}
  *
  * After each position-moving write, enqueues a [RecordPositionRequest] onto the
  * pending-operation queue so the sync engine pushes the updated position to the server.
- * Per-`(domain, entityId)` queue coalescing means rapid successive writes for one book
- * collapse to the latest — no flooding.
+ * Enqueues with `coalesce = true`: rapid successive writes for one book replace the
+ * still-queued op for that `(domain, entityId, opType)` slot instead of piling up, so
+ * only the latest position is ever pushed — no flooding.
  *
  * The [savePlaybackState] entry point owns per-book Mutex serialization
  * plus per-call transactional dispatch over the 11-variant [PlaybackUpdate]
@@ -277,6 +278,7 @@ internal class PlaybackPositionRepositoryImpl(
                 opType = "upsert",
                 payload = contractJson.encodeToString(RecordPositionRequest.serializer(), request),
                 ownerUserId = userId,
+                coalesce = true,
             )
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -32,7 +32,7 @@ private val logger = KotlinLogging.logger {}
  *
  * After each position-moving write, enqueues a [RecordPositionRequest] onto the
  * pending-operation queue so the sync engine pushes the updated position to the server.
- * Enqueues with `coalesce = true`: rapid successive writes for one book replace the
+ * Enqueues with coalescing on: rapid successive writes for one book replace the
  * still-queued op for that `(domain, entityId, opType)` slot instead of piling up, so
  * only the latest position is ever pushed — no flooding.
  *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventOpSender.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventOpSender.kt
@@ -2,9 +2,11 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.RecordListeningEventRequest
+import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
+import kotlinx.coroutines.CancellationException
 
 /**
  * Pushes a queued listening-event write to the server via
@@ -16,14 +18,24 @@ import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
  *
  * The [PendingOperation.payload] is a JSON-encoded [RecordListeningEventRequest].
  * The sender decodes it at dispatch time (not enqueue time) so the queue row is the
- * single durable representation of the pending write.
+ * single durable representation of the pending write. A corrupt/schema-drifted
+ * payload is surfaced as a [SyncError.SyncFailed] failure rather than thrown, so
+ * the drain wave can quarantine the op instead of aborting on the decode.
  */
 internal class ListeningEventOpSender(
     private val rpcFactory: PlaybackRpcFactory,
 ) : PendingOperationSender {
     override suspend fun send(op: PendingOperation): AppResult<Unit> {
         val request =
-            contractJson.decodeFromString(RecordListeningEventRequest.serializer(), op.payload)
+            try {
+                contractJson.decodeFromString(RecordListeningEventRequest.serializer(), op.payload)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                return AppResult.Failure(
+                    SyncError.SyncFailed(debugInfo = "failed to decode 'listening_events' payload: ${e.message}"),
+                )
+            }
         return when (val result = rpcFactory.playbackService().recordListeningEvent(request)) {
             is WireAppResult.Success -> AppResult.Success(Unit)
             is WireAppResult.Failure -> AppResult.Failure(result.error)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -28,11 +28,17 @@ internal const val MAX_RETRYABLE_ATTEMPTS = 5
  *   `failureCount` incremented, will be picked up by a future drain)
  * @property terminalFailures count of ops that failed non-retryably (flagged
  *   past [MAX_RETRYABLE_ATTEMPTS] and will not be retried)
+ * @property remainingDispatchable count of ops still within retry budget after this
+ *   wave — includes ops held back by per-entity FIFO (a second op queued behind
+ *   one just sent) AND this wave's own retryable failures (still eligible, just
+ *   not yet retried). The engine uses this to decide whether looping `drain()`
+ *   again immediately would make further progress.
  */
 internal data class DrainOutcome(
     val sent: Int,
     val retryableFailures: Int,
     val terminalFailures: Int,
+    val remainingDispatchable: Int,
 ) {
     /** True when this wave produced at least one retryable failure that the engine should reschedule. */
     val hasRetryableFailures: Boolean get() = retryableFailures > 0
@@ -201,6 +207,7 @@ internal class PendingOperationQueue(
             sent = sent,
             retryableFailures = retryableFailures,
             terminalFailures = terminalFailures,
+            remainingDispatchable = dao.countDispatchable(),
         )
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -136,6 +137,11 @@ internal class PendingOperationQueue(
      * One call = one wave. Caller schedules subsequent waves; drain() does not
      * loop. Returns a [DrainOutcome] so the engine can decide whether a retry
      * backoff is warranted.
+     *
+     * A [PendingOperationSender] that throws instead of returning
+     * [AppResult.Failure] is a bug in that sender, not a reason to abort the
+     * wave — the op is flagged terminally failed (past [MAX_RETRYABLE_ATTEMPTS])
+     * and the loop continues to the next op.
      */
     suspend fun drain(): DrainOutcome {
         val ops = dao.nextDispatchable()
@@ -144,7 +150,23 @@ internal class PendingOperationQueue(
         var terminalFailures = 0
         for (entity in ops) {
             val op = entity.toDomain()
-            val result = sender.send(op)
+            val result =
+                try {
+                    sender.send(op)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.error(e) { "Sender threw for op ${op.clientOpId} (${op.domainName}); flagging terminal" }
+                    dao.update(
+                        entity.copy(
+                            failureCount = MAX_RETRYABLE_ATTEMPTS + 1,
+                            lastAttemptAt = nowMillis(),
+                            lastError = e::class.simpleName ?: "SenderException",
+                        ),
+                    )
+                    terminalFailures++
+                    continue
+                }
             when (result) {
                 is AppResult.Success -> {
                     dao.delete(op.clientOpId)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -87,14 +87,30 @@ internal class PendingOperationQueue(
      */
     fun observeEnqueueSignal(): StateFlow<Long> = enqueueCounter.asStateFlow()
 
-    /** Enqueue a new op. Returns its generated `clientOpId`. */
+    /**
+     * Enqueue a new op. Returns its generated `clientOpId`.
+     *
+     * @param coalesce When true, deletes any still-queued (within retry budget) op for the same
+     *   (domainName, entityId, opType) slot before inserting — so rapid successive writes for one
+     *   entity collapse to the latest snapshot instead of piling up. Valid only for domains where
+     *   the payload is a last-write-wins snapshot of current state (e.g. playback positions);
+     *   event/entity-PATCH domains keep the default `false` so every op is replayed. Terminally
+     *   failed rows are never coalesced away — see [PendingOperationV2Dao.deleteQueuedOps]. The
+     *   delete-then-insert is non-atomic: the one coalescing caller today serializes per entity on
+     *   a Mutex, and racing a concurrent drain is benign (Room `@Update`/`@Delete` on an
+     *   already-removed row is a silent no-op).
+     */
     suspend fun enqueue(
         domainName: String,
         entityId: String,
         opType: String,
         payload: String,
         ownerUserId: String,
+        coalesce: Boolean = false,
     ): String {
+        if (coalesce) {
+            dao.deleteQueuedOps(domainName, entityId, opType)
+        }
         val opId = Uuid.random().toString()
         dao.insert(
             PendingOperationV2Entity(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PlaybackPositionOpSender.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PlaybackPositionOpSender.kt
@@ -2,9 +2,11 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.RecordPositionRequest
+import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
+import kotlinx.coroutines.CancellationException
 
 /**
  * Pushes a queued playback-position write to the server via
@@ -16,14 +18,24 @@ import com.calypsan.listenup.client.data.remote.PlaybackRpcFactory
  *
  * The [PendingOperation.payload] is a JSON-encoded [RecordPositionRequest]. The
  * sender decodes it at dispatch time (not enqueue time) so the queue row is the
- * single durable representation of the pending write.
+ * single durable representation of the pending write. A corrupt/schema-drifted
+ * payload is surfaced as a [SyncError.SyncFailed] failure rather than thrown, so
+ * the drain wave can quarantine the op instead of aborting on the decode.
  */
 internal class PlaybackPositionOpSender(
     private val rpcFactory: PlaybackRpcFactory,
 ) : PendingOperationSender {
     override suspend fun send(op: PendingOperation): AppResult<Unit> {
         val request =
-            contractJson.decodeFromString(RecordPositionRequest.serializer(), op.payload)
+            try {
+                contractJson.decodeFromString(RecordPositionRequest.serializer(), op.payload)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                return AppResult.Failure(
+                    SyncError.SyncFailed(debugInfo = "failed to decode 'playback_positions' payload: ${e.message}"),
+                )
+            }
         return when (val result = rpcFactory.playbackService().recordPosition(request)) {
             is WireAppResult.Success -> AppResult.Success(Unit)
             is WireAppResult.Failure -> AppResult.Failure(result.error)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -671,32 +671,45 @@ internal class SyncEngine(
     }
 
     /**
-     * Run one drain wave under [drainMutex] so concurrent triggers (connect-up,
-     * enqueue, retry) coalesce. If the wave produced retryable failures,
-     * schedule a backoff-delayed re-drain — that's the engine's retry timer.
-     * Non-retryable failures stay flagged past `MAX_RETRYABLE_ATTEMPTS` and
-     * are silently skipped on subsequent waves.
+     * Drain the outbox to empty in response to a single trigger (connect-up,
+     * enqueue, retry). A single [PendingOperationQueue.drain] wave dispatches
+     * only one op per (domain, entityId) group, so a per-entity backlog of N
+     * queued ops needs N waves to fully drain — loop immediately as long as a
+     * wave made progress (something sent or terminally quarantined) and more
+     * dispatchable ops remain beyond this wave's own retryable failures.
+     *
+     * Each wave runs under [drainMutex] so concurrent triggers (connect-up,
+     * enqueue, retry) coalesce. If the loop exits with retryable failures still
+     * outstanding, schedule a backoff-delayed re-drain — that's the engine's
+     * retry timer. Non-retryable failures stay flagged past
+     * `MAX_RETRYABLE_ATTEMPTS` and are silently skipped on subsequent waves.
      */
     private suspend fun runDrain() {
-        val outcome =
-            drainMutex.withLock {
-                try {
-                    queue.drain()
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Re-throwing here would tear down the trigger collector
-                    // and silently stop all future drains. Log and continue —
-                    // a future trigger will re-attempt.
-                    logger.warn(e) { "Drain wave failed unexpectedly; will retry on next trigger" }
-                    return
+        while (true) {
+            val outcome =
+                drainMutex.withLock {
+                    try {
+                        queue.drain()
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // Re-throwing here would tear down the trigger collector
+                        // and silently stop all future drains. Log and continue —
+                        // a future trigger will re-attempt.
+                        logger.warn(e) { "Drain wave failed unexpectedly; will retry on next trigger" }
+                        return
+                    }
+                }
+            val madeProgress = outcome.sent > 0 || outcome.terminalFailures > 0
+            val backlogBeyondThisWavesFailures = outcome.remainingDispatchable > outcome.retryableFailures
+            if (madeProgress && backlogBeyondThisWavesFailures) continue
+            if (outcome.hasRetryableFailures) {
+                scope.launch {
+                    delay(retryBackoffMillis)
+                    runDrain()
                 }
             }
-        if (outcome.hasRetryableFailures) {
-            scope.launch {
-                delay(retryBackoffMillis)
-                runDrain()
-            }
+            return
         }
     }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -74,6 +74,8 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
 
     override suspend fun nextDispatchable(maxAttempts: Int): List<PendingOperationV2Entity> = inserted.toList()
 
+    override suspend fun countDispatchable(maxAttempts: Int): Int = inserted.count { it.failureCount <= maxAttempts }
+
     override fun observeQueueDepth(): Flow<Int> = flowOf(inserted.size)
 
     override fun observeFailureCount(maxAttempts: Int): Flow<Int> = flowOf(0)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -76,6 +76,17 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
 
     override suspend fun countDispatchable(maxAttempts: Int): Int = inserted.count { it.failureCount <= maxAttempts }
 
+    override suspend fun deleteQueuedOps(
+        domainName: String,
+        entityId: String,
+        opType: String,
+        maxAttempts: Int,
+    ) {
+        inserted.removeAll {
+            it.domainName == domainName && it.entityId == entityId && it.opType == opType && it.failureCount <= maxAttempts
+        }
+    }
+
     override fun observeQueueDepth(): Flow<Int> = flowOf(inserted.size)
 
     override fun observeFailureCount(maxAttempts: Int): Flow<Int> = flowOf(0)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventOpSenderTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventOpSenderTest.kt
@@ -87,6 +87,20 @@ class ListeningEventOpSenderTest :
                 failure.error shouldBe expectedError
             }
         }
+
+        test("a corrupt payload returns AppResult.Failure instead of throwing") {
+            runTest {
+                val service: PlaybackService = mock()
+                val rpcFactory: PlaybackRpcFactory = mock()
+                everySuspend { rpcFactory.playbackService() } returns service
+                val sender = ListeningEventOpSender(rpcFactory)
+                val op = fakeOp(payload = "{ not json ]")
+                val result = sender.send(op)
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<SyncError.SyncFailed>()
+                verifySuspend(exactly(0)) { service.recordListeningEvent(any()) }
+            }
+        }
     })
 
 private fun fakeOp(payload: String): PendingOperation =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -188,4 +188,27 @@ class PendingOperationQueueTest :
                 db.close()
             }
         }
+
+        test("drain reports remaining dispatchable ops in DrainOutcome") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var clock = 0L
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { clock++ },
+                    )
+                queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                queue.enqueue("tags", "t2", "upsert", "{}", "u1")
+                val first = queue.drain()
+                first.sent shouldBe 2
+                first.remainingDispatchable shouldBe 1
+                val second = queue.drain()
+                second.sent shouldBe 1
+                second.remainingDispatchable shouldBe 0
+                db.close()
+            }
+        }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -163,4 +163,29 @@ class PendingOperationQueueTest :
                 db.close()
             }
         }
+
+        test("a sender that throws is flagged terminally failed and the wave continues") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val sent = mutableListOf<String>()
+                val sender =
+                    PendingOperationSender { op ->
+                        if (op.entityId == "poison") error("sender blew up")
+                        sent += op.clientOpId
+                        AppResult.Success(Unit)
+                    }
+                var clock = 0L
+                val queue = PendingOperationQueue(dao = db.pendingOperationV2Dao(), sender = sender, nowMillis = { clock++ })
+                val poison = queue.enqueue("tags", "poison", "upsert", "{}", "u1")
+                val healthy = queue.enqueue("tags", "healthy", "upsert", "{}", "u1")
+                val outcome = queue.drain()
+                sent shouldContainExactly listOf(healthy)
+                outcome.sent shouldBe 1
+                outcome.terminalFailures shouldBe 1
+                val stored = db.pendingOperationV2Dao().get(poison)
+                stored shouldNotBe null
+                ((stored?.failureCount ?: 0) > 5) shouldBe true
+                db.close()
+            }
+        }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.sync
 import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.PendingOperationV2Entity
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -208,6 +209,44 @@ class PendingOperationQueueTest :
                 val second = queue.drain()
                 second.sent shouldBe 1
                 second.remainingDispatchable shouldBe 0
+                db.close()
+            }
+        }
+
+        test("enqueue with coalesce=true keeps only the latest queued op for the same (domain, entity, opType)") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var clock = 0L
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { clock++ },
+                    )
+                val stale = queue.enqueue("playback_positions", "b1", "upsert", """{"v":1}""", "u1", coalesce = true)
+                val other = queue.enqueue("playback_positions", "b2", "upsert", """{"v":9}""", "u1", coalesce = true)
+                val latest = queue.enqueue("playback_positions", "b1", "upsert", """{"v":2}""", "u1", coalesce = true)
+                db.pendingOperationV2Dao().get(stale) shouldBe null
+                db.pendingOperationV2Dao().get(other) shouldNotBe null
+                db.pendingOperationV2Dao().get(latest)?.payload shouldBe """{"v":2}"""
+                db.pendingOperationV2Dao().countDispatchable() shouldBe 2
+                db.close()
+            }
+        }
+
+        test("coalescing enqueue preserves terminally-failed rows") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                db.pendingOperationV2Dao().insert(
+                    PendingOperationV2Entity(
+                        clientOpId = "terminal-1", domainName = "playback_positions", entityId = "b1",
+                        opType = "upsert", payload = "{}", enqueuedAt = 1L, lastAttemptAt = 2L,
+                        failureCount = 6, lastError = "SYNC_FAILED", ownerUserId = "u1",
+                    ),
+                )
+                val queue = PendingOperationQueue(dao = db.pendingOperationV2Dao(), sender = PendingOperationSender { AppResult.Success(Unit) }, nowMillis = { 1_000L })
+                queue.enqueue("playback_positions", "b1", "upsert", "{}", "u1", coalesce = true)
+                db.pendingOperationV2Dao().get("terminal-1") shouldNotBe null
                 db.close()
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -239,12 +239,24 @@ class PendingOperationQueueTest :
                 val db = createInMemoryTestDatabase()
                 db.pendingOperationV2Dao().insert(
                     PendingOperationV2Entity(
-                        clientOpId = "terminal-1", domainName = "playback_positions", entityId = "b1",
-                        opType = "upsert", payload = "{}", enqueuedAt = 1L, lastAttemptAt = 2L,
-                        failureCount = 6, lastError = "SYNC_FAILED", ownerUserId = "u1",
+                        clientOpId = "terminal-1",
+                        domainName = "playback_positions",
+                        entityId = "b1",
+                        opType = "upsert",
+                        payload = "{}",
+                        enqueuedAt = 1L,
+                        lastAttemptAt = 2L,
+                        failureCount = 6,
+                        lastError = "SYNC_FAILED",
+                        ownerUserId = "u1",
                     ),
                 )
-                val queue = PendingOperationQueue(dao = db.pendingOperationV2Dao(), sender = PendingOperationSender { AppResult.Success(Unit) }, nowMillis = { 1_000L })
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { 1_000L },
+                    )
                 queue.enqueue("playback_positions", "b1", "upsert", "{}", "u1", coalesce = true)
                 db.pendingOperationV2Dao().get("terminal-1") shouldNotBe null
                 db.close()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -378,6 +378,13 @@ private class CountingDao(
 
     override suspend fun countDispatchable(maxAttempts: Int) = delegate.countDispatchable(maxAttempts)
 
+    override suspend fun deleteQueuedOps(
+        domainName: String,
+        entityId: String,
+        opType: String,
+        maxAttempts: Int,
+    ) = delegate.deleteQueuedOps(domainName, entityId, opType, maxAttempts)
+
     override fun observeQueueDepth() = delegate.observeQueueDepth()
 
     override fun observeFailureCount(maxAttempts: Int) = delegate.observeFailureCount(maxAttempts)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -254,6 +255,34 @@ class PendingQueueDrainSchedulingTest :
                     scope.cancel()
                     scope.coroutineContext.job.children
                         .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("a multi-op backlog for one entity fully drains after a single Connected transition") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val sent = MutableSharedFlow<String>(replay = 64)
+                    val sender = PendingOperationSender { op -> sent.tryEmit(op.clientOpId); AppResult.Success(Unit) }
+                    val clock = AtomicLong(0)
+                    val queue = PendingOperationQueue(dao = db.pendingOperationV2Dao(), sender = sender, nowMillis = { clock.incrementAndGet() })
+                    val state = SyncEngineState()
+                    val sse = FakeSseClient(state)
+                    val engine = buildEngine(db, queue, state, sse, scope)
+                    val a = queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                    val b = queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                    val c = queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                    engine.start(currentUserId = "u1")
+                    withTimeout(TIMEOUT_SECONDS.seconds) { sent.first { it == c } }
+                    db.pendingOperationV2Dao().get(a) shouldBe null
+                    db.pendingOperationV2Dao().get(b) shouldBe null
+                    db.pendingOperationV2Dao().get(c) shouldBe null
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children.forEach { it.join() }
                     db.close()
                 }
             }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -266,9 +266,18 @@ class PendingQueueDrainSchedulingTest :
                 val db = createInMemoryTestDatabase()
                 try {
                     val sent = MutableSharedFlow<String>(replay = 64)
-                    val sender = PendingOperationSender { op -> sent.tryEmit(op.clientOpId); AppResult.Success(Unit) }
+                    val sender =
+                        PendingOperationSender { op ->
+                            sent.tryEmit(op.clientOpId)
+                            AppResult.Success(Unit)
+                        }
                     val clock = AtomicLong(0)
-                    val queue = PendingOperationQueue(dao = db.pendingOperationV2Dao(), sender = sender, nowMillis = { clock.incrementAndGet() })
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                            nowMillis = { clock.incrementAndGet() },
+                        )
                     val state = SyncEngineState()
                     val sse = FakeSseClient(state)
                     val engine = buildEngine(db, queue, state, sse, scope)
@@ -282,7 +291,8 @@ class PendingQueueDrainSchedulingTest :
                     db.pendingOperationV2Dao().get(c) shouldBe null
                 } finally {
                     scope.cancel()
-                    scope.coroutineContext.job.children.forEach { it.join() }
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
                     db.close()
                 }
             }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -347,6 +347,8 @@ private class CountingDao(
         return delegate.nextDispatchable(maxAttempts)
     }
 
+    override suspend fun countDispatchable(maxAttempts: Int) = delegate.countDispatchable(maxAttempts)
+
     override fun observeQueueDepth() = delegate.observeQueueDepth()
 
     override fun observeFailureCount(maxAttempts: Int) = delegate.observeFailureCount(maxAttempts)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PlaybackPositionOpSenderTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PlaybackPositionOpSenderTest.kt
@@ -81,6 +81,20 @@ class PlaybackPositionOpSenderTest :
                 failure.error shouldBe expectedError
             }
         }
+
+        test("a corrupt payload returns AppResult.Failure instead of throwing") {
+            runTest {
+                val service: PlaybackService = mock()
+                val rpcFactory: PlaybackRpcFactory = mock()
+                everySuspend { rpcFactory.playbackService() } returns service
+                val sender = PlaybackPositionOpSender(rpcFactory)
+                val op = fakeOp(payload = "{ not json ]")
+                val result = sender.send(op)
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<SyncError.SyncFailed>()
+                verifySuspend(exactly(0)) { service.recordPosition(any()) }
+            }
+        }
     })
 
 private fun fakeOp(payload: String): PendingOperation =


### PR DESCRIPTION
Fixes three defects in the offline pending-operation outbox (from the /improve batch-5 audit, plan 054).

**Problems**
1. **Drain never fully drains a per-entity backlog** — one reconnect sent only the *oldest* queued op per (domain, entityId); the newest could never reach the server, silently regressing playback position across devices.
2. **A poison payload permanently stalled the whole outbox** — the position/listening-event senders decoded JSON unguarded; a decode throw aborted the drain wave and, since dispatch is `enqueuedAt`-ordered, that op re-threw on every future wave, blocking everything behind it.
3. **False coalescing KDoc** — the position repo claimed per-entity coalescing that did not exist; rapid writes flooded the queue.

**Fix**
- `runDrain()` now loops until the dispatchable backlog is empty (with a no-hot-loop guard: progress required + retryable-only remainders take the backoff path).
- Both event/position senders guard decode (rethrow `CancellationException`, else typed `SyncError.SyncFailed`); `drain()` gained a defensive per-op catch that quarantines any sender that throws.
- Real replace-on-enqueue coalescing for the `playback_positions` domain (opt-in `coalesce` flag; event/entity domains keep every op).

**Tests**: 7 new (Kotest, jvmTest) — headline: a 3-op single-entity backlog fully drains after one Connected transition; poison payload → Failure, RPC never called; coalescing keeps only the latest + preserves terminally-failed rows.

**Verification (reviewer-run)**: `:sharedLogic:jvmTest` ✅, `:sharedLogic:compileCommonMainKotlinMetadata` ✅, `spotlessCheck detekt` ✅. No Room schema change.