### PR TITLE
📝 docs: fix stale CLAUDE.md/README references + drop orphan module dirs (plan 066)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 # Generated localization files
-composeApp/src/commonMain/composeResources/values/strings.xml
-composeApp/src/commonMain/composeResources/values-*/strings.xml
 iosApp/ListenUp/Resources/*.lproj/Localizable.strings
 iosApp/iosApp/Resources/*.lproj/Localizable.strings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The SOUL's principles are not separate from the technical rules. They ARE the te
 - **"Honest over silent"** → the Error Model rule: re-throw `CancellationException`, never swallow exceptions, surface errors with `AppResult<T>` — because software that lies by omission is the deepest failure.
 - **"Never stranded"** → the Single Source of Truth rule: Room is the only read path, writes always flow through Room — because the user must never be left with stale state and no path forward.
 - **"Seamless over clever"** → the `stateIn(WhileSubscribed)` + sealed UiState rules: no illegal state combinations, no subscription-lifetime races, no cross-book contamination — because the moment the user notices a glitch, the story is broken.
-- **"Adaptive, not ported"** → the shared presentation layer: ViewModels in `shared/presentation/`, one set of UI state types, window-size-class-driven layouts — because desktop work IS Android work.
+- **"Adaptive, not ported"** → the shared presentation layer: ViewModels in `sharedLogic/.../presentation/`, one set of UI state types, window-size-class-driven layouts — because desktop work IS Android work.
 
 ---
 
@@ -182,7 +182,7 @@ Strict Kotlin everywhere. Types are not a formality — they are the first layer
 These are the rules most likely to affect day-to-day work.
 
 - **`AppResult<T>`** is the single result type for every fallible suspend function. See *Error Architecture* below.
-- **Always re-throw `CancellationException`** in catch blocks. `SyncManager` and `SearchRepositoryImpl` are the compliance references.
+- **Always re-throw `CancellationException`** in catch blocks. `SyncEngine` and `SearchRepositoryImpl` are the compliance references.
 - **ViewModels produce state via `.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue)`**, not via `init { viewModelScope.launch { collect { state.update { } } } }`.
 - **UI state is a per-screen sealed hierarchy**, not a flat `data class` with `error: String?`.
 - **One-shot events use `Channel<Event>(Channel.BUFFERED).receiveAsFlow()`** — never `StateFlow<Event?>`.
@@ -194,7 +194,7 @@ These are the rules most likely to affect day-to-day work.
 
 Day-to-day rules:
 
-- **Fallible suspend functions return `AppResult<T>`** (`shared/.../client/core/AppResult.kt`). Not `Result<T>`, not `throw`. A small set of un-migrated APIs still throws; those files are tracked in `NoThrowsInDataLayerRule`'s `RESIDUAL_THROWS_ALLOWLIST` and migrate opportunistically as the in-place rewrite re-touches each domain.
+- **Fallible suspend functions return `AppResult<T>`** (`contract/.../api/result/AppResult.kt`). Not `Result<T>`, not `throw`. A small set of un-migrated APIs still throws; those files are tracked in `NoThrowsInDataLayerRule`'s `RESIDUAL_THROWS_ALLOWLIST` and migrate opportunistically as the in-place rewrite re-touches each domain.
 - **Data-layer APIs use `apiCall { ... }` / `apiCallUnit { ... }`** (in `data/remote/ApiCallHelper.kt`) at the request boundary. The Ktor plugin (`installListenUpErrorHandling`, `expectSuccess = true`) raises `ResponseException` on non-2xx; `apiCall` catches it via `suspendRunCatching` and routes through `ErrorMapper` to a typed `AppResult.Failure`. API method bodies are just request shape + a `.map { it.toDomain() }` transform on success.
 - **Errors are typed `AppError` subtypes** in `commonMain api.error.*` — `@Serializable`. Hierarchy: `AppError`, `AuthError`, `TransportError`, `SyncError`, `ScanError`, `DownloadError`, `ImportError`, `ServerConnectError`. Every subtype carries `correlationId`, `message`, `code`, `isRetryable`, `debugInfo`.
 - **`message` is a body-level constant per subtype** — user-facing-quality, period-terminated, no jargon. Per-instance technical detail goes in `debugInfo`. UI consumes `message` directly; logs consume `debugInfo`.
@@ -227,7 +227,7 @@ JS export is opt-in (`@JsExport`) — never blanket-export. The macOS CI `Test (
 ## Commits
 
 - **Gitmoji prefix, always.** Every commit starts with a gitmoji (e.g., `✨`, `🐛`, `♻️`, `📦`, `🚨`, `👷`, `🎨`, `📝`, `✅`). See [gitmoji.dev](https://gitmoji.dev) for the full list.
-- **Conventional `type(scope):` for domain clarity.** When the change is in a clear domain, follow the gitmoji with a Conventional Commits prefix: `<gitmoji> <type>(<scope>): <subject>`. The repo has multiple domains — `server`, `shared`, `composeApp`, `androidApp`, `desktopApp`, `ci`, `quality`, `docs` — and the scope makes it obvious at a glance which one a commit touches.
+- **Conventional `type(scope):` for domain clarity.** When the change is in a clear domain, follow the gitmoji with a Conventional Commits prefix: `<gitmoji> <type>(<scope>): <subject>`. The repo has multiple domains — `server`, `shared`, `sharedUI`, `contract`, `androidApp`, `iosApp`, `desktopApp`, `ci`, `quality`, `docs` — and the scope makes it obvious at a glance which one a commit touches.
   - Examples: `📦 chore(server): include :server module in settings.gradle.kts` · `✨ feat(server): GET /healthz endpoint with Kotest contract test` · `🐛 fix(shared): re-enqueue position events on WAITING_FOR_SERVER` · `🚨 chore(quality): extend Detekt source.setFrom to :server` · `👷 ci(server): build and test :server module on every PR`.
   - Common types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `perf`, `style`. Pick the one that matches the dominant intent.
 - **Bare gitmoji is fine for cross-cutting trivia** that doesn't belong to a single domain — formatting sweeps, dependency bumps, gitignore tweaks. Example: `🎨 spotless apply across repo`.
@@ -287,7 +287,7 @@ client/
 ├── sharedLogic/                # KMP shared core (no UI)
 │   └── src/
 │       ├── commonMain/.../
-│       │   ├── core/           # AppResult, value types, utilities
+│       │   ├── core/           # Utilities — ResultCatching, Flow extensions, error plumbing (AppResult lives in :contract)
 │       │   ├── data/           # Repositories, sync, Room DAOs
 │       │   ├── di/             # Koin module definitions
 │       │   ├── domain/         # Domain models, repository interfaces

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Beta ships on the two platforms below; more are on the way.
 | Android  | ✅ Beta | Media3 / ExoPlayer |
 | iOS      | ✅ Beta | AVFoundation |
 
-**Coming soon:** Desktop (JVM and native macOS) and" Android TV — both already build from this codebase and will graduate to supported releases after the mobile beta settles. Other platforms to be integrated soon.
+**In development (not currently shipping):** Desktop (JVM and native macOS) and Android TV both build from this codebase, but the shipping focus is iOS and Android — desktop will be shored up and rebuilt later. Other platforms to follow.
 
 ## Getting the Beta
 
@@ -87,7 +87,15 @@ The ListenUp server lives in this repository as the `:server` module — there's
 ./gradlew :server:runJvm
 ```
 
-It serves on port `8080` by default. Point the app at `http://<your-host>:8080` (or rely on mDNS on the same network) and sign in. See [`server/`](server/) for configuration and deployment details.
+It serves on port `8080` by default. Point the app at `http://<your-host>:8080` (or rely on mDNS on the same network) and sign in. See the docs site for [installation (Docker)](https://listenup.audio/getting-started/installation/), [configuration](https://listenup.audio/server/configuration/), [backups](https://listenup.audio/server/backups/), and [reverse proxy / HTTPS](https://listenup.audio/server/reverse-proxy/).
+
+### Demo server
+
+Want to try ListenUp without pointing it at a real collection? The build can generate a small synthetic audiobook library and boot a seeded demo server against it (requires `ffmpeg`):
+
+```bash
+./gradlew :server:runDemo
+```
 
 ## Building From Source
 
@@ -95,7 +103,7 @@ For contributors who want to build the apps and server locally.
 
 ### Prerequisites
 
-- **JDK 17+** (the build enforces Java 17 compatibility)
+- **JDK 21** (the build pins `jvmToolchain(21)`; Gradle auto-provisions a matching JDK via the Foojay toolchain resolver if you don't have one)
 - **Android SDK** with API 33+ (for Android builds) — Android Studio Otter or later recommended
 - **Xcode 26** (for iOS builds, macOS only)
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        // :sharedLogic/:sharedUI compile against pre-release Kotlin 2.3.20 metadata.
+        // :sharedLogic/:sharedUI carry pre-release-marked metadata via the kotlinx-rpc dev-channel pin (see gradle/libs.versions.toml); drop this flag when migrating to rpc stable.
         freeCompilerArgs.add("-Xskip-prerelease-check")
     }
 }

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -94,7 +94,7 @@ kotlin {
     // JVM target for desktop (Windows/Linux)
     jvm("desktop") {
         compilerOptions {
-            freeCompilerArgs.add("-Xskip-prerelease-check") // Skip pre-release Kotlin metadata check
+            freeCompilerArgs.add("-Xskip-prerelease-check") // kotlinx-rpc dev-channel pin carries pre-release metadata; drop with the rpc-stable migration (libs.versions.toml)
         }
     }
 


### PR DESCRIPTION
Documentation drift cleanup (audit plan 066, client half).

**CLAUDE.md** — five stale references corrected:
- `shared/presentation/` → `sharedLogic/.../presentation/`
- deleted `SyncManager` → `SyncEngine` as the cancellation-rethrow exemplar
- `AppResult` path → `contract/.../api/result/AppResult.kt`
- commit-scope list: drop dead `composeApp`, add live `sharedUI`/`contract`/`iosApp` (keep `shared`)
- `core/` tree annotation no longer claims to hold `AppResult`

**README.md** — typo + stale claims:
- fixed the stray-quote typo and softened desktop to "in development (not currently shipping)" per the iOS+Android shipping focus
- replaced the dead `server/` deployment pointer with links to the docs site (installation/configuration/backups/reverse-proxy)
- JDK 17 → JDK 21 (matches `jvmToolchain(21)`)
- added a short Demo server subsection (`:server:runDemo`)

**Build-script comments** — corrected the stale "Kotlin 2.3.20" attribution on `-Xskip-prerelease-check` to point at the kotlinx-rpc dev-channel pin, in `desktopApp` and `sharedUI`. (The `server` occurrence was already relocated to the `listenup.kmp.server` convention plugin with an accurate comment by #993, so no server change here.)

**Cleanup** — removed the orphan `shared/` and `composeApp/` module directories (zero tracked files, not in `settings.gradle.kts`), the tracked 0-byte `desktopApp/hs_err_pid63975.log`, and the now-dead `composeApp` `.gitignore` lines.

Doc/comment-only; `./gradlew help` BUILD SUCCESSFUL. Site half (private-network stance) is a separate PR in ListenUpApp/website.

Desktop mentions elsewhere in README/CLAUDE.md were left as-is for a maintainer pass (desktop is parked, not purged).