### PR TITLE
✨ feat(client): offline-first book-readers and presence via Room mirror tables (v44)

### DIFF
--- a/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/44.json
+++ b/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/44.json
@@ -1,0 +1,2915 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 44,
+    "identityHash": "2d00a87c2db911d1f0ffab361e8ee543",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `firstName` TEXT, `lastName` TEXT, `isRoot` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `tagline` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRoot",
+            "columnName": "isRoot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `metadataPrecedence` TEXT NOT NULL, `accessMode` TEXT NOT NULL, `createdByUserId` TEXT, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `clientOpId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataPrecedence",
+            "columnName": "metadataPrecedence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessMode",
+            "columnName": "accessMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdByUserId",
+            "columnName": "createdByUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `rootPath` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `clientOpId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`libraryId`) REFERENCES `libraries`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootPath",
+            "columnName": "rootPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_folders_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_folders_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "libraries",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "libraryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `folderId` TEXT NOT NULL, `title` TEXT NOT NULL, `sortTitle` TEXT, `subtitle` TEXT, `coverHash` TEXT, `coverBlurHash` TEXT, `coverDownloadedAt` INTEGER, `totalDuration` INTEGER NOT NULL, `description` TEXT, `publishYear` INTEGER, `publisher` TEXT, `language` TEXT, `isbn` TEXT, `asin` TEXT, `abridged` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `hasScanWarning` INTEGER NOT NULL, `userEditedFields` TEXT NOT NULL DEFAULT '', `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortTitle",
+            "columnName": "sortTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverHash",
+            "columnName": "coverHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverDownloadedAt",
+            "columnName": "coverDownloadedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalDuration",
+            "columnName": "totalDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishYear",
+            "columnName": "publishYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abridged",
+            "columnName": "abridged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasScanWarning",
+            "columnName": "hasScanWarning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEditedFields",
+            "columnName": "userEditedFields",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_books_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `startTime` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `description` TEXT, `asin` TEXT, `coverPath` TEXT, `coverBlurHash` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `asin` TEXT, `description` TEXT, `imagePath` TEXT, `imageBlurHash` TEXT, `website` TEXT, `birthDate` TEXT, `deathDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "imagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "website",
+            "columnName": "website",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deathDate",
+            "columnName": "deathDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `contributorId` TEXT NOT NULL, `role` TEXT NOT NULL, `creditedAs` TEXT, PRIMARY KEY(`bookId`, `contributorId`, `role`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditedAs",
+            "columnName": "creditedAs",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "contributorId",
+            "role"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_contributors_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_contributors_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contributor_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contributorId` TEXT NOT NULL, `alias` TEXT NOT NULL, PRIMARY KEY(`contributorId`, `alias`), FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contributorId",
+            "alias"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributor_aliases_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributor_aliases_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `sequence` TEXT, PRIMARY KEY(`bookId`, `seriesId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "seriesId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_series_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_series_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `hasCustomSpeed` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `syncedAt` INTEGER, `lastPlayedAt` INTEGER, `isFinished` INTEGER NOT NULL, `finishedAt` INTEGER, `startedAt` INTEGER, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomSpeed",
+            "columnName": "hasCustomSpeed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFinished",
+            "columnName": "isFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`audioFileId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `filename` TEXT NOT NULL, `fileIndex` INTEGER NOT NULL, `state` TEXT NOT NULL, `localPath` TEXT, `totalBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, `startedAt` INTEGER, `completedAt` INTEGER, `errorMessage` TEXT, `retryCount` INTEGER NOT NULL, PRIMARY KEY(`audioFileId`))",
+        "fields": [
+          {
+            "fieldPath": "audioFileId",
+            "columnName": "audioFileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileIndex",
+            "columnName": "fileIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "audioFileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `name` TEXT NOT NULL, `isInbox` INTEGER NOT NULL, `isSystem` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInbox",
+            "columnName": "isInbox",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "isSystem",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_collections_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`collectionId`, `bookId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_collection_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_shares",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `collectionId` TEXT NOT NULL, `sharedWithUserId` TEXT NOT NULL, `sharedByUserId` TEXT NOT NULL, `permission` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedWithUserId",
+            "columnName": "sharedWithUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedByUserId",
+            "columnName": "sharedByUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permission",
+            "columnName": "permission",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_shares_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          },
+          {
+            "name": "index_collection_shares_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelves",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `isPrivate` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelves_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelves_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelf_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `shelfId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelf_books_shelfId",
+            "unique": false,
+            "columnNames": [
+              "shelfId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_shelfId` ON `${TABLE_NAME}` (`shelfId`)"
+          },
+          {
+            "name": "index_shelf_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_shelf_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `tagId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `tagId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_book_tags_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_moods_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_moods_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `moodId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `moodId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodId",
+            "columnName": "moodId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "moodId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_moods_moodId",
+            "unique": false,
+            "columnNames": [
+              "moodId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_moodId` ON `${TABLE_NAME}` (`moodId`)"
+          },
+          {
+            "name": "index_book_moods_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `path` TEXT NOT NULL, `parentId` TEXT, `depth` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "depth",
+            "columnName": "depth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genres_slug",
+            "unique": true,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genres_slug` ON `${TABLE_NAME}` (`slug`)"
+          },
+          {
+            "name": "index_genres_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genres_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `genreId` TEXT NOT NULL, PRIMARY KEY(`bookId`, `genreId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`genreId`) REFERENCES `genres`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreId",
+            "columnName": "genreId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "genreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_genres_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_genres_genreId",
+            "unique": false,
+            "columnNames": [
+              "genreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_genreId` ON `${TABLE_NAME}` (`genreId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "genres",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "genreId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `codec` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, `codecProfile` TEXT, `spatial` TEXT, `bitrate` INTEGER, `sampleRate` INTEGER, `channels` INTEGER, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codec",
+            "columnName": "codec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecProfile",
+            "columnName": "codecProfile",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spatial",
+            "columnName": "spatial",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channels",
+            "columnName": "channels",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_files_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_files_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `size` INTEGER NOT NULL, `hash` TEXT NOT NULL, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_documents_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_documents_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `endPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPositionMs",
+            "columnName": "endPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_userId_endedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "endedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_endedAt` ON `${TABLE_NAME}` (`userId`, `endedAt`)"
+          },
+          {
+            "name": "index_listening_events_userId_revision",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_revision` ON `${TABLE_NAME}` (`userId`, `revision`)"
+          },
+          {
+            "name": "index_listening_events_userId_bookId",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_bookId` ON `${TABLE_NAME}` (`userId`, `bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "activities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `type` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `userDisplayName` TEXT NOT NULL, `userAvatarColor` TEXT NOT NULL, `userAvatarType` TEXT NOT NULL, `userAvatarValue` TEXT, `bookId` TEXT, `bookTitle` TEXT, `bookAuthorName` TEXT, `bookCoverPath` TEXT, `isReread` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `milestoneValue` INTEGER NOT NULL, `milestoneUnit` TEXT, `shelfId` TEXT, `shelfName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarColor",
+            "columnName": "userAvatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarType",
+            "columnName": "userAvatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarValue",
+            "columnName": "userAvatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookTitle",
+            "columnName": "bookTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookAuthorName",
+            "columnName": "bookAuthorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCoverPath",
+            "columnName": "bookCoverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isReread",
+            "columnName": "isReread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneValue",
+            "columnName": "milestoneValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneUnit",
+            "columnName": "milestoneUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfName",
+            "columnName": "shelfName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_activities_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_activities_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `booksStarted` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `lastEventDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksStarted",
+            "columnName": "booksStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEventDate",
+            "columnName": "lastEventDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `defaultPlaybackSpeed` REAL NOT NULL, `defaultSkipForwardSec` INTEGER NOT NULL, `defaultSkipBackwardSec` INTEGER NOT NULL, `defaultSleepTimerMin` INTEGER, `shakeToResetSleepTimer` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPlaybackSpeed",
+            "columnName": "defaultPlaybackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipForwardSec",
+            "columnName": "defaultSkipForwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipBackwardSec",
+            "columnName": "defaultSkipBackwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSleepTimerMin",
+            "columnName": "defaultSleepTimerMin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shakeToResetSleepTimer",
+            "columnName": "shakeToResetSleepTimer",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "public_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `tagline` TEXT, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `totalSecondsLast365Days` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `booksFinishedLast7Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast30Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast365Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast7Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast30Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast365Days` INTEGER NOT NULL DEFAULT 0, `avatarUpdatedAt` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast365Days",
+            "columnName": "totalSecondsLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinishedLast7Days",
+            "columnName": "booksFinishedLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast30Days",
+            "columnName": "booksFinishedLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast365Days",
+            "columnName": "booksFinishedLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast7Days",
+            "columnName": "longestStreakLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast30Days",
+            "columnName": "longestStreakLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast365Days",
+            "columnName": "longestStreakLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avatarUpdatedAt",
+            "columnName": "avatarUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tentative_span",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `currentPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `lastHeartbeatAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeartbeatAt",
+            "columnName": "lastHeartbeatAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cover_download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `status` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `error` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_cursor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domainName` TEXT NOT NULL, `revision` INTEGER NOT NULL, PRIMARY KEY(`domainName`))",
+        "fields": [
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domainName"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_operation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clientOpId` TEXT NOT NULL, `domainName` TEXT NOT NULL, `entityId` TEXT NOT NULL, `opType` TEXT NOT NULL, `payload` TEXT NOT NULL, `enqueuedAt` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `failureCount` INTEGER NOT NULL, `lastError` TEXT, `ownerUserId` TEXT NOT NULL, PRIMARY KEY(`clientOpId`))",
+        "fields": [
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opType",
+            "columnName": "opType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clientOpId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_operation_domainName_entityId_enqueuedAt",
+            "unique": false,
+            "columnNames": [
+              "domainName",
+              "entityId",
+              "enqueuedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_domainName_entityId_enqueuedAt` ON `${TABLE_NAME}` (`domainName`, `entityId`, `enqueuedAt`)"
+          },
+          {
+            "name": "index_pending_operation_ownerUserId",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_ownerUserId` ON `${TABLE_NAME}` (`ownerUserId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "admin_user_roster",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `role` TEXT NOT NULL, `status` TEXT NOT NULL, `canShare` INTEGER NOT NULL, `accountCreatedAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canShare",
+            "columnName": "canShare",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountCreatedAt",
+            "columnName": "accountCreatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_readership",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `currentProgressPct` INTEGER, `finishesJson` TEXT NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`, `userId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentProgressPct",
+            "columnName": "currentProgressPct",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishesJson",
+            "columnName": "finishesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_active_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startedAtMs` INTEGER NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "startedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2d00a87c2db911d1f0ffab361e8ee543')"
+    ]
+  }
+}

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_39_40
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_43_44
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -61,6 +62,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_40_41,
                     MIGRATION_41_42,
                     MIGRATION_42_43,
+                    MIGRATION_43_44,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_39_40
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_43_44
 import com.calypsan.listenup.core.IODispatcher
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -78,6 +79,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_40_41,
                     MIGRATION_41_42,
                     MIGRATION_42_43,
+                    MIGRATION_43_44,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadershipEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadershipEntity.kt
@@ -1,0 +1,56 @@
+package com.calypsan.listenup.client.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Room mirror of a book's readership — the last server-fetched `bookReadership` snapshot for one book,
+ * one row per reader. Persisted so the Book Detail "readers" section renders (possibly stale) offline
+ * or on a transient RPC failure, instead of blanking. Refreshed wholesale per book on each presence
+ * ping while online; never cleared on failure. [observedAt] records when the snapshot was taken so the
+ * UI can show a staleness affordance.
+ *
+ * `finishesJson` holds the reader's finish timestamps (epoch-ms, newest-first) as a JSON array — the
+ * repository (de)serializes it; keeping it a scalar column avoids a normalized child table for a small,
+ * always-replaced-together list.
+ */
+@Entity(tableName = "book_readership", primaryKeys = ["bookId", "userId"])
+internal data class BookReadershipEntity(
+    val bookId: String,
+    val userId: String,
+    val displayName: String,
+    val avatarType: String,
+    val currentProgressPct: Int?,
+    val finishesJson: String,
+    val observedAt: Long,
+)
+
+@Dao
+internal interface BookReadershipDao {
+    /** Readers of [bookId], in-progress first (by descending progress), then finished-only readers. */
+    @Query(
+        "SELECT * FROM book_readership WHERE bookId = :bookId " +
+            "ORDER BY currentProgressPct IS NULL, currentProgressPct DESC",
+    )
+    fun observeForBook(bookId: String): Flow<List<BookReadershipEntity>>
+
+    @Upsert
+    suspend fun upsertAll(rows: List<BookReadershipEntity>)
+
+    @Query("DELETE FROM book_readership WHERE bookId = :bookId")
+    suspend fun deleteForBook(bookId: String)
+
+    /** Atomically replace [bookId]'s cached readership with [rows] (the latest server snapshot). */
+    @Transaction
+    suspend fun replaceForBook(
+        bookId: String,
+        rows: List<BookReadershipEntity>,
+    ) {
+        deleteForBook(bookId)
+        upsertAll(rows)
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CachedActiveSessionEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CachedActiveSessionEntity.kt
@@ -1,0 +1,46 @@
+package com.calypsan.listenup.client.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Room mirror of the "who's listening now" presence roster — the last server-fetched
+ * `currentlyListening` snapshot, one row per listening user. Persisted so the presence surface renders
+ * (possibly stale) offline or on a transient RPC failure instead of blanking; [observedAt] records when
+ * the snapshot was taken so the UI can flag staleness (presence is time-sensitive). Book identity is
+ * enriched from the local library at read time, so only the wire fields are stored here. Refreshed
+ * wholesale on each presence ping while online; never cleared on failure.
+ */
+@Entity(tableName = "cached_active_sessions")
+internal data class CachedActiveSessionEntity(
+    @PrimaryKey val userId: String,
+    val displayName: String,
+    val avatarType: String,
+    val bookId: String,
+    val startedAtMs: Long,
+    val observedAt: Long,
+)
+
+@Dao
+internal interface CachedActiveSessionDao {
+    @Query("SELECT * FROM cached_active_sessions ORDER BY startedAtMs DESC")
+    fun observeAll(): Flow<List<CachedActiveSessionEntity>>
+
+    @Upsert
+    suspend fun upsertAll(rows: List<CachedActiveSessionEntity>)
+
+    @Query("DELETE FROM cached_active_sessions")
+    suspend fun deleteAll()
+
+    /** Atomically replace the cached presence roster with [rows] (the latest server snapshot). */
+    @Transaction
+    suspend fun replaceAll(rows: List<CachedActiveSessionEntity>) {
+        deleteAll()
+        upsertAll(rows)
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -60,8 +60,10 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
         SyncCursorEntity::class,
         PendingOperationV2Entity::class,
         AdminUserRosterEntity::class,
+        BookReadershipEntity::class,
+        CachedActiveSessionEntity::class,
     ],
-    version = 43,
+    version = 44,
     exportSchema = true,
 )
 @TypeConverters(
@@ -145,6 +147,10 @@ internal abstract class ListenUpDatabase : RoomDatabase() {
     abstract fun pendingOperationV2Dao(): PendingOperationV2Dao
 
     abstract fun adminUserRosterDao(): AdminUserRosterDao
+
+    abstract fun bookReadershipDao(): BookReadershipDao
+
+    abstract fun cachedActiveSessionDao(): CachedActiveSessionDao
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration43To44.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration43To44.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+/**
+ * Room schema migration v43 → v44 — add the two offline mirror tables that let the Book Detail
+ * "readers" section and the "who's listening now" presence surface render (possibly stale) offline
+ * instead of blanking on a transient RPC failure. Both are server-fetched caches with an `observedAt`
+ * staleness marker; upgraders start empty and the next presence ping fills them.
+ *
+ * The `CREATE TABLE` statements are copied verbatim from the generated v44 schema so
+ * `runMigrationsAndValidate` sees an identical shape.
+ */
+internal val MIGRATION_43_44: Migration =
+    object : Migration(43, 44) {
+        override fun migrate(connection: SQLiteConnection) {
+            connection.execSQL(
+                "CREATE TABLE IF NOT EXISTS `book_readership` " +
+                    "(`bookId` TEXT NOT NULL, `userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, " +
+                    "`avatarType` TEXT NOT NULL, `currentProgressPct` INTEGER, `finishesJson` TEXT NOT NULL, " +
+                    "`observedAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`, `userId`))",
+            )
+            connection.execSQL(
+                "CREATE TABLE IF NOT EXISTS `cached_active_sessions` " +
+                    "(`userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, " +
+                    "`bookId` TEXT NOT NULL, `startedAtMs` INTEGER NOT NULL, `observedAt` INTEGER NOT NULL, " +
+                    "PRIMARY KEY(`userId`))",
+            )
+        }
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ActiveSessionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ActiveSessionRepositoryImpl.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 
 package com.calypsan.listenup.client.data.repository
 
@@ -6,6 +6,8 @@ import com.calypsan.listenup.api.dto.social.CurrentlyListeningSession
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.BookSummary
+import com.calypsan.listenup.client.data.local.db.CachedActiveSessionDao
+import com.calypsan.listenup.client.data.local.db.CachedActiveSessionEntity
 import com.calypsan.listenup.client.data.remote.SocialRpcFactory
 import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
 import com.calypsan.listenup.client.domain.model.ActiveSession
@@ -17,66 +19,87 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transform
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 private val logger = KotlinLogging.logger {}
 
 /**
- * Active-session repository backed by the [com.calypsan.listenup.api.SocialService] RPC.
+ * Offline-first active-session ("What Others Are Listening To") repository. Room's
+ * `cached_active_sessions` mirror is the single read source, so the presence surface renders the
+ * last-known roster (possibly stale) when offline or on a transient RPC failure — Never-Stranded, no
+ * blank flash. A background refresh re-fetches the ACL-filtered
+ * [com.calypsan.listenup.api.SocialService] `currentlyListening` RPC on first subscribe and on every
+ * [PresenceRefreshSignal] ping, replacing the cache wholesale; on failure the cache is left untouched.
  *
- * The "What Others Are Listening To" list is ACL-filtered server-side, so this repository fetches
- * it on first subscribe and re-fetches on every [PresenceRefreshSignal] ping (the server's
- * presence nudge or a firehose reconnect). Book identity arrives as a [BookId] only; title,
- * author, blur hash, and the local cover path are enriched from the viewer's local Room library,
- * which holds exactly the books they can access. Sessions whose book is absent locally are dropped.
- *
- * On any RPC failure the flow emits an empty list — Never-Stranded: the UI shows nothing rather
- * than hanging, and the next ping recovers. The avatar background colour is derived from the user
- * id via [stableAvatarColorHex] so it matches the rest of the app; the wire DTO carries no colour.
+ * Book identity is enriched at read time from the viewer's local Room library (which holds exactly the
+ * books they can access); sessions whose book is absent locally are dropped. Because presence is
+ * time-sensitive, each cached row keeps an `observedAt` for a UI staleness affordance. The avatar
+ * background colour is derived from the user id via [stableAvatarColorHex]; the wire DTO carries none.
  *
  * @property socialRpc Supplies the [com.calypsan.listenup.api.SocialService] RPC proxy.
  * @property bookDao Local library reads for enriching each session's book fields.
  * @property imageStorage Resolves the local cover path when a cover is cached.
- * @property presence Pings whenever presence may have changed, driving a re-fetch.
+ * @property presence Pings whenever presence may have changed, driving a background refresh.
+ * @property cachedSessionDao The Room mirror — the offline read source.
+ * @property clock Supplies `observedAt` for each cached row; injected for tests.
  */
 internal class ActiveSessionRepositoryImpl(
     private val socialRpc: SocialRpcFactory,
     private val bookDao: BookDao,
     private val imageStorage: ImageStorage,
     private val presence: PresenceRefreshSignal,
+    private val cachedSessionDao: CachedActiveSessionDao,
+    private val clock: Clock = Clock.System,
 ) : ActiveSessionRepository {
     override fun observeActiveSessions(currentUserId: String): Flow<List<ActiveSession>> =
-        presence.signal
-            .onStart { emit(Unit) }
-            .flatMapLatest { flow { emit(fetchSessions()) } }
+        merge(
+            refreshOnPing(),
+            cachedSessions(),
+        )
 
     override fun observeActiveCount(currentUserId: String): Flow<Int> =
         observeActiveSessions(currentUserId).map { it.size }
 
-    private suspend fun fetchSessions(): List<ActiveSession> =
+    private fun cachedSessions(): Flow<List<ActiveSession>> =
+        cachedSessionDao.observeAll().map { rows -> rows.mapNotNull { it.toDomainOrNull() } }
+
+    private fun refreshOnPing(): Flow<List<ActiveSession>> =
+        presence.signal
+            .onStart { emit(Unit) }
+            .transform { refresh() } // never emits — the Room read carries the data
+
+    /** Re-fetch the presence roster and replace the cache; leave it intact on failure. */
+    private suspend fun refresh() {
         try {
             when (val result = socialRpc.get().currentlyListening()) {
-                is AppResult.Success -> result.data.mapNotNull { it.toDomainOrNull() }
-                is AppResult.Failure -> emptyList()
+                is AppResult.Success -> {
+                    val observedAt = clock.now().toEpochMilliseconds()
+                    cachedSessionDao.replaceAll(result.data.map { it.toEntity(observedAt) })
+                }
+
+                is AppResult.Failure -> {
+                    logger.warn { "currently-listening refresh failed (${result.error.code}); keeping cache" }
+                }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            // Never-Stranded: an RPC fault or a transient Room/disk error during book enrichment
-            // must not terminate the flow. Emit an empty list; the next presence ping recovers.
-            logger.warn(e) { "currently-listening fetch failed" }
-            emptyList()
+            // Never-Stranded: an RPC fault or transient error must not clear the cache or kill the flow.
+            logger.warn(e) { "currently-listening refresh failed; keeping cache" }
         }
+    }
 
-    private suspend fun CurrentlyListeningSession.toDomainOrNull(): ActiveSession? {
+    private suspend fun CachedActiveSessionEntity.toDomainOrNull(): ActiveSession? {
         val summary = bookDao.getBookSummary(bookId) ?: return null
         return toDomain(summary)
     }
 
-    private fun CurrentlyListeningSession.toDomain(summary: BookSummary): ActiveSession {
+    private fun CachedActiveSessionEntity.toDomain(summary: BookSummary): ActiveSession {
         val coverPath = imageStorage.takeIf { it.exists(BookId(bookId)) }?.getCoverPath(BookId(bookId))
         return ActiveSession(
             sessionId = "$userId:$bookId",
@@ -103,3 +126,13 @@ internal class ActiveSessionRepositoryImpl(
         )
     }
 }
+
+private fun CurrentlyListeningSession.toEntity(observedAt: Long): CachedActiveSessionEntity =
+    CachedActiveSessionEntity(
+        userId = userId,
+        displayName = displayName,
+        avatarType = avatarType,
+        bookId = bookId,
+        startedAtMs = startedAtMs,
+        observedAt = observedAt,
+    )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImpl.kt
@@ -1,10 +1,12 @@
-@file:OptIn(ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.api.dto.social.BookReaderEntry
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.core.error.ErrorMapper
+import com.calypsan.listenup.client.data.local.db.BookReadershipDao
+import com.calypsan.listenup.client.data.local.db.BookReadershipEntity
 import com.calypsan.listenup.client.data.remote.SocialRpcFactory
 import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
 import com.calypsan.listenup.client.domain.readers.BookReaders
@@ -17,62 +19,73 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transform
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 private val logger = KotlinLogging.logger {}
 
 /**
- * Book-readers repository over the [com.calypsan.listenup.api.SocialService] `bookReadership` RPC.
+ * Offline-first book-readers repository. Room's `book_readership` mirror is the single read source, so
+ * the Book Detail readers section renders the last-known readership (possibly stale) when offline or on
+ * a transient RPC failure — Never-Stranded, no blank flash. A background refresh re-fetches the
+ * ACL-filtered [com.calypsan.listenup.api.SocialService] `bookReadership` RPC on first subscribe and on
+ * every [PresenceRefreshSignal] ping, replacing the book's cached rows wholesale; on failure the cache
+ * is left untouched and the next ping recovers.
  *
- * The RPC is ACL-filtered and now *includes* the caller, so each [BookReaderEntry] maps straight to a
- * domain [Reader] — the current user flagged via [Reader.isYou] from [UserRepository]. The readership
- * is fetched on first subscribe and re-fetched on every [PresenceRefreshSignal] ping.
- *
- * On any RPC failure the list is empty — Never-Stranded: the section renders empty rather than
- * hanging, and the next ping recovers.
+ * The current user is flagged via [Reader.isYou] from [UserRepository]. `finishes` timestamps are stored
+ * in the mirror as a comma-joined scalar (small, always replaced together — no child table needed).
  *
  * @property socialRpc Supplies the [com.calypsan.listenup.api.SocialService] RPC proxy.
- * @property presence Pings whenever presence may have changed, driving a re-fetch of the readership.
+ * @property presence Pings whenever presence may have changed, driving a background refresh.
  * @property userRepository Source of the current user's identity, used to flag [Reader.isYou].
+ * @property readershipDao The Room mirror — the offline read source.
+ * @property clock Supplies `observedAt` for each cached row; injected for tests.
  */
 internal class BookReadersRepositoryImpl(
     private val socialRpc: SocialRpcFactory,
     private val presence: PresenceRefreshSignal,
     private val userRepository: UserRepository,
+    private val readershipDao: BookReadershipDao,
+    private val clock: Clock = Clock.System,
 ) : BookReadersRepository {
     override fun observeReadersFor(bookId: String): Flow<BookReaders> =
+        merge(
+            // Side-effect flow: refreshes the Room mirror on each ping; emits nothing itself.
+            refreshOnPing(bookId),
+            // Read source: the Room mirror joined with the current user, mapped to the domain.
+            cachedReaders(bookId),
+        )
+
+    private fun cachedReaders(bookId: String): Flow<BookReaders> =
         combine(
-            readershipFlow(bookId),
+            readershipDao.observeForBook(bookId),
             userRepository.observeCurrentUser(),
-        ) { entries, currentUser ->
+        ) { rows, currentUser ->
             val myId = currentUser?.id?.value
-            BookReaders(
-                readers =
-                    entries.map { entry ->
-                        Reader(
-                            userId = entry.userId,
-                            displayName = entry.displayName,
-                            isYou = entry.userId == myId,
-                            currentProgressPct = entry.currentProgressPct,
-                            finishes = entry.finishes,
-                        )
-                    },
-            )
+            BookReaders(readers = rows.map { it.toReader(myId) })
         }
 
-    /** The full readership of the book — ACL-filtered server-side; empty on any RPC failure. */
-    private fun readershipFlow(bookId: String): Flow<List<BookReaderEntry>> =
+    private fun refreshOnPing(bookId: String): Flow<BookReaders> =
         presence.signal
             .onStart { emit(Unit) }
-            .flatMapLatest { flow { emit(fetchReadership(bookId)) } }
+            .transform { refresh(bookId) } // never emits — the Room read carries the data
 
-    private suspend fun fetchReadership(bookId: String): List<BookReaderEntry> =
+    /** Re-fetch the readership and replace the book's cached rows; leave the cache intact on failure. */
+    private suspend fun refresh(bookId: String) {
         when (val result = bookReadership(bookId)) {
-            is AppResult.Success -> result.data.readers
-            is AppResult.Failure -> emptyList()
+            is AppResult.Success -> {
+                val observedAt = clock.now().toEpochMilliseconds()
+                readershipDao.replaceForBook(bookId, result.data.readers.map { it.toEntity(bookId, observedAt) })
+            }
+
+            is AppResult.Failure -> {
+                logger.warn { "bookReadership refresh failed (${result.error.code}); keeping cached readership" }
+            }
         }
+    }
 
     private suspend fun bookReadership(bookId: String) =
         try {
@@ -84,3 +97,26 @@ internal class BookReadersRepositoryImpl(
             AppResult.Failure(ErrorMapper.map(e))
         }
 }
+
+private fun BookReaderEntry.toEntity(
+    bookId: String,
+    observedAt: Long,
+): BookReadershipEntity =
+    BookReadershipEntity(
+        bookId = bookId,
+        userId = userId,
+        displayName = displayName,
+        avatarType = avatarType,
+        currentProgressPct = currentProgressPct,
+        finishesJson = finishes.joinToString(","),
+        observedAt = observedAt,
+    )
+
+private fun BookReadershipEntity.toReader(currentUserId: String?): Reader =
+    Reader(
+        userId = userId,
+        displayName = displayName,
+        isYou = userId == currentUserId,
+        currentProgressPct = currentProgressPct,
+        finishes = if (finishesJson.isEmpty()) emptyList() else finishesJson.split(",").map { it.toLong() },
+    )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PersistenceModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PersistenceModule.kt
@@ -43,6 +43,8 @@ internal val persistenceModule: Module =
         single { get<ListenUpDatabase>().userPreferencesDao() }
         single { get<ListenUpDatabase>().tentativeSpanDao() }
         single { get<ListenUpDatabase>().publicProfileDao() }
+        single { get<ListenUpDatabase>().bookReadershipDao() }
+        single { get<ListenUpDatabase>().cachedActiveSessionDao() }
 
         // Hygiene additions: three DAOs consumed by repositories but previously
         // fetched inline via `get<ListenUpDatabase>().xDao()` at the call site

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SocialModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SocialModule.kt
@@ -119,6 +119,7 @@ internal val socialModule: Module =
                 bookDao = get(),
                 imageStorage = get(),
                 presence = get(),
+                cachedSessionDao = get(),
             )
         }
 
@@ -140,6 +141,7 @@ internal val socialModule: Module =
                 socialRpc = get(),
                 presence = get(),
                 userRepository = get(),
+                readershipDao = get(),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ActiveSessionRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ActiveSessionRepositoryImplTest.kt
@@ -2,17 +2,18 @@ package com.calypsan.listenup.client.data.repository
 
 import app.cash.turbine.test
 import com.calypsan.listenup.api.SocialService
-import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.dto.social.CurrentlyListeningSession
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.BookSummary
+import com.calypsan.listenup.client.data.local.db.CachedActiveSessionDao
+import com.calypsan.listenup.client.data.local.db.CachedActiveSessionEntity
 import com.calypsan.listenup.client.data.remote.SocialRpcFactory
 import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
+import com.calypsan.listenup.client.domain.model.ActiveSession
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import dev.mokkery.MockMode
-import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.every
@@ -22,18 +23,15 @@ import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * Tests for [ActiveSessionRepositoryImpl] over the [SocialService] RPC seam.
- *
- * The repository fetches the ACL-filtered currently-listening list on first subscribe and
- * re-fetches on every [PresenceRefreshSignal] ping, enriching each session's book fields
- * from the local Room library. A failed RPC yields an empty list (Never-Stranded), while
- * [CancellationException] always propagates.
+ * Tests for the offline-first [ActiveSessionRepositoryImpl]. Room's `cached_active_sessions` mirror is
+ * the read source; the RPC refresh replaces it on subscribe and on every [PresenceRefreshSignal] ping,
+ * and on failure the cache is left intact (Never-Stranded). Book fields are enriched at read time from
+ * the local library. The in-memory [FakeCachedActiveSessionDao] stands in for Room in commonTest.
  */
 class ActiveSessionRepositoryImplTest :
     FunSpec({
@@ -59,13 +57,6 @@ class ActiveSessionRepositoryImplTest :
                 override suspend fun invalidate() = Unit
             }
 
-        fun throwingRpc(throwable: Throwable): SocialRpcFactory =
-            object : SocialRpcFactory {
-                override suspend fun get(): SocialService = throw throwable
-
-                override suspend fun invalidate() = Unit
-            }
-
         fun bookDaoReturning(vararg summaries: BookSummary): BookDao {
             val dao = mock<BookDao>(MockMode.autoUnit)
             val byId = summaries.associateBy { it.id }
@@ -85,16 +76,16 @@ class ActiveSessionRepositoryImplTest :
         fun repo(
             rpc: SocialRpcFactory,
             bookDao: BookDao,
-            presence: PresenceRefreshSignal,
+            dao: CachedActiveSessionDao,
+            presence: PresenceRefreshSignal = PresenceRefreshSignal(),
             images: ImageStorage = imageStorage(),
         ) = ActiveSessionRepositoryImpl(
             socialRpc = rpc,
             bookDao = bookDao,
             imageStorage = images,
             presence = presence,
+            cachedSessionDao = dao,
         )
-
-        // ── Maps RPC → domain, enriched from local Room ───────────────────────
 
         test("maps currently-listening sessions and enriches title/author from local Room") {
             runTest {
@@ -102,7 +93,6 @@ class ActiveSessionRepositoryImplTest :
                     mock<SocialService> {
                         everySuspend { currentlyListening() } returns
                             AppResult.Success(listOf(session(userId = "u2", bookId = "bookA", displayName = "Bob")))
-                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 val bookDao =
                     bookDaoReturning(
@@ -114,25 +104,21 @@ class ActiveSessionRepositoryImplTest :
                             authorName = "Brandon",
                         ),
                     )
-                val presence = PresenceRefreshSignal()
 
-                repo(fakeRpc(service), bookDao, presence).observeActiveSessions("u1").test {
-                    val sessions = awaitItem()
-                    sessions.size shouldBe 1
-                    val s = sessions.first()
-                    s.userId shouldBe "u2"
-                    s.bookId shouldBe "bookA"
-                    s.user.displayName shouldBe "Bob"
-                    s.book.title shouldBe "The Way of Kings"
-                    s.book.coverBlurHash shouldBe "blur"
-                    s.book.coverHash shouldBe "cover-hash-a"
-                    s.book.authorName shouldBe "Brandon"
-                    cancelAndIgnoreRemainingEvents()
-                }
+                repo(fakeRpc(service), bookDao, FakeCachedActiveSessionDao())
+                    .observeActiveSessions("u1")
+                    .test {
+                        val s = awaitNonEmpty().first()
+                        s.userId shouldBe "u2"
+                        s.bookId shouldBe "bookA"
+                        s.user.displayName shouldBe "Bob"
+                        s.book.title shouldBe "The Way of Kings"
+                        s.book.coverBlurHash shouldBe "blur"
+                        s.book.authorName shouldBe "Brandon"
+                        cancelAndIgnoreRemainingEvents()
+                    }
             }
         }
-
-        // ── Drops sessions whose book is not in the local library ─────────────
 
         test("drops sessions whose book is absent from the local library") {
             runTest {
@@ -145,23 +131,22 @@ class ActiveSessionRepositoryImplTest :
                                     session(userId = "u3", bookId = "missing"),
                                 ),
                             )
-                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 val bookDao =
                     bookDaoReturning(
                         BookSummary(id = "present", title = "Present", coverBlurHash = null, coverHash = null, authorName = null),
                     )
 
-                repo(fakeRpc(service), bookDao, PresenceRefreshSignal()).observeActiveSessions("u1").test {
-                    val sessions = awaitItem()
-                    sessions.size shouldBe 1
-                    sessions.first().bookId shouldBe "present"
-                    cancelAndIgnoreRemainingEvents()
-                }
+                repo(fakeRpc(service), bookDao, FakeCachedActiveSessionDao())
+                    .observeActiveSessions("u1")
+                    .test {
+                        val sessions = awaitNonEmpty()
+                        sessions.size shouldBe 1
+                        sessions.first().bookId shouldBe "present"
+                        cancelAndIgnoreRemainingEvents()
+                    }
             }
         }
-
-        // ── Re-fetches on every presence ping ─────────────────────────────────
 
         test("re-fetches when the presence signal pings") {
             runTest {
@@ -171,13 +156,9 @@ class ActiveSessionRepositoryImplTest :
                             listOf(
                                 AppResult.Success(listOf(session(userId = "u2", bookId = "bookA"))),
                                 AppResult.Success(
-                                    listOf(
-                                        session(userId = "u2", bookId = "bookA"),
-                                        session(userId = "u3", bookId = "bookA"),
-                                    ),
+                                    listOf(session(userId = "u2", bookId = "bookA"), session(userId = "u3", bookId = "bookA")),
                                 ),
                             )
-                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
                 val bookDao =
                     bookDaoReturning(
@@ -185,92 +166,85 @@ class ActiveSessionRepositoryImplTest :
                     )
                 val presence = PresenceRefreshSignal()
 
-                repo(fakeRpc(service), bookDao, presence).observeActiveSessions("u1").test {
-                    awaitItem().size shouldBe 1
-                    presence.ping()
-                    awaitItem().size shouldBe 2
-                    cancelAndIgnoreRemainingEvents()
-                }
+                repo(fakeRpc(service), bookDao, FakeCachedActiveSessionDao(), presence = presence)
+                    .observeActiveSessions("u1")
+                    .test {
+                        awaitNonEmpty().size shouldBe 1
+                        presence.ping()
+                        awaitItem().size shouldBe 2
+                        cancelAndIgnoreRemainingEvents()
+                    }
             }
         }
 
-        // ── RPC failure → empty list (Never-Stranded) ─────────────────────────
+        test("a refresh failure keeps the cached sessions instead of blanking (Never-Stranded)") {
+            runTest {
+                val service =
+                    mock<SocialService> {
+                        everySuspend { currentlyListening() } sequentiallyReturns
+                            listOf(
+                                AppResult.Success(listOf(session(userId = "u2", bookId = "bookA"))),
+                                AppResult.Failure(TransportError.NetworkUnavailable()),
+                            )
+                    }
+                val bookDao =
+                    bookDaoReturning(
+                        BookSummary(id = "bookA", title = "A", coverBlurHash = null, coverHash = null, authorName = null),
+                    )
+                val presence = PresenceRefreshSignal()
 
-        test("RPC failure result yields an empty list") {
+                repo(fakeRpc(service), bookDao, FakeCachedActiveSessionDao(), presence = presence)
+                    .observeActiveSessions("u1")
+                    .test {
+                        awaitNonEmpty().size shouldBe 1
+                        presence.ping() // triggers the failing refresh
+                        expectNoEvents() // cache untouched — still one session
+                        cancelAndIgnoreRemainingEvents()
+                    }
+            }
+        }
+
+        test("an empty cache with a failing RPC emits empty gracefully") {
             runTest {
                 val service =
                     mock<SocialService> {
                         everySuspend { currentlyListening() } returns
                             AppResult.Failure(TransportError.NetworkUnavailable())
-                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
                     }
 
-                repo(fakeRpc(service), bookDaoReturning(), PresenceRefreshSignal())
+                repo(fakeRpc(service), bookDaoReturning(), FakeCachedActiveSessionDao())
                     .observeActiveSessions("u1")
                     .test {
                         awaitItem().shouldBeEmpty()
                         cancelAndIgnoreRemainingEvents()
                     }
-            }
-        }
-
-        // ── Thrown RPC → empty list, but CancellationException propagates ─────
-
-        test("thrown RPC error yields an empty list") {
-            runTest {
-                repo(throwingRpc(RuntimeException("boom")), bookDaoReturning(), PresenceRefreshSignal())
-                    .observeActiveSessions("u1")
-                    .test {
-                        awaitItem().shouldBeEmpty()
-                        cancelAndIgnoreRemainingEvents()
-                    }
-            }
-        }
-
-        // A swallowed CancellationException would surface as an emitted empty list; re-throwing
-        // cancels the in-flight fetch instead, so no item is emitted within the window.
-        test("CancellationException from the RPC is not swallowed into an empty emission") {
-            runTest {
-                val flow =
-                    repo(throwingRpc(CancellationException("cancel")), bookDaoReturning(), PresenceRefreshSignal())
-                        .observeActiveSessions("u1")
-
-                val emitted = withTimeoutOrNull(100) { flow.first() }
-                emitted shouldBe null
-            }
-        }
-
-        // ── Enrichment throw → empty list (Never-Stranded), next ping recovers ──
-
-        // A transient Room/disk error during book enrichment must not terminate the flow:
-        // the fetch maps to an empty list, and the next presence ping re-fetches and succeeds.
-        test("book enrichment throwable yields an empty list, and the next ping recovers") {
-            runTest {
-                val service =
-                    mock<SocialService> {
-                        everySuspend { currentlyListening() } returns
-                            AppResult.Success(listOf(session(userId = "u2", bookId = "bookA")))
-                        everySuspend { bookReadership(any()) } returns AppResult.Success(BookReadership(emptyList()))
-                    }
-                // First lookup throws (transient SQLite/disk error); second lookup succeeds.
-                var lookups = 0
-                val bookDao = mock<BookDao>(MockMode.autoUnit)
-                everySuspend { bookDao.getBookSummary("bookA") } calls {
-                    if (lookups++ == 0) throw RuntimeException("transient Room failure")
-                    BookSummary(id = "bookA", title = "A", coverBlurHash = null, coverHash = null, authorName = null)
-                }
-                val presence = PresenceRefreshSignal()
-
-                repo(fakeRpc(service), bookDao, presence).observeActiveSessions("u1").test {
-                    // Enrichment threw → empty list, flow stays alive.
-                    awaitItem().shouldBeEmpty()
-                    // A subsequent ping triggers a fresh fetch that now succeeds → recovers.
-                    presence.ping()
-                    val recovered = awaitItem()
-                    recovered.size shouldBe 1
-                    recovered.first().bookId shouldBe "bookA"
-                    cancelAndIgnoreRemainingEvents()
-                }
             }
         }
     })
+
+/** In-memory [CachedActiveSessionDao] for commonTest — a single [MutableStateFlow] mirror. */
+private class FakeCachedActiveSessionDao : CachedActiveSessionDao {
+    private val flow = MutableStateFlow<List<CachedActiveSessionEntity>>(emptyList())
+
+    override fun observeAll(): Flow<List<CachedActiveSessionEntity>> = flow
+
+    override suspend fun upsertAll(rows: List<CachedActiveSessionEntity>) {
+        flow.value = flow.value.filter { c -> rows.none { it.userId == c.userId } } + rows
+    }
+
+    override suspend fun deleteAll() {
+        flow.value = emptyList()
+    }
+
+    // Match the real DAO's @Transaction: one atomic replacement, not a delete-then-insert flicker.
+    override suspend fun replaceAll(rows: List<CachedActiveSessionEntity>) {
+        flow.value = rows
+    }
+}
+
+/** Await the first non-empty sessions emission (skips the initial empty cache emission). */
+private suspend fun app.cash.turbine.TurbineTestContext<List<ActiveSession>>.awaitNonEmpty(): List<ActiveSession> {
+    var sessions = awaitItem()
+    while (sessions.isEmpty()) sessions = awaitItem()
+    return sessions
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookReadersRepositoryImplTest.kt
@@ -7,6 +7,8 @@ import com.calypsan.listenup.api.dto.social.BookReaderEntry
 import com.calypsan.listenup.api.dto.social.BookReadership
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.BookReadershipDao
+import com.calypsan.listenup.client.data.local.db.BookReadershipEntity
 import com.calypsan.listenup.client.data.remote.SocialRpcFactory
 import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
 import com.calypsan.listenup.client.domain.model.User
@@ -22,21 +24,17 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * Tests for [BookReadersRepositoryImpl].
- *
- * The repository maps the ACL-filtered [SocialService] `bookReadership` RPC — which includes the
- * caller — straight to domain [com.calypsan.listenup.client.domain.readers.Reader]s, flagging the
- * current user via `isYou`, re-fetching on every [PresenceRefreshSignal] ping. On RPC failure it
- * yields an empty list (Never-Stranded); a cancelled fetch always propagates rather than collapsing
- * into an empty emission.
+ * Tests for the offline-first [BookReadersRepositoryImpl]. Room's `book_readership` mirror is the read
+ * source: the RPC refresh replaces a book's cached rows on subscribe and on every [PresenceRefreshSignal]
+ * ping, and on failure the cache is left intact (Never-Stranded) rather than blanking. The in-memory
+ * [FakeBookReadershipDao] stands in for Room in commonTest.
  */
 class BookReadersRepositoryImplTest :
     FunSpec({
@@ -73,13 +71,6 @@ class BookReadersRepositoryImplTest :
                 override suspend fun invalidate() = Unit
             }
 
-        fun throwingRpc(throwable: Throwable): SocialRpcFactory =
-            object : SocialRpcFactory {
-                override suspend fun get(): SocialService = throw throwable
-
-                override suspend fun invalidate() = Unit
-            }
-
         fun fakeUsers(current: User?): UserRepository =
             object : UserRepository {
                 override fun observeCurrentUser(): Flow<User?> = flowOf(current)
@@ -97,17 +88,17 @@ class BookReadersRepositoryImplTest :
 
         fun repo(
             rpc: SocialRpcFactory,
+            dao: BookReadershipDao,
             presence: PresenceRefreshSignal = PresenceRefreshSignal(),
             currentUser: User? = user(),
         ) = BookReadersRepositoryImpl(
             socialRpc = rpc,
             presence = presence,
             userRepository = fakeUsers(currentUser),
+            readershipDao = dao,
         )
 
-        // ── Mapping ───────────────────────────────────────────────────────────
-
-        test("maps bookReadership entries to domain readers and flags the current user") {
+        test("maps a fetched readership to domain readers and flags the current user") {
             runTest {
                 val service =
                     mock<SocialService> {
@@ -122,43 +113,44 @@ class BookReadersRepositoryImplTest :
                             )
                     }
 
-                repo(fakeRpc(service), currentUser = user(id = "me")).observeReadersFor("b1").test {
-                    val readers = awaitItem().readers
-                    readers.first { it.userId == "me" }.let {
-                        it.isYou shouldBe true
-                        it.finishes shouldBe listOf(300L, 100L)
-                        it.currentProgressPct shouldBe null
+                repo(fakeRpc(service), FakeBookReadershipDao(), currentUser = user(id = "me"))
+                    .observeReadersFor("b1")
+                    .test {
+                        // First emission is the empty cache; the refresh then fills it.
+                        val readers = awaitNonEmpty()
+                        readers.first { it.userId == "me" }.let {
+                            it.isYou shouldBe true
+                            it.finishes shouldBe listOf(300L, 100L)
+                            it.currentProgressPct shouldBe null
+                        }
+                        readers.first { it.userId == "u2" }.let {
+                            it.isYou shouldBe false
+                            it.currentProgressPct shouldBe 43
+                            it.finishes.shouldBeEmpty()
+                        }
+                        cancelAndIgnoreRemainingEvents()
                     }
-                    readers.first { it.userId == "u2" }.let {
-                        it.isYou shouldBe false
-                        it.currentProgressPct shouldBe 43
-                        it.finishes.shouldBeEmpty()
-                    }
-                    cancelAndIgnoreRemainingEvents()
-                }
             }
         }
 
-        test("maps readers in server order, preserving entries with no current user") {
+        test("preserves entries with no current user") {
             runTest {
                 val service =
                     mock<SocialService> {
                         everySuspend { bookReadership(BookId("b1")) } returns
-                            AppResult.Success(
-                                BookReadership(listOf(entry("u2", "Bob"), entry("u3", "Carol"))),
-                            )
+                            AppResult.Success(BookReadership(listOf(entry("u2", "Bob"), entry("u3", "Carol"))))
                     }
 
-                repo(fakeRpc(service), currentUser = null).observeReadersFor("b1").test {
-                    val readers = awaitItem().readers
-                    readers.map { it.userId } shouldContainExactly listOf("u2", "u3")
-                    readers.all { !it.isYou } shouldBe true
-                    cancelAndIgnoreRemainingEvents()
-                }
+                repo(fakeRpc(service), FakeBookReadershipDao(), currentUser = null)
+                    .observeReadersFor("b1")
+                    .test {
+                        val readers = awaitNonEmpty()
+                        readers.map { it.userId } shouldContainExactly listOf("u2", "u3")
+                        readers.all { !it.isYou } shouldBe true
+                        cancelAndIgnoreRemainingEvents()
+                    }
             }
         }
-
-        // ── Re-fetches on presence ping ───────────────────────────────────────
 
         test("re-fetches readership when the presence signal pings") {
             runTest {
@@ -172,10 +164,10 @@ class BookReadersRepositoryImplTest :
                     }
                 val presence = PresenceRefreshSignal()
 
-                repo(fakeRpc(service), presence = presence, currentUser = null)
+                repo(fakeRpc(service), FakeBookReadershipDao(), presence = presence, currentUser = null)
                     .observeReadersFor("b1")
                     .test {
-                        awaitItem().readers shouldHaveSize 1
+                        awaitNonEmpty() shouldHaveSize 1
                         presence.ping()
                         awaitItem().readers shouldHaveSize 2
                         cancelAndIgnoreRemainingEvents()
@@ -183,9 +175,32 @@ class BookReadersRepositoryImplTest :
             }
         }
 
-        // ── RPC failure → empty (Never-Stranded) ──────────────────────────────
+        test("a refresh failure keeps the cached readers instead of blanking (Never-Stranded)") {
+            runTest {
+                // Prior successful fetch, then the RPC starts failing.
+                val service =
+                    mock<SocialService> {
+                        everySuspend { bookReadership(BookId("b1")) } sequentiallyReturns
+                            listOf(
+                                AppResult.Success(BookReadership(listOf(entry("u2", "Bob")))),
+                                AppResult.Failure(TransportError.NetworkUnavailable()),
+                            )
+                    }
+                val presence = PresenceRefreshSignal()
 
-        test("RPC failure yields empty readers") {
+                repo(fakeRpc(service), FakeBookReadershipDao(), presence = presence, currentUser = null)
+                    .observeReadersFor("b1")
+                    .test {
+                        awaitNonEmpty().map { it.userId } shouldContainExactly listOf("u2")
+                        presence.ping() // triggers the failing refresh
+                        // No new emission — the cache is untouched, still showing Bob.
+                        expectNoEvents()
+                        cancelAndIgnoreRemainingEvents()
+                    }
+            }
+        }
+
+        test("an empty cache with a failing RPC emits empty gracefully") {
             runTest {
                 val service =
                     mock<SocialService> {
@@ -193,16 +208,7 @@ class BookReadersRepositoryImplTest :
                             AppResult.Failure(TransportError.NetworkUnavailable())
                     }
 
-                repo(fakeRpc(service)).observeReadersFor("b1").test {
-                    awaitItem().readers.shouldBeEmpty()
-                    cancelAndIgnoreRemainingEvents()
-                }
-            }
-        }
-
-        test("thrown RPC error yields empty readers") {
-            runTest {
-                repo(throwingRpc(RuntimeException("boom")))
+                repo(fakeRpc(service), FakeBookReadershipDao())
                     .observeReadersFor("b1")
                     .test {
                         awaitItem().readers.shouldBeEmpty()
@@ -210,17 +216,41 @@ class BookReadersRepositoryImplTest :
                     }
             }
         }
+    })
 
-        // A swallowed CancellationException would surface as an emitted (empty) readers list;
-        // re-throwing cancels the in-flight fetch instead, so no item is emitted in the window.
-        test("CancellationException from the RPC is not swallowed into an emission") {
-            runTest {
-                val flow =
-                    repo(throwingRpc(CancellationException("cancel")))
-                        .observeReadersFor("b1")
+/** In-memory [BookReadershipDao] for commonTest — a per-book [MutableStateFlow] mirror. */
+private class FakeBookReadershipDao : BookReadershipDao {
+    private val byBook = mutableMapOf<String, MutableStateFlow<List<BookReadershipEntity>>>()
 
-                val emitted = withTimeoutOrNull(100) { flow.first() }
-                emitted shouldBe null
+    private fun flowFor(bookId: String) = byBook.getOrPut(bookId) { MutableStateFlow(emptyList()) }
+
+    override fun observeForBook(bookId: String): Flow<List<BookReadershipEntity>> = flowFor(bookId)
+
+    override suspend fun upsertAll(rows: List<BookReadershipEntity>) {
+        rows.groupBy { it.bookId }.forEach { (bookId, bookRows) ->
+            flowFor(bookId).update { existing ->
+                existing.filter { e -> bookRows.none { it.userId == e.userId } } + bookRows
             }
         }
-    })
+    }
+
+    override suspend fun deleteForBook(bookId: String) {
+        flowFor(bookId).value = emptyList()
+    }
+
+    // Match the real DAO's @Transaction: one atomic replacement, not a delete-then-insert flicker.
+    override suspend fun replaceForBook(
+        bookId: String,
+        rows: List<BookReadershipEntity>,
+    ) {
+        flowFor(bookId).value = rows
+    }
+}
+
+/** Await the first non-empty readers emission (skips the initial empty cache emission). */
+private suspend fun app.cash.turbine.TurbineTestContext<com.calypsan.listenup.client.domain.readers.BookReaders>.awaitNonEmpty() =
+    run {
+        var readers = awaitItem().readers
+        while (readers.isEmpty()) readers = awaitItem().readers
+        readers
+    }

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_39_40
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_43_44
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -64,6 +65,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_40_41,
                     MIGRATION_41_42,
                     MIGRATION_42_43,
+                    MIGRATION_43_44,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration43To44Test.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration43To44Test.kt
@@ -1,0 +1,72 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+import com.calypsan.listenup.client.test.db.createMigrationTestHelper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for [MIGRATION_43_44] — the two offline mirror tables for readers/presence.
+ *
+ * Asserts the migration creates `book_readership` and `cached_active_sessions` with the expected
+ * columns and that a round-trip insert into each succeeds. `runMigrationsAndValidate` additionally
+ * fails if the migrated shape diverges from the generated v44 schema.
+ */
+class Migration43To44Test :
+    FunSpec({
+
+        test("v43 → v44 creates the book_readership and cached_active_sessions mirror tables") {
+            val helper = createMigrationTestHelper()
+            try {
+                helper.createDatabase(version = 43)
+
+                val db = helper.runMigrationsAndValidate(version = 44, migrations = listOf(MIGRATION_43_44))
+
+                db.columnsOf("book_readership") shouldContainAll
+                    setOf("bookId", "userId", "displayName", "avatarType", "currentProgressPct", "finishesJson", "observedAt")
+                db.columnsOf("cached_active_sessions") shouldContainAll
+                    setOf("userId", "displayName", "avatarType", "bookId", "startedAtMs", "observedAt")
+
+                // Round-trip a readership row (including a null progress and a comma-joined finishes list).
+                db.execSQL(
+                    "INSERT INTO book_readership " +
+                        "(bookId, userId, displayName, avatarType, currentProgressPct, finishesJson, observedAt) " +
+                        "VALUES ('b1', 'u1', 'Alice', 'auto', NULL, '300,100', 5000)",
+                )
+                db
+                    .prepare("SELECT displayName, finishesJson FROM book_readership WHERE bookId = 'b1' AND userId = 'u1'")
+                    .use { stmt ->
+                        stmt.step().shouldBeTrue()
+                        stmt.getText(0) shouldBe "Alice"
+                        stmt.getText(1) shouldBe "300,100"
+                    }
+
+                // Round-trip a presence row.
+                db.execSQL(
+                    "INSERT INTO cached_active_sessions " +
+                        "(userId, displayName, avatarType, bookId, startedAtMs, observedAt) " +
+                        "VALUES ('u2', 'Bob', 'auto', 'b2', 1000, 5000)",
+                )
+                db
+                    .prepare("SELECT displayName, bookId FROM cached_active_sessions WHERE userId = 'u2'")
+                    .use { stmt ->
+                        stmt.step().shouldBeTrue()
+                        stmt.getText(0) shouldBe "Bob"
+                        stmt.getText(1) shouldBe "b2"
+                    }
+            } finally {
+                helper.close()
+            }
+        }
+    })
+
+/** Column names of [table], read from `PRAGMA table_info`. */
+private fun SQLiteConnection.columnsOf(table: String): Set<String> =
+    prepare("PRAGMA table_info(`$table`)").use { stmt ->
+        buildSet {
+            while (stmt.step()) add(stmt.getText(1))
+        }
+    }


### PR DESCRIPTION
Independent (base = `main`).

The Book Detail readers section and the "who's listening now" presence surface were RPC-only and blanked offline / on transient failure. Adds two Room mirror tables (`book_readership`, `cached_active_sessions`, schema **v44**), with `MIGRATION_43_44` registered across all three platform `DatabaseModule`s, the committed `44.json`, and a migration test. Both repos are now offline-first: Room is the read source via `merge(refreshOnPing, cachedFlow)`; the RPC refresh replaces the cache while online; on failure the cache is kept (Never-Stranded).

**Review notes:**
- The DB still uses `fallbackToDestructiveMigration(true)` pre-launch, so v44 is belt-and-suspenders today; the migration + test are in place for when that flips to `false`.
- Dropped the old "CancellationException → no emission" and "enrichment-throw recovery" tests — offline-first always emits from Room, so those premises no longer hold; replaced with cache-retention tests.
