### PR TITLE
✨ feat(server): broadcast LibraryDataChanged after a suppressed scan — rescanned books appear live (#16)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
@@ -330,6 +330,7 @@ private fun Module.coverAndPersisterBindings(
             sql = get<ListenUpDatabase>(),
             scanResultBus = get<MutableSharedFlow<ScanResult>>(EventBusQualifiers.ScanResults),
             eventBus = get<MutableSharedFlow<ScanEvent>>(EventBusQualifiers.ScanEvents),
+            changeBus = get(),
             scope = get(),
             coverImageStore = get<CoverImageStore>(),
             coverSpool = get(),

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.api.dto.scanner.ScanScope
 import com.calypsan.listenup.api.event.ScanEvent
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.CoverSource as SyncCoverSource
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.server.api.CollectionServiceImpl
@@ -19,6 +20,7 @@ import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
 import com.calypsan.listenup.server.scanner.CoverSpool
 import com.calypsan.listenup.server.scanner.toSummary
+import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.FirehoseSuppressed
 import com.calypsan.listenup.server.io.readBytes
 import com.calypsan.listenup.server.logging.loggerFor
@@ -106,6 +108,7 @@ class BookPersister internal constructor(
     private val sql: ListenUpDatabase,
     private val scanResultBus: SharedFlow<ScanResult>,
     private val eventBus: MutableSharedFlow<ScanEvent>,
+    private val changeBus: ChangeBus,
     private val scope: CoroutineScope,
     private val coverImageStore: CoverImageStore? = null,
     private val coverSpool: CoverSpool? = null,
@@ -156,6 +159,18 @@ class BookPersister internal constructor(
             // server-authoritative signal the client's initial-population gate reads: once set, a rescan
             // of the populated library never re-shows the "Building your library" screen.
             libraryRepository.markInitialScanCompleted(libraryId, Clock.System.now().toEpochMilliseconds())
+
+            // A suppressed bulk persist wrote its rows ABOVE the client cursor without publishing to
+            // the lossy live tail, so connected clients have no live signal for them — the added books
+            // would surface only after an app restart (bug #16). Broadcast the standard post-suppressed-
+            // burst accelerator so every client reconciles now (Phase 0's lifecycleReconcile forward-
+            // catches-up the above-cursor rows); a dropped frame still self-heals on the next lifecycle
+            // edge, since books are a cursored domain. Same rule ImportApplier follows. Gated on
+            // persisted > 0: a suppressed scan that changed nothing has no above-cursor rows to
+            // reconcile, so a nudge would only cost every client a wasted full reconcile pass.
+            if (suppressFirehose && counts.persisted > 0) {
+                changeBus.broadcastControl(SyncControl.LibraryDataChanged)
+            }
 
             // Completed is emitted HERE — after every book is committed and (for a full scan) the
             // tombstone sweep has run — not by the Scanner before this persist runs. `Completed` must

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/FirehoseSuppressed.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/FirehoseSuppressed.kt
@@ -22,6 +22,15 @@ import kotlin.coroutines.CoroutineContext
  *
  * Defaults to *publishing*: absence of the marker is the universal case, so all
  * existing write paths are unchanged.
+ *
+ * **Pairing rule — every `FirehoseSuppressed` bulk write path MUST broadcast exactly one
+ * [SyncControl.LibraryDataChanged] after commit.** The suppressed rows land above the client
+ * cursor with no live signal; the broadcast is the accelerator that makes connected clients
+ * reconcile them now (via the client's lifecycle reconcile) instead of only after a restart.
+ * A dropped frame still self-heals on the next lifecycle edge for any cursored domain, so the
+ * broadcast is an accelerator, never the sole carrier. Current call sites:
+ * [com.calypsan.listenup.server.services.BookPersister] (post-scan) and
+ * [com.calypsan.listenup.server.absimport.ImportApplier] (post-import).
  */
 object FirehoseSuppressed : AbstractCoroutineContextElement(Key) {
     object Key : CoroutineContext.Key<FirehoseSuppressed>

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterLibraryChangedTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterLibraryChangedTest.kt
@@ -1,0 +1,134 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.dto.scanner.ChangeEventDto
+import com.calypsan.listenup.api.dto.scanner.ScanScope
+import com.calypsan.listenup.api.sync.SyncControl
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.ControlFrame
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+
+/**
+ * #16 recently-added: a `FirehoseSuppressed` bulk write that CHANGED rows must be followed by exactly
+ * one [SyncControl.LibraryDataChanged] broadcast. The suppressed rows are written ABOVE the client
+ * cursor and never hit the lossy live tail, so this nudge is the only thing that makes connected
+ * clients reconcile them live (via the client's lifecycle reconcile) — otherwise the added books
+ * surface only after an app restart. This is the same rule `ImportApplier` follows.
+ *
+ * Split from [BookPersisterTest] (which owns the persist-orchestration concern) so each file stays
+ * one concern; the shared fixtures — `persister`, `FakeBookIngest`, `scanResult`, `analyzedBook`,
+ * `LARGE_INCREMENTAL_COUNT` — are the `internal` helpers declared there.
+ */
+class BookPersisterLibraryChangedTest :
+    FunSpec({
+
+        test("a firehose-suppressed full scan that persists books broadcasts exactly one LibraryDataChanged") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    val persister = persister(FakeBookIngest(), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() } // ensure the collector is subscribed before persist broadcasts
+
+                    persister.persist(
+                        scanResult(
+                            books = listOf(analyzedBook("a"), analyzedBook("b")),
+                            changes = listOf(ChangeEventDto.Added(analyzedBook("a")), ChangeEventDto.Added(analyzedBook("b"))),
+                            scope = ScanScope.Full,
+                        ),
+                    )
+                    repeat(8) { yield() } // let the post-commit broadcast drain to the collector
+
+                    frames.map { it.control }.filter { it == SyncControl.LibraryDataChanged } shouldHaveSize 1
+                }
+            }
+        }
+
+        test("a firehose-suppressed large incremental that persists books broadcasts exactly one LibraryDataChanged") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    val persister = persister(FakeBookIngest(), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    // Above the suppress threshold → suppressed like a full scan, so it needs the nudge too.
+                    val many = (1..LARGE_INCREMENTAL_COUNT).map { "book-$it" }
+                    persister.persist(
+                        scanResult(
+                            books = many.map { analyzedBook(it) },
+                            changes = many.map { ChangeEventDto.Added(analyzedBook(it)) },
+                            scope = ScanScope.Subtree("big/folder"),
+                        ),
+                    )
+                    repeat(8) { yield() }
+
+                    frames.map { it.control }.filter { it == SyncControl.LibraryDataChanged } shouldHaveSize 1
+                }
+            }
+        }
+
+        test("a live (non-suppressed) incremental scan broadcasts no LibraryDataChanged") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    val persister = persister(FakeBookIngest(), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    // A small incremental publishes per-book live deltas — no suppressed gap, so no nudge.
+                    persister.persist(
+                        scanResult(
+                            books = listOf(analyzedBook("a")),
+                            changes = listOf(ChangeEventDto.Modified(analyzedBook("a"), previousRootRelPath = "a")),
+                            scope = ScanScope.Subtree("some/path"),
+                        ),
+                    )
+                    repeat(8) { yield() }
+
+                    frames.map { it.control } shouldNotContain SyncControl.LibraryDataChanged
+                }
+            }
+        }
+
+        test("a firehose-suppressed scan that persists zero books broadcasts no LibraryDataChanged") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    val persister = persister(FakeBookIngest(), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    // A full scan is suppressed, but nothing changed (books present, changes empty) → no
+                    // rows written above the cursor → nothing to reconcile → no wasteful nudge.
+                    persister.persist(
+                        scanResult(
+                            books = listOf(analyzedBook("a")),
+                            changes = emptyList(),
+                            scope = ScanScope.Full,
+                        ),
+                    )
+                    repeat(8) { yield() }
+
+                    frames.map { it.control } shouldNotContain SyncControl.LibraryDataChanged
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -728,7 +728,7 @@ class BookPersisterTest :
     })
 
 /** Changed-book count for the large-incremental suppression test — above the production threshold. */
