### PR TITLE
🐛 fix(server): decay lapsed streaks via lazy full-heal + freshness sweep

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.server.scheduler.ActiveSessionCleanupTask
 import com.calypsan.listenup.server.scheduler.ExpiredSessionCleanupTask
 import com.calypsan.listenup.server.scheduler.MetadataCacheCleanupTask
 import com.calypsan.listenup.server.scheduler.OrphanImageCleanupTask
+import com.calypsan.listenup.server.scheduler.StatsFreshnessSweepTask
 import com.calypsan.listenup.server.services.BookPersister
 import com.calypsan.listenup.server.services.LibraryRegistry
 import com.calypsan.listenup.server.sync.ChangeBus
@@ -67,6 +68,8 @@ internal fun Application.startBackgroundTasks(
     metadataCacheCleanupTask.start(scope)
     val orphanImageCleanupTask by inject<OrphanImageCleanupTask>()
     orphanImageCleanupTask.start(scope)
+    val statsFreshnessSweepTask by inject<StatsFreshnessSweepTask>()
+    statsFreshnessSweepTask.start(scope)
 
     val rescanOnStartup = environment.config.rescanOnStartup()
     scope.launch {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/PlaybackModule.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserRoleLookup
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.scheduler.ActiveSessionCleanupTask
+import com.calypsan.listenup.server.scheduler.StatsFreshnessSweepTask
 import com.calypsan.listenup.server.services.ActiveSessionRepository
 import com.calypsan.listenup.server.services.ActivityRecorder
 import com.calypsan.listenup.server.services.ActivityRepository
@@ -126,6 +127,7 @@ fun playbackModule(): Module =
             UserStatsUpdater(
                 sql = get<ListenUpDatabase>(),
                 userStatsRepo = get(),
+                publicProfileMaintainer = get(),
             )
         }
         single(createdAtStart = true) {
@@ -138,6 +140,7 @@ fun playbackModule(): Module =
         }
         single { UserStatsBackfillService(sql = get<ListenUpDatabase>(), userStatsRepo = get()) }
         single { ActiveSessionCleanupTask(sql = get(), bus = get()) }
+        single { StatsFreshnessSweepTask(sql = get(), updater = get()) }
         single<PlaybackService> {
             PlaybackServiceImpl(
                 bookRepository = get<BookRepository>(),

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/StatsFreshnessSweepTask.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/scheduler/StatsFreshnessSweepTask.kt
@@ -1,0 +1,61 @@
+package com.calypsan.listenup.server.scheduler
+
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import com.calypsan.listenup.server.logging.loggerFor
+import com.calypsan.listenup.server.services.UserStatsUpdater
+import com.calypsan.listenup.server.util.runCatchingCancellable
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+private val log = loggerFor<StatsFreshnessSweepTask>()
+
+/**
+ * Periodic sweep that heals clock-relative stats decay for idle users.
+ *
+ * A user who keeps listening stays fresh via the `StatsRecorder` cascade, and a user who opens the app
+ * self-heals on pull (`UserStatsRepository.pullSince`'s lazy path). But a fully-idle user — one who
+ * neither listens nor syncs — keeps a frozen `current_streak_days` and stale rolling windows in their
+ * `user_stats` row and, worse, in the global `public_profiles` leaderboard everyone else reads. This
+ * sweep re-derives every user's stats against the current clock on a fixed [interval]; the per-user heal
+ * is a cheap no-op when nothing drifted, so an all-fresh fleet costs one derive-and-compare each.
+ *
+ * O(users) derives per run — fine for the self-hosted small-userbase scale this app targets, not a
+ * large-fleet design. Runs on the supplied [CoroutineScope]; cancel the returned [Job] to stop. Re-raises
+ * `CancellationException`; suppresses other failures with a warning so a transient hiccup doesn't kill it.
+ */
+internal class StatsFreshnessSweepTask(
+    private val sql: ListenUpDatabase,
+    private val updater: UserStatsUpdater,
+    private val clock: Clock = Clock.System,
+    private val interval: Duration = 6.hours,
+) {
+    /** Start the sweep loop on [scope]. Returns the [Job] — cancel it to stop. */
+    fun start(scope: CoroutineScope): Job =
+        scope.launch {
+            while (isActive) {
+                runCatchingCancellable { runOnce() }
+                    .onFailure { log.warn(it) { "StatsFreshnessSweepTask sweep failed; will retry next interval" } }
+                delay(interval)
+            }
+        }
+
+    /** Heal every live user's stats against the current clock. Returns the number of rows healed. */
+    suspend fun runOnce(): Int {
+        val userIds =
+            suspendTransaction(sql) { sql.userStatsQueries.selectAllLiveUserIds().executeAsList() }
+        val nowMs = clock.now().toEpochMilliseconds()
+        var healed = 0
+        for (userId in userIds) {
+            if (updater.healStaleStats(userId, asOfMs = nowMs)) healed++
+        }
+        if (healed > 0) log.info { "StatsFreshnessSweepTask healed $healed stale user_stats rows" }
+        return healed
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookReadsRepository.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.server.db.sqldelight.Book_reads
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Clock
+import kotlin.uuid.Uuid
 
 /** A single completion event: who finished what, when, and how. */
 data class BookReadRow(
@@ -16,20 +17,17 @@ data class BookReadRow(
 )
 
 /**
- * Server-only persistence for per-completion read history.
+ * Server-only persistence for per-completion read history — the single finished-books primitive.
  *
- * Append-only: rows are never updated or deleted. Re-reads of the same book stack
- * as distinct rows (naturally deduplicated by [finishedAt]). Used by the readership
- * RPC surface to show persistent readers on the Book Detail screen.
+ * A genuine re-read stacks as a distinct row; a below-threshold replay instead advances the existing
+ * row's `finished_at` in place (see [recordCompletion]), so the log is append-mostly rather than
+ * strictly append-only. Rows are never deleted. Used by the readership RPC surface to show persistent
+ * readers on the Book Detail screen, and counted by [deriveUserStats] for `booksFinished`.
  *
- * This is a **plain** (non-syncable) append-only log — there is no revision /
- * soft-delete substrate, so it persists directly over the generated
- * [ListenUpDatabase.bookReadsQueries] rather than through `SqlSyncableRepository`.
- *
- * [recordRead] is a hook target of `PlaybackPositionRepository.recordPosition`: when
- * that repo runs SQLDelight, its `recordRead` call nests as a savepoint inside the
- * open `recordPosition` transaction (same [ListenUpDatabase] connection), so the
- * completion row commits atomically with the position write — no `SQLITE_BUSY`.
+ * This is a **plain** (non-syncable) log — there is no revision / soft-delete substrate, so it persists
+ * directly over the generated [ListenUpDatabase.bookReadsQueries] rather than through
+ * `SqlSyncableRepository`. [recordCompletion] is the completion write path fired by [StatsRecorder];
+ * [recordRead] remains the low-level unconditional append used for test seeding.
  */
 class BookReadsRepository(
     private val db: ListenUpDatabase,
@@ -56,6 +54,57 @@ class BookReadsRepository(
             source = source,
             created_at = clock.now().toEpochMilliseconds(),
         )
+    }
+
+    /**
+     * Record a completion of [bookId] by [userId] at [finishedAtMs], applying the re-read coverage
+     * rule: a new [book_reads] row is appended only when the user covered at least
+     * [RE_READ_COVERAGE_THRESHOLD] of the book's duration since their previous finish — a genuine
+     * re-read. A below-threshold replay (e.g. finishing, then rewinding just the last chapter and
+     * "finishing" again) instead moves the existing row's `finished_at` forward, so it counts as the
+     * same read. The first-ever finish always appends; when the book's duration is unknown or zero the
+     * coverage can't be assessed, so it appends (matching the pre-rule always-append behavior).
+     *
+     * The whole decision runs in one transaction so a concurrent completion can't interleave between
+     * the coverage read and the write.
+     */
+    suspend fun recordCompletion(
+        userId: String,
+        bookId: String,
+        finishedAtMs: Long,
+    ) {
+        val createdAt = clock.now().toEpochMilliseconds()
+        suspendTransaction(db) {
+            // The id of the existing read to merge this finish into, or null to append a new read. The
+            // first-ever finish (no previous row) always appends.
+            val mergeIntoId: String? =
+                db.bookReadsQueries.latestFinishForUserBook(userId, bookId).executeAsOneOrNull()?.let { previous ->
+                    val duration = db.booksQueries.durationForBook(bookId).executeAsOneOrNull()
+                    val coverage =
+                        db.listeningEventsQueries
+                            .sumPositionDeltaForBookSince(
+                                userId = userId,
+                                bookId = bookId,
+                                sinceMs = previous.finished_at,
+                            ).executeAsOne()
+                    val isNewRead =
+                        duration == null || duration <= 0 ||
+                            coverage >= (duration * RE_READ_COVERAGE_THRESHOLD).toLong()
+                    if (isNewRead) null else previous.id
+                }
+            if (mergeIntoId == null) {
+                db.bookReadsQueries.insert(
+                    id = Uuid.random().toString(),
+                    user_id = userId,
+                    book_id = bookId,
+                    finished_at = finishedAtMs,
+                    source = "playback",
+                    created_at = createdAt,
+                )
+            } else {
+                db.bookReadsQueries.updateFinishedAtById(finished_at = finishedAtMs, id = mergeIntoId)
+            }
+        }
     }
 
     /** All completions of [bookId] across all users, newest-first. */
@@ -85,4 +134,14 @@ class BookReadsRepository(
             finishedAt = finished_at,
             source = source,
         )
+
+    private companion object {
+        /**
+         * A completion counts as a genuine re-read only when the user covered at least this fraction of
+         * the book's duration since their previous finish. Because coverage is derived from the
+         * `listening_events` primitive, this threshold is retroactively tunable — change it and run
+         * `BulkRecompute` to re-settle history.
+         */
+        const val RE_READ_COVERAGE_THRESHOLD = 0.5
+    }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/StatsRecorder.kt
@@ -4,7 +4,6 @@ import com.calypsan.listenup.api.dto.activity.ActivityType
 import com.calypsan.listenup.api.sync.UserStatsSyncPayload
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import kotlin.time.Clock
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.currentCoroutineContext
 
 /**
@@ -50,27 +49,20 @@ class StatsRecorder(
     }
 
     /**
-     * Source row (`book_reads`) → `user_stats.booksFinished` → `public_profiles.refresh()` → the
-     * `FINISHED_BOOK` activity, dated [StatsEvent.BookCompleted.occurredAt]. The `user_stats` bump
-     * and the projection refresh are skipped under [StatsCascadeDeferred] — a bulk import writes the
-     * source row per row but defers the expensive recompute to one terminal [StatsEvent.BulkRecompute].
+     * `book_reads` (via the coverage rule — append a new read or merge a below-threshold replay) →
+     * re-derived `user_stats` (booksFinished counted from `book_reads`) → `public_profiles.refresh()` →
+     * the `FINISHED_BOOK` activity, dated [StatsEvent.BookCompleted.occurredAt]. The re-derive and the
+     * projection refresh are skipped under [StatsCascadeDeferred] — a bulk import writes the source row
+     * per row but defers the recompute to one terminal [StatsEvent.BulkRecompute].
      */
     private suspend fun recordBookCompleted(event: StatsEvent.BookCompleted) {
         val finishedAtMs = event.occurredAt.toEpochMilliseconds()
-        bookReadsRepository.recordRead(
-            id = Uuid.random().toString(),
-            userId = event.userId,
-            bookId = event.bookId,
-            finishedAt = finishedAtMs,
-            source = "playback",
-        )
+        // The coverage rule decides append-vs-merge on `book_reads`; the re-derive then reads the new
+        // count. booksFinished is a pure function of `book_reads`, so a merge leaves it unchanged.
+        bookReadsRepository.recordCompletion(event.userId, event.bookId, finishedAtMs)
         if (currentCoroutineContext()[StatsCascadeDeferred.Key] == null) {
-            val base = userStatsRepo.getForUser(event.userId) ?: emptyStatsFor(event.userId)
-            userStatsRepo.upsert(
-                base.copy(booksFinished = base.booksFinished + 1),
-                clientOpId = null,
-                userId = event.userId,
-            )
+            val derived = deriveUserStats(sql, event.userId, clock.now().toEpochMilliseconds())
+            userStatsRepo.upsert(derived, clientOpId = null, userId = event.userId)
             publicProfileMaintainer.refresh(event.userId)
         }
         activityRecorder.record(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillService.kt
@@ -27,7 +27,10 @@ class UserStatsBackfillService(
      * derivation [StatsRecorder] runs per event — so a bulk rebuild and the live path always agree.
      */
     suspend fun backfillFor(userId: String) {
-        val derived = deriveUserStats(sql, userId, clock.now().toEpochMilliseconds())
-        userStatsRepo.upsert(derived, clientOpId = null, userId = userId)
+        val nowMs = clock.now().toEpochMilliseconds()
+        // Self-heal the `book_reads` primitive first, so the re-derived booksFinished reflects every
+        // finished book even for crash-orphaned or pre-Spec-004-imported completions.
+        reconcileBookReadsFromPositions(sql, userId, nowMs)
+        userStatsRepo.upsert(deriveUserStats(sql, userId, nowMs), clientOpId = null, userId = userId)
     }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
@@ -5,8 +5,40 @@ import com.calypsan.listenup.domain.stats.StreakReducer
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Insert a `source = "reconcile"` `book_reads` row for every finished, non-deleted `playback_positions`
+ * row that has no completion row yet — recovering finishes lost to a crash between the position commit
+ * and the completion cascade, and backfilling pre-Spec-004 imports that never wrote `book_reads`.
+ * Idempotent: a book that already has any completion row is skipped. Runs as the first step of a full
+ * rebuild ([UserStatsBackfillService.backfillFor]) so the re-derived `booksFinished` — counted from
+ * `book_reads` — reflects every finished book. Re-read multiplicity for pre-crash finishes is
+ * unrecoverable; reconcile restores at least one read per finished book, never invents extras.
+ */
+suspend fun reconcileBookReadsFromPositions(
+    sql: ListenUpDatabase,
+    userId: String,
+    nowMs: Long,
+) {
+    suspendTransaction(sql) {
+        sql.playbackPositionsQueries.selectFinishedBooksForUser(userId).executeAsList().forEach { finished ->
+            val alreadyLogged = sql.bookReadsQueries.existsForUserBook(userId, finished.book_id).executeAsOne()
+            if (!alreadyLogged) {
+                sql.bookReadsQueries.insert(
+                    id = Uuid.random().toString(),
+                    user_id = userId,
+                    book_id = finished.book_id,
+                    finished_at = finished.last_played_at,
+                    source = "reconcile",
+                    created_at = nowMs,
+                )
+            }
+        }
+    }
+}
 
 /**
  * The single pure re-derivation of a user's `user_stats` from the durable primitives
@@ -65,12 +97,12 @@ suspend fun deriveUserStats(
         if (endedAtMs >= cutoff30) last30 += (endedAtMs - maxOf(event.started_at, cutoff30)) / 1_000L
     }
 
-    // 4. Finished-book count (non-deleted positions). Spec 004 will move this onto the `book_reads`
-    //    primitive; kept here for now so the incremental and rebuilt rows agree.
+    // 4. Finished-book count from the `book_reads` primitive (re-reads counted). All-time and windowed
+    //    finished-books now derive from the same table, so they cannot disagree.
     val booksFinished =
         suspendTransaction(sql) {
-            sql.playbackPositionsQueries
-                .countFinishedForUser(userId)
+            sql.bookReadsQueries
+                .countForUser(userId)
                 .executeAsOne()
                 .toInt()
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsRepository.kt
@@ -209,21 +209,21 @@ class UserStatsRepository(
         limit: Int,
         extraWhere: SqlFragment?,
     ): Page<UserStatsSyncPayload> {
-        if (userId != null) refreshWindowsIfStale(userId)
+        if (userId != null) healStatsIfStale(userId)
         return super.pullSince(userId, cursor, limit, extraWhere)
     }
 
     /**
-     * Recomputes [userId]'s rolling windows when the stats row is older than
-     * [STATS_STALENESS_LIMIT_MS] — the lazy correction path described on [pullSince].
-     * A no-op when no updater is wired or the user has no stats row yet.
+     * Re-derives [userId]'s stats (rolling windows AND current streak) and refreshes the projection
+     * when the stats row is older than [STATS_STALENESS_LIMIT_MS] — the lazy correction path described
+     * on [pullSince]. A no-op when no updater is wired, the user has no stats row yet, or nothing drifted.
      */
-    private suspend fun refreshWindowsIfStale(userId: String) {
+    private suspend fun healStatsIfStale(userId: String) {
         val updater = userStatsUpdaterProvider() ?: return
         val existing = getForUser(userId) ?: return
         val now = clock.now().toEpochMilliseconds()
         if (now - existing.updatedAt > STATS_STALENESS_LIMIT_MS) {
-            updater.recomputeWindowsOnly(userId, asOfMs = now)
+            updater.healStaleStats(userId, asOfMs = now)
         }
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsUpdater.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsUpdater.kt
@@ -1,55 +1,52 @@
 package com.calypsan.listenup.server.services
 
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
-import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 
 /**
- * Lazy window-decay self-heal for [UserStatsRepository.pullSince]: recomputes the rolling 7/30-day
- * window fields against the current clock when a user's materialized `user_stats` row has gone
- * stale from inactivity (an event from 6 days ago is inside the 7-day window today but outside it
- * in 2 days). This is its only remaining job — the event-driven write cascade (all-time counters,
- * streaks, milestones, the `book_reads` / `public_profiles` writes, and activity emission) now lives
- * in [StatsRecorder], the single choke-point for every stats-affecting write ([StatsEvent]).
+ * Stale-stats self-heal for the two clock-relative reads that drift on inactivity: the rolling
+ * 7/30-day window totals AND the current streak (a lapsed user's streak must fall to 0 once their
+ * last listening day is older than yesterday). Both are pure functions of the committed primitives, so
+ * healing is a full [deriveUserStats] re-run against the current clock — the same derivation the event
+ * cascade and the bulk rebuild use, so a healed row can't diverge from a freshly-written one.
+ *
+ * Two callers drive it: [UserStatsRepository.pullSince]'s lazy path (heal a stale row before returning
+ * it to a syncing client) and the periodic [com.calypsan.listenup.server.scheduler.StatsFreshnessSweepTask]
+ * (heal idle users who never pull). When a heal changes the row, the `public_profiles` projection is
+ * refreshed too (best-effort) so the leaderboard everyone else reads decays with it.
  *
  * Allowlisted alongside [StatsRecorder] and [UserStatsBackfillService] in
- * [com.calypsan.listenup.server.konsist.StatsRecorderIsSoleStatsWriterRule]: this recompute is an
- * idempotent re-derive of already-committed `listening_events`, the same character as
- * [UserStatsBackfillService.backfillFor] — not a new write path that could under-deliver an
- * ordering guarantee.
+ * [com.calypsan.listenup.server.konsist.StatsRecorderIsSoleStatsWriterRule]: an idempotent re-derive of
+ * already-committed primitives, not a new ordering-sensitive write path.
+ *
+ * [publicProfileMaintainer] is optional so unit tests can exercise the `user_stats` heal without wiring
+ * the projection; production (DI) always supplies it.
  */
 class UserStatsUpdater(
     private val sql: ListenUpDatabase,
     private val userStatsRepo: UserStatsRepository,
+    private val publicProfileMaintainer: PublicProfileMaintainer? = null,
 ) {
     /**
-     * Recompute the rolling-window fields against [asOfMs]. Used by
-     * [UserStatsRepository.pullSince]'s lazy-decay path so an idle user's windows don't stay stale
-     * forever.
+     * Re-derive [userId]'s stats as of [asOfMs] and, if the decay-sensitive fields (rolling windows or
+     * current streak) changed, write the row and refresh the projection. A no-op — returning `false`
+     * without writing — when the user has no stats row or nothing drifted, so it's cheap to call on
+     * every pull and on every sweep tick.
+     *
+     * @return `true` if the row was healed (and the projection refreshed), `false` otherwise.
      */
-    internal suspend fun recomputeWindowsOnly(
+    internal suspend fun healStaleStats(
         userId: String,
         asOfMs: Long,
-    ) {
-        val existing = userStatsRepo.getForUser(userId) ?: return
-        val last7 = sumWindowSeconds(userId, days = 7, asOfMs = asOfMs)
-        val last30 = sumWindowSeconds(userId, days = 30, asOfMs = asOfMs)
-        if (last7 != existing.totalSecondsLast7Days || last30 != existing.totalSecondsLast30Days) {
-            userStatsRepo.upsert(
-                existing.copy(totalSecondsLast7Days = last7, totalSecondsLast30Days = last30),
-                clientOpId = null,
-                userId = userId,
-            )
-        }
-    }
-
-    private suspend fun sumWindowSeconds(
-        userId: String,
-        days: Int,
-        asOfMs: Long,
-    ): Long {
-        val cutoffMs = asOfMs - days * 86_400_000L
-        return suspendTransaction(sql) {
-            sql.listeningEventsQueries.sumWallSecondsSince(userId = userId, cutoffMs = cutoffMs).executeAsOne()
-        }
+    ): Boolean {
+        val existing = userStatsRepo.getForUser(userId) ?: return false
+        val derived = deriveUserStats(sql, userId, asOfMs)
+        val drifted =
+            derived.totalSecondsLast7Days != existing.totalSecondsLast7Days ||
+                derived.totalSecondsLast30Days != existing.totalSecondsLast30Days ||
+                derived.currentStreakDays != existing.currentStreakDays
+        if (!drifted) return false
+        userStatsRepo.upsert(derived, clientOpId = null, userId = userId)
+        publicProfileMaintainer?.refreshBestEffort(userId)
+        return true
     }
 }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookReads.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookReads.sq
@@ -36,3 +36,24 @@ ORDER BY finished_at DESC;
 countDistinctFinishedSince:
 SELECT COUNT(DISTINCT book_id) FROM book_reads
 WHERE user_id = :userId AND finished_at >= :cutoffMs;
+
+-- All-time completions for a user (re-reads counted) — the all-time booksFinished metric, now sourced
+-- from this primitive so it agrees with the windowed counts above.
+countForUser:
+SELECT COUNT(*) FROM book_reads WHERE user_id = :userId;
+
+-- The most recent completion row for a user+book pair (id + timestamp). The re-read rule reads its
+-- finished_at as the "previous finish" and, on a below-threshold replay, updates that row in place.
+latestFinishForUserBook:
+SELECT id, finished_at FROM book_reads
+WHERE user_id = :userId AND book_id = :bookId
+ORDER BY finished_at DESC
+LIMIT 1;
+
+-- Move an existing completion's finish time forward (the below-threshold "same read" case).
+updateFinishedAtById:
+UPDATE book_reads SET finished_at = :finished_at WHERE id = :id;
+
+-- True iff the user has any completion row for this book — gates the idempotent reconcile insert.
+existsForUserBook:
+SELECT EXISTS(SELECT 1 FROM book_reads WHERE user_id = :userId AND book_id = :bookId);

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
@@ -223,6 +223,11 @@ UPDATE books SET revision = :revision, updated_at = :updated_at WHERE id = :id;
 updateTotalDuration:
 UPDATE books SET total_duration = :total_duration WHERE id = :id;
 
+-- Total duration (ms) of a single live book — feeds the re-read coverage threshold. A tombstoned or
+-- absent book yields no row (the caller then treats coverage as unassessable and appends).
+durationForBook:
+SELECT total_duration FROM books WHERE id = :id AND deleted_at IS NULL;
+
 -- Sets chapter_source only — written by writePayload after replaceChapters so the
 -- provenance enum persists with every aggregate upsert (insert and update paths both
 -- land here via BookRepository.writePayload).

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
@@ -109,6 +109,15 @@ SELECT CAST(COALESCE(SUM((ended_at - MAX(started_at, :cutoffMs)) / 1000), 0) AS 
 FROM listening_events
 WHERE user_id = :userId AND ended_at >= :cutoffMs AND deleted_at IS NULL;
 
+-- Stats support: content coverage (summed end-start position deltas, negatives clamped to 0) a user
+-- accrued on :bookId strictly after :sinceMs. Drives the re-read coverage rule — a genuine re-read
+-- traverses real content since the last finish, a "rewound to the last chapter" replay does not.
+-- Live rows only. CAST keeps the result Long; the two-arg MAX is SQLite's scalar max, not the aggregate.
+sumPositionDeltaForBookSince:
+SELECT CAST(COALESCE(SUM(MAX(end_position_ms - start_position_ms, 0)), 0) AS INTEGER)
+FROM listening_events
+WHERE user_id = :userId AND book_id = :bookId AND ended_at > :sinceMs AND deleted_at IS NULL;
+
 -- Stats support: the ended-at timestamps of a user's non-deleted events at/after :cutoffMs, ascending.
 -- Feeds the windowed-streak walk (longest consecutive listening-day run within a trailing window).
 selectEndedAtForUserSince:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
@@ -104,6 +104,13 @@ countFinishedForUser:
 SELECT COUNT(*) FROM playback_positions
 WHERE user_id = :userId AND finished = 1 AND deleted_at IS NULL;
 
+-- Stats support: (book_id, last_played_at) for every finished, non-deleted position of a user. The
+-- book_reads reconcile inserts a completion row for any of these lacking one (crash between the
+-- position commit and the book_reads insert, or a pre-Spec-004 import that never wrote book_reads).
+selectFinishedBooksForUser:
+SELECT book_id, last_played_at FROM playback_positions
+WHERE user_id = :userId AND finished = 1 AND deleted_at IS NULL;
+
 insert:
 INSERT INTO playback_positions (
     id, user_id, book_id, position_ms, last_played_at, finished, playback_speed,

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/UserStats.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/UserStats.sq
@@ -30,6 +30,11 @@ CREATE        INDEX idx_user_stats_user_revision ON user_stats(user_id, revision
 existsById:
 SELECT EXISTS(SELECT 1 FROM user_stats WHERE id = :id);
 
+-- Every live user with a materialized stats row — drives the periodic freshness sweep, which heals
+-- clock-relative decay (windows + streak) for idle users who never trigger the lazy pull path.
+selectAllLiveUserIds:
+SELECT user_id FROM user_stats WHERE deleted_at IS NULL;
+
 softDeleteById:
 UPDATE user_stats
 SET revision = :revision, updated_at = :updated_at, deleted_at = :deleted_at,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/StatsRecorderIsSoleStatsWriterRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/StatsRecorderIsSoleStatsWriterRule.kt
@@ -60,7 +60,13 @@ class StatsRecorderIsSoleStatsWriterRule :
          */
         val USER_STATS_WRITE_ALLOWLIST = setOf("StatsRecorder", "UserStatsBackfillService", "UserStatsUpdater")
 
-        /** Holders of [com.calypsan.listenup.server.services.BookReadsRepository] allowed to call `.recordRead(`. */
+        /**
+         * Holders of [com.calypsan.listenup.server.services.BookReadsRepository] allowed to call its
+         * write methods — the low-level `.recordRead(` and the Spec-004 coverage-rule entry point
+         * `.recordCompletion(`. Both are stats-source writes and must stay behind the ordered
+         * choke-point. (The rebuild reconcile writes `book_reads` via the top-level
+         * `reconcileBookReadsFromPositions`, not a repository method, so it isn't matched here.)
+         */
         val BOOK_READS_WRITE_ALLOWLIST = setOf("StatsRecorder")
 
         fun findOffenders(scope: KoScope): List<String> =
@@ -74,6 +80,12 @@ class StatsRecorderIsSoleStatsWriterRule :
                     scope,
                     holderType = "BookReadsRepository",
                     callToken = ".recordRead(",
+                    allowlist = BOOK_READS_WRITE_ALLOWLIST,
+                ) +
+                violatingClasses(
+                    scope,
+                    holderType = "BookReadsRepository",
+                    callToken = ".recordCompletion(",
                     allowlist = BOOK_READS_WRITE_ALLOWLIST,
                 )
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsFreshnessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsFreshnessTest.kt
@@ -1,0 +1,153 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
+import com.calypsan.listenup.api.sync.UserStatsSyncPayload
+import com.calypsan.listenup.server.scheduler.StatsFreshnessSweepTask
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.PublicProfileRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Spec 005: a lapsed user's current streak must decay to 0 — in `user_stats` AND in the
+ * `public_profiles` leaderboard everyone else reads — even though no new event arrives to trigger the
+ * write cascade. The lazy pull path heals a user who opens the app; the periodic sweep heals a user who
+ * never does.
+ */
+class StatsFreshnessTest :
+    FunSpec({
+
+        val nowMs = 1_779_451_200_000L // 2026-05-22 12:00:00 UTC
+        val dayMs = 86_400_000L
+
+        fun eventAt(
+            id: String,
+            endedAtMs: Long,
+        ): ListeningEventSyncPayload =
+            ListeningEventSyncPayload(
+                id = id,
+                bookId = "b1",
+                startPositionMs = 0L,
+                endPositionMs = 30_000L,
+                startedAt = endedAtMs - 30_000L,
+                endedAt = endedAtMs,
+                playbackSpeed = 1.0f,
+                tz = "UTC",
+                deviceLabel = null,
+                revision = 0L,
+                updatedAt = 0L,
+                createdAt = 0L,
+                deletedAt = null,
+            )
+
+        // A 5-day streak that ended 3 days ago: as of now it has lapsed (last listening day is older
+        // than yesterday), so a re-derive against "now" must report currentStreakDays = 0.
+        suspend fun seedLapsedUser(
+            statsRepo: UserStatsRepository,
+            eventRepo: ListeningEventRepository,
+        ) {
+            (3..7).forEach { d -> eventRepo.upsert(eventAt("evt-$d", nowMs - d * dayMs), clientOpId = null, userId = "u1") }
+            statsRepo.upsert(
+                UserStatsSyncPayload(
+                    id = "u1",
+                    totalSecondsAllTime = 150L,
+                    totalSecondsLast7Days = 150L,
+                    totalSecondsLast30Days = 150L,
+                    booksStarted = 1,
+                    booksFinished = 0,
+                    currentStreakDays = 5,
+                    longestStreakDays = 5,
+                    lastEventDate = "2026-05-19",
+                    revision = 0L,
+                    updatedAt = 0L,
+                    createdAt = 0L,
+                    deletedAt = null,
+                ),
+                clientOpId = null,
+                userId = "u1",
+            )
+        }
+
+        test("lazy pull path decays a lapsed streak in user_stats AND the public_profiles projection") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                val thenClock = FixedClock(Instant.fromEpochMilliseconds(nowMs - 2 * 60 * 60 * 1_000L)) // 2h ago → stale
+                val nowClock = FixedClock(Instant.fromEpochMilliseconds(nowMs))
+                val bus = ChangeBus()
+                val statsRepoThen = UserStatsRepository(db = sql, bus = bus, registry = SyncRegistry(), clock = thenClock)
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val publicProfileRepo = PublicProfileRepository(db = sql, bus = bus, registry = SyncRegistry())
+                val maintainer = PublicProfileMaintainer(sql = sql, publicProfileRepo = publicProfileRepo, clock = nowClock)
+
+                runTest {
+                    seedLapsedUser(statsRepoThen, eventRepo)
+                    // Seed the projection at streak = 5 (what everyone else currently sees on the leaderboard).
+                    maintainer.refresh("u1")
+                    publicProfileRepo
+                        .pullSince(userId = null, cursor = 0L, limit = 10)
+                        .items
+                        .single { it.id == "u1" }
+                        .currentStreakDays shouldBe 5
+
+                    val updater =
+                        UserStatsUpdater(sql = sql, userStatsRepo = statsRepoThen, publicProfileMaintainer = maintainer)
+                    val statsRepoDecay =
+                        UserStatsRepository(
+                            db = sql,
+                            bus = bus,
+                            registry = SyncRegistry(),
+                            clock = nowClock,
+                            userStatsUpdaterProvider = { updater },
+                        )
+
+                    statsRepoDecay.pullSince(userId = "u1", cursor = 0L, limit = 50)
+
+                    statsRepoThen.getForUser("u1").shouldNotBeNull().currentStreakDays shouldBe 0
+                    publicProfileRepo
+                        .pullSince(userId = null, cursor = 0L, limit = 10)
+                        .items
+                        .single { it.id == "u1" }
+                        .currentStreakDays shouldBe 0
+                }
+            }
+        }
+
+        test("the freshness sweep decays a lapsed streak for an idle user who never pulls") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                val nowClock = FixedClock(Instant.fromEpochMilliseconds(nowMs))
+                val bus = ChangeBus()
+                val statsRepo = UserStatsRepository(db = sql, bus = bus, registry = SyncRegistry(), clock = nowClock)
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val publicProfileRepo = PublicProfileRepository(db = sql, bus = bus, registry = SyncRegistry())
+                val maintainer = PublicProfileMaintainer(sql = sql, publicProfileRepo = publicProfileRepo, clock = nowClock)
+
+                runTest {
+                    seedLapsedUser(statsRepo, eventRepo)
+                    maintainer.refresh("u1")
+
+                    val updater =
+                        UserStatsUpdater(sql = sql, userStatsRepo = statsRepo, publicProfileMaintainer = maintainer)
+                    val healed =
+                        StatsFreshnessSweepTask(sql = sql, updater = updater, clock = nowClock).runOnce()
+
+                    healed shouldBe 1
+                    statsRepo.getForUser("u1").shouldNotBeNull().currentStreakDays shouldBe 0
+                    publicProfileRepo
+                        .pullSince(userId = null, cursor = 0L, limit = 10)
+                        .items
+                        .single { it.id == "u1" }
+                        .currentStreakDays shouldBe 0
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderBookReadsCoverageTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderBookReadsCoverageTest.kt
@@ -1,0 +1,193 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.PublicProfileRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Spec 004: `book_reads` is the single finished-books primitive, and a completion becomes a new read
+ * only when real content was covered since the previous finish (the coverage rule). A "finished, then
+ * rewound to the last chapter, then finished again" replay must not double-count; a genuine re-read
+ * (≥ 50% of the book covered since the last finish) must. A crash that left a finished position without
+ * a `book_reads` row is reconciled by a rebuild.
+ */
+class StatsRecorderBookReadsCoverageTest :
+    FunSpec({
+
+        val day0Ms = 1_779_451_200_000L
+        val oneHourMs = 3_600_000L
+
+        fun eventOnBook(
+            id: String,
+            bookId: String,
+            endedAtMs: Long,
+            startPositionMs: Long,
+            endPositionMs: Long,
+        ): ListeningEventSyncPayload =
+            ListeningEventSyncPayload(
+                id = id,
+                bookId = bookId,
+                startPositionMs = startPositionMs,
+                endPositionMs = endPositionMs,
+                startedAt = endedAtMs - 60_000L,
+                endedAt = endedAtMs,
+                playbackSpeed = 1.0f,
+                tz = "UTC",
+                deviceLabel = null,
+                revision = 0L,
+                updatedAt = 0L,
+                createdAt = 0L,
+                deletedAt = null,
+            )
+
+        fun SqlTestDatabases.recorder(clock: FixedClock): Triple<StatsRecorder, BookReadsRepository, UserStatsRepository> {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val userStatsRepo = UserStatsRepository(db = sql, bus = bus, registry = registry)
+            val bookReads = BookReadsRepository(db = sql, clock = clock)
+            val recorder =
+                StatsRecorder(
+                    sql = sql,
+                    userStatsRepo = userStatsRepo,
+                    bookReadsRepository = bookReads,
+                    publicProfileMaintainer =
+                        PublicProfileMaintainer(
+                            sql = sql,
+                            publicProfileRepo = PublicProfileRepository(db = sql, bus = bus, registry = registry),
+                            clock = clock,
+                        ),
+                    activityRecorder = ActivityRecorder(repo = ActivityRepository(db = sql), bus = bus),
+                    statsBackfill = UserStatsBackfillService(sql = sql, userStatsRepo = userStatsRepo, clock = clock),
+                    clock = clock,
+                )
+            return Triple(recorder, bookReads, userStatsRepo)
+        }
+
+        test("finish then rewind the last chapter and finish again records ONE read, booksFinished stays 1") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b1")
+                sql.booksQueries.updateTotalDuration(total_duration = oneHourMs, id = "b1")
+                val clock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 60_000L))
+                val (recorder, bookReads, userStatsRepo) = recorder(clock)
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+
+                runTest {
+                    // First finish — always a new read.
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms)),
+                    )
+
+                    // A short replay covering only the last 10 minutes (< 50% of the 1h book).
+                    eventRepo.upsert(
+                        eventOnBook("rewind", "b1", endedAtMs = day0Ms + 10_000L, startPositionMs = 3_000_000L, endPositionMs = 3_600_000L),
+                        clientOpId = null,
+                        userId = "u1",
+                    )
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms + 20_000L)),
+                    )
+
+                    bookReads.finishesForUserBook("u1", "b1") shouldHaveSize 1
+                    userStatsRepo.getForUser("u1").shouldNotBeNull().booksFinished shouldBe 1
+                }
+            }
+        }
+
+        test("finish then genuinely re-read (>=50% covered) records TWO reads, booksFinished 2") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b1")
+                sql.booksQueries.updateTotalDuration(total_duration = oneHourMs, id = "b1")
+                val clock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 60_000L))
+                val (recorder, bookReads, userStatsRepo) = recorder(clock)
+                val eventRepo = ListeningEventRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+
+                runTest {
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms)),
+                    )
+
+                    // A replay covering 2,000,000 ms (> 50% of the 1h = 1,800,000 ms threshold).
+                    eventRepo.upsert(
+                        eventOnBook("reread", "b1", endedAtMs = day0Ms + 10_000L, startPositionMs = 0L, endPositionMs = 2_000_000L),
+                        clientOpId = null,
+                        userId = "u1",
+                    )
+                    recorder.record(
+                        StatsEvent.BookCompleted("u1", "b1", Instant.fromEpochMilliseconds(day0Ms + 20_000L)),
+                    )
+
+                    bookReads.finishesForUserBook("u1", "b1") shouldHaveSize 2
+                    userStatsRepo.getForUser("u1").shouldNotBeNull().booksFinished shouldBe 2
+                }
+            }
+        }
+
+        test("BulkRecompute reconciles a finished position with no book_reads row, idempotently") {
+            withSqlDatabase {
+                sql.seedTestUser("u1")
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("b2")
+                val clock = FixedClock(Instant.fromEpochMilliseconds(day0Ms + 60_000L))
+                val (recorder, bookReads, _) = recorder(clock)
+
+                // A finished position that never produced a book_reads row (crash between the position
+                // commit and the completion cascade, or a pre-Spec-004 import).
+                sql.insertFinishedPosition(userId = "u1", bookId = "b2", lastPlayedAt = day0Ms)
+
+                runTest {
+                    bookReads.finishesForUserBook("u1", "b2") shouldHaveSize 0
+
+                    recorder.record(StatsEvent.BulkRecompute("u1"))
+                    bookReads.finishesForUserBook("u1", "b2") shouldHaveSize 1
+
+                    // Running the rebuild again must not add a duplicate.
+                    recorder.record(StatsEvent.BulkRecompute("u1"))
+                    bookReads.finishesForUserBook("u1", "b2") shouldHaveSize 1
+                }
+            }
+        }
+    })
+
+private fun ListenUpDatabase.insertFinishedPosition(
+    userId: String,
+    bookId: String,
+    lastPlayedAt: Long,
+) {
+    transaction {
+        playbackPositionsQueries.insert(
+            id = "pos-$userId-$bookId",
+            user_id = userId,
+            book_id = bookId,
+            position_ms = 3_600_000L,
+            last_played_at = lastPlayedAt,
+            finished = 1L,
+            playback_speed = 1.0,
+            current_chapter_id = null,
+            revision = 0L,
+            created_at = 0L,
+            updated_at = 0L,
+            deleted_at = null,
+            client_op_id = null,
+        )
+    }
+}


### PR DESCRIPTION
**Spec 005 of 5** (stacked; base = `fix/stats-bookreads-primitive`).

A lapsed user kept a frozen streak and stale windows indefinitely — in `user_stats` and, worse, in the `public_profiles` leaderboard everyone else reads. The lazy self-heal now does a full re-derive (windows AND streak) + refreshes the projection; a new `StatsFreshnessSweepTask` (6h) heals idle users who never pull.

**Review note:** `UserStatsUpdater` gains a nullable `publicProfileMaintainer` (DI passes it; unit tests can omit) to avoid constructor churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
