### PR TITLE
🐛 fix(sharedUI): beta UI polish — mini-player label, dialog shape, edit-profile save clearance

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/theme/Theme.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/theme/Theme.kt
@@ -1,7 +1,6 @@
 package com.calypsan.listenup.client.design.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -20,7 +19,11 @@ import androidx.compose.ui.unit.dp
  * - extraSmall/small: Input fields, chips
  * - medium (20.dp): Buttons, text fields - primary touch targets
  * - large (28.dp): Cards, elevated surfaces
- * - extraLarge: Fully rounded elements (FABs, avatars)
+ * - extraLarge (28.dp): Dialogs and large expressive surfaces (the M3 extra-large corner token)
+ *
+ * Fully-circular elements (FABs, avatars, pills, badges) apply CircleShape locally. The
+ * extraLarge token must stay a bounded radius: components that resolve their default shape to
+ * it — notably AlertDialog — render as clipped ellipses if it is CircleShape on a wide surface.
  */
 private val ExpressiveShapes =
     Shapes(
@@ -28,7 +31,7 @@ private val ExpressiveShapes =
         small = RoundedCornerShape(12.dp),
         medium = RoundedCornerShape(20.dp),
         large = RoundedCornerShape(28.dp),
-        extraLarge = CircleShape,
+        extraLarge = RoundedCornerShape(28.dp),
     )
 
 /**

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/metadata/MetadataSearchScreen.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.features.metadata
 
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -206,7 +207,8 @@ private fun Overline(text: String) {
 @Composable
 private fun MatchingContextPill(title: String) {
     Surface(
-        shape = MaterialTheme.shapes.extraLarge,
+        // A pill; keep it fully rounded now that the extraLarge token is a bounded 28.dp radius.
+        shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         modifier = Modifier.fillMaxWidth(),
     ) {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/DockedNowPlayingBar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/DockedNowPlayingBar.kt
@@ -176,12 +176,12 @@ private fun ActiveDockedContent(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
+            // Show the chapter's own title; no "Ch. N · " prefix — the title is often itself
+            // "Chapter N", and chapterIndex counts front-matter tracks (Introduction, Epigraph),
+            // so the prefix produced confusing, offset labels like "Ch. 3 · Chapter 1".
             val chapterLine =
-                if (state.chapterTitle != null) {
-                    "Ch. ${state.chapterIndex + 1} · ${state.chapterTitle}"
-                } else {
-                    "Ch. ${state.chapterIndex + 1}"
-                }
+                state.chapterTitle?.takeIf { it.isNotBlank() }
+                    ?: "Chapter ${state.chapterIndex + 1}"
             Text(
                 text = chapterLine,
                 style = MaterialTheme.typography.bodySmall,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingBar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingBar.kt
@@ -162,12 +162,12 @@ private fun MiniPlayerContent(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                // Show the chapter's own title; no "Ch. N · " prefix — the title is often itself
+                // "Chapter N", and chapterIndex counts front-matter tracks (Introduction, Epigraph),
+                // so the prefix produced confusing, offset labels like "Ch. 3 · Chapter 1".
                 val chapterLine =
-                    if (state.chapterTitle != null) {
-                        "Ch. ${state.chapterIndex + 1} · ${state.chapterTitle}"
-                    } else {
-                        "Ch. ${state.chapterIndex + 1}"
-                    }
+                    state.chapterTitle?.takeIf { it.isNotBlank() }
+                        ?: "Chapter ${state.chapterIndex + 1}"
                 Text(
                     text = chapterLine,
                     style = MaterialTheme.typography.bodySmall,

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/EditProfileScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/profile/EditProfileScreen.kt
@@ -145,15 +145,25 @@ fun EditProfileScreen(
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        floatingActionButton = {
+        // Dock Save in the bottomBar slot so ListenUpScaffold's mini-player clearance spacer sits
+        // directly beneath it — the floatingActionButton slot does not clear the mini-player overlay.
+        bottomBar = {
             if (ready != null) {
-                ListenUpExtendedFab(
-                    onClick = viewModel::save,
-                    icon = Icons.Default.Check,
-                    text = stringResource(Res.string.common_save_changes),
-                    enabled = ready.isDirty && !ready.isSaving,
-                    isLoading = ready.isSaving,
-                )
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 18.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    ListenUpExtendedFab(
+                        onClick = viewModel::save,
+                        icon = Icons.Default.Check,
+                        text = stringResource(Res.string.common_save_changes),
+                        enabled = ready.isDirty && !ready.isSaving,
+                        isLoading = ready.isSaving,
+                    )
+                }
             }
         },
     ) { paddingValues ->
@@ -220,9 +230,6 @@ private fun EditProfileContent(
             } else {
                 CompactLayout(ready = ready, onPickImage = onPickImage, viewModel = viewModel)
             }
-
-            // Bottom padding so the FAB doesn't overlap the last card
-            Spacer(modifier = Modifier.height(80.dp))
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/search/SearchResultsOverlay.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -850,7 +851,8 @@ private fun PersonResultRow(
             modifier =
                 Modifier
                     .size(52.dp)
-                    .clip(MaterialTheme.shapes.extraLarge)
+                    // A circular icon badge; keep it round now that extraLarge is a bounded radius.
+                    .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.primaryContainer),
             contentAlignment = Alignment.Center,
         ) {


### PR DESCRIPTION
Three isolated UI fixes from the 2026-07-03 beta test session (all `sharedUI/commonMain` → Android + Desktop):

- **Mini-player chapter label** — drop the confusing `Ch. N · <title>` prefix (`N` was a track index that counts front-matter tracks, so it drifted, e.g. "Ch. 3 · Chapter 1"). Now shows the chapter title, falling back to `Chapter N` only when blank — matching the existing `CompactNowPlaying`/`WideNowPlaying` pattern.
- **Dialog renders as an ellipse** — the `extraLarge` shape token was `CircleShape`, and `AlertDialog`'s default shape resolves to it, so dialogs rendered as clipped stadiums/ellipses on wide-but-short surfaces. Flip the token to `RoundedCornerShape(28.dp)` (also fixes the latent shapeless dialogs in Admin Categories / alias editor) and re-pin the two genuinely-circular sites (`MatchingContextPill`, the 52dp icon badge) to `CircleShape` locally.
- **Edit Profile "Save Changes" overlapped by the mini-player** — move Save from the `floatingActionButton` slot into the `bottomBar` slot so `ListenUpScaffold`'s mini-player-insets clearance spacer sits beneath it (the FAB slot did not clear the mini-player overlay); remove the hardcoded `Spacer(80.dp)`.

Verified locally: `:sharedUI:testAndroidHostTest`, `spotlessCheck`, and `detekt` all green. iOS lane runs in CI.