### PR TITLE
🐛 fix(shared): surface failed offline edits from the live outbox (was a dead stub)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2Dao.kt
@@ -54,6 +54,36 @@ internal interface PendingOperationV2Dao {
     fun observeFailureCount(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<Int>
 
     /**
+     * Live snapshots of ops still within retry budget, oldest first. Backs the
+     * sync indicator's visible pending list.
+     */
+    @Query(
+        """
+        SELECT * FROM pending_operation
+         WHERE failureCount <= :maxAttempts
+         ORDER BY enqueuedAt ASC
+        """,
+    )
+    fun observePending(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<List<PendingOperationV2Entity>>
+
+    /**
+     * Live snapshots of terminally failed ops (past [maxAttempts]), oldest first.
+     * Backs the sync indicator's failed-operations list.
+     */
+    @Query(
+        """
+        SELECT * FROM pending_operation
+         WHERE failureCount > :maxAttempts
+         ORDER BY enqueuedAt ASC
+        """,
+    )
+    fun observeFailed(maxAttempts: Int = MAX_RETRYABLE_ATTEMPTS): Flow<List<PendingOperationV2Entity>>
+
+    /** Re-arm an op for dispatch: zero its retry budget and clear the stored error. */
+    @Query("UPDATE pending_operation SET failureCount = 0, lastError = NULL WHERE clientOpId = :clientOpId")
+    suspend fun resetFailureCount(clientOpId: String)
+
+    /**
      * Delete still-queued (within retry budget) ops for one (domain, entity, opType) slot.
      * Backs replace-on-enqueue coalescing; terminally-failed rows (failureCount > [maxAttempts])
      * are preserved — diagnostic state for the failed-operation surface, not superseded work.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImpl.kt
@@ -1,19 +1,71 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.client.data.sync.BookEdit
+import com.calypsan.listenup.client.data.sync.ContributorEdit
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.data.sync.PreferencesEdit
+import com.calypsan.listenup.client.data.sync.ProfileEdit
+import com.calypsan.listenup.client.data.sync.SeriesEdit
+import com.calypsan.listenup.client.data.sync.PendingOperation as QueuedOperation
 import com.calypsan.listenup.client.domain.model.PendingOperation
+import com.calypsan.listenup.client.domain.model.PendingOperationStatus
+import com.calypsan.listenup.client.domain.model.PendingOperationType
 import com.calypsan.listenup.client.domain.repository.PendingOperationRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
-/** Empty compatibility facade after legacy pending operations are removed. */
-internal class PendingOperationRepositoryImpl : PendingOperationRepository {
-    override fun observeVisibleOperations(): Flow<List<PendingOperation>> = flowOf(emptyList())
+/**
+ * Read-model over [PendingOperationQueue] for the sync indicator: maps outbox
+ * rows to UI-facing [PendingOperation] values and routes retry/dismiss back
+ * to the queue.
+ */
+internal class PendingOperationRepositoryImpl(
+    private val queue: PendingOperationQueue,
+) : PendingOperationRepository {
+    override fun observeVisibleOperations(): Flow<List<PendingOperation>> =
+        queue.observePendingOperations().map { ops ->
+            ops
+                .filterNot { it.domainName in SILENT_DOMAINS }
+                .map { it.toDomainModel(PendingOperationStatus.PENDING) }
+        }
 
+    // The outbox has no in-flight marker (drain deletes on ack); there is no
+    // "currently sending" row to observe. Syncing comes from SyncRepository.
     override fun observeInProgressOperation(): Flow<PendingOperation?> = flowOf(null)
 
-    override fun observeFailedOperations(): Flow<List<PendingOperation>> = flowOf(emptyList())
+    override fun observeFailedOperations(): Flow<List<PendingOperation>> =
+        queue.observeFailedOperations().map { ops ->
+            ops.map { it.toDomainModel(PendingOperationStatus.FAILED) }
+        }
 
-    override suspend fun retry(id: String) = Unit
+    override suspend fun retry(id: String) = queue.retryOp(id)
 
-    override suspend fun dismiss(id: String) = Unit
+    override suspend fun dismiss(id: String) = queue.dismissOp(id)
+
+    private companion object {
+        /** Background domains users don't manage by hand; hidden from the pending count. */
+        val SILENT_DOMAINS = setOf("listening_events", "playback_positions", PreferencesEdit.name)
+    }
 }
+
+private fun QueuedOperation.toDomainModel(status: PendingOperationStatus): PendingOperation =
+    PendingOperation(
+        id = clientOpId,
+        operationType = operationTypeFor(domainName),
+        entityId = entityId,
+        status = status,
+        lastError = lastError,
+    )
+
+private fun operationTypeFor(domainName: String): PendingOperationType =
+    when (domainName) {
+        BookEdit.name -> PendingOperationType.BOOK_UPDATE
+        SeriesEdit.name -> PendingOperationType.SERIES_UPDATE
+        ContributorEdit.name -> PendingOperationType.CONTRIBUTOR_UPDATE
+        ProfileEdit.name -> PendingOperationType.PROFILE_UPDATE
+        PreferencesEdit.name -> PendingOperationType.USER_PREFERENCES
+        "playback_positions" -> PendingOperationType.PLAYBACK_POSITION
+        "listening_events" -> PendingOperationType.LISTENING_EVENT
+        else -> PendingOperationType.OTHER
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperation.kt
@@ -13,4 +13,6 @@ internal data class PendingOperation(
     val enqueuedAt: Long,
     val failureCount: Int,
     val ownerUserId: String,
+    /** Stable [com.calypsan.listenup.api.error.AppError.code] of the last failure, if any. */
+    val lastError: String? = null,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueue.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 
 private val logger = KotlinLogging.logger {}
@@ -233,6 +234,32 @@ internal class PendingOperationQueue(
     /** Live count of ops past [MAX_RETRYABLE_ATTEMPTS]. Engine forwards to `SyncEngineState`. */
     fun observeFailureCount(): Flow<Int> = dao.observeFailureCount()
 
+    /** Live snapshots of ops still within retry budget, oldest first. */
+    fun observePendingOperations(): Flow<List<PendingOperation>> =
+        dao.observePending().map { rows -> rows.map { it.toDomain() } }
+
+    /** Live snapshots of terminally failed ops (past [MAX_RETRYABLE_ATTEMPTS]), oldest first. */
+    fun observeFailedOperations(): Flow<List<PendingOperation>> =
+        dao.observeFailed().map { rows -> rows.map { it.toDomain() } }
+
+    /**
+     * Re-arm a terminally failed op and tick the enqueue signal so the engine
+     * schedules a drain wave (the same trigger a fresh [enqueue] uses). If the
+     * op fails non-retryably again it returns to the terminal state.
+     */
+    suspend fun retryOp(clientOpId: String) {
+        dao.resetFailureCount(clientOpId)
+        enqueueCounter.update { it + 1 }
+    }
+
+    /**
+     * Drop an op permanently. The optimistic local edit stays in Room; it
+     * reconciles to server truth on the next catch-up/reconcile pass.
+     */
+    suspend fun dismissOp(clientOpId: String) {
+        dao.delete(clientOpId)
+    }
+
     /**
      * Wipe ops not owned by [currentUserId]. Called by `SyncEngine.start` when
      * the signed-in user differs from the one whose ops are queued. Same-user
@@ -252,5 +279,6 @@ internal class PendingOperationQueue(
             enqueuedAt = enqueuedAt,
             failureCount = failureCount,
             ownerUserId = ownerUserId,
+            lastError = lastError,
         )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/LibraryModule.kt
@@ -39,6 +39,7 @@ private const val APP_SCOPE = "appScope"
  *  - [com.calypsan.listenup.client.data.sync.SyncEngine] — `clientSyncRenovationModule`
  *  - [com.calypsan.listenup.client.data.sync.SyncEngineState] — `clientSyncRenovationModule`
  *  - [com.calypsan.listenup.client.data.sync.OfflineEditor] — `clientSyncRenovationModule`
+ *  - [com.calypsan.listenup.client.data.sync.PendingOperationQueue] — `clientSyncRenovationModule`
  *  - [com.calypsan.listenup.client.domain.repository.AuthSession] — `clientAuthModule`
  *  - [com.calypsan.listenup.client.playback.ListeningEventRecorder] — `listeningModule`
  *  - [com.calypsan.listenup.client.data.local.db.BookDao] — `persistenceModule`
@@ -129,7 +130,7 @@ internal val libraryModule: Module =
         // PendingOperationRepository (domain) for UI observation of sync status
         // Wraps the data layer contract to provide domain models to ViewModels
         single<PendingOperationRepository> {
-            PendingOperationRepositoryImpl()
+            PendingOperationRepositoryImpl(queue = get())
         }
 
         // LibraryRepository — observation-only Room-backed view of the libraries domain.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/PendingOperation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/PendingOperation.kt
@@ -22,33 +22,19 @@ data class PendingOperation(
 )
 
 /**
- * Operation types visible to the UI layer.
- *
- * Mirrors the data layer OperationType but lives in the domain layer
- * to avoid entity leakage into the presentation layer.
+ * Operation types visible to the UI layer, keyed off the outbox row's
+ * `domainName`. [OTHER] is the forward-compat fallback for a domain name
+ * this build doesn't recognize.
  */
 enum class PendingOperationType {
     BOOK_UPDATE,
-    CONTRIBUTOR_UPDATE,
     SERIES_UPDATE,
-    SET_BOOK_CONTRIBUTORS,
-    SET_BOOK_SERIES,
-    MERGE_CONTRIBUTOR,
-    UNMERGE_CONTRIBUTOR,
-    LISTENING_EVENT,
-    PLAYBACK_POSITION,
-    USER_PREFERENCES,
+    CONTRIBUTOR_UPDATE,
     PROFILE_UPDATE,
-    PROFILE_AVATAR,
-    MARK_COMPLETE,
-    DISCARD_PROGRESS,
-    RESTART_BOOK,
-    END_PLAYBACK_SESSION,
-    CREATE_SHELF,
-    UPDATE_SHELF,
-    DELETE_SHELF,
-    ADD_BOOKS_TO_SHELF,
-    REMOVE_BOOK_FROM_SHELF,
+    USER_PREFERENCES,
+    PLAYBACK_POSITION,
+    LISTENING_EVENT,
+    OTHER,
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PendingOperationRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PendingOperationRepository.kt
@@ -26,7 +26,8 @@ interface PendingOperationRepository {
     /**
      * Observe the currently in-progress operation.
      *
-     * Used to display "Syncing: ..." status.
+     * Always null with the current outbox — it keeps no in-flight marker (a drain
+     * wave deletes an op on success rather than flagging it "sending").
      *
      * @return Flow of the current operation, null if none in progress
      */
@@ -44,7 +45,7 @@ interface PendingOperationRepository {
     /**
      * Retry a failed operation.
      *
-     * Resets the operation to pending state for another sync attempt.
+     * Re-arms the operation for another dispatch attempt.
      *
      * @param id The operation ID to retry
      */
@@ -53,7 +54,8 @@ interface PendingOperationRepository {
     /**
      * Dismiss a failed operation.
      *
-     * Discards local changes and marks the entity for re-sync from server.
+     * Deletes the queued operation; local optimistic state reconciles from the
+     * server on the next catch-up.
      *
      * @param id The operation ID to dismiss
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
@@ -204,23 +204,28 @@ class SyncIndicatorViewModel(
 
 internal sealed interface OpDescription {
     /** Operation describes work on a specific entity; [template] is invoked with the entity name. */
-    data class Entity(val template: (String) -> String) : OpDescription
+    data class Entity(
+        val template: (String) -> String,
+    ) : OpDescription
 
     /** Operation has no per-entity context; [text] is the fixed description shown to the user. */
-    data class Global(val text: String) : OpDescription
+    data class Global(
+        val text: String,
+    ) : OpDescription
 }
 
 internal val PendingOperationType.description: OpDescription
-    get() = when (this) {
-        PendingOperationType.BOOK_UPDATE -> OpDescription.Entity { name -> "Updating book $name" }
-        PendingOperationType.SERIES_UPDATE -> OpDescription.Entity { name -> "Updating series $name" }
-        PendingOperationType.CONTRIBUTOR_UPDATE -> OpDescription.Entity { name -> "Updating contributor $name" }
-        PendingOperationType.PROFILE_UPDATE -> OpDescription.Global("Updating profile")
-        PendingOperationType.USER_PREFERENCES -> OpDescription.Global("Syncing preferences")
-        PendingOperationType.PLAYBACK_POSITION -> OpDescription.Global("Syncing playback position")
-        PendingOperationType.LISTENING_EVENT -> OpDescription.Global("Syncing listening data")
-        PendingOperationType.OTHER -> OpDescription.Global("Syncing changes")
-    }
+    get() =
+        when (this) {
+            PendingOperationType.BOOK_UPDATE -> OpDescription.Entity { name -> "Updating book $name" }
+            PendingOperationType.SERIES_UPDATE -> OpDescription.Entity { name -> "Updating series $name" }
+            PendingOperationType.CONTRIBUTOR_UPDATE -> OpDescription.Entity { name -> "Updating contributor $name" }
+            PendingOperationType.PROFILE_UPDATE -> OpDescription.Global("Updating profile")
+            PendingOperationType.USER_PREFERENCES -> OpDescription.Global("Syncing preferences")
+            PendingOperationType.PLAYBACK_POSITION -> OpDescription.Global("Syncing playback position")
+            PendingOperationType.LISTENING_EVENT -> OpDescription.Global("Syncing listening data")
+            PendingOperationType.OTHER -> OpDescription.Global("Syncing changes")
+        }
 
 internal fun PendingOperationType.describe(entityName: String): String =
     when (val d = description) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
@@ -213,26 +213,13 @@ internal sealed interface OpDescription {
 internal val PendingOperationType.description: OpDescription
     get() = when (this) {
         PendingOperationType.BOOK_UPDATE -> OpDescription.Entity { name -> "Updating book $name" }
-        PendingOperationType.CONTRIBUTOR_UPDATE -> OpDescription.Entity { name -> "Updating contributor $name" }
         PendingOperationType.SERIES_UPDATE -> OpDescription.Entity { name -> "Updating series $name" }
-        PendingOperationType.SET_BOOK_CONTRIBUTORS -> OpDescription.Entity { name -> "Setting contributors for book $name" }
-        PendingOperationType.SET_BOOK_SERIES -> OpDescription.Entity { name -> "Setting series for book $name" }
-        PendingOperationType.MERGE_CONTRIBUTOR -> OpDescription.Global("Merging contributors")
-        PendingOperationType.UNMERGE_CONTRIBUTOR -> OpDescription.Global("Unmerging contributor")
-        PendingOperationType.LISTENING_EVENT -> OpDescription.Global("Syncing listening data")
-        PendingOperationType.PLAYBACK_POSITION -> OpDescription.Global("Syncing playback position")
-        PendingOperationType.USER_PREFERENCES -> OpDescription.Global("Syncing preferences")
+        PendingOperationType.CONTRIBUTOR_UPDATE -> OpDescription.Entity { name -> "Updating contributor $name" }
         PendingOperationType.PROFILE_UPDATE -> OpDescription.Global("Updating profile")
-        PendingOperationType.PROFILE_AVATAR -> OpDescription.Global("Uploading avatar")
-        PendingOperationType.MARK_COMPLETE -> OpDescription.Global("Marking book complete")
-        PendingOperationType.DISCARD_PROGRESS -> OpDescription.Entity { name -> "Discarding progress for book $name" }
-        PendingOperationType.RESTART_BOOK -> OpDescription.Entity { name -> "Restarting book $name" }
-        PendingOperationType.END_PLAYBACK_SESSION -> OpDescription.Global("Syncing playback session")
-        PendingOperationType.CREATE_SHELF -> OpDescription.Global("Creating shelf")
-        PendingOperationType.UPDATE_SHELF -> OpDescription.Global("Updating shelf")
-        PendingOperationType.DELETE_SHELF -> OpDescription.Global("Deleting shelf")
-        PendingOperationType.ADD_BOOKS_TO_SHELF -> OpDescription.Global("Adding books to shelf")
-        PendingOperationType.REMOVE_BOOK_FROM_SHELF -> OpDescription.Global("Removing book from shelf")
+        PendingOperationType.USER_PREFERENCES -> OpDescription.Global("Syncing preferences")
+        PendingOperationType.PLAYBACK_POSITION -> OpDescription.Global("Syncing playback position")
+        PendingOperationType.LISTENING_EVENT -> OpDescription.Global("Syncing listening data")
+        PendingOperationType.OTHER -> OpDescription.Global("Syncing changes")
     }
 
 internal fun PendingOperationType.describe(entityName: String): String =

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImplTest.kt
@@ -87,6 +87,14 @@ private class FakePendingOperationV2Dao : PendingOperationV2Dao {
         }
     }
 
+    override fun observePending(maxAttempts: Int): Flow<List<PendingOperationV2Entity>> = flowOf(inserted.toList())
+
+    override fun observeFailed(maxAttempts: Int): Flow<List<PendingOperationV2Entity>> = flowOf(emptyList())
+
+    override suspend fun resetFailureCount(clientOpId: String) {
+        inserted.replaceAll { if (it.clientOpId == clientOpId) it.copy(failureCount = 0, lastError = null) else it }
+    }
+
     override fun observeQueueDepth(): Flow<Int> = flowOf(inserted.size)
 
     override fun observeFailureCount(maxAttempts: Int): Flow<Int> = flowOf(0)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryModuleVerifyTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.local.db.dao.LibraryFolderDao
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
 import com.calypsan.listenup.client.data.sync.FtsPopulatorContract
 import com.calypsan.listenup.client.data.sync.OfflineEditor
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
 import com.calypsan.listenup.client.data.sync.SyncEngine
 import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -30,6 +31,7 @@ import org.koin.test.verify.verify
  *  - [SyncEngine] — owned by `clientSyncRenovationModule`.
  *  - [SyncEngineState] — owned by `clientSyncRenovationModule`.
  *  - [OfflineEditor] — owned by `clientSyncRenovationModule`.
+ *  - [PendingOperationQueue] — owned by `clientSyncRenovationModule`.
  *  - [AuthSession] — owned by `clientAuthModule`.
  *  - [ListeningEventRecorder] — owned by `listeningModule`.
  *  - [BookDao] — owned by `persistenceModule`.
@@ -55,6 +57,7 @@ class LibraryModuleVerifyTest :
                         SyncEngine::class,
                         SyncEngineState::class,
                         OfflineEditor::class,
+                        PendingOperationQueue::class,
                         AuthSession::class,
                         ListeningEventRecorder::class,
                         BookDao::class,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModelTest.kt
@@ -1,0 +1,167 @@
+package com.calypsan.listenup.client.presentation.sync
+
+import app.cash.turbine.test
+import com.calypsan.listenup.client.domain.model.PendingOperation
+import com.calypsan.listenup.client.domain.model.PendingOperationStatus
+import com.calypsan.listenup.client.domain.model.PendingOperationType
+import com.calypsan.listenup.client.domain.model.SyncState
+import com.calypsan.listenup.client.domain.repository.PendingOperationRepository
+import com.calypsan.listenup.client.domain.repository.SyncRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+/**
+ * Hand-written fake over [PendingOperationRepository] — a state-carrying test double per the
+ * repo's fake-with-state convention, rather than a mock, since the tests drive multiple flows
+ * plus retry/dismiss recording.
+ */
+private class FakePendingOperationRepository : PendingOperationRepository {
+    val visible = MutableStateFlow<List<PendingOperation>>(emptyList())
+    val failed = MutableStateFlow<List<PendingOperation>>(emptyList())
+    val retried = mutableListOf<String>()
+    val dismissed = mutableListOf<String>()
+
+    override fun observeVisibleOperations(): Flow<List<PendingOperation>> = visible
+
+    override fun observeInProgressOperation(): Flow<PendingOperation?> = flowOf(null)
+
+    override fun observeFailedOperations(): Flow<List<PendingOperation>> = failed
+
+    override suspend fun retry(id: String) {
+        retried += id
+    }
+
+    override suspend fun dismiss(id: String) {
+        dismissed += id
+    }
+}
+
+private fun pendingOp(
+    id: String,
+    entityId: String = "entity1",
+): PendingOperation =
+    PendingOperation(
+        id = id,
+        operationType = PendingOperationType.BOOK_UPDATE,
+        entityId = entityId,
+        status = PendingOperationStatus.PENDING,
+        lastError = null,
+    )
+
+private fun failedOp(
+    id: String,
+    entityId: String,
+    lastError: String,
+): PendingOperation =
+    PendingOperation(
+        id = id,
+        operationType = PendingOperationType.BOOK_UPDATE,
+        entityId = entityId,
+        status = PendingOperationStatus.FAILED,
+        lastError = lastError,
+    )
+
+/**
+ * Characterization tests for [SyncIndicatorViewModel] against the now-real repository contract.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncIndicatorViewModelTest :
+    FunSpec({
+
+        val testDispatcher = StandardTestDispatcher()
+
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
+
+        fun buildViewModel(repo: FakePendingOperationRepository): SyncIndicatorViewModel {
+            val syncRepository =
+                mock<SyncRepository> {
+                    every { syncState } returns MutableStateFlow<SyncState>(SyncState.Idle)
+                }
+            return SyncIndicatorViewModel(pendingOperationRepository = repo, syncRepository = syncRepository)
+        }
+
+        test("state derives pendingCount from visible PENDING operations") {
+            runTest(testDispatcher) {
+                val repo = FakePendingOperationRepository()
+                repo.visible.value = listOf(pendingOp("op1"), pendingOp("op2"))
+                val vm = buildViewModel(repo)
+
+                vm.state.test {
+                    var item = awaitItem()
+                    while (item.pendingCount == 0) item = awaitItem()
+                    val expectedCount = 2
+                    item.pendingCount shouldBe expectedCount
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("state maps failed operations to descriptions with hasErrors") {
+            runTest(testDispatcher) {
+                val repo = FakePendingOperationRepository()
+                repo.failed.value = listOf(failedOp("op1", entityId = "book1234xyz", lastError = "SYNC_NOT_FOUND"))
+                val vm = buildViewModel(repo)
+
+                vm.state.test {
+                    var item = awaitItem()
+                    while (!item.hasErrors) item = awaitItem()
+                    item.hasErrors shouldBe true
+                    val failedUi = item.failedOperations.single()
+                    failedUi.id shouldBe "op1"
+                    failedUi.isFailed shouldBe true
+                    failedUi.error shouldBe "SYNC_NOT_FOUND"
+                    failedUi.description shouldBe "Updating book book1234"
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+        test("RetryOperation and DismissOperation route to the repository") {
+            runTest(testDispatcher) {
+                val repo = FakePendingOperationRepository()
+                val vm = buildViewModel(repo)
+
+                vm.onEvent(SyncIndicatorUiEvent.RetryOperation("op1"))
+                vm.onEvent(SyncIndicatorUiEvent.DismissOperation("op2"))
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                repo.retried shouldBe listOf("op1")
+                repo.dismissed shouldBe listOf("op2")
+            }
+        }
+
+        test("RetryAll retries every failed operation") {
+            runTest(testDispatcher) {
+                val repo = FakePendingOperationRepository()
+                repo.failed.value =
+                    listOf(
+                        failedOp("op1", entityId = "e1", lastError = "SYNC_NOT_FOUND"),
+                        failedOp("op2", entityId = "e2", lastError = "SYNC_NOT_FOUND"),
+                    )
+                val vm = buildViewModel(repo)
+
+                vm.state.test {
+                    var item = awaitItem()
+                    while (item.failedOperations.isEmpty()) item = awaitItem()
+                    vm.onEvent(SyncIndicatorUiEvent.RetryAll)
+                    testDispatcher.scheduler.advanceUntilIdle()
+                    cancelAndIgnoreRemainingEvents()
+                }
+
+                repo.retried shouldBe listOf("op1", "op2")
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2DaoTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationV2DaoTest.kt
@@ -102,4 +102,56 @@ class PendingOperationV2DaoTest :
                 db.close()
             }
         }
+
+        test("observePending emits only ops within retry budget, oldest first") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val dao = db.pendingOperationV2Dao()
+                val maxAttempts = 5
+                dao.insert(row("healthy", "tags", "t1", 100L, failureCount = 0))
+                dao.insert(row("terminal", "tags", "t2", 200L, failureCount = maxAttempts + 1))
+                val pending = dao.observePending().first()
+                pending.map { it.clientOpId } shouldContainExactly listOf("healthy")
+                db.close()
+            }
+        }
+
+        test("observeFailed emits only ops past the retry budget") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val dao = db.pendingOperationV2Dao()
+                val maxAttempts = 5
+                dao.insert(row("healthy", "tags", "t1", 100L, failureCount = 0))
+                dao.insert(row("terminal", "tags", "t2", 200L, failureCount = maxAttempts + 1))
+                val failed = dao.observeFailed().first()
+                failed.map { it.clientOpId } shouldContainExactly listOf("terminal")
+                db.close()
+            }
+        }
+
+        test("resetFailureCount zeroes failureCount and clears lastError") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val dao = db.pendingOperationV2Dao()
+                dao.insert(
+                    PendingOperationV2Entity(
+                        clientOpId = "terminal",
+                        domainName = "tags",
+                        entityId = "t1",
+                        opType = "upsert",
+                        payload = "{}",
+                        enqueuedAt = 100L,
+                        lastAttemptAt = 200L,
+                        failureCount = 6,
+                        lastError = "SOME_CODE",
+                        ownerUserId = "u1",
+                    ),
+                )
+                dao.resetFailureCount("terminal")
+                val updated = dao.get("terminal")
+                updated?.failureCount shouldBe 0
+                updated?.lastError shouldBe null
+                db.close()
+            }
+        }
     })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImplTest.kt
@@ -1,0 +1,101 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.data.sync.PendingOperationSender
+import com.calypsan.listenup.client.domain.model.PendingOperationStatus
+import com.calypsan.listenup.client.domain.model.PendingOperationType
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [PendingOperationRepositoryImpl] — the read-model over the live
+ * [PendingOperationQueue] that backs the sync indicator.
+ */
+class PendingOperationRepositoryImplTest :
+    FunSpec({
+
+        test("observeVisibleOperations excludes silent domains and maps status PENDING") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { 1_000L },
+                    )
+                val repo = PendingOperationRepositoryImpl(queue = queue)
+                queue.enqueue("books", "b1", "update", "{}", "u1")
+                queue.enqueue("playback_positions", "b1", "upsert", "{}", "u1")
+                queue.enqueue("listening_events", "e1", "upsert", "{}", "u1")
+                queue.enqueue("preferences", "u1", "update", "{}", "u1")
+
+                val visible = repo.observeVisibleOperations().first()
+
+                visible shouldHaveSize 1
+                visible.single().operationType shouldBe PendingOperationType.BOOK_UPDATE
+                visible.single().status shouldBe PendingOperationStatus.PENDING
+                db.close()
+            }
+        }
+
+        test("observeFailedOperations maps terminal ops with FAILED status, error code, and OTHER fallback") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val error = SyncError.NotFound(domain = "books", entityId = "b1")
+                val sender = PendingOperationSender { AppResult.Failure(error) }
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { 1_000L },
+                    )
+                val repo = PendingOperationRepositoryImpl(queue = queue)
+                queue.enqueue("books", "b1", "update", "{}", "u1")
+                queue.enqueue("tags", "t1", "update", "{}", "u1")
+                queue.drain()
+
+                val failed = repo.observeFailedOperations().first()
+
+                failed shouldHaveSize 2
+                failed.forEach { it.status shouldBe PendingOperationStatus.FAILED }
+                failed.forEach { it.lastError shouldBe error.code }
+                failed.map { it.operationType } shouldContainExactlyInAnyOrder
+                    listOf(PendingOperationType.BOOK_UPDATE, PendingOperationType.OTHER)
+                db.close()
+            }
+        }
+
+        test("retry and dismiss delegate to the queue") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val error = SyncError.NotFound(domain = "books", entityId = "b1")
+                val sender = PendingOperationSender { AppResult.Failure(error) }
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { 1_000L },
+                    )
+                val repo = PendingOperationRepositoryImpl(queue = queue)
+                val opId = queue.enqueue("books", "b1", "update", "{}", "u1")
+                queue.drain()
+                db.pendingOperationV2Dao().nextDispatchable() shouldHaveSize 0
+
+                repo.retry(opId)
+
+                db.pendingOperationV2Dao().nextDispatchable().map { it.clientOpId } shouldContainExactlyInAnyOrder listOf(opId)
+
+                repo.dismiss(opId)
+
+                db.pendingOperationV2Dao().get(opId) shouldBe null
+                db.close()
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingOperationQueueTest.kt
@@ -9,6 +9,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 class PendingOperationQueueTest :
@@ -230,6 +231,85 @@ class PendingOperationQueueTest :
                 db.pendingOperationV2Dao().get(other) shouldNotBe null
                 db.pendingOperationV2Dao().get(latest)?.payload shouldBe """{"v":2}"""
                 db.pendingOperationV2Dao().countDispatchable() shouldBe 2
+                db.close()
+            }
+        }
+
+        test("observeFailedOperations emits terminal ops with their lastError code") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val sender =
+                    PendingOperationSender { op ->
+                        if (op.entityId == "t1") {
+                            AppResult.Failure(SyncError.NotFound(domain = "tags", entityId = "t1"))
+                        } else {
+                            AppResult.Success(Unit)
+                        }
+                    }
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { 1_000L },
+                    )
+                queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                queue.drain()
+                val healthy = queue.enqueue("tags", "t2", "upsert", "{}", "u1")
+                val failed = queue.observeFailedOperations().first()
+                failed.map { it.entityId } shouldContainExactly listOf("t1")
+                failed.single().lastError shouldBe SyncError.NotFound(domain = "tags", entityId = "t1").code
+                val pending = queue.observePendingOperations().first()
+                pending.map { it.clientOpId } shouldContainExactly listOf(healthy)
+                db.close()
+            }
+        }
+
+        test("retryOp makes a terminal op dispatchable again and ticks the enqueue signal") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var shouldFail = true
+                val sender =
+                    PendingOperationSender {
+                        if (shouldFail) {
+                            AppResult.Failure(SyncError.NotFound(domain = "tags", entityId = "t1"))
+                        } else {
+                            AppResult.Success(Unit)
+                        }
+                    }
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = sender,
+                        nowMillis = { 1_000L },
+                    )
+                val opId = queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                queue.drain()
+                db.pendingOperationV2Dao().nextDispatchable().map { it.clientOpId } shouldBe emptyList()
+                val signalBefore = queue.observeEnqueueSignal().value
+                queue.retryOp(opId)
+                queue.observeEnqueueSignal().value shouldBe signalBefore + 1
+                db.pendingOperationV2Dao().nextDispatchable().map { it.clientOpId } shouldContainExactly listOf(opId)
+                shouldFail = false
+                queue.drain()
+                db.pendingOperationV2Dao().get(opId) shouldBe null
+                db.close()
+            }
+        }
+
+        test("dismissOp removes the op from the queue") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                val queue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = PendingOperationSender { AppResult.Success(Unit) },
+                        nowMillis = { 1_000L },
+                    )
+                val opId = queue.enqueue("tags", "t1", "upsert", "{}", "u1")
+                queue.dismissOp(opId)
+                db.pendingOperationV2Dao().get(opId) shouldBe null
+                val expectedDepth = 0
+                queue.observeQueueDepth().first() shouldBe expectedDepth
                 db.close()
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -395,6 +395,12 @@ private class CountingDao(
         maxAttempts: Int,
     ) = delegate.deleteQueuedOps(domainName, entityId, opType, maxAttempts)
 
