### PR TITLE
🐛 fix(shared): close lifecycleReconcile finally-block race + monotonic debounce clock

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -3,6 +3,8 @@ package com.calypsan.listenup.client.data.sync
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -118,7 +120,12 @@ internal class SyncEngine(
     private val lifecycleReconcileMutex = Mutex()
     private var lifecycleReconcileRunning = false
     private var lifecycleReconcilePending = false
-    private var lastLifecycleReconcileAtMs = 0L
+
+    // Debounce anchor for [lifecycleReconcile]. MONOTONIC, not wall-clock: the debounce is a
+    // "duration since the last completed pass" comparison, and an NTP step (back OR forward) on a
+    // wall clock would arbitrarily extend or collapse the suppression window. null means "no pass
+    // has completed yet" → the first trigger is never debounced.
+    private var lastLifecycleReconcileMark: TimeSource.Monotonic.ValueTimeMark? = null
 
     // Flips to true on the last line of [runStart] for the active user. If
     // [runStart] throws before that line, the flag stays false even though
@@ -242,7 +249,7 @@ internal class SyncEngine(
         // Stamp the lifecycle-reconcile debounce clock: runStart just did the equivalent work
         // (forward catch-up + digest reconcile), so the connectRealtime() foreground reconcile
         // that immediately follows a cold start is debounced instead of redundantly re-draining.
-        lifecycleReconcileMutex.withLock { lastLifecycleReconcileAtMs = currentEpochMilliseconds() }
+        lifecycleReconcileMutex.withLock { lastLifecycleReconcileMark = TimeSource.Monotonic.markNow() }
     }
 
     /** Invoke [primeActivityFeed], swallowing non-cancellation failures so priming never aborts a caller. */
@@ -367,26 +374,35 @@ internal class SyncEngine(
                 }
             }
         if (!shouldLead) return
