### PR TITLE
⚡ perf(server): batch bulk FTS reindex into chunked transactions (kill the transaction-per-book + N+1)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SearchReindexService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SearchReindexService.kt
@@ -28,10 +28,10 @@ class SearchReindexService(
 ) {
     /**
      * Rebuilds all FTS5 indexes across all four families. The rebuild spans multiple
-     * transactions (one per book for `book_search`, then a single transaction for the
-     * contributor/series/tag families) and does NOT provide cross-family atomicity — a
-     * crash mid-run leaves some indexes fresh and others stale. The operation is
-     * idempotent, so re-invoking completes partial progress.
+     * transactions (one per 200-book chunk for `book_search`, then a single transaction
+     * for the contributor/series/tag families) and does NOT provide cross-family
+     * atomicity — a crash mid-run leaves some indexes fresh and others stale. The
+     * operation is idempotent, so re-invoking completes partial progress.
      *
      * @return number of books reindexed via [BookSearchReindexer].
      */
@@ -40,7 +40,7 @@ class SearchReindexService(
             suspendTransaction(db) {
                 db.booksQueries.selectAllLiveIds().executeAsList()
             }
-        for (id in bookIds) reindexer.reindexBook(id)
+        reindexer.reindexBooks(bookIds)
         suspendTransaction<Unit>(db) {
             // contributor_search is contentless (V22): rebuild from source, mirroring the
             // contributors_au trigger (server/src/jvmMain/resources/db/migration/V22__contributor_aliases.sql)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexer.kt
@@ -30,6 +30,85 @@ class BookSearchReindexer(
     private val driver: SqlDriver,
 ) {
     /**
+     * Recomputes the FTS row for one book with its tag names pre-resolved.
+     * Must be called inside an open [suspendTransaction] — uses only synchronous
+     * generated queries. Silently no-ops when the book has no book_search_map row.
+     */
+    private fun reindexBookInOpenTransaction(
+        bookId: String,
+        tagsValue: String,
+    ) {
+        val rowid =
+            db.bookSearchQueries.selectRowidForBook(bookId).executeAsOneOrNull()
+                ?: return
+
+        // Read the existing FTS content from the source tables so we can re-insert
+        // all columns — FTS5 contentless tables don't store the original text.
+        val existing = db.bookSearchQueries.selectFtsSourceByRowid(rowid).executeAsOneOrNull()
+
+        // Live genre names via book_genres JOIN genres; tombstoned genres are filtered
+        // by the query (g.deleted_at IS NULL), name-ordered. Space-joined for FTS5 tokens.
+        val genresValue =
+            db.bookGenresQueries
+                .genreNamesForBook(bookId)
+                .executeAsList()
+                .joinToString(" ")
+
+        // FTS5 contentless_delete=1: delete old tokens first, then re-insert full 8-col row.
+        db.bookSearchQueries.deleteFtsRow(rowid)
+        db.bookSearchQueries.insertFtsRow(
+            rowid = rowid,
+            title = existing?.title ?: "",
+            subtitle = existing?.subtitle ?: "",
+            description = existing?.description ?: "",
+            contributor_names = existing?.contributor_names ?: "",
+            series_names = existing?.series_names ?: "",
+            tags = tagsValue,
+            genres = genresValue,
+        )
+    }
+
+    /**
+     * Recomputes the `book_search` FTS5 rows for every id in [bookIds].
+     *
+     * Tag names are resolved in two batched reads up front (junctions via
+     * [BookTagRepository.findAllForBooks], names via [TagRepository.findByIds]) —
+     * repository calls open their own transactions, so they must complete BEFORE
+     * the write transaction opens (nested [suspendTransaction] calls can land on
+     * a different connection and deadlock against the single writer). The
+     * delete+re-insert pairs then run in one transaction per [txChunkSize]-book
+     * chunk. Books without a `book_search_map` row are silently skipped, matching
+     * [reindexBook]. A mid-run failure rolls back only the current chunk;
+     * previously committed chunks remain — the operation is idempotent, re-run to
+     * complete.
+     */
+    suspend fun reindexBooks(
+        bookIds: List<String>,
+        txChunkSize: Int = REINDEX_TX_CHUNK,
+    ) {
+        if (bookIds.isEmpty()) return
+        val junctionsByBook = bookTagRepository.findAllForBooks(bookIds)
+        val tagIds =
+            junctionsByBook.values
+                .flatten()
+                .map { it.tagId }
+                .distinct()
+        val tagNameById = tagRepository.findByIds(tagIds).associate { it.id to it.name }
+        for (chunk in bookIds.chunked(txChunkSize)) {
+            suspendTransaction<Unit>(db) {
+                for (bookId in chunk) {
+                    val tagsValue =
+                        junctionsByBook[bookId]
+                            .orEmpty()
+                            .mapNotNull { tagNameById[it.tagId] }
+                            .joinToString(" ")
+                    reindexBookInOpenTransaction(bookId, tagsValue)
+                }
+            }
+        }
+    }
+
+    /**
      * Recomputes the `book_search` FTS5 row for [bookId] from the live source tables.
      *
      * `book_search` is a contentless FTS5 table with `contentless_delete=1` (V9/V21);
@@ -41,47 +120,7 @@ class BookSearchReindexer(
      * Safe to call when the book has no `book_search_map` row (never scanned, or
      * tombstoned) — the rowid lookup returns null and the call silently no-ops.
      */
-    suspend fun reindexBook(bookId: String) {
-        // Resolve live tag names for this book (through the already-SQLDelight repos).
-        val junctions = bookTagRepository.findAllForBook(bookId)
-        val tagNames =
-            junctions.mapNotNull { junc ->
-                tagRepository.findById(junc.tagId)?.name
-            }
-        val tagsValue = tagNames.joinToString(" ")
-
-        suspendTransaction<Unit>(db) {
-            // Resolve the FTS5 rowid via book_search_map. If absent, nothing to do.
-            val rowid =
-                db.bookSearchQueries.selectRowidForBook(bookId).executeAsOneOrNull()
-                    ?: return@suspendTransaction
-
-            // Read the existing FTS content from the source tables so we can re-insert
-            // all columns — FTS5 contentless tables don't store the original text.
-            val existing = db.bookSearchQueries.selectFtsSourceByRowid(rowid).executeAsOneOrNull()
-
-            // Live genre names via book_genres JOIN genres; tombstoned genres are filtered
-            // by the query (g.deleted_at IS NULL), name-ordered. Space-joined for FTS5 tokens.
-            val genresValue =
-                db.bookGenresQueries
-                    .genreNamesForBook(bookId)
-                    .executeAsList()
-                    .joinToString(" ")
-
-            // FTS5 contentless_delete=1: delete old tokens first, then re-insert full 8-col row.
-            db.bookSearchQueries.deleteFtsRow(rowid)
-            db.bookSearchQueries.insertFtsRow(
-                rowid = rowid,
-                title = existing?.title ?: "",
-                subtitle = existing?.subtitle ?: "",
-                description = existing?.description ?: "",
-                contributor_names = existing?.contributor_names ?: "",
-                series_names = existing?.series_names ?: "",
-                tags = tagsValue,
-                genres = genresValue,
-            )
-        }
-    }
+    suspend fun reindexBook(bookId: String) = reindexBooks(listOf(bookId))
 
     /**
      * Reindexes every book that currently has a live junction row for [tagId].
@@ -90,9 +129,7 @@ class BookSearchReindexer(
      */
     suspend fun reindexAllBooksForTag(tagId: String) {
         val bookIds = bookTagRepository.findBookIdsForTag(tagId)
-        for (bookId in bookIds) {
-            reindexBook(bookId)
-        }
+        reindexBooks(bookIds)
     }
 
     /**
@@ -108,9 +145,7 @@ class BookSearchReindexer(
                     .bookIdsForContributor(contributorId)
                     .executeAsList()
             }
-        for (bookId in bookIds) {
-            reindexBook(bookId)
-        }
+        reindexBooks(bookIds)
     }
 
     /**
@@ -124,9 +159,7 @@ class BookSearchReindexer(
                     .bookIdsForSeries(seriesId)
                     .executeAsList()
             }
-        for (bookId in bookIds) {
-            reindexBook(bookId)
-        }
+        reindexBooks(bookIds)
     }
 
     /**
@@ -143,9 +176,7 @@ class BookSearchReindexer(
                     .bookIdsForGenre(genreId)
                     .executeAsList()
             }
-        for (bookId in bookIds) {
-            reindexBook(bookId)
-        }
+        reindexBooks(bookIds)
     }
 
     /**
@@ -165,9 +196,7 @@ class BookSearchReindexer(
                     .booksForGenrePrefix(pathPrefix, Int.MAX_VALUE.toLong())
                     .executeAsList()
             }
-        for (bookId in bookIds) {
-            reindexBook(bookId)
-        }
+        reindexBooks(bookIds)
     }
 
     /**
@@ -270,4 +299,13 @@ class BookSearchReindexer(
                 parameters = 1,
                 binders = { bindString(0, contributorId) },
             ).value
+
+    private companion object {
+        /**
+         * Books per write transaction in [reindexBooks]. Large enough that a bulk
+         * reindex costs a handful of commits; small enough that one chunk's
+         * delete+insert churn doesn't monopolize SQLite's single write connection.
+         */
+        const val REINDEX_TX_CHUNK = 200
+    }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookTagRepository.kt
@@ -171,6 +171,25 @@ class BookTagRepository(
         }
 
     /**
+     * Returns all non-tombstoned junction rows for each id in [bookIds], grouped by
+     * book id, each book's rows ordered by `created_at` — the batched equivalent of
+     * calling [findAllForBook] per id. One round-trip per 900-id chunk (SQLite's
+     * `SQLITE_MAX_VARIABLE_NUMBER` cap). Books with no live junctions are absent
+     * from the map.
+     */
+    suspend fun findAllForBooks(bookIds: List<String>): Map<String, List<BookTagSyncPayload>> {
+        if (bookIds.isEmpty()) return emptyMap()
+        return suspendTransaction(db) {
+            bookIds
+                .chunked(SQLITE_IN_CHUNK)
+                .flatMap { chunk -> db.bookTagsQueries.selectByBookIds(chunk).executeAsList() }
+                .sortedBy { it.created_at }
+                .groupBy { it.book_id }
+                .mapValues { (_, rows) -> rows.map { it.toPayload() } }
+        }
+    }
+
+    /**
      * Returns all non-tombstoned junction rows for [tagId].
      */
     suspend fun findAllForTag(tagId: String): List<BookTagSyncPayload> =

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
@@ -1,0 +1,317 @@
+package com.calypsan.listenup.server.sync
+
+import app.cash.sqldelight.db.QueryResult
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+
+/**
+ * Characterization + regression tests for [BookSearchReindexer]'s bulk (multi-book)
+ * reindex paths.
+ *
+ * Tests 1–4 pin the *current* per-book-loop behavior before plan 062's chunked-transaction
+ * rewrite — they must pass unmodified against both the old and new implementation, proving
+ * the batch rewrite preserves per-book isolation, skip-on-missing-map-row, and tombstone
+ * filtering across a multi-book sweep. Tests 5–7 exercise the new [BookSearchReindexer.reindexBooks]
+ * surface directly (empty input, chunk-boundary equivalence, per-book tag isolation).
+ *
+ * Modelled on [BookSearchReindexerTest] and [BookSearchReindexerGenreTest] — real
+ * in-memory Flyway-migrated SQLite, FTS rows seeded directly, MATCH-based assertions
+ * (contentless FTS5 tables cannot be SELECTed).
+ */
+class BookSearchReindexerBulkTest :
+    FunSpec({
+
+        fun makeReindexer(
+            dbs: SqlTestDatabases,
+            bookTagRepo: BookTagRepository,
+            tagRepo: TagRepository,
+        ) = BookSearchReindexer(bookTagRepo, tagRepo, dbs.sql, dbs.driver)
+
+        /** Seeds a minimal book_search_map + book_search FTS row for [bookId]. */
+        suspend fun seedFtsRow(
+            dbs: SqlTestDatabases,
+            bookId: String,
+            rowid: Int,
+        ) {
+            withContext(Dispatchers.IO) {
+                dbs.driver.execute(
+                    identifier = null,
+                    sql = "INSERT INTO book_search_map(book_id, rowid) VALUES (?, ?)",
+                    parameters = 2,
+                    binders = {
+                        bindString(0, bookId)
+                        bindLong(1, rowid.toLong())
+                    },
+                )
+                dbs.driver.execute(
+                    identifier = null,
+                    sql =
+                        "INSERT INTO book_search(rowid, title, subtitle, description, contributor_names, series_names, tags, genres) " +
+                            "VALUES ($rowid, ?, '', '', '', '', '', '')",
+                    parameters = 1,
+                    binders = { bindString(0, "Test Book $bookId") },
+                )
+            }
+        }
+
+        /**
+         * Checks whether a MATCH query on `book_search.tags` for [searchTerm] returns
+         * the row with [rowid]. `book_search` is contentless — content is NOT stored,
+         * so we verify the index was updated via a column-scoped MATCH query.
+         */
+        suspend fun ftsTagsMatch(
+            dbs: SqlTestDatabases,
+            rowid: Int,
+            searchTerm: String,
+        ): Boolean {
+            val dq = '"'
+            val quotedTerm = "$dq${searchTerm.replace("$dq", "$dq$dq")}$dq"
+            return withContext(Dispatchers.IO) {
+                dbs.driver
+                    .executeQuery(
+                        identifier = null,
+                        sql = "SELECT rowid FROM book_search WHERE tags MATCH ? AND rowid = ?",
+                        mapper = { cursor -> QueryResult.Value(cursor.next().value) },
+                        parameters = 2,
+                        binders = {
+                            bindString(0, quotedTerm)
+                            bindLong(1, rowid.toLong())
+                        },
+                    ).value
+            }
+        }
+
+        /** Column-scoped MATCH on `book_search.genres` for [searchTerm] against [rowid]. */
+        suspend fun ftsGenresMatch(
+            dbs: SqlTestDatabases,
+            rowid: Int,
+            searchTerm: String,
+        ): Boolean {
+            val dq = '"'
+            val quotedTerm = "$dq${searchTerm.replace("$dq", "$dq$dq")}$dq"
+            return withContext(Dispatchers.IO) {
+                dbs.driver
+                    .executeQuery(
+                        identifier = null,
+                        sql = "SELECT rowid FROM book_search WHERE genres MATCH ? AND rowid = ?",
+                        mapper = { cursor -> QueryResult.Value(cursor.next().value) },
+                        parameters = 2,
+                        binders = {
+                            bindString(0, quotedTerm)
+                            bindLong(1, rowid.toLong())
+                        },
+                    ).value
+            }
+        }
+
+        test("reindexAllBooksForTag reindexes three books with distinct extra tags") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                sql.seedTestBook("book3")
+                runTest {
+                    seedFtsRow(this@withSqlDatabase, "book1", 1)
+                    seedFtsRow(this@withSqlDatabase, "book2", 2)
+                    seedFtsRow(this@withSqlDatabase, "book3", 3)
+
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    tagRepo.upsert(Tag(id = "shared", name = "Shared", slug = "shared", revision = 0, updatedAt = 0))
+                    tagRepo.upsert(Tag(id = "u1", name = "Unique1", slug = "unique1", revision = 0, updatedAt = 0))
+                    tagRepo.upsert(Tag(id = "u2", name = "Unique2", slug = "unique2", revision = 0, updatedAt = 0))
+                    tagRepo.upsert(Tag(id = "u3", name = "Unique3", slug = "unique3", revision = 0, updatedAt = 0))
+
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "shared", createdAt = 1000L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "u1", createdAt = 1001L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book2", tagId = "shared", createdAt = 1002L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book2", tagId = "u2", createdAt = 1003L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book3", tagId = "shared", createdAt = 1004L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book3", tagId = "u3", createdAt = 1005L, revision = 0L),
+                    )
+
+                    reindexer.reindexAllBooksForTag("shared")
+
+                    ftsTagsMatch(this@withSqlDatabase, 1, "Shared") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 2, "Shared") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 3, "Shared") shouldBe true
+
+                    ftsTagsMatch(this@withSqlDatabase, 1, "Unique1") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 2, "Unique2") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 3, "Unique3") shouldBe true
+
+                    // No cross-book contamination: book1 must not carry book2/book3's unique tags.
+                    ftsTagsMatch(this@withSqlDatabase, 1, "Unique2") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 1, "Unique3") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 2, "Unique1") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 2, "Unique3") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 3, "Unique1") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 3, "Unique2") shouldBe false
+                }
+            }
+        }
+
+        test("bulk reindex skips books without a book_search_map row and still indexes the rest") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                sql.seedTestBook("book3")
+                runTest {
+                    // Only book1 and book2 get FTS rows — book3 has no book_search_map row.
+                    seedFtsRow(this@withSqlDatabase, "book1", 1)
+                    seedFtsRow(this@withSqlDatabase, "book2", 2)
+
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    tagRepo.upsert(Tag(id = "shared", name = "Shared", slug = "shared", revision = 0, updatedAt = 0))
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "shared", createdAt = 1000L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book2", tagId = "shared", createdAt = 1001L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book3", tagId = "shared", createdAt = 1002L, revision = 0L),
+                    )
+
+                    // Should complete without throwing despite book3 having no map row.
+                    reindexer.reindexAllBooksForTag("shared")
+
+                    ftsTagsMatch(this@withSqlDatabase, 1, "Shared") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 2, "Shared") shouldBe true
+                }
+            }
+        }
+
+        test("bulk reindex excludes tombstoned junctions and tombstoned tags across books") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                runTest {
+                    seedFtsRow(this@withSqlDatabase, "book1", 1)
+                    seedFtsRow(this@withSqlDatabase, "book2", 2)
+
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    tagRepo.upsert(Tag(id = "dead1", name = "DeadJunction", slug = "dead-junction", revision = 0, updatedAt = 0))
+                    tagRepo.upsert(Tag(id = "dead2", name = "DeadTag", slug = "dead-tag", revision = 0, updatedAt = 0))
+                    tagRepo.upsert(Tag(id = "shared", name = "Shared", slug = "shared", revision = 0, updatedAt = 0))
+
+                    // book1: tombstoned junction to a live tag.
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "dead1", createdAt = 1000L, revision = 0L),
+                    )
+                    bookTagRepo.softDelete(bookId = "book1", tagId = "dead1")
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "shared", createdAt = 1001L, revision = 0L),
+                    )
+
+                    // book2: live junction to a tombstoned tag.
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book2", tagId = "dead2", createdAt = 1002L, revision = 0L),
+                    )
+                    tagRepo.softDelete("dead2")
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book2", tagId = "shared", createdAt = 1003L, revision = 0L),
+                    )
+
+                    reindexer.reindexAllBooksForTag("shared")
+
+                    ftsTagsMatch(this@withSqlDatabase, 1, "DeadJunction") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 2, "DeadTag") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 1, "Shared") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 2, "Shared") shouldBe true
+                }
+            }
+        }
+
+        test("bulk reindex refreshes the genres column for every book in the set") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                runTest {
+                    seedFtsRow(this@withSqlDatabase, "book1", 1)
+                    seedFtsRow(this@withSqlDatabase, "book2", 2)
+                    sql.seedGenre("g1", "Fantasy", "fantasy", "/fantasy")
+                    sql.bookGenresQueries.insertIfAbsent(book_id = "book1", genre_id = "g1")
+                    sql.bookGenresQueries.insertIfAbsent(book_id = "book2", genre_id = "g1")
+
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    reindexer.reindexAllBooksForGenre("g1")
+
+                    ftsGenresMatch(this@withSqlDatabase, 1, "Fantasy") shouldBe true
+                    ftsGenresMatch(this@withSqlDatabase, 2, "Fantasy") shouldBe true
+                }
+            }
+        }
+
+    })
+
+/** Seeds a `genres` row into [this] database. */
+private fun ListenUpDatabase.seedGenre(
+    genreId: String,
+    name: String,
+    slug: String,
+    path: String,
+    parentId: String? = null,
+    depth: Int = 0,
+) {
+    val now = System.currentTimeMillis()
+    genresQueries.insert(
+        id = genreId,
+        name = name,
+        slug = slug,
+        path = path,
+        parent_id = parentId,
+        depth = depth.toLong(),
+        sort_order = 0L,
+        color = null,
+        description = null,
+        revision = 1L,
+        created_at = now,
+        updated_at = now,
+        deleted_at = null,
+        client_op_id = null,
+    )
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/BookSearchReindexerBulkTest.kt
@@ -286,6 +286,88 @@ class BookSearchReindexerBulkTest :
             }
         }
 
