### PR TITLE
✨ feat(ios): foreign profile screen + wire Readers/Leaderboard/Activity avatars to it

### DIFF
--- a/iosApp/ListenUp/Features/BookDetail/Components/BookReadersSection.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/BookReadersSection.swift
@@ -6,8 +6,7 @@ import SwiftUI
 /// A heading with a "{N} listening now" subtitle leads, then flat display-only rows: a
 /// tinted initials avatar (with a coral ring when the reader is listening now), the name,
 /// and either a progress bar + percent (reading) or a "Finished {date}" line. The current
-/// user's row gets a "(You)" suffix. Rows are plain content — never buttons — because iOS
-/// has no general per-user detail screen yet; this section is informational.
+/// user's row gets a "(You)" suffix. Tapping a row opens that reader's profile.
 ///
 /// Pure/presentational: it takes the projected rows. Renders nothing when empty (the
 /// observer's `.empty` phase keeps it out of the layout entirely).
@@ -28,7 +27,10 @@ struct BookReadersSection: View {
                     Divider()
                         .padding(.leading, 57)
                 }
-                readerRow(reader)
+                NavigationLink(value: ProfileDestination(userId: reader.id)) {
+                    readerRow(reader)
+                }
+                .buttonStyle(.pressScaleRow)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
@@ -17,20 +17,34 @@ struct ActivityRow: View {
     }
 
     var body: some View {
+        HStack(spacing: 13) {
+            // The avatar is its own tap target → the actor's profile. Kept a sibling of (not nested
+            // inside) the book link below, since nested NavigationLinks don't compose.
+            NavigationLink(value: ProfileDestination(userId: item.userId)) {
+                UserAvatarView(userId: item.userId, fallbackName: item.who, avatarColor: item.avatarColor)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(item.who)
+
+            detail
+        }
+        .padding(.vertical, 8)
+    }
+
+    /// The phrase + timestamp → the book's detail when the activity carries a book; otherwise plain.
+    @ViewBuilder private var detail: some View {
         if let bookId = item.bookId {
             NavigationLink(value: BookDestination(id: bookId)) {
-                content
+                detailContent
             }
             .buttonStyle(.pressScaleRow)
         } else {
-            content
+            detailContent
         }
     }
 
-    private var content: some View {
-        HStack(spacing: 13) {
-            UserAvatarView(userId: item.userId, fallbackName: item.who, avatarColor: item.avatarColor)
-
+    private var detailContent: some View {
+        HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 2) {
                 phrase
                     .font(.subheadline)
@@ -43,7 +57,6 @@ struct ActivityRow: View {
 
             Spacer(minLength: 0)
         }
-        .padding(.vertical, 8)
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityText)

--- a/iosApp/ListenUp/Features/Discover/Components/LeaderRow.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/LeaderRow.swift
@@ -7,31 +7,34 @@ struct LeaderRow: View {
     let row: LeaderboardRow
 
     var body: some View {
-        HStack(spacing: 13) {
-            Text("\(row.rank)")
-                .font(.callout.weight(.bold).monospacedDigit())
-                .foregroundStyle(rankColor)
-                .frame(width: 22)
+        NavigationLink(value: ProfileDestination(userId: row.id)) {
+            HStack(spacing: 13) {
+                Text("\(row.rank)")
+                    .font(.callout.weight(.bold).monospacedDigit())
+                    .foregroundStyle(rankColor)
+                    .frame(width: 22)
 
-            UserAvatarView(userId: row.id, fallbackName: row.displayName, size: 38)
+                UserAvatarView(userId: row.id, fallbackName: row.displayName, size: 38)
 
-            Text(name)
-                .font(.callout.weight(row.isCurrentUser ? .semibold : .regular))
-                .foregroundStyle(.primary)
-                .lineLimit(1)
+                Text(name)
+                    .font(.callout.weight(row.isCurrentUser ? .semibold : .regular))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
 
-            Spacer(minLength: 8)
+                Spacer(minLength: 8)
 
-            Text(row.value)
-                .font(.system(.subheadline, design: .default).monospacedDigit())
-                .fontWeight(row.isCurrentUser ? .bold : .medium)
-                .foregroundStyle(row.isCurrentUser ? Color.luTint : Color.luLabel2)
+                Text(row.value)
+                    .font(.system(.subheadline, design: .default).monospacedDigit())
+                    .fontWeight(row.isCurrentUser ? .bold : .medium)
+                    .foregroundStyle(row.isCurrentUser ? Color.luTint : Color.luLabel2)
+            }
+            .padding(.vertical, 10)
+            .padding(.horizontal, row.isCurrentUser ? 10 : 0)
+            .background(rowBackground)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(row.rank). \(name), \(row.value)")
         }
-        .padding(.vertical, 10)
-        .padding(.horizontal, row.isCurrentUser ? 10 : 0)
-        .background(rowBackground)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(row.rank). \(name), \(row.value)")
+        .buttonStyle(.pressScaleRow)
     }
 
     private var name: String {

--- a/iosApp/ListenUp/Features/Main/MainTabView.swift
+++ b/iosApp/ListenUp/Features/Main/MainTabView.swift
@@ -209,6 +209,9 @@ private extension View {
             .navigationDestination(for: UserProfileDestination.self) { _ in
                 UserProfileView()
             }
+            .navigationDestination(for: ProfileDestination.self) { destination in
+                ForeignProfileView(userId: destination.userId)
+            }
             .navigationDestination(for: SettingsDestination.self) { _ in
                 SettingsView()
             }

--- a/iosApp/ListenUp/Features/Profile/ForeignProfileView.swift
+++ b/iosApp/ListenUp/Features/Profile/ForeignProfileView.swift
@@ -1,0 +1,109 @@
+import Shared
+import SwiftUI
+
+/// Another user's profile, viewed read-only — reached by tapping a user's avatar in the book
+/// Readers section, the Leaderboard, or the Activity feed.
+///
+/// A deliberately lean, read-only counterpart to `UserProfileView`: the same header + stat strip,
+/// but no Edit / Settings / account chrome. Everything shown (name, tagline, avatar, listening stats)
+/// resolves from the synced `public_profiles` Room row, so it renders offline (Never-Stranded) — the
+/// shared `UserProfileViewModel.loadProfile(userId:)` needs no network for this surface. Public shelves
+/// are intentionally out of scope for now (they'd need a live RPC + shelf-detail wiring).
+///
+/// Own-vs-foreign is transparent: loading the signed-in user's own id simply resolves with
+/// `isOwnProfile == true` and still renders read-only here.
+struct ForeignProfileView: View {
+    let userId: String
+
+    @Environment(\.dependencies) private var deps
+
+    @State private var observer: UserProfileObserver?
+
+    var body: some View {
+        ScrollView {
+            content
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 24)
+                .readableWidth()
+        }
+        .background(Color.luSurface)
+        .navigationTitle(observer?.displayName ?? "")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            let observer = observer ?? UserProfileObserver(viewModel: deps.createUserProfileViewModel())
+            self.observer = observer
+            observer.loadProfile(userId: userId)
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder private var content: some View {
+        switch observer?.phase ?? .loading {
+        case .ready:
+            VStack(spacing: 22) {
+                header
+                statStrip
+            }
+        case .error(let message):
+            ContentUnavailableView(
+                String(localized: "common.error"),
+                systemImage: "person.slash",
+                description: Text(message)
+            )
+            .frame(maxWidth: .infinity, minHeight: 320)
+        case .loading:
+            ProgressView()
+                .frame(maxWidth: .infinity, minHeight: 320)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            UserAvatarView(
+                userId: userId,
+                fallbackName: observer?.displayName ?? "",
+                avatarColor: observer?.avatarColorHex,
+                hasImageAvatar: observer?.hasImageAvatar ?? true,
+                size: 104
+            )
+
+            VStack(spacing: 3) {
+                Text(observer?.displayName ?? "")
+                    .font(.title.bold())
+                    .multilineTextAlignment(.center)
+
+                if let tagline = observer?.tagline, !tagline.isEmpty {
+                    Text(tagline)
+                        .font(.subheadline)
+                        .foregroundStyle(Color.luLabel2)
+                        .multilineTextAlignment(.center)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Stats
+
+    @ViewBuilder private var statStrip: some View {
+        if let stats = observer {
+            StatStrip(stats: [
+                .init(value: ProfileStatFormat.listened(totalMs: stats.totalListenTimeMs),
+                      label: String(localized: "profile.stat_listened")),
+                .init(value: "\(stats.booksFinished)",
+                      label: String(localized: "profile.stat_finished")),
+                .init(value: "\(stats.currentStreak)",
+                      label: String(localized: "profile.stat_day_streak")),
+                .init(value: "\(stats.longestStreak)",
+                      label: String(localized: "profile.stat_best"))
+            ])
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity)
+            .background(Color.luSurface2, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+}

--- a/iosApp/ListenUp/Features/Profile/UserProfileObserver.swift
+++ b/iosApp/ListenUp/Features/Profile/UserProfileObserver.swift
@@ -36,6 +36,12 @@ final class UserProfileObserver {
     private(set) var displayName: String = ""
     private(set) var tagline: String?
     private(set) var avatarColorHex: String = "#6B7280"
+    /// Whether this user has a real uploaded avatar image (vs. a generated monogram). Drives whether
+    /// the foreign-profile avatar attempts an image load. `avatarType == "image"` on the shared state.
+    private(set) var hasImageAvatar: Bool = true
+    /// True when the loaded profile is the signed-in user's own — lets a shared observer back both the
+    /// own-profile and foreign-profile screens (the foreign screen renders read-only regardless).
+    private(set) var isOwnProfile: Bool = false
     private(set) var totalListenTimeMs: Int64 = 0
     private(set) var booksFinished: Int = 0
     private(set) var currentStreak: Int = 0
@@ -64,6 +70,8 @@ final class UserProfileObserver {
             displayName = r.displayName
             tagline = r.tagline
             avatarColorHex = r.avatarColor
+            hasImageAvatar = r.avatarType == "image"
+            isOwnProfile = r.isOwnProfile
             totalListenTimeMs = r.totalListenTimeMs
             booksFinished = Int(r.booksFinished)
             currentStreak = Int(r.currentStreak)

--- a/iosApp/ListenUp/Navigation/Destinations.swift
+++ b/iosApp/ListenUp/Navigation/Destinations.swift
@@ -89,6 +89,12 @@ enum SearchSeeAllType: Hashable {
 /// The current user's profile.
 struct UserProfileDestination: Hashable {}
 
+/// Another user's profile, reached by tapping their avatar in the book Readers section,
+/// the Leaderboard, or the Activity feed. Keyed by `userId`; the screen renders read-only.
+struct ProfileDestination: Hashable {
+    let userId: String
+}
+
 /// Settings.
 struct SettingsDestination: Hashable {}
 


### PR DESCRIPTION
iOS had no way to view another user's profile — tapping a user's avatar anywhere did nothing. This adds a read-only foreign-profile screen and wires the three social surfaces to it.

## What it turned out to be
Not the deep gap it looked like: the shared `UserProfileViewModel` **already** handles foreign profiles (`loadProfile(userId)` branches own/foreign internally), and the iOS `UserProfileObserver` already binds it. So this is almost entirely iOS UI + navigation — **no shared/contract/server changes.**

## The screen — `ForeignProfileView`
A lean, read-only counterpart to `UserProfileView`: same header + stat strip (Listened / Finished / Day streak / Best), **no** Edit/Settings/account chrome. Everything shown resolves from the synced `public_profiles` Room row, so it **renders offline** (Never-Stranded); the VM needs no network for this surface. Loading own id just resolves `isOwnProfile == true` and still renders read-only.
- New `ProfileDestination(userId:)` route (mirrors `BookDestination`), registered in `MainTabView`.
- `UserProfileObserver` extended to surface `isOwnProfile` + `hasImageAvatar` (drives the avatar). No new localized strings (reuses `profile.stat_*` / `common.error`).

## Wiring the three avatars
- **Readers** (`BookReadersSection`) — rows now `NavigationLink` → `ProfileDestination`; dropped the stale "no per-user detail screen yet" comment.
- **Leaderboard** (`LeaderRow`) — row wrapped in the same link.
- **Activity** (`ActivityRow`) — the one with a wrinkle: the row was already a book `NavigationLink`. Split into **sibling** links (nested don't compose) — the **avatar → profile**, the **phrase/timestamp → book**. Two distinct tap targets, two a11y elements.

## Deferred (Phase 3, separate PR)
Public shelves — needs the `getUserShelves` RPC + a shelf section (the `ShelfDetailView` nav target already exists, so it's ready when we want it). Recent-books / handle / join-date aren't available from the shared layer at all.

## Verification
- `xcodebuild build` (device) → **BUILD SUCCEEDED**; SwiftLint clean on all seven files.
- No new unit tests: the observer's state mapping isn't Swift-unit-testable (the sealed `UserProfileUiState` is non-constructible — same reason the existing `UserProfileObserverTests` only cover `ProfileStatFormat`); the own/foreign VM branching is covered by the Kotlin `UserProfileViewModelTest`. `Test (iOS)` runs the target on CI.

### On-device check (interactions are view-level, can't verify locally)
- Tap a reader avatar → their profile (header + stats); a leaderboard row → same.
- **Activity: tapping the avatar → the actor's profile, tapping the text → the book** (confirm the split works, no tap conflict).
- Tap your own avatar → your profile, read-only.
- Offline: profile still renders header + stats.
