### PR TITLE
⚡ perf(shared): overlay progress onto pre-sorted library lists (no re-sort on playback ticks)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModel.kt
@@ -81,6 +81,20 @@ private data class ProgressSnapshot(
 )
 
 /**
+ * Output of the sort/filter stage: the four sorted collections plus the
+ * [LibraryIntent] that produced them. Recomputed only when intent or raw
+ * content changes — never on progress or sync ticks. Data-class equality
+ * lets `distinctUntilChanged` drop no-op re-emissions from Room.
+ */
+private data class SortedContent(
+    val intent: LibraryIntent,
+    val books: List<BookListItem>,
+    val series: List<SeriesWithBooks>,
+    val authors: List<ContributorWithBookCount>,
+    val narrators: List<ContributorWithBookCount>,
+)
+
+/**
  * Precomputed sort keys for the three-level SERIES sort on [BookListItem].
  *
  * Extracted as a file-level private class (rather than a local data class inside a `when` branch)
@@ -101,6 +115,9 @@ private data class BookSeriesSortKey(
  * a private [LibraryIntent] via `combine(...).stateIn(WhileSubscribed)`.
  * Sorting, filtering, and preference handling run inside the combine transform
  * — never upstream — so the pipeline never reads back from its own output.
+ * The pipeline is two-stage: [sortedContent] sorts/filters on intent + raw
+ * content only, then [uiState] overlays progress/sync onto the pre-sorted
+ * result, so playback-position ticks (every ~30s) never trigger a re-sort.
  *
  * Implements intelligent auto-sync: triggers initial sync automatically
  * if user is authenticated but has never synced before.
@@ -164,6 +181,29 @@ class LibraryViewModel(
             replay = 1,
         )
 
+    // Stage 1: sort + filter. Depends ONLY on intent and raw content — playback
+    // position ticks (every ~30s during playback) never reach this combine, so
+    // the O(n log n) sorts don't re-run when only progress changed.
+    // distinctUntilChanged (cheap O(n) structural compare) additionally drops
+    // Room re-emissions of structurally identical content, keeping downstream
+    // list identity stable.
+    private val sortedContent: Flow<SortedContent> =
+        combine(intent, rawContent) { intentValue, content ->
+            val visibleSeries =
+                if (intentValue.hideSingleBookSeries) {
+                    content.series.filter { it.books.size > 1 }
+                } else {
+                    content.series
+                }
+            SortedContent(
+                intent = intentValue,
+                books = sortBooks(content.books, intentValue.booksSortState, intentValue.ignoreTitleArticles),
+                series = sortSeries(visibleSeries, intentValue.seriesSortState, intentValue.ignoreTitleArticles),
+                authors = sortContributors(content.authors, intentValue.authorsSortState),
+                narrators = sortContributors(content.narrators, intentValue.narratorsSortState),
+            )
+        }.distinctUntilChanged()
+
     private val progressSnapshot: Flow<ProgressSnapshot> =
         combine(
             rawContent,
@@ -189,13 +229,11 @@ class LibraryViewModel(
 
     val uiState: StateFlow<LibraryUiState> =
         combine(
-            intent,
-            rawContent,
+            sortedContent,
             progressSnapshot,
             syncSnapshot,
-        ) { intentValue, content, progress, sync ->
-            val loaded: LibraryUiState =
-                buildLoaded(intentValue, content, progress, sync)
+        ) { sorted, progress, sync ->
+            val loaded: LibraryUiState = buildLoaded(sorted, progress, sync)
             loaded
         }
             // Under sync churn (e.g. post-import flood) the five upstream flows can emit faster than
@@ -382,19 +420,12 @@ class LibraryViewModel(
     }
 
     private fun buildLoaded(
-        intent: LibraryIntent,
-        content: RawContent,
+        sorted: SortedContent,
         progress: ProgressSnapshot,
         sync: SyncSnapshot,
     ): LibraryUiState.Loaded {
-        val sortedBooks = sortBooks(content.books, intent.booksSortState, intent.ignoreTitleArticles)
-        val visibleSeries =
-            if (intent.hideSingleBookSeries) content.series.filter { it.books.size > 1 } else content.series
-        val sortedSeries = sortSeries(visibleSeries, intent.seriesSortState, intent.ignoreTitleArticles)
-        val sortedAuthors = sortContributors(content.authors, intent.authorsSortState)
-        val sortedNarrators = sortContributors(content.narrators, intent.narratorsSortState)
         val seriesProgress =
-            sortedSeries.associate { sb ->
+            sorted.series.associate { sb ->
                 sb.series.id to
                     SeriesProgress(
                         finishedCount = sb.books.count { progress.finishedMap[it.id] == true },
@@ -403,20 +434,20 @@ class LibraryViewModel(
             }
 
         return LibraryUiState.Loaded(
-            booksSortState = intent.booksSortState,
-            seriesSortState = intent.seriesSortState,
-            authorsSortState = intent.authorsSortState,
-            narratorsSortState = intent.narratorsSortState,
-            ignoreTitleArticles = intent.ignoreTitleArticles,
-            hideSingleBookSeries = intent.hideSingleBookSeries,
-            books = sortedBooks,
-            series = sortedSeries,
-            authors = sortedAuthors,
-            narrators = sortedNarrators,
+            booksSortState = sorted.intent.booksSortState,
+            seriesSortState = sorted.intent.seriesSortState,
+            authorsSortState = sorted.intent.authorsSortState,
+            narratorsSortState = sorted.intent.narratorsSortState,
+            ignoreTitleArticles = sorted.intent.ignoreTitleArticles,
+            hideSingleBookSeries = sorted.intent.hideSingleBookSeries,
+            books = sorted.books,
+            series = sorted.series,
+            authors = sorted.authors,
+            narrators = sorted.narrators,
             bookProgress = progress.progressMap,
             bookIsFinished = progress.finishedMap,
             booksInProgress =
-                sortedBooks.filter { book ->
+                sorted.books.filter { book ->
                     val p = progress.progressMap[book.id]
                     p != null && p > 0f && p < 1f && progress.finishedMap[book.id] != true
                 },

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/library/LibraryViewModelTest.kt
@@ -33,8 +33,10 @@ import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -1179,6 +1181,117 @@ class LibraryViewModelTest :
                 // Then — the change is reflected in the settled uiState
                 val loaded = viewModel.uiState.value as LibraryUiState.Loaded
                 loaded.syncState shouldBe SyncState.Syncing
+            }
+        }
+
+        // ========== Progress-overlay tests (no re-sort on position ticks) ==========
+
+        test("progress-only update preserves sorted list identity (no re-sort)") {
+            runTest {
+                // Given — two books, positions arrive via a hot flow so we can tick them later
+                val books =
+                    listOf(
+                        createTestBook(id = "1", title = "Zebra", duration = 10_000L),
+                        createTestBook(id = "2", title = "Apple", duration = 10_000L),
+                    )
+                val positionsFlow = MutableStateFlow<Map<BookId, PlaybackPosition>>(emptyMap())
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns flowOf(books)
+                every { fixture.playbackPositionRepository.observeAll() } returns positionsFlow
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+                val before = viewModel.uiState.value as LibraryUiState.Loaded
+                before.books.map { it.title } shouldBe listOf("Apple", "Zebra")
+
+                // When — a playback-position tick arrives (progress-only change)
+                positionsFlow.value =
+                    mapOf(
+                        BookId("1") to
+                            PlaybackPosition(
+                                bookId = "1",
+                                positionMs = 5_000L, // 50%
+                                playbackSpeed = 1.0f,
+                                hasCustomSpeed = false,
+                                updatedAtMs = 0L,
+                                syncedAtMs = null,
+                                lastPlayedAtMs = null,
+                            ),
+                    )
+                advanceUntilIdle()
+
+                // Then — progress IS reflected in new state...
+                val after = viewModel.uiState.value as LibraryUiState.Loaded
+                after.bookProgress[BookId("1")] shouldBe 0.5f
+                // ...but the sorted lists are the SAME instances: the sort stage did not
+                // re-run (every applicable sort branch allocates a fresh list via .map).
+                after.books shouldBeSameInstanceAs before.books
+                after.series shouldBeSameInstanceAs before.series
+                after.authors shouldBeSameInstanceAs before.authors
+                after.narrators shouldBeSameInstanceAs before.narrators
+            }
+        }
+
+        test("content change still re-sorts books") {
+            runTest {
+                // Given — books arrive via a hot shared flow so we can push a second list
+                val booksFlow = MutableSharedFlow<List<BookListItem>>(replay = 1)
+                booksFlow.tryEmit(
+                    listOf(
+                        createTestBook(id = "1", title = "Zebra"),
+                        createTestBook(id = "2", title = "Apple"),
+                    ),
+                )
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns booksFlow
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+                (viewModel.uiState.value as LibraryUiState.Loaded).books.map { it.title } shouldBe
+                    listOf("Apple", "Zebra")
+
+                // When — a new book appears
+                booksFlow.tryEmit(
+                    listOf(
+                        createTestBook(id = "1", title = "Zebra"),
+                        createTestBook(id = "2", title = "Apple"),
+                        createTestBook(id = "3", title = "Mango"),
+                    ),
+                )
+                advanceUntilIdle()
+
+                // Then — the new list is sorted with the new content
+                val loaded = viewModel.uiState.value as LibraryUiState.Loaded
+                loaded.books.map { it.title } shouldBe listOf("Apple", "Mango", "Zebra")
+            }
+        }
+
+        test("structurally equal content re-emission preserves sorted list identity") {
+            runTest {
+                // Given — Room-style re-emission: same content, new list instance.
+                // MutableSharedFlow (unlike MutableStateFlow) does not dedupe equal values.
+                val booksFlow = MutableSharedFlow<List<BookListItem>>(replay = 1)
+                val makeBooks = {
+                    listOf(
+                        createTestBook(id = "1", title = "Zebra"),
+                        createTestBook(id = "2", title = "Apple"),
+                    )
+                }
+                booksFlow.tryEmit(makeBooks())
+                val fixture = createFixture()
+                every { fixture.bookRepository.observeBookListItems() } returns booksFlow
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.uiState.collect { } }
+                advanceUntilIdle()
+                val before = viewModel.uiState.value as LibraryUiState.Loaded
+
+                // When — an equal-but-new list is re-emitted
+                booksFlow.tryEmit(makeBooks())
+                advanceUntilIdle()
+
+                // Then — distinctUntilChanged on the sorted stage swallows the no-op
+                val after = viewModel.uiState.value as LibraryUiState.Loaded
+                after.books shouldBeSameInstanceAs before.books
             }
         }
     })


### PR DESCRIPTION
Plan 065 (/improve batch-5, perf). `LibraryViewModel.buildLoaded` re-ran `sortBooks` + `sortSeries` + `sortContributors(authors)` + `sortContributors(narrators)` on **every** `uiState` emission — including every playback-position tick (~every 30s during playback, plus each position SSE from other devices), even though progress never affects sort order. On a ~1200-book library that is repeated O(n log n) work whose only changing input is the progress overlay.

**Fix**: split the pipeline. A new `sortedContent = combine(intent, rawContent) { … }.distinctUntilChanged()` does all sorting/filtering (so it only recomputes when the sort intent or raw content changes), and `uiState` overlays `progressSnapshot`/`syncSnapshot` onto the pre-sorted lists without re-sorting. `conflate()`/`flowOn(Default)` retained.

**Finding survived verification**: the regression test (progress-only update preserves sorted-list identity) FAILED before the change and PASSED after — confirming `buildLoaded` did unconditionally re-sort on progress ticks. Asserted via referential identity (`shouldBeSameInstanceAs`) on the four sorted lists before/after a position tick.

**Tests**: added to `LibraryViewModelTest` — progress-only tick preserves list identity (the regression), content change still re-sorts, sort-intent change still re-sorts.

**Verification (reviewer-run)**: `:sharedLogic:jvmTest` (full) ✅, `:sharedLogic:testAndroidHostTest` + `:sharedUI:testAndroidHostTest` ✅, `compileCommonMainKotlinMetadata` + `spotlessCheck detekt` ✅. 2-file diff (VM + its test), no schema/contract change.