### PR TITLE
✅ test(shared): pin single-flight token refresh under parallel 401s

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -8,6 +8,8 @@ import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
@@ -164,6 +166,13 @@ internal class KtorApiClientFactory(
     private val serverConfig: ServerConfig,
     private val authSession: AuthSession,
     private val refreshAccessToken: RefreshAccessToken,
+    /**
+     * Test-only engine override. `null` (production) selects the platform-default
+     * engine; tests inject a `MockEngine` so the real client configuration —
+     * bearer plugin, refresh bridge, retry policy, HttpSend interceptor — can be
+     * driven without a network.
+     */
+    private val engine: HttpClientEngine? = null,
 ) : ApiClientFactory {
     private val mutex = Mutex()
     private var cachedClient: HttpClient? = null
@@ -242,80 +251,80 @@ internal class KtorApiClientFactory(
 
         logger.info { "Creating HTTP client for server: ${initialUrl.value}" }
 
-        val client =
-            HttpClient {
-                installListenUpErrorHandling()
+        val config: HttpClientConfig<*>.() -> Unit = {
+            installListenUpErrorHandling()
 
-                install(ContentNegotiation) {
-                    json(appJson)
+            install(ContentNegotiation) {
+                json(appJson)
+            }
+
+            // Install HttpTimeout plugin to allow per-request timeout configuration
+            // Default timeouts for regular API calls (SSE uses separate client)
+            @Suppress("MagicNumber")
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 10_000
+                socketTimeoutMillis = 30_000
+            }
+
+            // Keepalive for the kotlinx.rpc WebSockets (installKrpc opens its sessions over this
+            // base client). Without pings, a half-open / "black-hole" socket is never detected and
+            // an in-flight RPC call awaits its response forever — the contributor-merge hang. A
+            // periodic ping fails the dead session so the call surfaces an error instead of spinning.
+            install(WebSockets) {
+                pingIntervalMillis = WS_PING_INTERVAL_MS
+            }
+
+            // Retry idempotent requests on 5xx responses and transient IO failures.
+            // POST/PATCH are never retried — callers must treat them as at-most-once
+            // or implement their own idempotency keys. See Finding 04 D3.
+            @Suppress("MagicNumber")
+            install(HttpRequestRetry) {
+                retryIf(maxRetries = 3) { request, response ->
+                    request.method in IDEMPOTENT_METHODS && response.status.value in 500..599
                 }
-
-                // Install HttpTimeout plugin to allow per-request timeout configuration
-                // Default timeouts for regular API calls (SSE uses separate client)
-                @Suppress("MagicNumber")
-                install(HttpTimeout) {
-                    requestTimeoutMillis = 30_000
-                    connectTimeoutMillis = 10_000
-                    socketTimeoutMillis = 30_000
+                retryOnExceptionIf(maxRetries = 3) { request, cause ->
+                    request.method in IDEMPOTENT_METHODS &&
+                        (cause is IOException || cause is HttpRequestTimeoutException)
                 }
+                exponentialDelay(base = 2.0, maxDelayMs = 10_000L)
+            }
 
-                // Keepalive for the kotlinx.rpc WebSockets (installKrpc opens its sessions over this
-                // base client). Without pings, a half-open / "black-hole" socket is never detected and
-                // an in-flight RPC call awaits its response forever — the contributor-merge hang. A
-                // periodic ping fails the dead session so the call surfaces an error instead of spinning.
-                install(WebSockets) {
-                    pingIntervalMillis = WS_PING_INTERVAL_MS
-                }
+            install(Auth) {
+                bearer {
+                    // Load initial tokens from storage
+                    loadTokens {
+                        val access = authSession.getAccessToken()?.value
+                        val refresh = authSession.getRefreshToken()?.value
 
-                // Retry idempotent requests on 5xx responses and transient IO failures.
-                // POST/PATCH are never retried — callers must treat them as at-most-once
-                // or implement their own idempotency keys. See Finding 04 D3.
-                @Suppress("MagicNumber")
-                install(HttpRequestRetry) {
-                    retryIf(maxRetries = 3) { request, response ->
-                        request.method in IDEMPOTENT_METHODS && response.status.value in 500..599
-                    }
-                    retryOnExceptionIf(maxRetries = 3) { request, cause ->
-                        request.method in IDEMPOTENT_METHODS &&
-                            (cause is IOException || cause is HttpRequestTimeoutException)
-                    }
-                    exponentialDelay(base = 2.0, maxDelayMs = 10_000L)
-                }
-
-                install(Auth) {
-                    bearer {
-                        // Load initial tokens from storage
-                        loadTokens {
-                            val access = authSession.getAccessToken()?.value
-                            val refresh = authSession.getRefreshToken()?.value
-
-                            if (access != null && refresh != null) {
-                                BearerTokens(
-                                    accessToken = access,
-                                    refreshToken = refresh,
-                                )
-                            } else {
-                                null
-                            }
+                        if (access != null && refresh != null) {
+                            BearerTokens(
+                                accessToken = access,
+                                refreshToken = refresh,
+                            )
+                        } else {
+                            null
                         }
-
-                        // Refresh tokens when receiving 401 Unauthorized
-                        refreshTokens {
-                            refreshAuthTokens(authSession, refreshAccessToken)
-                        }
-
-                        // Send bearer for every request EXCEPT auth endpoints (login, refresh,
-                        // logout) — those authenticate themselves via request body, and
-                        // attaching a bearer would trigger a refresh loop. See Finding 04 D2.
-                        sendWithoutRequest { request -> !isAuthEndpoint(request) }
                     }
-                }
 
-                defaultRequest {
-                    url(initialUrl.value)
-                    contentType(ContentType.Application.Json)
+                    // Refresh tokens when receiving 401 Unauthorized
+                    refreshTokens {
+                        refreshAuthTokens(authSession, refreshAccessToken)
+                    }
+
+                    // Send bearer for every request EXCEPT auth endpoints (login, refresh,
+                    // logout) — those authenticate themselves via request body, and
+                    // attaching a bearer would trigger a refresh loop. See Finding 04 D2.
+                    sendWithoutRequest { request -> !isAuthEndpoint(request) }
                 }
             }
+
+            defaultRequest {
+                url(initialUrl.value)
+                contentType(ContentType.Application.Json)
+            }
+        }
+        val client = engine?.let { HttpClient(it, config) } ?: HttpClient(config)
 
         // Install HttpSend interceptor for dynamic URL resolution and fallback.
         // Skipped for WebSocket upgrades: kotlinx.rpc opens RPC sessions over

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/TokenRefreshSingleFlightTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/TokenRefreshSingleFlightTest.kt
@@ -1,0 +1,219 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.api.AuthServiceAuthed
+import com.calypsan.listenup.api.AuthServicePublic
+import com.calypsan.listenup.api.dto.auth.AccessToken
+import com.calypsan.listenup.api.dto.auth.AuthSession as ContractAuthSession
+import com.calypsan.listenup.api.dto.auth.RefreshToken
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.User
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.dto.auth.UserStatus
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.repository.AuthRepositoryImpl
+import com.calypsan.listenup.client.domain.model.AuthState
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.PendingRegistration
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.test.http.testMockEngine
+import com.calypsan.listenup.core.ServerUrl
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+
+private const val PARALLEL_CALLERS = 5
+private const val STALE_ACCESS = "stale-access"
+private const val FRESH_ACCESS = "fresh-access"
+
+/**
+ * In-memory [AuthSession] fake: read-your-writes token state. The bearer
+ * plugin's `loadTokens` and the refresh bridge's `saveAuthTokens` both hit
+ * this. Members the flow never touches throw, so an unexpected call fails
+ * the test loudly instead of silently returning a default.
+ */
+private class FakeAuthSession : AuthSession {
+    var access: AccessToken? = AccessToken(STALE_ACCESS)
+    var refresh: RefreshToken? = RefreshToken("rt-0")
+
+    override val authState: StateFlow<AuthState> get() = throw NotImplementedError()
+
+    override suspend fun saveAuthTokens(
+        access: AccessToken,
+        refresh: RefreshToken,
+        sessionId: String,
+        userId: String,
+    ) {
+        this.access = access
+        this.refresh = refresh
+    }
+
+    override suspend fun getAccessToken(): AccessToken? = access
+
+    override suspend fun getRefreshToken(): RefreshToken? = refresh
+
+    override suspend fun updateAccessToken(token: AccessToken) {
+        access = token
+    }
+
+    override suspend fun clearAuthTokens() {
+        access = null
+        refresh = null
+    }
+
+    override suspend fun getSessionId(): String? = throw NotImplementedError()
+
+    override suspend fun getUserId(): String? = throw NotImplementedError()
+
+    override suspend fun isAuthenticated(): Boolean = throw NotImplementedError()
+
+    override suspend fun initializeAuthState() = throw NotImplementedError()
+
+    override suspend fun checkServerStatus(): AuthState = throw NotImplementedError()
+
+    override suspend fun refreshOpenRegistration() = throw NotImplementedError()
+
+    override suspend fun savePendingRegistration(
+        userId: String,
+        email: String,
+    ) = throw NotImplementedError()
+
+    override suspend fun getPendingRegistration(): PendingRegistration? = throw NotImplementedError()
+
+    override suspend fun clearPendingRegistration() = throw NotImplementedError()
+}
+
+/** Copied shape from RefreshAuthTokensTest.fakeContractSession. */
+private fun freshContractSession(): ContractAuthSession =
+    ContractAuthSession(
+        accessToken = AccessToken(FRESH_ACCESS),
+        accessTokenExpiresAt = 0L,
+        refreshToken = RefreshToken("rt-1"),
+        refreshTokenExpiresAt = 0L,
+        sessionId = SessionId("session-1"),
+        user =
+            User(
+                id = UserId("user-1"),
+                email = "alice@example.com",
+                displayName = "Alice",
+                role = UserRole.MEMBER,
+                status = UserStatus.ACTIVE,
+                createdAt = 0L,
+            ),
+    )
+
+/**
+ * End-to-end tripwire for single-flight token refresh: N parallel 401s through
+ * the REAL client built by [KtorApiClientFactory.createClient] — real bearer
+ * plugin, real [refreshAuthTokens] bridge, real [AuthRepositoryImpl]
+ * single-flight — must produce exactly ONE rotation RPC, and every caller must
+ * complete. This is the regression net for any future HttpClient/auth-plugin
+ * restructuring; the cross-client (REST + SSE) race is pinned separately at
+ * the invariant layer by AuthRepositoryImplTest's coalescing test, because all
+ * refresh paths funnel into the same Koin-singleton AuthRepository
+ * (AuthModule.kt `singleOf`).
+ */
+class TokenRefreshSingleFlightTest :
+    FunSpec({
+
+        test("five parallel 401s coalesce into one rotation and all callers complete") {
+            runTest(timeout = 30.seconds) {
+                val authSession = FakeAuthSession()
+
+                // Counts 401s served; the rotation RPC is gated on it so every
+                // caller's refresh attempt is concurrent with the rotation.
+                val staleServed = MutableStateFlow(0)
+                val refreshRpcCalls = MutableStateFlow(0)
+
+                val public = mock<AuthServicePublic>()
+                everySuspend { public.refreshSession(any()) } calls {
+                    refreshRpcCalls.update { it + 1 }
+                    staleServed.first { it >= PARALLEL_CALLERS }
+                    AppResult.Success(freshContractSession())
+                }
+
+                val repo =
+                    AuthRepositoryImpl(
+                        rpc =
+                            object : AuthRpcFactory {
+                                override suspend fun publicService(): AuthServicePublic = public
+
+                                override suspend fun authedService(): AuthServiceAuthed = throw NotImplementedError()
+
+                                override suspend fun invalidate() = Unit
+                            },
+                        authSession = authSession,
+                    )
+
+                val engine =
+                    testMockEngine {
+                        handle("/protected") { request ->
+                            if (request.headers[HttpHeaders.Authorization] == "Bearer $FRESH_ACCESS") {
+                                respond(
+                                    content = "{}",
+                                    status = HttpStatusCode.OK,
+                                    headers =
+                                        headersOf(
+                                            HttpHeaders.ContentType,
+                                            ContentType.Application.Json.toString(),
+                                        ),
+                                )
+                            } else {
+                                staleServed.update { it + 1 }
+                                respondError(HttpStatusCode.Unauthorized)
+                            }
+                        }
+                    }
+
+                val serverConfig = mock<ServerConfig>()
+                everySuspend { serverConfig.getActiveUrl() } returns ServerUrl("http://unit.test")
+                everySuspend { serverConfig.switchToFallbackUrl() } returns null
+
+                val factory =
+                    KtorApiClientFactory(
+                        serverConfig = serverConfig,
+                        authSession = authSession,
+                        // Mirrors NetworkModule's `{ get<AuthRepository>().refreshAccessToken() }`.
+                        refreshAccessToken = { repo.refreshAccessToken() },
+                        engine = engine,
+                    )
+                val client = factory.getClient()
+
+                val responses =
+                    (1..PARALLEL_CALLERS)
+                        .map { async { client.get("/protected") } }
+                        .awaitAll()
+
+                // Every caller completed with the retried, freshly-authed request.
+                responses.forEach { it.status shouldBe HttpStatusCode.OK }
+                // Each caller 401'd exactly once before the rotation landed.
+                staleServed.value shouldBe PARALLEL_CALLERS
+                // THE invariant: exactly one rotation despite five concurrent triggers.
+                refreshRpcCalls.value shouldBe 1
+                // The rotated pair is what's persisted.
+                authSession.access shouldBe AccessToken(FRESH_ACCESS)
+                authSession.refresh shouldBe RefreshToken("rt-1")
+
+                client.close()
+            }
+        }
+    })


### PR DESCRIPTION
Plan 074 (/improve batch-5, tests). `RefreshAuthTokens` outcomes are well covered, but single-flight de-duplication of *concurrent* refreshes — the invariant that N simultaneous 401s trigger exactly ONE refresh round-trip (rotating the token once) rather than N (which would trip the server's refresh-family revocation and log the user out under load) — was asserted by no app-owned end-to-end test. An app-owned mutex single-flight already exists (`AuthRepositoryImpl`, tested at the repo layer); this pins it end-to-end through the real client.

**Change**: adds a test-only `engine: HttpClientEngine? = null` seam to `KtorApiClientFactory` (config extracted to a reused lambda; `null` default selects the production platform engine — **inert in production**, no DI caller passes it), and a new `TokenRefreshSingleFlightTest`: fire N parallel requests that all 401, count refresh round-trips via a MockEngine, assert exactly 1 (+ one token rotation).

**Result**: the test PASSES — single refresh confirmed on the initial run and 3 `--rerun-tasks` flake checks. No production bug. SSE and REST refresh paths both funnel through the same `refreshAuthTokens` bridge → the same Koin-singleton `AuthRepositoryImpl`, so they coalesce at the repo layer (already tested) — no separate seam needed.

**Verification (reviewer-run)**: `:sharedLogic:jvmTest` (full) + `:sharedLogic:testAndroidHostTest` + `:sharedUI:testAndroidHostTest` ✅, `compileCommonMainKotlinMetadata` + `spotlessCheck detekt` ✅. 2-file diff (factory seam + new test).