### PR TITLE
✨ feat(shared): unified sync domains 3 — nudge tier (RefreshedDomain)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserPreferencesRepositoryImpl.kt
@@ -101,7 +101,7 @@ internal class UserPreferencesRepositoryImpl(
     /**
      * Offline-first write: apply [mutate] to the cached row inside the outbox transaction and
      * enqueue [patch] for durable replay on reconnect. The server's authoritative merged result
-     * arrives via the SSE firehose (`onPreferencesChanged`) and reconciles the cache — so a change
+     * arrives via the SSE firehose (the `PreferencesChanged` control nudge) and reconciles the cache — so a change
      * made offline is no longer lost, and no inline RPC is fired.
      */
     private suspend fun optimisticUpdate(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.sync
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -12,7 +13,9 @@ private val logger = KotlinLogging.logger {}
  * Routes parsed SSE frames to the right handler. The single seam where:
  *  - typed event payloads are decoded using the handler's `KSerializer<T>`,
  *  - `clientOpId` echoes are matched against the pending queue (and acked),
- *  - control events (`CursorStale`, `StreamError`, `AccessChanged`, `PreferencesChanged`, `LibraryDataChanged`) are recognised and acted on,
+ *  - control events are recognised: nudge controls run their catalog-declared refresh
+ *    strategy via [refreshedRouter]; engine/lifecycle controls (`CursorStale`,
+ *    `StreamError`, `AccessChanged`, `UserDeleted`, `LibraryDataChanged`) fire their callbacks,
  *  - unknown domains are logged and dropped (graceful for forward-compat).
  */
 internal class SyncEventDispatcher(
@@ -20,13 +23,10 @@ internal class SyncEventDispatcher(
     private val queue: PendingOperationQueue,
     private val state: SyncEngineState,
     private val cursorAdvance: suspend (domainName: String, revision: Long) -> Unit,
+    private val refreshedRouter: RefreshedDomainRouter = RefreshedDomainRouter(emptyList()),
     private val onCursorStale: suspend () -> Unit = {},
     private val onAccessChanged: suspend () -> Unit = {},
     private val onUserDeleted: suspend (reason: String?) -> Unit = {},
-    private val onActiveSessionsChanged: () -> Unit = {},
-    private val onActivityChanged: () -> Unit = {},
-    private val onServerInfoChanged: suspend () -> Unit = {},
-    private val onPreferencesChanged: suspend () -> Unit = {},
     private val onLibraryDataChanged: suspend () -> Unit = {},
 ) {
     /** Route a parsed SSE frame: control events, data events, or no-op for missing event lines. */
@@ -48,6 +48,8 @@ internal class SyncEventDispatcher(
                 logger.warn(e) { "Failed to decode SyncControl frame" }
                 return
             }
+        // Nudge tier: catalog-declared refresh strategies. Engine/lifecycle controls fall through.
+        if (refreshedRouter.dispatch(control)) return
         when (control) {
             is SyncControl.CursorStale -> {
                 logger.info {
@@ -71,30 +73,19 @@ internal class SyncEventDispatcher(
                 onUserDeleted(control.reason)
             }
 
-            SyncControl.ActiveSessionsChanged -> {
-                logger.debug { "presence nudge" }
-                onActiveSessionsChanged()
-            }
-
-            SyncControl.ActivityChanged -> {
-                logger.debug { "activity nudge" }
-                onActivityChanged()
-            }
-
-            SyncControl.ServerInfoChanged -> {
-                logger.debug { "server-info nudge; re-fetching getServerInfo" }
-                onServerInfoChanged()
-            }
-
-            SyncControl.PreferencesChanged -> {
-                logger.debug { "preferences nudge; re-fetching getMyPreferences into Room" }
-                onPreferencesChanged()
-            }
-
             SyncControl.LibraryDataChanged -> {
                 logger.info { "LibraryDataChanged received; reconciling all domains via digest" }
                 onLibraryDataChanged()
             }
+
+            // The nudge tier is handled by refreshedRouter above. Reaching here means a
+            // catalog RefreshedDomain entry is missing — log loudly rather than drop silently.
+            SyncControl.ActiveSessionsChanged,
+            SyncControl.ActivityChanged,
+            SyncControl.ServerInfoChanged,
+            SyncControl.PreferencesChanged,
+            ->
+                logger.warn { "Nudge control $control unclaimed by any RefreshedDomain; dropped" }
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -84,8 +84,9 @@ internal class SyncEventDispatcher(
             SyncControl.ActivityChanged,
             SyncControl.ServerInfoChanged,
             SyncControl.PreferencesChanged,
-            ->
+            -> {
                 logger.warn { "Nudge control $control unclaimed by any RefreshedDomain; dropped" }
+            }
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ClientSyncDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ClientSyncDomain.kt
@@ -1,10 +1,13 @@
 package com.calypsan.listenup.client.data.sync.domains
 
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncDomainKey
+import kotlin.reflect.KClass
 
 /**
- * A declared sync domain — one entry in the catalog. Phase 3 adds the second kind
- * (`RefreshedDomain`, nudge-driven); until then [MirroredDomain] is the only variant.
+ * A declared sync domain — one entry in the catalog. Two kinds: [MirroredDomain]
+ * (Room-mirrored via SSE fat events + catch-up + digest) and [RefreshedDomain]
+ * (nudge-driven; no cursor, a declared refresh strategy fired on a named control).
  */
 internal sealed interface ClientSyncDomain
 
@@ -24,4 +27,14 @@ internal class MirroredDomain<T : Any>(
     val digest: DigestParticipation,
     val writes: WriteTier,
     val accessGate: AccessGate? = null,
+) : ClientSyncDomain
+
+/**
+ * A nudge-driven domain: no Room cursor and no digest. When the server pushes its
+ * [trigger] control frame, the dispatcher runs [refresh]. Server-side emission of the
+ * trigger is unchanged (it stays where it is, semantically owned by each feature).
+ */
+internal class RefreshedDomain(
+    val trigger: KClass<out SyncControl>,
+    val refresh: RefreshStrategy,
 ) : ClientSyncDomain

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshStrategy.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshStrategy.kt
@@ -11,12 +11,16 @@ internal sealed interface RefreshStrategy {
      * fire-and-forget — a dropped ping is harmless (the collector re-fetches on the
      * next one, or on reconnect).
      */
-    class Ping(val ping: () -> Unit) : RefreshStrategy
+    class Ping(
+        val ping: () -> Unit,
+    ) : RefreshStrategy
 
     /**
      * Run a suspend re-fetch inline. Declared best-effort: the router swallows
      * non-cancellation failures so a nudge re-fetch can never take the SSE dispatch
      * loop down (codifies `SyncEngine.primeActivityFeedSafely`).
      */
-    class Refetch(val refetch: suspend () -> Unit) : RefreshStrategy
+    class Refetch(
+        val refetch: suspend () -> Unit,
+    ) : RefreshStrategy
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshStrategy.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshStrategy.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.client.data.sync.domains
+
+/**
+ * How a [RefreshedDomain] responds to its nudge. Extracted from what the two nudge
+ * mechanisms do today: fire a hot refresh signal (collectors re-fetch), or run a
+ * best-effort suspend re-fetch directly.
+ */
+internal sealed interface RefreshStrategy {
+    /**
+     * Ping a hot refresh signal so its collectors re-fetch. Non-suspending and
+     * fire-and-forget — a dropped ping is harmless (the collector re-fetches on the
+     * next one, or on reconnect).
+     */
+    class Ping(val ping: () -> Unit) : RefreshStrategy
+
+    /**
+     * Run a suspend re-fetch inline. Declared best-effort: the router swallows
+     * non-cancellation failures so a nudge re-fetch can never take the SSE dispatch
+     * loop down (codifies `SyncEngine.primeActivityFeedSafely`).
+     */
+    class Refetch(val refetch: suspend () -> Unit) : RefreshStrategy
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouter.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouter.kt
@@ -27,6 +27,7 @@ internal class RefreshedDomainRouter(
      */
     suspend fun dispatch(control: SyncControl): Boolean {
         val strategy = byTrigger[control::class] ?: return false
+        logger.debug { "Nudge $control claimed by a refreshed domain; running ${strategy::class.simpleName} refresh" }
         when (strategy) {
             is RefreshStrategy.Ping -> strategy.ping()
             is RefreshStrategy.Refetch -> runRefetchSafely(strategy.refetch)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouter.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouter.kt
@@ -1,0 +1,46 @@
+package com.calypsan.listenup.client.data.sync.domains
+
+import com.calypsan.listenup.api.sync.SyncControl
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.reflect.KClass
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Routes a nudge [SyncControl] to its declared [RefreshStrategy], derived from the
+ * catalog's [RefreshedDomain] entries. Replaces the four ad-hoc nudge lambdas that
+ * used to live in the DI module: one table, one runner, all driven by the catalog.
+ */
+internal class RefreshedDomainRouter(
+    refreshed: List<RefreshedDomain>,
+) {
+    // Trigger distinctness is not enforced here (a collision would silently keep the
+    // last entry); the completeness spec asserts the catalog's triggers are distinct.
+    private val byTrigger: Map<KClass<out SyncControl>, RefreshStrategy> =
+        refreshed.associate { it.trigger to it.refresh }
+
+    /**
+     * Run the declared refresh for [control]. Returns `true` if a refreshed domain
+     * claimed it, `false` if it is an engine/lifecycle control the dispatcher must
+     * handle itself.
+     */
+    suspend fun dispatch(control: SyncControl): Boolean {
+        val strategy = byTrigger[control::class] ?: return false
+        when (strategy) {
+            is RefreshStrategy.Ping -> strategy.ping()
+            is RefreshStrategy.Refetch -> runRefetchSafely(strategy.refetch)
+        }
+        return true
+    }
+
+    private suspend fun runRefetchSafely(refetch: suspend () -> Unit) {
+        try {
+            refetch()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Nudge refetch failed; continuing" }
+        }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomains.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomains.kt
@@ -2,7 +2,7 @@ package com.calypsan.listenup.client.data.sync.domains
 
 import com.calypsan.listenup.api.sync.SyncControl
 
-/**
+/*
  * The nudge tier: content-free control frames the server pushes to prompt a client
  * re-fetch. Each declares its trigger and refresh strategy — the whole nudge rulebook
  * in one file. Engine/lifecycle controls (`CursorStale`, `StreamError`, `AccessChanged`,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomains.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomains.kt
@@ -1,0 +1,38 @@
+package com.calypsan.listenup.client.data.sync.domains
+
+import com.calypsan.listenup.api.sync.SyncControl
+
+/**
+ * The nudge tier: content-free control frames the server pushes to prompt a client
+ * re-fetch. Each declares its trigger and refresh strategy — the whole nudge rulebook
+ * in one file. Engine/lifecycle controls (`CursorStale`, `StreamError`, `AccessChanged`,
+ * `UserDeleted`, `LibraryDataChanged`) are NOT here — they stay engine callbacks.
+ */
+
+/** Presence changed: ping the signal the social repos (currently-listening, book-readers) collect. */
+internal fun presenceDomain(ping: () -> Unit): RefreshedDomain =
+    RefreshedDomain(
+        trigger = SyncControl.ActiveSessionsChanged::class,
+        refresh = RefreshStrategy.Ping(ping),
+    )
+
+/** Activity feed changed: ping the signal the activity feed collects. */
+internal fun activityDomain(ping: () -> Unit): RefreshedDomain =
+    RefreshedDomain(
+        trigger = SyncControl.ActivityChanged::class,
+        refresh = RefreshStrategy.Ping(ping),
+    )
+
+/** Server info changed (admin edited name / remote URL): re-fetch getServerInfo (persists the remote-URL fallback). */
+internal fun serverInfoDomain(refetch: suspend () -> Unit): RefreshedDomain =
+    RefreshedDomain(
+        trigger = SyncControl.ServerInfoChanged::class,
+        refresh = RefreshStrategy.Refetch(refetch),
+    )
+
+/** Preferences changed on another device: re-fetch getMyPreferences (write-through into Room). */
+internal fun preferencesDomain(refetch: suspend () -> Unit): RefreshedDomain =
+    RefreshedDomain(
+        trigger = SyncControl.PreferencesChanged::class,
+        refresh = RefreshStrategy.Refetch(refetch),
+    )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCatalog.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCatalog.kt
@@ -10,13 +10,14 @@ import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 
 /**
- * The explicit list of every declared sync domain — the client's complete
- * sync rulebook in one value. Grows as Phase 2 migrates the remaining hand-written
- * handlers; when the migration completes, this list and the server's registrations
- * are asserted 1:1 by the completeness spec.
+ * The explicit list of every declared sync domain — the client's complete sync
+ * rulebook in one value. [mirrored] domains are Room-mirrored; [refreshed] domains
+ * are nudge-driven. The server's registrations are asserted 1:1 against [mirrored]
+ * by the completeness spec; the four [refreshed] triggers are asserted there too.
  */
 internal class SyncDomainCatalog(
     val mirrored: List<MirroredDomain<*>>,
+    val refreshed: List<RefreshedDomain>,
 )
 
 /**
@@ -30,6 +31,10 @@ internal fun syncDomainCatalog(
     imageStorage: ImageStorage,
     authSession: AuthSession,
     avatarDownloadRepository: AvatarDownloadRepository,
+    pingPresence: () -> Unit,
+    pingActivity: () -> Unit,
+    refetchServerInfo: suspend () -> Unit,
+    refetchPreferences: suspend () -> Unit,
     documentStorage: DocumentStorage? = null,
 ): SyncDomainCatalog =
     SyncDomainCatalog(
@@ -63,6 +68,13 @@ internal fun syncDomainCatalog(
                     documentStorage = documentStorage,
                 ),
                 adminUserRosterDomain(database = database),
+            ),
+        refreshed =
+            listOf(
+                presenceDomain(ping = pingPresence),
+                activityDomain(ping = pingActivity),
+                serverInfoDomain(refetch = refetchServerInfo),
+                preferencesDomain(refetch = refetchPreferences),
             ),
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -43,6 +43,8 @@ import com.calypsan.listenup.client.data.sync.SyncEventDispatcher
 import com.calypsan.listenup.client.data.sync.SyncSseClient
 import com.calypsan.listenup.client.data.sync.SyncDomainHandler
 import com.calypsan.listenup.client.data.sync.domains.ComposedHandlerRegistrar
+import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
+import com.calypsan.listenup.client.data.sync.domains.SyncDomainCatalog
 import com.calypsan.listenup.client.data.sync.domains.syncDomainCatalog
 import com.calypsan.listenup.client.data.repository.DefaultBookAvailability
 import com.calypsan.listenup.client.data.repository.SseServerReachability
@@ -190,6 +192,9 @@ internal val clientSyncModule =
                 queue = get(),
                 state = get(),
                 cursorAdvance = { domain, rev -> get<SyncCursorStore>().setCursor(domain, rev) },
+                // The four content-free re-fetch nudges (presence, activity, server-info,
+                // preferences) are catalog-declared RefreshedDomains, routed here.
+                refreshedRouter = get(),
                 // Route stale-cursor recovery through the engine so the full
                 // disconnect → catchUp → reseed → reconnect lifecycle stays in
                 // one place. Resolving SyncEngine lazily breaks the Koin
@@ -205,21 +210,6 @@ internal val clientSyncModule =
                 // AuthSession into the dispatcher's construction graph. The reason is logged
                 // by the dispatcher; there's no existing one-shot channel here to surface it.
                 onUserDeleted = { _ -> get<AuthSession>().clearAuthTokens() },
-                // The server's content-free presence nudge pings the shared signal so the social
-                // repos (currently-listening, book-readers) re-fetch their ACL-filtered RPCs.
-                onActiveSessionsChanged = { get<PresenceRefreshSignal>().ping() },
-                // The server's content-free activity nudge pings the shared signal so the activity
-                // feed re-fetches its ACL-filtered RPC page.
-                onActivityChanged = { get<ActivityRefreshSignal>().ping() },
-                // The server's content-free server-info nudge (admin changed name / remote URL):
-                // re-fetch getServerInfo, whose persistRemoteUrl side-effect updates the stored
-                // remote-URL fallback so an admin's new domain reaches us without a cold start.
-                onServerInfoChanged = { val _ = get<InstanceRepository>().getServerInfo(forceRefresh = true) },
-                // The server's content-free per-user preferences nudge (a change made on another of
-                // this user's devices): re-fetch getMyPreferences, whose write-through updates the Room
-                // cache the Settings/player UI observes — so the change lands live. Idempotent: an echo
-                // of this device's own change re-applies identical values and does not re-emit.
-                onPreferencesChanged = { val _ = get<UserPreferencesRepository>().getPreferences() },
                 // The server's content-free bulk-write nudge (e.g. an ABS import's firehose-suppressed
                 // burst): re-derive every domain via digest reconciliation so the imported positions/
                 // sessions land live instead of only on the next reconnect. Same lazy-SyncEngine
@@ -237,10 +227,10 @@ internal val clientSyncModule =
                 imageStorage = get(),
                 authSession = get(),
                 avatarDownloadRepository = get(),
-                // The nudge tier's refresh strategies — the same closures that used to be
-                // the dispatcher's four nudge lambdas. Presence/activity ping their hot
+                // The nudge tier's refresh strategies. Presence/activity ping their hot
                 // signals (social repos + activity feed collect them); server-info/preferences
-                // re-fetch through their repositories' write-through side effects.
+                // re-fetch through their repositories' write-through side effects. These are the
+                // sole home of this wiring now — the dispatcher routes nudges via RefreshedDomainRouter.
                 pingPresence = { get<PresenceRefreshSignal>().ping() },
                 pingActivity = { get<ActivityRefreshSignal>().ping() },
                 refetchServerInfo = { val _ = get<InstanceRepository>().getServerInfo(forceRefresh = true) },
@@ -248,6 +238,9 @@ internal val clientSyncModule =
                 documentStorage = get(),
             )
         }
+        // Derived from the catalog's refreshed entries: one table maps each nudge control
+        // to its refresh strategy, replacing the four ad-hoc nudge lambdas.
+        single { RefreshedDomainRouter(get<SyncDomainCatalog>().refreshed) }
         single(createdAtStart = true) {
             ComposedHandlerRegistrar(
                 catalog = get(),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -237,6 +237,14 @@ internal val clientSyncModule =
                 imageStorage = get(),
                 authSession = get(),
                 avatarDownloadRepository = get(),
+                // The nudge tier's refresh strategies — the same closures that used to be
+                // the dispatcher's four nudge lambdas. Presence/activity ping their hot
+                // signals (social repos + activity feed collect them); server-info/preferences
+                // re-fetch through their repositories' write-through side effects.
+                pingPresence = { get<PresenceRefreshSignal>().ping() },
+                pingActivity = { get<ActivityRefreshSignal>().ping() },
+                refetchServerInfo = { val _ = get<InstanceRepository>().getServerInfo(forceRefresh = true) },
+                refetchPreferences = { val _ = get<UserPreferencesRepository>().getPreferences() },
                 documentStorage = get(),
             )
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcherTest.kt
@@ -6,6 +6,11 @@ import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.api.sync.Tag
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
+import com.calypsan.listenup.client.data.sync.domains.activityDomain
+import com.calypsan.listenup.client.data.sync.domains.preferencesDomain
+import com.calypsan.listenup.client.data.sync.domains.presenceDomain
+import com.calypsan.listenup.client.data.sync.domains.serverInfoDomain
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -183,10 +188,14 @@ class SyncEventDispatcherTest :
             }
         }
 
-        test("control: SyncControl.ServerInfoChanged invokes onServerInfoChanged") {
+        test("control: ServerInfoChanged runs the refreshed-domain refetch strategy") {
             runTest {
                 val db = createInMemoryTestDatabase()
-                var refreshed = false
+                var refetched = false
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(serverInfoDomain(refetch = { refetched = true })),
+                    )
                 val dispatcher =
                     SyncEventDispatcher(
                         registry = ClientSyncDomainRegistry(),
@@ -197,7 +206,7 @@ class SyncEventDispatcherTest :
                             ),
                         state = SyncEngineState(),
                         cursorAdvance = { _, _ -> },
-                        onServerInfoChanged = { refreshed = true },
+                        refreshedRouter = router,
                     )
                 val frame =
                     ParsedSseFrame(
@@ -206,15 +215,19 @@ class SyncEventDispatcherTest :
                         data = contractJson.encodeToString(SyncControl.serializer(), SyncControl.ServerInfoChanged),
                     )
                 dispatcher.handle(frame)
-                refreshed shouldBe true
+                refetched shouldBe true
                 db.close()
             }
         }
 
-        test("control: SyncControl.PreferencesChanged invokes onPreferencesChanged") {
+        test("control: PreferencesChanged runs the refreshed-domain refetch strategy") {
             runTest {
                 val db = createInMemoryTestDatabase()
                 var refetched = false
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(preferencesDomain(refetch = { refetched = true })),
+                    )
                 val dispatcher =
                     SyncEventDispatcher(
                         registry = ClientSyncDomainRegistry(),
@@ -225,7 +238,7 @@ class SyncEventDispatcherTest :
                             ),
                         state = SyncEngineState(),
                         cursorAdvance = { _, _ -> },
-                        onPreferencesChanged = { refetched = true },
+                        refreshedRouter = router,
                     )
                 val frame =
                     ParsedSseFrame(
@@ -235,6 +248,74 @@ class SyncEventDispatcherTest :
                     )
                 dispatcher.handle(frame)
                 refetched shouldBe true
+                db.close()
+            }
+        }
+
+        test("control: ActiveSessionsChanged runs the refreshed-domain ping strategy") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var pinged = false
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(presenceDomain(ping = { pinged = true })),
+                    )
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = ClientSyncDomainRegistry(),
+                        queue =
+                            PendingOperationQueue(
+                                dao = db.pendingOperationV2Dao(),
+                                sender = PendingOperationSender { AppResult.Success(Unit) },
+                            ),
+                        state = SyncEngineState(),
+                        cursorAdvance = { _, _ -> },
+                        refreshedRouter = router,
+                    )
+                val frame =
+                    ParsedSseFrame(
+                        id = null,
+                        event = "control",
+                        data =
+                            contractJson.encodeToString(
+                                SyncControl.serializer(),
+                                SyncControl.ActiveSessionsChanged,
+                            ),
+                    )
+                dispatcher.handle(frame)
+                pinged shouldBe true
+                db.close()
+            }
+        }
+
+        test("control: ActivityChanged runs the refreshed-domain ping strategy") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                var pinged = false
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(activityDomain(ping = { pinged = true })),
+                    )
+                val dispatcher =
+                    SyncEventDispatcher(
+                        registry = ClientSyncDomainRegistry(),
+                        queue =
+                            PendingOperationQueue(
+                                dao = db.pendingOperationV2Dao(),
+                                sender = PendingOperationSender { AppResult.Success(Unit) },
+                            ),
+                        state = SyncEngineState(),
+                        cursorAdvance = { _, _ -> },
+                        refreshedRouter = router,
+                    )
+                val frame =
+                    ParsedSseFrame(
+                        id = null,
+                        event = "control",
+                        data = contractJson.encodeToString(SyncControl.serializer(), SyncControl.ActivityChanged),
+                    )
+                dispatcher.handle(frame)
+                pinged shouldBe true
                 db.close()
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouterTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouterTest.kt
@@ -1,0 +1,81 @@
+package com.calypsan.listenup.client.data.sync.domains
+
+import com.calypsan.listenup.api.sync.SyncControl
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.test.runTest
+
+class RefreshedDomainRouterTest :
+    FunSpec({
+
+        test("Ping strategy fires the ping when its trigger arrives") {
+            runTest {
+                var pinged = false
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(presenceDomain(ping = { pinged = true })),
+                    )
+
+                val handled = router.dispatch(SyncControl.ActiveSessionsChanged)
+
+                handled shouldBe true
+                pinged shouldBe true
+            }
+        }
+
+        test("Refetch strategy runs the suspend refetch when its trigger arrives") {
+            runTest {
+                var refetched = false
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(serverInfoDomain(refetch = { refetched = true })),
+                    )
+
+                val handled = router.dispatch(SyncControl.ServerInfoChanged)
+
+                handled shouldBe true
+                refetched shouldBe true
+            }
+        }
+
+        test("Refetch failure is swallowed so dispatch never throws") {
+            runTest {
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(preferencesDomain(refetch = { error("boom") })),
+                    )
+
+                // Must not throw — best-effort contract.
+                val handled = router.dispatch(SyncControl.PreferencesChanged)
+
+                handled shouldBe true
+            }
+        }
+
+        test("Refetch that throws CancellationException propagates out of dispatch") {
+            runTest {
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(serverInfoDomain(refetch = { throw CancellationException("cancelled") })),
+                    )
+
+                shouldThrow<CancellationException> {
+                    router.dispatch(SyncControl.ServerInfoChanged)
+                }
+            }
+        }
+
+        test("an engine/lifecycle control is not claimed by the router") {
+            runTest {
+                val router =
+                    RefreshedDomainRouter(
+                        listOf(presenceDomain(ping = {})),
+                    )
+
+                router.dispatch(SyncControl.AccessChanged) shouldBe false
+                router.dispatch(SyncControl.LibraryDataChanged) shouldBe false
+            }
+        }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -73,7 +73,9 @@ class SyncDomainCompletenessSpec :
             }
         }
 
-        test("refreshed tier claims exactly the four fold-candidate controls, distinct and disjoint from engine controls") {
+        test(
+            "refreshed tier claims exactly the four fold-candidate controls, distinct and disjoint from engine controls",
+        ) {
             val db = createInMemoryTestDatabase()
             try {
                 val catalog =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.dto.auth.AuthSession
 import com.calypsan.listenup.api.dto.auth.RegisterRequest
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.DomainList
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
@@ -14,6 +15,7 @@ import com.calypsan.listenup.client.test.stubImageStorage
 import com.calypsan.listenup.server.module
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContainAnyOf
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -57,11 +59,60 @@ class SyncDomainCompletenessSpec :
                         imageStorage = stubImageStorage(),
                         authSession = FakeAuthSession(userId = "spec-user"),
                         avatarDownloadRepository = StubAvatarDownloadRepository(),
+                        pingPresence = {},
+                        pingActivity = {},
+                        refetchServerInfo = {},
+                        refetchPreferences = {},
                     )
                 val catalogNames = catalog.mirrored.map { it.key.name }
 
                 catalogNames.toSet() shouldHaveSize catalogNames.size
                 catalogNames.toSet() shouldBe SyncDomains.all.map { it.name }.toSet()
+            } finally {
+                db.close()
+            }
+        }
+
+        test("refreshed tier claims exactly the four fold-candidate controls, distinct and disjoint from engine controls") {
+            val db = createInMemoryTestDatabase()
+            try {
+                val catalog =
+                    syncDomainCatalog(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                        authSession = FakeAuthSession(userId = "spec-user"),
+                        avatarDownloadRepository = StubAvatarDownloadRepository(),
+                        pingPresence = {},
+                        pingActivity = {},
+                        refetchServerInfo = {},
+                        refetchPreferences = {},
+                    )
+
+                val triggers = catalog.refreshed.map { it.trigger }
+
+                // Distinct — no two refreshed domains claim the same control (else the
+                // router's KClass map would silently drop one).
+                triggers.toSet() shouldHaveSize triggers.size
+
+                // Exactly the four fold-candidate nudges.
+                triggers.toSet() shouldBe
+                    setOf(
+                        SyncControl.ActiveSessionsChanged::class,
+                        SyncControl.ActivityChanged::class,
+                        SyncControl.ServerInfoChanged::class,
+                        SyncControl.PreferencesChanged::class,
+                    )
+
+                // Disjoint from the engine/lifecycle controls the dispatcher owns.
+                triggers shouldNotContainAnyOf
+                    listOf(
+                        SyncControl.CursorStale::class,
+                        SyncControl.StreamError::class,
+                        SyncControl.AccessChanged::class,
+                        SyncControl.UserDeleted::class,
+                        SyncControl.LibraryDataChanged::class,
+                    )
             } finally {
                 db.close()
             }


### PR DESCRIPTION
Folds the four content-free re-fetch nudges into the declarative sync catalog as a second `ClientSyncDomain` variant, `RefreshedDomain`, deleting the four ad-hoc nudge lambdas from `ClientSyncModule`.

## What changed
- **`RefreshStrategy`** (`Ping` / `Refetch`) + **`RefreshedDomain(trigger, refresh)`** descriptor + **`RefreshedDomainRouter`** — matches a nudge `SyncControl` by its runtime class and runs the declared strategy (`Refetch` is best-effort: re-throws `CancellationException`, swallows+logs the rest, codifying `primeActivityFeedSafely`).
- **Catalog** gains a `refreshed` list (four factories: presence/activity = `Ping`, server-info/preferences = `Refetch`); `syncDomainCatalog(...)` takes four lambda params, wired at the DI boundary.
- **`SyncEventDispatcher`** routes nudges via `refreshedRouter.dispatch(control)` first, keeping an **exhaustive `when`** over all 9 `SyncControl` variants (nudges in a safety-net branch) so a new variant forces a compile-time decision. The five engine/lifecycle controls (`CursorStale`, `StreamError`, `AccessChanged`, `UserDeleted`, `LibraryDataChanged`) keep their explicit callbacks.

## Scope / safety
- Behavior-preserving: same signals pinged, same repos re-fetched, same best-effort swallow. Server-side nudge emission (7 call sites) untouched. No `:contract` change → no Swift-Export baseline regen.
- New types are `internal`. `refreshedRouter` defaults to an empty router, so the ~13 other `SyncEventDispatcher(` test construction sites are untouched.
- `SyncDomainCompletenessSpec` gains an assertion that the four refreshed triggers are distinct and disjoint from the engine controls.

## Tests / gate
- `RefreshedDomainRouterTest` (5, incl. cancellation-propagates), `SyncEventDispatcherTest` (11), `SyncDomainCompletenessSpec` (3), `ClientSyncModuleVerifyTest` (1) — all green.
- Local Linux gate green: `spotlessCheck detekt :sharedLogic:compileCommonMainKotlinMetadata :sharedLogic:jvmTest :sharedLogic:testAndroidHostTest :androidApp:assembleDebug`.

Phase 3 of the unified-sync-domains arc. Every task implementer + spec-review + quality-review, all approved.