### PR TITLE
🔒 fix(server): move the scanner surface behind authentication

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ScannerService.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/ScannerService.kt
@@ -9,8 +9,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.rpc.annotations.Rpc
 
 /**
- * Public scanner contract. Mounted at `/api/rpc/public` (no auth wall
- * currently; admin-gating lands when the auth surface gets a role check).
+ * Scanner contract. Mounted at `/api/rpc/authed` behind the JWT gate — every RPC call
+ * requires a valid access token. The REST trigger (`POST /api/v1/scan`) is additionally
+ * ROOT/ADMIN-gated; `scanFull()` over RPC is reachable by any authenticated user but is
+ * unused by first-party clients — scan triggering flows through `LibraryAdminService`.
  *
  * `observeProgress()` is a server-pushed [Flow] of [RpcEvent]-wrapped [ScanEvent]s —
  * kotlinx.rpc opens a dedicated WebSocket frame stream for it. Multiple

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationRoutes.kt
@@ -182,8 +182,8 @@ internal fun Application.installAppRoutes(homeDir: Path) {
             profileRoutes(sql, avatarImageStore, publicProfileMaintainer)
             backupRoutes(backupPaths, backupArchive)
             importRoutes(importPaths)
+            scannerRoutes(scannerService, eventBus)
         }
-        scannerRoutes(scannerService, eventBus)
         audioRoutes(audioFileLocator, audioUrlSigner, audioRoleLookup, bookAccessPolicy)
         coverCastRoutes(coverResponder, coverUrlSigner, audioRoleLookup, bookAccessPolicy)
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/ScannerRoutes.kt
@@ -2,13 +2,17 @@ package com.calypsan.listenup.server.routes
 
 import com.calypsan.listenup.api.ScannerService
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.dto.scanner.ScanResult
 import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
 import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.server.plugins.userPrincipalOrNull
 import com.calypsan.listenup.server.routes.resources.ScannerResources
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.resources.get
 import io.ktor.server.resources.post
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
@@ -25,6 +29,11 @@ import kotlinx.coroutines.flow.Flow
  *  - `GET /sse/scan` — server-sent events; emits every [ScanEvent]
  *    serialized as JSON in the SSE `data` field.
  *
+ * Mounted inside the `authenticate(JWT_PROVIDER)` block — the auth gate is JWT-level, so
+ * every endpoint here requires a valid access token. `POST /api/v1/scan` is additionally
+ * ROOT/ADMIN-gated inline (the disk-heavy full-scan trigger is an admin operation); reading the
+ * last result and streaming progress stay visible to any authenticated user.
+ *
  * The kotlinx.rpc surface for the same service is mounted separately by
  * [rpcRoutes].
  */
