### PR TITLE
👷 ci: gate the GitHub Release on all platforms + SHA-pin third-party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: '26.4.1'
 
@@ -289,7 +289,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: '26.4.1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         run: ./gradlew :androidApp:bundleRelease :androidApp:assembleRelease --no-daemon
 
       - name: Upload to Google Play (internal, draft)
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.calypsan.listenup.client
@@ -146,7 +146,7 @@ jobs:
           path: artifacts
 
       - name: Publish Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ needs.set-version.outputs.version }}
           name: v${{ needs.set-version.outputs.version }}
@@ -166,7 +166,7 @@ jobs:
           ref: ${{ needs.set-version.outputs.sha }}
 
       - name: Select Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: '26.4.1'
 
@@ -291,14 +291,14 @@ jobs:
         run: cp server/build/bin/linuxX64/releaseExecutable/server.kexe server/server-binary
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: server
           file: server/Dockerfile.native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,16 @@ jobs:
   github-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [set-version, android]
-    if: ${{ always() && needs.set-version.result == 'success' }}
+    needs: [set-version, android, ios, server]
+    # Publish only after every SELECTED platform succeeded. always() lets this
+    # job run past deselected (skipped) needs; each clause then requires the
+    # platform's success only when its boolean input selected it.
+    if: >-
+      always() &&
+      needs.set-version.result == 'success' &&
+      (inputs.android == false || needs.android.result == 'success') &&
+      (inputs.ios == false || needs.ios.result == 'success') &&
+      (inputs.server == false || needs.server.result == 'success')
     permissions:
       contents: write
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ listenup.db
 listenup.db-shm
 listenup.db-wal
 
+# Locally staged native server binary (release.yml stages server.kexe here for Dockerfile.native)
+server/server-binary
+
 # Git worktrees (Claude Code subagent-driven development)
 .worktrees/
 


### PR DESCRIPTION
Plan 067 (/improve batch-5, security/dx). Three release-pipeline hardening items:

**A — Release gating**: `github-release` only `needs: [set-version, android]`, so the Release page (tag + notes + Android artifacts) published even while iOS/server jobs were still running or had failed (CLAUDE.md says a failed server build should fail the release). Now `needs: [set-version, android, ios, server]` with per-platform `inputs.X == false || needs.X.result == 'success'` gating (valid because the inputs are `type: boolean`).

**B — Supply-chain pinning**: 5 third-party actions in secret-bearing jobs were pinned by mutable tag → SHA-pinned (release.yml ×5, ci.yml setup-xcode ×2), `# vN` comments retained. GitHub-owned + Gradle-owned actions and the SwiftLint container stay tag-pinned (documented). Added `.github/dependabot.yml` (github-actions, monthly) to keep pins fresh.

**C — Hygiene**: `.gitignore` rule for the locally-staged `server/server-binary` artifact.

**Verification (reviewer-run)**: all 3 YAML files parse; gating truth-table checked; live `git ls-remote` spot-check confirms a pinned SHA equals its tag.