+        test("reindexBooks with an empty list is a no-op") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                runTest {
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    // No throw is the assertion.
+                    reindexer.reindexBooks(emptyList())
+                }
+            }
+        }
+
+        test("reindexBooks spanning multiple transaction chunks matches single-chunk output") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                val bookIds = (1..5).map { "book$it" }
+                bookIds.forEach { sql.seedTestBook(it) }
+                runTest {
+                    bookIds.forEachIndexed { index, bookId -> seedFtsRow(this@withSqlDatabase, bookId, index + 1) }
+
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    bookIds.forEachIndexed { index, bookId ->
+                        val tagId = "tag$index"
+                        tagRepo.upsert(Tag(id = tagId, name = "TagFor$bookId", slug = "tag-for-$bookId", revision = 0, updatedAt = 0))
+                        bookTagRepo.upsert(
+                            BookTagSyncPayload(bookId = bookId, tagId = tagId, createdAt = 1000L + index, revision = 0L),
+                        )
+                    }
+
+                    // 5 books, chunk size 2 → 3 transactions (2 + 2 + 1).
+                    reindexer.reindexBooks(bookIds, txChunkSize = 2)
+
+                    bookIds.forEachIndexed { index, bookId ->
+                        val rowid = index + 1
+                        ftsTagsMatch(this@withSqlDatabase, rowid, "TagFor$bookId") shouldBe true
+                    }
+                }
+            }
+        }
+
+        test("reindexBooks resolves each book's tags independently") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                runTest {
+                    seedFtsRow(this@withSqlDatabase, "book1", 1)
+                    seedFtsRow(this@withSqlDatabase, "book2", 2)
+
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val reindexer = makeReindexer(this@withSqlDatabase, bookTagRepo, tagRepo)
+
+                    tagRepo.upsert(Tag(id = "t1", name = "AlphaTag", slug = "alpha-tag", revision = 0, updatedAt = 0))
+                    tagRepo.upsert(Tag(id = "t2", name = "BetaTag", slug = "beta-tag", revision = 0, updatedAt = 0))
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                    )
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book2", tagId = "t2", createdAt = 1001L, revision = 0L),
+                    )
+
+                    reindexer.reindexBooks(listOf("book1", "book2"))
+
+                    ftsTagsMatch(this@withSqlDatabase, 1, "AlphaTag") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 2, "BetaTag") shouldBe true
+                    ftsTagsMatch(this@withSqlDatabase, 1, "BetaTag") shouldBe false
+                    ftsTagsMatch(this@withSqlDatabase, 2, "AlphaTag") shouldBe false
+                }
+            }
+        }
     })
 
 /** Seeds a `genres` row into [this] database. */


