### PR TITLE
🐛 fix(server): broadcast LibraryDataChanged after delete-only suppressed scans

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookIngestPort.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookIngestPort.kt
@@ -162,11 +162,14 @@ interface BookIngestPort {
      * Accepts the set of folder-qualified [FolderScopedPath] locators seen on disk during a full
      * scan — no BookId resolution required for books that did not change. Folder-qualifying the
      * seen set closes a cross-folder path-aliasing bug (two folders sharing a relative path).
+     *
+     * Returns the number of books tombstoned, so the orchestrator knows a delete-only full scan
+     * changed rows above the client cursor and must broadcast the reconcile nudge.
      */
     suspend fun softDeleteAbsentByPaths(
         libraryId: LibraryId,
         seen: Set<FolderScopedPath>,
-    )
+    ): Int
 
     /**
      * Soft-delete the live book at `(folderId, rootRelPath)`, if one exists.
@@ -176,6 +179,9 @@ interface BookIngestPort {
      * [com.calypsan.listenup.api.sync.SyncEvent.Deleted] to the change bus so connected clients
      * reflow immediately.
      *
+     * Returns 1 when a live book was tombstoned, 0 on the idempotent no-op — so the orchestrator
+     * can count the deletions a delete-only suppressed scan applied and broadcast the reconcile nudge.
+     *
      * Called from [com.calypsan.listenup.server.services.BookPersister] when a
      * [com.calypsan.listenup.api.dto.scanner.ChangeEventDto.Removed] arrives on an
      * incremental scan — the only path that explicitly notifies of a deletion without
@@ -184,7 +190,7 @@ interface BookIngestPort {
     suspend fun softDeleteByPath(
         folderId: FolderId,
         rootRelPath: String,
-    )
+    ): Int
 }
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookPersister.kt
@@ -147,9 +147,11 @@ class BookPersister internal constructor(
                 // OOM means the JVM heap is compromised. We still emit Completed with the partial
                 // counts gathered so far (stored in the thrown PersistAbortedByOom) so clients get
                 // honest numbers, then rethrow so the process can surface the failure.
+                // OOM aborts before any removal path runs, so removed = 0 on the partial counts. A
+                // dropped delete-nudge here self-heals on the next lifecycle edge (books are cursored).
                 val partial =
-                    (e as? PersistAbortedByOom)?.result?.let { PersistCounts(it.persisted, it.failed) }
-                        ?: PersistCounts(0, 0)
+                    (e as? PersistAbortedByOom)?.result?.let { PersistCounts(it.persisted, it.failed, removed = 0) }
+                        ?: PersistCounts(0, 0, 0)
                 eventBus.emit(ScanEvent.Completed(result.correlationId, libraryId, result.toSummary(partial)))
                 throw e
             }
@@ -161,14 +163,17 @@ class BookPersister internal constructor(
             libraryRepository.markInitialScanCompleted(libraryId, Clock.System.now().toEpochMilliseconds())
 
             // A suppressed bulk persist wrote its rows ABOVE the client cursor without publishing to
-            // the lossy live tail, so connected clients have no live signal for them — the added books
+            // the lossy live tail, so connected clients have no live signal for them — the changed books
             // would surface only after an app restart (bug #16). Broadcast the standard post-suppressed-
             // burst accelerator so every client reconciles now (Phase 0's lifecycleReconcile forward-
             // catches-up the above-cursor rows); a dropped frame still self-heals on the next lifecycle
-            // edge, since books are a cursored domain. Same rule ImportApplier follows. Gated on
-            // persisted > 0: a suppressed scan that changed nothing has no above-cursor rows to
-            // reconcile, so a nudge would only cost every client a wasted full reconcile pass.
-            if (suppressFirehose && counts.persisted > 0) {
+            // edge, since books are a cursored domain. Same rule ImportApplier follows. Gated on ANY row
+            // changed — adds (persisted) OR deletions (removed: incremental Removed tombstones and the
+            // full-scan sweep). A delete-only suppressed scan persists nothing yet still writes tombstones
+            // above the cursor, so gating on persisted alone stranded deleted books in every client's
+            // library until the next lifecycle edge. A scan that changed nothing skips the nudge — no
+            // above-cursor rows to reconcile, so it would only cost every client a wasted reconcile pass.
+            if (suppressFirehose && (counts.persisted > 0 || counts.removed > 0)) {
                 changeBus.broadcastControl(SyncControl.LibraryDataChanged)
             }
 
@@ -334,8 +339,9 @@ class BookPersister internal constructor(
 
         // Incremental Removed changes tombstone the book at their path immediately so deletions reflow
         // without waiting for the next Full scan. For Full scans the softDeleteAbsentByPaths sweep below
-        // would catch it too, so the overlap is harmless.
-        applyIncrementalRemovals(result, folderIdByRoot)
+        // would catch it too, so the overlap is harmless. The tombstone count feeds the reconcile-nudge
+        // gate so a delete-only suppressed scan still broadcasts.
+        var removed = applyIncrementalRemovals(result, folderIdByRoot)
 
         // Final tick at the total so the bar lands on 100% before the terminal Completed, even if the
         // last chunk boundary didn't fall exactly on the final book.
@@ -355,11 +361,13 @@ class BookPersister internal constructor(
                 }
             } else {
                 // Path-based sweep is safe: every book present on disk (including any that failed
-                // to persist) is in seenPaths, so the sweep never tombstones a present book.
-                ingest.softDeleteAbsentByPaths(libraryId, seenPaths)
+                // to persist) is in seenPaths, so the sweep never tombstones a present book. Its
+                // tombstone count joins the incremental-removal count so a full rescan whose ONLY
+                // change is a sweep-caught deletion still fires the reconcile nudge.
+                removed += ingest.softDeleteAbsentByPaths(libraryId, seenPaths)
             }
         }
-        return PersistCounts(persisted, failed)
+        return PersistCounts(persisted, failed, removed)
     }
 
     /**
@@ -370,27 +378,32 @@ class BookPersister internal constructor(
      * tombstones the right book and never a same-relpath book in another folder. A root that resolves to
      * the sentinel yields a no-op (the sentinel id matches no live book), so a stale root is harmless.
      * Falls back to the primary root for a pre-attribution Removed (null folder).
+     *
+     * Returns the number of books actually tombstoned (a no-op removal — already gone — counts 0),
+     * so the caller can broadcast the reconcile nudge for a delete-only suppressed scan.
      */
     private suspend fun applyIncrementalRemovals(
         result: ScanResult,
         folderIdByRoot: Map<String, FolderId>,
-    ) {
+    ): Int {
         val removedChanges = result.changes.filterIsInstance<ChangeEventDto.Removed>()
-        if (removedChanges.isEmpty()) return
+        if (removedChanges.isEmpty()) return 0
         val folderIdForRemoved: Map<String, FolderId> =
             removedChanges
                 .mapTo(mutableSetOf()) { it.folderRootPath ?: result.rootPath }
                 .associateWith { folderIdByRoot[it] ?: resolveFolderId(it) }
+        var tombstoned = 0
         for (change in removedChanges) {
             val root = change.folderRootPath ?: result.rootPath
             try {
-                ingest.softDeleteByPath(folderIdForRemoved.getValue(root), change.rootRelPath)
+                tombstoned += ingest.softDeleteByPath(folderIdForRemoved.getValue(root), change.rootRelPath)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
                 log.warn(e) { "softDeleteByPath failed for ${change.rootRelPath} — continuing" }
             }
         }
+        return tombstoned
     }
 
     /**
@@ -516,10 +529,17 @@ class BookPersister internal constructor(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Counts of books successfully persisted vs failed during [BookPersister.persistAll]. */
+/**
+ * Counts of books touched during [BookPersister.persistAll]: [persisted] (Added/Modified/Moved
+ * written) vs [failed], plus [removed] — the tombstones written by the incremental Removed path and
+ * the full-scan sweep. [removed] is NOT part of the [persisted] tally; it exists so the caller can
+ * broadcast the reconcile nudge after a delete-only suppressed scan, which persists nothing yet
+ * still writes rows above every client cursor.
+ */
 internal data class PersistCounts(
     val persisted: Int,
     val failed: Int,
+    val removed: Int,
 )
 
 /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -964,7 +964,7 @@ class BookRepository(
     override suspend fun softDeleteAbsentByPaths(
         libraryId: LibraryId,
         seen: Set<FolderScopedPath>,
-    ) {
+    ): Int {
         val toDelete =
             suspendTransaction(db) {
                 db.booksQueries
@@ -976,6 +976,7 @@ class BookRepository(
         for (id in toDelete) {
             softDelete(BookId(id), clientOpId = null)
         }
+        return toDelete.size
     }
 
     /**
@@ -986,15 +987,16 @@ class BookRepository(
     override suspend fun softDeleteByPath(
         folderId: FolderId,
         rootRelPath: String,
-    ) {
+    ): Int {
         val id =
             suspendTransaction<BookId?>(db) {
                 db.booksQueries
                     .selectLiveIdByPath(folderId.value, rootRelPath)
                     .executeAsOneOrNull()
                     ?.let { BookId(it) }
-            } ?: return // already gone — idempotent no-op
+            } ?: return 0 // already gone — idempotent no-op
         softDelete(id, clientOpId = null)
+        return 1
     }
 
     /**

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterLibraryChangedTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterLibraryChangedTest.kt
@@ -81,6 +81,62 @@ class BookPersisterLibraryChangedTest :
             }
         }
 
+        test("a firehose-suppressed full scan whose only change is a delete-sweep tombstone broadcasts exactly one LibraryDataChanged") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    // A full rescan after a restart carries no Differ `previous`, so a vanished book emits no
+                    // Removed change — the full-scan sweep is the ONLY path that tombstones it. Nothing is
+                    // added/modified, so persisted == 0; the delete still wrote a tombstone above every client
+                    // cursor and must be reconciled. `sweepTombstoneCount = 1` models one book swept.
+                    val persister = persister(FakeBookIngest(sweepTombstoneCount = 1), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    persister.persist(
+                        scanResult(
+                            books = listOf(analyzedBook("survivor")),
+                            changes = emptyList(),
+                            scope = ScanScope.Full,
+                        ),
+                    )
+                    repeat(8) { yield() }
+
+                    frames.map { it.control }.filter { it == SyncControl.LibraryDataChanged } shouldHaveSize 1
+                }
+            }
+        }
+
+        test("a firehose-suppressed large incremental of only Removed changes broadcasts exactly one LibraryDataChanged") {
+            withSqlDatabase {
+                runTest(UnconfinedTestDispatcher()) {
+                    val bus = ChangeBus()
+                    val persister = persister(FakeBookIngest(), scope = this, changeBus = bus)
+
+                    val frames = mutableListOf<ControlFrame>()
+                    bus.subscribeControl().onEach { frames += it }.launchIn(backgroundScope)
+                    repeat(8) { yield() }
+
+                    // Above the suppress threshold and ALL removals — nothing persisted, only tombstones
+                    // written above the cursor. Without counting removals this would suppress with no
+                    // nudge (the bug), stranding deleted books in every connected client's library.
+                    val gone = (1..LARGE_INCREMENTAL_COUNT).map { "gone-$it" }
+                    persister.persist(
+                        scanResult(
+                            books = emptyList(),
+                            changes = gone.map { ChangeEventDto.Removed(rootRelPath = it) },
+                            scope = ScanScope.Subtree("big/folder"),
+                        ),
+                    )
+                    repeat(8) { yield() }
+
+                    frames.map { it.control }.filter { it == SyncControl.LibraryDataChanged } shouldHaveSize 1
+                }
+            }
+        }
+
         test("a live (non-suppressed) incremental scan broadcasts no LibraryDataChanged") {
             withSqlDatabase {
                 runTest(UnconfinedTestDispatcher()) {

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookPersisterTest.kt
@@ -745,6 +745,7 @@ internal class FakeBookIngest(
     private val failForRootRelPath: Set<String> = emptySet(),
     private val throwForRootRelPath: Set<String> = emptySet(),
     private val oomForRootRelPath: Set<String> = emptySet(),
+    private val sweepTombstoneCount: Int = 0,
 ) : BookIngestPort {
     /** rootRelPaths successfully resolved, in call order. */
     val resolved = mutableListOf<String>()
@@ -807,20 +808,22 @@ internal class FakeBookIngest(
     override suspend fun softDeleteAbsentByPaths(
         libraryId: LibraryId,
         seen: Set<FolderScopedPath>,
-    ) {
+    ): Int {
         softDeleteAbsentByPathsSuppressed += currentCoroutineContext()[FirehoseSuppressed.Key] != null
         // Record just the paths — these orchestration tests assert WHICH paths are swept, not folder
         // attribution (the folder-qualified sweep is covered at the repository level in
         // BookIdentityStabilityTest).
         softDeleteAbsentByPathsCalls += seen.mapTo(mutableSetOf()) { it.rootRelPath }
+        return sweepTombstoneCount
     }
 
     override suspend fun softDeleteByPath(
         folderId: FolderId,
         rootRelPath: String,
-    ) {
+    ): Int {
         softDeleteByPathCalls += rootRelPath
         softDeleteByPathFolderIds[rootRelPath] = folderId
+        return 1
     }
 }
 


### PR DESCRIPTION
## Fix-forward for a gap an adversarial review found in #1026 (Phase 1)

`BookPersister` broadcasts `LibraryDataChanged` after a `FirehoseSuppressed` bulk scan only when `counts.persisted > 0`. But `persisted` counts **only** Added/Modified/Moved books — not removals (`applyIncrementalRemovals` tombstones + the full-scan `softDeleteAbsentByPaths` sweep).

**Consequence:** a suppressed scan whose only change is deletions — a full rescan that only removed books, or a large all-`Removed` incremental (>50 changes, over the suppress threshold) — writes tombstones **above every client's cursor**, suppressed, with **no** accelerator broadcast. Ghost (deleted) books then linger in every connected client's library until the next foreground/reconnect edge — violating the real-time property for deletions, and contradicting `FirehoseSuppressed`'s own KDoc ("every FirehoseSuppressed bulk write path MUST broadcast exactly one LibraryDataChanged after commit").

## Fix
- Thread a `removed` count through `PersistCounts` — incremented by `applyIncrementalRemovals` (Removed tombstones) and the full-scan `softDeleteAbsentByPaths` sweep (rows tombstoned).
- Gate the broadcast on `suppressFirehose && (counts.persisted > 0 || counts.removed > 0)`.
- OOM path unchanged (rethrows before the broadcast; the next lifecycle edge heals).

## Test Plan
- [x] `BookPersisterLibraryChangedTest`: a suppressed **delete-only full scan** broadcasts exactly one `LibraryDataChanged`; a suppressed **large delete-only incremental** broadcasts one; a no-op scan broadcasts none.
- [x] `:server:jvmTest` green (`*BookPersister*` + full run; the single `StarterShelfTest` blip is a pre-existing under-load SQLite flake, confirmed passing in isolation) + spotless + detekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)