### PR TITLE
✨ feat(iosApp): show listened duration on activity-feed rows (#3A)

### DIFF
--- a/iosApp/ListenUp/Features/Discover/ActivityFeedObserver.swift
+++ b/iosApp/ListenUp/Features/Discover/ActivityFeedObserver.swift
@@ -77,6 +77,9 @@ struct ActivityRowItem: Identifiable, Equatable {
     /// The book id, for navigation; nil for book-less activities.
     let bookId: String?
     let occurredAt: Date
+    /// Formatted listened duration ("54m" / "1h 5m") for `listening_session` activities;
+    /// nil for every other type and for zero-duration sessions.
+    let duration: String?
 
     init(from model: ActivityUiModel) {
         self.id = model.id
@@ -88,6 +91,7 @@ struct ActivityRowItem: Identifiable, Equatable {
         self.book = model.bookTitle
         self.bookId = model.bookId
         self.occurredAt = Date(timeIntervalSince1970: TimeInterval(model.occurredAt) / 1_000)
+        self.duration = ActivityRowItem.duration(for: model)
     }
 
     init(
@@ -99,7 +103,8 @@ struct ActivityRowItem: Identifiable, Equatable {
         action: String,
         book: String?,
         bookId: String?,
-        occurredAt: Date
+        occurredAt: Date,
+        duration: String? = nil
     ) {
         self.id = id
         self.userId = userId
@@ -110,6 +115,7 @@ struct ActivityRowItem: Identifiable, Equatable {
         self.book = book
         self.bookId = bookId
         self.occurredAt = occurredAt
+        self.duration = duration
     }
 
     /// Pure: map an activity's `type` (+ `isReread`) to its localized action phrase.
@@ -134,5 +140,13 @@ struct ActivityRowItem: Identifiable, Equatable {
         default:
             String(localized: "discover.activity_did_something")
         }
+    }
+
+    /// Pure: the formatted listened duration for a `listening_session` with real time on the
+    /// clock ("54m" / "1h 5m"), else nil. Other activity types and zero-duration sessions
+    /// carry no duration detail. Mirrors Android surfacing the session length on the row.
+    static func duration(for model: ActivityUiModel) -> String? {
+        guard model.type == "listening_session", model.durationMs > 0 else { return nil }
+        return DurationFormatting.hoursMinutes(ms: model.durationMs)
     }
 }

--- a/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
@@ -16,6 +16,15 @@ struct ActivityRow: View {
         Self.relativeFormatter.localizedString(for: item.occurredAt, relativeTo: Date())
     }
 
+    /// Timestamp, with the listened duration appended as a middot-separated detail when present
+    /// ("2h ago · 1h 5m").
+    private var detailLabel: String {
+        if let duration = item.duration {
+            return "\(timeLabel) · \(duration)"
+        }
+        return timeLabel
+    }
+
     var body: some View {
         if let bookId = item.bookId {
             NavigationLink(value: BookDestination(id: bookId)) {
@@ -36,7 +45,7 @@ struct ActivityRow: View {
                     .font(.subheadline)
                     .lineLimit(2)
 
-                Text(timeLabel)
+                Text(detailLabel)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -62,8 +71,8 @@ struct ActivityRow: View {
 
     private var accessibilityText: String {
         if let book = item.book, !book.isEmpty {
-            return "\(item.who) \(item.action) \(book), \(timeLabel)"
+            return "\(item.who) \(item.action) \(book), \(detailLabel)"
         }
-        return "\(item.who) \(item.action), \(timeLabel)"
+        return "\(item.who) \(item.action), \(detailLabel)"
     }
 }

--- a/iosApp/ListenUpTests/DiscoverObserverTests.swift
+++ b/iosApp/ListenUpTests/DiscoverObserverTests.swift
@@ -117,7 +117,12 @@ struct LeaderboardObserverTests {
 @Suite("Activity phrase mapping")
 struct ActivityFeedObserverTests {
 
-    private func model(type: String, isReread: Bool = false, book: String? = "Dune") -> ActivityUiModel {
+    private func model(
+        type: String,
+        isReread: Bool = false,
+        book: String? = "Dune",
+        durationMs: Int64 = 0
+    ) -> ActivityUiModel {
         ActivityUiModel(
             id: "a1",
             userId: "u1",
@@ -132,7 +137,7 @@ struct ActivityFeedObserverTests {
             bookAuthorName: "Frank Herbert",
             bookCoverPath: nil,
             isReread: isReread,
-            durationMs: 0,
+            durationMs: durationMs,
             milestoneValue: 30,
             milestoneUnit: "days",
             shelfId: nil,
@@ -174,6 +179,30 @@ struct ActivityFeedObserverTests {
         #expect(item.book == nil)
         #expect(item.bookId == nil)
         #expect(item.action == "joined the server")
+    }
+
+    @Test func listeningSessionCarriesFormattedDuration() {
+        // 1h 5m = 65 minutes = 3_900_000 ms
+        let item = ActivityRowItem(from: model(type: "listening_session", durationMs: 3_900_000))
+        #expect(item.duration == "1h 5m")
+    }
+
+    @Test func listeningSessionUnderAnHourShowsMinutesOnly() {
+        // 54m = 3_240_000 ms
+        let item = ActivityRowItem(from: model(type: "listening_session", durationMs: 3_240_000))
+        #expect(item.duration == "54m")
+    }
+
+    @Test func zeroDurationListeningSessionHasNoDuration() {
+        let item = ActivityRowItem(from: model(type: "listening_session", durationMs: 0))
+        #expect(item.duration == nil)
+    }
+
+    @Test func nonListeningActivityHasNoDurationEvenWithMs() {
+        let started = ActivityRowItem(from: model(type: "started_book", durationMs: 3_900_000))
+        let finished = ActivityRowItem(from: model(type: "finished_book", durationMs: 3_900_000))
+        #expect(started.duration == nil)
+        #expect(finished.duration == nil)
     }
 }
 


### PR DESCRIPTION
Fixes bug #3 Part A: iOS activity-feed rows didn't show the listened duration (Android does). The shared `ActivityUiModel` already carried `durationMs` — iOS just never bound it.

## Change (iOS-only, no shared Kotlin touched)
- `ActivityRowItem` gains a `duration: String?`, populated only for `listening_session` with `durationMs > 0`, formatted via existing `DurationFormatting.hoursMinutes` ("54m" / "1h 5m").
- `ActivityRow` renders it as a "· 1h 5m" detail after the timestamp (semantic caption font, `.secondary`), and VoiceOver reads it.
- 4 Swift Testing cases: formatted duration, minutes-only, zero-duration → nil, non-listening → nil.

Verified by inspection on Linux (Apple targets can't build here) — relying on the CI **Test (iOS)** lane for the compile + Swift tests.