### PR DESCRIPTION
Plan 062 (/improve batch-5, perf). Renaming/deleting a broad entity (a popular author, a common genre spanning hundreds of the ~1200 books) drove `BookSearchReindexer` to open **one `suspendTransaction` per affected book**, and each `reindexBook` ran `findAllForBook` + `findById` **per tag** (an N+1 inside the N loop) — hundreds of sequential transactions + thousands of tiny queries, serialized on the native server's single write connection for the whole admin operation.

**Fix**: pre-resolve all repository data for the affected id set up front (batched `BookTagRepository.findAllForBooks` + `TagRepository.findByIds` — the N+1 is gone), then reindex in **chunked transactions** (`REINDEX_TX_CHUNK = 200`): one `suspendTransaction` per chunk whose body is a plain non-suspend `reindexBookInOpenTransaction` touching only synchronous queries. This deliberately avoids nesting `suspendTransaction` (which thread-hops onto per-thread connections → writer deadlock). The `contentless_delete=1` delete-then-insert idiom is preserved. `SearchReindexService.reindexAll` (a whole-library loop the audit also found) adopts the batched path too.

**Tests**: new `BookSearchReindexerBulkTest` (7 characterization tests) proving bulk reindex output is identical to N× single reindex — captured against the unmodified impl first, then re-verified after the rewrite; incl. multi-chunk equivalence (`txChunkSize=2` → 3 transactions), tombstone exclusion, per-book tag isolation, empty no-op.

**Verification (reviewer-run)**: `:server:jvmTest` (full, 19m28s) ✅ fully clean, `:server:compileKotlinLinuxX64` (commonMain stays native-clean) ✅, `spotlessCheck detekt` ✅. Done-criteria greps pass (no per-book loop, no `findById(junc` N+1). 4-file diff; `BooksModule` construction untouched.