### PR TITLE
✨ feat(shared): centralized lifecycle reconcile — self-heal dropped sync signals without restart

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SyncRepositoryImpl.kt
@@ -126,7 +126,14 @@ internal class SyncRepositoryImpl(
     override suspend fun sync(): AppResult<Unit> = startEngineForCurrentUser()
 
     override suspend fun connectRealtime() {
+        // Every platform's app-foreground path funnels through here (MainActivity.onResume, the
+        // auth-transition collector, shell entry, the offline-banner retry). Starting the engine
+        // no-ops when it's already running for this user — so foregrounding used to do ZERO
+        // reconciliation, and anything a live event dropped while backgrounded sat invisible until a
+        // cold restart. lifecycleReconcile closes that hole: it's debounced (the cold-start
+        // double-run right after start() is skipped) and heals anything missed on every foreground.
         startEngineForCurrentUser()
+        syncEngine.lifecycleReconcile()
     }
 
     override suspend fun disconnect() {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -57,6 +57,7 @@ internal class SyncEngine(
     private val scope: CoroutineScope,
     private val primeActivityFeed: suspend () -> Unit = {},
     private val retryBackoffMillis: Long = DEFAULT_RETRY_BACKOFF_MILLIS,
+    private val lifecycleReconcileMinIntervalMs: Long = LIFECYCLE_RECONCILE_MIN_INTERVAL_MS,
 ) {
     private var frameCollectorJob: Job? = null
     private var connectionUpDrainJob: Job? = null
@@ -105,6 +106,19 @@ internal class SyncEngine(
     // satisfied by a pass that began after it registered (and the pending flag guarantees that pass
     // runs), the caller suspends exactly until a catch-up pass covering its request has drained.
     private val cursorStaleWaiters = mutableListOf<CompletableDeferred<Unit>>()
+
+    // Serializes + debounces the standing lifecycle reconcile — the one recovery pass every
+    // lifecycle edge (app-foreground via connectRealtime, firehose reconnect) funnels into.
+    // Distinct from [handleCursorStale]: the live SSE tail stays UP; only forward catch-up +
+    // digest re-run. A pass within [LIFECYCLE_RECONCILE_MIN_INTERVAL_MS] of the last completed
+    // pass is skipped unless force = true, so onResume storms and the cold-start double-run
+    // (runStart already reconciled) collapse to nothing. A forced trigger arriving mid-pass
+    // schedules exactly one covering follow-up so its effect (e.g. LibraryDataChanged) is never
+    // lost to the coalescing.
+    private val lifecycleReconcileMutex = Mutex()
+    private var lifecycleReconcileRunning = false
+    private var lifecycleReconcilePending = false
+    private var lastLifecycleReconcileAtMs = 0L
 
     // Flips to true on the last line of [runStart] for the active user. If
     // [runStart] throws before that line, the flag stays false even though
@@ -225,6 +239,10 @@ internal class SyncEngine(
         // start() for the same user is a no-op. If any step above threw, this
         // line is never reached, the flag stays false, and start() retries.
         currentUserStarted = true
+        // Stamp the lifecycle-reconcile debounce clock: runStart just did the equivalent work
+        // (forward catch-up + digest reconcile), so the connectRealtime() foreground reconcile
+        // that immediately follows a cold start is debounced instead of redundantly re-draining.
+        lifecycleReconcileMutex.withLock { lastLifecycleReconcileAtMs = currentEpochMilliseconds() }
     }
 
     /** Invoke [primeActivityFeed], swallowing non-cancellation failures so priming never aborts a caller. */
@@ -303,6 +321,109 @@ internal class SyncEngine(
      */
     suspend fun forceReconcile() {
         reconciler.reconcileAll()
+    }
+
+    /**
+     * The standing recovery pass every lifecycle edge funnels into — app-foreground (via
+     * [com.calypsan.listenup.client.data.repository.SyncRepository.connectRealtime]) and firehose
+     * reconnect ([runReconnectRefresh]). Removes the "restart required" failure class structurally:
+     * anything a live event or control nudge dropped while the app was backgrounded or the firehose
+     * was down self-heals on the next edge.
+     *
+     * Ordering is load-bearing:
+     *  1. **Forward catch-up FIRST** ([CatchUp.catchUpAll]) — drains rows written server-side ABOVE
+     *     the client's cursor (exactly what a `FirehoseSuppressed` bulk write produces). The digest
+     *     reconcile is blind to these: it fingerprints AT the cursor, so above-cursor rows are
+     *     excluded from both sides' digests.
+     *  2. **Digest reconcile SECOND** ([SyncReconciler.reconcileAll]) — repairs in-place divergence
+     *     at/below the cursor.
+     *  3. **Nudge refreshes** — re-fetch the ephemeral refreshed tier (presence, activity) so a
+     *     dropped control frame heals on this edge too.
+     *
+     * Coalesced + debounced: a pass within [LIFECYCLE_RECONCILE_MIN_INTERVAL_MS] of the last is
+     * skipped unless [force] is true, so rapid foreground/reconnect edges collapse to one pass.
+     * A [force] = true trigger arriving while a pass runs schedules exactly one covering follow-up.
+     * Unlike [handleCursorStale] this never tears down the SSE connection — the live tail is healthy.
+     */
+    suspend fun lifecycleReconcile(force: Boolean = false) {
+        val shouldLead =
+            lifecycleReconcileMutex.withLock {
+                when {
+                    lifecycleReconcileRunning -> {
+                        // A pass is already in flight. A forced trigger needs a covering follow-up so
+                        // its effect isn't lost to coalescing; a debounced trigger folds into it.
+                        if (force) lifecycleReconcilePending = true
+                        false
+                    }
+
+                    force || debounceElapsedLocked() -> {
+                        lifecycleReconcileRunning = true
+                        true
+                    }
+
+                    else -> {
+                        false
+                    } // within the debounce window and not forced → drop
+                }
+            }
+        if (!shouldLead) return
+        try {
+            var more = true
+            while (more) {
+                runLifecycleReconcilePass()
+                more =
+                    lifecycleReconcileMutex.withLock {
+                        lastLifecycleReconcileAtMs = currentEpochMilliseconds()
+                        if (lifecycleReconcilePending) {
+                            lifecycleReconcilePending = false
+                            true
+                        } else {
+                            lifecycleReconcileRunning = false
+                            false
+                        }
+                    }
+            }
+        } finally {
+            // Normal exit already cleared the running flag in the loop; this only fires when a pass
+            // threw or was cancelled, so a future edge can still lead a recovery.
+            if (lifecycleReconcileRunning) {
+                lifecycleReconcileMutex.withLock {
+                    lifecycleReconcileRunning = false
+                    lifecycleReconcilePending = false
+                }
+            }
+        }
+    }
+
+    /** Whether the debounce window has elapsed since the last completed pass. MUST hold [lifecycleReconcileMutex]. */
+    private fun debounceElapsedLocked(): Boolean =
+        currentEpochMilliseconds() - lastLifecycleReconcileAtMs >= lifecycleReconcileMinIntervalMs
+
+    /** One lifecycle reconcile pass: forward catch-up → digest reconcile → nudge refreshes. */
+    private suspend fun runLifecycleReconcilePass() {
+        when (val result = catchUp.catchUpAll(registry)) {
+            is AppResult.Success -> {}
+
+            is AppResult.Failure -> {
+                logger.warn {
+                    "Lifecycle catch-up failed: ${result.error.code}; continuing to digest reconcile"
+                }
+            }
+        }
+        // reconcileAll is non-throwing; nudge refreshes are individually guarded.
+        reconciler.reconcileAll()
+        runLifecycleRefreshHooks()
+    }
+
+    /**
+     * Re-fetch the ephemeral refreshed tier so a dropped nudge frame heals on this edge. Presence is
+     * a non-throwing tryEmit; the activity prime is guarded so an offline/failed fetch never aborts
+     * the pass. (Server-info + preferences keep their own control triggers until Phase 3 folds them
+     * in here via declared recovery.)
+     */
+    private suspend fun runLifecycleRefreshHooks() {
+        presenceRefreshSignal.ping()
+        primeActivityFeedSafely()
     }
 
     /**
@@ -571,9 +692,10 @@ internal class SyncEngine(
      *
      * The offline→online path ([ReconnectionSupervisor] → [SseClient.reconnectNow]) only resumes the
      * SSE stream; without this the activity feed and leaderboard stay stale until the server happens
-     * to emit a `CursorStale`. On each reconnect edge we deterministically prime the activity feed
-     * into Room (UI-independent), ping presence so currently-listening re-fetches, and run the
-     * digest-gated [SyncReconciler.reconcileAll] (refreshing `public_profiles` → the leaderboard).
+     * to emit a `CursorStale`. On each reconnect edge we run [lifecycleReconcile] — forward catch-up
+     * (draining rows written above the cursor during the outage), digest reconcile (refreshing
+     * `public_profiles` → the leaderboard), and the nudge refreshes (priming the activity feed into
+     * Room, pinging presence so currently-listening re-fetches).
      *
      * Subscribed before [SseClient.connect] and [drop]ping the first Connected, so the initial
      * start-connect (already covered by [runStart]'s prime + reconcile) does not double-fire.
@@ -596,24 +718,12 @@ internal class SyncEngine(
     }
 
     private suspend fun runReconnectRefresh() {
-        // Presence ping is a non-throwing tryEmit. The two suspend actions are guarded independently
-        // so one failure neither tears down the collector nor starves the other. Cancellation always
-        // propagates.
-        presenceRefreshSignal.ping()
-        try {
-            primeActivityFeed()
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.warn(e) { "Reconnect activity-feed prime failed; continuing" }
-        }
-        try {
-            reconciler.reconcileAll()
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.warn(e) { "Reconnect reconcile failed; continuing" }
-        }
+        // A reconnect may have missed live events AND control nudges while the firehose was down.
+        // Funnel into the one lifecycle reconcile: forward catch-up drains rows written above the
+        // cursor during the outage (the digest can't see them), digest repairs below-cursor
+        // divergence, and the nudge refreshes re-fetch presence/activity. force = true bypasses the
+        // debounce so a reconnect edge always heals.
+        lifecycleReconcile(force = true)
     }
 
     /**
@@ -719,5 +829,10 @@ internal class SyncEngine(
         // MAX_RETRYABLE_ATTEMPTS = 5 to bound total retry time to ~5s on
         // transient failures without hammering the server.
         const val DEFAULT_RETRY_BACKOFF_MILLIS = 1_000L
+
+        // Debounce floor for [lifecycleReconcile]. Guards against onResume storms: a full pass is
+        // ~20 cheap catch-up GETs (empty pages when idle) + ~20 digest GETs — fine on a genuine
+        // edge, wasteful at 1 Hz. force = true (reconnect, LibraryDataChanged) bypasses it.
+        const val LIFECYCLE_RECONCILE_MIN_INTERVAL_MS = 30_000L
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncReconciler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncReconciler.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.currentEpochMilliseconds
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -71,13 +72,38 @@ internal class SyncReconciler(
                     }
                 }
             if (local.count != remote.count || local.hash != remote.hash) {
-                logger.info { "Digest drift on ${handler.domainName}; re-pulling from 0" }
-                catchUp.catchUpFromZero(handler)
+                repairDrift(handler)
             }
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e
         } catch (e: Throwable) {
             logger.warn(e) { "Reconcile failed for ${handler.domainName}; skipping" }
+        }
+    }
+
+    /**
+     * Repair a drifted domain. For an [AccessFilteredSyncHandler] a plain upsert-only re-pull cannot
+     * remove rows the server no longer counts (a revoked share leaves inaccessible rows local), so
+     * the digest would detect drift on EVERY pass and never converge. Route these through the same
+     * transient catch-up + prune sequence as [SyncEngine.handleAccessChanged], giving `AccessChanged`
+     * its lifecycle backstop: a dropped access frame heals on the next reconcile edge. Every other
+     * domain re-pulls from zero (upsert is sufficient — no rows to evict).
+     */
+    private suspend fun <T : Any> repairDrift(handler: SyncDomainHandler<T>) {
+        if (handler is AccessFilteredSyncHandler) {
+            logger.info { "Digest drift on ${handler.domainName} (access-gated); re-deriving + pruning" }
+            when (val ids = catchUp.catchUpTransient(handler)) {
+                is AppResult.Success -> {
+                    handler.pruneTo(ids.data, currentEpochMilliseconds())
+                }
+
+                is AppResult.Failure -> {
+                    logger.warn { "Access-gated re-derive failed for ${handler.domainName}: ${ids.error.code}" }
+                }
+            }
+        } else {
+            logger.info { "Digest drift on ${handler.domainName}; re-pulling from 0" }
+            catchUp.catchUpFromZero(handler)
         }
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -203,10 +203,12 @@ internal val clientSyncModule =
                 // by the dispatcher; there's no existing one-shot channel here to surface it.
                 onUserDeleted = { _ -> get<AuthSession>().clearAuthTokens() },
                 // The server's content-free bulk-write nudge (e.g. an ABS import's firehose-suppressed
-                // burst): re-derive every domain via digest reconciliation so the imported positions/
-                // sessions land live instead of only on the next reconnect. Same lazy-SyncEngine
-                // resolution as onCursorStale/onAccessChanged to break the construction cycle.
-                onLibraryDataChanged = { get<SyncEngine>().forceReconcile() },
+                // burst): the suppressed rows are written ABOVE the client cursor, so a digest-only
+                // reconcile (forceReconcile) can't see them — it fingerprints AT the cursor. Route
+                // through lifecycleReconcile(force = true), whose forward catch-up drains the
+                // above-cursor rows before the digest pass. Same lazy-SyncEngine resolution as
+                // onCursorStale/onAccessChanged to break the construction cycle.
+                onLibraryDataChanged = { get<SyncEngine>().lifecycleReconcile(force = true) },
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncReconcilerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncReconcilerTest.kt
@@ -14,6 +14,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -199,4 +200,80 @@ class SyncReconcilerTest :
                 verifySuspend(VerifyMode.not) { catchUp.catchUpFromZero(any<SyncDomainHandler<Any>>()) }
             }
         }
+
+        // ---------------------------------------------------------------------------------
+        // (d) an access-gated handler that drifted is re-derived + pruned, NOT upsert-only re-pulled
+        // ---------------------------------------------------------------------------------
+
+        test("(d) drifted AccessFilteredSyncHandler prunes to the accessible set instead of catchUpFromZero") {
+            runTest {
+                val max = 100L
+
+                // "collections" is access-gated. Local digest diverges from the server's, so the
+                // reconciler must re-derive the accessible set and prune — an upsert-only re-pull
+                // could never remove a revoked row, so the digest would never converge.
+                val localRows = listOf("c1" to 5L, "c2" to 5L)
+                // Server digest counts only c1 — c2's share was revoked. Divergence → drift.
+                val serverDigest = DigestComputer.compute(max, listOf("c1" to 5L))
+
+                val prunedTo = mutableListOf<Set<String>>()
+                val accessibleFromServer = setOf("c1")
+                val handler = accessGatedHandler("collections", localRows, prunedTo)
+
+                val registry = ClientSyncDomainRegistry()
+                registry.register(handler)
+
+                val store = inMemoryStore(max)
+                val digestClient = fakeDigestClient(mapOf("collections" to serverDigest))
+                val catchUp = mock<CatchUp>()
+                everySuspend { catchUp.catchUpTransient(any<SyncDomainHandler<Any>>()) } returns
+                    AppResult.Success(accessibleFromServer)
+
+                SyncReconciler(registry, store, digestClient, catchUp).reconcileAll()
+
+                // The upsert-only path must NOT be taken for an access-gated domain.
+                verifySuspend(VerifyMode.not) { catchUp.catchUpFromZero(any<SyncDomainHandler<Any>>()) }
+                // The transient re-derive drove a prune to exactly the accessible set.
+                verifySuspend { catchUp.catchUpTransient(handler) }
+                prunedTo shouldContainExactly listOf(accessibleFromServer)
+            }
+        }
     })
+
+/**
+ * Fake handler that is BOTH a [SyncDomainHandler] and an [AccessFilteredSyncHandler] — the shape of
+ * the four access-gated domains (books + the three collection domains). Records every [pruneTo]
+ * call's accessible set so the test can assert the reconciler routed drift through the prune path.
+ */
+private fun accessGatedHandler(
+    name: String,
+    rows: List<Pair<String, Long>>,
+    prunedTo: MutableList<Set<String>>,
+): SyncDomainHandler<Tag> =
+    object : SyncDomainHandler<Tag>, AccessFilteredSyncHandler {
+        override val domainName = name
+        override val payloadSerializer: KSerializer<Tag> = Tag.serializer()
+
+        override fun syncId(item: Tag): String = item.id
+
+        override suspend fun onEvent(
+            event: SyncEvent<Tag>,
+            isOwnEcho: Boolean,
+        ): AppResult<Unit> = AppResult.Success(Unit)
+
+        override suspend fun onCatchUpItem(
+            item: Tag,
+            isTombstone: Boolean,
+        ): AppResult<Unit> = AppResult.Success(Unit)
+
+        override suspend fun localDigestRows(maxRevision: Long): List<Pair<String, Long>> = rows
+
+        override suspend fun localLiveIds(): Set<String> = rows.map { it.first }.toSet()
+
+        override suspend fun pruneTo(
+            accessibleIds: Set<String>,
+            now: Long,
+        ) {
+            prunedTo += accessibleIds
+        }
+    }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
@@ -111,6 +111,10 @@ class ArchitectureTest :
                 // manufacture a sub-floor gap row, then proves reconcileAll repairs it. Same exemption
                 // class as DigestParityE2ETest — confined to jvmTest, not production.
                 .filter { "/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestReconcileGapE2ETest" !in it.path }
+                // Lifecycle-reconcile invariant E2E: boots real server in-process under FirehoseSuppressed
+                // to manufacture an above-cursor gap row, then proves lifecycleReconcile's forward catch-up
+                // lands it where forceReconcile cannot. Same exemption class — confined to jvmTest.
+                .filter { "data/sync/LifecycleReconcileInvariantTest" !in it.path }
                 // Backup RPC E2E: drives the client BackupRepository through the real BackupService
                 // in-process to prove the admin backup routes return domain-typed results (not a
                 // transport 404). Same exemption class as the Profile E2E — confined to jvmTest.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ForceReconcileWhileActiveTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ForceReconcileWhileActiveTest.kt
@@ -19,6 +19,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -187,9 +188,15 @@ class ForceReconcileWhileActiveTest :
 
                     repo.refreshListeningHistory()
 
-                    // Exactly one forward catch-up was forced, despite start()'s no-op. Pre-fix this was
-                    // a digest reconcile that added no catch-up (delta 0), stranding the import progress.
-                    catchUp.allInvocations.get() shouldBe afterStart + 1
+                    // refreshListeningHistory forces a forward catch-up (handleCursorStale → catchUpAll),
+                    // despite start()'s no-op. Pre-fix it did a digest reconcile that added NO catch-up
+                    // (delta 0), stranding the import progress — so the guard is "at least one forward
+                    // catch-up was forced". It must be `>=`, not `==`: handleCursorStale's recovery also
+                    // reseeds and RECONNECTS the SSE, and since Phase 0 every reconnect edge fires a forced
+                    // lifecycleReconcile (another catchUpAll) on the reconnect-refresh collector — async and
+                    // unjoined, so the count settles at +1 or +2 by timing. The invariant under test is that
+                    // a forward catch-up happened, not the exact number of downstream reconnect heals.
+                    catchUp.allInvocations.get() shouldBeGreaterThanOrEqual afterStart + 1
                 } finally {
                     scope.cancel()
                     scope.coroutineContext.job.children

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LifecycleReconcileInvariantTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LifecycleReconcileInvariantTest.kt
@@ -1,0 +1,77 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.sync.testing.withClientSyncEngineAgainstServer
+import com.calypsan.listenup.server.sync.FirehoseSuppressed
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+private val ROUND_TRIP_TIMEOUT = 30.seconds
+
+/**
+ * Invariant-level proof that [SyncEngine.lifecycleReconcile] self-heals a live event dropped ABOVE
+ * the client cursor — the `FirehoseSuppressed` gap that a digest-only reconcile is structurally
+ * blind to. This is the ordering guarantee (forward catch-up FIRST, then digest) made observable.
+ *
+ * Gap arrangement:
+ *   1. Start the engine; write "VisibleSeries" normally so the client receives its SSE event and
+ *      advances its `series` cursor to that revision.
+ *   2. Write "GapSeries" under [FirehoseSuppressed] — the server bumps the revision (now ABOVE the
+ *      client cursor) and commits the row, but publishes NO SSE event. Because no later visible
+ *      write follows, the client cursor stays below the gap revision.
+ *   3. Assert the gap: "GapSeries" is absent from client Room.
+ *   4. [SyncEngine.forceReconcile] (digest-only, AT the cursor) must FAIL to land it — the gap row
+ *      is above the cursor, excluded from both sides' digests. This is why forceReconcile was the
+ *      wrong tool for LibraryDataChanged.
+ *   5. [SyncEngine.lifecycleReconcile] (force = true) runs forward catch-up FIRST, draining the
+ *      above-cursor row, then digests. "GapSeries" lands in Room — no restart, no reconnect.
+ *
+ * The "absent after forceReconcile, present after lifecycleReconcile" pair is the whole point — it
+ * proves the catch-up-then-digest ordering is load-bearing. Do not weaken either half.
+ */
+class LifecycleReconcileInvariantTest :
+    FunSpec({
+
+        test("lifecycleReconcile lands an above-cursor suppressed row that forceReconcile cannot")
+            .config(timeout = 2.seconds * 60) {
+                withClientSyncEngineAgainstServer {
+
+                    // ── Step 1: start + a normal series write that advances the client cursor ─────
+                    engine.start(currentUserId = "u1")
+                    val visibleId = serverSeriesRepository.resolveOrCreate("VisibleSeries").value
+                    withTimeout(ROUND_TRIP_TIMEOUT) {
+                        while (clientDatabase.seriesDao().getById(visibleId) == null) {
+                            delay(10)
+                        }
+                    }
+
+                    // ── Step 2: write the GAP series suppressed, ABOVE the client cursor ─────────
+                    // Its revision bumps past the visible one and the row commits, but ChangeBus is
+                    // never published, so no SSE event reaches the client and the cursor does not move.
+                    val gapId =
+                        withContext(FirehoseSuppressed) {
+                            serverSeriesRepository.resolveOrCreate("GapSeries")
+                        }.value
+
+                    // ── Step 3: assert the gap exists ───────────────────────────────────────────
+                    clientDatabase.seriesDao().getById(gapId).shouldBeNull()
+
+                    // ── Step 4: digest-only reconcile CANNOT see the above-cursor row ────────────
+                    engine.forceReconcile()
+                    clientDatabase.seriesDao().getById(gapId).shouldBeNull()
+
+                    // ── Step 5: lifecycle reconcile's forward catch-up drains it ─────────────────
+                    engine.lifecycleReconcile(force = true)
+                    withTimeout(ROUND_TRIP_TIMEOUT) {
+                        while (clientDatabase.seriesDao().getById(gapId) == null) {
+                            delay(10)
+                        }
+                    }
+                    clientDatabase.seriesDao().getById(gapId).shouldNotBeNull()
+                }
+            }
+    })

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleReconcileTest.kt
@@ -1,0 +1,210 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Verifies [SyncEngine.lifecycleReconcile] — the centralized recovery pass every lifecycle edge
+ * (app-foreground, firehose reconnect) funnels into.
+ *
+ * Contract:
+ *  1. It runs a FORWARD catch-up (`catchUpAll`) — the piece the digest-only [SyncEngine.forceReconcile]
+ *     lacks, and the whole reason a `FirehoseSuppressed` above-cursor gap self-heals.
+ *  2. It runs even when the engine is already started (unlike `start()`, which no-ops for the same
+ *     user) — killing the "foreground does zero reconciliation" hole.
+ *  3. It is debounced: a non-forced pass within the min interval of the last is skipped.
+ *  4. `force = true` bypasses the debounce.
+ *  5. Concurrent triggers coalesce into a single pass.
+ */
+class SyncEngineLifecycleReconcileTest :
+    FunSpec({
+
+        test("lifecycleReconcile runs a forward catch-up") {
+            withLifecycleEngine(minIntervalMs = 0L) { engine, catchUp, _ ->
+                engine.lifecycleReconcile()
+                catchUp.catchUpAllInvocations.get() shouldBe 1
+            }
+        }
+
+        test("lifecycleReconcile runs even when the engine is already started (no foreground no-op hole)") {
+            withLifecycleEngine(minIntervalMs = 0L) { engine, catchUp, sse ->
+                engine.start(currentUserId = "u1")
+                // start() ran its own catch-up once; a same-user re-start would no-op.
+                catchUp.catchUpAllInvocations.get() shouldBe 1
+
+                // The foreground edge on an already-started engine still reconciles.
+                engine.lifecycleReconcile()
+                catchUp.catchUpAllInvocations.get() shouldBe 2
+
+                engine.stopAndJoin()
+            }
+        }
+
+        test("a second lifecycleReconcile within the debounce window is skipped") {
+            // A large interval means the second call is always inside the window.
+            withLifecycleEngine(minIntervalMs = 60_000L) { engine, catchUp, _ ->
+                engine.lifecycleReconcile()
+                engine.lifecycleReconcile()
+                catchUp.catchUpAllInvocations.get() shouldBe 1
+            }
+        }
+
+        test("force = true bypasses the debounce window") {
+            withLifecycleEngine(minIntervalMs = 60_000L) { engine, catchUp, _ ->
+                engine.lifecycleReconcile()
+                engine.lifecycleReconcile(force = true)
+                catchUp.catchUpAllInvocations.get() shouldBe 2
+            }
+        }
+
+        test("concurrent lifecycleReconcile triggers coalesce into one pass") {
+            withLifecycleEngine(minIntervalMs = 60_000L) { engine, catchUp, _ ->
+                coroutineScope {
+                    repeat(8) { launch { engine.lifecycleReconcile() } }
+                }
+                catchUp.catchUpAllInvocations.get() shouldBe 1
+            }
+        }
+    })
+
+/** Recording [CatchUp] that counts forward `catchUpAll` passes — the lifecycle-reconcile signal. */
+private class RecordingLifecycleCatchUp : CatchUp {
+    val catchUpAllInvocations = AtomicInteger(0)
+
+    override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun <T : Any> catchUpFromZero(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
+        catchUpAllInvocations.incrementAndGet()
+        return AppResult.Success(Unit)
+    }
+
+    override suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>> = AppResult.Success(emptySet())
+
+    override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
+}
+
+private fun withLifecycleEngine(
+    minIntervalMs: Long,
+    block: suspend (SyncEngine, RecordingLifecycleCatchUp, FakeLifecycleSse) -> Unit,
+) = runBlocking {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val db = createInMemoryTestDatabase()
+    try {
+        val engineAndCatchUp = buildLifecycleEngine(db, scope, minIntervalMs)
+        block(engineAndCatchUp.first, engineAndCatchUp.second, engineAndCatchUp.third)
+    } finally {
+        scope.cancel()
+        scope.coroutineContext.job.children
+            .forEach { it.join() }
+        db.close()
+    }
+}
+
+private fun buildLifecycleEngine(
+    db: ListenUpDatabase,
+    scope: CoroutineScope,
+    minIntervalMs: Long,
+): Triple<SyncEngine, RecordingLifecycleCatchUp, FakeLifecycleSse> {
+    val registry = ClientSyncDomainRegistry()
+    registry.register(LifecycleNoopTagHandler)
+    val store = SyncCursorStore(db.syncCursorDao())
+    val state = SyncEngineState()
+    val sse = FakeLifecycleSse(state)
+    val catchUp = RecordingLifecycleCatchUp()
+    val queue =
+        PendingOperationQueue(
+            dao = db.pendingOperationV2Dao(),
+            sender = PendingOperationSender { AppResult.Failure(SyncError.NotFound(domain = "tags", entityId = "t1")) },
+        )
+    val dispatcher =
+        SyncEventDispatcher(
+            registry = registry,
+            queue = queue,
+            state = state,
+            cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
+        )
+    val engine =
+        SyncEngine(
+            registry = registry,
+            queue = queue,
+            state = state,
+            store = store,
+            catchUp = catchUp,
+            sseClient = sse,
+            reconciler = noopSyncReconciler(registry, store, catchUp),
+            dispatcher = dispatcher,
+            presenceRefreshSignal = PresenceRefreshSignal(),
+            activityRefreshSignal = ActivityRefreshSignal(),
+            scope = scope,
+            lifecycleReconcileMinIntervalMs = minIntervalMs,
+        )
+    return Triple(engine, catchUp, sse)
+}
+
+private object LifecycleNoopTagHandler : SyncDomainHandler<Tag> {
+    override val domainName = "tags"
+    override val payloadSerializer = Tag.serializer()
+
+    override fun syncId(item: Tag): String = item.id
+
+    override suspend fun onEvent(
+        event: com.calypsan.listenup.api.sync.SyncEvent<Tag>,
+        isOwnEcho: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun onCatchUpItem(
+        item: Tag,
+        isTombstone: Boolean,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun localDigestRows(maxRevision: Long): List<Pair<String, Long>> = emptyList()
+}
+
+/** Fake SSE that flips [SyncEngineState] on connect/disconnect, mirroring production semantics. */
+private class FakeLifecycleSse(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+    private var seeded: Long? = null
+
+    override fun seedLastEventId(initial: Long?) {
+        seeded = initial
+    }
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Connected(lastEventId = seeded))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "test"))
+    }
+
+    override fun currentLastEventId(): Long? = seeded
+
+    override suspend fun reseed(newLastEventId: Long?) {
+        disconnect()
+        seeded = newLastEventId
+    }
+
+    override fun reconnectNow() = Unit
+}


