### PR TITLE
🐛 fix(server): window sums exclude soft-deleted events and clip cutoff-spanning spans

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PublicProfileMaintainer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PublicProfileMaintainer.kt
@@ -63,7 +63,11 @@ class PublicProfileMaintainer(
             suspendTransaction(sql) {
                 val stats = sql.userStatsQueries.selectLiveForUser(userId).executeAsOneOrNull()
                 val yearWindowSeconds =
-                    sql.listeningEventsQueries.sumWallSecondsSince(userId, yearCutoff).executeAsOne()
+                    sql.listeningEventsQueries
+                        .sumWallSecondsSince(
+                            userId = userId,
+                            cutoffMs = yearCutoff,
+                        ).executeAsOne()
 
                 // Windowed books: distinct books finished within each trailing window.
                 val books = sql.bookReadsQueries

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
@@ -208,7 +208,7 @@ class StatsRecorder(
     ): Long {
         val cutoffMs = asOfMs - days * 86_400_000L
         return suspendTransaction(sql) {
-            sql.listeningEventsQueries.sumWallSecondsSince(userId, cutoffMs).executeAsOne()
+            sql.listeningEventsQueries.sumWallSecondsSince(userId = userId, cutoffMs = cutoffMs).executeAsOne()
         }
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
@@ -85,9 +85,9 @@ class UserStatsBackfillService(
         var last30 = 0L
         for (event in events) {
             val endedAtMs = event.ended_at
-            val wallSeconds = (endedAtMs - event.started_at) / 1_000L
-            if (endedAtMs >= cutoff7) last7 += wallSeconds
-            if (endedAtMs >= cutoff30) last30 += wallSeconds
+            // Clip a span straddling the cutoff to its post-cutoff seconds, matching sumWallSecondsSince.
+            if (endedAtMs >= cutoff7) last7 += (endedAtMs - maxOf(event.started_at, cutoff7)) / 1_000L
+            if (endedAtMs >= cutoff30) last30 += (endedAtMs - maxOf(event.started_at, cutoff30)) / 1_000L
         }
 
         // 4. Count finished positions (non-deleted) for this user.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsUpdater.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsUpdater.kt
@@ -49,7 +49,7 @@ class UserStatsUpdater(
     ): Long {
         val cutoffMs = asOfMs - days * 86_400_000L
         return suspendTransaction(sql) {
-            sql.listeningEventsQueries.sumWallSecondsSince(userId, cutoffMs).executeAsOne()
+            sql.listeningEventsQueries.sumWallSecondsSince(userId = userId, cutoffMs = cutoffMs).executeAsOne()
         }
     }
 }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
@@ -99,12 +99,15 @@ SELECT EXISTS(
     WHERE user_id = :userId AND book_id = :bookId AND id != :excludingId
 );
 
--- Stats support: SUM of wall-clock seconds for events ended at/after :cutoffMs (rolling window).
--- Computed in SQL via integer division by 1000; returns 0 when there are no rows in the window.
+-- Stats support: SUM of wall-clock seconds for live events ended at/after :cutoffMs (rolling window).
+-- A span that started before :cutoffMs but ended inside it is clipped to its post-cutoff portion via
+-- MAX(started_at, :cutoffMs), so a session straddling the boundary contributes only its in-window
+-- seconds. Soft-deleted rows are excluded (deleted_at IS NULL) so the window agrees with the all-time
+-- and streak reads that derive from the same primitive. Returns 0 when no live rows fall in the window.
 sumWallSecondsSince:
-SELECT COALESCE(SUM((ended_at - started_at) / 1000), 0)
+SELECT CAST(COALESCE(SUM((ended_at - MAX(started_at, :cutoffMs)) / 1000), 0) AS INTEGER)
 FROM listening_events
-WHERE user_id = :userId AND ended_at >= :cutoffMs;
+WHERE user_id = :userId AND ended_at >= :cutoffMs AND deleted_at IS NULL;
 
 -- Stats support: the ended-at timestamps of a user's non-deleted events at/after :cutoffMs, ascending.
 -- Feeds the windowed-streak walk (longest consecutive listening-day run within a trailing window).

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/WindowSumSoftDeleteClipTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/WindowSumSoftDeleteClipTest.kt
@@ -1,0 +1,115 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the two invariants the rolling-window sum must hold so windowed totals can never disagree
+ * with the all-time / streak reads that derive from the same `listening_events` primitive:
+ *
+ * 1. **Soft-deleted events contribute nothing.** `sumWallSecondsSince` must filter `deleted_at IS
+ *    NULL` like its sibling queries; otherwise a client-deleted event still inflates the leaderboard
+ *    windows while the deleted-filtered backfill excludes it.
+ * 2. **Boundary-spanning sessions are clipped, not counted whole.** A span that started before the
+ *    window cutoff but ended inside it contributes only its post-cutoff seconds — `MAX(started_at,
+ *    cutoffMs)` — not the full wall-clock span.
+ */
+class WindowSumSoftDeleteClipTest :
+    FunSpec({
+
+        test("sumWallSecondsSince excludes soft-deleted events") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                // Live 60s span, ended after the cutoff.
+                sql.insertEvent(id = "live", userId = "u1", startedAt = 1_000L, endedAt = 61_000L)
+                // Soft-deleted 120s span, also ended after the cutoff — must NOT count.
+                sql.insertEvent(id = "gone", userId = "u1", startedAt = 1_000L, endedAt = 121_000L, deletedAt = 500_000L)
+
+                sql.listeningEventsQueries.sumWallSecondsSince(userId = "u1", cutoffMs = 0L).executeAsOne() shouldBe 60L
+            }
+        }
+
+        test("sumWallSecondsSince clips a span that straddles the cutoff to its post-cutoff seconds") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                // Total wall span 120s (40_000..160_000); cutoff at 100_000 → only 60s is post-cutoff.
+                sql.insertEvent(id = "straddle", userId = "u1", startedAt = 40_000L, endedAt = 160_000L)
+
+                sql.listeningEventsQueries.sumWallSecondsSince(userId = "u1", cutoffMs = 100_000L).executeAsOne() shouldBe 60L
+            }
+        }
+
+        test("backfill window totals equal the clipped SQL sum on the same straddling fixture") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                val nowMs = 1_779_451_200_000L
+                val dayMs = 86_400_000L
+                val cutoff7 = nowMs - 7 * dayMs
+                // A span straddling the 7-day cutoff: 60s wall, only the 30s after cutoff7 is in-window.
+                sql.insertEvent(id = "edge", userId = "u1", startedAt = cutoff7 - 30_000L, endedAt = cutoff7 + 30_000L)
+
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val statsRepo = UserStatsRepository(db = sql, bus = bus, registry = registry)
+                val backfill =
+                    UserStatsBackfillService(
+                        sql = sql,
+                        userStatsRepo = statsRepo,
+                        clock = FixedClock(Instant.fromEpochMilliseconds(nowMs)),
+                    )
+
+                runTest {
+                    backfill.backfillFor("u1")
+                    val stats = statsRepo.getForUser("u1").shouldNotBeNull()
+                    val sqlSum = sql.listeningEventsQueries.sumWallSecondsSince(userId = "u1", cutoffMs = cutoff7).executeAsOne()
+
+                    // The in-memory backfill loop and the SQL query must agree …
+                    stats.totalSecondsLast7Days shouldBe sqlSum
+                    // … and both must reflect only the post-cutoff 30s, not the whole 60s span.
+                    stats.totalSecondsLast7Days shouldBe 30L
+                    // All-time always counts the full span.
+                    stats.totalSecondsAllTime shouldBe 60L
+                }
+            }
+        }
+    })
+
+private fun ListenUpDatabase.insertEvent(
+    id: String,
+    userId: String,
+    startedAt: Long,
+    endedAt: Long,
+    bookId: String = "b1",
+    deletedAt: Long? = null,
+) {
+    transaction {
+        listeningEventsQueries.insert(
+            id = id,
+            user_id = userId,
+            book_id = bookId,
+            start_position_ms = 0L,
+            end_position_ms = endedAt - startedAt,
+            started_at = startedAt,
+            ended_at = endedAt,
+            playback_speed = 1.0,
+            tz = "UTC",
+            device_label = null,
+            revision = 0L,
+            created_at = 0L,
+            updated_at = 0L,
+            deleted_at = deletedAt,
+            client_op_id = null,
+        )
+    }
+}


### PR DESCRIPTION
**Spec 001 of 5** in the listening-stats robustness pass (stacked; base = `main`).

`sumWallSecondsSince` feeds every rolling window (write cascade, lazy decay, the `public_profiles` projection). It counted soft-deleted events and counted a session straddling the cutoff in full — silently diverging windowed totals from the all-time/streak reads that derive from the same primitive.

Adds `deleted_at IS NULL` + `MAX(started_at, :cutoffMs)` clipping (with `CAST(... AS INTEGER)` to keep the `Long` return; callers move to named args since the bind-param-in-SELECT reorders the generated params), and aligns the backfill's in-memory window loop. 3 tests in `WindowSumSoftDeleteClipTest`.
