### PR TITLE
🐛 fix: avatar cluster — resolve all users' avatars from public_profiles

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImpl.kt
@@ -1,33 +1,44 @@
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.client.data.local.db.UserProfileDao
-import com.calypsan.listenup.client.data.local.db.UserProfileEntity
+import com.calypsan.listenup.client.data.local.db.PublicProfileDao
+import com.calypsan.listenup.client.data.local.db.PublicProfileEntity
 import com.calypsan.listenup.client.domain.model.CachedUserProfile
 import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /**
- * Implementation of UserProfileRepository backed by Room database.
+ * Implementation of [UserProfileRepository] backed by the synced `public_profiles` roster.
+ *
+ * Reads from [PublicProfileDao] — the server-synced social roster that already powers the
+ * leaderboard — so it resolves EVERY user, including the signed-in one. This is what lets an
+ * avatar render a real name/color/photo for any user, not only the current user (whose profile
+ * used to be the only row ever written to the local cache).
  */
 internal class UserProfileRepositoryImpl(
-    private val userProfileDao: UserProfileDao,
+    private val publicProfileDao: PublicProfileDao,
 ) : UserProfileRepository {
-    override suspend fun getById(userId: String): CachedUserProfile? = userProfileDao.getById(userId)?.toDomain()
+    override suspend fun getById(userId: String): CachedUserProfile? =
+        publicProfileDao.findById(userId)?.takeIf { it.deletedAt == null }?.toDomain()
 
     override fun observeProfile(userId: String): Flow<CachedUserProfile?> =
-        userProfileDao.observeById(userId).map { it?.toDomain() }
+        publicProfileDao.observeById(userId).map { it?.toDomain() }
 }
 
 /**
- * Map entity to domain model.
+ * Map a synced public-profile row to the lightweight avatar model.
+ *
+ * [avatarColor] is deliberately blank: [PublicProfileEntity] carries no server-assigned hex, so
+ * the avatar renderer's `parseAvatarHexColor` fallback derives a stable per-user color from the
+ * id. [PublicProfileEntity.avatarUpdatedAt] maps to [CachedUserProfile.updatedAt] so the Coil
+ * cache key versions on avatar-byte changes — a re-uploaded avatar busts the stale bitmap.
  */
-private fun UserProfileEntity.toDomain(): CachedUserProfile =
+private fun PublicProfileEntity.toDomain(): CachedUserProfile =
     CachedUserProfile(
         id = id,
         displayName = displayName,
         avatarType = avatarType,
-        avatarValue = avatarValue,
-        avatarColor = avatarColor,
-        updatedAt = updatedAt,
+        avatarValue = null,
+        avatarColor = "",
+        updatedAt = avatarUpdatedAt,
     )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SocialModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/SocialModule.kt
@@ -95,9 +95,10 @@ internal val socialModule: Module =
             UserRepositoryImpl(userDao = get(), authRpcFactory = get())
         }
 
-        // UserProfileRepository for other users' profile data (avatars in activity feed, etc.)
+        // UserProfileRepository resolves EVERY user's avatar profile (self + others) from the
+        // synced public_profiles roster, so avatars render everywhere instead of only for self.
         single<UserProfileRepository> {
-            UserProfileRepositoryImpl(userProfileDao = get())
+            UserProfileRepositoryImpl(publicProfileDao = get())
         }
 
         // LeaderboardRepository — Room-observed, offline-first; reads the synced

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/UserProfileRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/UserProfileRepository.kt
@@ -6,8 +6,9 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Repository for accessing cached user profile data.
  *