+    override fun observePending(maxAttempts: Int) = delegate.observePending(maxAttempts)
+
+    override fun observeFailed(maxAttempts: Int) = delegate.observeFailed(maxAttempts)
+
+    override suspend fun resetFailureCount(clientOpId: String) = delegate.resetFailureCount(clientOpId)
+
     override fun observeQueueDepth() = delegate.observeQueueDepth()
 
     override fun observeFailureCount(maxAttempts: Int) = delegate.observeFailureCount(maxAttempts)


### PR DESCRIPTION
Plan 055 (/improve batch-5, bug) — completes the offline-outbox trilogy with #979 (054) and #982 (061).

The sync indicator promised users a pending count, a failed-operations list with per-item Retry/Dismiss, and "Retry all" — but it was wired to `PendingOperationRepositoryImpl`, a self-described "empty compatibility facade" whose flows are constant `flowOf(emptyList())` and whose retry/dismiss are no-ops. Meanwhile the real outbox silently accumulated terminally-failed edits (past `MAX_RETRYABLE_ATTEMPTS`) that were never retried and never shown — a lost offline edit with zero indication and zero recovery, violating the "never stranded" pillar.

**Fix**: rewire the repository over the live `PendingOperationQueue`.
- New queue/dao read model: `observePending`/`observeFailed` (`@Query` list flows), `resetFailureCount`; `observePendingOperations`/`observeFailedOperations`/`retryOp`/`dismissOp` on the queue. `retryOp` zeroes the retry budget and ticks the enqueue signal so 054's drain loop re-dispatches it; `dismissOp` deletes the row (local optimistic edit reconciles from server on next catch-up).
- `PendingOperationRepositoryImpl` maps outbox rows to UI models, mutes routine domains (positions/events/preferences) from the *pending* count but surfaces *failures* from all domains, and routes retry/dismiss to the queue.
- Trimmed `PendingOperationType` from 22 stale values to the 7 domains that actually enqueue ops + an `OTHER` fallback.
- **No sharedUI change** — the existing `SyncDetailsDropdown`/`AppShell` bindings become live.

**Tests**: 13 new (dao filter/reset, queue failed-list/retry/dismiss, repository mapping + silent-domain filtering, and the first-ever `SyncIndicatorViewModel` characterization suite).

**Verification (reviewer-run)**: `:sharedLogic:jvmTest` (full, incl. Konsist) ✅, `:sharedLogic:testAndroidHostTest` + `:sharedUI:testAndroidHostTest` ✅, `compileCommonMainKotlinMetadata` + `spotlessCheck detekt` ✅. No schema/contract/export-surface change.

Base note: branched off main before #985 (059) merged; both touch `di/LibraryModule.kt` on different bindings.