### PR TITLE
🚨 chore(shared): unified sync domains 5 — Konsist pins, test factory, wrinkle cleanup, Room v45

### DIFF
--- a/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/45.json
+++ b/sharedLogic/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/45.json
@@ -1,0 +1,2905 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 45,
+    "identityHash": "2db66b6c5e572280022004dc42e799bf",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `firstName` TEXT, `lastName` TEXT, `isRoot` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `tagline` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRoot",
+            "columnName": "isRoot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `avatarValue` TEXT, `avatarColor` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarValue",
+            "columnName": "avatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `metadataPrecedence` TEXT NOT NULL, `accessMode` TEXT NOT NULL, `createdByUserId` TEXT, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataPrecedence",
+            "columnName": "metadataPrecedence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessMode",
+            "columnName": "accessMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdByUserId",
+            "columnName": "createdByUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `rootPath` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`libraryId`) REFERENCES `libraries`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootPath",
+            "columnName": "rootPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_folders_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_folders_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "libraries",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "libraryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `folderId` TEXT NOT NULL, `title` TEXT NOT NULL, `sortTitle` TEXT, `subtitle` TEXT, `coverHash` TEXT, `coverBlurHash` TEXT, `coverDownloadedAt` INTEGER, `totalDuration` INTEGER NOT NULL, `description` TEXT, `publishYear` INTEGER, `publisher` TEXT, `language` TEXT, `isbn` TEXT, `asin` TEXT, `abridged` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `hasScanWarning` INTEGER NOT NULL, `userEditedFields` TEXT NOT NULL DEFAULT '', `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortTitle",
+            "columnName": "sortTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverHash",
+            "columnName": "coverHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverDownloadedAt",
+            "columnName": "coverDownloadedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalDuration",
+            "columnName": "totalDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishYear",
+            "columnName": "publishYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abridged",
+            "columnName": "abridged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasScanWarning",
+            "columnName": "hasScanWarning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEditedFields",
+            "columnName": "userEditedFields",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_books_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_books_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookId` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `startTime` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `description` TEXT, `asin` TEXT, `coverPath` TEXT, `coverBlurHash` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverBlurHash",
+            "columnName": "coverBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `sortName` TEXT, `asin` TEXT, `description` TEXT, `imagePath` TEXT, `imageBlurHash` TEXT, `website` TEXT, `birthDate` TEXT, `deathDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortName",
+            "columnName": "sortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "imagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "website",
+            "columnName": "website",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deathDate",
+            "columnName": "deathDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_contributors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `contributorId` TEXT NOT NULL, `role` TEXT NOT NULL, `creditedAs` TEXT, PRIMARY KEY(`bookId`, `contributorId`, `role`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditedAs",
+            "columnName": "creditedAs",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "contributorId",
+            "role"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_contributors_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_contributors_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_contributors_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contributor_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contributorId` TEXT NOT NULL, `alias` TEXT NOT NULL, PRIMARY KEY(`contributorId`, `alias`), FOREIGN KEY(`contributorId`) REFERENCES `contributors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "contributorId",
+            "columnName": "contributorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contributorId",
+            "alias"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contributor_aliases_contributorId",
+            "unique": false,
+            "columnNames": [
+              "contributorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contributor_aliases_contributorId` ON `${TABLE_NAME}` (`contributorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contributors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "contributorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `seriesId` TEXT NOT NULL, `sequence` TEXT, PRIMARY KEY(`bookId`, `seriesId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "seriesId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_series_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_series_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_series_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `hasCustomSpeed` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `syncedAt` INTEGER, `lastPlayedAt` INTEGER, `isFinished` INTEGER NOT NULL, `finishedAt` INTEGER, `startedAt` INTEGER, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomSpeed",
+            "columnName": "hasCustomSpeed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFinished",
+            "columnName": "isFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`audioFileId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `filename` TEXT NOT NULL, `fileIndex` INTEGER NOT NULL, `state` TEXT NOT NULL, `localPath` TEXT, `totalBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, `startedAt` INTEGER, `completedAt` INTEGER, `errorMessage` TEXT, `retryCount` INTEGER NOT NULL, PRIMARY KEY(`audioFileId`))",
+        "fields": [
+          {
+            "fieldPath": "audioFileId",
+            "columnName": "audioFileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileIndex",
+            "columnName": "fileIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "audioFileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `name` TEXT NOT NULL, `isInbox` INTEGER NOT NULL, `isSystem` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInbox",
+            "columnName": "isInbox",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "isSystem",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_libraryId",
+            "unique": false,
+            "columnNames": [
+              "libraryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_libraryId` ON `${TABLE_NAME}` (`libraryId`)"
+          },
+          {
+            "name": "index_collections_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`collectionId`, `bookId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_collection_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "collection_shares",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `collectionId` TEXT NOT NULL, `sharedWithUserId` TEXT NOT NULL, `sharedByUserId` TEXT NOT NULL, `permission` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedWithUserId",
+            "columnName": "sharedWithUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedByUserId",
+            "columnName": "sharedByUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permission",
+            "columnName": "permission",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_shares_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          },
+          {
+            "name": "index_collection_shares_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_shares_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelves",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `isPrivate` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelves_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelves_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "shelf_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `shelfId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shelf_books_shelfId",
+            "unique": false,
+            "columnNames": [
+              "shelfId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_shelfId` ON `${TABLE_NAME}` (`shelfId`)"
+          },
+          {
+            "name": "index_shelf_books_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_shelf_books_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_shelf_books_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `tagId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `tagId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_book_tags_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_tags_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_moods_slug",
+            "unique": false,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_moods_slug` ON `${TABLE_NAME}` (`slug`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_moods",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `moodId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`bookId`, `moodId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodId",
+            "columnName": "moodId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "moodId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_moods_moodId",
+            "unique": false,
+            "columnNames": [
+              "moodId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_moodId` ON `${TABLE_NAME}` (`moodId`)"
+          },
+          {
+            "name": "index_book_moods_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_moods_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `path` TEXT NOT NULL, `parentId` TEXT, `depth` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "depth",
+            "columnName": "depth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genres_slug",
+            "unique": true,
+            "columnNames": [
+              "slug"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genres_slug` ON `${TABLE_NAME}` (`slug`)"
+          },
+          {
+            "name": "index_genres_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genres_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_genres",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `genreId` TEXT NOT NULL, PRIMARY KEY(`bookId`, `genreId`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`genreId`) REFERENCES `genres`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreId",
+            "columnName": "genreId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "genreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_genres_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_book_genres_genreId",
+            "unique": false,
+            "columnNames": [
+              "genreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_genres_genreId` ON `${TABLE_NAME}` (`genreId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "genres",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "genreId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `codec` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, `codecProfile` TEXT, `spatial` TEXT, `bitrate` INTEGER, `sampleRate` INTEGER, `channels` INTEGER, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codec",
+            "columnName": "codec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecProfile",
+            "columnName": "codecProfile",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spatial",
+            "columnName": "spatial",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channels",
+            "columnName": "channels",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_files_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_files_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, `filename` TEXT NOT NULL, `format` TEXT NOT NULL, `size` INTEGER NOT NULL, `hash` TEXT NOT NULL, PRIMARY KEY(`bookId`, `index`), FOREIGN KEY(`bookId`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_documents_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_documents_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `endPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endPositionMs",
+            "columnName": "endPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_userId_endedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "endedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_endedAt` ON `${TABLE_NAME}` (`userId`, `endedAt`)"
+          },
+          {
+            "name": "index_listening_events_userId_revision",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_revision` ON `${TABLE_NAME}` (`userId`, `revision`)"
+          },
+          {
+            "name": "index_listening_events_userId_bookId",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_userId_bookId` ON `${TABLE_NAME}` (`userId`, `bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "activities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `type` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `userDisplayName` TEXT NOT NULL, `userAvatarColor` TEXT NOT NULL, `userAvatarType` TEXT NOT NULL, `userAvatarValue` TEXT, `bookId` TEXT, `bookTitle` TEXT, `bookAuthorName` TEXT, `bookCoverPath` TEXT, `isReread` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `milestoneValue` INTEGER NOT NULL, `milestoneUnit` TEXT, `shelfId` TEXT, `shelfName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarColor",
+            "columnName": "userAvatarColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarType",
+            "columnName": "userAvatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAvatarValue",
+            "columnName": "userAvatarValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookTitle",
+            "columnName": "bookTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookAuthorName",
+            "columnName": "bookAuthorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCoverPath",
+            "columnName": "bookCoverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isReread",
+            "columnName": "isReread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneValue",
+            "columnName": "milestoneValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "milestoneUnit",
+            "columnName": "milestoneUnit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfId",
+            "columnName": "shelfId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shelfName",
+            "columnName": "shelfName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_activities_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_activities_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_activities_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `booksStarted` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `lastEventDate` TEXT, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksStarted",
+            "columnName": "booksStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEventDate",
+            "columnName": "lastEventDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `defaultPlaybackSpeed` REAL NOT NULL, `defaultSkipForwardSec` INTEGER NOT NULL, `defaultSkipBackwardSec` INTEGER NOT NULL, `defaultSleepTimerMin` INTEGER, `shakeToResetSleepTimer` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPlaybackSpeed",
+            "columnName": "defaultPlaybackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipForwardSec",
+            "columnName": "defaultSkipForwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSkipBackwardSec",
+            "columnName": "defaultSkipBackwardSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultSleepTimerMin",
+            "columnName": "defaultSleepTimerMin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shakeToResetSleepTimer",
+            "columnName": "shakeToResetSleepTimer",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "public_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `tagline` TEXT, `totalSecondsAllTime` INTEGER NOT NULL, `totalSecondsLast7Days` INTEGER NOT NULL, `totalSecondsLast30Days` INTEGER NOT NULL, `totalSecondsLast365Days` INTEGER NOT NULL, `booksFinished` INTEGER NOT NULL, `currentStreakDays` INTEGER NOT NULL, `longestStreakDays` INTEGER NOT NULL, `booksFinishedLast7Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast30Days` INTEGER NOT NULL DEFAULT 0, `booksFinishedLast365Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast7Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast30Days` INTEGER NOT NULL DEFAULT 0, `longestStreakLast365Days` INTEGER NOT NULL DEFAULT 0, `avatarUpdatedAt` INTEGER NOT NULL DEFAULT 0, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "totalSecondsAllTime",
+            "columnName": "totalSecondsAllTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast7Days",
+            "columnName": "totalSecondsLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast30Days",
+            "columnName": "totalSecondsLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSecondsLast365Days",
+            "columnName": "totalSecondsLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinished",
+            "columnName": "booksFinished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStreakDays",
+            "columnName": "currentStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longestStreakDays",
+            "columnName": "longestStreakDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "booksFinishedLast7Days",
+            "columnName": "booksFinishedLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast30Days",
+            "columnName": "booksFinishedLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "booksFinishedLast365Days",
+            "columnName": "booksFinishedLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast7Days",
+            "columnName": "longestStreakLast7Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast30Days",
+            "columnName": "longestStreakLast30Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "longestStreakLast365Days",
+            "columnName": "longestStreakLast365Days",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avatarUpdatedAt",
+            "columnName": "avatarUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tentative_span",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startPositionMs` INTEGER NOT NULL, `currentPositionMs` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `lastHeartbeatAt` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `tz` TEXT NOT NULL, `deviceLabel` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startPositionMs",
+            "columnName": "startPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeartbeatAt",
+            "columnName": "lastHeartbeatAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tz",
+            "columnName": "tz",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceLabel",
+            "columnName": "deviceLabel",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cover_download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `status` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `error` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_cursor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domainName` TEXT NOT NULL, `revision` INTEGER NOT NULL, PRIMARY KEY(`domainName`))",
+        "fields": [
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domainName"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_operation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clientOpId` TEXT NOT NULL, `domainName` TEXT NOT NULL, `entityId` TEXT NOT NULL, `opType` TEXT NOT NULL, `payload` TEXT NOT NULL, `enqueuedAt` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `failureCount` INTEGER NOT NULL, `lastError` TEXT, `ownerUserId` TEXT NOT NULL, PRIMARY KEY(`clientOpId`))",
+        "fields": [
+          {
+            "fieldPath": "clientOpId",
+            "columnName": "clientOpId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opType",
+            "columnName": "opType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clientOpId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_operation_domainName_entityId_enqueuedAt",
+            "unique": false,
+            "columnNames": [
+              "domainName",
+              "entityId",
+              "enqueuedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_domainName_entityId_enqueuedAt` ON `${TABLE_NAME}` (`domainName`, `entityId`, `enqueuedAt`)"
+          },
+          {
+            "name": "index_pending_operation_ownerUserId",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_operation_ownerUserId` ON `${TABLE_NAME}` (`ownerUserId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "admin_user_roster",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `displayName` TEXT NOT NULL, `role` TEXT NOT NULL, `status` TEXT NOT NULL, `canShare` INTEGER NOT NULL, `accountCreatedAt` INTEGER NOT NULL, `revision` INTEGER NOT NULL, `deletedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canShare",
+            "columnName": "canShare",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountCreatedAt",
+            "columnName": "accountCreatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_readership",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `currentProgressPct` INTEGER, `finishesJson` TEXT NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`, `userId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentProgressPct",
+            "columnName": "currentProgressPct",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishesJson",
+            "columnName": "finishesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId",
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_active_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `avatarType` TEXT NOT NULL, `bookId` TEXT NOT NULL, `startedAtMs` INTEGER NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarType",
+            "columnName": "avatarType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "startedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2db66b6c5e572280022004dc42e799bf')"
+    ]
+  }
+}

--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -22,6 +22,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_43_44
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_44_45
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -63,6 +64,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_41_42,
                     MIGRATION_42_43,
                     MIGRATION_43_44,
+                    MIGRATION_44_45,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
+++ b/sharedLogic/src/appleMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_43_44
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_44_45
 import com.calypsan.listenup.core.IODispatcher
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -80,6 +81,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_41_42,
                     MIGRATION_42_43,
                     MIGRATION_43_44,
+                    MIGRATION_44_45,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -15,7 +15,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
  *
  * Stores user data, books, and sync metadata for offline-first functionality.
  *
- * Schema is at v43. Migrations live in the `data/local/migrations/` package
+ * Schema is at v44. Migrations live in the `data/local/migrations/` package
  * (e.g. `Migration14To15`, `Migration19To20`) and are registered via `.addMigrations(...)`
  * in each platform `DatabaseModule`. Pre-launch policy: `fallbackToDestructiveMigration(true)`
  * is set on each `DatabaseModule`; before launch, flip the fallback to `false` and

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -15,7 +15,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
  *
  * Stores user data, books, and sync metadata for offline-first functionality.
  *
- * Schema is at v44. Migrations live in the `data/local/migrations/` package
+ * Schema is at v45. Migrations live in the `data/local/migrations/` package
  * (e.g. `Migration14To15`, `Migration19To20`) and are registered via `.addMigrations(...)`
  * in each platform `DatabaseModule`. Pre-launch policy: `fallbackToDestructiveMigration(true)`
  * is set on each `DatabaseModule`; before launch, flip the fallback to `false` and
@@ -63,7 +63,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
         BookReadershipEntity::class,
         CachedActiveSessionEntity::class,
     ],
-    version = 44,
+    version = 45,
     exportSchema = true,
 )
 @TypeConverters(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryEntity.kt
@@ -33,6 +33,4 @@ internal data class LibraryEntity(
     val revision: Long,
     /** Epoch ms tombstone; null when the library is live. */
     val deletedAt: Long?,
-    /** Client operation ID for echo detection. Null for server-originated events. */
-    val clientOpId: String?,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryFolderEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/entity/LibraryFolderEntity.kt
@@ -40,6 +40,4 @@ internal data class LibraryFolderEntity(
     val revision: Long,
     /** Epoch ms tombstone; null when the folder is live. */
     val deletedAt: Long?,
-    /** Client operation ID for echo detection. Null for server-originated events. */
-    val clientOpId: String?,
 )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration44To45.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration44To45.kt
@@ -1,0 +1,18 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+/**
+ * Drops the vestigial `clientOpId` columns from `libraries` and `library_folders`.
+ * They were declared "for echo detection" but echo detection is the pending-queue's
+ * `containsAndAck`; no code path ever wrote a non-null value.
+ */
+internal val MIGRATION_44_45: Migration =
+    object : Migration(44, 45) {
+        override fun migrate(connection: SQLiteConnection) {
+            connection.execSQL("ALTER TABLE `libraries` DROP COLUMN `clientOpId`")
+            connection.execSQL("ALTER TABLE `library_folders` DROP COLUMN `clientOpId`")
+        }
+    }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -18,7 +18,6 @@ import com.calypsan.listenup.client.data.remote.model.SyncListeningEventsRespons
 import com.calypsan.listenup.client.data.remote.model.SyncManifestResponse
 import com.calypsan.listenup.client.data.remote.model.SyncSeriesResponse
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
@@ -438,33 +437,6 @@ internal class SyncApi(
                         setBody(MarkCompleteRequest(startedAt = startedAt, finishedAt = finishedAt))
                     }
                 }.body()
-        }
-
-    /**
-     * Discard all progress for a book.
-     *
-     * Endpoint: DELETE /api/v1/books/{bookId}/progress/discard
-     * Auth: Required
-     */
-    override suspend fun discardProgress(
-        bookId: String,
-        keepHistory: Boolean,
-    ): AppResult<Unit> =
-        suspendRunCatching {
-            clientFactory.getClient().delete("/api/v1/books/$bookId/progress/discard") {
-                parameter("keep_history", keepHistory)
-            }
-        }
-
-    /**
-     * Restart a book from the beginning.
-     *
-     * Endpoint: POST /api/v1/books/{bookId}/progress/restart
-     * Auth: Required
-     */
-    override suspend fun restartBook(bookId: String): AppResult<PlaybackProgressResponse> =
-        apiCall(errorMessage = "Failed to restart book $bookId") {
-            clientFactory.getClient().post("/api/v1/books/$bookId/progress/restart").body()
         }
 }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApiContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApiContract.kt
@@ -200,38 +200,6 @@ interface SyncApiContract {
         startedAt: String? = null,
         finishedAt: String? = null,
     ): AppResult<PlaybackProgressResponse>
-
-    /**
-     * Discard all progress for a book.
-     *
-     * Removes the progress record entirely, optionally preserving
-     * listening history (events and stats).
-     *
-     * Endpoint: DELETE /api/v1/books/{bookId}/progress/discard
-     * Auth: Required
-     *
-     * @param bookId Book to discard progress for
-     * @param keepHistory Whether to preserve listening history (default true)
-     * @return Result containing Unit on success or error
-     */
-    suspend fun discardProgress(
-        bookId: String,
-        keepHistory: Boolean = true,
-    ): AppResult<Unit>
-
-    /**
-     * Restart a book from the beginning.
-     *
-     * Resets progress to position 0, increments reread count,
-     * creates a new reading session, and generates a "started_book" activity.
-     *
-     * Endpoint: POST /api/v1/books/{bookId}/progress/restart
-     * Auth: Required
-     *
-     * @param bookId Book to restart
-     * @return Result containing updated PlaybackProgressResponse or error
-     */
-    suspend fun restartBook(bookId: String): AppResult<PlaybackProgressResponse>
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/AdminUserRosterDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/AdminUserRosterDomain.kt
@@ -21,10 +21,7 @@ internal fun adminUserRosterDomain(database: ListenUpDatabase): MirroredDomain<A
         apply = AdminUserRosterMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.adminUserRosterDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.adminUserRosterDao()::digestRows),
         writes = WriteTier.ServerOwned,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMoodsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMoodsDomain.kt
@@ -27,10 +27,7 @@ internal fun bookMoodsDomain(database: ListenUpDatabase): MirroredDomain<BookMoo
         apply = BookMoodMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.bookMoodDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.bookMoodDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookTagsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookTagsDomain.kt
@@ -30,10 +30,7 @@ internal fun bookTagsDomain(database: ListenUpDatabase): MirroredDomain<BookTagS
         apply = BookTagMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.bookTagDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.bookTagDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
@@ -67,10 +67,7 @@ internal fun booksDomain(
                 }
             },
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.bookDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.bookDao()::digestRows),
         writes = WriteTier.Outbox(OutboxChannels.Books),
         accessGate =
             AccessGate(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionBooksDomain.kt
@@ -30,10 +30,7 @@ internal fun collectionBooksDomain(database: ListenUpDatabase): MirroredDomain<C
         apply = CollectionBookMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.collectionBookDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.collectionBookDao()::digestRows),
         writes = WriteTier.OnlineOnly,
         accessGate =
             AccessGate(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionSharesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionSharesDomain.kt
@@ -29,10 +29,7 @@ internal fun collectionSharesDomain(database: ListenUpDatabase): MirroredDomain<
         apply = CollectionShareMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.collectionShareDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.collectionShareDao()::digestRows),
         writes = WriteTier.OnlineOnly,
         accessGate =
             AccessGate(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/CollectionsDomain.kt
@@ -25,10 +25,7 @@ internal fun collectionsDomain(database: ListenUpDatabase): MirroredDomain<Colle
         apply = CollectionMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.collectionDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.collectionDao()::digestRows),
         writes = WriteTier.OnlineOnly,
         accessGate =
             AccessGate(

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ContributorsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ContributorsDomain.kt
@@ -33,10 +33,7 @@ internal fun contributorsDomain(
         apply = ContributorMirrorApply(database, imageStorage),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.contributorDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.contributorDao()::digestRows),
         writes = WriteTier.Outbox(OutboxChannels.Contributors),
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/DigestParticipation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/DigestParticipation.kt
@@ -1,5 +1,7 @@
 package com.calypsan.listenup.client.data.sync.domains
 
+import com.calypsan.listenup.client.data.local.db.IdRevision
+
 /**
  * Whether the domain participates in digest-based drift reconciliation.
  */
@@ -22,3 +24,12 @@ internal sealed interface DigestParticipation {
         val reason: String,
     ) : DigestParticipation
 }
+
+/**
+ * The standard [DigestParticipation.Full] shape: every participating domain
+ * fingerprints via its DAO's `digestRows` returning the shared [IdRevision]
+ * projection. Factored so a descriptor cannot mis-map the pair (a wrong field
+ * here would be a silent digest bug 19 times over).
+ */
+internal fun fullDigest(rows: suspend (maxRevision: Long) -> List<IdRevision>): DigestParticipation.Full =
+    DigestParticipation.Full { maxRevision -> rows(maxRevision).map { it.id to it.revision } }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/GenresDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/GenresDomain.kt
@@ -18,10 +18,7 @@ internal fun genresDomain(database: ListenUpDatabase): MirroredDomain<GenreSyncP
         apply = GenreMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.genreDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.genreDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibrariesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibrariesDomain.kt
@@ -8,8 +8,6 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryEntity
 /**
  * The `libraries` domain: cross-user rows written only via the LibraryAdminService
  * RPC — server-wins apply, soft-delete tombstones, full digest, online-only writes.
- * Inbound snapshots always write `clientOpId = null`: the column belongs to the
- * offline-edit echo path and a server snapshot is never a client echo.
  */
 internal fun librariesDomain(database: ListenUpDatabase): MirroredDomain<LibrarySyncPayload> =
     MirroredDomain(
@@ -37,7 +35,6 @@ internal class LibraryMirrorApply(
                 createdAt = payload.createdAt,
                 revision = payload.revision,
                 deletedAt = payload.deletedAt,
-                clientOpId = null,
             ),
         )
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibrariesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibrariesDomain.kt
@@ -18,10 +18,7 @@ internal fun librariesDomain(database: ListenUpDatabase): MirroredDomain<Library
         apply = LibraryMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.libraryDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.libraryDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibraryFoldersDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibraryFoldersDomain.kt
@@ -10,7 +10,7 @@ import com.calypsan.listenup.client.data.local.db.entity.LibraryFolderEntity
  * RPC — server-wins apply, soft-delete tombstones, full digest, online-only writes.
  * Folder rows FK to `libraries`; the server guarantees the parent library's event
  * precedes folder events during catch-up, so the constraint holds without client
- * ordering logic. Inbound snapshots write `clientOpId = null` (never a client echo).
+ * ordering logic.
  */
 internal fun libraryFoldersDomain(database: ListenUpDatabase): MirroredDomain<LibraryFolderSyncPayload> =
     MirroredDomain(
@@ -36,7 +36,6 @@ internal class LibraryFolderMirrorApply(
                 createdAt = payload.createdAt,
                 revision = payload.revision,
                 deletedAt = payload.deletedAt,
-                clientOpId = null,
             ),
         )
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibraryFoldersDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/LibraryFoldersDomain.kt
@@ -19,10 +19,7 @@ internal fun libraryFoldersDomain(database: ListenUpDatabase): MirroredDomain<Li
         apply = LibraryFolderMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.libraryFolderDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.libraryFolderDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ListeningEventsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ListeningEventsDomain.kt
@@ -39,10 +39,7 @@ internal fun listeningEventsDomain(
             DeleteSemantics.CatchUpOnly(
                 "server never emits listening-event tombstones over SSE; catch-up converges them",
             ),
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.listeningEventDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.listeningEventDao()::digestRows),
         writes = WriteTier.Outbox(OutboxChannels.ListeningEvents),
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/MirrorApply.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/MirrorApply.kt
@@ -26,6 +26,14 @@ internal interface MirrorApply<T : Any> {
         revision: Long,
     )
 
-    /** Apply a catch-up tombstone from the full payload. */
+    /**
+     * Apply a catch-up tombstone from the full payload.
+     *
+     * The `deletedAt ?: <fallback>` expression is deliberately per-domain: most payloads
+     * fall back to `updatedAt`, the junction payloads only carry `createdAt`. A generic
+     * default can't see payload fields without new contract-side interfaces, so the
+     * invariant is pinned by tests instead — every Full-digest domain asserts a
+     * tombstoned row survives in `digestRows`.
+     */
     suspend fun tombstoneFromItem(item: T)
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/MoodsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/MoodsDomain.kt
@@ -18,10 +18,7 @@ internal fun moodsDomain(database: ListenUpDatabase): MirroredDomain<Mood> =
         apply = MoodMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.moodDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.moodDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/PublicProfilesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/PublicProfilesDomain.kt
@@ -26,10 +26,7 @@ internal fun publicProfilesDomain(
         apply = PublicProfileMirrorApply(database, avatarDownloadRepository),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.publicProfileDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.publicProfileDao()::digestRows),
         writes = WriteTier.ServerOwned,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/SeriesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/SeriesDomain.kt
@@ -23,10 +23,7 @@ internal fun seriesDomain(database: ListenUpDatabase): MirroredDomain<SeriesSync
         apply = SeriesMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.seriesDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.seriesDao()::digestRows),
         writes = WriteTier.Outbox(OutboxChannels.Series),
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ShelfBooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ShelfBooksDomain.kt
@@ -26,10 +26,7 @@ internal fun shelfBooksDomain(database: ListenUpDatabase): MirroredDomain<ShelfB
         apply = ShelfBookMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.shelfBookDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.shelfBookDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ShelvesDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ShelvesDomain.kt
@@ -19,10 +19,7 @@ internal fun shelvesDomain(database: ListenUpDatabase): MirroredDomain<ShelfSync
         apply = ShelfMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.shelfDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.shelfDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/TagsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/TagsDomain.kt
@@ -18,10 +18,7 @@ internal fun tagsDomain(database: ListenUpDatabase): MirroredDomain<Tag> =
         apply = TagMirrorApply(database),
         conflict = ConflictPolicy.ServerWins(),
         deletes = DeleteSemantics.SoftDelete,
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.tagDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.tagDao()::digestRows),
         writes = WriteTier.OnlineOnly,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/UserStatsDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/UserStatsDomain.kt
@@ -31,10 +31,7 @@ internal fun userStatsDomain(database: ListenUpDatabase): MirroredDomain<UserSta
             DeleteSemantics.CatchUpOnly(
                 "server never tombstones user_stats; the row lives for the user's lifetime",
             ),
-        digest =
-            DigestParticipation.Full { maxRevision ->
-                database.userStatsDao().digestRows(maxRevision).map { it.id to it.revision }
-            },
+        digest = fullDigest(database.userStatsDao()::digestRows),
         writes = WriteTier.ServerOwned,
     )
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/WriteTier.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/WriteTier.kt
@@ -34,7 +34,5 @@ internal sealed interface WriteTier {
     /** Mutations write Room optimistically and queue durable ops on [channel]. */
     data class Outbox(
         val channel: OutboxChannel<*>,
-    ) : WriteTier {
-        val ops: Set<OpKind> get() = channel.ops
-    }
+    ) : WriteTier
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/LibraryRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/LibraryRepositoryImplTest.kt
@@ -39,7 +39,6 @@ class LibraryRepositoryImplTest :
                 createdAt = 1_000L,
                 revision = 3L,
                 deletedAt = null,
-                clientOpId = null,
             )
 
         val expectedLibrary =
@@ -61,7 +60,6 @@ class LibraryRepositoryImplTest :
                 createdAt = 2_000L,
                 revision = 1L,
                 deletedAt = null,
-                clientOpId = null,
             )
 
         val expectedFolder =

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/OnlyComposedHandlerImplementsSyncDomainHandlerRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/OnlyComposedHandlerImplementsSyncDomainHandlerRule.kt
@@ -1,0 +1,33 @@
+package com.calypsan.listenup.konsist
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
+
+/**
+ * Every mirrored domain is a declarative descriptor compiled by the ONE composed
+ * factory. A new hand-written `SyncDomainHandler` implementation would reopen the
+ * pre-Phase-2 world of bespoke handler classes; descriptors + `toHandler` are the
+ * only sanctioned path. (Test doubles live in test source sets, outside this
+ * production scope.)
+ */
+class OnlyComposedHandlerImplementsSyncDomainHandlerRule :
+    FunSpec({
+        test("only the composed factory implements SyncDomainHandler in production") {
+            val allowlist = setOf("ComposedSyncDomainHandler", "AccessFilteredComposedSyncDomainHandler")
+            // A parent's `name` carries its type arguments (e.g. "SyncDomainHandler<T>"),
+            // so compare on the bare type name before the angle bracket.
+            val syncHandlerParents = setOf("SyncDomainHandler", "ComposedSyncDomainHandler")
+            val implementors =
+                productionScope()
+                    .classes()
+                    .filter { cls ->
+                        cls.parents().any { it.name.substringBefore("<") in syncHandlerParents }
+                    }
+
+            implementors.shouldNotBeEmpty()
+
+            val offenders = implementors.filterNot { it.name in allowlist }.map { "${it.name} in ${it.path}" }
+            offenders.shouldBeEmpty()
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/PendingQueueAccessRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/PendingQueueAccessRule.kt
@@ -1,0 +1,41 @@
+package com.calypsan.listenup.konsist
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
+
+/**
+ * The pending-operation queue is reachable only through declared seams: the sync
+ * engine machinery (`data/sync/`, same-package — no import), the DI modules that
+ * wire it, and the two sanctioned repository consumers (positions enqueue; the
+ * pending-ops UI read model). An `OnlineOnly` domain's repository importing the
+ * queue would be a silent-queueing side door — exactly what the tier forbids.
+ */
+class PendingQueueAccessRule :
+    FunSpec({
+        test("only declared seams import PendingOperationQueue") {
+            val allowedPaths =
+                setOf(
+                    "/data/repository/PlaybackPositionRepositoryImpl.kt",
+                    "/data/repository/PendingOperationRepositoryImpl.kt",
+                )
+            val importers =
+                productionScope()
+                    .files
+                    .filter { file ->
+                        file.imports.any { it.name == "com.calypsan.listenup.client.data.sync.PendingOperationQueue" }
+                    }
+
+            // Guard against a vacuous pass: if the import FQN ever drifts (package rename),
+            // the filter would silently match nothing and the rule would test nothing.
+            importers.shouldNotBeEmpty()
+
+            val offenders =
+                importers
+                    .filterNot { "/data/sync/" in it.path }
+                    .filterNot { "/di/" in it.path }
+                    .filterNot { file -> allowedPaths.any { it in file.path } }
+                    .map { it.path }
+            offenders.shouldBeEmpty()
+        }
+    })

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/local/db/DatabaseModule.jvm.kt
@@ -22,6 +22,7 @@ import com.calypsan.listenup.client.data.local.migrations.MIGRATION_40_41
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_41_42
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_42_43
 import com.calypsan.listenup.client.data.local.migrations.MIGRATION_43_44
+import com.calypsan.listenup.client.data.local.migrations.MIGRATION_44_45
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -66,6 +67,7 @@ internal actual val platformDatabaseModule: Module =
                     MIGRATION_41_42,
                     MIGRATION_42_43,
                     MIGRATION_43_44,
+                    MIGRATION_44_45,
                 )
                 // No public installs yet — every schema change nukes and re-creates local
                 // data. Flip back to `false` + a proper Migration chain before launch.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/AdminRosterRealtimeE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/AdminRosterRealtimeE2ETest.kt
@@ -26,9 +26,7 @@ import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.data.sync.SyncEventDispatcher
 import com.calypsan.listenup.client.data.sync.SyncReconciler
 import com.calypsan.listenup.client.data.sync.SyncSseClient
-import com.calypsan.listenup.client.data.sync.domains.adminUserRosterDomain
-import com.calypsan.listenup.client.data.sync.domains.genresDomain
-import com.calypsan.listenup.client.data.sync.domains.toHandler
+import com.calypsan.listenup.client.data.sync.testing.registerTestSyncDomains
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.server.auth.UserPrincipal
@@ -261,8 +259,10 @@ private fun rosterRowFixture(id: String): AdminUserRosterSyncPayload =
     )
 
 /**
- * Assembles a client [SyncEngine] wired ONLY for the `admin_user_roster` + `genres` domains —
- * this harness needs no RPC/WebSocket surface and no books/collections access-gating machinery.
+ * Assembles a client [SyncEngine] wired against the full production catalog (the test only
+ * drives the `admin_user_roster` and `genres` domains, but every handler is registered so
+ * SSE events on other domains don't get logged as "unhandled" warnings) — this harness needs
+ * no RPC/WebSocket surface and no books/collections access-gating machinery.
  */
 private fun buildRosterSyncEngine(
     clientDb: ListenUpDatabase,
@@ -270,10 +270,8 @@ private fun buildRosterSyncEngine(
     scope: CoroutineScope,
 ): SyncEngine {
     val registry = ClientSyncDomainRegistry()
-    val txn = RoomTransactionRunner(clientDb)
 
-    adminUserRosterDomain(database = clientDb).toHandler(transactionRunner = txn, registry = registry)
-    genresDomain(database = clientDb).toHandler(transactionRunner = txn, registry = registry)
+    registerTestSyncDomains(db = clientDb, registry = registry)
 
     val state = SyncEngineState()
     val store = SyncCursorStore(clientDb.syncCursorDao())

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration44To45Test.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/migrations/Migration44To45Test.kt
@@ -1,0 +1,40 @@
+package com.calypsan.listenup.client.data.local.migrations
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+import com.calypsan.listenup.client.test.db.createMigrationTestHelper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
+
+/**
+ * Regression test for [MIGRATION_44_45] — drops the vestigial `clientOpId` columns
+ * from `libraries` and `library_folders`.
+ *
+ * `runMigrationsAndValidate` fails if the migrated shape diverges from the generated
+ * v45 schema, so this also proves the DROP COLUMN result matches the entity definitions.
+ */
+class Migration44To45Test :
+    FunSpec({
+
+        test("v44 → v45 drops clientOpId from libraries and library_folders") {
+            val helper = createMigrationTestHelper()
+            try {
+                helper.createDatabase(version = 44)
+
+                val db = helper.runMigrationsAndValidate(version = 45, migrations = listOf(MIGRATION_44_45))
+
+                db.columnsOf("libraries") shouldNotContain "clientOpId"
+                db.columnsOf("library_folders") shouldNotContain "clientOpId"
+            } finally {
+                helper.close()
+            }
+        }
+    })
+
+/** Column names of [table], read from `PRAGMA table_info`. */
+private fun SQLiteConnection.columnsOf(table: String): Set<String> =
+    prepare("PRAGMA table_info(`$table`)").use { stmt ->
+        buildSet {
+            while (stmt.step()) add(stmt.getText(1))
+        }
+    }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AdminUserRosterDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AdminUserRosterDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.adminUserRosterDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -106,6 +107,24 @@ class AdminUserRosterDomainTest :
 
                 val liveRows = db.adminUserRosterDao().observeAll().first()
                 liveRows.none { it.id == "user-deleted" } shouldBe true
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("user-deleted", revision = 1L)), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "user-deleted", revision = 2L, occurredAt = 999_000L),
+                    isOwnEcho = false,
+                )
+                // observeAll filters tombstones — invisible to reads
+                db
+                    .adminUserRosterDao()
+                    .observeAll()
+                    .first()
+                    .none { it.id == "user-deleted" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation
+                db.adminUserRosterDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "user-deleted"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
@@ -9,9 +9,11 @@ import com.calypsan.listenup.client.data.sync.domains.bookMoodsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -63,6 +65,24 @@ class BookMoodsDomainTest :
                         isOwnEcho = false,
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
                 db.bookMoodDao().findByKey("b1", "m1")!!.deletedAt shouldBe 900L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(junctionPayload("b1", "m1")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "b1:m1", revision = 2L, occurredAt = 900L),
+                    isOwnEcho = false,
+                )
+                // observeForBook filters tombstones — invisible to reads
+                db
+                    .bookMoodDao()
+                    .observeForBook("b1")
+                    .first()
+                    .none { it.moodId == "m1" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation (synthetic "$bookId:$moodId" id)
+                db.bookMoodDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "b1:m1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
@@ -9,9 +9,11 @@ import com.calypsan.listenup.client.data.sync.domains.bookTagsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -67,6 +69,24 @@ class BookTagsDomainTest :
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
                 val row = db.bookTagDao().findByKey("b1", "t1")!!
                 row.deletedAt shouldBe 800L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(junctionPayload("b1", "t1", revision = 1L)), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "b1:t1", revision = 2L, occurredAt = 800L),
+                    isOwnEcho = false,
+                )
+                // observeForBook filters tombstones — invisible to reads
+                db
+                    .bookTagDao()
+                    .observeForBook("b1")
+                    .first()
+                    .none { it.tagId == "t1" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation (synthetic "$bookId:$tagId" id)
+                db.bookTagDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "b1:t1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BooksDomainTest.kt
@@ -35,6 +35,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -258,6 +259,21 @@ class BooksDomainTest :
                     .shouldBeInstanceOf<AppResult.Success<Unit>>()
 
                 db.bookDao().getById(BookId("b1"))?.deletedAt shouldBe 100L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withTestHandler { handler, db ->
+                val initial = bookPayload(id = "b1")
+                handler.onEvent(created(initial), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "b1", revision = 2L, occurredAt = 200L, clientOpId = null),
+                    isOwnEcho = false,
+                )
+                // getAllLive filters tombstones — invisible to reads
+                db.bookDao().getAllLive().none { it.id == BookId("b1") } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation
+                db.bookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "b1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
@@ -9,9 +9,11 @@ import com.calypsan.listenup.client.data.sync.domains.collectionBooksDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -66,6 +68,21 @@ class CollectionBooksDomainTest :
                 val row = db.collectionBookDao().findByKey("c1", "b1")!!
                 row.deletedAt shouldBe 800L
                 row.revision shouldBe 2L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(createdJunction(junctionPayload("c1", "b1", revision = 1L)), isOwnEcho = false)
+                handler.onEvent(SyncEvent.Deleted(id = "c1:b1", revision = 2L, occurredAt = 800L), isOwnEcho = false)
+                // observeBookIds filters tombstones — invisible to reads
+                db
+                    .collectionBookDao()
+                    .observeBookIds("c1")
+                    .first()
+                    .none { it == "b1" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation (synthetic "$collectionId:$bookId" id)
+                db.collectionBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "c1:b1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionSharesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionSharesDomainTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.sync.domains.collectionSharesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -54,6 +55,15 @@ class CollectionSharesDomainTest :
                     .onEvent(SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
                     .shouldBeInstanceOf<AppResult.Success<Unit>>()
                 db.collectionShareDao().getById("s1") shouldBe null
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(createdShare(sharePayload("s1", "c1")), isOwnEcho = false)
+                handler.onEvent(SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
+                db.collectionShareDao().getById("s1") shouldBe null
+                db.collectionShareDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionsDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -63,6 +64,15 @@ class CollectionsDomainTest :
                     .onEvent(SyncEvent.Deleted(id = "c1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
                     .shouldBeInstanceOf<AppResult.Success<Unit>>()
                 db.collectionDao().getById("c1") shouldBe null
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(createdCollection(collectionPayload("c1")), isOwnEcho = false)
+                handler.onEvent(SyncEvent.Deleted(id = "c1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
+                db.collectionDao().getById("c1") shouldBe null
+                db.collectionDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "c1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorsDomainTest.kt
@@ -21,9 +21,11 @@ import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -177,6 +179,20 @@ class ContributorsDomainTest :
 
                 db.contributorDao().getById("c1")!!.deletedAt shouldBe 200L
                 db.contributorAliasDao().getForContributor("c1").shouldBeEmpty()
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("c1", "Brandon Sanderson")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "c1", revision = 2, occurredAt = 200L, clientOpId = null),
+                    isOwnEcho = false,
+                )
+                // observeById filters tombstones — invisible to reads
+                db.contributorDao().observeById("c1").first() shouldBe null
+                // but still fingerprinted for digest-drift reconciliation
+                db.contributorDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "c1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestOptOutSetTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestOptOutSetTest.kt
@@ -1,25 +1,7 @@
 package com.calypsan.listenup.client.data.sync
 
-import com.calypsan.listenup.client.data.local.db.BookEntityMapper
-import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
-import com.calypsan.listenup.client.data.sync.domains.booksDomain
-import com.calypsan.listenup.client.data.sync.domains.toHandler
-import com.calypsan.listenup.client.data.sync.domains.tagsDomain
-import com.calypsan.listenup.client.data.sync.domains.bookTagsDomain
-import com.calypsan.listenup.client.data.sync.domains.collectionBooksDomain
-import com.calypsan.listenup.client.data.sync.domains.collectionSharesDomain
-import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
-import com.calypsan.listenup.client.data.sync.domains.contributorsDomain
-import com.calypsan.listenup.client.data.sync.domains.genresDomain
-import com.calypsan.listenup.client.data.sync.domains.librariesDomain
-import com.calypsan.listenup.client.data.sync.domains.libraryFoldersDomain
-import com.calypsan.listenup.client.data.sync.domains.listeningEventsDomain
-import com.calypsan.listenup.client.data.sync.domains.userStatsDomain
-import com.calypsan.listenup.client.data.sync.domains.playbackPositionsDomain
-import com.calypsan.listenup.client.test.fake.FakeAuthSession
-import com.calypsan.listenup.client.data.sync.domains.seriesDomain
+import com.calypsan.listenup.client.data.sync.testing.registerTestSyncDomains
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
-import com.calypsan.listenup.client.test.stubImageStorage
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
@@ -43,30 +25,10 @@ class DigestOptOutSetTest :
                 val clientDb = createInMemoryTestDatabase()
                 try {
                     val registry = ClientSyncDomainRegistry()
-                    val txRunner = RoomTransactionRunner(clientDb)
 
-                    // Register all production handlers — mirrors the clientSyncModule
-                    // Koin wiring so this test tracks production exactly.
-                    tagsDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    bookTagsDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    booksDomain(
-                        database = clientDb,
-                        mapper = BookEntityMapper(),
-                        imageStorage = stubImageStorage(),
-                    ).toHandler(transactionRunner = txRunner, registry = registry)
-                    contributorsDomain(database = clientDb, imageStorage = stubImageStorage())
-                        .toHandler(transactionRunner = txRunner, registry = registry)
-                    seriesDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    genresDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    playbackPositionsDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    listeningEventsDomain(clientDb, FakeAuthSession())
-                        .toHandler(transactionRunner = txRunner, registry = registry)
-                    userStatsDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    librariesDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    libraryFoldersDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    collectionsDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    collectionBooksDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
-                    collectionSharesDomain(database = clientDb).toHandler(transactionRunner = txRunner, registry = registry)
+                    // Register every production handler via the real catalog, so this test
+                    // tracks production exactly (no hand-listed subset to drift).
+                    registerTestSyncDomains(db = clientDb, registry = registry)
 
                     // Collect the domains whose handler returns null from localDigestRows against
                     // an empty DB. An empty DB ensures reconcilable domains return emptyList() (non-null)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/GenresDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/GenresDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.genresDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -65,6 +66,18 @@ class GenresDomainTest :
                         isOwnEcho = false,
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
                 db.genreDao().getById("g1") shouldBe null
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(genrePayload("g1", "Fantasy", "fantasy")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "g1", revision = 2L, occurredAt = 500L),
+                    isOwnEcho = false,
+                )
+                db.genreDao().getById("g1") shouldBe null
+                db.genreDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "g1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibrariesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibrariesDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.librariesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -62,6 +63,18 @@ class LibrariesDomainTest :
                 val tombstone = db.libraryDao().findAll().first { it.id == "lib1" }
                 tombstone.deletedAt shouldBe 999L
                 tombstone.revision shouldBe 5L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("lib1", "My Library")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "lib1", revision = 5L, occurredAt = 999L, clientOpId = null),
+                    isOwnEcho = false,
+                )
+                db.libraryDao().findById("lib1") shouldBe null
+                db.libraryDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "lib1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryFoldersDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryFoldersDomainTest.kt
@@ -138,7 +138,6 @@ private suspend fun seedLibrary(
             createdAt = 1L,
             revision = 1L,
             deletedAt = null,
-            clientOpId = null,
         ),
     )
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryFoldersDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryFoldersDomainTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.sync.domains.libraryFoldersDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -66,6 +67,21 @@ class LibraryFoldersDomainTest :
                 val tombstone = db.libraryFolderDao().findById("f1")!!
                 tombstone.deletedAt shouldBe 999L
                 tombstone.revision shouldBe 5L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                seedLibrary(db, "lib1")
+                handler.onEvent(created(payload("f1", "lib1", "/audiobooks")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "f1", revision = 5L, occurredAt = 999L, clientOpId = null),
+                    isOwnEcho = false,
+                )
+                // findAllForLibrary filters tombstones — invisible to reads
+                db.libraryFolderDao().findAllForLibrary("lib1").none { it.id == "f1" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation
+                db.libraryFolderDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "f1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventsDomainTest.kt
@@ -11,11 +11,13 @@ import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakeAuthSession
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 class ListeningEventsDomainTest :
@@ -132,6 +134,24 @@ class ListeningEventsDomainTest :
                 val row = db.listeningEventDao().getById("ev-5").shouldNotBeNull()
                 row.deletedAt shouldBe 555L
                 row.revision shouldBe 9L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("ev-6", "book-1")), isOwnEcho = false)
+                handler.onCatchUpItem(
+                    payload("ev-6", "book-1", deletedAt = 555L, revision = 9L),
+                    isTombstone = true,
+                )
+                // observeEventsForBook filters tombstones — invisible to reads
+                db
+                    .listeningEventDao()
+                    .observeEventsForBook("book-1")
+                    .first()
+                    .none { it.id == "ev-6" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation
+                db.listeningEventDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "ev-6"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/MoodsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/MoodsDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.moodsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -67,6 +68,18 @@ class MoodsDomainTest :
                         isOwnEcho = false,
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
                 db.moodDao().getById("m1") shouldBe null
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(moodPayload("m1", "Feel-Good", "feel-good")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "m1", revision = 2L, occurredAt = 500L),
+                    isOwnEcho = false,
+                )
+                db.moodDao().getById("m1") shouldBe null
+                db.moodDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "m1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PublicProfilesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PublicProfilesDomainTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -101,6 +102,20 @@ class PublicProfilesDomainTest :
                 // (collect one emission — we're inside runTest so the Room Flow is synchronous)
                 val liveRows = db.publicProfileDao().observeAll().first()
                 liveRows.none { it.id == "user-deleted" } shouldBe true
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("user-tomb-digest", revision = 1L)), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "user-tomb-digest", revision = 2L, occurredAt = 999_000L),
+                    isOwnEcho = false,
+                )
+                // observeById filters tombstones — invisible to reads
+                db.publicProfileDao().observeById("user-tomb-digest").first() shouldBe null
+                // but still fingerprinted for digest-drift reconciliation
+                db.publicProfileDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "user-tomb-digest"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SeriesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SeriesDomainTest.kt
@@ -12,9 +12,11 @@ import com.calypsan.listenup.client.data.sync.domains.seriesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -65,6 +67,20 @@ class SeriesDomainTest :
                 row.description shouldBe "An epic."
                 row.asin shouldBe "B00ASIN"
                 row.coverPath shouldBe "/covers/s1.jpg"
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("s1", "The Stormlight Archive")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L),
+                    isOwnEcho = false,
+                )
+                // observeById filters tombstones — invisible to reads
+                db.seriesDao().observeById("s1").first() shouldBe null
+                // but still fingerprinted for digest-drift reconciliation
+                db.seriesDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelfBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelfBooksDomainTest.kt
@@ -9,9 +9,11 @@ import com.calypsan.listenup.client.data.sync.domains.shelfBooksDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -68,6 +70,21 @@ class ShelfBooksDomainTest :
                 val row = db.shelfBookDao().findById("s1:b1")!!
                 row.deletedAt shouldBe 800L
                 row.revision shouldBe 2L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(createdJunction(junctionPayload("s1", "b1", revision = 1L)), isOwnEcho = false)
+                handler.onEvent(SyncEvent.Deleted(id = "s1:b1", revision = 2L, occurredAt = 800L), isOwnEcho = false)
+                // observeShelfBooks filters tombstones — invisible to reads
+                db
+                    .shelfBookDao()
+                    .observeShelfBooks("s1")
+                    .first()
+                    .none { it == "b1" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation
+                db.shelfBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1:b1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelvesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelvesDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.shelvesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -62,6 +63,15 @@ class ShelvesDomainTest :
                     .onEvent(SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
                     .shouldBeInstanceOf<AppResult.Success<Unit>>()
                 db.shelfDao().getById("s1") shouldBe null
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withShelfHandler { handler, db ->
+                handler.onEvent(createdShelf(shelfPayload("s1")), isOwnEcho = false)
+                handler.onEvent(SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
+                db.shelfDao().getById("s1") shouldBe null
+                db.shelfDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/TagsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/TagsDomainTest.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.tagsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -64,6 +65,18 @@ class TagsDomainTest :
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
                 // getById filters tombstones — should return null after soft-delete
                 db.tagDao().getById("t1") shouldBe null
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(tagPayload("t1", "Sci-Fi", "sci-fi")), isOwnEcho = false)
+                handler.onEvent(
+                    SyncEvent.Deleted(id = "t1", revision = 2L, occurredAt = 500L),
+                    isOwnEcho = false,
+                )
+                db.tagDao().getById("t1") shouldBe null
+                db.tagDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "t1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/UserStatsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/UserStatsDomainTest.kt
@@ -9,10 +9,12 @@ import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.data.sync.domains.userStatsDomain
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 class UserStatsDomainTest :
@@ -88,6 +90,24 @@ class UserStatsDomainTest :
                 val row = db.userStatsDao().getForUser("user-3").shouldNotBeNull()
                 row.totalSecondsAllTime shouldBe 7777L
                 row.revision shouldBe 3L
+            }
+        }
+
+        test("tombstoned row survives in digestRows — the digest covers deletes") {
+            withHandler { handler, db ->
+                handler.onEvent(created(payload("user-tomb")), isOwnEcho = false)
+                handler.onCatchUpItem(
+                    payload("user-tomb", revision = 2L, deletedAt = 999_000L),
+                    isTombstone = true,
+                )
+                // observeAll filters tombstones — invisible to reads
+                db
+                    .userStatsDao()
+                    .observeAll()
+                    .first()
+                    .none { it.id == "user-tomb" } shouldBe true
+                // but still fingerprinted for digest-drift reconciliation
+                db.userStatsDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "user-tomb"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -8,7 +8,7 @@ import com.calypsan.listenup.api.sync.DomainList
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.BookEntityMapper
-import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
+import com.calypsan.listenup.client.data.sync.testing.StubAvatarDownloadRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakeAuthSession
 import com.calypsan.listenup.client.test.stubImageStorage
@@ -232,11 +232,3 @@ private suspend fun HttpClient.setupRoot(): String {
 
 private const val JWT_SECRET_LENGTH = 32
 private const val REFRESH_PEPPER_LENGTH = 32
-
-private class StubAvatarDownloadRepository : AvatarDownloadRepository {
-    override fun queueAvatarDownload(userId: String) = Unit
-
-    override fun queueAvatarForceRefresh(userId: String) = Unit
-
-    override suspend fun deleteAvatar(userId: String) = Unit
-}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -168,6 +168,38 @@ class SyncDomainCompletenessSpec :
             }
         }
 
+        test("declared delete and digest postures match the frozen rulebook") {
+            val db = createInMemoryTestDatabase()
+            try {
+                val catalog =
+                    syncDomainCatalog(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                        authSession = FakeAuthSession(userId = "spec-user"),
+                        avatarDownloadRepository = StubAvatarDownloadRepository(),
+                        pingPresence = {},
+                        pingActivity = {},
+                        refetchServerInfo = {},
+                        refetchPreferences = {},
+                    )
+
+                // Changing any of these is a product decision, not a side effect:
+                // update this spec consciously alongside the descriptor.
+                catalog.mirrored
+                    .filter { it.deletes is DeleteSemantics.CatchUpOnly }
+                    .map { it.key.name }
+                    .toSet() shouldBe setOf("playback_positions", "listening_events", "user_stats")
+
+                catalog.mirrored
+                    .filter { it.digest is DigestParticipation.OptOut }
+                    .map { it.key.name }
+                    .toSet() shouldBe setOf("playback_positions")
+            } finally {
+                db.close()
+            }
+        }
+
         test("server registrations mirror SyncDomains.all exactly (1:1, both directions)") {
             val homeDir = Files.createTempDirectory("listenup-completeness-home-")
             val tmpDb =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/TestSyncDomains.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/TestSyncDomains.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.client.data.sync.testing
+
+import com.calypsan.listenup.client.data.local.db.BookEntityMapper
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
+import com.calypsan.listenup.client.data.sync.domains.SyncDomainCatalog
+import com.calypsan.listenup.client.data.sync.domains.syncDomainCatalog
+import com.calypsan.listenup.client.data.sync.domains.toHandler
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
+import com.calypsan.listenup.client.test.fake.FakeAuthSession
+import com.calypsan.listenup.client.test.stubImageStorage
+
+/**
+ * Registers the REAL production catalog's handlers into [registry] — the one place
+ * test harnesses obtain sync-domain handlers from. Replaces per-harness hand-lists,
+ * so adding a domain to [syncDomainCatalog] automatically covers every harness and
+ * a migration touches ZERO harness call sites (wrinkles ledger #4).
+ *
+ * [exclude] skips domains a harness registers its own double for (the registry
+ * throws on a second instance per name — e.g. `RecordingTagSyncDomainHandler`).
+ *
+ * [authSession]'s default `userId` is arbitrary — it only stamps locally-written
+ * `listening_events` rows and never gates inbound apply. A harness whose server
+ * bearer identity matters (so those local writes must match it) should override it,
+ * as `WithClientSyncEngineAgainstServer` does with `FakeAuthSession()` (`"u1"`).
+ */
+internal fun registerTestSyncDomains(
+    db: ListenUpDatabase,
+    registry: ClientSyncDomainRegistry,
+    transactionRunner: TransactionRunner = RoomTransactionRunner(db),
+    authSession: AuthSession = FakeAuthSession(userId = "test-user"),
+    exclude: Set<String> = emptySet(),
+): SyncDomainCatalog {
+    val catalog =
+        syncDomainCatalog(
+            database = db,
+            mapper = BookEntityMapper(),
+            imageStorage = stubImageStorage(),
+            authSession = authSession,
+            avatarDownloadRepository = StubAvatarDownloadRepository(),
+            pingPresence = {},
+            pingActivity = {},
+            refetchServerInfo = {},
+            refetchPreferences = {},
+        )
+    catalog.mirrored
+        .filterNot { it.key.name in exclude }
+        .forEach { it.toHandler(transactionRunner, registry) }
+    return catalog
+}
+
+/** No-op [AvatarDownloadRepository] double shared by every test harness that pulls in the public-profiles domain. */
+internal class StubAvatarDownloadRepository : AvatarDownloadRepository {
+    override fun queueAvatarDownload(userId: String) = Unit
+
+    override fun queueAvatarForceRefresh(userId: String) = Unit
+
+    override suspend fun deleteAvatar(userId: String) = Unit
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.api.SeriesService
 import com.calypsan.listenup.api.UserPreferencesService
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.client.data.local.db.BookEntityMapper
+import com.calypsan.listenup.api.sync.SyncDomains
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.api.dto.RecordListeningEventRequest
@@ -42,26 +42,13 @@ import com.calypsan.listenup.client.data.sync.PresenceRefreshSignal
 import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.data.sync.SyncEventDispatcher
 import com.calypsan.listenup.client.data.sync.SyncSseClient
-import com.calypsan.listenup.client.data.sync.domains.booksDomain
-import com.calypsan.listenup.client.data.sync.domains.toHandler
-import com.calypsan.listenup.client.data.sync.domains.contributorsDomain
-import com.calypsan.listenup.client.data.sync.domains.genresDomain
-import com.calypsan.listenup.client.data.sync.domains.librariesDomain
-import com.calypsan.listenup.client.data.sync.domains.libraryFoldersDomain
-import com.calypsan.listenup.client.data.sync.domains.listeningEventsDomain
-import com.calypsan.listenup.client.data.sync.domains.userStatsDomain
-import com.calypsan.listenup.client.data.sync.domains.playbackPositionsDomain
 import com.calypsan.listenup.client.data.sync.domains.OutboxChannels
 import com.calypsan.listenup.client.test.fake.FakeAuthSession
-import com.calypsan.listenup.client.data.sync.domains.seriesDomain
-import com.calypsan.listenup.client.data.sync.domains.publicProfilesDomain
-import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.BookEditRepository
 import com.calypsan.listenup.client.domain.repository.ContributorEditRepository
 import com.calypsan.listenup.client.domain.repository.GenreRepository as ClientGenreRepository
 import com.calypsan.listenup.client.domain.repository.SeriesEditRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
-import com.calypsan.listenup.client.test.stubImageStorage
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ContributorId
 import com.calypsan.listenup.core.SeriesId
@@ -613,69 +600,23 @@ private data class ServerRepositories(
 )
 
 /**
- * Constructs and registers the real books sync handler ([booksDomain]),
- * [contributorsDomain], the series composed handler,
- * [com.calypsan.listenup.client.data.sync.domains.playbackPositionsDomain] handler,
- * [com.calypsan.listenup.client.data.sync.domains.listeningEventsDomain] handler,
- * [com.calypsan.listenup.client.data.sync.domains.userStatsDomain] handler,
- * [com.calypsan.listenup.client.data.sync.domains.librariesDomain] handler,
- * [com.calypsan.listenup.client.data.sync.domains.libraryFoldersDomain] handler,
- * and [com.calypsan.listenup.client.data.sync.domains.publicProfilesDomain] handler into [registry]. Each handler self-registers under its
- * `domainName` on construction, so the client dispatcher routes domain SSE frames here,
- * applying them into [clientDb] exactly as production does.
+ * Registers the real production catalog's handlers into [registry] — the client dispatcher
+ * routes domain SSE frames here, applying them into [clientDb] exactly as production does.
+ * The `tags` domain is excluded: this harness registers [RecordingTagSyncDomainHandler] for it
+ * separately below (the registry throws on a second instance per domain name). [FakeAuthSession]
+ * with the default "u1" user id matches the harness's `defaultUserId = "u1"` test auth provider,
+ * so `listening_events` records against the same user the SSE firehose is scoped to.
  */
 private fun registerClientSyncHandlers(
     clientDb: ListenUpDatabase,
     registry: ClientSyncDomainRegistry,
 ) {
-    librariesDomain(database = clientDb).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
+    registerTestSyncDomains(
+        db = clientDb,
         registry = registry,
+        authSession = FakeAuthSession(),
+        exclude = setOf(SyncDomains.TAGS.name),
     )
-    libraryFoldersDomain(database = clientDb).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    booksDomain(
-        database = clientDb,
-        mapper = BookEntityMapper(),
-        imageStorage = stubImageStorage(),
-    ).toHandler(transactionRunner = RoomTransactionRunner(clientDb), registry = registry)
-    contributorsDomain(database = clientDb, imageStorage = stubImageStorage()).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    seriesDomain(database = clientDb).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    genresDomain(database = clientDb).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    playbackPositionsDomain(database = clientDb).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    listeningEventsDomain(clientDb, FakeAuthSession()).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    userStatsDomain(clientDb).toHandler(
-        transactionRunner = RoomTransactionRunner(clientDb),
-        registry = registry,
-    )
-    publicProfilesDomain(
-        database = clientDb,
-        avatarDownloadRepository =
-            object : AvatarDownloadRepository {
-                override fun queueAvatarDownload(userId: String) = Unit
-
-                override fun queueAvatarForceRefresh(userId: String) = Unit
-
-                override suspend fun deleteAvatar(userId: String) = Unit
-            },
-    ).toHandler(transactionRunner = RoomTransactionRunner(clientDb), registry = registry)
 }
 
 /**

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
@@ -5,7 +5,6 @@ import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
-import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
@@ -21,13 +20,7 @@ import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.data.sync.SyncEventDispatcher
 import com.calypsan.listenup.client.data.sync.SyncReconciler
 import com.calypsan.listenup.client.data.sync.SyncSseClient
-import com.calypsan.listenup.client.data.sync.domains.booksDomain
-import com.calypsan.listenup.client.data.sync.domains.collectionBooksDomain
-import com.calypsan.listenup.client.data.sync.domains.collectionSharesDomain
-import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
-import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
-import com.calypsan.listenup.client.test.stubImageStorage
 import com.calypsan.listenup.server.api.BookAccessPolicy
 import com.calypsan.listenup.server.api.collectionServiceScopedTo
 import com.calypsan.listenup.server.api.createCollectionService
@@ -264,11 +257,11 @@ internal fun withCollectionSyncEngineAgainstServer(block: suspend CollectionSync
 }
 
 /**
- * Assembles the MEMBER's client [SyncEngine]: registers the four access-gated handlers (books +
- * the three collection domains) into a fresh registry, wires the catch-up / SSE clients against
- * [testClient], and — load-bearing — binds the dispatcher's `onAccessChanged` to
- * [SyncEngine.handleAccessChanged] so a firehose `AccessChanged` frame triggers the transient
- * catch-up + `pruneTo` reconcile under test.
+ * Assembles the MEMBER's client [SyncEngine]: registers the real production catalog's handlers
+ * (including the four access-gated domains under test — books + the three collection domains)
+ * into a fresh registry, wires the catch-up / SSE clients against [testClient], and — load-bearing
+ * — binds the dispatcher's `onAccessChanged` to [SyncEngine.handleAccessChanged] so a firehose
+ * `AccessChanged` frame triggers the transient catch-up + `pruneTo` reconcile under test.
  */
 private fun buildMemberSyncEngine(
     clientDb: ListenUpDatabase,
@@ -276,16 +269,8 @@ private fun buildMemberSyncEngine(
     clientScope: CoroutineScope,
 ): SyncEngine {
     val registry = ClientSyncDomainRegistry()
-    val txn = RoomTransactionRunner(clientDb)
 
-    booksDomain(
-        database = clientDb,
-        mapper = BookEntityMapper(),
-        imageStorage = stubImageStorage(),
-    ).toHandler(transactionRunner = txn, registry = registry)
-    collectionsDomain(clientDb).toHandler(txn, registry)
-    collectionBooksDomain(clientDb).toHandler(txn, registry)
-    collectionSharesDomain(clientDb).toHandler(txn, registry)
+    registerTestSyncDomains(db = clientDb, registry = registry)
 
     val state = SyncEngineState()
     val store = SyncCursorStore(clientDb.syncCursorDao())

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithTagSyncEngineAgainstServer.kt
@@ -1,7 +1,6 @@
 package com.calypsan.listenup.client.data.sync.testing
 
 import com.calypsan.listenup.api.contractJson
-import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.sync.ClientSyncDomainRegistry
@@ -17,20 +16,7 @@ import com.calypsan.listenup.client.data.sync.SyncEngineState
 import com.calypsan.listenup.client.data.sync.SyncEventDispatcher
 import com.calypsan.listenup.client.data.sync.SyncReconciler
 import com.calypsan.listenup.client.data.sync.SyncSseClient
-import com.calypsan.listenup.client.data.sync.domains.tagsDomain
-import com.calypsan.listenup.client.data.sync.domains.toHandler
-import com.calypsan.listenup.client.data.sync.domains.booksDomain
-import com.calypsan.listenup.client.data.sync.domains.librariesDomain
-import com.calypsan.listenup.client.data.sync.domains.bookTagsDomain
-import com.calypsan.listenup.client.data.sync.domains.contributorsDomain
-import com.calypsan.listenup.client.data.sync.domains.libraryFoldersDomain
-import com.calypsan.listenup.client.data.sync.domains.listeningEventsDomain
-import com.calypsan.listenup.client.data.sync.domains.userStatsDomain
-import com.calypsan.listenup.client.data.sync.domains.playbackPositionsDomain
-import com.calypsan.listenup.client.test.fake.FakeAuthSession
-import com.calypsan.listenup.client.data.sync.domains.seriesDomain
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
-import com.calypsan.listenup.client.test.stubImageStorage
 import com.calypsan.listenup.server.db.DatabaseConfig
 import com.calypsan.listenup.server.db.DatabaseFactory
 import com.calypsan.listenup.server.db.sqldelight.DriverFactory
@@ -166,51 +152,10 @@ internal fun withTagSyncEngineAgainstServer(block: suspend TagSyncEngineScope.()
         try {
             val registry = ClientSyncDomainRegistry()
 
-            // Register the REAL tag handlers — not the recording fixture.
-            tagsDomain(database = clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            bookTagsDomain(database = clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-
-            // Register remaining handlers so SSE events on other domains don't
-            // get logged as "unhandled" warnings during the test.
-            librariesDomain(database = clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            libraryFoldersDomain(database = clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            booksDomain(
-                database = clientDb,
-                mapper = BookEntityMapper(),
-                imageStorage = stubImageStorage(),
-            ).toHandler(transactionRunner = RoomTransactionRunner(clientDb), registry = registry)
-            contributorsDomain(database = clientDb, imageStorage = stubImageStorage()).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            seriesDomain(database = clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            playbackPositionsDomain(database = clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            listeningEventsDomain(clientDb, FakeAuthSession()).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
-            userStatsDomain(clientDb).toHandler(
-                transactionRunner = RoomTransactionRunner(clientDb),
-                registry = registry,
-            )
+            // Register the real production catalog's handlers — including the real tag
+            // handlers (no recording fixture here), so SSE events on every domain land in
+            // Room and none get logged as "unhandled" warnings during the test.
+            registerTestSyncDomains(db = clientDb, registry = registry)
 
             val state = SyncEngineState()
             val store = SyncCursorStore(clientDb.syncCursorDao())


### PR DESCRIPTION
Closes the unified-sync-domains arc (Plan 5).

- **registerTestSyncDomains factory**: the 5 multi-domain sync test harnesses now derive handlers from the REAL production catalog (kills per-migration harness toil — wrinkles #4; fixes DigestOptOutSetTest's silent 13-of-20 drift).
- **fullDigest(dao::digestRows)** collapses 19 copy-pasted digest lambdas onto the shared IdRevision projection (wrinkle #2); wrinkle #1 (tombstone fallback) deliberately stays per-domain — rationale in MirrorApply KDoc.
- **Tombstone digest-retention pinned** in all 19 Full-digest domain tests (wrinkle #10) — the unit-level guard that makes a wrong tombstone fallback non-silent. Found no real bugs; the invariant holds everywhere.
- **Konsist pins**: only the composed factory implements SyncDomainHandler; only declared seams import PendingOperationQueue; delete/digest posture snapshot in the completeness spec. Both new rules carry anti-vacuity guards (one caught a real generic-parent-name bug during authoring).
- **Legacy deleted**: caller-less REST discardProgress/restartBook (the outbox path shipped in Plan 4); the now-unused WriteTier.Outbox.ops getter; stale schema KDoc.
- **Room v45**: drops the vestigial clientOpId columns from libraries/library_folders (wrinkle #3 — no code ever wrote them; echo detection lives in the queue's containsAndAck). Migration + validation test + all-platform registration.

**Deliberately NOT done — needs your call:** deleting the server /sse/ping route (Plan 5's planned Part A). It turns out NOT to be dead — `PluginSmokeTest` uses it as the SSE-over-CIO plugin smoke canary (the simplest unauthenticated SSE test, isolating 'plugin broken' from 'auth/scanner broken'). Retiring that coverage is a test-strategy decision, so I left both the route and its test untouched.

Local gate green: spotlessCheck / detekt / :contract:jvmTest / :sharedLogic:jvmTest / :sharedLogic:testAndroidHostTest / :sharedUI:testAndroidHostTest / :sharedUI:verifyStrings / :androidApp:assembleDebug (incl. the Room Migration44To45 validation test). No :contract or :server changes; all new types internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)