### PR TITLE
♻️ refactor(shared): consolidate streak math into one StreakReducer in :contract

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/stats/StreakReducer.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/domain/stats/StreakReducer.kt
@@ -1,0 +1,77 @@
+package com.calypsan.listenup.domain.stats
+
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+
+/**
+ * A user's current and longest listening streaks, in whole days.
+ *
+ * @property current The consecutive-day run ending on the most recent listening day, or 0 if that
+ *   day is older than yesterday (the streak has lapsed).
+ * @property longest The maximum consecutive-day run across the user's whole listening history.
+ */
+data class Streaks(
+    val current: Int,
+    val longest: Int,
+)
+
+/**
+ * The single, pure streak calculation shared by the server (per-event derive, bulk backfill, and the
+ * windowed leaderboard projection) and the client Home screen. Consolidating the day-run logic here
+ * means every surface reports the same streak from the same primitive — no per-surface reimplementation
+ * that can drift.
+ *
+ * A "streak day" is any calendar day on which the user listened at least once. The reducer speaks only
+ * in calendar dates: resolving event timestamps to a [LocalDate] in the correct timezone is the
+ * caller's responsibility (device timezone on the client, the user's home timezone on the server).
+ *
+ * The reducer is **order- and duplicate-independent**: it distinct-sorts its input, so callers may pass
+ * listening days in any order and with repeats (multiple sessions on one day collapse to a single
+ * streak day).
+ */
+object StreakReducer {
+    /**
+     * Reduce [listeningDays] (the calendar days the user listened, any order, duplicates allowed) to
+     * the [Streaks] as of [today].
+     *
+     * [Streaks.longest] is the longest consecutive-day run anywhere in the history. [Streaks.current]
+     * is the run ending on the most recent listening day, but only when that day is [today] or the day
+     * before — otherwise the streak has lapsed and it is 0. Empty input yields `Streaks(0, 0)`.
+     */
+    fun reduce(
+        listeningDays: List<LocalDate>,
+        today: LocalDate,
+    ): Streaks {
+        if (listeningDays.isEmpty()) return Streaks(current = 0, longest = 0)
+
+        val days = listeningDays.distinct().sorted()
+
+        var longest = 0
+        var run = 0
+        var previous: LocalDate? = null
+        for (day in days) {
+            run = if (previous != null && day == previous.plus(DatePeriod(days = 1))) run + 1 else 1
+            longest = maxOf(longest, run)
+            previous = day
+        }
+
+        val mostRecent = days.last()
+        val current =
+            if (mostRecent == today || mostRecent == today.minus(DatePeriod(days = 1))) {
+                val present = days.toSet()
+                var count = 0
+                var cursor = mostRecent
+                while (cursor in present) {
+                    count++
+                    cursor = cursor.minus(DatePeriod(days = 1))
+                }
+                count
+            } else {
+                0
+            }
+
+        return Streaks(current = current, longest = longest)
+    }
+}