-private const val LARGE_INCREMENTAL_COUNT = 60
+internal const val LARGE_INCREMENTAL_COUNT = 60
 
 // --- Fakes ------------------------------------------------------------------
 
@@ -830,6 +830,7 @@ internal suspend fun SqlTestDatabases.persister(
     ingest: BookIngestPort,
     scope: CoroutineScope,
     eventBus: MutableSharedFlow<ScanEvent> = MutableSharedFlow(),
+    changeBus: ChangeBus = ChangeBus(),
 ): BookPersister {
     // Seed a library_folders row at the default scanResult rootPath ("/lib") so folder resolution
     // finds a REAL folder rather than the "unknown" sentinel — which now (finding 5) skips the
@@ -856,6 +857,7 @@ internal suspend fun SqlTestDatabases.persister(
         sql = sql,
         scanResultBus = MutableSharedFlow(),
         eventBus = eventBus,
+        changeBus = changeBus,
         scope = scope,
     )
 }


### PR DESCRIPTION
## Phase 1 of the sync-core centralization arc — bug-bash #16 (recently-added)

Stacked conceptually on **#1025 (Phase 0)** — best merged *after* it. Phase 1 is independently green (server-side change + tests), but its live-recovery story leans on Phase 0's `LibraryDataChanged → lifecycleReconcile(force)` mapping: on `main` today the client answers `LibraryDataChanged` with a digest-only `forceReconcile`, which can't see the above-cursor suppressed rows. Phase 0 makes the client forward-catch-up; this PR makes the server *fire the accelerator*.

## The bug (#16)
A `FirehoseSuppressed` bulk persist (full scan, or a large incremental) bumps revisions and commits rows **above** the client cursor but never publishes to the lossy live tail. With no follow-up signal, rescanned/added books surfaced on other devices only after an app restart.

## Change
- **`BookPersister.persist`** broadcasts exactly one `SyncControl.LibraryDataChanged` after a suppressed persist **that changed rows** — gated `suppressFirehose && counts.persisted > 0`, emitted post-commit, before `ScanEvent.Completed`. Clients reconcile now; a dropped frame still self-heals on the next lifecycle edge (books are a cursored domain). This is the same accelerator `ImportApplier` already fires.
- **`FirehoseSuppressed` KDoc** now documents the pairing rule: *every `FirehoseSuppressed` bulk write path must broadcast exactly one `LibraryDataChanged` after commit* (Konsist enforcement lands in Phase 4).
- The zero-change guard (`persisted > 0`) avoids a wasteful full reconcile on every client when a suppressed scan changed nothing.

## Test Plan (TDD, RED→GREEN verified)
New `BookPersisterLibraryChangedTest` (split from `BookPersisterTest` to keep each file one concern; the two "should broadcast" tests were RED before the emit):
- [x] a suppressed **full scan** that persists books broadcasts exactly one `LibraryDataChanged`
- [x] a suppressed **large incremental** (above the suppress threshold) broadcasts exactly one
- [x] a **live** (non-suppressed) incremental broadcasts **none** (per-book live deltas handle it)
- [x] a suppressed scan that persists **zero** books broadcasts **none**
- [x] Full `:server:jvmTest` + `spotlessCheck` + `detekt` green locally