### PR TITLE
✅ test(quality): make E2E auto-retries visible — ledger + CI summary + per-spec budget (plan 064)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,32 @@ jobs:
       - name: Run JVM tests
         run: ./gradlew :sharedLogic:compileCommonMainKotlinMetadata :contract:jvmTest :sharedLogic:jvmTest :sharedLogic:testAndroidHostTest :server:jvmTest :sharedUI:testAndroidHostTest :build-logic:convention:test --no-daemon
 
+      # The E2E retry extensions (sharedLogic + server ProjectConfig) absorb transient
+      # failures, so a flaking spec can trend worse while runs stay green. Each retry is
+      # appended to <module>/build/e2e-retries.log; surface it in the job summary so
+      # retries are visible per-PR without failing the build. The RetryExtensionProbe
+      # specs retry BY DESIGN every run — filtered out so the summary is signal-only.
+      - name: Report E2E auto-retries in job summary
+        if: always()
+        run: |
+          found=0
+          for f in sharedLogic/build/e2e-retries.log server/build/e2e-retries.log; do
+            [ -f "$f" ] || continue
+            entries=$(grep -v 'RetryExtensionProbeE2ETest' "$f" || true)
+            [ -n "$entries" ] || continue
+            if [ "$found" -eq 0 ]; then
+              echo '## E2E auto-retries (absorbed by the retry extension)' >> "$GITHUB_STEP_SUMMARY"
+              found=1
+            fi
+            echo "**\`$f\`**" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$entries" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo 'No E2E auto-retries recorded (probe retries excluded).'
+          fi
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()
@@ -113,6 +139,8 @@ jobs:
           path: |
             sharedLogic/build/reports/tests/
             server/build/reports/tests/
+            sharedLogic/build/e2e-retries.log
+            server/build/e2e-retries.log
           retention-days: 7
 
   test-ios:

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -367,12 +367,23 @@ tasks.named<Test>("jvmTest") {
             .get()
             .asFile
     systemProperty("java.io.tmpdir", testTmpDir.absolutePath)
+    // Pin the E2E retry ledger (written by FlakyServerSpecRetryExtension) to an absolute path under
+    // this module's build/ — the redirected workingDir above would otherwise land it under
+    // build/test-cwd/build/, where the CI summary + artifact steps don't look.
+    val e2eRetryLedger = layout.buildDirectory.file("e2e-retries.log").get().asFile
+    systemProperty("listenup.e2eRetryLedger", e2eRetryLedger.absolutePath)
     // Wipe and recreate before each run: starts every run from empty (bounding disk use) and
     // reclaims leftovers from any previous run whose workers were force-killed.
     doFirst {
         workingDir.mkdirs()
         testTmpDir.deleteRecursively()
         testTmpDir.mkdirs()
+        // Truncate the retry ledger ONCE per task run, before any worker forks. This task recycles
+        // its worker JVM every 25 classes (setForkEvery above), and the retry extension's
+        // beforeProject fires per-worker — so the extension only ever APPENDS; if it truncated, each
+        // fresh worker would wipe the previous worker's retries and the ledger would keep only the
+        // last batch. Truncating here (pre-fork, once) lets every worker's appends accumulate.
+        e2eRetryLedger.delete()
     }
 }
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testinfra/RetryExtensionProbeE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testinfra/RetryExtensionProbeE2ETest.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.server.testinfra
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Proves the `:server` project-level retry extension (`FlakyServerSpecRetryExtension` in
+ * `io.kotest.provided.ProjectConfig`) actually re-executes a transiently-failing leaf test **and**
+ * records that retry in the machine-readable ledger.
+ *
+ * This spec's name ends in `E2ETest`, so the extension is in scope. The first test's body fails on
+ * its **first** invocation and passes on the **second**; the only way it reports green is if the
+ * extension caught the first failure and re-ran the body. The second test then asserts that the
+ * retry left a line in `build/e2e-retries.log` carrying the spec, the test name, `attempt=2/3`, and
+ * the original failure — so the ledger (surfaced in CI and the input for future de-flaking) can
+ * never silently stop recording. If the retry mechanism ever regresses (removed, mis-scoped, attempt
+ * budget < 2) or stops writing the ledger, this probe goes red — it is the regression guard for the
+ * retry feature itself. Coverage is unchanged: a test that fails *every* attempt still fails.
+ */
+class RetryExtensionProbeE2ETest :
+    FunSpec({
+        test("a transient first-attempt failure is retried to success") {
+            val attempt = attempts.incrementAndGet()
+            // Green only on the retry — the first attempt asserts false on purpose.
+            (attempt >= 2) shouldBe true
+        }
+
+        test("the retry is recorded in the machine-readable ledger") {
+            // Written by FlakyServerSpecRetryExtension at retry time; resolve the path via the same
+            // Gradle-provided `listenup.e2eRetryLedger` system property the extension uses, so this
+            // is independent of the Test task's workingDir (`:server:jvmTest` redirects it under
+            // build/test-cwd).
+            val ledger = File(System.getProperty("listenup.e2eRetryLedger") ?: "build/e2e-retries.log")
+            ledger.exists() shouldBe true
+            val probeLines = ledger.readLines().filter { it.contains("RetryExtensionProbeE2ETest") }
+            probeLines.shouldNotBeEmpty()
+            val entry = probeLines.first()
+            entry shouldContain "a transient first-attempt failure is retried to success"
+            entry shouldContain "attempt=2/3"
+            // The ledger must carry the ORIGINAL failure, not just the fact of a retry.
+            // Kotest's shouldBe throws org.opentest4j.AssertionFailedError.
+            entry shouldContain "AssertionFailedError"
+        }
+    }) {
+    private companion object {
+        val attempts = AtomicInteger(0)
+    }
+}

