### PR TITLE
✨ feat(server): coverage-based re-read rule; book_reads as the sole finished-books primitive

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.server.db.sqldelight.Book_reads
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Clock
+import kotlin.uuid.Uuid
 
 /** A single completion event: who finished what, when, and how. */
 data class BookReadRow(
@@ -16,20 +17,17 @@ data class BookReadRow(
 )
 
 /**
- * Server-only persistence for per-completion read history.
+ * Server-only persistence for per-completion read history — the single finished-books primitive.
  *
- * Append-only: rows are never updated or deleted. Re-reads of the same book stack
- * as distinct rows (naturally deduplicated by [finishedAt]). Used by the readership
- * RPC surface to show persistent readers on the Book Detail screen.
+ * A genuine re-read stacks as a distinct row; a below-threshold replay instead advances the existing
+ * row's `finished_at` in place (see [recordCompletion]), so the log is append-mostly rather than
+ * strictly append-only. Rows are never deleted. Used by the readership RPC surface to show persistent
+ * readers on the Book Detail screen, and counted by [deriveUserStats] for `booksFinished`.
  *
- * This is a **plain** (non-syncable) append-only log — there is no revision /
- * soft-delete substrate, so it persists directly over the generated
- * [ListenUpDatabase.bookReadsQueries] rather than through `SqlSyncableRepository`.
- *
- * [recordRead] is a hook target of `PlaybackPositionRepository.recordPosition`: when
- * that repo runs SQLDelight, its `recordRead` call nests as a savepoint inside the
- * open `recordPosition` transaction (same [ListenUpDatabase] connection), so the
- * completion row commits atomically with the position write — no `SQLITE_BUSY`.
+ * This is a **plain** (non-syncable) log — there is no revision / soft-delete substrate, so it persists
+ * directly over the generated [ListenUpDatabase.bookReadsQueries] rather than through
+ * `SqlSyncableRepository`. [recordCompletion] is the completion write path fired by [StatsRecorder];
+ * [recordRead] remains the low-level unconditional append used for test seeding.
  */
 class BookReadsRepository(
     private val db: ListenUpDatabase,
@@ -56,6 +54,57 @@ class BookReadsRepository(
             source = source,
             created_at = clock.now().toEpochMilliseconds(),
         )
+    }
+
+    /**
+     * Record a completion of [bookId] by [userId] at [finishedAtMs], applying the re-read coverage
+     * rule: a new [book_reads] row is appended only when the user covered at least
+     * [RE_READ_COVERAGE_THRESHOLD] of the book's duration since their previous finish — a genuine
+     * re-read. A below-threshold replay (e.g. finishing, then rewinding just the last chapter and
+     * "finishing" again) instead moves the existing row's `finished_at` forward, so it counts as the
+     * same read. The first-ever finish always appends; when the book's duration is unknown or zero the
+     * coverage can't be assessed, so it appends (matching the pre-rule always-append behavior).
+     *
+     * The whole decision runs in one transaction so a concurrent completion can't interleave between
+     * the coverage read and the write.
+     */
+    suspend fun recordCompletion(
+        userId: String,
+        bookId: String,
+        finishedAtMs: Long,
+    ) {
+        val createdAt = clock.now().toEpochMilliseconds()
+        suspendTransaction(db) {
+            // The id of the existing read to merge this finish into, or null to append a new read. The
+            // first-ever finish (no previous row) always appends.
+            val mergeIntoId: String? =
+                db.bookReadsQueries.latestFinishForUserBook(userId, bookId).executeAsOneOrNull()?.let { previous ->
+                    val duration = db.booksQueries.durationForBook(bookId).executeAsOneOrNull()
+                    val coverage =
+                        db.listeningEventsQueries
+                            .sumPositionDeltaForBookSince(
+                                userId = userId,
+                                bookId = bookId,
+                                sinceMs = previous.finished_at,
+                            ).executeAsOne()
+                    val isNewRead =
+                        duration == null || duration <= 0 ||
+                            coverage >= (duration * RE_READ_COVERAGE_THRESHOLD).toLong()
+                    if (isNewRead) null else previous.id
+                }
+            if (mergeIntoId == null) {
+                db.bookReadsQueries.insert(
+                    id = Uuid.random().toString(),
+                    user_id = userId,
+                    book_id = bookId,
+                    finished_at = finishedAtMs,
+                    source = "playback",
+                    created_at = createdAt,
+                )
+            } else {
+                db.bookReadsQueries.updateFinishedAtById(finished_at = finishedAtMs, id = mergeIntoId)
+            }
+        }
     }
 
     /** All completions of [bookId] across all users, newest-first. */
@@ -85,4 +134,14 @@ class BookReadsRepository(
             finishedAt = finished_at,
             source = source,
         )
+
+    private companion object {
+        /**
+         * A completion counts as a genuine re-read only when the user covered at least this fraction of
+         * the book's duration since their previous finish. Because coverage is derived from the
+         * `listening_events` primitive, this threshold is retroactively tunable — change it and run
+         * `BulkRecompute` to re-settle history.
+         */
+        const val RE_READ_COVERAGE_THRESHOLD = 0.5
+    }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
@@ -4,7 +4,6 @@ import com.calypsan.listenup.api.dto.activity.ActivityType
 import com.calypsan.listenup.api.sync.UserStatsSyncPayload
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import kotlin.time.Clock
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.currentCoroutineContext
 
 /**
@@ -50,27 +49,20 @@ class StatsRecorder(
     }
 
     /**
-     * Source row (`book_reads`) → `user_stats.booksFinished` → `public_profiles.refresh()` → the
-     * `FINISHED_BOOK` activity, dated [StatsEvent.BookCompleted.occurredAt]. The `user_stats` bump
-     * and the projection refresh are skipped under [StatsCascadeDeferred] — a bulk import writes the
-     * source row per row but defers the expensive recompute to one terminal [StatsEvent.BulkRecompute].
+     * `book_reads` (via the coverage rule — append a new read or merge a below-threshold replay) →
+     * re-derived `user_stats` (booksFinished counted from `book_reads`) → `public_profiles.refresh()` →
+     * the `FINISHED_BOOK` activity, dated [StatsEvent.BookCompleted.occurredAt]. The re-derive and the
+     * projection refresh are skipped under [StatsCascadeDeferred] — a bulk import writes the source row
+     * per row but defers the recompute to one terminal [StatsEvent.BulkRecompute].
      */
     private suspend fun recordBookCompleted(event: StatsEvent.BookCompleted) {
         val finishedAtMs = event.occurredAt.toEpochMilliseconds()
-        bookReadsRepository.recordRead(
-            id = Uuid.random().toString(),
-            userId = event.userId,
-            bookId = event.bookId,
-            finishedAt = finishedAtMs,
-            source = "playback",
-        )
+        // The coverage rule decides append-vs-merge on `book_reads`; the re-derive then reads the new
+        // count. booksFinished is a pure function of `book_reads`, so a merge leaves it unchanged.
+        bookReadsRepository.recordCompletion(event.userId, event.bookId, finishedAtMs)
         if (currentCoroutineContext()[StatsCascadeDeferred.Key] == null) {
-            val base = userStatsRepo.getForUser(event.userId) ?: emptyStatsFor(event.userId)
-            userStatsRepo.upsert(
-                base.copy(booksFinished = base.booksFinished + 1),
-                clientOpId = null,
-                userId = event.userId,
-            )
+            val derived = deriveUserStats(sql, event.userId, clock.now().toEpochMilliseconds())
+            userStatsRepo.upsert(derived, clientOpId = null, userId = event.userId)
             publicProfileMaintainer.refresh(event.userId)
         }
         activityRecorder.record(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
@@ -27,7 +27,10 @@ class UserStatsBackfillService(
      * derivation [StatsRecorder] runs per event — so a bulk rebuild and the live path always agree.
      */
     suspend fun backfillFor(userId: String) {
-        val derived = deriveUserStats(sql, userId, clock.now().toEpochMilliseconds())
-        userStatsRepo.upsert(derived, clientOpId = null, userId = userId)
+        val nowMs = clock.now().toEpochMilliseconds()
+        // Self-heal the `book_reads` primitive first, so the re-derived booksFinished reflects every
+        // finished book even for crash-orphaned or pre-Spec-004-imported completions.
+        reconcileBookReadsFromPositions(sql, userId, nowMs)
+        userStatsRepo.upsert(deriveUserStats(sql, userId, nowMs), clientOpId = null, userId = userId)
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
@@ -5,8 +5,40 @@ import com.calypsan.listenup.domain.stats.StreakReducer
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Insert a `source = "reconcile"` `book_reads` row for every finished, non-deleted `playback_positions`
+ * row that has no completion row yet — recovering finishes lost to a crash between the position commit
+ * and the completion cascade, and backfilling pre-Spec-004 imports that never wrote `book_reads`.
+ * Idempotent: a book that already has any completion row is skipped. Runs as the first step of a full
+ * rebuild ([UserStatsBackfillService.backfillFor]) so the re-derived `booksFinished` — counted from
+ * `book_reads` — reflects every finished book. Re-read multiplicity for pre-crash finishes is
+ * unrecoverable; reconcile restores at least one read per finished book, never invents extras.
+ */
+suspend fun reconcileBookReadsFromPositions(
+    sql: ListenUpDatabase,
+    userId: String,
+    nowMs: Long,
+) {
+    suspendTransaction(sql) {
+        sql.playbackPositionsQueries.selectFinishedBooksForUser(userId).executeAsList().forEach { finished ->
+            val alreadyLogged = sql.bookReadsQueries.existsForUserBook(userId, finished.book_id).executeAsOne()
+            if (!alreadyLogged) {
+                sql.bookReadsQueries.insert(
+                    id = Uuid.random().toString(),
+                    user_id = userId,
+                    book_id = finished.book_id,
+                    finished_at = finished.last_played_at,
+                    source = "reconcile",
+                    created_at = nowMs,
+                )
+            }
+        }
+    }
+}
 
 /**
  * The single pure re-derivation of a user's `user_stats` from the durable primitives
@@ -65,12 +97,12 @@ suspend fun deriveUserStats(
         if (endedAtMs >= cutoff30) last30 += (endedAtMs - maxOf(event.started_at, cutoff30)) / 1_000L
     }
 
-    // 4. Finished-book count (non-deleted positions). Spec 004 will move this onto the `book_reads`
-    //    primitive; kept here for now so the incremental and rebuilt rows agree.
+    // 4. Finished-book count from the `book_reads` primitive (re-reads counted). All-time and windowed
+    //    finished-books now derive from the same table, so they cannot disagree.
     val booksFinished =
         suspendTransaction(sql) {
-            sql.playbackPositionsQueries
-                .countFinishedForUser(userId)
+            sql.bookReadsQueries
+                .countForUser(userId)
                 .executeAsOne()
                 .toInt()
         }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookReads.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookReads.sq
@@ -36,3 +36,24 @@ ORDER BY finished_at DESC;
 countDistinctFinishedSince:
 SELECT COUNT(DISTINCT book_id) FROM book_reads
 WHERE user_id = :userId AND finished_at >= :cutoffMs;
+
+-- All-time completions for a user (re-reads counted) — the all-time booksFinished metric, now sourced
+-- from this primitive so it agrees with the windowed counts above.
+countForUser:
+SELECT COUNT(*) FROM book_reads WHERE user_id = :userId;
+
+-- The most recent completion row for a user+book pair (id + timestamp). The re-read rule reads its
+-- finished_at as the "previous finish" and, on a below-threshold replay, updates that row in place.
+latestFinishForUserBook:
+SELECT id, finished_at FROM book_reads
+WHERE user_id = :userId AND book_id = :bookId
+ORDER BY finished_at DESC
+LIMIT 1;
+
+-- Move an existing completion's finish time forward (the below-threshold "same read" case).
+updateFinishedAtById:
+UPDATE book_reads SET finished_at = :finished_at WHERE id = :id;
+
+-- True iff the user has any completion row for this book — gates the idempotent reconcile insert.
+existsForUserBook:
+SELECT EXISTS(SELECT 1 FROM book_reads WHERE user_id = :userId AND book_id = :bookId);

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
@@ -223,6 +223,11 @@ UPDATE books SET revision = :revision, updated_at = :updated_at WHERE id = :id;
 updateTotalDuration:
 UPDATE books SET total_duration = :total_duration WHERE id = :id;
 
+-- Total duration (ms) of a single live book — feeds the re-read coverage threshold. A tombstoned or
+-- absent book yields no row (the caller then treats coverage as unassessable and appends).
+durationForBook:
+SELECT total_duration FROM books WHERE id = :id AND deleted_at IS NULL;
+
 -- Sets chapter_source only — written by writePayload after replaceChapters so the
 -- provenance enum persists with every aggregate upsert (insert and update paths both
 -- land here via BookRepository.writePayload).

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
@@ -109,6 +109,15 @@ SELECT CAST(COALESCE(SUM((ended_at - MAX(started_at, :cutoffMs)) / 1000), 0) AS 
 FROM listening_events
 WHERE user_id = :userId AND ended_at >= :cutoffMs AND deleted_at IS NULL;
 
+-- Stats support: content coverage (summed end-start position deltas, negatives clamped to 0) a user
+-- accrued on :bookId strictly after :sinceMs. Drives the re-read coverage rule — a genuine re-read
+-- traverses real content since the last finish, a "rewound to the last chapter" replay does not.
+-- Live rows only. CAST keeps the result Long; the two-arg MAX is SQLite's scalar max, not the aggregate.
+sumPositionDeltaForBookSince:
+SELECT CAST(COALESCE(SUM(MAX(end_position_ms - start_position_ms, 0)), 0) AS INTEGER)
+FROM listening_events
+WHERE user_id = :userId AND book_id = :bookId AND ended_at > :sinceMs AND deleted_at IS NULL;
+
 -- Stats support: the ended-at timestamps of a user's non-deleted events at/after :cutoffMs, ascending.
 -- Feeds the windowed-streak walk (longest consecutive listening-day run within a trailing window).
 selectEndedAtForUserSince:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
@@ -104,6 +104,13 @@ countFinishedForUser:
 SELECT COUNT(*) FROM playback_positions
 WHERE user_id = :userId AND finished = 1 AND deleted_at IS NULL;
 
+-- Stats support: (book_id, last_played_at) for every finished, non-deleted position of a user. The
+-- book_reads reconcile inserts a completion row for any of these lacking one (crash between the
+-- position commit and the book_reads insert, or a pre-Spec-004 import that never wrote book_reads).
+selectFinishedBooksForUser:
+SELECT book_id, last_played_at FROM playback_positions
+WHERE user_id = :userId AND finished = 1 AND deleted_at IS NULL;
+
 insert:
 INSERT INTO playback_positions (
     id, user_id, book_id, position_ms, last_played_at, finished, playback_speed,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/StatsRecorderIsSoleStatsWriterRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/StatsRecorderIsSoleStatsWriterRule.kt
@@ -60,7 +60,13 @@ class StatsRecorderIsSoleStatsWriterRule :
          */
         val USER_STATS_WRITE_ALLOWLIST = setOf("StatsRecorder", "UserStatsBackfillService", "UserStatsUpdater")
 
-        /** Holders of [com.calypsan.listenup.server.services.BookReadsRepository] allowed to call `.recordRead(`. */
+        /**
+         * Holders of [com.calypsan.listenup.server.services.BookReadsRepository] allowed to call its
+         * write methods — the low-level `.recordRead(` and the Spec-004 coverage-rule entry point
+         * `.recordCompletion(`. Both are stats-source writes and must stay behind the ordered
+         * choke-point. (The rebuild reconcile writes `book_reads` via the top-level
+         * `reconcileBookReadsFromPositions`, not a repository method, so it isn't matched here.)
+         */
         val BOOK_READS_WRITE_ALLOWLIST = setOf("StatsRecorder")
 
         fun findOffenders(scope: KoScope): List<String> =
@@ -74,6 +80,12 @@ class StatsRecorderIsSoleStatsWriterRule :
                     scope,
                     holderType = "BookReadsRepository",
                     callToken = ".recordRead(",
+                    allowlist = BOOK_READS_WRITE_ALLOWLIST,
+                ) +
+                violatingClasses(
+                    scope,
+                    holderType = "BookReadsRepository",
+                    callToken = ".recordCompletion(",
                     allowlist = BOOK_READS_WRITE_ALLOWLIST,
                 )
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderBookReadsCoverageTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderBookReadsCoverageTest.kt
@@ -1,0 +1,193 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.PublicProfileRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Spec 004: `book_reads` is the single finished-books primitive, and a completion becomes a new read
+ * only when real content was covered since the previous finish (the coverage rule). A "finished, then
+ * rewound to the last chapter, then finished again" replay must not double-count; a genuine re-read
+ * (≥ 50% of the book covered since the last finish) must. A crash that left a finished position without
+ * a `book_reads` row is reconciled by a rebuild.
+ */
+class StatsRecorderBookReadsCoverageTest :
+    FunSpec({
+
+        val day0Ms = 1_779_451_200_000L
+        val oneHourMs = 3_600_000L
+
+        fun eventOnBook(
+            id: String,
+            bookId: String,
+            endedAtMs: Long,
+            startPositionMs: Long,
+            endPositionMs: Long,
+        ): ListeningEventSyncPayload =
+            ListeningEventSyncPayload(
+                id = id,
+                bookId = bookId,
+                startPositionMs = startPositionMs,
+                endPositionMs = endPositionMs,
+                startedAt = endedAtMs - 60_000L,
+                endedAt = endedAtMs,
+                playbackSpeed = 1.0f,
+                tz = "UTC",
+                deviceLabel = null,
+                revision = 0L,
+                updatedAt = 0L,
+                createdAt = 0L,
+                deletedAt = null,
+            )
+
+        fun SqlTestDatabases.recorder(clock: FixedClock): Triple<StatsRecorder, BookReadsRepository, UserStatsRepository> {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val userStatsRepo = UserStatsRepository(db = sql, bus = bus, registry = registry)
+            val bookReads = BookReadsRepository(db = sql, clock = clock)
+            val recorder =
+                StatsRecorder(
+                    sql = sql,
+                    userStatsRepo = userStatsRepo,
+                    bookReadsRepository = bookReads,
+                    publicProfileMaintainer =
+                        PublicProfileMaintainer(
+                            sql = sql,
+                            publicProfileRepo = PublicProfileRepository(db = sql, bus = bus, registry = registry),
+                            clock = clock,
+                        ),
+                    activityRecorder = ActivityRecorder(repo = ActivityRepository(db = sql), bus = bus),
+                    statsBackfill = UserStatsBackfillService(sql = sql, userStatsRepo = userStatsRepo, clock = clock),
+                    clock = clock,
+                )
+            return Triple(recorder, bookReads, userStatsRepo)
+        }
+
+        test("finish then rewind the last chapter and finish again records ONE read, booksFinished stays 1") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b1")
+                sql.booksQueries.updateTotalDuration(total_duration = oneHourMs, id = "b1")
+                val clock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 60_000L))
+                val (recorder, bookReads, userStatsRepo) = recorder(clock)
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+
+                runTest {
+                    // First finish — always a new read.
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms)),
+                    )
+
+                    // A short replay covering only the last 10 minutes (< 50% of the 1h book).
+                    eventRepo.upsert(
+                        eventOnBook("rewind", "b1", endedAtMs = day0Ms + 10_000L, startPositionMs = 3_000_000L, endPositionMs = 3_600_000L),
+                        clientOpId = null,
+                        userId = "u1",
+                    )
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms + 20_000L)),
+                    )
+
+                    bookReads.finishesForUserBook("u1", "b1") shouldHaveSize 1
+                    userStatsRepo.getForUser("u1").shouldNotBeNull().booksFinished shouldBe 1
+                }
+            }
+        }
+
+        test("finish then genuinely re-read (>=50% covered) records TWO reads, booksFinished 2") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b1")
+                sql.booksQueries.updateTotalDuration(total_duration = oneHourMs, id = "b1")
+                val clock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 60_000L))
+                val (recorder, bookReads, userStatsRepo) = recorder(clock)
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+
+                runTest {
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms)),
+                    )
+
+                    // A replay covering 2,000,000 ms (> 50% of the 1h = 1,800,000 ms threshold).
+                    eventRepo.upsert(
+                        eventOnBook("reread", "b1", endedAtMs = day0Ms + 10_000L, startPositionMs = 0L, endPositionMs = 2_000_000L),
+                        clientOpId = null,
+                        userId = "u1",
+                    )
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms + 20_000L)),
+                    )
+
+                    bookReads.finishesForUserBook("u1", "b1") shouldHaveSize 2
+                    userStatsRepo.getForUser("u1").shouldNotBeNull().booksFinished shouldBe 2
+                }
+            }
+        }
+
+        test("BulkRecompute reconciles a finished position with no book_reads row, idempotently") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b2")
+                val clock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 60_000L))
+                val (recorder, bookReads, _) = recorder(clock)
+
+                // A finished position that never produced a book_reads row (crash between the position
+                // commit and the completion cascade, or a pre-Spec-004 import).
+                sql.insertFinishedPosition(userId = "u1", bookId = "b2", lastPlayedAt = day0Ms)
+
+                runTest {
+                    bookReads.finishesForUserBook("u1", "b2") shouldHaveSize 0
+
+                    recorder.record(StatsEvent.BulkRecompute("u1"))
+                    bookReads.finishesForUserBook("u1", "b2") shouldHaveSize 1
+
+                    // Running the rebuild again must not add a duplicate.
+                    recorder.record(StatsEvent.BulkRecompute("u1"))
+                    bookReads.finishesForUserBook("u1", "b2") shouldHaveSize 1
+                }
+            }
+        }
+    })
+
+private fun ListenUpDatabase.insertFinishedPosition(
+    userId: String,
+    bookId: String,
+    lastPlayedAt: Long,
+) {
+    transaction {
+        playbackPositionsQueries.insert(
+            id = "pos-$userId-$bookId",
+            user_id = userId,
+            book_id = bookId,
+            position_ms = 3_600_000L,
+            last_played_at = lastPlayedAt,
+            finished = 1L,
+            playback_speed = 1.0,
+            current_chapter_id = null,
+            revision = 0L,
+            created_at = 0L,
+            updated_at = 0L,
+            deleted_at = null,
+            client_op_id = null,
+        )
+    }
+}


### PR DESCRIPTION
**Spec 004 of 5** (stacked; base = `fix/stats-rederive`).

`booksFinished` had three divergent definitions and `book_reads` had no rebuild path (a crash lost a finish forever). Now `book_reads` is the single finished-books primitive: a completion appends a new read only when content coverage since the previous finish ≥ 50% of the book's duration (`RE_READ_COVERAGE_THRESHOLD` — a genuine re-read vs "rewound the last chapter"); below that it moves the existing finish forward in place. A rebuild reconciles missing `book_reads` rows from finished positions, and `deriveUserStats` counts `book_reads` for `booksFinished`.

**Review note:** the reconcile is a top-level fn called inside `backfillFor` (so a direct rebuild self-heals), not in `recordBulkRecompute`. The 50% threshold is derived from primitives → retroactively tunable via `BulkRecompute`.