### PR TITLE
🐛 fix(ios): harden audio-session interruption resume state machine (plan 073)

### DIFF
--- a/iosApp/ListenUp/Features/Player/AudioEngine.swift
+++ b/iosApp/ListenUp/Features/Player/AudioEngine.swift
@@ -130,6 +130,17 @@ actor AudioEngine: PlaybackEngine {
         }
     }
 
+    /// Re-assert the shared session active — used when resuming after an
+    /// interruption. Best-effort: on failure the subsequent `play()` surfaces
+    /// the real symptom, and the error is logged for diagnosis.
+    func activateSession() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            Log.error("Failed to reactivate audio session", error: error)
+        }
+    }
+
     /// Tear down: stop playback, remove every observer, finish the event stream.
     func release() {
         if let timeObserver {

--- a/iosApp/ListenUp/Features/Player/PlaybackSeam.swift
+++ b/iosApp/ListenUp/Features/Player/PlaybackSeam.swift
@@ -15,6 +15,10 @@ protocol PlaybackEngine: Sendable {
     func setVolume(_ volume: Float) async
     /// Deactivate the shared audio session so other apps' audio can resume.
     func deactivateSession() async
+    /// Re-assert the shared audio session as active. Called before resuming
+    /// after an interruption — some interruptions deactivate the session, and
+    /// resuming into a dead session plays silence.
+    func activateSession() async
     func release() async
 }
 

--- a/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
+++ b/iosApp/ListenUp/Features/Player/PlayerCoordinator.swift
@@ -199,6 +199,11 @@ final class PlayerCoordinator: RemoteCommandHandler {
     private var lastReportedPositionMs: Int64 = 0
     private var lastSyncedChapterIndex: Int = -1
     private var isFading = false
+    /// True only while playback is paused *because of* an audio-session
+    /// interruption. Gates `.ended + .shouldResume`: resume is honored only
+    /// when the interruption did the pausing — a user's deliberate pause is
+    /// never overridden (Apple's "was playing when interrupted" contract).
+    private var pausedByInterruption = false
     private static let positionReportIntervalMs: Int64 = 5000
 
     // MARK: - Init
@@ -300,14 +305,19 @@ final class PlayerCoordinator: RemoteCommandHandler {
         guard let loaded = phase.playingState else { return }
         switch action {
         case .pause:
-            if phase.isPlaying {
+            // .playing OR .buffering: both mean audio intent is "advancing".
+            if phase.isPlaying || isBuffering {
+                pausedByInterruption = true
                 await engine.pause()
                 phase = .paused(loaded)
                 progress.onPlaybackPaused(bookId: loaded.bookId, positionMs: bookPositionMs, speed: playbackSpeed)
                 updateNowPlaying()
             }
         case .resume:
+            guard pausedByInterruption else { return }
+            pausedByInterruption = false
             if !phase.isPlaying {
+                await engine.activateSession()
                 await engine.play()
                 phase = .playing(loaded)
                 progress.onPlaybackStarted(bookId: loaded.bookId, positionMs: bookPositionMs, speed: playbackSpeed)
@@ -343,6 +353,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
 
     /// Prepare and start playback of a book.
     func play(bookId: String) {
+        pausedByInterruption = false
         phase = .preparing(PreparingState(bookId: bookId))
         currentBookId = bookId
         Task { await prepareAndStart(bookId: bookId) }
@@ -350,6 +361,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
 
     /// Toggle between play and pause.
     func togglePlayback() {
+        pausedByInterruption = false
         guard let loaded = phase.playingState else { return }
         // KMP value-class `BookId` is erased at the Swift boundary — its APIs take
         // the underlying id value directly.
@@ -434,6 +446,7 @@ final class PlayerCoordinator: RemoteCommandHandler {
     /// deterministic: the audio session is deactivated and the engine released
     /// *before* the call returns.
     func stop() async {
+        pausedByInterruption = false
         bridge.cancelAll()
         positionTracker.reset()
         await engine.deactivateSession()

--- a/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
+++ b/iosApp/ListenUpTests/Fakes/PlayerSeamFakes.swift
@@ -14,6 +14,11 @@ actor FakePlaybackEngine: PlaybackEngine {
     private(set) var lastVolume: Float?
     private(set) var didRelease = false
     private(set) var didDeactivateSession = false
+    private(set) var didActivateSession = false
+    private(set) var playCount = 0
+    /// Every engine command in arrival order, so a test can assert relative
+    /// ordering (e.g. `activate` immediately before the resuming `play`).
+    private(set) var commandLog: [String] = []
     /// Records teardown calls in the order they arrive, so a test can assert the
     /// session is deactivated before the engine is released.
     private(set) var teardownOrder: [String] = []
@@ -32,18 +37,28 @@ actor FakePlaybackEngine: PlaybackEngine {
     nonisolated func emit(_ event: AudioEngineEvent) { continuation.yield(event) }
 
     func load(segments: [AudioSegment], startPositionMs: Int64) async {}
-    func play() async { didPlay = true; gate.fire("play") }
-    func pause() async { didPause = true; gate.fire("pause") }
+    func play() async {
+        didPlay = true; playCount += 1; commandLog.append("play")
+        gate.fire("play"); gate.fire("play-\(playCount)")
+    }
+    func pause() async { didPause = true; commandLog.append("pause"); gate.fire("pause") }
     func seek(toMs positionMs: Int64) async { lastSeekMs = positionMs; gate.fire("seek") }
     func setRate(_ newRate: Float) async { lastRate = newRate; gate.fire("setRate") }
     func setVolume(_ volume: Float) async { lastVolume = volume; gate.fire("setVolume") }
     func deactivateSession() async {
         didDeactivateSession = true; teardownOrder.append("deactivate"); gate.fire("deactivate")
     }
+    func activateSession() async {
+        didActivateSession = true; commandLog.append("activate"); gate.fire("activate")
+    }
     func release() async { didRelease = true; teardownOrder.append("release"); gate.fire("release") }
 
     /// Suspend until `pause()` has executed. Returns immediately if it already has.
     func waitUntilPaused() async { await gate.wait(forKey: "pause") }
+
+    /// Suspend until `play()` has executed for the `count`-th time. Keyed, because a
+    /// predicate closure can't read this actor's state (see AsyncGate lines 46–59).
+    func waitForPlayCount(_ count: Int) async { await gate.wait(forKey: "play-\(count)") }
 }
 
 // MARK: - Task 2 seam fakes

--- a/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
+++ b/iosApp/ListenUpTests/PlayerCoordinatorTests.swift
@@ -218,6 +218,142 @@ struct RouteChangeTests {
 
 }
 
+// `.serialized`: every test here posts `AVAudioSession.interruptionNotification`
+// to `NotificationCenter.default`, which every live `PlayerCoordinator` observes.
+// Run in parallel, one test's `began`/`ended` post reaches a sibling test's
+// coordinator and flips its phase — so the suite must run its tests one at a time.
+@Suite("Audio-session interruption handling", .serialized)
+@MainActor
+struct AudioSessionInterruptionTests {
+    private func makeCoordinator() -> (PlayerCoordinator, FakePlaybackEngine, FakeProgressReporting) {
+        let engine = FakePlaybackEngine()
+        let progress = FakeProgressReporting()
+        let preparer = FakePlaybackPreparing()
+        preparer.result = PreparedPlayback(
+            bookTitle: "T", bookAuthor: "A", bookNarrator: "N", coverPath: nil, resumeSpeed: 1.0,
+            resumePositionMs: 0, chapters: [],
+            timeline: PreparedTimeline(totalDurationMs: 60000, files: [
+                PreparedFile(localPath: "/a.m4a", streamingUrl: "", durationMs: 60000, startOffsetMs: 0)])
+        )
+        let coordinator = PlayerCoordinator(
+            preparer: preparer, progress: progress, sleep: FakeSleepTiming(),
+            engine: engine, coverProvider: FakeBookCoverProviding())
+        return (coordinator, engine, progress)
+    }
+
+    private func postInterruptionBegan() {
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification, object: nil,
+            userInfo: [AVAudioSessionInterruptionTypeKey:
+                NSNumber(value: AVAudioSession.InterruptionType.began.rawValue)])
+    }
+
+    private func postInterruptionEnded(shouldResume: Bool) {
+        var userInfo: [AnyHashable: Any] = [
+            AVAudioSessionInterruptionTypeKey:
+                NSNumber(value: AVAudioSession.InterruptionType.ended.rawValue)
+        ]
+        if shouldResume {
+            userInfo[AVAudioSessionInterruptionOptionKey] =
+                NSNumber(value: AVAudioSession.InterruptionOptions.shouldResume.rawValue)
+        }
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification, object: nil, userInfo: userInfo)
+    }
+
+    @Test func interruptionBeganPausesPlayback() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        postInterruptionBegan()
+        await engine.waitUntilPaused()
+
+        #expect(await engine.didPause)
+        #expect(coordinator.isPlaying == false)
+        // `>= 1`, not `== 1`: every live coordinator observes `NotificationCenter.default`,
+        // so a sibling suite's route-change/interruption post can add a pause here. Our own
+        // code can't double-report one interruption — the `.pause` phase guard blocks the
+        // second — so `>= 1` verifies the interruption was reported to KMP without over-
+        // specifying a count the shared global center makes non-deterministic across suites.
+        #expect(progress.pausedCalls.count >= 1)
+    }
+
+    @Test func interruptionEndedWithShouldResumeResumesAfterInterruptionPause() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        postInterruptionBegan()
+        await engine.waitUntilPaused()
+        postInterruptionEnded(shouldResume: true)
+        await engine.waitForPlayCount(2)
+
+        #expect(coordinator.isPlaying)
+        let log = await engine.commandLog
+        #expect(Array(log.suffix(2)) == ["activate", "play"])
+        #expect(await engine.didActivateSession)
+    }
+
+    @Test func interruptionEndedWithoutShouldResumeStaysPaused() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        postInterruptionBegan()
+        await engine.waitUntilPaused()
+        postInterruptionEnded(shouldResume: false)
+
+        await awaitUntil(timeout: .milliseconds(300)) { coordinator.isPlaying }
+        #expect(coordinator.isPlaying == false)
+        #expect(await engine.playCount == 1)
+    }
+
+    @Test func interruptionEndedDoesNotResumeUserInitiatedPause() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        coordinator.togglePlayback()   // user pauses deliberately
+        await engine.waitUntilPaused()
+        postInterruptionEnded(shouldResume: true)
+
+        await awaitUntil(timeout: .milliseconds(300)) { coordinator.isPlaying }
+        #expect(coordinator.isPlaying == false)
+        #expect(await engine.playCount == 1)
+    }
+
+    @Test func interruptionBeganWhileBufferingPauses() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        engine.emit(.statusChanged(.buffering))
+        await awaitUntil { coordinator.isBuffering }
+
+        postInterruptionBegan()
+        await engine.waitUntilPaused()
+
+        #expect(coordinator.isPlaying == false)
+        #expect(coordinator.isBuffering == false)
+    }
+
+    @Test func stopSeversInterruptionObservation() async {
+        let (coordinator, engine, progress) = makeCoordinator()
+        coordinator.play(bookId: "book1")
+        await progress.waitForStarted(bookId: "book1")
+
+        await coordinator.stop()
+        let pausesBefore = await engine.commandLog.filter { $0 == "pause" }.count
+
+        postInterruptionBegan()
+        await awaitUntil(timeout: .milliseconds(300)) {
+            await engine.commandLog.filter { $0 == "pause" }.count > pausesBefore
+        }
+        #expect(await engine.commandLog.filter { $0 == "pause" }.count == pausesBefore)
+    }
+}
+
 @Suite("Route change policy")
 struct RouteChangePolicyTests {
     @Test func oldDeviceUnavailablePauses() {


### PR DESCRIPTION
Audit plan 073. The audit premise was partly stale — `PlayerCoordinator` already observes interruption + route-change notifications with tested pure policies — so this narrows to the genuine residual gaps and pins the interruption state machine with notification-driven tests.

**Production fixes (`PlayerCoordinator` / `PlaybackSeam` / `AudioEngine`):**
1. **Was-playing-when-interrupted contract.** `.ended + .shouldResume` previously resumed whenever the player was merely *not playing* — a user who paused deliberately before a call could have playback forced back on when the call ended. Now gated by a `pausedByInterruption` flag: resume is honored only when the interruption itself did the pausing, and the flag is cleared on every user transport action (`play`/`togglePlayback`/`stop`).
2. **Buffering blind spot.** An interruption arriving while `phase == .buffering` was ignored (pause path only checked `.isPlaying`). Now pauses on `.playing` *or* `.buffering`.
3. **Session re-activation on resume.** Added `activateSession()` to the platform-neutral `PlaybackEngine` protocol + `AudioEngine`; the resume path re-asserts `AVAudioSession.setActive(true)` before `play()` — some interruptions deactivate the session, and resuming into a dead session plays silence.

**Tests** — new `AudioSessionInterruptionTests` suite (Swift Testing, notification-driven via `NotificationCenter.default`, asserting through the fakes): began→pause, ended+shouldResume→resume (with `activate` ordered before `play`), ended-without-resume→stays paused, the two regressions (user-pause not overridden; buffering pause), and a teardown pin. Full iOS lane green (435 passed / 0 failed).

Notes: the suite is `.serialized` (its tests all post to the shared `NotificationCenter.default`); one exact-count assertion is `>= 1` rather than `== 1` because sibling suites sharing that global center can add pauses (our own code cannot double-report a single interruption — the phase guard blocks it). `AVAudioSession.mediaServicesWereResetNotification` handling remains deferred (separate, larger change).