--- a/contract/src/commonTest/kotlin/com/calypsan/listenup/domain/stats/StreakReducerTest.kt
+++ b/contract/src/commonTest/kotlin/com/calypsan/listenup/domain/stats/StreakReducerTest.kt
@@ -1,0 +1,76 @@
+package com.calypsan.listenup.domain.stats
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+
+private val today = LocalDate(2026, 7, 2)
+
+private fun daysAgo(n: Int): LocalDate = today.minus(DatePeriod(days = n))
+
+class StreakReducerTest :
+    FunSpec({
+
+        test("empty history yields zero current and longest") {
+            StreakReducer.reduce(emptyList(), today) shouldBe Streaks(current = 0, longest = 0)
+        }
+
+        test("a single listen today is a current and longest streak of 1") {
+            StreakReducer.reduce(listOf(today), today) shouldBe Streaks(current = 1, longest = 1)
+        }
+
+        test("current streak anchors on yesterday when today has no listen yet") {
+            StreakReducer.reduce(listOf(daysAgo(2), daysAgo(1)), today) shouldBe Streaks(current = 2, longest = 2)
+        }
+
+        test("current streak is 0 once the last listen is older than yesterday (lapsed)") {
+            // A 3-day run ending 3 days ago: longest survives, current has lapsed.
+            val result = StreakReducer.reduce(listOf(daysAgo(5), daysAgo(4), daysAgo(3)), today)
+            result shouldBe Streaks(current = 0, longest = 3)
+        }
+
+        test("multiple listens on the same day collapse to one streak day") {
+            val result = StreakReducer.reduce(listOf(today, today, today, daysAgo(1)), today)
+            result shouldBe Streaks(current = 2, longest = 2)
+        }
+
+        test("a gap restarts the current run but longest remembers the best past run") {
+            // 4-day run ending 6 days ago, then a fresh 2-day run ending today.
+            val days =
+                listOf(daysAgo(9), daysAgo(8), daysAgo(7), daysAgo(6)) + listOf(daysAgo(1), today)
+            StreakReducer.reduce(days, today) shouldBe Streaks(current = 2, longest = 4)
+        }
+
+        test("output is independent of input order (shuffled input yields identical result)") {
+            // A deterministic mixed history: two runs plus a duplicate day.
+            val sorted =
+                listOf(daysAgo(10), daysAgo(9), daysAgo(8)) + // past 3-day run
+                    listOf(daysAgo(2), daysAgo(1), today, today) // current 3-day run with a dupe
+            val expected = StreakReducer.reduce(sorted, today)
+            expected shouldBe Streaks(current = 3, longest = 3)
+
+            // Every shuffle of the same multiset must reduce to the same Streaks.
+            val rng = Random(seed = 20260702)
+            repeat(50) {
+                StreakReducer.reduce(sorted.shuffled(rng), today) shouldBe expected
+            }
+        }
+
+        test("today extends a run started earlier") {
+            val days = (1..4).map { daysAgo(it) } + today // daysAgo 4,3,2,1 + today = 5 consecutive
+            StreakReducer.reduce(days, today) shouldBe Streaks(current = 5, longest = 5)
+        }
+
+        test("a future-dated day beyond today does not count toward the current run") {
+            // Defensive: a day after `today` is not `today`/`today-1`, so the anchor rule leaves
+            // current at 0 (the most-recent day is in the future). longest still reflects the run.
+            val tomorrow = today.plus(DatePeriod(days = 1))
+            val result = StreakReducer.reduce(listOf(daysAgo(1), today, tomorrow), today)
+            result.longest shouldBe 3
+            result.current shouldBe 0
+        }
+    })

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PublicProfileMaintainer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/PublicProfileMaintainer.kt
@@ -63,7 +63,11 @@ class PublicProfileMaintainer(
             suspendTransaction(sql) {
                 val stats = sql.userStatsQueries.selectLiveForUser(userId).executeAsOneOrNull()
                 val yearWindowSeconds =
-                    sql.listeningEventsQueries.sumWallSecondsSince(userId, yearCutoff).executeAsOne()
+                    sql.listeningEventsQueries
+                        .sumWallSecondsSince(
+                            userId = userId,
+                            cutoffMs = yearCutoff,
+                        ).executeAsOne()
 
                 // Windowed books: distinct books finished within each trailing window.
                 val books = sql.bookReadsQueries

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
@@ -208,7 +208,7 @@ class StatsRecorder(
     ): Long {
         val cutoffMs = asOfMs - days * 86_400_000L
         return suspendTransaction(sql) {
-            sql.listeningEventsQueries.sumWallSecondsSince(userId, cutoffMs).executeAsOne()
+            sql.listeningEventsQueries.sumWallSecondsSince(userId = userId, cutoffMs = cutoffMs).executeAsOne()
         }
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StreakWindows.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StreakWindows.kt
@@ -1,21 +1,14 @@
 package com.calypsan.listenup.server.services
 
-import kotlin.math.max
+import com.calypsan.listenup.domain.stats.StreakReducer
 import kotlin.time.Instant
-import kotlinx.datetime.DatePeriod
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
 /**
  * Longest consecutive listening-day run among [endedAtMsAscending] — the event-end epoch-ms
- * timestamps, **already sorted ascending** — counted in the user's home timezone [tz].
- *
- * Each event is reduced to the calendar date of its end in [tz]; a run grows while dates advance by
- * exactly one day, restarts on any gap, and same-day events don't extend it. Returns the maximum run
- * length, or 0 when there are no events. The walk mirrors the all-time streak math in
- * [UserStatsBackfillService] / [UserStatsUpdater], so windowed and all-time streaks stay consistent.
+ * timestamps — counted in the user's home timezone [tz]. Delegates the day-run logic to the shared
+ * [StreakReducer] so windowed, all-time, and client streaks are computed one way and cannot drift.
  *
  * For the windowed leaderboard metric, pass only the events whose end falls inside the trailing
  * window — the result is then the best run achieved within that window (and so caps at its length).
@@ -24,24 +17,8 @@ internal fun longestStreakInWindow(
     endedAtMsAscending: List<Long>,
     tz: TimeZone,
 ): Int {
-    var lastDate: LocalDate? = null
-    var current = 0
-    var longest = 0
-    for (endedAt in endedAtMsAscending) {
-        val date =
-            Instant
-                .fromEpochMilliseconds(endedAt)
-                .toLocalDateTime(tz)
-                .date
-        current =
-            when {
-                lastDate == null -> 1
-                date == lastDate -> current.coerceAtLeast(1)
-                date == lastDate.plus(DatePeriod(days = 1)) -> current + 1
-                else -> 1
-            }
-        longest = max(longest, current)
-        lastDate = date
-    }
-    return longest
+    if (endedAtMsAscending.isEmpty()) return 0
+    val days = endedAtMsAscending.map { Instant.fromEpochMilliseconds(it).toLocalDateTime(tz).date }
+    // The longest run is independent of `today`; anchor on the latest day to satisfy the reducer's arg.
+    return StreakReducer.reduce(days, today = days.max()).longest
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
@@ -1,15 +1,12 @@
 package com.calypsan.listenup.server.services
 
 import com.calypsan.listenup.api.sync.UserStatsSyncPayload
+import com.calypsan.listenup.domain.stats.StreakReducer
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
-import kotlin.math.max
 import kotlin.time.Clock
 import kotlin.time.Instant
-import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.minus
-import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
 /**
@@ -52,30 +49,16 @@ class UserStatsBackfillService(
         val userTz = sql.homeTimeZone(userId)
         var totalAllTime = 0L
         val distinctBooks = mutableSetOf<String>()
-        var lastDate: LocalDate? = null
-        var currentStreak = 0
-        var longestStreak = 0
+        val listeningDays = ArrayList<LocalDate>(events.size)
 
         for (event in events) {
-            val wallSeconds = (event.ended_at - event.started_at) / 1_000L
-            totalAllTime += wallSeconds
+            totalAllTime += (event.ended_at - event.started_at) / 1_000L
             distinctBooks.add(event.book_id)
-
-            val eventDate =
+            listeningDays +=
                 Instant
                     .fromEpochMilliseconds(event.ended_at)
                     .toLocalDateTime(userTz)
                     .date
-
-            currentStreak =
-                when {
-                    lastDate == null -> 1
-                    eventDate == lastDate -> currentStreak.coerceAtLeast(1)
-                    eventDate == lastDate.plus(DatePeriod(days = 1)) -> currentStreak + 1
-                    else -> 1
-                }
-            longestStreak = max(longestStreak, currentStreak)
-            lastDate = eventDate
         }
 
         // 3. Rolling-window sums against nowMs.
@@ -99,16 +82,11 @@ class UserStatsBackfillService(
                     .toInt()
             }
 
-        // 5. The walk's currentStreak is the streak as of lastDate; the *current* streak is only that
-        // value if the last event was today or yesterday — otherwise the streak has lapsed. "Today"
-        // is resolved in the user's home timezone (same frame as the walk above), not the per-event tz.
+        // 5. Current + longest streak via the shared reducer, resolved as-of-today in the user's home
+        // timezone (same frame as the day extraction above). The reducer decays `current` to 0 when the
+        // most recent listening day is older than yesterday, so a lapsed user's streak self-corrects.
         val today = Instant.fromEpochMilliseconds(nowMs).toLocalDateTime(userTz).date
-        val currentStreakAsOfToday =
-            when {
-                lastDate == null -> 0
-                lastDate == today || lastDate == today.minus(DatePeriod(days = 1)) -> currentStreak
-                else -> 0
-            }
+        val streaks = StreakReducer.reduce(listeningDays, today)
 
         // 6. Upsert the rebuilt row. The substrate assigns revision and timestamps.
         val rebuilt =
@@ -119,9 +97,9 @@ class UserStatsBackfillService(
                 totalSecondsLast30Days = last30,
                 booksStarted = distinctBooks.size,
                 booksFinished = booksFinished,
-                currentStreakDays = currentStreakAsOfToday,
-                longestStreakDays = longestStreak,
-                lastEventDate = lastDate?.toString(),
+                currentStreakDays = streaks.current,
+                longestStreakDays = streaks.longest,
+                lastEventDate = listeningDays.lastOrNull()?.toString(),
                 revision = 0L,
                 updatedAt = 0L,
                 createdAt = 0L,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
@@ -85,9 +85,9 @@ class UserStatsBackfillService(
         var last30 = 0L
         for (event in events) {
             val endedAtMs = event.ended_at
-            val wallSeconds = (endedAtMs - event.started_at) / 1_000L
-            if (endedAtMs >= cutoff7) last7 += wallSeconds
-            if (endedAtMs >= cutoff30) last30 += wallSeconds
+            // Clip a span straddling the cutoff to its post-cutoff seconds, matching sumWallSecondsSince.
+            if (endedAtMs >= cutoff7) last7 += (endedAtMs - maxOf(event.started_at, cutoff7)) / 1_000L
+            if (endedAtMs >= cutoff30) last30 += (endedAtMs - maxOf(event.started_at, cutoff30)) / 1_000L
         }
 
         // 4. Count finished positions (non-deleted) for this user.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsUpdater.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsUpdater.kt
@@ -49,7 +49,7 @@ class UserStatsUpdater(
     ): Long {
         val cutoffMs = asOfMs - days * 86_400_000L
         return suspendTransaction(sql) {
-            sql.listeningEventsQueries.sumWallSecondsSince(userId, cutoffMs).executeAsOne()
+            sql.listeningEventsQueries.sumWallSecondsSince(userId = userId, cutoffMs = cutoffMs).executeAsOne()
         }
     }
 }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
@@ -99,12 +99,15 @@ SELECT EXISTS(
     WHERE user_id = :userId AND book_id = :bookId AND id != :excludingId
 );
 
--- Stats support: SUM of wall-clock seconds for events ended at/after :cutoffMs (rolling window).
--- Computed in SQL via integer division by 1000; returns 0 when there are no rows in the window.
+-- Stats support: SUM of wall-clock seconds for live events ended at/after :cutoffMs (rolling window).
+-- A span that started before :cutoffMs but ended inside it is clipped to its post-cutoff portion via
+-- MAX(started_at, :cutoffMs), so a session straddling the boundary contributes only its in-window
+-- seconds. Soft-deleted rows are excluded (deleted_at IS NULL) so the window agrees with the all-time
+-- and streak reads that derive from the same primitive. Returns 0 when no live rows fall in the window.
 sumWallSecondsSince:
-SELECT COALESCE(SUM((ended_at - started_at) / 1000), 0)
+SELECT CAST(COALESCE(SUM((ended_at - MAX(started_at, :cutoffMs)) / 1000), 0) AS INTEGER)
 FROM listening_events
-WHERE user_id = :userId AND ended_at >= :cutoffMs;
+WHERE user_id = :userId AND ended_at >= :cutoffMs AND deleted_at IS NULL;
 
 -- Stats support: the ended-at timestamps of a user's non-deleted events at/after :cutoffMs, ascending.
 -- Feeds the windowed-streak walk (longest consecutive listening-day run within a trailing window).

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/WindowSumSoftDeleteClipTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/WindowSumSoftDeleteClipTest.kt
@@ -1,0 +1,115 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the two invariants the rolling-window sum must hold so windowed totals can never disagree
+ * with the all-time / streak reads that derive from the same `listening_events` primitive:
+ *
+ * 1. **Soft-deleted events contribute nothing.** `sumWallSecondsSince` must filter `deleted_at IS
+ *    NULL` like its sibling queries; otherwise a client-deleted event still inflates the leaderboard
+ *    windows while the deleted-filtered backfill excludes it.
+ * 2. **Boundary-spanning sessions are clipped, not counted whole.** A span that started before the
+ *    window cutoff but ended inside it contributes only its post-cutoff seconds — `MAX(started_at,
+ *    cutoffMs)` — not the full wall-clock span.
+ */
+class WindowSumSoftDeleteClipTest :
+    FunSpec({
+
+        test("sumWallSecondsSince excludes soft-deleted events") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                // Live 60s span, ended after the cutoff.
+                sql.insertEvent(id = "live", userId = "u1", startedAt = 1_000L, endedAt = 61_000L)
+                // Soft-deleted 120s span, also ended after the cutoff — must NOT count.
+                sql.insertEvent(id = "gone", userId = "u1", startedAt = 1_000L, endedAt = 121_000L, deletedAt = 500_000L)
+
+                sql.listeningEventsQueries.sumWallSecondsSince(userId = "u1", cutoffMs = 0L).executeAsOne() shouldBe 60L
+            }
+        }
+
+        test("sumWallSecondsSince clips a span that straddles the cutoff to its post-cutoff seconds") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                // Total wall span 120s (40_000..160_000); cutoff at 100_000 → only 60s is post-cutoff.
+                sql.insertEvent(id = "straddle", userId = "u1", startedAt = 40_000L, endedAt = 160_000L)
+
+                sql.listeningEventsQueries.sumWallSecondsSince(userId = "u1", cutoffMs = 100_000L).executeAsOne() shouldBe 60L
+            }
+        }
+
+        test("backfill window totals equal the clipped SQL sum on the same straddling fixture") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                val nowMs = 1_779_451_200_000L
+                val dayMs = 86_400_000L
+                val cutoff7 = nowMs - 7 * dayMs
+                // A span straddling the 7-day cutoff: 60s wall, only the 30s after cutoff7 is in-window.
+                sql.insertEvent(id = "edge", userId = "u1", startedAt = cutoff7 - 30_000L, endedAt = cutoff7 + 30_000L)
+
+                val bus = ChangeBus()
+                val registry = SyncRegistry()
+                val statsRepo = UserStatsRepository(db = sql, bus = bus, registry = registry)
+                val backfill =
+                    UserStatsBackfillService(
+                        sql = sql,
+                        userStatsRepo = statsRepo,
+                        clock = FixedClock(Instant.fromEpochMilliseconds(nowMs)),
+                    )
+
+                runTest {
+                    backfill.backfillFor("u1")
+                    val stats = statsRepo.getForUser("u1").shouldNotBeNull()
+                    val sqlSum = sql.listeningEventsQueries.sumWallSecondsSince(userId = "u1", cutoffMs = cutoff7).executeAsOne()
+
+                    // The in-memory backfill loop and the SQL query must agree …
+                    stats.totalSecondsLast7Days shouldBe sqlSum
+                    // … and both must reflect only the post-cutoff 30s, not the whole 60s span.
+                    stats.totalSecondsLast7Days shouldBe 30L
+                    // All-time always counts the full span.
+                    stats.totalSecondsAllTime shouldBe 60L
+                }
+            }
+        }
+    })
+
+private fun ListenUpDatabase.insertEvent(
+    id: String,
+    userId: String,
+    startedAt: Long,
+    endedAt: Long,
+    bookId: String = "b1",
+    deletedAt: Long? = null,
+) {
+    transaction {
+        listeningEventsQueries.insert(
+            id = id,
+            user_id = userId,
+            book_id = bookId,
+            start_position_ms = 0L,
+            end_position_ms = endedAt - startedAt,
+            started_at = startedAt,
+            ended_at = endedAt,
+            playback_speed = 1.0,
+            tz = "UTC",
+            device_label = null,
+            revision = 0L,
+            created_at = 0L,
+            updated_at = 0L,
+            deleted_at = deletedAt,
+            client_op_id = null,
+        )
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.domain.leaderboard.LeaderboardPeriod
 import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.StatsRepository
+import com.calypsan.listenup.domain.stats.StreakReducer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -23,11 +24,8 @@ import kotlinx.coroutines.flow.map
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.minus
-import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
 private const val MIDNIGHT_PULSE_DELAY_MS = 60_000L
@@ -151,36 +149,9 @@ private fun computeStreaks(
     tz: TimeZone,
     today: LocalDate,
 ): Pair<Int, Int> {
-    if (endedAtMs.isEmpty()) return 0 to 0
-    // distinct().sorted() (multiplatform-safe; toSortedSet/TreeSet are JVM-only) → ascending unique days.
-    val days =
-        endedAtMs
-            .map { Instant.fromEpochMilliseconds(it).toLocalDateTime(tz).date }
-            .distinct()
-            .sorted()
-    val daySet = days.toSet()
-    var longest = 0
-    var run = 0
-    var prev: LocalDate? = null
-    for (d in days) {
-        run = if (prev != null && d == prev.plus(DatePeriod(days = 1))) run + 1 else 1
-        longest = maxOf(longest, run)
-        prev = d
-    }
-    val last = days.last()
-    val current =
-        if (last == today || last == today.minus(DatePeriod(days = 1))) {
-            var c = 0
-            var cursor = last
-            while (cursor in daySet) {
-                c++
-                cursor = cursor.minus(DatePeriod(days = 1))
-            }
-            c
-        } else {
-            0
-        }
-    return current to longest
+    val days = endedAtMs.map { Instant.fromEpochMilliseconds(it).toLocalDateTime(tz).date }
+    val streaks = StreakReducer.reduce(days, today)
+    return streaks.current to streaks.longest
 }
 
 /**


### PR DESCRIPTION
**Spec 002 of 5** (stacked; base = `fix/stats-window-sums`).

Streak math existed 4× (3 server: `newStreakValue`, the backfill walk, `longestStreakInWindow`; 1 client: `computeStreaks`). Collapses them into one pure, order-independent `StreakReducer` in `:contract`, adopted everywhere. Net −96 lines at the call sites; 9 property/example tests.

**Review note:** verified the two new public `:contract` types are NOT reachable from the exported iOS API (device build + inventory script), so the Swift-export baseline needs no change.