### PR DESCRIPTION
## Phase 0 of the sync-core centralization arc

Implements the **centralized safety net** from `docs/sync-core-centralization-plan.md` §3 — the standing lifecycle-triggered reconcile that removes the systemic "restart required" sync-propagation class (beta bug-bash #17, #2, #16).

### The hard invariant this establishes
Every domain must (1) push live, (2) self-heal via delta/catch-up if a live event is missed, (3) **never require a restart**. Foregrounding the app used to do zero reconciliation (`SyncEngine.start()` no-ops when already running), so any dropped live event or lossy control nudge sat invisible until a cold start. This closes that hole universally.

## Summary
- **New `SyncEngine.lifecycleReconcile(force)`** — the one recovery pass every lifecycle edge funnels into. Ordering is load-bearing: **forward catch-up first** (drains rows written *above* the cursor — the `FirehoseSuppressed` gap a digest-only reconcile is structurally blind to), **digest reconcile second** (repairs at/below-cursor divergence), then the nudge refreshes (presence ping + activity prime). Coalesced + debounced (30s floor; `force` bypasses).
- **Foreground hook** — `SyncRepositoryImpl.connectRealtime()` now calls `lifecycleReconcile()` after the (no-op-when-started) engine start. The single seam every platform's foreground path already funnels through.
- **Reconnect edge** — `runReconnectRefresh()` now delegates to `lifecycleReconcile(force = true)`, gaining the forward catch-up it previously lacked.
- **`LibraryDataChanged` mapping** — retargeted from `forceReconcile()` (digest-only, blind to above-cursor suppressed rows) to `lifecycleReconcile(force = true)`.
- **Access-gated digest drift now prunes** — `SyncReconciler` routes a drifted `AccessFilteredSyncHandler` through the transient catch-up + `pruneTo` path instead of upsert-only `catchUpFromZero`, so a dropped `AccessChanged` frame converges (an upsert-only re-pull can never evict a revoked row → the digest would never converge). Gives `AccessChanged` its lifecycle backstop.

## Test Plan
- [x] `LifecycleReconcileInvariantTest` (jvmTest, real `:server` in-process): an above-cursor `FirehoseSuppressed` row that `forceReconcile()` **cannot** land is healed by `lifecycleReconcile()` — proves the catch-up-then-digest ordering is load-bearing.
- [x] `SyncEngineLifecycleReconcileTest`: runs forward catch-up; reconciles even when the engine is already started (kills the foreground no-op hole); debounce skips a second call in-window; `force` bypasses; concurrent triggers coalesce to one pass.
- [x] `SyncReconcilerTest`: a drifted access-gated handler prunes to the accessible set instead of `catchUpFromZero`.
- [x] Full Linux-lane gate green locally (`verifyLocal`: spotless + detekt + all JVM tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)