### PR TITLE
♻️ refactor(shared): typed ShelfId through the shelf domain — value-class-ID pilot (plan 069)

### DIFF
--- a/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
@@ -135,11 +135,11 @@ final class BookDetailObserver {
         self.downloadService = downloadService
         bridge.bind(viewModel.state) { [weak self] in self?.apply($0) }
         bridge.bind(viewModel.myShelves) { [weak self] shelves in
-            self?.allShelves = shelves.map { ShelfRow(id: $0.id, name: $0.name, containsBook: false) }
+            self?.allShelves = shelves.map { ShelfRow(id: $0.idString, name: $0.name, containsBook: false) }
             self?.recomputeShelfRows()
         }
         bridge.bind(viewModel.shelvesContainingBook) { [weak self] shelves in
-            self?.shelfIdsContainingBook = Set(shelves.map { $0.id })
+            self?.shelfIdsContainingBook = Set(shelves.map { $0.idString })
             self?.recomputeShelfRows()
         }
         bridge.bind(viewModel.collections) { [weak self] collections in

--- a/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
@@ -52,7 +52,7 @@ struct ShelfPickerSheet: View {
     private var shelvesSection: some View {
         Section {
             ForEach(observer.myShelves) { shelf in
-                Button { observer.addToShelf(shelfId: shelf.idString) } label: {
+                Button { observer.addToShelf(shelfId: shelf.id) } label: {
                     HStack {
                         Text(shelf.name)
                             .foregroundStyle(.primary)

--- a/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
@@ -52,7 +52,7 @@ struct ShelfPickerSheet: View {
     private var shelvesSection: some View {
         Section {
             ForEach(observer.myShelves) { shelf in
-                Button { observer.addToShelf(shelfId: shelf.id) } label: {
+                Button { observer.addToShelf(shelfId: shelf.idString) } label: {
                     HStack {
                         Text(shelf.name)
                             .foregroundStyle(.primary)

--- a/iosApp/ListenUp/Features/Home/Components/ShelfCard.swift
+++ b/iosApp/ListenUp/Features/Home/Components/ShelfCard.swift
@@ -119,7 +119,7 @@ struct MyShelvesRow: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 14) {
                     ForEach(shelves) { shelf in
-                        NavigationLink(value: ShelfDestination(id: shelf.id)) {
+                        NavigationLink(value: ShelfDestination(id: shelf.idString)) {
                             ShelfCard(shelf: shelf)
                         }
                         .buttonStyle(.plain)

--- a/iosApp/ListenUp/Features/Home/Components/ShelfCard.swift
+++ b/iosApp/ListenUp/Features/Home/Components/ShelfCard.swift
@@ -119,7 +119,7 @@ struct MyShelvesRow: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 14) {
                     ForEach(shelves) { shelf in
-                        NavigationLink(value: ShelfDestination(id: shelf.idString)) {
+                        NavigationLink(value: ShelfDestination(id: shelf.id)) {
                             ShelfCard(shelf: shelf)
                         }
                         .buttonStyle(.plain)

--- a/iosApp/ListenUp/Features/Home/HomeViewModelWrapper.swift
+++ b/iosApp/ListenUp/Features/Home/HomeViewModelWrapper.swift
@@ -181,7 +181,7 @@ struct ShelfItem: Identifiable, Equatable {
     let coverPaths: [String]
 
     init(from shelf: Shelf) {
-        self.id = shelf.id
+        self.id = shelf.idString
         self.name = shelf.name
         self.bookCount = Int(shelf.bookCount)
         self.durationLabel = shelf.formattedDuration

--- a/iosApp/ListenUp/Features/Selection/BookSelectionObserver.swift
+++ b/iosApp/ListenUp/Features/Selection/BookSelectionObserver.swift
@@ -54,7 +54,7 @@ final class BookSelectionObserver {
             self?.isAdmin = value
         }
         bridge.bind(viewModel.myShelves) { [weak self] shelves in
-            self?.myShelves = shelves.map { SelectionShelfRow(id: $0.id, name: $0.name) }
+            self?.myShelves = shelves.map { SelectionShelfRow(id: $0.idString, name: $0.name) }
         }
         bridge.bind(viewModel.collections) { [weak self] collections in
             self?.allCollections = collections.map { SelectionCollectionRow(id: $0.id, name: $0.name) }

--- a/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
@@ -50,7 +50,7 @@ struct BulkShelfPickerSheet: View {
     private var shelvesSection: some View {
         Section {
             ForEach(observer.myShelves) { shelf in
-                Button { observer.addToShelf(shelfId: shelf.id) } label: {
+                Button { observer.addToShelf(shelfId: shelf.idString) } label: {
                     Text(shelf.name)
                         .foregroundStyle(.primary)
                 }

--- a/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
@@ -50,7 +50,7 @@ struct BulkShelfPickerSheet: View {
     private var shelvesSection: some View {
         Section {
             ForEach(observer.myShelves) { shelf in
-                Button { observer.addToShelf(shelfId: shelf.idString) } label: {
+                Button { observer.addToShelf(shelfId: shelf.id) } label: {
                     Text(shelf.name)
                         .foregroundStyle(.primary)
                 }

--- a/iosApp/ListenUp/Features/ShelfDetail/ShelfDetailObserver.swift
+++ b/iosApp/ListenUp/Features/ShelfDetail/ShelfDetailObserver.swift
@@ -26,7 +26,7 @@ struct ShelfBookRow: Identifiable, Equatable {
     let coverPath: String?
 
     init(_ book: ShelfBook) {
-        self.id = book.id
+        self.id = book.idString
         self.title = book.title
         self.authorNames = Array(book.authorNames)   // copy the bridged list into a Swift array
         self.coverPath = book.coverPath

--- a/iosApp/ListenUpTests/Home/HomeWrapperTests.swift
+++ b/iosApp/ListenUpTests/Home/HomeWrapperTests.swift
@@ -57,7 +57,7 @@ struct HomeWrapperTests {
 
     @Test func shelfItemMapsFields() {
         let shelf = Shelf(
-            id: "shelf-1",
+            id: ShelfId(value: "shelf-1"),
             name: "To Read",
             description: nil,
             isPrivate: false,

--- a/scripts/export-surface-baseline.txt
+++ b/scripts/export-surface-baseline.txt
@@ -472,6 +472,7 @@ ShelfDetail
 ShelfDetailUiState
 ShelfDetailViewModel
 ShelfGridWidth
+ShelfId
 ShelfRepository
 ShortcutAction
 ShortcutActionManager

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
@@ -54,23 +54,23 @@ internal class ShelfRepositoryImpl(
     override fun observeMyShelves(userId: String): Flow<List<Shelf>> =
         dao.observeMyShelvesWithBookCount().map { rows -> rows.map { it.toDomain() } }
 
-    override fun observeShelvesContainingBook(bookId: String): Flow<List<Shelf>> =
-        dao.observeShelvesContainingBookWithBookCount(bookId).map { rows -> rows.map { it.toDomain() } }
+    override fun observeShelvesContainingBook(bookId: BookId): Flow<List<Shelf>> =
+        dao.observeShelvesContainingBookWithBookCount(bookId.value).map { rows -> rows.map { it.toDomain() } }
 
-    override fun observeById(id: String): Flow<Shelf?> =
-        dao.observeById(id).map { entity ->
+    override fun observeById(id: ShelfId): Flow<Shelf?> =
+        dao.observeById(id.value).map { entity ->
             entity?.toDomainWithDerived(
-                coverPaths = dao.coverHashesFor(id),
-                totalDurationMs = dao.totalDurationMsFor(id),
-                bookCountOverride = dao.bookCountFor(id),
+                coverPaths = dao.coverHashesFor(id.value),
+                totalDurationMs = dao.totalDurationMsFor(id.value),
+                bookCountOverride = dao.bookCountFor(id.value),
             )
         }
 
-    override suspend fun getById(id: String): Shelf? =
-        dao.getById(id)?.toDomainWithDerived(
-            coverPaths = dao.coverHashesFor(id),
-            totalDurationMs = dao.totalDurationMsFor(id),
-            bookCountOverride = dao.bookCountFor(id),
+    override suspend fun getById(id: ShelfId): Shelf? =
+        dao.getById(id.value)?.toDomainWithDerived(
+            coverPaths = dao.coverHashesFor(id.value),
+            totalDurationMs = dao.totalDurationMsFor(id.value),
+            bookCountOverride = dao.bookCountFor(id.value),
         )
 
     // ── Discovery (on-demand RPC) ─────────────────────────────────────────────────
@@ -85,10 +85,10 @@ internal class ShelfRepositoryImpl(
 
     // ── Detail (on-demand RPC) ────────────────────────────────────────────────────
 
-    override suspend fun getShelfDetail(shelfId: String): AppResult<ShelfDetail> =
-        rpcCall { rpcFactory.get().getShelf(ShelfId(shelfId)) }
+    override suspend fun getShelfDetail(shelfId: ShelfId): AppResult<ShelfDetail> =
+        rpcCall { rpcFactory.get().getShelf(shelfId) }
             .map { detail ->
-                val coverHashByBook = dao.coverHashesByBookFor(shelfId).associate { it.bookId to it.coverHash }
+                val coverHashByBook = dao.coverHashesByBookFor(shelfId.value).associate { it.bookId to it.coverHash }
                 detail.toDomain(coverHashByBook)
             }
 
@@ -108,47 +108,47 @@ internal class ShelfRepositoryImpl(
         }.map { it.toDomain() }
 
     override suspend fun updateShelf(
-        shelfId: String,
+        shelfId: ShelfId,
         name: String,
         description: String?,
         isPrivate: Boolean,
     ): AppResult<Shelf> =
         rpcCall {
             rpcFactory.get().updateShelf(
-                shelfId = ShelfId(shelfId),
+                shelfId = shelfId,
                 name = name,
                 description = description ?: "",
                 isPrivate = isPrivate,
             )
         }.map { it.toDomain() }
 
-    override suspend fun deleteShelf(shelfId: String): AppResult<Unit> =
-        rpcCall { rpcFactory.get().deleteShelf(ShelfId(shelfId)) }
+    override suspend fun deleteShelf(shelfId: ShelfId): AppResult<Unit> =
+        rpcCall { rpcFactory.get().deleteShelf(shelfId) }
 
     override suspend fun addBooksToShelf(
-        shelfId: String,
-        bookIds: List<String>,
+        shelfId: ShelfId,
+        bookIds: List<BookId>,
     ): AppResult<Unit> {
         // The RPC surface adds one book at a time (idempotent); dispatch each and
         // fail fast on the first error. SSE echoes update Room — no optimistic write.
         bookIds.forEach { bookId ->
-            val result = rpcCall { rpcFactory.get().addBookToShelf(ShelfId(shelfId), BookId(bookId)) }
+            val result = rpcCall { rpcFactory.get().addBookToShelf(shelfId, bookId) }
             if (result is AppResult.Failure) return result
         }
         return AppResult.Success(Unit)
     }
 
     override suspend fun removeBookFromShelf(
-        shelfId: String,
-        bookId: String,
-    ): AppResult<Unit> = rpcCall { rpcFactory.get().removeBookFromShelf(ShelfId(shelfId), BookId(bookId)) }
+        shelfId: ShelfId,
+        bookId: BookId,
+    ): AppResult<Unit> = rpcCall { rpcFactory.get().removeBookFromShelf(shelfId, bookId) }
 
     override suspend fun reorderBooks(
-        shelfId: String,
-        orderedBookIds: List<String>,
+        shelfId: ShelfId,
+        orderedBookIds: List<BookId>,
     ): AppResult<Unit> =
         rpcCall {
-            rpcFactory.get().reorderShelfBooks(ShelfId(shelfId), orderedBookIds.map { BookId(it) })
+            rpcFactory.get().reorderShelfBooks(shelfId, orderedBookIds)
         }
 
     // ── Mapping ───────────────────────────────────────────────────────────────────
@@ -172,7 +172,7 @@ internal class ShelfRepositoryImpl(
     ): Shelf {
         val currentUser = userDao.getCurrentUser()
         return Shelf(
-            id = id,
+            id = ShelfId(id),
             name = name,
             description = description.ifEmpty { null },
             isPrivate = isPrivate,
@@ -204,7 +204,7 @@ internal class ShelfRepositoryImpl(
 
 private fun com.calypsan.listenup.api.dto.shelf.Shelf.toDomain(): Shelf =
     Shelf(
-        id = id.value,
+        id = id,
         name = name,
         description = description.ifEmpty { null },
         isPrivate = isPrivate,
@@ -218,7 +218,7 @@ private fun com.calypsan.listenup.api.dto.shelf.Shelf.toDomain(): Shelf =
 
 private fun DiscoveredShelf.toDomain(): Shelf =
     Shelf(
-        id = shelf.id.value,
+        id = shelf.id,
         name = shelf.name,
         description = shelf.description.ifEmpty { null },
         isPrivate = shelf.isPrivate,
@@ -232,7 +232,7 @@ private fun DiscoveredShelf.toDomain(): Shelf =
 
 private fun ShelfDetailDto.toDomain(coverHashByBook: Map<String, String?>): ShelfDetail =
     ShelfDetail(
-        id = id.value,
+        id = id,
         name = name,
         description = description.ifEmpty { null },
         isPrivate = isPrivate,
@@ -242,7 +242,7 @@ private fun ShelfDetailDto.toDomain(coverHashByBook: Map<String, String?>): Shel
         books =
             books.map { book ->
                 ShelfBook(
-                    id = book.bookId,
+                    id = BookId(book.bookId),
                     title = book.title,
                     authorNames = book.authors,
                     coverPath = null,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Shelf.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/Shelf.kt
@@ -1,5 +1,7 @@
 package com.calypsan.listenup.client.domain.model
 
+import com.calypsan.listenup.core.ShelfId
+
 /**
  * Domain model for a personal curation shelf.
  *
@@ -13,7 +15,7 @@ package com.calypsan.listenup.client.domain.model
  * books in the local Room mirror — discovered (other-user) shelves carry empty
  * covers and zero duration because their member books never enter the mirror.
  *
- * @property id Unique identifier
+ * @property id Unique identifier (typed [ShelfId])
  * @property name Display name (e.g., "To Read", "Favorites")
  * @property description Optional description
  * @property isPrivate `true` if only the owner can see this shelf
@@ -26,7 +28,7 @@ package com.calypsan.listenup.client.domain.model
  * @property coverPaths Cover hashes for the shelf's first few member books, in sort order
  */
 data class Shelf(
-    val id: String,
+    val id: ShelfId,
     val name: String,
     val description: String?,
     val isPrivate: Boolean,
@@ -38,6 +40,9 @@ data class Shelf(
     val updatedAtMs: Long,
     val coverPaths: List<String> = emptyList(),
 ) {
+    /** The shelf id as a plain String, for the Swift/SKIE boundary (the value class is unboxed there). */
+    val idString: String get() = id.value
+
     /**
      * Returns the display name formatted for the current user context.
      * - Owner sees: "To Read"

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/ShelfDetail.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/ShelfDetail.kt
@@ -1,5 +1,8 @@
 package com.calypsan.listenup.client.domain.model
 
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
+
 /**
  * Domain model representing full shelf details for the shelf detail screen.
  *
@@ -10,7 +13,7 @@ package com.calypsan.listenup.client.domain.model
  * viewer cannot access are silently excluded, so [bookCount] reflects only the
  * visible set.
  *
- * @property id Unique shelf identifier
+ * @property id Unique shelf identifier (typed [ShelfId])
  * @property name Shelf display name
  * @property description Optional shelf description
  * @property isPrivate `true` if only the owner can see this shelf
@@ -20,7 +23,7 @@ package com.calypsan.listenup.client.domain.model
  * @property books Ordered list of books in the shelf
  */
 data class ShelfDetail(
-    val id: String,
+    val id: ShelfId,
     val name: String,
     val description: String?,
     val isPrivate: Boolean,
@@ -29,6 +32,9 @@ data class ShelfDetail(
     val totalDurationSeconds: Long,
     val books: List<ShelfBook>,
 ) {
+    /** The shelf id as a plain String, for the Swift/SKIE boundary (the value class is unboxed there). */
+    val idString: String get() = id.value
+
     /**
      * Returns the total duration formatted as hours and minutes.
      */
@@ -52,7 +58,7 @@ data class ShelfDetail(
  * duration is not part of the contract, so it is omitted here. [coverPath] is
  * resolved client-side from the local image cache when available.
  *
- * @property id Book's unique identifier
+ * @property id Book's unique identifier (typed [BookId])
  * @property title Book title
  * @property authorNames List of author names for this book
  * @property coverPath Local path to cover image (optional)
@@ -60,9 +66,12 @@ data class ShelfDetail(
  *   cover changes (optional; resolved from the local `books` mirror)
  */
 data class ShelfBook(
-    val id: String,
+    val id: BookId,
     val title: String,
     val authorNames: List<String>,
     val coverPath: String?,
     val coverHash: String? = null,
-)
+) {
+    /** The book id as a plain String, for the Swift/SKIE boundary (the value class is unboxed there). */
+    val idString: String get() = id.value
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ShelfRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ShelfRepository.kt
@@ -5,6 +5,8 @@ package com.calypsan.listenup.client.domain.repository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.Shelf
 import com.calypsan.listenup.client.domain.model.ShelfDetail
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -41,7 +43,7 @@ interface ShelfRepository {
      * Reactive and offline — reads the local Room mirror, re-emitting when membership changes.
      * Empty when the book is on none of the caller's shelves.
      */
-    fun observeShelvesContainingBook(bookId: String): Flow<List<Shelf>>
+    fun observeShelvesContainingBook(bookId: BookId): Flow<List<Shelf>>
 
     /**
      * Observe a single shelf by ID.
@@ -49,7 +51,7 @@ interface ShelfRepository {
      * @param id The shelf ID
      * @return Flow emitting the shelf or null
      */
-    fun observeById(id: String): Flow<Shelf?>
+    fun observeById(id: ShelfId): Flow<Shelf?>
 
     /**
      * Get a shelf by ID synchronously from the local mirror.
@@ -57,7 +59,7 @@ interface ShelfRepository {
      * @param id The shelf ID
      * @return Shelf if found, null otherwise
      */
-    suspend fun getById(id: String): Shelf?
+    suspend fun getById(id: ShelfId): Shelf?
 
     /**
      * Get a specific user's public shelves (view-other-profile surface).
@@ -87,7 +89,7 @@ interface ShelfRepository {
      * @param shelfId The shelf ID to fetch
      * @return [AppResult.Success] with the shelf detail, or [AppResult.Failure] on RPC error
      */
-    suspend fun getShelfDetail(shelfId: String): AppResult<ShelfDetail>
+    suspend fun getShelfDetail(shelfId: ShelfId): AppResult<ShelfDetail>
 
     /**
      * Remove a book from a shelf.
@@ -96,8 +98,8 @@ interface ShelfRepository {
      * @param bookId The book to remove
      */
     suspend fun removeBookFromShelf(
-        shelfId: String,
-        bookId: String,
+        shelfId: ShelfId,
+        bookId: BookId,
     ): AppResult<Unit>
 
     /**
@@ -107,8 +109,8 @@ interface ShelfRepository {
      * @param bookIds The books to add
      */
     suspend fun addBooksToShelf(
-        shelfId: String,
-        bookIds: List<String>,
+        shelfId: ShelfId,
+        bookIds: List<BookId>,
     ): AppResult<Unit>
 
     /**
@@ -120,8 +122,8 @@ interface ShelfRepository {
      * @param orderedBookIds The books in their new order
      */
     suspend fun reorderBooks(
-        shelfId: String,
-        orderedBookIds: List<String>,
+        shelfId: ShelfId,
+        orderedBookIds: List<BookId>,
     ): AppResult<Unit>
 
     /**
@@ -148,7 +150,7 @@ interface ShelfRepository {
      * @return [AppResult.Success] with the updated shelf, or [AppResult.Failure] on RPC error
      */
     suspend fun updateShelf(
-        shelfId: String,
+        shelfId: ShelfId,
         name: String,
         description: String?,
         isPrivate: Boolean,
@@ -159,5 +161,5 @@ interface ShelfRepository {
      *
      * @param shelfId The shelf ID to delete
      */
-    suspend fun deleteShelf(shelfId: String): AppResult<Unit>
+    suspend fun deleteShelf(shelfId: ShelfId): AppResult<Unit>
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/AddBooksToShelfUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/AddBooksToShelfUseCase.kt
@@ -3,6 +3,8 @@ package com.calypsan.listenup.client.domain.usecase.shelf
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.validationError
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -32,8 +34,8 @@ open class AddBooksToShelfUseCase(
      * @return Result indicating success or failure
      */
     open suspend operator fun invoke(
-        shelfId: String,
-        bookIds: List<String>,
+        shelfId: ShelfId,
+        bookIds: List<BookId>,
     ): AppResult<Unit> {
         if (bookIds.isEmpty()) {
             return validationError("At least one book must be selected")

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/DeleteShelfUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/DeleteShelfUseCase.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.domain.usecase.shelf
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -26,7 +27,7 @@ open class DeleteShelfUseCase(
      * @param shelfId The ID of the shelf to delete
      * @return Result indicating success or failure
      */
-    open suspend operator fun invoke(shelfId: String): AppResult<Unit> {
+    open suspend operator fun invoke(shelfId: ShelfId): AppResult<Unit> {
         logger.info { "Deleting shelf $shelfId" }
         return shelfRepository.deleteShelf(shelfId)
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/LoadShelfDetailUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/LoadShelfDetailUseCase.kt
@@ -1,7 +1,7 @@
 package com.calypsan.listenup.client.domain.usecase.shelf
 
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.api.result.map
 import com.calypsan.listenup.client.domain.model.ShelfDetail
 import com.calypsan.listenup.client.domain.repository.ImageRepository
@@ -31,14 +31,14 @@ open class LoadShelfDetailUseCase(
      * @param shelfId The shelf ID to load
      * @return Result containing the shelf detail or a failure
      */
-    open suspend operator fun invoke(shelfId: String): AppResult<ShelfDetail> {
+    open suspend operator fun invoke(shelfId: ShelfId): AppResult<ShelfDetail> {
         logger.debug { "Loading shelf detail: $shelfId" }
 
         return shelfRepository.getShelfDetail(shelfId).map { shelfDetail ->
             // Resolve local cover paths for books
             val booksWithLocalCovers =
                 shelfDetail.books.map { book ->
-                    val bookId = BookId(book.id)
+                    val bookId = book.id
                     val localCoverPath =
                         if (imageRepository.bookCoverExists(bookId)) {
                             imageRepository.getBookCoverPath(bookId)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/RemoveBookFromShelfUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/RemoveBookFromShelfUseCase.kt
@@ -2,6 +2,8 @@ package com.calypsan.listenup.client.domain.usecase.shelf
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -30,8 +32,8 @@ open class RemoveBookFromShelfUseCase(
      * @return Result indicating success or failure
      */
     open suspend operator fun invoke(
-        shelfId: String,
-        bookId: String,
+        shelfId: ShelfId,
+        bookId: BookId,
     ): AppResult<Unit> {
         logger.info { "Removing book $bookId from shelf $shelfId" }
         return shelfRepository.removeBookFromShelf(shelfId, bookId)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/ReorderShelfBooksUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/ReorderShelfBooksUseCase.kt
@@ -3,6 +3,8 @@ package com.calypsan.listenup.client.domain.usecase.shelf
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.validationError
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -32,8 +34,8 @@ open class ReorderShelfBooksUseCase(
      * @return Result indicating success or failure
      */
     open suspend operator fun invoke(
-        shelfId: String,
-        orderedBookIds: List<String>,
+        shelfId: ShelfId,
+        orderedBookIds: List<BookId>,
     ): AppResult<Unit> {
         if (orderedBookIds.isEmpty()) {
             return validationError("Cannot reorder an empty shelf")

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/UpdateShelfUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/UpdateShelfUseCase.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.validationError
 import com.calypsan.listenup.client.domain.model.Shelf
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -37,7 +38,7 @@ open class UpdateShelfUseCase(
      * @return Result containing the updated shelf or a failure
      */
     open suspend operator fun invoke(
-        shelfId: String,
+        shelfId: ShelfId,
         name: String,
         description: String?,
         isPrivate: Boolean = false,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -26,6 +26,7 @@ import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.client.core.Failure
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -154,7 +155,7 @@ class BookDetailViewModel(
     val shelvesContainingBook: StateFlow<List<Shelf>> =
         bookIdFlow
             .filterNotNull()
-            .flatMapLatest { id -> shelfRepository.observeShelvesContainingBook(id) }
+            .flatMapLatest { id -> shelfRepository.observeShelvesContainingBook(BookId(id)) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     /**
@@ -516,7 +517,7 @@ class BookDetailViewModel(
         val bookId = (state.value as? BookDetailUiState.Ready)?.book?.id?.value ?: return
         viewModelScope.launch {
             updateReady { it.copy(isAddingToShelf = true) }
-            when (val result = addBooksToShelfUseCase(shelfId, listOf(bookId))) {
+            when (val result = addBooksToShelfUseCase(ShelfId(shelfId), listOf(BookId(bookId)))) {
                 is AppResult.Success -> {
                     updateReady { it.copy(isAddingToShelf = false, showShelfPicker = false) }
                     logger.info { "Added book $bookId to shelf $shelfId" }
@@ -540,7 +541,7 @@ class BookDetailViewModel(
             when (val result = createShelfUseCase(name, null)) {
                 is AppResult.Success -> {
                     val shelf = result.data
-                    when (val addResult = addBooksToShelfUseCase(shelf.id, listOf(bookId))) {
+                    when (val addResult = addBooksToShelfUseCase(shelf.id, listOf(BookId(bookId)))) {
                         is AppResult.Success -> {
                             updateReady { it.copy(isAddingToShelf = false, showShelfPicker = false) }
                             logger.info { "Created shelf '${shelf.name}' and added book $bookId" }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModel.kt
@@ -11,6 +11,8 @@ import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.domain.usecase.collection.AddBooksToCollectionUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.core.error.ErrorBus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -245,7 +247,7 @@ class BookMultiSelectViewModel(
             isAddingToShelf.value = true
             val bookIds = selectedIds.toList()
 
-            when (val result = addBooksToShelfUseCase(shelfId, bookIds)) {
+            when (val result = addBooksToShelfUseCase(ShelfId(shelfId), bookIds.map { BookId(it) })) {
                 is AppResult.Success -> {
                     logger.info { "Added ${bookIds.size} books to shelf $shelfId" }
                     eventsChannel.send(BookMultiSelectEvent.BooksAddedToShelf(bookIds.size))
@@ -282,7 +284,7 @@ class BookMultiSelectViewModel(
                     val newShelf = createResult.data
                     logger.info { "Created shelf '${newShelf.name}' with id ${newShelf.id}" }
 
-                    when (val addResult = addBooksToShelfUseCase(newShelf.id, bookIds)) {
+                    when (val addResult = addBooksToShelfUseCase(newShelf.id, bookIds.map { BookId(it) })) {
                         is AppResult.Success -> {
                             logger.info { "Added ${bookIds.size} books to new shelf ${newShelf.id}" }
                             eventsChannel.send(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModel.kt
@@ -201,7 +201,7 @@ class DiscoverViewModel(
      */
     private fun Shelf.toUiModel(): DiscoverShelfUi =
         DiscoverShelfUi(
-            id = id,
+            id = id.value,
             name = name,
             description = description,
             bookCount = bookCount,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/UserProfileViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/profile/UserProfileViewModel.kt
@@ -261,7 +261,7 @@ class UserProfileViewModel internal constructor(
         withAvatarSelfHeal(userId) { it }
 
     private fun List<Shelf>.toSummaries(): List<ProfileShelfSummary> =
-        map { ProfileShelfSummary(id = it.id, name = it.name, bookCount = it.bookCount) }
+        map { ProfileShelfSummary(id = it.id.value, name = it.name, bookCount = it.bookCount) }
 
     private fun resolveLocalAvatarPath(
         userId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/CreateEditShelfViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/CreateEditShelfViewModel.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.DeleteShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.UpdateShelfUseCase
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -44,7 +45,7 @@ class CreateEditShelfViewModel(
     private val _navActions = Channel<CreateEditShelfNavAction>(Channel.BUFFERED)
     val navActions: Flow<CreateEditShelfNavAction> = _navActions.receiveAsFlow()
 
-    private var editingShelfId: String? = null
+    private var editingShelfId: ShelfId? = null
 
     /** Prepare for creating a new shelf. */
     fun initCreate() {
@@ -54,13 +55,14 @@ class CreateEditShelfViewModel(
 
     /** Prepare for editing an existing shelf by id. Fetches the current data. */
     fun initEdit(shelfId: String) {
-        editingShelfId = shelfId
+        val id = ShelfId(shelfId)
+        editingShelfId = id
         viewModelScope.launch {
             state.value = CreateEditShelfUiState.LoadingExisting
 
             state.value =
                 try {
-                    val shelf = shelfRepository.getById(shelfId)
+                    val shelf = shelfRepository.getById(id)
                     if (shelf != null) {
                         CreateEditShelfUiState.Loaded(
                             name = shelf.name,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfDetailViewModel.kt
@@ -7,6 +7,8 @@ import com.calypsan.listenup.client.domain.model.ShelfDetail
 import com.calypsan.listenup.client.domain.usecase.shelf.LoadShelfDetailUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.RemoveBookFromShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.ReorderShelfBooksUseCase
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -35,17 +37,18 @@ class ShelfDetailViewModel(
     private val _snackbarMessages = Channel<String>(Channel.BUFFERED)
     val snackbarMessages: Flow<String> = _snackbarMessages.receiveAsFlow()
 
-    private var currentShelfId: String? = null
+    private var currentShelfId: ShelfId? = null
 
     /** Load shelf detail from the server. Always re-fetches to ensure fresh data. */
     fun loadShelf(shelfId: String) {
-        currentShelfId = shelfId
+        val id = ShelfId(shelfId)
+        currentShelfId = id
 
         viewModelScope.launch {
             state.value = ShelfDetailUiState.Loading
 
             state.value =
-                when (val result = loadShelfDetailUseCase(shelfId)) {
+                when (val result = loadShelfDetailUseCase(id)) {
                     is AppResult.Success -> {
                         val shelfDetail = result.data
                         logger.debug { "Loaded shelf detail: ${shelfDetail.name}" }
@@ -71,11 +74,11 @@ class ShelfDetailViewModel(
         val shelfId = currentShelfId ?: return
 
         viewModelScope.launch {
-            when (val result = reorderShelfBooksUseCase(shelfId, orderedBookIds)) {
+            when (val result = reorderShelfBooksUseCase(shelfId, orderedBookIds.map { BookId(it) })) {
                 is AppResult.Success -> {
                     logger.info { "Reordered books in shelf $shelfId" }
                     currentShelfId = null // Force reload
-                    loadShelf(shelfId)
+                    loadShelf(shelfId.value)
                 }
 
                 is AppResult.Failure -> {
@@ -91,11 +94,11 @@ class ShelfDetailViewModel(
         val shelfId = currentShelfId ?: return
 
         viewModelScope.launch {
-            when (val result = removeBookFromShelfUseCase(shelfId, bookId)) {
+            when (val result = removeBookFromShelfUseCase(shelfId, BookId(bookId))) {
                 is AppResult.Success -> {
                     logger.info { "Removed book $bookId from shelf $shelfId" }
                     currentShelfId = null // Force reload
-                    loadShelf(shelfId)
+                    loadShelf(shelfId.value)
                 }
 
                 is AppResult.Failure -> {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
@@ -107,7 +107,7 @@ class ShelfRepositoryImplTest :
                         everySuspend { totalDurationMsFor("s1") } returns 7_200_000L
                     }
                 val result = repo(shelfDao = dao).observeMyShelves("owner1").first()
-                result.map { it.id } shouldContainExactly listOf("s1")
+                result.map { it.id.value } shouldContainExactly listOf("s1")
                 val shelf = result.first()
                 shelf.bookCount shouldBe 5
                 shelf.isPrivate shouldBe true
@@ -127,7 +127,7 @@ class ShelfRepositoryImplTest :
                     }
                 val result = repo(service = service).createShelf("New", null, isPrivate = true)
                 val shelf = (result as AppResult.Success).data
-                shelf.id shouldBe "s-new"
+                shelf.id.value shouldBe "s-new"
                 shelf.name shouldBe "New"
                 shelf.isPrivate shouldBe true
             }
@@ -153,7 +153,7 @@ class ShelfRepositoryImplTest :
                             updateShelf(ShelfId("s1"), "Renamed", "", true)
                         } returns AppResult.Success(summary("s1", "Renamed", isPrivate = true))
                     }
-                repo(service = service).updateShelf("s1", "Renamed", null, isPrivate = true)
+                repo(service = service).updateShelf(ShelfId("s1"), "Renamed", null, isPrivate = true)
                 verifySuspend { service.updateShelf(ShelfId("s1"), "Renamed", "", true) }
             }
         }
@@ -164,7 +164,7 @@ class ShelfRepositoryImplTest :
                     mock<ShelfService> {
                         everySuspend { deleteShelf(ShelfId("s1")) } returns AppResult.Success(Unit)
                     }
-                val result = repo(service = service).deleteShelf("s1")
+                val result = repo(service = service).deleteShelf(ShelfId("s1"))
                 result.shouldBeInstanceOf<AppResult.Success<Unit>>()
             }
         }
@@ -177,7 +177,7 @@ class ShelfRepositoryImplTest :
                         everySuspend { addBookToShelf(ShelfId("s1"), BookId("b2")) } returns
                             AppResult.Failure(ValidationError(message = "nope"))
                     }
-                val result = repo(service = service).addBooksToShelf("s1", listOf("b1", "b2"))
+                val result = repo(service = service).addBooksToShelf(ShelfId("s1"), listOf(BookId("b1"), BookId("b2")))
                 result.shouldBeInstanceOf<AppResult.Failure>()
             }
         }
@@ -188,7 +188,7 @@ class ShelfRepositoryImplTest :
                     mock<ShelfService> {
                         everySuspend { removeBookFromShelf(ShelfId("s1"), BookId("b1")) } returns AppResult.Success(Unit)
                     }
-                val result = repo(service = service).removeBookFromShelf("s1", "b1")
+                val result = repo(service = service).removeBookFromShelf(ShelfId("s1"), BookId("b1"))
                 result.shouldBeInstanceOf<AppResult.Success<Unit>>()
             }
         }
@@ -201,7 +201,7 @@ class ShelfRepositoryImplTest :
                             reorderShelfBooks(ShelfId("s1"), listOf(BookId("b2"), BookId("b1")))
                         } returns AppResult.Success(Unit)
                     }
-                repo(service = service).reorderBooks("s1", listOf("b2", "b1"))
+                repo(service = service).reorderBooks(ShelfId("s1"), listOf(BookId("b2"), BookId("b1")))
                 verifySuspend { service.reorderShelfBooks(ShelfId("s1"), listOf(BookId("b2"), BookId("b1"))) }
             }
         }
@@ -225,7 +225,7 @@ class ShelfRepositoryImplTest :
                 val shelves = (result as AppResult.Success).data
                 shelves shouldContainExactly shelves // size assertion below
                 val shelf = shelves.first()
-                shelf.id shouldBe "s9"
+                shelf.id.value shouldBe "s9"
                 shelf.ownerId shouldBe "u2"
                 shelf.ownerDisplayName shouldBe "Sam"
                 shelf.bookCount shouldBe 3
@@ -242,7 +242,7 @@ class ShelfRepositoryImplTest :
                         everySuspend { bookCountFor("s1") } returns 7
                         everySuspend { totalDurationMsFor("s1") } returns 0L
                     }
-                val shelf = repo(shelfDao = dao).observeById("s1").first()
+                val shelf = repo(shelfDao = dao).observeById(ShelfId("s1")).first()
                 shelf!!.bookCount shouldBe 7
             }
         }
@@ -269,7 +269,7 @@ class ShelfRepositoryImplTest :
                 val shelves = (result as AppResult.Success).data
                 shelves.size shouldBe 1
                 val shelf = shelves.first()
-                shelf.id shouldBe "s9"
+                shelf.id.value shouldBe "s9"
                 shelf.name shouldBe "Alice's picks"
                 shelf.bookCount shouldBe 4
             }
@@ -298,8 +298,8 @@ class ShelfRepositoryImplTest :
                         everySuspend { coverHashesFor("s1") } returns listOf("hash1")
                         everySuspend { totalDurationMsFor("s1") } returns 3_600_000L
                     }
-                val result = repo(shelfDao = dao).observeShelvesContainingBook("b1").first()
-                result.map { it.id } shouldContainExactly listOf("s1")
+                val result = repo(shelfDao = dao).observeShelvesContainingBook(BookId("b1")).first()
+                result.map { it.id.value } shouldContainExactly listOf("s1")
                 result.first().bookCount shouldBe 3
                 result.first().ownerId shouldBe "owner1"
             }
@@ -335,10 +335,10 @@ class ShelfRepositoryImplTest :
                                 ShelfBookCoverHash(bookId = "b2", coverHash = null),
                             )
                     }
-                val result = repo(shelfDao = dao, service = service).getShelfDetail("s1")
+                val result = repo(shelfDao = dao, service = service).getShelfDetail(ShelfId("s1"))
                 val detail = (result as AppResult.Success).data
-                detail.books.first { it.id == "b1" }.coverHash shouldBe "hash-b1"
-                detail.books.first { it.id == "b2" }.coverHash shouldBe null
+                detail.books.first { it.id.value == "b1" }.coverHash shouldBe "hash-b1"
+                detail.books.first { it.id.value == "b2" }.coverHash shouldBe null
             }
         }
 
@@ -348,7 +348,7 @@ class ShelfRepositoryImplTest :
                     mock<ShelfService> {
                         everySuspend { deleteShelf(ShelfId("s1")) } throws CancellationException("cancelled")
                     }
-                shouldThrow<CancellationException> { repo(service = service).deleteShelf("s1") }
+                shouldThrow<CancellationException> { repo(service = service).deleteShelf(ShelfId("s1")) }
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/ShelfUseCasesTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/shelf/ShelfUseCasesTest.kt
@@ -5,6 +5,8 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.checkIs
 import com.calypsan.listenup.client.domain.model.Shelf
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -31,7 +33,7 @@ class ShelfUseCasesTest :
             description: String? = null,
             isPrivate: Boolean = false,
         ) = Shelf(
-            id = id,
+            id = ShelfId(id),
             name = name,
             description = description,
             isPrivate = isPrivate,
@@ -125,7 +127,7 @@ class ShelfUseCasesTest :
                 } returns AppResult.Success(expectedShelf)
                 val useCase = UpdateShelfUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-123", name = "Updated Name", description = null)
+                val result = useCase(shelfId = ShelfId("shelf-123"), name = "Updated Name", description = null)
 
                 val success = result.shouldBeInstanceOf<AppResult.Success<Shelf>>()
                 success.data.name shouldBe "Updated Name"
@@ -140,9 +142,9 @@ class ShelfUseCasesTest :
                 } returns AppResult.Success(createShelf())
                 val useCase = UpdateShelfUseCase(shelfRepository)
 
-                useCase(shelfId = "shelf-456", name = "New Name", description = "New description", isPrivate = true)
+                useCase(shelfId = ShelfId("shelf-456"), name = "New Name", description = "New description", isPrivate = true)
 
-                verifySuspend { shelfRepository.updateShelf("shelf-456", "New Name", "New description", true) }
+                verifySuspend { shelfRepository.updateShelf(ShelfId("shelf-456"), "New Name", "New description", true) }
             }
         }
 
@@ -151,7 +153,7 @@ class ShelfUseCasesTest :
                 val shelfRepository: ShelfRepository = mock()
                 val useCase = UpdateShelfUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-123", name = "   ", description = null)
+                val result = useCase(shelfId = ShelfId("shelf-123"), name = "   ", description = null)
 
                 val failure = result.shouldBeInstanceOf<AppResult.Failure>()
                 failure.error.shouldBeInstanceOf<ValidationError>()
@@ -167,7 +169,7 @@ class ShelfUseCasesTest :
                 everySuspend { shelfRepository.deleteShelf(any()) } returns AppResult.Success(Unit)
                 val useCase = DeleteShelfUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-123")
+                val result = useCase(shelfId = ShelfId("shelf-123"))
 
                 checkIs<AppResult.Success<Unit>>(result)
             }
@@ -179,9 +181,9 @@ class ShelfUseCasesTest :
                 everySuspend { shelfRepository.deleteShelf(any()) } returns AppResult.Success(Unit)
                 val useCase = DeleteShelfUseCase(shelfRepository)
 
-                useCase(shelfId = "shelf-456")
+                useCase(shelfId = ShelfId("shelf-456"))
 
-                verifySuspend { shelfRepository.deleteShelf("shelf-456") }
+                verifySuspend { shelfRepository.deleteShelf(ShelfId("shelf-456")) }
             }
         }
 
@@ -193,7 +195,7 @@ class ShelfUseCasesTest :
                 } returns AppResult.Failure(ValidationError(message = "boom"))
                 val useCase = DeleteShelfUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-123")
+                val result = useCase(shelfId = ShelfId("shelf-123"))
 
                 result.shouldBeInstanceOf<AppResult.Failure>()
             }
@@ -207,10 +209,10 @@ class ShelfUseCasesTest :
                 everySuspend { shelfRepository.reorderBooks(any(), any()) } returns AppResult.Success(Unit)
                 val useCase = ReorderShelfBooksUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-1", orderedBookIds = listOf("b2", "b1", "b3"))
+                val result = useCase(shelfId = ShelfId("shelf-1"), orderedBookIds = listOf(BookId("b2"), BookId("b1"), BookId("b3")))
 
                 checkIs<AppResult.Success<Unit>>(result)
-                verifySuspend { shelfRepository.reorderBooks("shelf-1", listOf("b2", "b1", "b3")) }
+                verifySuspend { shelfRepository.reorderBooks(ShelfId("shelf-1"), listOf(BookId("b2"), BookId("b1"), BookId("b3"))) }
             }
         }
 
@@ -219,7 +221,7 @@ class ShelfUseCasesTest :
                 val shelfRepository: ShelfRepository = mock()
                 val useCase = ReorderShelfBooksUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-1", orderedBookIds = emptyList())
+                val result = useCase(shelfId = ShelfId("shelf-1"), orderedBookIds = emptyList())
 
                 val failure = result.shouldBeInstanceOf<AppResult.Failure>()
                 failure.error.shouldBeInstanceOf<ValidationError>()
@@ -233,7 +235,7 @@ class ShelfUseCasesTest :
                 val shelfRepository: ShelfRepository = mock()
                 val useCase = AddBooksToShelfUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-1", bookIds = emptyList())
+                val result = useCase(shelfId = ShelfId("shelf-1"), bookIds = emptyList())
 
                 val failure = result.shouldBeInstanceOf<AppResult.Failure>()
                 failure.error.shouldBeInstanceOf<ValidationError>()
@@ -246,10 +248,10 @@ class ShelfUseCasesTest :
                 everySuspend { shelfRepository.addBooksToShelf(any(), any()) } returns AppResult.Success(Unit)
                 val useCase = AddBooksToShelfUseCase(shelfRepository)
 
-                val result = useCase(shelfId = "shelf-1", bookIds = listOf("b1", "b2"))
+                val result = useCase(shelfId = ShelfId("shelf-1"), bookIds = listOf(BookId("b1"), BookId("b2")))
 
                 checkIs<AppResult.Success<Unit>>(result)
-                verifySuspend { shelfRepository.addBooksToShelf("shelf-1", listOf("b1", "b2")) }
+                verifySuspend { shelfRepository.addBooksToShelf(ShelfId("shelf-1"), listOf(BookId("b1"), BookId("b2"))) }
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.turbineScope
 import com.calypsan.listenup.client.TestData
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.core.error.ErrorBus
 import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.Genre
@@ -943,11 +944,11 @@ class BookDetailViewModelTest :
                 val book = TestData.bookDetail(title = "My Book")
                 every { fixture.bookRepository.observeBookDetail("book-1") } returns flowOf(book)
                 everySuspend { fixture.bookRepository.getChapters("book-1") } returns emptyList()
-                every { fixture.shelfRepository.observeShelvesContainingBook("book-1") } returns
+                every { fixture.shelfRepository.observeShelvesContainingBook(BookId("book-1")) } returns
                     flowOf(
                         listOf(
                             Shelf(
-                                id = "s1",
+                                id = ShelfId("s1"),
                                 name = "To Read",
                                 description = null,
                                 isPrivate = false,
@@ -967,7 +968,7 @@ class BookDetailViewModelTest :
                     membership.awaitItem() // initial emptyList seed
                     viewModel.loadBook("book-1")
                     advanceUntilIdle()
-                    membership.expectMostRecentItem().map { it.id } shouldContainExactly listOf("s1")
+                    membership.expectMostRecentItem().map { it.id.value } shouldContainExactly listOf("s1")
                     membership.cancel()
                 }
             }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModelTest.kt
@@ -15,6 +15,7 @@ import com.calypsan.listenup.client.domain.usecase.collection.AddBooksToCollecti
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.core.error.ErrorBus
+import com.calypsan.listenup.core.ShelfId
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -100,7 +101,7 @@ class BookMultiSelectViewModelTest :
             name: String = "My Shelf",
         ): Shelf =
             Shelf(
-                id = id,
+                id = ShelfId(id),
                 name = name,
                 description = "",
                 isPrivate = false,
@@ -233,7 +234,7 @@ class BookMultiSelectViewModelTest :
                 }
 
                 viewModel.selectionMode.value shouldBe SelectionMode.None
-                verifySuspend { fixture.addBooksToShelfUseCase("shelf-1", any()) }
+                verifySuspend { fixture.addBooksToShelfUseCase(ShelfId("shelf-1"), any()) }
             }
         }
 
@@ -367,7 +368,7 @@ class BookMultiSelectViewModelTest :
                 }
 
                 verifySuspend { fixture.createShelfUseCase("My New Shelf", null) }
-                verifySuspend { fixture.addBooksToShelfUseCase("new-shelf", any()) }
+                verifySuspend { fixture.addBooksToShelfUseCase(ShelfId("new-shelf"), any()) }
                 viewModel.selectionMode.value shouldBe SelectionMode.None
             }
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/discover/DiscoverViewModelTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.error.ErrorBus
+import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.error.TransportError
 
@@ -109,7 +110,7 @@ class DiscoverViewModelTest :
             ownerDisplayName: String = "Alice",
         ): Shelf =
             Shelf(
-                id = id,
+                id = ShelfId(id),
                 name = "A Shelf",
                 description = null,
                 isPrivate = false,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/UserProfileViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/profile/UserProfileViewModelTest.kt
@@ -11,6 +11,7 @@ import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.core.error.ErrorBus
+import com.calypsan.listenup.core.ShelfId
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -94,7 +95,7 @@ class UserProfileViewModelTest :
             bookCount: Int = 3,
         ): Shelf =
             Shelf(
-                id = id,
+                id = ShelfId(id),
                 name = name,
                 description = null,
                 isPrivate = false,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/CreateEditShelfViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/CreateEditShelfViewModelTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.DeleteShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.UpdateShelfUseCase
 import com.calypsan.listenup.core.error.ErrorBus
+import com.calypsan.listenup.core.ShelfId
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -39,7 +40,7 @@ class CreateEditShelfViewModelTest :
 
         fun shelf(isPrivate: Boolean) =
             Shelf(
-                id = "s1",
+                id = ShelfId("s1"),
                 name = "Reads",
                 description = "desc",
                 isPrivate = isPrivate,
@@ -81,7 +82,7 @@ class CreateEditShelfViewModelTest :
         test("save in edit mode forwards the privacy flag to update") {
             runTest {
                 val repo: ShelfRepository =
-                    mock { everySuspend { getById("s1") } returns shelf(isPrivate = false) }
+                    mock { everySuspend { getById(ShelfId("s1")) } returns shelf(isPrivate = false) }
                 val update: UpdateShelfUseCase =
                     mock {
                         everySuspend {
@@ -95,14 +96,14 @@ class CreateEditShelfViewModelTest :
                 vm.save(name = "Reads", description = "desc", isPrivate = true)
                 advanceUntilIdle()
 
-                verifySuspend { update.invoke("s1", "Reads", "desc", true) }
+                verifySuspend { update.invoke(ShelfId("s1"), "Reads", "desc", true) }
             }
         }
 
         test("initEdit seeds the private flag from the loaded shelf") {
             runTest {
                 val repo: ShelfRepository =
-                    mock { everySuspend { getById("s1") } returns shelf(isPrivate = true) }
+                    mock { everySuspend { getById(ShelfId("s1")) } returns shelf(isPrivate = true) }
                 val vm = viewModel(repo = repo)
 
                 vm.initEdit("s1")

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfBookSortTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfBookSortTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.presentation.shelf
 
 import com.calypsan.listenup.client.domain.model.ShelfBook
+import com.calypsan.listenup.core.BookId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -14,7 +15,7 @@ class ShelfBookSortTest :
             id: String,
             title: String,
             author: String,
-        ) = ShelfBook(id = id, title = title, authorNames = listOf(author), coverPath = null)
+        ) = ShelfBook(id = BookId(id), title = title, authorNames = listOf(author), coverPath = null)
 
         // Natural order = added oldest → newest.
         val first = book("1", "Mistborn", "Brandon Sanderson")
@@ -23,11 +24,11 @@ class ShelfBookSortTest :
         val natural = listOf(first, second, third)
 
         test("ADDED_OLDEST keeps the natural added order") {
-            sortShelfBooks(natural, ShelfBookSort.ADDED_OLDEST).map { it.id } shouldBe listOf("1", "2", "3")
+            sortShelfBooks(natural, ShelfBookSort.ADDED_OLDEST).map { it.id.value } shouldBe listOf("1", "2", "3")
         }
 
         test("ADDED_NEWEST reverses to newest-first") {
-            sortShelfBooks(natural, ShelfBookSort.ADDED_NEWEST).map { it.id } shouldBe listOf("3", "2", "1")
+            sortShelfBooks(natural, ShelfBookSort.ADDED_NEWEST).map { it.id.value } shouldBe listOf("3", "2", "1")
         }
 
         test("TITLE sorts case-insensitively A–Z") {
@@ -41,7 +42,7 @@ class ShelfBookSortTest :
         }
 
         test("a book with no authors sorts last under AUTHOR without crashing") {
-            val orphan = ShelfBook(id = "x", title = "Orphan", authorNames = emptyList(), coverPath = null)
-            sortShelfBooks(listOf(orphan, third), ShelfBookSort.AUTHOR).map { it.id } shouldBe listOf("3", "x")
+            val orphan = ShelfBook(id = BookId("x"), title = "Orphan", authorNames = emptyList(), coverPath = null)
+            sortShelfBooks(listOf(orphan, third), ShelfBookSort.AUTHOR).map { it.id.value } shouldBe listOf("3", "x")
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfDetailViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/shelf/ShelfDetailViewModelTest.kt
@@ -6,6 +6,8 @@ import com.calypsan.listenup.client.domain.model.ShelfDetail
 import com.calypsan.listenup.client.domain.usecase.shelf.LoadShelfDetailUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.RemoveBookFromShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.ReorderShelfBooksUseCase
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.ShelfId
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -37,7 +39,7 @@ class ShelfDetailViewModelTest :
 
         fun detail(isOwner: Boolean) =
             ShelfDetail(
-                id = "s1",
+                id = ShelfId("s1"),
                 name = "Reads",
                 description = null,
                 isPrivate = false,
@@ -59,7 +61,7 @@ class ShelfDetailViewModelTest :
         test("loadShelf surfaces isOwner from the detail (owner)") {
             runTest {
                 val load: LoadShelfDetailUseCase =
-                    mock { everySuspend { invoke("s1") } returns AppResult.Success(detail(isOwner = true)) }
+                    mock { everySuspend { invoke(ShelfId("s1")) } returns AppResult.Success(detail(isOwner = true)) }
                 val vm = viewModel(load = load)
 
                 vm.loadShelf("s1")
@@ -73,7 +75,7 @@ class ShelfDetailViewModelTest :
         test("loadShelf surfaces isOwner from the detail (non-owner)") {
             runTest {
                 val load: LoadShelfDetailUseCase =
-                    mock { everySuspend { invoke("s1") } returns AppResult.Success(detail(isOwner = false)) }
+                    mock { everySuspend { invoke(ShelfId("s1")) } returns AppResult.Success(detail(isOwner = false)) }
                 val vm = viewModel(load = load)
 
                 vm.loadShelf("s1")
@@ -87,7 +89,7 @@ class ShelfDetailViewModelTest :
         test("loadShelf failure maps to the Error state") {
             runTest {
                 val load: LoadShelfDetailUseCase =
-                    mock { everySuspend { invoke("s1") } returns AppResult.Failure(ShelfError.NotFound()) }
+                    mock { everySuspend { invoke(ShelfId("s1")) } returns AppResult.Failure(ShelfError.NotFound()) }
                 val vm = viewModel(load = load)
 
                 vm.loadShelf("s1")
@@ -100,7 +102,7 @@ class ShelfDetailViewModelTest :
         test("reorderBooks dispatches the new order and reloads") {
             runTest {
                 val load: LoadShelfDetailUseCase =
-                    mock { everySuspend { invoke("s1") } returns AppResult.Success(detail(isOwner = true)) }
+                    mock { everySuspend { invoke(ShelfId("s1")) } returns AppResult.Success(detail(isOwner = true)) }
                 val reorder: ReorderShelfBooksUseCase =
                     mock { everySuspend { invoke(any(), any()) } returns AppResult.Success(Unit) }
                 val vm = viewModel(load = load, reorder = reorder)
@@ -110,7 +112,7 @@ class ShelfDetailViewModelTest :
                 vm.reorderBooks(listOf("b2", "b1"))
                 advanceUntilIdle()
 
-                verifySuspend { reorder.invoke("s1", listOf("b2", "b1")) }
+                verifySuspend { reorder.invoke(ShelfId("s1"), listOf(BookId("b2"), BookId("b1"))) }
             }
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DomainModelIdsAreTypedRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/DomainModelIdsAreTypedRule.kt
@@ -1,0 +1,60 @@
+package com.calypsan.listenup.konsist
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Pin: domain-model files that have completed the value-class id migration must
+ * not regress to raw `String` id properties.
+ *
+ * [MIGRATED_DOMAIN_MODELS] grows one entry per migrated domain — adding a file
+ * here is the explicit signal that its domain's ids are typed end-to-end (the
+ * `id`/`*Id` properties are `@JvmInline value class` wrappers from
+ * `contract/.../core/ValueClasses.kt`, not `String`).
+ *
+ * [ALLOWED_STRING_ID_NAMES] lists id-suffixed properties that legitimately stay
+ * `String` until THEIR owning domain migrates (e.g. `ownerId` is a user id and
+ * migrates with the User domain). The `id`/`idString` split is deliberate: the
+ * typed identity is `id`; `idString` is the plain-`String` Swift/SKIE bridge and
+ * is intentionally excluded (`name == "id"` only, never `idString`).
+ */
+class DomainModelIdsAreTypedRule :
+    FunSpec({
+        test("migrated domain models use value-class ids, not String") {
+            val offenders =
+                productionScope()
+                    .classes()
+                    .filter { cls -> MIGRATED_DOMAIN_MODELS.any { cls.path.endsWith(it) } }
+                    .flatMap { cls ->
+                        cls
+                            .properties()
+                            .filter {
+                                it.name == "id" || (
+                                    it.name.endsWith(
+                                        "Id",
+                                    ) && it.name !in ALLOWED_STRING_ID_NAMES
+                                )
+                            }.filter { it.type?.name == "String" }
+                            .map { "${cls.name}.${it.name} in ${it.path}" }
+                    }
+
+            offenders.shouldBeEmpty()
+        }
+    })
+
+/**
+ * Domain-model files whose ids are typed end-to-end. Extending this set is the
+ * "domain done" signal for the value-class id migration (Plan 069 onward).
+ */
+private val MIGRATED_DOMAIN_MODELS =
+    setOf(
+        "domain/model/Shelf.kt",
+        "domain/model/ShelfDetail.kt",
+    )
+
+/**
+ * Id-suffixed properties that legitimately remain `String` on a migrated model
+ * because they belong to a domain that has not migrated yet (removed as each
+ * owning domain is typed).
+ */
+private val ALLOWED_STRING_ID_NAMES = setOf("ownerId")

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverModel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverModel.kt
@@ -69,7 +69,7 @@ fun SearchHit.toCoverModel(): BookCoverModel =
 /** Bundle a shelf book's cover identity. */
 fun ShelfBook.toCoverModel(): BookCoverModel =
     BookCoverModel(
-        bookId = id,
+        bookId = id.value,
         title = title,
         author = authorNames.joinToString(", "),
         coverPath = coverPath,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomePreviews.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/HomePreviews.kt
@@ -23,6 +23,7 @@ import com.calypsan.listenup.client.domain.GenreShare
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
 import com.calypsan.listenup.client.domain.model.ContinueListeningItem
 import com.calypsan.listenup.client.domain.model.Shelf
+import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.client.features.home.components.ContinueListeningRow
 import com.calypsan.listenup.client.features.home.components.HomeHeader
 import com.calypsan.listenup.client.features.home.components.HomeStatsContent
@@ -63,7 +64,7 @@ private fun mockShelf(
     name: String,
     count: Int,
 ) = Shelf(
-    id = id,
+    id = ShelfId(id),
     name = name,
     description = null,
     isPrivate = false,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/MyShelvesRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/home/components/MyShelvesRow.kt
@@ -63,7 +63,7 @@ fun MyShelvesRow(
                         shelf = shelf,
                         containerColor = container,
                         contentColor = content,
-                        onClick = { onShelfClick(shelf.id) },
+                        onClick = { onShelfClick(shelf.id.value) },
                         fillWidth = true,
                     )
                 }
@@ -75,14 +75,14 @@ fun MyShelvesRow(
                 itemWidth = 180.dp,
                 itemSpacing = Spacing.itemGap,
                 contentPadding = PaddingValues(horizontal = Spacing.screenMargin),
-                key = { it.id },
+                key = { it.id.value },
             ) { shelf ->
                 val (container, content) = shelfColors(shelves.indexOf(shelf))
                 ShelfCard(
                     shelf = shelf,
                     containerColor = container,
                     contentColor = content,
-                    onClick = { onShelfClick(shelf.id) },
+                    onClick = { onShelfClick(shelf.id.value) },
                 )
             }
         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/ShelfPickerSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/ShelfPickerSheet.kt
@@ -158,11 +158,11 @@ fun ShelfPickerSheet(
                     } else {
                         items(
                             items = shelves,
-                            key = { it.id },
+                            key = { it.id.value },
                         ) { shelf ->
                             ShelfRow(
                                 shelf = shelf,
-                                onClick = { onShelfSelected(shelf.id) },
+                                onClick = { onShelfSelected(shelf.id.value) },
                                 enabled = !isLoading,
                             )
                         }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/shelf/ShelfDetailScreen.kt
@@ -262,8 +262,8 @@ private fun ShelfDetailContent(
                 ShelfEmptyState(isOwner = isOwner)
             }
         } else {
-            items(items = sortedBooks, key = { it.id }) { book ->
-                ShelfBookGridItem(book = book, onClick = { onBookClick(book.id) })
+            items(items = sortedBooks, key = { it.id.value }) { book ->
+                ShelfBookGridItem(book = book, onClick = { onBookClick(book.id.value) })
             }
         }
     }


### PR DESCRIPTION
Audit plan 069 — the **Shelf-domain pilot** of a client-wide value-class-ID migration, establishing a documented, repeatable recipe + a Konsist regression rule so later domains burn down one at a time.

The contract layer is already `ShelfId`-typed; this migrates the `sharedLogic` domain layer (models, repository interface, 7 use cases, impl, ViewModels) end-to-end, plus the sharedUI/iOS call sites. The elegance win: `ShelfRepositoryImpl` no longer wraps/unwraps `ShelfId(...)`/`BookId(...)` around every RPC call — those are now clean pass-throughs (contract is typed); conversion lives only at the Room (`.value`) and entity→domain (`ShelfId(...)`) seams.

**Conventions preserved:** ViewModel PUBLIC signatures stay `String` (iOS Swift/Compose-nav call with plain strings; convert once internally); Room layer stays `String` for Shelf (out of scope); `ownerId` stays `String` (migrates with the User domain). Domain models gain an `idString` bridge for the Swift boundary.

**Regression pin:** new Konsist rule `DomainModelIdsAreTypedRule` — `MIGRATED_DOMAIN_MODELS` grows one entry per migrated domain; demonstrated to fail on a String-id regression.

**iOS:** `.id`→`.idString` only where the receiver is the **Kotlin `Shelf`/`ShelfBook`** (observers, wrapper, test). The Swift observer-boundary structs (`ShelfItem`/`ShelfRow`/`SelectionShelfRow`) already carry plain `String id` and keep `.id` — the plan mis-listed 3 such sites and missed one (`BookSelectionObserver`); corrected here and verified by a green `xcodebuild build-for-testing` on Xcode 26.5.

**Export surface:** exactly `+ShelfId` — verified against the canonical generated `Shared.swift` (532 names, content-identical to the baseline with `ShelfId` present).

Linux gates green: `:sharedLogic:jvmTest :server:jvmTest`, `:sharedUI:testAndroidHostTest :androidApp:assembleDebug`, `spotlessCheck detekt`. 37 files; zero changes under `contract/`, `server/`, `data/local/db/`, `data/sync/`.