### PR TITLE
🐛 fix(server): don't reset streaks on late-arriving listening events

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
@@ -118,7 +118,9 @@ class StatsRecorder(
      * `LISTENING_SESSION` emission is folded in from [ListeningEventRepository.upsert]'s former
      * caller-side hook. The `user_stats` upsert, refresh, and milestone activity are skipped under
      * [StatsCascadeDeferred] (stale base totals mid-import would misfire milestones); the
-     * `LISTENING_SESSION` row still fires, historically dated.
+     * `LISTENING_SESSION` row still fires, historically dated. A late-arriving event (older than
+     * the stored `lastEventDate`) leaves the streak and `lastEventDate` untouched — see the guard
+     * below.
      */
     private suspend fun recordListeningSessionClosed(event: StatsEvent.ListeningSessionClosed) {
         val userId = event.userId
@@ -127,17 +129,28 @@ class StatsRecorder(
             val wallSeconds = (span.endedAt - span.startedAt) / 1_000L
             val tz = sql.homeTimeZone(userId)
             val eventInstant = Instant.fromEpochMilliseconds(span.endedAt)
-            val eventDateStr = eventInstant.toLocalDateTime(tz).date.toString()
+            val eventDate = eventInstant.toLocalDateTime(tz).date
 
             val existing = userStatsRepo.getForUser(userId)
+            val base = existing ?: emptyStatsFor(userId)
+
+            // A late-arriving event (offline-outbox replay after another device recorded newer
+            // events) must not rewind lastEventDate or reset the streak: streak math is
+            // path-dependent and never self-heals, unlike the as-of-now window sums below.
+            val lastDate = base.lastEventDate?.let(LocalDate::parse)
+            val isLateArrival = lastDate != null && eventDate < lastDate
+
             val isFirstEventForBook = !hasOtherEventForBook(userId, span.bookId, excludingId = span.id)
             val newCurrentStreak =
-                newStreakValue(existing?.lastEventDate, eventDateStr, existing?.currentStreakDays ?: 0)
+                if (isLateArrival) {
+                    base.currentStreakDays
+                } else {
+                    newStreakValue(base.lastEventDate, eventDate.toString(), base.currentStreakDays)
+                }
             val nowMs = clock.now().toEpochMilliseconds()
             val last7 = sumWindowSeconds(userId, days = 7, asOfMs = nowMs)
             val last30 = sumWindowSeconds(userId, days = 30, asOfMs = nowMs)
 
-            val base = existing ?: emptyStatsFor(userId)
             val updated =
                 base.copy(
                     totalSecondsAllTime = base.totalSecondsAllTime + wallSeconds,
@@ -146,7 +159,7 @@ class StatsRecorder(
                     booksStarted = base.booksStarted + if (isFirstEventForBook) 1 else 0,
                     currentStreakDays = newCurrentStreak,
                     longestStreakDays = max(base.longestStreakDays, newCurrentStreak),
-                    lastEventDate = eventDateStr,
+                    lastEventDate = if (isLateArrival) base.lastEventDate else eventDate.toString(),
                 )
             userStatsRepo.upsert(updated, clientOpId = null, userId = userId)
             publicProfileMaintainer.refresh(userId)
@@ -201,7 +214,9 @@ class StatsRecorder(
 
     /**
      * New `currentStreakDays` given the prior `lastEventDate`, the new event's date, and the prior
-     * streak count. Moved verbatim from [UserStatsUpdater.newStreakValue].
+     * streak count. Moved verbatim from [UserStatsUpdater.newStreakValue]. Callers guard against
+     * `eventDate` being older than `lastEventDate` (a late-arriving event) before calling this —
+     * the `else -> 1` branch here is reached only for a genuine forward gap.
      */
     private fun newStreakValue(
         lastEventDate: String?,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderStreakOrderingTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderStreakOrderingTest.kt
@@ -1,0 +1,205 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.dto.activity.ActivityType
+import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.PublicProfileRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression coverage for late-arriving listening events (offline-outbox replay landing an
+ * older-dated event after a newer one already updated `user_stats`). Streak math is
+ * path-dependent — unlike the as-of-now window sums, it never self-heals — so a late arrival
+ * must leave `currentStreakDays` and `lastEventDate` untouched.
+ */
+class StatsRecorderStreakOrderingTest :
+    FunSpec({
+
+        val day0Ms = 1_779_451_200_000L // 2026-05-22 12:00:00 UTC
+        val dayMs = 86_400_000L
+
+        fun eventAt(
+            id: String,
+            bookId: String,
+            endedAtMs: Long,
+            wallSeconds: Long = 30L,
+            tz: String = "UTC",
+        ): ListeningEventSyncPayload =
+            ListeningEventSyncPayload(
+                id = id,
+                bookId = bookId,
+                startPositionMs = 0L,
+                endPositionMs = wallSeconds * 1_000L,
+                startedAt = endedAtMs - wallSeconds * 1_000L,
+                endedAt = endedAtMs,
+                playbackSpeed = 1.0f,
+                tz = tz,
+                deviceLabel = null,
+                revision = 0L,
+                updatedAt = 0L,
+                createdAt = 0L,
+                deletedAt = null,
+            )
+
+        fun SqlTestDatabases.recorderWith(
+            userStatsRepo: UserStatsRepository,
+            activities: ActivityRepository,
+            testClock: FixedClock,
+        ): StatsRecorder {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            return StatsRecorder(
+                sql = sql,
+                userStatsRepo = userStatsRepo,
+                bookReadsRepository = BookReadsRepository(db = sql),
+                publicProfileMaintainer =
+                    PublicProfileMaintainer(
+                        sql = sql,
+                        publicProfileRepo = PublicProfileRepository(db = sql, bus = bus, registry = registry),
+                        clock = testClock,
+                    ),
+                activityRecorder = ActivityRecorder(repo = activities, bus = bus),
+                statsBackfill = UserStatsBackfillService(sql = sql, userStatsRepo = userStatsRepo),
+                clock = testClock,
+            )
+        }
+
+        test("late-arriving older event preserves streak and lastEventDate") {
+            withSqlDatabase {
+                val testClock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + dayMs))
+                val userStatsRepo = UserStatsRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val recorder = recorderWith(userStatsRepo, ActivityRepository(db = sql), testClock)
+
+                runTest {
+                    val e1 = eventAt("evt-1", "book-1", endedAtMs = day0Ms, wallSeconds = 30L)
+                    eventRepo.upsert(e1, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e1))
+
+                    val e2 = eventAt("evt-2", "book-1", endedAtMs = day0Ms + dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(e2, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e2))
+
+                    // Late arrival: an older-dated event (offline-outbox replay) lands after the
+                    // newer ones above.
+                    val e3 = eventAt("evt-late", "book-1", endedAtMs = day0Ms - 3 * dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(e3, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e3))
+
+                    val stats = userStatsRepo.getForUser("u1").shouldNotBeNull()
+                    stats.currentStreakDays shouldBe 2
+                    stats.longestStreakDays shouldBe 2
+                    stats.lastEventDate shouldBe "2026-05-23"
+                    stats.totalSecondsAllTime shouldBe 90L
+                }
+            }
+        }
+
+        test("same-date event with a different id leaves streak and lastEventDate unchanged") {
+            withSqlDatabase {
+                val testClock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + dayMs))
+                val userStatsRepo = UserStatsRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val recorder = recorderWith(userStatsRepo, ActivityRepository(db = sql), testClock)
+
+                runTest {
+                    val e1 = eventAt("evt-1", "book-1", endedAtMs = day0Ms, wallSeconds = 30L)
+                    eventRepo.upsert(e1, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e1))
+
+                    val e2 = eventAt("evt-2", "book-1", endedAtMs = day0Ms + dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(e2, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e2))
+
+                    // A different event id landing on the same calendar day.
+                    val e4 = eventAt("evt-same-day", "book-1", endedAtMs = day0Ms + dayMs + 60_000L, wallSeconds = 30L)
+                    eventRepo.upsert(e4, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e4))
+
+                    val stats = userStatsRepo.getForUser("u1").shouldNotBeNull()
+                    stats.currentStreakDays shouldBe 2
+                    stats.lastEventDate shouldBe "2026-05-23"
+                }
+            }
+        }
+
+        test("next-day event after a late arrival increments from the preserved state") {
+            withSqlDatabase {
+                val testClock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 2 * dayMs))
+                val userStatsRepo = UserStatsRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val recorder = recorderWith(userStatsRepo, ActivityRepository(db = sql), testClock)
+
+                runTest {
+                    val e1 = eventAt("evt-1", "book-1", endedAtMs = day0Ms, wallSeconds = 30L)
+                    eventRepo.upsert(e1, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e1))
+
+                    val e2 = eventAt("evt-2", "book-1", endedAtMs = day0Ms + dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(e2, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e2))
+
+                    val e3 = eventAt("evt-late", "book-1", endedAtMs = day0Ms - 3 * dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(e3, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e3))
+
+                    val e5 = eventAt("evt-5", "book-1", endedAtMs = day0Ms + 2 * dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(e5, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e5))
+
+                    val stats = userStatsRepo.getForUser("u1").shouldNotBeNull()
+                    stats.currentStreakDays shouldBe 3
+                    stats.longestStreakDays shouldBe 3
+                    stats.lastEventDate shouldBe "2026-05-24"
+                }
+            }
+        }
+
+        test("late event does not re-fire or un-fire a streak milestone") {
+            withSqlDatabase {
+                val testClock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 6 * dayMs))
+                val userStatsRepo = UserStatsRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val activities = ActivityRepository(db = sql)
+                val recorder = recorderWith(userStatsRepo, activities, testClock)
+
+                runTest {
+                    // Seven consecutive days → streak climbs 1..7, firing STREAK_MILESTONE(7).
+                    repeat(7) { day ->
+                        val e = eventAt("evt-$day", "book-1", endedAtMs = day0Ms + day * dayMs, wallSeconds = 30L)
+                        eventRepo.upsert(e, clientOpId = null, userId = "u1")
+                        recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = e))
+                    }
+                    userStatsRepo.getForUser("u1").shouldNotBeNull().currentStreakDays shouldBe 7
+
+                    val beforeLate =
+                        activities.page(before = null, limit = 50).filter { it.type == ActivityType.STREAK_MILESTONE }
+                    beforeLate shouldHaveSize 1
+
+                    // A late arrival (offline-outbox replay of a much older event) must not
+                    // rewind the streak, and therefore must not re-fire or un-fire the milestone.
+                    val late = eventAt("evt-late", "book-1", endedAtMs = day0Ms - 5 * dayMs, wallSeconds = 30L)
+                    eventRepo.upsert(late, clientOpId = null, userId = "u1")
+                    recorder.record(StatsEvent.ListeningSessionClosed(userId = "u1", span = late))
+
+                    val stats = userStatsRepo.getForUser("u1").shouldNotBeNull()
+                    stats.currentStreakDays shouldBe 7
+
+                    activities
+                        .page(before = null, limit = 50)
+                        .filter { it.type == ActivityType.STREAK_MILESTONE } shouldHaveSize 1
+                }
+            }
+        }
+    })


### PR DESCRIPTION
Plan 057 (/improve batch-5). `StatsRecorder.recordListeningSessionClosed` computed the streak incrementally and unconditionally wrote the event’s date into `user_stats.lastEventDate`. An event dated *older* than `lastEventDate` (routine: offline-outbox replay after another device recorded newer events) fell through `newStreakValue`’s `else -> 1`, resetting the streak to 1 and rewinding `lastEventDate` — corrupting all subsequent streak math and able to double-fire streak milestones. Unlike the rolling windows, the streak is path-dependent and never self-heals.

**Fix**: guard late arrivals — when the event date is strictly before the stored `lastEventDate`, leave `currentStreakDays` and `lastEventDate` untouched; order-safe fields (all-time seconds, 7/30-day windows, booksStarted) still accrue.

**Tests**: 4 new (Kotest, server jvmTest) — older-event preserves streak+date, next-day-after-late increments from preserved state, same-day idempotent, milestone doesn’t double-fire.

**Verification (reviewer-run)**: `*StatsRecorder*` + `:server:compileKotlinLinuxX64` + `spotlessCheck detekt` ✅ in isolation; full `:server:jvmTest` = 2522 tests, only failure the known `ScannerSseRouteTest` load-flake (passes isolated). No migration.