+        // Set true ONLY on the loop's normal-exit branch, where this coroutine clears
+        // running/pending under the lock and ends the loop. It gates the finally so cleanup is
+        // ownership-scoped: a normally-completed leader must NOT touch shared state in finally,
+        // because a follow-on leader may already own it (the cross-leader stomp this guards).
+        var ledToCompletion = false
         try {
             var more = true
             while (more) {
                 runLifecycleReconcilePass()
                 more =
                     lifecycleReconcileMutex.withLock {
-                        lastLifecycleReconcileAtMs = currentEpochMilliseconds()
+                        lastLifecycleReconcileMark = TimeSource.Monotonic.markNow()
                         if (lifecycleReconcilePending) {
                             lifecycleReconcilePending = false
                             true
                         } else {
                             lifecycleReconcileRunning = false
+                            ledToCompletion = true
                             false
                         }
                     }
             }
         } finally {
-            // Normal exit already cleared the running flag in the loop; this only fires when a pass
-            // threw or was cancelled, so a future edge can still lead a recovery.
-            if (lifecycleReconcileRunning) {
+            // Ownership-scoped cleanup. On normal completion the loop already cleared the flags under
+            // the lock, so this does nothing — reaching in would let a returning leader stomp a NEW
+            // leader's in-flight pass (and silently drop its forced follow-up). This reset therefore
+            // fires ONLY when a pass threw or was cancelled before the loop's normal exit, and it does
+            // the read+reset entirely under the lock so no unsynchronized flag read remains.
+            if (!ledToCompletion) {
                 lifecycleReconcileMutex.withLock {
                     lifecycleReconcileRunning = false
                     lifecycleReconcilePending = false
@@ -396,8 +412,10 @@ internal class SyncEngine(
     }
 
     /** Whether the debounce window has elapsed since the last completed pass. MUST hold [lifecycleReconcileMutex]. */
-    private fun debounceElapsedLocked(): Boolean =
-        currentEpochMilliseconds() - lastLifecycleReconcileAtMs >= lifecycleReconcileMinIntervalMs
+    private fun debounceElapsedLocked(): Boolean {
+        val lastMark = lastLifecycleReconcileMark ?: return true
+        return lastMark.elapsedNow() >= lifecycleReconcileMinIntervalMs.milliseconds
+    }
 
     /** One lifecycle reconcile pass: forward catch-up → digest reconcile → nudge refreshes. */
     private suspend fun runLifecycleReconcilePass() {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -8,6 +8,8 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
@@ -403,9 +405,15 @@ internal class SyncEngine(
             // fires ONLY when a pass threw or was cancelled before the loop's normal exit, and it does
             // the read+reset entirely under the lock so no unsynchronized flag read remains.
             if (!ledToCompletion) {
-                lifecycleReconcileMutex.withLock {
-                    lifecycleReconcileRunning = false
-                    lifecycleReconcilePending = false
+                // NonCancellable: this cleanup usually runs BECAUSE the pass was cancelled, and the
+                // mutex may be momentarily contended by another trigger — a bare `withLock` would then
+                // throw CancellationException and leave `running` stuck true forever, permanently
+                // no-op'ing every future reconcile (the "restart required" class this engine kills).
+                withContext(NonCancellable) {
+                    lifecycleReconcileMutex.withLock {
+                        lifecycleReconcileRunning = false
+                        lifecycleReconcilePending = false
+                    }
                 }
             }
         }
@@ -511,11 +519,16 @@ internal class SyncEngine(
             // still outstanding (their covering pass never completed) must be released so coalesced
             // callers are not stranded — cancelled, not completed, since their request was not served.
             if (cursorStaleRunning) {
+                // NonCancellable for the same reason as lifecycleReconcile's cleanup: a contended
+                // `withLock` on the cancellation path would throw and strand `cursorStaleRunning` true,
+                // wedging all future CursorStale recovery.
                 val stranded =
-                    cursorStaleMutex.withLock {
-                        cursorStaleRunning = false
-                        cursorStalePending = false
-                        drainWaiters()
+                    withContext(NonCancellable) {
+                        cursorStaleMutex.withLock {
+                            cursorStaleRunning = false
+                            cursorStalePending = false
+                            drainWaiters()
+                        }
                     }
                 stranded.forEach { it.cancel() }
             }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncEngineLifecycleReconcileTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -82,10 +83,32 @@ class SyncEngineLifecycleReconcileTest :
                 catchUp.catchUpAllInvocations.get() shouldBe 1
             }
         }
+
+        // M1 regression: a forced trigger that arrives WHILE a pass is in flight must not be lost to
+        // the coalescing — the leader has to run one covering follow-up pass for it. Before the
+        // ownership-scoped finally fix, a returning leader could stomp the pending flag and silently
+        // drop exactly this forced follow-up.
+        test("a forced trigger arriving mid-pass schedules a covering follow-up pass") {
+            val catchUp = GatingLifecycleCatchUp()
+            // Large interval so the follow-up is earned by force alone, never by the debounce window.
+            withLifecycleEngine(minIntervalMs = 60_000L, catchUp = catchUp) { engine, _, _ ->
+                coroutineScope {
+                    val leader = launch { engine.lifecycleReconcile() }
+                    // Wait until the leader is provably inside pass 1 (running flag already set).
+                    catchUp.firstPassStarted.await()
+                    // Forced trigger during the in-flight pass → must register a covering follow-up.
+                    engine.lifecycleReconcile(force = true)
+                    // Let pass 1 finish; the leader's loop must now honor the pending follow-up.
+                    catchUp.releaseFirstPass.complete(Unit)
+                    leader.join()
+                }
+                catchUp.catchUpAllInvocations.get() shouldBe 2
+            }
+        }
     })
 
 /** Recording [CatchUp] that counts forward `catchUpAll` passes — the lifecycle-reconcile signal. */
-private class RecordingLifecycleCatchUp : CatchUp {
+private open class RecordingLifecycleCatchUp : CatchUp {
     val catchUpAllInvocations = AtomicInteger(0)
 
     override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
@@ -102,14 +125,34 @@ private class RecordingLifecycleCatchUp : CatchUp {
     override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())
 }
 
+/**
+ * Recording [CatchUp] that blocks its FIRST `catchUpAll` pass until released, so a test can inject a
+ * concurrent trigger while a pass is provably in flight. [firstPassStarted] fires once the leader is
+ * inside pass 1 (running flag set); [releaseFirstPass] lets that pass complete.
+ */
+private class GatingLifecycleCatchUp : RecordingLifecycleCatchUp() {
+    val firstPassStarted = CompletableDeferred<Unit>()
+    val releaseFirstPass = CompletableDeferred<Unit>()
+
+    override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> {
+        val result = super.catchUpAll(registry)
+        if (catchUpAllInvocations.get() == 1) {
+            firstPassStarted.complete(Unit)
+            releaseFirstPass.await()
+        }
+        return result
+    }
+}
+
 private fun withLifecycleEngine(
     minIntervalMs: Long,
+    catchUp: RecordingLifecycleCatchUp = RecordingLifecycleCatchUp(),
     block: suspend (SyncEngine, RecordingLifecycleCatchUp, FakeLifecycleSse) -> Unit,
 ) = runBlocking {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val db = createInMemoryTestDatabase()
     try {
-        val engineAndCatchUp = buildLifecycleEngine(db, scope, minIntervalMs)
+        val engineAndCatchUp = buildLifecycleEngine(db, scope, minIntervalMs, catchUp)
         block(engineAndCatchUp.first, engineAndCatchUp.second, engineAndCatchUp.third)
     } finally {
         scope.cancel()
@@ -123,13 +166,13 @@ private fun buildLifecycleEngine(
     db: ListenUpDatabase,
     scope: CoroutineScope,
     minIntervalMs: Long,
+    catchUp: RecordingLifecycleCatchUp = RecordingLifecycleCatchUp(),
 ): Triple<SyncEngine, RecordingLifecycleCatchUp, FakeLifecycleSse> {
     val registry = ClientSyncDomainRegistry()
     registry.register(LifecycleNoopTagHandler)
     val store = SyncCursorStore(db.syncCursorDao())
     val state = SyncEngineState()
     val sse = FakeLifecycleSse(state)
-    val catchUp = RecordingLifecycleCatchUp()
     val queue =
         PendingOperationQueue(
             dao = db.pendingOperationV2Dao(),


### PR DESCRIPTION
## Fix-forward for two issues an adversarial review found in #1025 (Phase 0)

**M1 — finally-block cross-leader stomp.** `lifecycleReconcile`'s `try/finally` read `if (lifecycleReconcileRunning)` **without holding the mutex**. Race: leader A clears `running=false` inside its final `withLock` and exits the loop; before A's finally reads the flag, coroutine B enters, becomes the new leader, and sets `running=true`; A's finally then reads `true` and stomps `running`/`pending` while B's pass is in flight — silently dropping a **forced** follow-up (e.g. a `LibraryDataChanged` accelerator that arrived during B's pass), the exact effect this coalescing exists to never lose.

Fix: a local `ledToCompletion` flag set (under the mutex) in the loop's normal-exit branch; the finally runs its reset **only when `!ledToCompletion`** (the pass threw/was cancelled) and does the read+reset entirely under the lock. On normal completion the finally is a no-op, so a returning leader can never touch another leader's state. Coalescing semantics unchanged.

**L1 — wall-clock debounce.** The 30s debounce compared `currentEpochMilliseconds()`, so an NTP step could arbitrarily extend/shrink the suppression window. Switched to `TimeSource.Monotonic` marks (the codebase's existing convention — `AuthSessionStore`, `SettingsRepositoryImpl`), comparing `elapsedNow()`. The `lifecycleReconcileMinIntervalMs` test seam is preserved.

## Test Plan
- [x] Existing `SyncEngineLifecycleReconcileTest` (debounce + coalescing) unchanged, still green.
- [x] New: a forced trigger arriving mid-pass earns exactly one covering follow-up pass (the M1 invariant), via a gating catch-up that blocks pass 1 until released.
- [x] Full `:sharedLogic:jvmTest` + spotless + detekt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)