### PR TITLE
👷 build: re-enable Kover coverage on the JVM-pure modules (plan 072)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,25 @@ jobs:
             echo 'No E2E auto-retries recorded (probe retries excluded).'
           fi
 
+      # Coverage signal (non-gating): Kover is applied on the JVM-pure modules only
+      # (:server, :rpc-guard-ksp) — the androidKmpLibrary modules are unsupported
+      # upstream. The XML artifact enables future diff-coverage tooling; there is
+      # deliberately NO threshold/verify gate here.
+      - name: Generate coverage reports (Kover, non-gating)
+        continue-on-error: true
+        run: ./gradlew :server:koverXmlReport :rpc-guard-ksp:koverXmlReport --no-daemon
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: kover-coverage
+          path: |
+            server/build/reports/kover/report.xml
+            rpc-guard-ksp/build/reports/kover/report.xml
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,9 +15,11 @@ plugins {
     // Quality Tools
     alias(libs.plugins.detekt)
     alias(libs.plugins.spotless)
-    // Note: Kover code coverage is temporarily disabled due to incompatibility
-    // with the new androidKmpLibrary plugin. Can be re-enabled when Kover
-    // supports the new KMP configuration.
+    // Note: Kover coverage is applied per-module on the JVM-pure modules only
+    // (:server, :rpc-guard-ksp — see their build files). The androidKmpLibrary
+    // modules (:contract, :sharedLogic, :sharedUI) remain uncovered: Kover is
+    // incompatible with the com.android.kotlin.multiplatform.library plugin.
+    // Extend coverage to them when upstream Kover supports that plugin.
 }
 
 // =============================================================================

--- a/rpc-guard-ksp/build.gradle.kts
+++ b/rpc-guard-ksp/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("listenup.jvm")
+    alias(libs.plugins.kover)
 }
 
 dependencies {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("listenup.kmp.server")
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.sqldelight)
+    alias(libs.plugins.kover)
 }
 
 sqldelight {


### PR DESCRIPTION
Restores a code-coverage signal (audit plan 072). Kover was dropped in `382fd2f4a` for incompatibility with the `androidKmpLibrary` plugin and never re-applied — leaving a TDD-mandated codebase with ~1,180 test files and zero coverage measurement.

Re-enables Kover **per-module on the two JVM-pure modules only** — `:server` (KMP jvm+linuxX64, no Android) and `:rpc-guard-ksp` (plain Kotlin/JVM). The three `androidKmpLibrary` modules (`:contract`, `:sharedLogic`, `:sharedUI`) stay uncovered until upstream Kover supports that plugin; the root build comment documents the trigger to extend them.

**Explicitly no thresholds, no gating** — signal first, gates are a separate decision once baselines exist.

- `server/build.gradle.kts`, `rpc-guard-ksp/build.gradle.kts` — add `alias(libs.plugins.kover)` (catalog pin `0.9.8` already present; not bumped).
- root `build.gradle.kts` — replace the stale "temporarily disabled" comment with an accurate partial-re-enable note naming the excluded modules.
- `.github/workflows/ci.yml` — two non-gating `test-jvm` steps: generate Kover XML (`continue-on-error: true`) + upload as the `kover-coverage` artifact (`if-no-files-found: ignore`). The XML is the hook for future diff-coverage tooling.

Verified locally: `:server:koverXmlReport` **86.3%** line coverage (23,904/27,703), `:rpc-guard-ksp` **94.7%** (196/207) — both non-degenerate, proving instrumentation attached. `:server:jvmTest` green under the agent; `spotlessCheck` green; ci.yml parses.