--- a/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -3,9 +3,14 @@ package io.kotest.provided
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.listeners.AfterProjectListener
+import io.kotest.core.listeners.BeforeProjectListener
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
 import io.kotest.engine.test.TestResult
+import java.io.File
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -47,12 +52,83 @@ class ProjectConfig : AbstractProjectConfig() {
  * A short [RETRY_DELAY_MS] between attempts lets the previous attempt's async teardown (the
  * `testApplication` shutdown, the port unbind, the connection-pool drain) settle before the retry
  * boots its own server — otherwise the retry can hit the very contention it is recovering from.
+ *
+ * **The retry is visible, never silent.** Every retry attempt is appended to `build/e2e-retries.log`
+ * (a per-run ledger, truncated in [beforeProject]), which CI cats into the `test-jvm` job summary and
+ * uploads with the test-results artifact — so a flake that the retry absorbs still leaves a durable,
+ * greppable trace instead of a `println` buried in a green run's log.
+ *
+ * **The budget turns a worsening flake red.** [afterProject] fails the run if any spec burned retries
+ * on more than [MAX_RETRIED_TESTS_PER_SPEC] distinct leaf tests — because the retry math is
+ * unforgiving: a genuinely 50%-flaky test passes a 3-attempt retry with probability 1 − 0.5³ ≈ 87.5%,
+ * so absent a ceiling a slowly-worsening spec (including the two named [FLAKY_SPEC_NAMES], which are
+ * exactly "diagnosed but not root-fixed") stays invisibly green. The budget is a trend-to-failure
+ * guard, not instant strictness: one stubbornly-retried test never trips it.
  */