@@ -33,6 +42,10 @@ fun Route.scannerRoutes(
     events: Flow<ScanEvent>,
 ) {
     post<ScannerResources> {
+        val p = call.userPrincipalOrNull() ?: return@post call.respond(HttpStatusCode.Unauthorized)
+        if (p.role != UserRole.ROOT && p.role != UserRole.ADMIN) {
+            return@post call.respond(HttpStatusCode.Forbidden)
+        }
         call.respondAppResult<ScanResultSummary>(scannerService.scanFull())
     }
     get<ScannerResources.Last> {

--- a/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt
+++ b/server/src/jvmMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.jvm.kt
@@ -72,13 +72,15 @@ private fun Route.publicRpc(services: RpcServices) {
         registerService<InstanceService> { guard(services.instanceService) }
         registerService<AuthServicePublic> { guard(services.authService as AuthServicePublic) }
         registerService<InviteServicePublic> { guard(services.inviteService as InviteServicePublic) }
-        registerService<ScannerService> { guard(services.scannerService) }
     }
 }
 
 private fun Route.authedRpc(services: RpcServices) {
     rpc("/api/rpc/authed") {
         rpcConfig { serialization { json(contractJson) } }
+        // ScannerService is a principal-free singleton (no copyWith); registered here so the
+        // JWT gate on the authed mount applies, but as a plain service rather than registerScoped.
+        registerService<ScannerService> { guard(services.scannerService) }
         registerScoped<AuthServiceAuthed> { guard(services.authService.copyWith(it) as AuthServiceAuthed) }
         registerScoped<BookService> { guard((services.bookService as BookServiceImpl).copyWith(it)) }
         registerScoped<ContributorService> {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/ScannerRoutesAuthGateTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/routes/ScannerRoutesAuthGateTest.kt
@@ -1,0 +1,228 @@
+package com.calypsan.listenup.server.routes
+
+import com.calypsan.listenup.api.ScannerService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.scanner.ScanResult
+import com.calypsan.listenup.api.dto.scanner.ScanResultSummary
+import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.streaming.RpcEvent
+import com.calypsan.listenup.server.module
+import com.calypsan.listenup.server.plugins.JWT_PROVIDER
+import com.calypsan.listenup.server.testing.testAuth
+import com.calypsan.listenup.server.testing.useIsolatedTestConfig
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
+import io.ktor.server.resources.Resources
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.client.rpcConfig
+import kotlinx.rpc.krpc.serialization.json.json as rpcJson
+import kotlinx.rpc.withService
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Auth-gate contract tests for the scanner surface (REST/SSE + kotlinx.rpc).
+ *
+ * The scanner used to be reachable with zero authentication. These tests pin the gate:
+ *
+ *  - Every `/api/v1/scan*` + `/sse/scan` endpoint requires a JWT (401 without one).
+ *  - `POST /api/v1/scan` (the disk-heavy full-scan trigger) additionally requires ADMIN/ROOT (403 for a MEMBER).
+ *  - `GET /api/v1/scan/last` stays visible to any authenticated user (MEMBER → 200).
+ *  - `ScannerService` is no longer on the public RPC mount, and is reachable on the authed mount with a JWT.
+ */
+class ScannerRoutesAuthGateTest :
+    FunSpec({
+
+        test("POST /api/v1/scan without bearer token returns 401") {
+            testApplication {
+                useIsolatedTestConfig()
+                application { module() }
+                val r: HttpResponse = client.post("/api/v1/scan")
+                r.status shouldBe HttpStatusCode.Unauthorized
+            }
+        }
+
+        test("GET /api/v1/scan/last without bearer token returns 401") {
+            testApplication {
+                useIsolatedTestConfig()
+                application { module() }
+                val r: HttpResponse = client.get("/api/v1/scan/last")
+                r.status shouldBe HttpStatusCode.Unauthorized
+            }
+        }
+
+        test("GET /sse/scan without bearer token returns 401") {
+            testApplication {
+                useIsolatedTestConfig()
+                application { module() }
+                val r: HttpResponse = client.get("/sse/scan")
+                r.status shouldBe HttpStatusCode.Unauthorized
+            }
+        }
+
+        test("POST /api/v1/scan with a MEMBER principal returns 403") {
+            testApplication {
+                application {
+                    install(ServerContentNegotiation) { json(contractJson) }
+                    install(Resources)
+                    install(SSE)
+                    install(Authentication) {
+                        testAuth(roleResolver = { if (it == "admin") UserRole.ADMIN else UserRole.MEMBER })
+                    }
+                    routing { authenticate(JWT_PROVIDER) { scannerRoutes(FakeScannerService, emptyFlow()) } }
+                }
+                client.post("/api/v1/scan") { bearerAuth("member") }.status shouldBe HttpStatusCode.Forbidden
+            }
+        }
+
+        test("POST /api/v1/scan with an ADMIN principal returns 200") {
+            testApplication {
+                application {
+                    install(ServerContentNegotiation) { json(contractJson) }
+                    install(Resources)
+                    install(SSE)
+                    install(Authentication) {
+                        testAuth(roleResolver = { if (it == "admin") UserRole.ADMIN else UserRole.MEMBER })
+                    }
+                    routing { authenticate(JWT_PROVIDER) { scannerRoutes(FakeScannerService, emptyFlow()) } }
+                }
+                client.post("/api/v1/scan") { bearerAuth("admin") }.status shouldBe HttpStatusCode.OK
+            }
+        }
+
+        test("GET /api/v1/scan/last with a MEMBER principal is allowed") {
+            testApplication {
+                application {
+                    install(ServerContentNegotiation) { json(contractJson) }
+                    install(Resources)
+                    install(SSE)
+                    install(Authentication) {
+                        testAuth(roleResolver = { if (it == "admin") UserRole.ADMIN else UserRole.MEMBER })
+                    }
+                    routing { authenticate(JWT_PROVIDER) { scannerRoutes(FakeScannerService, emptyFlow()) } }
+                }
+                client.get("/api/v1/scan/last") { bearerAuth("member") }.status shouldBe HttpStatusCode.OK
+            }
+        }
+
+        test("public RPC mount no longer serves ScannerService") {
+            testApplication {
+                useIsolatedTestConfig()
+                application { module() }
+
+                val rpcClient =
+                    createClient {
+                        install(WebSockets)
+                        installKrpc()
+                    }
+
+                val service =
+                    rpcClient
+                        .rpc("ws://localhost/api/rpc/public") {
+                            rpcConfig { serialization { rpcJson(contractJson) } }
+                        }.withService<ScannerService>()
+
+                shouldThrowAny { withTimeout(10.seconds) { service.lastScanResult() } }
+            }
+        }
+
+        test("authed RPC mount serves ScannerService with a valid JWT") {
+            testApplication {
+                useIsolatedTestConfig()
+                application { module() }
+
+                val setupClient = createClient { install(ContentNegotiation) { json(contractJson) } }
+                val token =
+                    setupClient
+                        .post("/api/v1/auth/setup") {
+                            contentType(ContentType.Application.Json)
+                            setBody(RegisterRequest("root@scanner-gate.test", "x".repeat(MIN_PASSWORD_LENGTH), "Root"))
+                        }.body<AppResult<AuthSession>>()
+                        .shouldBeInstanceOf<AppResult.Success<AuthSession>>()
+                        .data.accessToken.value
+
+                val rpcClient =
+                    createClient {
+                        install(WebSockets)
+                        installKrpc()
+                    }
+
+                val service =
+                    rpcClient
+                        .rpc("ws://localhost/api/rpc/authed") {
+                            bearerAuth(token)
+                            rpcConfig { serialization { rpcJson(contractJson) } }
+                        }.withService<ScannerService>()
+
+                service.lastScanResult().shouldBeInstanceOf<AppResult<ScanResult>>()
+            }
+        }
+    })
+
+private const val MIN_PASSWORD_LENGTH = 8
+
+/**
+ * Minimal in-process [ScannerService] for the role-gate route tests. `scanFull` and
+ * `lastScanResult` return trivial Success values so the route's status-code contract
+ * (401/403/200) is what's under test, not the scanner pipeline. `observeProgress` is unused.
+ */
+private object FakeScannerService : ScannerService {
+    override suspend fun scanFull(): AppResult<ScanResultSummary> =
+        AppResult.Success(
+            ScanResultSummary(
+                correlationId = "test",
+                totalBooks = 0,
+                added = 0,
+                modified = 0,
+                removed = 0,
+                moved = 0,
+                errors = 0,
+                durationMs = 0,
+                filesWalked = 0,
+            ),
+        )
+
+    override suspend fun lastScanResult(): AppResult<ScanResult> =
+        AppResult.Success(
+            ScanResult(
+                correlationId = "t",
+                rootPath = "/tmp",
+                books = emptyList(),
+                changes = emptyList(),
+                errors = emptyList(),
+                durationMs = 0,
+                filesWalked = 0,
+                filesSkipped = 0,
+            ),
+        )
+
+    override fun observeProgress(): Flow<RpcEvent<ScanEvent>> = error("unused in this test")
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/LiveCorpusBooksPersistenceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/LiveCorpusBooksPersistenceTest.kt
@@ -125,17 +125,18 @@ class LiveCorpusBooksPersistenceTest :
                         }
 
                     try {
+                        // Mint an auth token first — required for both the now JWT-gated
+                        // /api/v1/scan/last route and the sync (catch-up) route below.
+                        val token = mintAccessToken(client, baseUrl)
+
                         // Wait for the bootstrap scan to complete. Real corpora can be large;
                         // use a generous timeout to avoid false failures on slow disks.
-                        val scanResult = waitForScanResult(client, baseUrl, timeoutMs = SCAN_TIMEOUT_MS)
+                        val scanResult = waitForScanResult(client, baseUrl, token, timeoutMs = SCAN_TIMEOUT_MS)
 
                         val scannedCount = scanResult.books.size
                         withClue("Live corpus scan produced zero books — check $LIVE_CORPUS_ENV points to a valid audiobook library") {
                             scannedCount shouldBeGreaterThan 0
                         }
-
-                        // Mint an auth token — required for the sync (catch-up) route.
-                        val token = mintAccessToken(client, baseUrl)
 
                         // BookPersister drains the scan-result bus asynchronously in its own
                         // coroutine. waitForScanResult() above guarantees the scan itself is
@@ -205,11 +206,12 @@ class LiveCorpusBooksPersistenceTest :
 private suspend fun waitForScanResult(
     client: HttpClient,
     baseUrl: String,
+    token: String,
     timeoutMs: Long,
 ): ScanResult {
     val deadline = System.currentTimeMillis() + timeoutMs
     while (System.currentTimeMillis() < deadline) {
-        val response = client.get("$baseUrl/api/v1/scan/last")
+        val response = client.get("$baseUrl/api/v1/scan/last") { bearerAuth(token) }
         if (response.status == HttpStatusCode.OK) {
             val text: String = response.body()
             val result =

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndFixture.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/scanner/ScannerEndToEndFixture.kt
@@ -1,14 +1,24 @@
 package com.calypsan.listenup.server.scanner
 
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
 import com.calypsan.listenup.api.event.ScanEvent
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.server.di.EventBusQualifiers
 import com.calypsan.listenup.server.module
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.cio.CIO as ServerCIO
 import io.ktor.server.config.MapApplicationConfig
@@ -28,6 +38,12 @@ import org.koin.ktor.ext.get
  * resolved port. Mirrors the pattern from `AuthEndToEndFixture`: NO
  * test-side overrides on the production graph — anything that breaks here
  * breaks production identically.
+ *
+ * The returned [client] is ROOT-authenticated: on boot, this fixture mints a
+ * fresh ROOT account via `POST /api/v1/auth/setup` and attaches the resulting
+ * access token to every request via `defaultRequest`, so scanner tests can
+ * exercise the now-JWT-gated `/api/v1/scan*` surface without minting tokens
+ * themselves.
  *
  * Use [populate] to seed the library before the server boots. The boot
  * triggers an initial full scan via `bootstrapScannerOnStartup` so by the
@@ -100,6 +116,18 @@ internal class ScannerEndToEndFixture private constructor(
             val resolvedPort = runBlocking { server.engine.resolvedConnectors() }.first().port
             val baseUrl = "http://127.0.0.1:$resolvedPort"
 
+            val setupClient = HttpClient(CIO) { install(ContentNegotiation) { json(contractJson) } }
+            val accessToken =
+                runBlocking {
+                    setupClient
+                        .post("$baseUrl/api/v1/auth/setup") {
+                            contentType(ContentType.Application.Json)
+                            setBody(RegisterRequest("root@scanner.test", "x".repeat(MIN_PASSWORD_LENGTH), "Root"))
+                        }.body<AppResult<AuthSession>>()
+                        .let { it as? AppResult.Success ?: error("fixture setup-root failed: $it") }
+                        .data.accessToken.value
+                }.also { setupClient.close() }
+
             val client =
                 HttpClient(CIO) {
                     install(ContentNegotiation) { json(contractJson) }
@@ -107,6 +135,7 @@ internal class ScannerEndToEndFixture private constructor(
                     install(HttpTimeout) {
                         requestTimeoutMillis = REQUEST_TIMEOUT_MS
                     }
+                    defaultRequest { bearerAuth(accessToken) }
                 }
 
             val scanEventBus: MutableSharedFlow<ScanEvent> =
@@ -118,5 +147,6 @@ internal class ScannerEndToEndFixture private constructor(
         private const val JWT_SECRET_LENGTH = 32
         private const val REFRESH_PEPPER_LENGTH = 32
         private const val REQUEST_TIMEOUT_MS = 10_000L
+        private const val MIN_PASSWORD_LENGTH = 8
     }
 }

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/routes/RpcRoutes.linux.kt
@@ -72,13 +72,15 @@ private fun Route.publicRpc(services: RpcServices) {
         registerService<InstanceService> { guard(services.instanceService) }
         registerService<AuthServicePublic> { guard(services.authService as AuthServicePublic) }
         registerService<InviteServicePublic> { guard(services.inviteService as InviteServicePublic) }
-        registerService<ScannerService> { guard(services.scannerService) }
     }
 }
 
 private fun Route.authedRpc(services: RpcServices) {
     rpc("/api/rpc/authed") {
         rpcConfig { serialization { json(contractJson) } }
+        // ScannerService is a principal-free singleton (no copyWith); registered here so the
+        // JWT gate on the authed mount applies, but as a plain service rather than registerScoped.
+        registerService<ScannerService> { guard(services.scannerService) }
         registerScoped<AuthServiceAuthed> { guard(services.authService.copyWith(it) as AuthServiceAuthed) }
         registerScoped<BookService> { guard((services.bookService as BookServiceImpl).copyWith(it)) }
         registerScoped<ContributorService> {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ScannerRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ScannerRpcFactory.kt
@@ -15,11 +15,12 @@ import kotlinx.rpc.withService
  * Supplies the [ScannerService] kotlinx.rpc proxy used to observe live scan
  * progress (`observeProgress(): Flow<RpcEvent<ScanEvent>>`).
  *
- * [ScannerService] is mounted on the **public** RPC surface (`/api/rpc/public`),
- * so this factory does not attach a bearer token — it mirrors the public-mount
- * pattern of the auth/instance factories. The proxy is cached and reused; the
- * underlying [HttpClient] comes from [ApiClientFactory] (same one the rest of the
- * app uses), so [invalidate] drops the cached proxy when that client is recycled.
+ * [ScannerService] is mounted on the **authed** RPC surface (`/api/rpc/authed`),
+ * so the shared [ApiClientFactory] attaches the bearer token to the WebSocket
+ * upgrade automatically — `/api/rpc/authed` is deliberately not in the auth-exempt
+ * prefix list. The proxy is cached and reused; the underlying [HttpClient] comes
+ * from [ApiClientFactory] (same one the rest of the app uses), so [invalidate]
+ * drops the cached proxy when that client is recycled.
  */
 internal interface ScannerRpcFactory {
     /** Returns the cached [ScannerService] proxy, connecting on first use. */
@@ -30,8 +31,9 @@ internal interface ScannerRpcFactory {
 }
 
 /**
- * Production [ScannerRpcFactory]: mounts [ScannerService] over `/api/rpc/public`.
- * Mirrors [KtorLibraryAdminRpcFactory], substituting the public mount.
+ * Production [ScannerRpcFactory]: mounts [ScannerService] over `/api/rpc/authed` — the
+ * bearer-gated RPC surface. Mirrors [KtorLibraryAdminRpcFactory]; the shared
+ * [ApiClientFactory]'s `Auth`/`bearer` plugin carries the token onto the WebSocket upgrade.
  */
 internal open class KtorScannerRpcFactory(
     private val apiClientFactory: ApiClientFactory,
@@ -56,7 +58,7 @@ internal open class KtorScannerRpcFactory(
 
     internal open suspend fun connect(): ScannerService {
         val baseUrl = rpcBaseUrl()
-        return rpcClient().rpc("$baseUrl/api/rpc/public").withService<ScannerService>()
+        return rpcClient().rpc("$baseUrl/api/rpc/authed").withService<ScannerService>()
     }
 
     private suspend fun rpcClient(): HttpClient =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -75,7 +75,7 @@ internal val libraryModule: Module =
             )
         } bind LibraryResetHelper::class
 
-        // ScannerRpcFactory — kotlinx.rpc proxy for ScannerService (public mount):
+        // ScannerRpcFactory — kotlinx.rpc proxy for ScannerService (authed mount):
         // live scan-progress stream that drives the scan UI + post-scan reconcile.
         single<ScannerRpcFactory> {
             KtorScannerRpcFactory(


### PR DESCRIPTION
Plan 056 (/improve batch-5, security). The scanner surface was reachable with **zero authentication**: any LAN peer could trigger a full library scan (`POST /api/v1/scan`), read `scan/last` (incl. the library’s absolute host path), stream `/sse/scan`, and call `ScannerService` on the public RPC mount.

**Fix**
- `scannerRoutes` moved inside `authenticate(JWT_PROVIDER)`; `POST /api/v1/scan` additionally ROOT/ADMIN-gated (401→403); `scan/last` + SSE stay member-visible (clients watch scan progress).
- `ScannerService` RPC registration moved from the public mount to the authed mount (both `RpcRoutes` actuals kept byte-identical).
- Client `ScannerRpcFactory` swings to `/api/rpc/authed` (the shared client attaches the bearer automatically — URL is the only change).

**Tests**: new `ScannerRoutesAuthGateTest` = 8 tests (401s, MEMBER 403 / ADMIN 200 on the trigger, member-visible `scan/last`, public-mount-no-longer-serves, authed-mount-serves-with-JWT).

**Verification (reviewer-run)**: `:server:jvmTest` (8 gate tests pass isolated), native `compileKotlinLinuxX64`+`linuxX64Test` ✅, `:sharedLogic:jvmTest` ✅, `spotlessCheck detekt` ✅; RpcRoutes actuals byte-identical. (Follow-up noted: RPC `scanFull()` is authed-but-not-role-gated — deliberate scope cut.)