### PR TITLE
⚡️ perf(shared): persist cover presence instead of stat-per-book on every library emission (Room v43)

### DIFF
--- a/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/43.json
+++ b/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/43.json
@@ -1,0 +1,2813 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 43,
+    "identityHash": "db6ad34b6e849d04deb57fe830762aa6",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `firstName` TEXT, `lastName` TEXT, `isRoot` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `tagline` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRoot",
+            "columnName": "isRoot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `metadataPrecedence` TEXT NOT NULL, `accessMode` TEXT NOT NULL, `createdByUserId` TEXT, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `clientOpId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataPrecedence",
+            "columnName": "metadataPrecedence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessMode",
+            "columnName": "accessMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdByUserId",
+            "columnName": "createdByUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `rootPath` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `clientOpId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`libraryId`) REFERENCES `libraries`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootPath",
+            "columnName": "rootPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_folders_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_folders_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "libraries",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "libraryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `folderId` TEXT NOT NULL, `title` TEXT NOT NULL, `sortTitle` TEXT, `subtitle` TEXT, `coverHash` TEXT, `coverBlurHash` TEXT, `coverDownloadedAt` INTEGER, `totalDuration` INTEGER NOT NULL, `description` TEXT, `publishYear` INTEGER, `publisher` TEXT, `language` TEXT, `isbn` TEXT, `asin` TEXT, `abridged` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `hasScanWarning` INTEGER NOT NULL, `userEditedFields` TEXT NOT NULL DEFAULT '', `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortTitle",
+            "columnName": "sortTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverHash",
+            "columnName": "coverHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverDownloadedAt",
+            "columnName": "coverDownloadedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalDuration",
+            "columnName": "totalDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishYear",
+            "columnName": "publishYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abridged",
+            "columnName": "abridged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasScanWarning",
+            "columnName": "hasScanWarning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEditedFields",
+            "columnName": "userEditedFields",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_books_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `startTime` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `description` TEXT, `asin` TEXT, `coverPath` TEXT, `coverBlurHash` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `asin` TEXT, `description` TEXT, `imagePath` TEXT, `imageBlurHash` TEXT, `website` TEXT, `birthDate` TEXT, `deathDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "imagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "website",
+            "columnName": "website",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deathDate",
+            "columnName": "deathDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `contributorId` TEXT NOT NULL, `role` TEXT NOT NULL, `creditedAs` TEXT, PRIMARY KEY(`bookId`, `contributorId`, `role`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditedAs",
+            "columnName": "creditedAs",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "contributorId",
+            "role"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_contributors_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_contributors_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contributor_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contributorId` TEXT NOT NULL, `alias` TEXT NOT NULL, PRIMARY KEY(`contributorId`, `alias`), FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contributorId",
+            "alias"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributor_aliases_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributor_aliases_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `sequence` TEXT, PRIMARY KEY(`bookId`, `seriesId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "seriesId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_series_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_series_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `hasCustomSpeed` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `syncedAt` INTEGER, `lastPlayedAt` INTEGER, `isFinished` INTEGER NOT NULL, `finishedAt` INTEGER, `startedAt` INTEGER, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomSpeed",
+            "columnName": "hasCustomSpeed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFinished",
+            "columnName": "isFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`audioFileId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `filename` TEXT NOT NULL, `fileIndex` INTEGER NOT NULL, `state` TEXT NOT NULL, `localPath` TEXT, `totalBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, `startedAt` INTEGER, `completedAt` INTEGER, `errorMessage` TEXT, `retryCount` INTEGER NOT NULL, PRIMARY KEY(`audioFileId`))",
+        "fields": [
+          {
+            "fieldPath": "audioFileId",
+            "columnName": "audioFileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileIndex",
+            "columnName": "fileIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "audioFileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `name` TEXT NOT NULL, `isInbox` INTEGER NOT NULL, `isSystem` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInbox",
+            "columnName": "isInbox",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "isSystem",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_collections_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`collectionId`, `bookId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_collection_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_shares",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `collectionId` TEXT NOT NULL, `sharedWithUserId` TEXT NOT NULL, `sharedByUserId` TEXT NOT NULL, `permission` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedWithUserId",
+            "columnName": "sharedWithUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedByUserId",
+            "columnName": "sharedByUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permission",
+            "columnName": "permission",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_shares_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          },
+          {
+            "name": "index_collection_shares_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelves",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `isPrivate` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelves_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelves_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelf_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `shelfId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelf_books_shelfId",
+            "unique": false,
+            "columnNames": [
+              "shelfId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_shelfId` ON `${TABLE_NAME}` (`shelfId`)"
+          },
+          {
+            "name": "index_shelf_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_shelf_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `tagId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `tagId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_book_tags_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_moods_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_moods_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `moodId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `moodId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodId",
+            "columnName": "moodId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "moodId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_moods_moodId",
+            "unique": false,
+            "columnNames": [
+              "moodId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_moodId` ON `${TABLE_NAME}` (`moodId`)"
+          },
+          {
+            "name": "index_book_moods_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `path` TEXT NOT NULL, `parentId` TEXT, `depth` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "depth",
+            "columnName": "depth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genres_slug",
+            "unique": true,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genres_slug` ON `${TABLE_NAME}` (`slug`)"
+          },
+          {
+            "name": "index_genres_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genres_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `genreId` TEXT NOT NULL, PRIMARY KEY(`bookId`, `genreId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`genreId`) REFERENCES `genres`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreId",
+            "columnName": "genreId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "genreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_genres_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_genres_genreId",
+            "unique": false,
+            "columnNames": [
+              "genreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_genreId` ON `${TABLE_NAME}` (`genreId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "genres",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "genreId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `codec` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, `codecProfile` TEXT, `spatial` TEXT, `bitrate` INTEGER, `sampleRate` INTEGER, `channels` INTEGER, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codec",
+            "columnName": "codec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecProfile",
+            "columnName": "codecProfile",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spatial",
+            "columnName": "spatial",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channels",
+            "columnName": "channels",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_files_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_files_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `size` INTEGER NOT NULL, `hash` TEXT NOT NULL, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_documents_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_documents_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `endPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPositionMs",
+            "columnName": "endPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_userId_endedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "endedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_endedAt` ON `${TABLE_NAME}` (`userId`, `endedAt`)"
+          },
+          {
+            "name": "index_listening_events_userId_revision",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_revision` ON `${TABLE_NAME}` (`userId`, `revision`)"
+          },
+          {
+            "name": "index_listening_events_userId_bookId",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_bookId` ON `${TABLE_NAME}` (`userId`, `bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "activities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `type` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `userDisplayName` TEXT NOT NULL, `userAvatarColor` TEXT NOT NULL, `userAvatarType` TEXT NOT NULL, `userAvatarValue` TEXT, `bookId` TEXT, `bookTitle` TEXT, `bookAuthorName` TEXT, `bookCoverPath` TEXT, `isReread` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `milestoneValue` INTEGER NOT NULL, `milestoneUnit` TEXT, `shelfId` TEXT, `shelfName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarColor",
+            "columnName": "userAvatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarType",
+            "columnName": "userAvatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarValue",
+            "columnName": "userAvatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookTitle",
+            "columnName": "bookTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookAuthorName",
+            "columnName": "bookAuthorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCoverPath",
+            "columnName": "bookCoverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isReread",
+            "columnName": "isReread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneValue",
+            "columnName": "milestoneValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneUnit",
+            "columnName": "milestoneUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfName",
+            "columnName": "shelfName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_activities_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_activities_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `booksStarted` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `lastEventDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksStarted",
+            "columnName": "booksStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEventDate",
+            "columnName": "lastEventDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `defaultPlaybackSpeed` REAL NOT NULL, `defaultSkipForwardSec` INTEGER NOT NULL, `defaultSkipBackwardSec` INTEGER NOT NULL, `defaultSleepTimerMin` INTEGER, `shakeToResetSleepTimer` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPlaybackSpeed",
+            "columnName": "defaultPlaybackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipForwardSec",
+            "columnName": "defaultSkipForwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipBackwardSec",
+            "columnName": "defaultSkipBackwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSleepTimerMin",
+            "columnName": "defaultSleepTimerMin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shakeToResetSleepTimer",
+            "columnName": "shakeToResetSleepTimer",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "public_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `tagline` TEXT, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `totalSecondsLast365Days` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `booksFinishedLast7Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast30Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast365Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast7Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast30Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast365Days` INTEGER NOT NULL DEFAULT 0, `avatarUpdatedAt` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast365Days",
+            "columnName": "totalSecondsLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinishedLast7Days",
+            "columnName": "booksFinishedLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast30Days",
+            "columnName": "booksFinishedLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast365Days",
+            "columnName": "booksFinishedLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast7Days",
+            "columnName": "longestStreakLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast30Days",
+            "columnName": "longestStreakLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast365Days",
+            "columnName": "longestStreakLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avatarUpdatedAt",
+            "columnName": "avatarUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tentative_span",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `currentPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `lastHeartbeatAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeartbeatAt",
+            "columnName": "lastHeartbeatAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cover_download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `status` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `error` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_cursor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domainName` TEXT NOT NULL, `revision` INTEGER NOT NULL, PRIMARY KEY(`domainName`))",
+        "fields": [
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domainName"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_operation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clientOpId` TEXT NOT NULL, `domainName` TEXT NOT NULL, `entityId` TEXT NOT NULL, `opType` TEXT NOT NULL, `payload` TEXT NOT NULL, `enqueuedAt` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `failureCount` INTEGER NOT NULL, `lastError` TEXT, `ownerUserId` TEXT NOT NULL, PRIMARY KEY(`clientOpId`))",
+        "fields": [
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opType",
+            "columnName": "opType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clientOpId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_operation_domainName_entityId_enqueuedAt",
+            "unique": false,
+            "columnNames": [
+              "domainName",
+              "entityId",
+              "enqueuedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_domainName_entityId_enqueuedAt` ON `${TABLE_NAME}` (`domainName`, `entityId`, `enqueuedAt`)"
+          },
+          {
+            "name": "index_pending_operation_ownerUserId",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_ownerUserId` ON `${TABLE_NAME}` (`ownerUserId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "admin_user_roster",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `role` TEXT NOT NULL, `status` TEXT NOT NULL, `canShare` INTEGER NOT NULL, `accountCreatedAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canShare",
+            "columnName": "canShare",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountCreatedAt",
+            "columnName": "accountCreatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'db6ad34b6e849d04deb57fe830762aa6')"
+    ]
+  }
+}

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_38_39
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_39_40
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -59,6 +60,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_39_40,
                     MIGRATION_40_41,
                     MIGRATION_41_42,
+                    MIGRATION_42_43,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -19,6 +19,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_38_39
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_39_40
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
 import com.calypsan.listenup.core.IODispatcher
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -76,6 +77,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_39_40,
                     MIGRATION_40_41,
                     MIGRATION_41_42,
+                    MIGRATION_42_43,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
@@ -232,20 +232,6 @@ internal interface BookDao {
     )
 
     /**
-     * Touch a book's updatedAt timestamp to trigger Flow re-emission.
-     *
-     * Used after cover downloads to force UI updates when cover files
-     * appear on disk (even though database content hasn't changed).
-     *
-     * @param id Type-safe book ID to touch
-     */
-    @Query("UPDATE books SET updatedAt = :timestamp WHERE id = :id")
-    suspend fun touchUpdatedAt(
-        id: BookId,
-        timestamp: Timestamp,
-    )
-
-    /**
      * Mark a single book's cover as present on disk. Conditioned on the column
      * currently being unset so a redundant mark (the cover was already recorded) touches
      * zero rows — Room's invalidation tracker only wakes observers on an actual row change.
@@ -414,7 +400,7 @@ internal interface BookDao {
     @Query(
         """
         SELECT
-            b.id, b.title, b.coverBlurHash, b.coverHash, b.createdAt,
+            b.id, b.title, b.coverBlurHash, b.coverHash, b.coverDownloadedAt, b.createdAt,
             (
                 SELECT c.name FROM book_contributors bc
                 INNER JOIN contributors c ON bc.contributorId = c.id
@@ -440,7 +426,7 @@ internal interface BookDao {
     @Query(
         """
         SELECT
-            b.id, b.title, b.coverBlurHash, b.coverHash, b.createdAt,
+            b.id, b.title, b.coverBlurHash, b.coverHash, b.coverDownloadedAt, b.createdAt,
             (
                 SELECT c.name FROM book_contributors bc
                 INNER JOIN contributors c ON bc.contributorId = c.id
@@ -470,7 +456,7 @@ internal interface BookDao {
     @Query(
         """
         SELECT
-            b.id, b.title, b.coverBlurHash, b.coverHash, b.createdAt,
+            b.id, b.title, b.coverBlurHash, b.coverHash, b.coverDownloadedAt, b.createdAt,
             (
                 SELECT c.name FROM book_contributors bc
                 INNER JOIN contributors c ON bc.contributorId = c.id
@@ -562,6 +548,7 @@ internal data class DiscoveryBookWithAuthor(
     val title: String,
     val coverBlurHash: String?,
     val coverHash: String?,
+    val coverDownloadedAt: Timestamp?,
     val createdAt: Timestamp,
     val authorName: String?,
 )
@@ -578,6 +565,7 @@ internal data class DiscoveryBookWithSeries(
     val title: String,
     val coverBlurHash: String?,
     val coverHash: String?,
+    val coverDownloadedAt: Timestamp?,
     val createdAt: Timestamp,
     val authorName: String?,
     val sequence: String?,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
@@ -246,6 +246,59 @@ internal interface BookDao {
     )
 
     /**
+     * Mark a single book's cover as present on disk. Conditioned on the column
+     * currently being unset so a redundant mark (the cover was already recorded) touches
+     * zero rows — Room's invalidation tracker only wakes observers on an actual row change.
+     *
+     * @param id The book whose cover just landed on disk.
+     * @param timestamp When the cover was recorded as downloaded.
+     */
+    @Query("UPDATE books SET coverDownloadedAt = :timestamp WHERE id = :id AND coverDownloadedAt IS NULL")
+    suspend fun markCoverDownloaded(
+        id: BookId,
+        timestamp: Timestamp,
+    )
+
+    /**
+     * Clear a single book's cover-presence marker (the local file was deleted or
+     * invalidated). Conditioned on the column currently being set, for the same
+     * no-op-touches-zero-rows reason as [markCoverDownloaded].
+     *
+     * @param id The book whose cover was removed or invalidated.
+     */
+    @Query("UPDATE books SET coverDownloadedAt = NULL WHERE id = :id AND coverDownloadedAt IS NOT NULL")
+    suspend fun clearCoverDownloaded(id: BookId)
+
+    /**
+     * Ids of every book currently marked as having a local cover file. Used by the startup
+     * cover-presence reconciler to diff the marker against the on-disk covers directory.
+     */
+    @Query("SELECT id FROM books WHERE coverDownloadedAt IS NOT NULL")
+    suspend fun idsWithCoverMarked(): List<BookId>
+
+    /**
+     * Batch variant of [markCoverDownloaded] for the startup reconciler's backfill pass —
+     * marks every id in [ids] whose column is currently unset in a single statement.
+     *
+     * @param ids Book ids found on disk but not yet marked in Room.
+     * @param timestamp When the covers were recorded as downloaded.
+     */
+    @Query("UPDATE books SET coverDownloadedAt = :timestamp WHERE id IN (:ids) AND coverDownloadedAt IS NULL")
+    suspend fun markCoversDownloaded(
+        ids: List<BookId>,
+        timestamp: Timestamp,
+    )
+
+    /**
+     * Batch variant of [clearCoverDownloaded] for the startup reconciler's heal pass —
+     * clears the marker for every id in [ids] (rows marked but missing on disk).
+     *
+     * @param ids Book ids marked in Room but absent from the on-disk covers directory.
+     */
+    @Query("UPDATE books SET coverDownloadedAt = NULL WHERE id IN (:ids)")
+    suspend fun clearCoversDownloaded(ids: List<BookId>)
+
+    /**
      * Observe all books belonging to a specific series.
      *
      * Returns books ordered by series sequence (position in series) if available,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
@@ -69,6 +69,10 @@ internal class BookEntityMapper {
             // When existing is null (first-seen book) it is null and will be populated after the
             // cover image is downloaded and analysed.
             coverBlurHash = existing?.coverBlurHash,
+            // Client-local cover-presence marker — preserved like coverBlurHash, except when the
+            // server's cover hash changed: BookSyncDomainHandler deletes the stale local file in the
+            // same upsert flow, so presence must reset until the new cover is downloaded.
+            coverDownloadedAt = existing?.takeIf { it.coverHash == payload.cover?.hash }?.coverDownloadedAt,
             // Wire-authoritative per-field edit provenance — the server owns this set (it unions an
             // edited field on every edit RPC), so a sync update always takes the payload's value.
             userEditedFields = payload.userEditedFields,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapper.kt
@@ -87,6 +87,15 @@ internal class BookEntityMapper {
 }
 
 /**
+ * Local cover path derived from the persisted cover-presence marker — pure string
+ * construction, no filesystem stat. Null when no local cover file is recorded.
+ */
+internal fun ImageStorage.coverPathFor(
+    bookId: BookId,
+    coverDownloadedAt: Timestamp?,
+): String? = coverDownloadedAt?.let { getCoverPath(bookId) }
+
+/**
  * Convert an [AudioFileEntity] to the domain [AudioFile].
  *
  * Single canonical mapper — used by both [BookWithContributors.toDetail] and [PlaybackPreparer].
@@ -173,7 +182,7 @@ internal fun BookWithContributors.toListItem(
         authors = authors,
         narrators = narrators,
         duration = book.totalDuration,
-        coverPath = if (imageStorage.exists(book.id)) imageStorage.getCoverPath(book.id) else null,
+        coverPath = imageStorage.coverPathFor(book.id, book.coverDownloadedAt),
         coverHash = book.coverHash,
         coverBlurHash = book.coverBlurHash,
         addedAt = book.createdAt,
@@ -247,7 +256,7 @@ internal fun BookWithContributors.toDetail(
         authors = authors,
         narrators = narrators,
         duration = book.totalDuration,
-        coverPath = if (imageStorage.exists(book.id)) imageStorage.getCoverPath(book.id) else null,
+        coverPath = imageStorage.coverPathFor(book.id, book.coverDownloadedAt),
         coverHash = book.coverHash,
         coverBlurHash = book.coverBlurHash,
         addedAt = book.createdAt,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Entities.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Entities.kt
@@ -126,6 +126,11 @@ internal data class BookEntity(
     val subtitle: String? = null, // Book subtitle
     val coverHash: String? = null, // Content hash of the cover image, supplied by the sync wire event
     val coverBlurHash: String? = null, // BlurHash for cover placeholder
+    // Client-local cover-presence marker: set when the cover file lands on disk
+    // (ImageDownloader), cleared when it is invalidated (server cover-hash change or
+    // local delete). Never on the wire — replaces the per-book filesystem stat that
+    // list mapping used to pay on every emission.
+    val coverDownloadedAt: Timestamp? = null,
     val totalDuration: Long, // Total audiobook duration in milliseconds
     val description: String? = null,
     // Series is now managed via book_series junction table (many-to-many)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -15,7 +15,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
  *
  * Stores user data, books, and sync metadata for offline-first functionality.
  *
- * Schema is at v42. Migrations live in the `data/local/migrations/` package
+ * Schema is at v43. Migrations live in the `data/local/migrations/` package
  * (e.g. `Migration14To15`, `Migration19To20`) and are registered via `.addMigrations(...)`
  * in each platform `DatabaseModule`. Pre-launch policy: `fallbackToDestructiveMigration(true)`
  * is set on each `DatabaseModule`; before launch, flip the fallback to `false` and
@@ -61,7 +61,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
         PendingOperationV2Entity::class,
         AdminUserRosterEntity::class,
     ],
-    version = 42,
+    version = 43,
     exportSchema = true,
 )
 @TypeConverters(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorage.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorage.kt
@@ -58,6 +58,15 @@ internal class CommonImageStorage(
 
     override fun exists(bookId: BookId): Boolean = SystemFileSystem.exists(getCoverFile(bookId))
 
+    override fun listCoverBookIds(): Set<BookId> {
+        if (!SystemFileSystem.exists(coversDir)) return emptySet()
+        return SystemFileSystem
+            .list(coversDir)
+            .filter { it.name.endsWith(".$FILE_EXTENSION") && !it.name.endsWith("_staging.$FILE_EXTENSION") }
+            .map { BookId(it.name.removeSuffix(".$FILE_EXTENSION")) }
+            .toSet()
+    }
+
     override suspend fun deleteCover(bookId: BookId): AppResult<Unit> =
         withContext(IODispatcher) {
             try {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration42To43.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration42To43.kt
@@ -1,0 +1,19 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+/**
+ * Room schema migration v42 → v43 — add the `coverDownloadedAt` cover-presence marker
+ * column to `books`.
+ *
+ * Upgraders get `NULL` for every existing row; the startup [com.calypsan.listenup.client.data.sync.CoverPresenceReconciler]
+ * self-heal backfills the marker from the on-disk covers directory on next launch.
+ */
+internal val MIGRATION_42_43: Migration =
+    object : Migration(42, 43) {
+        override fun migrate(connection: SQLiteConnection) {
+            connection.execSQL("ALTER TABLE `books` ADD COLUMN `coverDownloadedAt` INTEGER")
+        }
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImpl.kt
@@ -11,7 +11,7 @@ private val logger = KotlinLogging.logger {}
 /**
  * [AvatarDownloadRepository] implementation backed by [ImageDownloaderContract].
  *
- * Mirrors [CoverDownloadRepositoryImpl]. No `touchUpdatedAt` post-fetch — avatars paint
+ * Mirrors [CoverDownloadRepositoryImpl]. No post-fetch book-row marking — avatars paint
  * from a stable file path and do not require a Room invalidation signal for UI refresh.
  *
  * @property imageDownloader underlying downloader (platform-specific through Koin).

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.data.local.db.ChapterDao
 import com.calypsan.listenup.client.data.local.db.ChapterEntity
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.local.db.coverPathFor
 import com.calypsan.listenup.client.data.local.db.toAudioFile
 import com.calypsan.listenup.client.data.local.db.toDetail
 import com.calypsan.listenup.client.data.local.db.toListItem
@@ -188,20 +189,19 @@ internal class BookRepositoryImpl(
             bookDao
                 .observeAllWithContributors()
                 // conflate BEFORE the combine: during an initial-population burst the book table is
-                // invalidated once per inserted book, and re-mapping the whole library (a BookListItem +
-                // a blocking ImageStorage.exists cover stat per book) on every one is O(n²) allocation
-                // that exhausts the heap → OOM. Conflate collapses a burst into a single re-map of the
-                // latest snapshot; the UI still converges to the correct final list.
+                // invalidated once per inserted book, and re-mapping the whole library on every one is
+                // O(n²) allocation that exhausts the heap → OOM. Conflate collapses a burst into a
+                // single re-map of the latest snapshot; the UI still converges to the correct final
+                // list. (toListItem's coverPath is pure in-memory string construction now — no I/O —
+                // but the conflate is still needed for the O(n²) allocation cost alone.)
                 .conflate(),
             bookDao.observeBookIdsWithDocuments(),
         ) { rows, docIds ->
             val docIdSet = docIds.toSet()
-            // toListItem's per-book cover stat is blocking I/O — kept off Dispatchers.Main via
-            // the flowOn below; do not move this mapping into a non-IO context.
             rows.map { it.toListItem(imageStorage, hasDocuments = it.book.id.value in docIdSet) }
         }
-            // toListItem's per-book cover stat is blocking I/O — keep it off the collector
-            // (Dispatchers.Main for the Library screen), or a large library freezes the UI thread.
+            // Mapping itself is now pure in-memory work, but keep it off Dispatchers.Main (the
+            // Library screen's collector context) so a large library never blocks the UI thread.
             .flowOn(IODispatcher)
             // Room invalidates the entire result set on any book write (even a single row update).
             // distinctUntilChanged drops re-emissions where the mapped List<BookListItem> hasn't
@@ -407,7 +407,7 @@ private fun com.calypsan.listenup.client.data.local.db.DiscoveryBookWithAuthor.t
         id = id.value,
         title = title,
         authorName = authorName,
-        coverPath = if (imageStorage.exists(id)) imageStorage.getCoverPath(id) else null,
+        coverPath = imageStorage.coverPathFor(id, coverDownloadedAt),
         coverBlurHash = coverBlurHash,
         coverHash = coverHash,
         createdAt = createdAt.epochMillis,
@@ -423,7 +423,7 @@ private fun com.calypsan.listenup.client.data.local.db.DiscoveryBookWithSeries.t
         id = id.value,
         title = title,
         authorName = authorName,
-        coverPath = if (imageStorage.exists(id)) imageStorage.getCoverPath(id) else null,
+        coverPath = imageStorage.coverPathFor(id, coverDownloadedAt),
         coverBlurHash = coverBlurHash,
         coverHash = coverHash,
         createdAt = createdAt.epochMillis,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CoverDownloadRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CoverDownloadRepositoryImpl.kt
@@ -1,10 +1,6 @@
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.api.result.AppResult
-
 import com.calypsan.listenup.core.BookId
-import com.calypsan.listenup.core.Timestamp
-import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,35 +10,24 @@ import kotlinx.coroutines.launch
 private val logger = KotlinLogging.logger {}
 
 /**
- * [CoverDownloadRepository] implementation backed by [ImageDownloaderContract] for the
- * fetch and [BookDao] for a post-fetch `updatedAt` touch (triggers UI refresh on screens
- * observing the book).
+ * [CoverDownloadRepository] implementation backed by [ImageDownloaderContract] for the fetch.
+ *
+ * [ImageDownloaderContract.downloadCover] itself maintains the `coverDownloadedAt`
+ * cover-presence marker on a successful download, so Room's invalidation tracker wakes
+ * observers without this repository needing a separate post-fetch touch.
  *
  * @property imageDownloader underlying downloader (platform-specific through Koin).
- * @property bookDao used to touch the book row after a successful download so
- *   Room's invalidation tracker wakes observers.
  * @property scope the repository's structured-concurrency scope. Child jobs launched
  *   here are bounded by the scope's lifecycle — typically the application scope.
  */
 internal class CoverDownloadRepositoryImpl(
     private val imageDownloader: ImageDownloaderContract,
-    private val bookDao: BookDao,
     private val scope: CoroutineScope,
 ) : CoverDownloadRepository {
     override fun queueCoverDownload(bookId: BookId) {
         scope.launch {
             try {
-                val result = imageDownloader.downloadCover(bookId)
-                if (result is AppResult.Success && result.data) {
-                    try {
-                        bookDao.touchUpdatedAt(bookId, Timestamp.now())
-                        logger.debug { "Touched book ${bookId.value} to trigger UI refresh" }
-                    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        logger.warn(e) { "Failed to touch updatedAt for book ${bookId.value}" }
-                    }
-                }
+                imageDownloader.downloadCover(bookId)
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.client.data.local.db.ContributorEntity
 import com.calypsan.listenup.client.data.local.db.SearchDao
 import com.calypsan.listenup.client.data.local.db.SeriesEntity
 import com.calypsan.listenup.client.data.local.db.TagEntity
+import com.calypsan.listenup.client.data.local.db.coverPathFor
 import com.calypsan.listenup.client.data.repository.common.QueryUtils
 import com.calypsan.listenup.client.domain.model.SearchFacets
 import com.calypsan.listenup.client.domain.model.SearchHit
@@ -150,7 +151,7 @@ internal class SearchRepositoryImpl(
 // --- Extension functions for mapping ---
 
 private fun BookSearchResult.toSearchHit(imageStorage: ImageStorage): SearchHit {
-    val coverPath = if (imageStorage.exists(book.id)) imageStorage.getCoverPath(book.id) else null
+    val coverPath = imageStorage.coverPathFor(book.id, book.coverDownloadedAt)
 
     return SearchHit(
         id = book.id.value,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.remote.ScannerRpcFactory
 import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.CoverPresenceReconciler
 import com.calypsan.listenup.client.data.sync.EngineSnapshot
 import com.calypsan.listenup.client.data.sync.FtsPopulatorContract
 import com.calypsan.listenup.client.data.sync.SyncEngine
@@ -60,6 +61,7 @@ internal class SyncRepositoryImpl(
     private val bookDao: BookDao,
     private val listeningEventDao: ListeningEventDao,
     private val ftsPopulator: FtsPopulatorContract,
+    private val coverPresenceReconciler: CoverPresenceReconciler,
     private val scope: CoroutineScope,
 ) : SyncRepository {
     /**
@@ -198,6 +200,16 @@ internal class SyncRepositoryImpl(
                 throw e
             } catch (e: Exception) {
                 logger.warn(e) { "Search index self-heal failed; will retry on next startup" }
+            }
+            // Self-heal: converge the cover-presence marker with the on-disk covers directory
+            // (external deletions; upgraders whose files predate the marker column). Cheap —
+            // one directory listing + one SELECT. Isolated — must not fail engine startup.
+            try {
+                coverPresenceReconciler.reconcile()
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Cover-presence self-heal failed; will retry on next startup" }
             }
             val shouldRecover =
                 orphanRecoveryMutex.withLock {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverPresenceReconciler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverPresenceReconciler.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.core.Timestamp
+
+/**
+ * Startup self-heal for the `books.coverDownloadedAt` cover-presence marker.
+ *
+ * The marker is the single source of truth for local cover presence at mapping time
+ * (no per-book filesystem stat), so it must converge with disk reality: covers deleted
+ * externally, files written before the marker existed (v42→v43 upgraders), or a crash
+ * between file write and row update. One directory listing + one SELECT reconciles
+ * both directions; a no-op start touches zero rows and wakes no observers.
+ */
+internal class CoverPresenceReconciler(
+    private val bookDao: BookDao,
+    private val imageStorage: ImageStorage,
+) {
+    suspend fun reconcile() {
+        val onDisk = imageStorage.listCoverBookIds()
+        val marked = bookDao.idsWithCoverMarked().toSet()
+        val now = Timestamp.now()
+        (onDisk - marked).toList().chunked(CHUNK_SIZE).forEach { bookDao.markCoversDownloaded(it, now) }
+        (marked - onDisk).toList().chunked(CHUNK_SIZE).forEach { bookDao.clearCoversDownloaded(it) }
+    }
+
+    private companion object {
+        /** Stay far under SQLite's host-parameter limit for the IN (:ids) expansion. */
+        const val CHUNK_SIZE = 500
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.remote.ImageApiContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -25,10 +27,15 @@ private const val BATCH_SIZE = 3
  *
  * @property imageApi API client for downloading cover images
  * @property imageStorage Local storage for cover images
+ * @property bookDao maintains [com.calypsan.listenup.client.data.local.db.BookEntity.coverDownloadedAt] —
+ *   the cover-presence marker mapping reads instead of stat-ing the filesystem. This is the single
+ *   choke point every cover download and deletion funnels through, so it is the sole place the
+ *   marker is written.
  */
 internal class ImageDownloader(
     private val imageApi: ImageApiContract,
     private val imageStorage: ImageStorage,
+    private val bookDao: BookDao,
 ) : ImageDownloaderContract {
     // Per-userId serialization so a post-scan fan-out of concurrent avatar requests
     // collapses to a single network fetch + save instead of stampeding the server
@@ -64,7 +71,11 @@ internal class ImageDownloader(
      */
     override suspend fun deleteCover(bookId: BookId): AppResult<Unit> {
         logger.debug { "Deleting local cover for book ${bookId.value}" }
-        return imageStorage.deleteCover(bookId)
+        val result = imageStorage.deleteCover(bookId)
+        if (result is AppResult.Success) {
+            bookDao.clearCoverDownloaded(bookId)
+        }
+        return result
     }
 
     /**
@@ -77,9 +88,12 @@ internal class ImageDownloader(
      * @return Result indicating if cover was successfully downloaded and saved
      */
     override suspend fun downloadCover(bookId: BookId): AppResult<Boolean> {
-        // Skip if already exists locally
+        // Skip if already exists locally. This is also how a v42→v43 upgrader's pre-existing
+        // cover files (written before the marker column existed) get marked ahead of the
+        // startup reconciler running.
         if (imageStorage.exists(bookId)) {
             logger.info { "Cover already exists locally for book ${bookId.value}" }
+            bookDao.markCoverDownloaded(bookId, Timestamp.now())
             return AppResult.Success(false)
         }
 
@@ -104,6 +118,7 @@ internal class ImageDownloader(
             return saveResult
         }
 
+        bookDao.markCoverDownloaded(bookId, Timestamp.now())
         logger.info { "Successfully downloaded and saved cover for book ${bookId.value}" }
         return AppResult.Success(true)
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -103,6 +103,7 @@ internal val libraryModule: Module =
                 bookDao = get(),
                 listeningEventDao = get(),
                 ftsPopulator = get(),
+                coverPresenceReconciler = get(),
                 scope =
                     get(
                         qualifier =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/MediaModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/MediaModule.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.repository.DocumentRepositoryImpl
 import com.calypsan.listenup.client.data.repository.DownloadRepositoryImpl
 import com.calypsan.listenup.client.data.repository.ImageRepositoryImpl
 import com.calypsan.listenup.client.data.sync.CoverDownloadWorker
+import com.calypsan.listenup.client.data.sync.CoverPresenceReconciler
 import com.calypsan.listenup.client.data.sync.ImageDownloader
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
@@ -55,6 +56,7 @@ internal val mediaModule: Module =
             ImageDownloader(
                 imageApi = get(),
                 imageStorage = get(),
+                bookDao = get(),
             )
         } bind ImageDownloaderContract::class
 
@@ -100,7 +102,6 @@ internal val mediaModule: Module =
         single<CoverDownloadRepository> {
             CoverDownloadRepositoryImpl(
                 imageDownloader = get(),
-                bookDao = get(),
                 scope =
                     get(
                         qualifier =
@@ -126,6 +127,15 @@ internal val mediaModule: Module =
             CoverDownloadWorker(
                 coverDownloadDao = get(),
                 imageDownloader = get(),
+            )
+        }
+
+        // Startup self-heal that converges the coverDownloadedAt marker with the on-disk
+        // covers directory. Consumed by SyncRepositoryImpl at engine start.
+        single {
+            CoverPresenceReconciler(
+                bookDao = get(),
+                imageStorage = get(),
             )
         }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AvatarDownloadRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AvatarDownloadRepository.kt
@@ -7,7 +7,7 @@ package com.calypsan.listenup.client.domain.repository
  * from suspend contexts without launching unstructured child coroutines on the caller's scope
  * — the repository is the single structured-concurrency boundary for this work.
  *
- * Mirrors [CoverDownloadRepository] for avatars. No `touchUpdatedAt` analogue — avatars paint
+ * Mirrors [CoverDownloadRepository] for avatars. No post-fetch book-row marking — avatars paint
  * from a stable file path; no Room-invalidation signal is needed.
  */
 internal interface AvatarDownloadRepository {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageStorage.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageStorage.kt
@@ -48,6 +48,13 @@ interface ImageStorage {
     fun exists(bookId: BookId): Boolean
 
     /**
+     * List the book ids that have a cover image file on disk — one directory listing,
+     * no per-book stats. Staging files and non-cover entries are excluded. Used by the
+     * startup cover-presence reconciler to heal the persisted cover marker.
+     */
+    fun listCoverBookIds(): Set<BookId>
+
+    /**
      * Delete a cover image from local storage.
      * No-op if the cover doesn't exist.
      *

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapperTest.kt
@@ -272,7 +272,8 @@ class BookEntityMapperTest :
 
             bookWithContributors(coverDownloadedAt = null)
                 .toDetail(imageStorage, genres = emptyList(), tags = emptyList(), moods = emptyList())
-                .coverPath.shouldBeNull()
+                .coverPath
+                .shouldBeNull()
             bookWithContributors(coverDownloadedAt = Timestamp(ENTITY_UPDATED_AT_MS))
                 .toDetail(imageStorage, genres = emptyList(), tags = emptyList(), moods = emptyList())
                 .coverPath shouldBe "/covers/book-1.jpg"

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapperTest.kt
@@ -221,12 +221,16 @@ class BookEntityMapperTest :
 
         // --- toDetail mapping ---
 
-        fun bookWithContributors(hasScanWarning: Boolean): BookWithContributors =
+        fun bookWithContributors(
+            hasScanWarning: Boolean = false,
+            coverDownloadedAt: Timestamp? = null,
+        ): BookWithContributors =
             BookWithContributors(
                 book =
                     bookEntity().copy(
                         revision = 1L,
                         hasScanWarning = hasScanWarning,
+                        coverDownloadedAt = coverDownloadedAt,
                     ),
                 contributors = emptyList(),
                 contributorRoles = emptyList(),
@@ -235,7 +239,10 @@ class BookEntityMapperTest :
             )
 
         test("toDetail carries hasScanWarning from the book entity — true and false") {
-            val imageStorage = mock<ImageStorage> { every { exists(any()) } returns false }
+            // Stat-elimination regression guard: no `exists` stub — a strict Mokkery mock throws
+            // on any unstubbed call, so if toDetail ever regresses to calling
+            // ImageStorage.exists() again, this test fails.
+            val imageStorage = mock<ImageStorage> { every { getCoverPath(any()) } returns "/covers/book-1.jpg" }
 
             bookWithContributors(hasScanWarning = true)
                 .toDetail(imageStorage, genres = emptyList(), tags = emptyList(), moods = emptyList())
@@ -243,6 +250,32 @@ class BookEntityMapperTest :
             bookWithContributors(hasScanWarning = false)
                 .toDetail(imageStorage, genres = emptyList(), tags = emptyList(), moods = emptyList())
                 .hasScanWarning shouldBe false
+        }
+
+        test("toListItem derives coverPath from coverDownloadedAt — pure string construction, no stat") {
+            // Stat-elimination regression guard: no `exists` stub — a strict Mokkery mock throws
+            // on any unstubbed call, so if toListItem ever regresses to calling
+            // ImageStorage.exists() again, this test fails.
+            val imageStorage = mock<ImageStorage> { every { getCoverPath(any()) } returns "/covers/book-1.jpg" }
+
+            bookWithContributors(coverDownloadedAt = null).toListItem(imageStorage).coverPath.shouldBeNull()
+            bookWithContributors(coverDownloadedAt = Timestamp(ENTITY_UPDATED_AT_MS))
+                .toListItem(imageStorage)
+                .coverPath shouldBe "/covers/book-1.jpg"
+        }
+
+        test("toDetail derives coverPath from coverDownloadedAt — pure string construction, no stat") {
+            // Stat-elimination regression guard: no `exists` stub — a strict Mokkery mock throws
+            // on any unstubbed call, so if toDetail ever regresses to calling
+            // ImageStorage.exists() again, this test fails.
+            val imageStorage = mock<ImageStorage> { every { getCoverPath(any()) } returns "/covers/book-1.jpg" }
+
+            bookWithContributors(coverDownloadedAt = null)
+                .toDetail(imageStorage, genres = emptyList(), tags = emptyList(), moods = emptyList())
+                .coverPath.shouldBeNull()
+            bookWithContributors(coverDownloadedAt = Timestamp(ENTITY_UPDATED_AT_MS))
+                .toDetail(imageStorage, genres = emptyList(), tags = emptyList(), moods = emptyList())
+                .coverPath shouldBe "/covers/book-1.jpg"
         }
 
         test("toAudioFile carries the audio-stream fields") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapperTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/local/db/BookEntityMapperTest.kt
@@ -95,6 +95,8 @@ class BookEntityMapperTest :
         fun bookEntity(
             id: BookId = BookId("book-1"),
             coverBlurHash: String? = "L5H2EC=PM+yV",
+            coverHash: String? = null,
+            coverDownloadedAt: Timestamp? = null,
         ): BookEntity =
             BookEntity(
                 id = id,
@@ -103,6 +105,8 @@ class BookEntityMapperTest :
                 title = "Old Title",
                 totalDuration = 1_000L,
                 coverBlurHash = coverBlurHash,
+                coverHash = coverHash,
+                coverDownloadedAt = coverDownloadedAt,
                 createdAt = Timestamp(ENTITY_CREATED_AT_MS),
                 updatedAt = Timestamp(ENTITY_UPDATED_AT_MS),
             )
@@ -179,6 +183,31 @@ class BookEntityMapperTest :
             val result = mapper.toBookEntity(payload, existing = existing)
 
             result.title shouldBe "New Title from Server"
+        }
+
+        test("toBookEntity preserves coverDownloadedAt from existing row when coverHash is unchanged") {
+            val downloadedAt = Timestamp(ENTITY_UPDATED_AT_MS)
+            val existing = bookEntity(coverHash = "abc123", coverDownloadedAt = downloadedAt)
+            val payload = bookPayload(cover = CoverPayload(source = CoverSource.FILESYSTEM, hash = "abc123"))
+            val result = mapper.toBookEntity(payload, existing = existing)
+
+            result.coverDownloadedAt shouldBe downloadedAt
+        }
+
+        test("toBookEntity clears coverDownloadedAt when the server cover hash changed") {
+            val downloadedAt = Timestamp(ENTITY_UPDATED_AT_MS)
+            val existing = bookEntity(coverHash = "old-hash", coverDownloadedAt = downloadedAt)
+            val payload = bookPayload(cover = CoverPayload(source = CoverSource.FILESYSTEM, hash = "new-hash"))
+            val result = mapper.toBookEntity(payload, existing = existing)
+
+            result.coverDownloadedAt.shouldBeNull()
+        }
+
+        test("toBookEntity with existing null sets coverDownloadedAt to null") {
+            val payload = bookPayload()
+            val result = mapper.toBookEntity(payload, existing = null)
+
+            result.coverDownloadedAt.shouldBeNull()
         }
 
         test("toBookEntity carries hasScanWarning from payload — true and false") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverPresenceReconcilerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverPresenceReconcilerTest.kt
@@ -1,0 +1,101 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [CoverPresenceReconciler.reconcile] — the startup self-heal that converges the
+ * `books.coverDownloadedAt` marker with the on-disk covers directory.
+ */
+class CoverPresenceReconcilerTest :
+    FunSpec({
+
+        fun reconciler(
+            bookDao: BookDao,
+            imageStorage: ImageStorage,
+        ) = CoverPresenceReconciler(bookDao = bookDao, imageStorage = imageStorage)
+
+        test("marks ids found on disk but not marked, and clears ids marked but missing on disk") {
+            runTest {
+                val imageStorage =
+                    mock<ImageStorage> {
+                        every { listCoverBookIds() } returns setOf(BookId("a"), BookId("b"))
+                    }
+                val bookDao =
+                    mock<BookDao> {
+                        everySuspend { idsWithCoverMarked() } returns listOf(BookId("b"), BookId("c"))
+                        everySuspend { markCoversDownloaded(any(), any()) } returns Unit
+                        everySuspend { clearCoversDownloaded(any()) } returns Unit
+                    }
+
+                reconciler(bookDao, imageStorage).reconcile()
+
+                // "a" is on disk but not marked → gets marked.
+                verifySuspend { bookDao.markCoversDownloaded(listOf(BookId("a")), any()) }
+                // "c" is marked but missing on disk → gets cleared.
+                verifySuspend { bookDao.clearCoversDownloaded(listOf(BookId("c"))) }
+            }
+        }
+
+        test("does nothing when disk and the marker already agree") {
+            runTest {
+                val imageStorage =
+                    mock<ImageStorage> {
+                        every { listCoverBookIds() } returns setOf(BookId("a"), BookId("b"))
+                    }
+                val bookDao =
+                    mock<BookDao> {
+                        everySuspend { idsWithCoverMarked() } returns listOf(BookId("a"), BookId("b"))
+                    }
+
+                reconciler(bookDao, imageStorage).reconcile()
+
+                // No drift → neither batch call runs. A strict mock without these stubs would
+                // throw if the reconciler called them, so this also guards against a spurious
+                // no-op write that would wake Room observers for nothing.
+                verifySuspend(VerifyMode.not) { bookDao.markCoversDownloaded(any(), any()) }
+                verifySuspend(VerifyMode.not) { bookDao.clearCoversDownloaded(any()) }
+            }
+        }
+
+        test("chunks a large mark batch so no single call covers more than the chunk size") {
+            runTest {
+                val onDiskIds = (1..1200).map { BookId("book-$it") }.toSet()
+                val imageStorage = mock<ImageStorage> { every { listCoverBookIds() } returns onDiskIds }
+                val seenChunks = mutableListOf<List<BookId>>()
+                val bookDao =
+                    mock<BookDao> {
+                        everySuspend { idsWithCoverMarked() } returns emptyList()
+                        everySuspend { markCoversDownloaded(any(), any()) } calls { args ->
+                            @Suppress("UNCHECKED_CAST")
+                            seenChunks += args.args[0] as List<BookId>
+                        }
+                    }
+
+                reconciler(bookDao, imageStorage).reconcile()
+
+                // 1200 ids at a 500-per-call chunk size means at least 3 calls, no chunk exceeds
+                // the limit, and every id is covered across the chunks exactly once.
+                seenChunks.size shouldBe 3
+                seenChunks.forEach { chunk -> (chunk.size <= CHUNK_SIZE_UNDER_TEST) shouldBe true }
+                seenChunks.flatten().toSet() shouldBe onDiskIds
+            }
+        }
+    }) {
+    private companion object {
+        /** Mirrors [CoverPresenceReconciler]'s private chunk size — kept in sync intentionally. */
+        const val CHUNK_SIZE_UNDER_TEST = 500
+    }
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloaderTest.kt
@@ -2,7 +2,9 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.core.Failure
+import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.remote.ImageApiContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import dev.mokkery.answering.calls
@@ -11,6 +13,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -37,11 +40,13 @@ class ImageDownloaderTest :
         class TestFixture {
             val imageApi: ImageApiContract = mock()
             val imageStorage: ImageStorage = mock()
+            val bookDao: BookDao = mock()
 
             fun build(): ImageDownloader =
                 ImageDownloader(
                     imageApi = imageApi,
                     imageStorage = imageStorage,
+                    bookDao = bookDao,
                 )
         }
 
@@ -52,6 +57,8 @@ class ImageDownloaderTest :
             every { fixture.imageStorage.exists(any()) } returns false
             everySuspend { fixture.imageApi.downloadCover(any()) } returns AppResult.Success(ByteArray(100))
             everySuspend { fixture.imageStorage.saveCover(any(), any()) } returns AppResult.Success(Unit)
+            everySuspend { fixture.bookDao.markCoverDownloaded(any(), any()) } returns Unit
+            everySuspend { fixture.bookDao.clearCoverDownloaded(any()) } returns Unit
 
             return fixture
         }
@@ -154,6 +161,99 @@ class ImageDownloaderTest :
 
                 // Then - API should not be called
                 // (verify by not stubbing API - if called, test would fail)
+            }
+        }
+
+        // ========== Cover-Presence Marker Tests ==========
+
+        test("downloadCover marks the cover-presence column after a successful download") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val imageDownloader = fixture.build()
+                val bookId = BookId("book-1")
+                val imageBytes = ByteArray(100) { it.toByte() }
+                everySuspend { fixture.imageApi.downloadCover(bookId) } returns AppResult.Success(imageBytes)
+                everySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) } returns AppResult.Success(Unit)
+
+                // When
+                imageDownloader.downloadCover(bookId)
+
+                // Then
+                verifySuspend { fixture.bookDao.markCoverDownloaded(bookId, any()) }
+            }
+        }
+
+        test("downloadCover marks the cover-presence column when the cover already exists locally") {
+            runTest {
+                // Given - already-exists early return still means "present on disk", so the
+                // marker must be written (this is also how a v42→v43 upgrader's pre-existing
+                // cover files first get marked, ahead of the startup reconciler).
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                every { fixture.imageStorage.exists(bookId) } returns true
+                val imageDownloader = fixture.build()
+
+                // When
+                imageDownloader.downloadCover(bookId)
+
+                // Then
+                verifySuspend { fixture.bookDao.markCoverDownloaded(bookId, any()) }
+            }
+        }
+
+        test("downloadCover does not mark the cover-presence column when the API returns failure") {
+            runTest {
+                // Given - 404 Not Found (no cover available), no file was ever written.
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                everySuspend { fixture.imageApi.downloadCover(bookId) } returns Failure(Exception("Not found"))
+                val imageDownloader = fixture.build()
+
+                // When
+                imageDownloader.downloadCover(bookId)
+
+                // Then
+                verifySuspend(VerifyMode.not) { fixture.bookDao.markCoverDownloaded(any(), any()) }
+            }
+        }
+
+        test("downloadCover does not mark the cover-presence column when the storage save fails") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                val imageBytes = ByteArray(100)
+                val storageFailure =
+                    AppResult.Failure(
+                        com.calypsan.listenup.api.error
+                            .ValidationError(message = "Disk full"),
+                    )
+                everySuspend { fixture.imageApi.downloadCover(bookId) } returns AppResult.Success(imageBytes)
+                everySuspend { fixture.imageStorage.saveCover(bookId, imageBytes) } returns storageFailure
+                val imageDownloader = fixture.build()
+
+                // When
+                imageDownloader.downloadCover(bookId)
+
+                // Then
+                verifySuspend(VerifyMode.not) { fixture.bookDao.markCoverDownloaded(any(), any()) }
+            }
+        }
+
+        test("deleteCover clears the cover-presence column") {
+            runTest {
+                // Given
+                val fixture = createFixture()
+                val bookId = BookId("book-1")
+                everySuspend { fixture.imageStorage.deleteCover(bookId) } returns AppResult.Success(Unit)
+                val imageDownloader = fixture.build()
+
+                // When
+                imageDownloader.deleteCover(bookId)
+
+                // Then
+                verifySuspend { fixture.bookDao.clearCoverDownloaded(bookId) }
             }
         }
 

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_38_39
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_39_40
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -62,6 +63,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_39_40,
                     MIGRATION_40_41,
                     MIGRATION_41_42,
+                    MIGRATION_42_43,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorageListCoversTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorageListCoversTest.kt
@@ -1,0 +1,81 @@
+package com.calypsan.listenup.client.data.local.images
+
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Tests for [CommonImageStorage.listCoverBookIds] — the single directory listing the startup
+ * cover-presence reconciler uses instead of a per-book filesystem stat.
+ */
+@OptIn(ExperimentalUuidApi::class)
+class CommonImageStorageListCoversTest :
+    FunSpec({
+
+        fun freshFilesDir(): Path {
+            val dir = Path(SystemTemporaryDirectory.toString(), "listcovers-test-${Uuid.random()}")
+            SystemFileSystem.createDirectories(dir)
+            return dir
+        }
+
+        fun storageOver(filesDir: Path): CommonImageStorage =
+            CommonImageStorage(storagePaths = object : StoragePaths {
+                override val filesDir: Path = filesDir
+            })
+
+        test("returns an empty set when the covers directory does not exist") {
+            val storage = storageOver(freshFilesDir())
+
+            storage.listCoverBookIds() shouldBe emptySet()
+        }
+
+        test("returns the book ids of every cover file on disk") {
+            val filesDir = freshFilesDir()
+            val coversDir = Path(filesDir.toString(), "covers")
+            SystemFileSystem.createDirectories(coversDir)
+            SystemFileSystem.sink(Path(coversDir.toString(), "a.jpg")).close()
+            SystemFileSystem.sink(Path(coversDir.toString(), "b.jpg")).close()
+            val storage = storageOver(filesDir)
+
+            storage.listCoverBookIds() shouldBe setOf(BookId("a"), BookId("b"))
+        }
+
+        test("excludes staging cover files") {
+            val filesDir = freshFilesDir()
+            val coversDir = Path(filesDir.toString(), "covers")
+            SystemFileSystem.createDirectories(coversDir)
+            SystemFileSystem.sink(Path(coversDir.toString(), "a.jpg")).close()
+            SystemFileSystem.sink(Path(coversDir.toString(), "c_staging.jpg")).close()
+            val storage = storageOver(filesDir)
+
+            storage.listCoverBookIds() shouldBe setOf(BookId("a"))
+        }
+
+        test("excludes the series covers subdirectory") {
+            val filesDir = freshFilesDir()
+            val coversDir = Path(filesDir.toString(), "covers")
+            val seriesDir = Path(coversDir.toString(), "series")
+            SystemFileSystem.createDirectories(seriesDir)
+            SystemFileSystem.sink(Path(coversDir.toString(), "a.jpg")).close()
+            SystemFileSystem.sink(Path(seriesDir.toString(), "s1.jpg")).close()
+            val storage = storageOver(filesDir)
+
+            storage.listCoverBookIds() shouldBe setOf(BookId("a"))
+        }
+
+        test("excludes non-cover file extensions") {
+            val filesDir = freshFilesDir()
+            val coversDir = Path(filesDir.toString(), "covers")
+            SystemFileSystem.createDirectories(coversDir)
+            SystemFileSystem.sink(Path(coversDir.toString(), "a.jpg")).close()
+            SystemFileSystem.sink(Path(coversDir.toString(), "readme.txt")).close()
+            val storage = storageOver(filesDir)
+
+            storage.listCoverBookIds() shouldBe setOf(BookId("a"))
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorageListCoversTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/images/CommonImageStorageListCoversTest.kt
@@ -24,9 +24,12 @@ class CommonImageStorageListCoversTest :
         }
 
         fun storageOver(filesDir: Path): CommonImageStorage =
-            CommonImageStorage(storagePaths = object : StoragePaths {
-                override val filesDir: Path = filesDir
-            })
+            CommonImageStorage(
+                storagePaths =
+                    object : StoragePaths {
+                        override val filesDir: Path = filesDir
+                    },
+            )
 
         test("returns an empty set when the covers directory does not exist") {
             val storage = storageOver(freshFilesDir())

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration42To43Test.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration42To43Test.kt
@@ -1,0 +1,43 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.sqlite.SQLiteConnection
+import com.calypsan.listenup.client.test.db.createMigrationTestHelper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+
+/**
+ * Regression test for [MIGRATION_42_43] — adds the `coverDownloadedAt` cover-presence
+ * marker column to `books`.
+ *
+ * `runMigrationsAndValidate(version = 43, …)` runs the migration and validates the
+ * post-migration schema against the exported `43.json`, asserting the new column is
+ * present after the upgrade.
+ */
+class Migration42To43Test :
+    FunSpec({
+
+        test("v42 → v43 adds the coverDownloadedAt column to books") {
+            val helper = createMigrationTestHelper()
+            try {
+                helper.createDatabase(version = 42)
+
+                val db =
+                    helper.runMigrationsAndValidate(
+                        version = 43,
+                        migrations = listOf(MIGRATION_42_43),
+                    )
+
+                db.columnsOf("books") shouldContainAll setOf("coverDownloadedAt")
+            } finally {
+                helper.close()
+            }
+        }
+    })
+
+/** Column names of [table], read from `PRAGMA table_info`. */
+private fun SQLiteConnection.columnsOf(table: String): Set<String> =
+    prepare("PRAGMA table_info(`$table`)").use { stmt ->
+        buildSet {
+            while (stmt.step()) add(stmt.getText(1))
+        }
+    }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/OrphanRecoveryRaceTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/OrphanRecoveryRaceTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.ActivityRefreshSignal
 import com.calypsan.listenup.client.data.sync.CatchUp
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
 import com.calypsan.listenup.client.data.sync.ConnectionState
+import com.calypsan.listenup.client.data.sync.CoverPresenceReconciler
 import com.calypsan.listenup.client.data.sync.DomainDigestClient
 import com.calypsan.listenup.client.data.sync.FtsPopulatorContract
 import com.calypsan.listenup.client.data.sync.ParsedSseFrame
@@ -24,9 +25,11 @@ import com.calypsan.listenup.client.data.sync.SyncEventDispatcher
 import com.calypsan.listenup.client.data.sync.SyncReconciler
 import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
@@ -110,6 +113,11 @@ class OrphanRecoveryRaceTest :
                             bookDao = db.bookDao(),
                             listeningEventDao = db.listeningEventDao(),
                             ftsPopulator = ftsPopulator,
+                            coverPresenceReconciler =
+                                CoverPresenceReconciler(
+                                    bookDao = db.bookDao(),
+                                    imageStorage = mock<ImageStorage> { every { listCoverBookIds() } returns emptySet() },
+                                ),
                             scope = scope,
                         )
 
@@ -173,6 +181,11 @@ class OrphanRecoveryRaceTest :
                             bookDao = db.bookDao(),
                             listeningEventDao = db.listeningEventDao(),
                             ftsPopulator = ftsPopulator,
+                            coverPresenceReconciler =
+                                CoverPresenceReconciler(
+                                    bookDao = db.bookDao(),
+                                    imageStorage = mock<ImageStorage> { every { listCoverBookIds() } returns emptySet() },
+                                ),
                             scope = scope,
                         )
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ForceReconcileWhileActiveTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ForceReconcileWhileActiveTest.kt
@@ -11,9 +11,11 @@ import com.calypsan.listenup.client.data.remote.ScannerRpcFactory
 import com.calypsan.listenup.client.data.repository.SyncRepositoryImpl
 import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
@@ -171,6 +173,11 @@ class ForceReconcileWhileActiveTest :
                             bookDao = db.bookDao(),
                             listeningEventDao = db.listeningEventDao(),
                             ftsPopulator = ftsPopulator,
+                            coverPresenceReconciler =
+                                CoverPresenceReconciler(
+                                    bookDao = db.bookDao(),
+                                    imageStorage = mock<ImageStorage> { every { listCoverBookIds() } returns emptySet() },
+                                ),
                             scope = scope,
                         )
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelRealRoomTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelRealRoomTest.kt
@@ -5,8 +5,10 @@ package com.calypsan.listenup.client.presentation.library
 import com.calypsan.listenup.api.sync.BookSyncPayload
 import com.calypsan.listenup.api.sync.ContributorSyncPayload
 import com.calypsan.listenup.api.sync.SeriesSyncPayload
+import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.ChapterDao
@@ -35,21 +37,18 @@ import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.stubImageStorage
-import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
 
@@ -60,9 +59,9 @@ import kotlin.time.Duration.Companion.seconds
  *
  * Part 1 asserts each `rawContent` source flow emits its first value on an empty DB (so the
  * top-level combine can produce a value and `uiState` leaves its `Loading` seed). Part 2 pins the
- * threading fix: `observeBookListItems` does a blocking per-book cover stat
- * ([ImageStorage.exists]) and must run it OFF the collector (the UI's `Dispatchers.Main`), or a
- * large library freezes the thread.
+ * stat-elimination invariant: `observeBookListItems` derives `coverPath` purely from the
+ * persisted `coverDownloadedAt` marker and never performs a per-book filesystem stat
+ * ([ImageStorage.exists]).
  */
 class LibraryViewModelRealRoomTest :
     FunSpec({
@@ -123,42 +122,34 @@ class LibraryViewModelRealRoomTest :
             }
         }
 
-        // ───────────────────── Part 2: heavy per-book cover I/O runs off the collector ─────────────────────
+        // ───────────────────── Part 2: mapping performs zero per-book filesystem stats ─────────────────────
 
-        test("observeBookListItems performs its per-book cover lookup off the collector's thread") {
+        test("observeBookListItems maps without any per-book filesystem stat") {
             val db = createInMemoryTestDatabase()
-            val collectorDispatcher = newSingleThreadContext("library-collector-thread")
             try {
-                // ImageStorage.exists is a blocking filesystem stat in production. Capture which
-                // thread each call runs on: it must NOT be the flow's collector (in the app, Main).
-                val coverLookupThreads = mutableListOf<String>()
+                // Strict mock: only stub what the pure mapper legitimately needs (getCoverPath).
+                // `exists` is deliberately left unstubbed — Mokkery's default strict mode throws on
+                // any unstubbed call, so if the mapper still called `exists()` this test would fail
+                // with that throw. The absence of a throw IS the guard for the stat-elimination.
                 val imageStorage =
                     mock<ImageStorage> {
-                        every { exists(any()) } calls
-                            {
-                                coverLookupThreads.add(Thread.currentThread().name)
-                                false
-                            }
+                        every { getCoverPath(any()) } returns "/covers/b1.jpg"
                     }
                 val repository = bookRepositoryWith(db, imageStorage)
                 seedBook(db, "b1")
+                // Mark the cover as downloaded so coverPathFor() exercises getCoverPath().
+                db.bookDao().markCoverDownloaded(BookId("b1"), Timestamp(1L))
 
                 runBlocking {
                     val items =
                         withTimeout(5.seconds) {
-                            withContext(collectorDispatcher) {
-                                repository.observeBookListItems().first { it.isNotEmpty() }
-                            }
+                            repository.observeBookListItems().first { it.isNotEmpty() }
                         }
                     items.size shouldBe 1
 
-                    // The per-book cover stat must have happened, but never on the collector thread —
-                    // otherwise a large library blocks the UI thread and the Library tab spins forever.
-                    coverLookupThreads.shouldNotBeEmpty()
-                    coverLookupThreads.forEach { it shouldNotContain "library-collector-thread" }
+                    verify(VerifyMode.not) { imageStorage.exists(any()) }
                 }
             } finally {
-                collectorDispatcher.close()
                 db.close()
             }
         }

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
@@ -467,6 +467,8 @@ private class FakeHomeRepository(
 private class FakeImageStorage : ImageStorage {
     override fun exists(bookId: BookId): Boolean = false
 
+    override fun listCoverBookIds(): Set<BookId> = emptySet()
+
     override fun getCoverPath(bookId: BookId): String = "/fake/covers/${bookId.value}.jpg"
 
     override suspend fun saveCover(


### PR DESCRIPTION
Plan 059 (/improve batch-5, perf). `observeBookListItems()` re-mapped the whole library on every Room `books` invalidation, and the mapper did a **blocking filesystem stat per book** (`imageStorage.exists`) to decide `coverPath`. Room invalidates the whole table on any single-row write → on a ~1200-book library, one write cost ~1200 syscalls + a full re-map, all before `distinctUntilChanged()` could drop it (the documented O(n²)/OOM history). Same stat-per-item in the discovery, detail, and search mappers.

**Fix**: persist cover presence as a nullable `coverDownloadedAt` column (Room **v43**, hand-written migration + exported `43.json`); every mapper now derives `coverPath` via the pure `ImageStorage.coverPathFor(...)` helper — zero I/O per emission. The marker is maintained at the single download choke point (`ImageDownloader.downloadCover`/`.deleteCover`, conditional UPDATEs so a no-op wakes no observers), cleared on server cover-hash change (pairs with the existing stale-file delete in `BookSyncDomainHandler`), and healed by a startup `CoverPresenceReconciler` (one directory listing + one SELECT, isolated so it can't fail engine startup). The dead `touchUpdatedAt` hack is retired. Bonus: a finished download now correctly wakes Room observers (previously nothing invalidated `books` on download).

**Tests**: `Migration42To43Test`, `CoverPresenceReconcilerTest`, `CommonImageStorageListCoversTest` (new); extended `BookEntityMapperTest` (preserve/clear-on-hash-change + a strict-mock stat-elimination guard) and `ImageDownloaderTest`; `LibraryViewModelRealRoomTest` flipped from asserting the old off-thread stat to asserting **zero per-book stat**.

**Verification (reviewer-run)**: `:sharedLogic:compileCommonMainKotlinMetadata` + `:contract:jvmTest` + `:sharedLogic:jvmTest` (2879 tests) + `:sharedLogic:testAndroidHostTest` + `:sharedUI:testAndroidHostTest` ✅, `:androidApp:assembleDebug` ✅, `spotlessCheck detekt` ✅. `:server:jvmTest` not run locally (change touches zero server code; CI covers it). Safety net preserved: `BookCoverImage` slow path still paints a false-null cover.

Base note: branched pre-merge of #979–#984; touches `di/LibraryModule.kt` which #981 also edited (different lines).