- * Provides offline-first access to user profiles (other users, not current user).
- * Used primarily for displaying avatars and profile info in social features.
+ * Provides offline-first access to user profiles for ANY user — the signed-in user and everyone
+ * else — backed by the server-synced `public_profiles` roster. Used primarily for displaying
+ * avatars and profile info in social features.
  */
 interface UserProfileRepository {
     /**

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/UserProfileRepositoryImplTest.kt
@@ -1,0 +1,126 @@
+package com.calypsan.listenup.client.data.repository
+
+import app.cash.turbine.test
+import com.calypsan.listenup.client.data.local.db.IdRevision
+import com.calypsan.listenup.client.data.local.db.PublicProfileDao
+import com.calypsan.listenup.client.data.local.db.PublicProfileEntity
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+
+private fun publicProfile(
+    id: String = "other-user",
+    displayName: String = "Grace Hopper",
+    avatarType: String = "auto",
+    avatarUpdatedAt: Long = 0,
+    deletedAt: Long? = null,
+) = PublicProfileEntity(
+    id = id,
+    displayName = displayName,
+    avatarType = avatarType,
+    totalSecondsAllTime = 0,
+    totalSecondsLast7Days = 0,
+    totalSecondsLast30Days = 0,
+    totalSecondsLast365Days = 0,
+    booksFinished = 0,
+    currentStreakDays = 0,
+    longestStreakDays = 0,
+    avatarUpdatedAt = avatarUpdatedAt,
+    revision = 1,
+    deletedAt = deletedAt,
+)
+
+/** In-memory fake: only the two reads [UserProfileRepositoryImpl] uses are backed. */
+private class StubReadPublicProfileDao(
+    private val rows: MutableStateFlow<Map<String, PublicProfileEntity>>,
+) : PublicProfileDao {
+    override fun observeById(userId: String): Flow<PublicProfileEntity?> = rows.map { it[userId]?.takeIf { row -> row.deletedAt == null } }
+
+    override suspend fun findById(userId: String): PublicProfileEntity? = rows.value[userId]
+
+    override fun observeAll(): Flow<List<PublicProfileEntity>> = error("unused")
+
+    override suspend fun upsert(entity: PublicProfileEntity) = error("unused")
+
+    override suspend fun softDelete(
+        id: String,
+        deletedAt: Long,
+        revision: Long,
+    ) = error("unused")
+
+    override suspend fun digestRows(max: Long): List<IdRevision> = error("unused")
+}
+
+class UserProfileRepositoryImplTest :
+    FunSpec({
+        fun repoWith(
+            vararg entities: PublicProfileEntity,
+        ): Pair<UserProfileRepositoryImpl, MutableStateFlow<Map<String, PublicProfileEntity>>> {
+            val rows = MutableStateFlow(entities.associateBy { it.id })
+            return UserProfileRepositoryImpl(StubReadPublicProfileDao(rows)) to rows
+        }
+
+        test("observeProfile emits another user's displayName and avatarType from public_profiles") {
+            val (repo, _) = repoWith(publicProfile(id = "other", displayName = "Grace Hopper", avatarType = "image"))
+            repo.observeProfile("other").test {
+                val profile = awaitItem()
+                profile shouldNotBe null
+                profile!!.displayName shouldBe "Grace Hopper"
+                profile.avatarType shouldBe "image"
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        test("observeProfile maps avatarUpdatedAt onto updatedAt (the Coil cache-key version)") {
+            val (repo, _) = repoWith(publicProfile(id = "other", avatarUpdatedAt = 4242L))
+            repo.observeProfile("other").test {
+                awaitItem()!!.updatedAt shouldBe 4242L
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        test("observeProfile leaves avatarColor blank so the renderer derives a stable per-user color") {
+            val (repo, _) = repoWith(publicProfile(id = "other"))
+            repo.observeProfile("other").test {
+                awaitItem()!!.avatarColor shouldBe ""
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        test("observeProfile emits null for a tombstoned public profile") {
+            val (repo, _) = repoWith(publicProfile(id = "gone", deletedAt = 99L))
+            repo.observeProfile("gone").test {
+                awaitItem().shouldBeNull()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        test("observeProfile re-emits with a new updatedAt when avatarUpdatedAt bumps") {
+            val (repo, rows) = repoWith(publicProfile(id = "other", avatarUpdatedAt = 100L))
+            repo.observeProfile("other").test {
+                awaitItem()!!.updatedAt shouldBe 100L
+                rows.value = mapOf("other" to publicProfile(id = "other", avatarUpdatedAt = 200L))
+                awaitItem()!!.updatedAt shouldBe 200L
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        test("getById returns the mapped profile for a live row") {
+            val (repo, _) = repoWith(publicProfile(id = "other", displayName = "Ada Lovelace"))
+            runTest {
+                repo.getById("other")!!.displayName shouldBe "Ada Lovelace"
+            }
+        }
+
+        test("getById returns null for a tombstoned row") {
+            val (repo, _) = repoWith(publicProfile(id = "gone", deletedAt = 99L))
+            runTest {
+                repo.getById("gone").shouldBeNull()
+            }
+        }
+    })

--- a/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarStateTest.kt
+++ b/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/design/components/UserAvatarStateTest.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.client.design.components
 
+import androidx.compose.ui.graphics.Color
 import com.calypsan.listenup.client.domain.model.CachedUserProfile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 private fun profile(
@@ -84,6 +86,45 @@ class UserAvatarStateTest :
                 localPath = "/p",
                 userId = "u1",
             ).shouldBeInstanceOf<UserAvatarUiState.Initials>()
+        }
+
+        // --- public_profiles-derived profiles (blank server hex; updatedAt = avatarUpdatedAt) ---
+
+        test("a non-null public-profile-derived profile never maps to Loading") {
+            userAvatarUiState(
+                profile = profile(avatarType = "auto", avatarColor = ""),
+                hasLocalAvatar = false,
+                localPath = "/p",
+                userId = "u1",
+            ) shouldNotBe UserAvatarUiState.Loading
+        }
+
+        test("blank avatarColor yields Initials with a stable, non-transparent per-user color") {
+            fun colorFor(userId: String) =
+                (
+                    userAvatarUiState(
+                        profile = profile(avatarType = "auto", avatarColor = ""),
+                        hasLocalAvatar = false,
+                        localPath = "/p",
+                        userId = userId,
+                    ) as UserAvatarUiState.Initials
+                ).color
+            // Same user → same color (stable across recompositions), and fully opaque (not grey/unset).
+            colorFor("u1") shouldBe colorFor("u1")
+            colorFor("u1") shouldNotBe Color.Unspecified
+            colorFor("u1").alpha shouldBe 1f
+        }
+
+        test("cache key folds updatedAt (= avatarUpdatedAt) for a public-profile-derived image avatar") {
+            val state =
+                userAvatarUiState(
+                    profile = profile(avatarType = "image", avatarColor = "", updatedAt = 777L),
+                    hasLocalAvatar = true,
+                    localPath = "/avatars/u1.webp",
+                    userId = "u1",
+                )
+            state.shouldBeInstanceOf<UserAvatarUiState.Image>()
+            state.cacheKey shouldBe "u1-avatar-777"
         }
 
         test("avatarInitials takes the first letters of the first two words, uppercased") {

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/UserAvatar.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +32,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.CachedUserProfile
 import com.calypsan.listenup.client.domain.repository.ImageRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
@@ -128,14 +131,24 @@ internal fun rememberUserAvatarState(
     val imageRepository: ImageRepository = koinInject()
     val profile by repo.observeProfile(userId).collectAsStateWithLifecycle(initialValue = null)
 
-    val hasLocalAvatar = remember(userId, profile) { imageStorage.userAvatarExists(userId) }
+    // Re-check disk presence whenever the profile's avatar version changes or a download lands, so
+    // the avatar flips from initials to the real photo the moment the file appears — no revisit,
+    // no manual refresh. Keying on avatarUpdatedAt (profile.updatedAt) also re-checks after a
+    // synced avatar change.
+    var downloadTick by remember(userId) { mutableIntStateOf(0) }
+    val hasLocalAvatar =
+        remember(userId, profile?.updatedAt, downloadTick) { imageStorage.userAvatarExists(userId) }
 
-    // Lazily persist an image avatar we don't have on disk yet, so it renders the real photo
-    // (not initials) everywhere it appears — feeds, leaderboards — and survives offline, without
-    // first visiting the user's profile. No-op once the file exists.
-    LaunchedEffect(userId, profile?.avatarType, hasLocalAvatar) {
-        if (profile?.avatarType == "image" && !hasLocalAvatar) {
-            imageRepository.ensureUserAvatarCached(userId)
+    // Persist an image avatar we don't have on disk yet — and re-run when the synced avatarUpdatedAt
+    // changes — so it renders the real photo (not initials) everywhere it appears (feeds,
+    // leaderboards) and survives offline, without first visiting the user's profile. A real download
+    // bumps the tick, re-checking presence so the Image state renders.
+    LaunchedEffect(userId, profile?.avatarType, profile?.updatedAt) {
+        if (profile?.avatarType == "image") {
+            when (val result = imageRepository.downloadUserAvatar(userId, forceRefresh = false)) {
+                is AppResult.Success -> if (result.data) downloadTick++
+                is AppResult.Failure -> Unit
+            }
         }
     }
 


### PR DESCRIPTION
## Avatar cluster fix (#4 / #9 / #10 / #11)

`UserAvatar` resolved every user through `UserProfileRepository.observeProfile`, which read the `user_profiles` Room table. But the *only* writer of `user_profiles` is `ProfileRepositoryImpl.refreshMyProfile()` — the current user. So for any **other** user, `observeProfile` emitted `null` forever → indefinite `Loading` → grey circle. The all-users roster (with `displayName`, `avatarType`, `avatarUpdatedAt`) already lives in the server-synced `public_profiles` table used by the leaderboard; the UI just never read it.

### Changes

**Step 1 — resolve any user from `public_profiles` (#4, enables #9/#11)** — `sharedLogic`
- `UserProfileRepositoryImpl` now depends on `PublicProfileDao` instead of `UserProfileDao`. `observeProfile`/`getById` read the synced roster (tombstoned rows → `null`).
- New `PublicProfileEntity.toDomain()` maps `avatarUpdatedAt → updatedAt` (load-bearing: versions the `"$userId-avatar-$updatedAt"` Coil cache key on avatar-byte changes) and leaves `avatarColor` blank so `parseAvatarHexColor` falls back to the stable per-user color.
- `SocialModule` + `UserProfileRepository` KDoc updated (now serves **all** users, incl. self).
- Fixes the blank grey circle at every fallback-less site (Admin, activity feed, book readers, discover, book card, admin collection detail).

**Step 2 — reactive file presence + version-keyed cache (#11, #9)** — `sharedUI`
- `rememberUserAvatarState` replaces the fire-and-forget `ensureUserAvatarCached` + non-reactive `hasLocalAvatar` with a completion-driven re-check: a `downloadTick` bumps when `downloadUserAvatar` actually lands a file, and disk presence is re-checked on `userId` / `avatarUpdatedAt` / tick. A synced avatar change re-emits a new cache key (Coil re-decodes) and re-runs the download effect. Avatars now flip from initials to the real photo the moment the file appears — no revisit, no manual refresh.

**Step 3 — tap-to-profile (#10):** no code change needed. The leaderboard and book-readers rows are already fully clickable and navigate to `UserProfile(userId)`; the avatar sits inside that clickable row. Adding a nested `onClick` would be redundant. With Step 1 making avatars actually resolve, tapping through works. No new screens; Admin users-list avatar and decorative badges intentionally unchanged.

### Tests
- New `UserProfileRepositoryImplTest` (jvmTest): another user's name/type from `public_profiles`, `avatarUpdatedAt → updatedAt`, blank color, tombstone → `null`, avatarUpdatedAt bump re-emits.
- Extended `UserAvatarStateTest` (androidHostTest): public-profile-derived profile never maps to `Loading`; blank color → stable opaque per-user color; cache key folds `updatedAt`.

### Follow-up (out of scope)
After Step 1, the `user_profiles` table / `UserProfileDao` is still **written** by `refreshMyProfile()` but no longer **read** anywhere — a newly orphaned read left in place for a surgical follow-up cleanup.

### Verification
`./gradlew :sharedLogic:jvmTest :sharedUI:testAndroidHostTest spotlessCheck detekt --no-daemon` → **BUILD SUCCESSFUL**. (commonMain/sharedUI changes; iOS keeps its own `ensureUserAvatarCached` path and builds in CI.)