-private object FlakyServerSpecRetryExtension : TestCaseExtension {
+private object FlakyServerSpecRetryExtension :
+    TestCaseExtension,
+    BeforeProjectListener,
+    AfterProjectListener {
     private const val MAX_ATTEMPTS = 3
     private const val RETRY_DELAY_MS = 750L
     private val FLAKY_SPEC_NAMES = setOf("RestoreOrchestratorTest", "LibraryFolderSyncAccessTest")
     private val FLAKY_SPEC_SUFFIXES = listOf("E2ETest", "EndToEndTest")
+
+    /**
+     * Trend-to-failure guard, not instant strictness: a spec may burn retries on up to this many
+     * DISTINCT leaf tests in one run. Beyond it the run fails — a spec that flaky is no longer a
+     * "residual timing tail", it is a worsening defect the retry would otherwise keep absorbing (a
+     * 50%-flaky test passes 3 attempts ~87.5% of the time). Raise only with a ledger-backed argument.
+     */
+    private const val MAX_RETRIED_TESTS_PER_SPEC = 3
+
+    /** Longest error one-liner recorded per ledger entry. */
+    private const val MAX_ERROR_CHARS = 300
+
+    /**
+     * Machine-readable retry ledger, one line per retry ATTEMPT:
+     * `<ISO-8601 UTC>\t<spec>\t<test>\tattempt=<n>/<max>\t<original failure one-liner>`.
+     * Location is provided by the Gradle `jvmTest` task via the `listenup.e2eRetryLedger` system
+     * property (an absolute path under this module's `build/`), so it is independent of the Test
+     * task's `workingDir` — `:server:jvmTest` redirects that dir under `build/test-cwd`, which a
+     * bare relative path would follow. The `build/e2e-retries.log` fallback keeps ad-hoc IDE runs
+     * working.
+     *
+     * This extension is strictly **append-only** — the ledger is truncated once per task run by the
+     * Gradle test task's `doFirst`, before any worker forks. `:server:jvmTest` recycles its worker
+     * JVM every 25 classes (`setForkEvery(25)`), so [beforeProject] fires once per worker; if it
+     * truncated, each fresh worker would wipe the previous worker's retries and only the last batch
+     * would survive. Truncating in Gradle (pre-fork, once) lets every worker's appends accumulate.
+     * Workers run sequentially (no `maxParallelForks`) and each line is a single `O_APPEND` write, so
+     * appends from successive workers never interleave or clobber. CI cats the accumulated ledger
+     * into the job summary and uploads it with the test-results artifact.
+     */
+    private val ledgerFile = File(System.getProperty("listenup.e2eRetryLedger") ?: "build/e2e-retries.log")
+
+    private val retriedTestsBySpec = ConcurrentHashMap<String, MutableSet<String>>()
+
+    override suspend fun beforeProject() {
+        retriedTestsBySpec.clear()
+        ledgerFile.parentFile?.mkdirs()
+    }
+
+    override suspend fun afterProject() {
+        // Per-worker in-memory accounting is still complete PER SPEC: Gradle assigns a whole test
+        // class to one worker, so every leaf of a given spec (and thus its full retry set) runs in the
+        // JVM whose afterProject checks it — a spec never straddles workers.
+        val overBudget = retriedTestsBySpec.filterValues { it.size > MAX_RETRIED_TESTS_PER_SPEC }
+        if (overBudget.isNotEmpty()) {
+            val detail =
+                overBudget.entries.joinToString("; ") { (spec, tests) ->
+                    "$spec retried ${tests.size} distinct tests (budget $MAX_RETRIED_TESTS_PER_SPEC): ${tests.sorted()}"
+                }
+            throw AssertionError(
+                "E2E retry budget exceeded — $detail. " +
+                    "The auto-retry is masking a worsening flake; root-cause it (ledger: ${ledgerFile.path}) " +
+                    "or raise MAX_RETRIED_TESTS_PER_SPEC with justification.",
+            )
+        }
+    }
 
     override suspend fun intercept(
         testCase: TestCase,
@@ -64,6 +140,7 @@ private object FlakyServerSpecRetryExtension : TestCaseExtension {
         var attempt = 1
         while (attempt < MAX_ATTEMPTS && result.isErrorOrFailure) {
             attempt++
+            recordRetry(testCase, attempt, result)
             println(
                 "[FLAKY-RETRY] ${testCase.spec::class.simpleName} › ${testCase.name.name} " +
                     "failed transiently; retry $attempt/$MAX_ATTEMPTS",
@@ -73,6 +150,37 @@ private object FlakyServerSpecRetryExtension : TestCaseExtension {
         }
         return result
     }
+
+    /** Appends one ledger line recording the ORIGINAL failure that triggered this retry. */
+    private fun recordRetry(
+        testCase: TestCase,
+        attempt: Int,
+        failed: TestResult,
+    ) {
+        val specName = testCase.spec::class.simpleName ?: "UnknownSpec"
+        val testName = testCase.name.name.singleLine()
+        val error =
+            failed.errorOrNull
+                ?.let { "${it::class.simpleName}: ${it.message}" }
+                .orEmpty()
+                .ifBlank { "unknown error" }
+                .singleLine()
+                .take(MAX_ERROR_CHARS)
+        retriedTestsBySpec.getOrPut(specName) { ConcurrentHashMap.newKeySet() }.add(testName)
+        val line =
+            listOf(
+                Instant.now().toString(),
+                specName,
+                testName,
+                "attempt=$attempt/$MAX_ATTEMPTS",
+                error,
+            ).joinToString(separator = "\t", postfix = "\n")
+        synchronized(ledgerFile) {
+            ledgerFile.appendText(line)
+        }
+    }
+
+    private fun String.singleLine(): String = replace(Regex("""\s+"""), " ").trim()
 
     private fun isFlakyLeaf(testCase: TestCase): Boolean {
         if (testCase.type != TestType.Test) return false

--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -182,6 +182,22 @@ tasks.named<Test>("jvmTest") {
     // worker, and the Konsist architectural rules, which hold a single shared PSI scope of the whole
     // production tree (~1.5k files) for the lifetime of the run (see konsist/KonsistScope.kt).
     maxHeapSize = "4g"
+    // Pin the E2E retry ledger (written by HeavyweightE2ERetryExtension) to an absolute path under
+    // this module's build/, so its location is workingDir-independent and identical in shape to the
+    // server's — CI reads sharedLogic/build/e2e-retries.log.
+    val e2eRetryLedger =
+        layout.buildDirectory
+            .file("e2e-retries.log")
+            .get()
+            .asFile
+    systemProperty("listenup.e2eRetryLedger", e2eRetryLedger.absolutePath)
+    // Truncate the ledger ONCE per task run so the retry extension is purely append-only — identical
+    // model to :server:jvmTest (which forks workers every 25 classes and must not truncate per-worker).
+    // This module runs a single non-forked worker, but keeping both on the same append-only contract
+    // means the extension code is byte-identical and can't drift.
+    doFirst {
+        e2eRetryLedger.delete()
+    }
 }
 
 // androidHostTest compiles commonTest sources (which include Konsist rules) but is not part

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/testinfra/RetryExtensionProbeE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/testinfra/RetryExtensionProbeE2ETest.kt
@@ -1,18 +1,25 @@
 package com.calypsan.listenup.client.testinfra
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Proves the project-level heavyweight-E2E retry extension (in `io.kotest.provided.ProjectConfig`)
- * actually re-executes a transiently-failing leaf test.
+ * actually re-executes a transiently-failing leaf test **and** records that retry in the
+ * machine-readable ledger.
  *
- * This spec's name ends in `E2ETest`, so the extension is in scope. The body fails on its **first**
- * invocation and passes on the **second**; the only way the test reports green is if the extension
- * caught the first failure and re-ran the body. If the retry mechanism ever regresses (removed,
- * mis-scoped, attempt budget < 2), this probe goes red — it is the regression guard for the retry
- * feature itself. Coverage is unchanged: a test that fails *every* attempt still fails.
+ * This spec's name ends in `E2ETest`, so the extension is in scope. The first test's body fails on
+ * its **first** invocation and passes on the **second**; the only way it reports green is if the
+ * extension caught the first failure and re-ran the body. The second test then asserts that the
+ * retry left a line in `build/e2e-retries.log` carrying the spec, the test name, `attempt=2/3`, and
+ * the original failure — so the ledger (surfaced in CI and the input for future de-flaking) can
+ * never silently stop recording. If the retry mechanism ever regresses (removed, mis-scoped, attempt
+ * budget < 2) or stops writing the ledger, this probe goes red — it is the regression guard for the
+ * retry feature itself. Coverage is unchanged: a test that fails *every* attempt still fails.
  */
 class RetryExtensionProbeE2ETest :
     FunSpec({
@@ -20,6 +27,22 @@ class RetryExtensionProbeE2ETest :
             val attempt = attempts.incrementAndGet()
             // Green only on the retry — the first attempt asserts false on purpose.
             (attempt >= 2) shouldBe true
+        }
+
+        test("the retry is recorded in the machine-readable ledger") {
+            // Written by HeavyweightE2ERetryExtension at retry time; resolve the path via the same
+            // Gradle-provided `listenup.e2eRetryLedger` system property the extension uses, so this
+            // is independent of the Test task's workingDir.
+            val ledger = File(System.getProperty("listenup.e2eRetryLedger") ?: "build/e2e-retries.log")
+            ledger.exists() shouldBe true
+            val probeLines = ledger.readLines().filter { it.contains("RetryExtensionProbeE2ETest") }
+            probeLines.shouldNotBeEmpty()
+            val entry = probeLines.first()
+            entry shouldContain "a transient first-attempt failure is retried to success"
+            entry shouldContain "attempt=2/3"
+            // The ledger must carry the ORIGINAL failure, not just the fact of a retry.
+            // Kotest's shouldBe throws org.opentest4j.AssertionFailedError.
+            entry shouldContain "AssertionFailedError"
         }
     }) {
     private companion object {

--- a/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -3,13 +3,18 @@ package io.kotest.provided
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.listeners.AfterProjectListener
 import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.BeforeProjectListener
 import io.kotest.core.listeners.BeforeSpecListener
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
 import io.kotest.engine.test.TestResult
+import java.io.File
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.delay
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.stopKoin
@@ -95,11 +100,79 @@ private object GlobalKoinIsolationListener :
  * Between attempts the global Koin context is stopped and a short [RETRY_DELAY_MS] elapses, giving any
  * late async `stopKoin()` from the failed attempt time to drain — otherwise the retry's
  * `install(Koin)` could hit "Koin already started" and fail deterministically.
+ *
+ * **The retry is visible, never silent.** Every retry attempt is appended to `build/e2e-retries.log`
+ * (a per-run ledger, truncated in [beforeProject]), which CI cats into the `test-jvm` job summary and
+ * uploads with the test-results artifact — so a flake that the retry absorbs still leaves a durable,
+ * greppable trace instead of a `println` buried in a green run's log.
+ *
+ * **The budget turns a worsening flake red.** [afterProject] fails the run if any spec burned retries
+ * on more than [MAX_RETRIED_TESTS_PER_SPEC] distinct leaf tests — because the retry math is
+ * unforgiving: a genuinely 50%-flaky test passes a 3-attempt retry with probability 1 − 0.5³ ≈ 87.5%,
+ * so absent a ceiling a slowly-worsening spec stays invisibly green. The budget is a trend-to-failure
+ * guard, not instant strictness: one stubbornly-retried test never trips it.
  */
-private object HeavyweightE2ERetryExtension : TestCaseExtension {
+private object HeavyweightE2ERetryExtension :
+    TestCaseExtension,
+    BeforeProjectListener,
+    AfterProjectListener {
     private const val MAX_ATTEMPTS = 3
     private const val RETRY_DELAY_MS = 500L
     private val E2E_SPEC_SUFFIXES = listOf("E2ETest", "EndToEndTest")
+
+    /**
+     * Trend-to-failure guard, not instant strictness: a spec may burn retries on up to this many
+     * DISTINCT leaf tests in one run. Beyond it the run fails — a spec that flaky is no longer a
+     * "residual timing tail", it is a worsening defect the retry would otherwise keep absorbing (a
+     * 50%-flaky test passes 3 attempts ~87.5% of the time). Raise only with a ledger-backed argument.
+     */
+    private const val MAX_RETRIED_TESTS_PER_SPEC = 3
+
+    /** Longest error one-liner recorded per ledger entry. */
+    private const val MAX_ERROR_CHARS = 300
+
+    /**
+     * Machine-readable retry ledger, one line per retry ATTEMPT:
+     * `<ISO-8601 UTC>\t<spec>\t<test>\tattempt=<n>/<max>\t<original failure one-liner>`.
+     * Location is provided by the Gradle `jvmTest` task via the `listenup.e2eRetryLedger` system
+     * property (an absolute path under this module's `build/`), so it is independent of the Test
+     * task's `workingDir` — `:server:jvmTest` redirects that dir under `build/test-cwd`, which a
+     * bare relative path would follow. The `build/e2e-retries.log` fallback keeps ad-hoc IDE runs
+     * working.
+     *
+     * This extension is strictly **append-only** — the ledger is truncated once per task run by the
+     * Gradle test task's `doFirst`, before any worker forks. `:sharedLogic:jvmTest` runs a single
+     * non-forked worker, but `:server:jvmTest` recycles its worker every 25 classes, so truncating in
+     * [beforeProject] (which fires per-worker) would wipe earlier workers' retries there. Keeping both
+     * extensions append-only with Gradle-side truncation makes them byte-identical and drift-proof.
+     * CI cats the accumulated ledger into the job summary and uploads it with the test-results artifact.
+     */
+    private val ledgerFile = File(System.getProperty("listenup.e2eRetryLedger") ?: "build/e2e-retries.log")
+
+    private val retriedTestsBySpec = ConcurrentHashMap<String, MutableSet<String>>()
+
+    override suspend fun beforeProject() {
+        retriedTestsBySpec.clear()
+        ledgerFile.parentFile?.mkdirs()
+    }
+
+    override suspend fun afterProject() {
+        // Per-worker in-memory accounting is still complete PER SPEC: Gradle assigns a whole test
+        // class to one worker, so every leaf of a given spec (and thus its full retry set) runs in the
+        // JVM whose afterProject checks it — a spec never straddles workers.
+        val overBudget = retriedTestsBySpec.filterValues { it.size > MAX_RETRIED_TESTS_PER_SPEC }
+        if (overBudget.isNotEmpty()) {
+            val detail =
+                overBudget.entries.joinToString("; ") { (spec, tests) ->
+                    "$spec retried ${tests.size} distinct tests (budget $MAX_RETRIED_TESTS_PER_SPEC): ${tests.sorted()}"
+                }
+            throw AssertionError(
+                "E2E retry budget exceeded — $detail. " +
+                    "The auto-retry is masking a worsening flake; root-cause it (ledger: ${ledgerFile.path}) " +
+                    "or raise MAX_RETRIED_TESTS_PER_SPEC with justification.",
+            )
+        }
+    }
 
     override suspend fun intercept(
         testCase: TestCase,
@@ -111,6 +184,7 @@ private object HeavyweightE2ERetryExtension : TestCaseExtension {
         var attempt = 1
         while (attempt < MAX_ATTEMPTS && result.isErrorOrFailure) {
             attempt++
+            recordRetry(testCase, attempt, result)
             println(
                 "[E2E-RETRY] ${testCase.spec::class.simpleName} › ${testCase.name.name} " +
                     "failed transiently; retry $attempt/$MAX_ATTEMPTS",
@@ -121,6 +195,37 @@ private object HeavyweightE2ERetryExtension : TestCaseExtension {
         }
         return result
     }
+
+    /** Appends one ledger line recording the ORIGINAL failure that triggered this retry. */
+    private fun recordRetry(
+        testCase: TestCase,
+        attempt: Int,
+        failed: TestResult,
+    ) {
+        val specName = testCase.spec::class.simpleName ?: "UnknownSpec"
+        val testName = testCase.name.name.singleLine()
+        val error =
+            failed.errorOrNull
+                ?.let { "${it::class.simpleName}: ${it.message}" }
+                .orEmpty()
+                .ifBlank { "unknown error" }
+                .singleLine()
+                .take(MAX_ERROR_CHARS)
+        retriedTestsBySpec.getOrPut(specName) { ConcurrentHashMap.newKeySet() }.add(testName)
+        val line =
+            listOf(
+                Instant.now().toString(),
+                specName,
+                testName,
+                "attempt=$attempt/$MAX_ATTEMPTS",
+                error,
+            ).joinToString(separator = "\t", postfix = "\n")
+        synchronized(ledgerFile) {
+            ledgerFile.appendText(line)
+        }
+    }
+
+    private fun String.singleLine(): String = replace(Regex("""\s+"""), " ").trim()
 
     private fun isHeavyweightE2ELeaf(testCase: TestCase): Boolean {
         if (testCase.type != TestType.Test) return false


### PR DESCRIPTION
Both JVM test modules auto-retry failing leaf tests in `*E2ETest`/`*EndToEndTest` specs (and two named server specs) up to 3× to absorb the CI runner's async-teardown timing tail. That retry was invisible — a lone `println` in Gradle output — so a slowly-worsening flake stayed structurally hidden (a 50%-flaky test passes 3 attempts ~87.5% of the time). This makes retries **visible and trend-able** without removing the retry itself.

## What changed
- **Machine-readable ledger.** Every retry appends one tab-separated line (`ISO-8601 UTC · spec · test · attempt=n/max · original-failure-one-liner`) to `<module>/build/e2e-retries.log`, carrying the *original* failure, not just the fact of a retry.
- **CI job summary + artifact.** A new `if: always()` step in `test-jvm` surfaces retries per-PR in the job summary (probe entries filtered out), and both ledgers ride the test-results artifact so retries trend across runs.
- **Per-spec retry budget.** `afterProject` fails the run if any spec burns retries on >3 distinct leaf tests — a trend-to-failure guard so a worsening flake turns red instead of being absorbed indefinitely.
- **Server mirror + probe.** `:server` gets the same ledger/budget in `FlakyServerSpecRetryExtension` and a new `RetryExtensionProbeE2ETest` regression guard (it had none).

## Two plan-assumption corrections (verified on-disk)
1. **Ledger location.** `:server:jvmTest` redirects its `workingDir` under `build/test-cwd`, so a relative path missed the CI location. The ledger path is now injected as an absolute path via a Gradle `systemProperty("listenup.e2eRetryLedger", …)` (same idiom the task already uses for `java.io.tmpdir`); both extensions + probes resolve it identically, with a `build/e2e-retries.log` fallback for ad-hoc IDE runs.
2. **Fork-safe truncation.** `:server:jvmTest` sets `setForkEvery(25)`, so the extension's `beforeProject` fires per worker JVM — truncating there wiped earlier workers' retries. Truncation now happens **once** in the Gradle task's `doFirst` (pre-fork) and both extensions are strictly **append-only**. Per-spec budget accounting stays correct because Gradle keeps a whole spec class in one worker.

## Verification
- Full `:sharedLogic:jvmTest` + `:server:jvmTest`: green except one unrelated load-flake (`DemoProfileBootTest`, an `eventually` HTTP timeout under concurrent load; passes isolated, not retry-covered).
- `spotlessCheck` + `detekt` clean.
- Both ledgers **persist and accumulate across forked workers** in a real full run (captured the probe plus two genuine absorbed E2E flakes).
- Budget-trip verified via a throwaway 4-flaky-test fixture (`afterProject` failed the run), then deleted.