### PR TITLE
🐛 fix(shared): OfflineEditor returns typed failure instead of throwing

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/OfflineEditor.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/OfflineEditor.kt
@@ -2,7 +2,9 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.map
 import com.calypsan.listenup.client.core.error.ErrorMapper
+import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.domain.repository.AuthSession
 
@@ -15,7 +17,8 @@ import com.calypsan.listenup.client.domain.repository.AuthSession
  * leave a committed local edit without its outbox row (a silently lost sync). The edit therefore
  * persists and replays on reconnect rather than failing offline; the authoritative state still
  * arrives via the SSE sync engine. Callers pass only the two irreducible facts: which entity, and
- * how to merge the patch into Room.
+ * how to merge the patch into Room. A failing local write rolls the transaction back and surfaces
+ * as a typed [AppResult.Failure] — [edit] never throws (cancellation excepted).
  */
 internal class OfflineEditor(
     private val pendingQueue: PendingOperationQueue,
@@ -31,16 +34,17 @@ internal class OfflineEditor(
         val ownerUserId =
             authSession.getUserId()
                 ?: return AppResult.Failure(ErrorMapper.map(IllegalStateException("No signed-in user")))
-        transactionRunner.atomically {
-            applyLocally()
-            pendingQueue.enqueue(
-                domainName = domain.name,
-                entityId = entityId,
-                opType = "update",
-                payload = contractJson.encodeToString(domain.serializer, patch),
-                ownerUserId = ownerUserId,
-            )
-        }
-        return AppResult.Success(Unit)
+        return suspendRunCatching {
+            transactionRunner.atomically {
+                applyLocally()
+                pendingQueue.enqueue(
+                    domainName = domain.name,
+                    entityId = entityId,
+                    opType = "update",
+                    payload = contractJson.encodeToString(domain.serializer, patch),
+                    ownerUserId = ownerUserId,
+                )
+            }
+        }.map { }
     }
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/OfflineEditorTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/OfflineEditorTest.kt
@@ -11,6 +11,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.test.runTest
 
 class OfflineEditorTest :
@@ -79,7 +80,7 @@ class OfflineEditorTest :
             }
         }
 
-        test("a throwing local write rolls back the whole edit — no pending op is enqueued") {
+        test("a throwing local write yields Failure and rolls back — no pending op is enqueued") {
             runTest {
                 val db = createInMemoryTestDatabase()
                 val queue =
@@ -96,13 +97,42 @@ class OfflineEditorTest :
                         authSession = FakeAuthSession(userId = "u1"),
                     )
 
-                shouldThrow<IllegalStateException> {
+                val result =
                     editor.edit(BookEdit, entityId = "book1", patch = BookUpdate(title = "x")) {
                         error("local write blew up")
                     }
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                db.pendingOperationV2Dao().nextDispatchable(maxAttempts = 5).firstOrNull() shouldBe null
+                db.close()
+            }
+        }
+
+        test("CancellationException from the local write propagates — it is never folded into Failure") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                    )
+                val txRunner =
+                    object : TransactionRunner {
+                        override suspend fun <R> atomically(block: suspend () -> R): R = block()
+                    }
+                val editor =
+                    OfflineEditor(
+                        pendingQueue = queue,
+                        transactionRunner = txRunner,
+                        authSession = FakeAuthSession(userId = "u1"),
+                    )
+
+                shouldThrow<CancellationException> {
+                    editor.edit(BookEdit, entityId = "book1", patch = BookUpdate(title = "x")) {
+                        throw CancellationException("cancelled")
+                    }
                 }
 
-                db.pendingOperationV2Dao().nextDispatchable(maxAttempts = 5).firstOrNull() shouldBe null
                 db.close()
             }
         }


### PR DESCRIPTION
Plan 061 (/improve batch-5). `OfflineEditor.edit()` is the single funnel for every offline entity edit and declares `AppResult<Unit>`, but its transactional body (`atomically { applyLocally(); enqueue() }`) was unguarded — a Room `SQLiteException`/disk-full/merge-lambda bug propagated out as a **throw**, violating the "fallible suspends return AppResult, never throw" contract (crash on Android; can terminate the process on Native).

**Fix**: wrap the body in `suspendRunCatching { … }.map { }` (mirrors `PlaybackPositionRepositoryImpl.savePlaybackState`). Signed-out branch untouched; cancellation still propagates.

**Tests**: flipped the rollback test from `shouldThrow` to asserting `AppResult.Failure` with the real `RoomTransactionRunner` + queue-empty (atomicity); new cancellation-propagation test.

**Verification (reviewer-run)**: `:sharedLogic:jvmTest` ✅ (fully clean), `compileCommonMainKotlinMetadata` ✅, `spotlessCheck detekt` ✅. Independent of #979 in practice (OfflineEditor.kt untouched by it).