### PR TITLE
🐛 fix(sync): converge access-gated digests — exclude tombstones symmetrically, deliver deletions ungated

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
@@ -247,11 +247,12 @@ class SeriesRepository(
     internal fun idAsStringForTest(id: SeriesId): String = idAsString(id)
 
     /**
-     * Returns `(id, revision)` pairs for ALL rows in the series table, soft-deleted
-     * included, with no revision filter. Exists solely to feed the cross-stack digest
+     * Returns `(id, revision)` pairs for the LIVE rows in the series table (soft-deleted
+     * excluded), with no revision filter. Exists solely to feed the cross-stack digest
      * parity test (`DigestParityE2ETest` in `:sharedLogic:jvmTest`) so the client
      * [com.calypsan.listenup.client.data.sync.DigestComputer] can be driven over the
-     * identical row set the server [digest] covers.
+     * identical row set the server [digest] covers — which, since F1, is LIVE rows only
+     * (tombstones excluded, symmetric with the client's tombstone-excluding digest).
      *
      * Intentionally public (not internal) because the test lives in a different Gradle
      * module (`:sharedLogic`) and Kotlin's `internal` does not cross module boundaries.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReads.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReads.kt
@@ -44,6 +44,14 @@ import com.calypsan.listenup.server.io.hashBytesSha256
  *   the digest slice is unordered — it is sorted by id in Kotlin afterwards).
  * @param limit the page cap; when non-null a trailing `LIMIT ?` is appended and the value bound
  *   last (the pull path), null for the unbounded digest slice.
+ * @param includeTombstones when true, a tombstone (`deleted_at IS NOT NULL`) passes the access
+ *   gate regardless of the subquery — the member needs to learn what to remove even for a row it
+ *   can no longer "access" (a deleted row is never accessible: `accessibleBookIdsSql` requires
+ *   `deleted_at IS NULL`). This mirrors the firehose's tombstone-ungated rule (`isBookEventHidden`
+ *   lets every `SyncEvent.Deleted` through) so catch-up and the live tail agree, and it leaks no
+ *   content — a tombstone carries only id/revision/deleted_at. Set true on the pull path (catch-up
+ *   must deliver deletions), false on the digest path (the digest counts only LIVE accessible rows,
+ *   symmetric with the tombstone-excluding client digest).
  */
 internal fun SqlDriver.selectIdRevAccessFiltered(
     table: String,
@@ -52,6 +60,7 @@ internal fun SqlDriver.selectIdRevAccessFiltered(
     extraWhere: SqlFragment,
     ascendingByRevision: Boolean,
     limit: Int?,
+    includeTombstones: Boolean,
 ): List<IdRev> {
     val sql =
         buildString {
@@ -59,8 +68,10 @@ internal fun SqlDriver.selectIdRevAccessFiltered(
             append(table)
             append(" WHERE ")
             append(revisionPredicate)
-            append(" AND id IN (")
+            append(" AND (id IN (")
             append(extraWhere.sql)
+            append(")")
+            if (includeTombstones) append(" OR deleted_at IS NOT NULL")
             append(")")
             if (ascendingByRevision) append(" ORDER BY revision ASC")
             if (limit != null) append(" LIMIT ?")

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -492,6 +492,10 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                             extraWhere = extraWhere,
                             ascendingByRevision = true,
                             limit = limit,
+                            // Catch-up must deliver deletions: a tombstone passes the access gate so a
+                            // member who missed the live delete can still learn to remove the row and
+                            // converge. Mirrors the firehose (Deleted events are tombstone-ungated).
+                            includeTombstones = true,
                         )
                     }
 
@@ -514,8 +518,13 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
         }
 
     /**
-     * Returns a [DomainDigest] over all rows with `revision <= cursor`, soft-deleted
-     * rows included. Used by clients to detect drift cheaply.
+     * Returns a [DomainDigest] over the LIVE rows with `revision <= cursor` — tombstones are
+     * excluded (both the substrate slice and the access-filtered slice drop `deleted_at IS NOT
+     * NULL`). Used by clients to detect drift cheaply. The exclusion is symmetric with the client's
+     * tombstone-excluding `digestRows`, so a member who tombstoned a row locally (a delivered
+     * deletion or an `AccessGate` prune) still converges — the deleted row leaves both digests at
+     * once, instead of lingering in the client's forever (F1). Deletions still reach clients: the
+     * live firehose and the (now tombstone-ungated) filtered [pullSince] both deliver them.
      *
      * The `(id, revision)` slice — from the substrate (global or [userScoped]) or, when
      * [extraWhere] is non-null, from the access-filtered driver read — is sorted by id and
@@ -548,6 +557,10 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                             extraWhere = extraWhere,
                             ascendingByRevision = false,
                             limit = null,
+                            // The digest counts only LIVE accessible rows — the access subquery already
+                            // excludes tombstones (`deleted_at IS NULL`), symmetric with the client's
+                            // tombstone-excluding digest. Delivering tombstones here would break parity.
+                            includeTombstones = false,
                         )
                     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncableSubstrateQueries.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncableSubstrateQueries.kt
@@ -26,7 +26,9 @@ data class IdRev(
  * - [softDeleteById] — stamps `deleted_at`, bumps `revision` and `updated_at`, records
  *   the originating `client_op_id`. Returns the number of rows affected (0 = not found).
  * - [selectIdsAboveRevision] — cursor-forward page: `revision > cursor ORDER BY revision ASC LIMIT limit`.
- * - [selectIdRevAtMost] — digest slice: `revision <= cursor` (all rows, soft-deleted included).
+ * - [selectIdRevAtMost] — digest slice: `deleted_at IS NULL AND revision <= cursor` (LIVE rows
+ *   only; tombstones are excluded so the digest counts the same set the client's tombstone-excluding
+ *   digest does — see F1 convergence).
  *
  * **User-scoped variants.** A per-user aggregate (root table carries `user_id`, repo
  * sets `userScoped = true`) additionally implements [selectIdsAboveRevisionForUser] /

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Activities.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Activities.sq
@@ -84,7 +84,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM activities WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM activities WHERE revision <= :cursor;
+SELECT id, revision FROM activities WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- Tombstone-inclusive reads by id — back the base pullSince/readPayloads.
 selectById:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/AdminUserRoster.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/AdminUserRoster.sq
@@ -35,7 +35,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM admin_user_roster WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM admin_user_roster WHERE revision <= :cursor;
+SELECT id, revision FROM admin_user_roster WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
@@ -34,7 +34,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM book_moods WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM book_moods WHERE revision <= :cursor;
+SELECT id, revision FROM book_moods WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
@@ -34,7 +34,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM book_tags WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM book_tags WHERE revision <= :cursor;
+SELECT id, revision FROM book_tags WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
@@ -292,7 +292,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM books WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM books WHERE revision <= :cursor;
+SELECT id, revision FROM books WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- Live book ids ordered by sort_title, limited to :limit — used by demo seeders (playback
 -- positions, listening events, active sessions) to pick the first N demo books.

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionBooks.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionBooks.sq
@@ -52,7 +52,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM collection_books WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM collection_books WHERE revision <= :cursor;
+SELECT id, revision FROM collection_books WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── root-row reads / writes ──────────────────────────────────────────────────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionGrants.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionGrants.sq
@@ -43,7 +43,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM collection_grants WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM collection_grants WHERE revision <= :cursor;
+SELECT id, revision FROM collection_grants WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── root-row reads / writes ──────────────────────────────────────────────────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Collections.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Collections.sq
@@ -49,7 +49,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM collections WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM collections WHERE revision <= :cursor;
+SELECT id, revision FROM collections WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── root-row reads / writes ──────────────────────────────────────────────────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Contributors.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Contributors.sq
@@ -109,7 +109,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM contributors WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM contributors WHERE revision <= :cursor;
+SELECT id, revision FROM contributors WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── contributor_aliases queries ─────────────────────────────────────────────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Genres.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Genres.sq
@@ -80,7 +80,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM genres WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM genres WHERE revision <= :cursor;
+SELECT id, revision FROM genres WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── lookups ────────────────────────────────────────────────────────────────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Libraries.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Libraries.sq
@@ -39,7 +39,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM libraries WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM libraries WHERE revision <= :cursor;
+SELECT id, revision FROM libraries WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── Syncable read/write (carries the LibrarySyncPayload columns only) ─────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/LibraryFolders.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/LibraryFolders.sq
@@ -42,7 +42,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM library_folders WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM library_folders WHERE revision <= :cursor;
+SELECT id, revision FROM library_folders WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- ── Syncable read/write ───────────────────────────────────────────────────────
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ListeningEvents.sq
@@ -42,7 +42,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM listening_events WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM listening_events WHERE revision <= :cursor;
+SELECT id, revision FROM listening_events WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- User-scoped substrate variants — the per-user filtering the Exposed base applies
 -- via `(revision <cmp> cursor) AND user_id = userId`.
@@ -54,7 +54,7 @@ ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMostForUser:
 SELECT id, revision FROM listening_events
-WHERE user_id = :userId AND revision <= :cursor;
+WHERE user_id = :userId AND deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Moods.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Moods.sq
@@ -50,7 +50,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM moods WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM moods WHERE revision <= :cursor;
+SELECT id, revision FROM moods WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- True iff at least one live (non-deleted) mood row exists — drives MoodDomainSeeder.isAlreadySeeded.
 hasAnyLive:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
@@ -41,7 +41,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM playback_positions WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM playback_positions WHERE revision <= :cursor;
+SELECT id, revision FROM playback_positions WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- User-scoped substrate variants — the per-user filtering the Exposed base applies
 -- via `(revision <cmp> cursor) AND user_id = userId`.
@@ -53,7 +53,7 @@ ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMostForUser:
 SELECT id, revision FROM playback_positions
-WHERE user_id = :userId AND revision <= :cursor;
+WHERE user_id = :userId AND deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PublicProfiles.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PublicProfiles.sq
@@ -50,7 +50,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM public_profiles WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM public_profiles WHERE revision <= :cursor;
+SELECT id, revision FROM public_profiles WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Series.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Series.sq
@@ -56,7 +56,7 @@ SELECT id FROM book_series WHERE deleted_at IS NULL;
 -- (id, revision) for ALL rows, soft-deleted included, no filter — feeds the
 -- cross-stack digest parity test (allIdRevisionsForTest).
 selectAllIdRevisions:
-SELECT id, revision FROM book_series;
+SELECT id, revision FROM book_series WHERE deleted_at IS NULL;
 
 insert:
 INSERT INTO book_series (
@@ -92,4 +92,4 @@ selectIdsAboveRevision:
 SELECT id, revision FROM book_series WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM book_series WHERE revision <= :cursor;
+SELECT id, revision FROM book_series WHERE deleted_at IS NULL AND revision <= :cursor;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ShelfBooks.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/ShelfBooks.sq
@@ -44,7 +44,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM shelf_books WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM shelf_books WHERE revision <= :cursor;
+SELECT id, revision FROM shelf_books WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- User-scoped substrate variants — the per-user filtering the Exposed base applies
 -- via `(revision <cmp> cursor) AND user_id = userId`. Used by the userScoped
@@ -57,7 +57,7 @@ ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMostForUser:
 SELECT id, revision FROM shelf_books
-WHERE user_id = :userId AND revision <= :cursor;
+WHERE user_id = :userId AND deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Shelves.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Shelves.sq
@@ -34,7 +34,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM shelves WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM shelves WHERE revision <= :cursor;
+SELECT id, revision FROM shelves WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- User-scoped substrate variants — the per-user filtering the Exposed base applies
 -- via `(revision <cmp> cursor) AND user_id = userId`. Used by the userScoped
@@ -47,7 +47,7 @@ ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMostForUser:
 SELECT id, revision FROM shelves
-WHERE user_id = :userId AND revision <= :cursor;
+WHERE user_id = :userId AND deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Tags.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Tags.sq
@@ -50,7 +50,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM tags WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM tags WHERE revision <= :cursor;
+SELECT id, revision FROM tags WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- True iff at least one live (non-deleted) tag row exists — drives TagDomainSeeder.isAlreadySeeded.
 hasAnyLive:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/UserStats.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/UserStats.sq
@@ -45,7 +45,7 @@ selectIdsAboveRevision:
 SELECT id, revision FROM user_stats WHERE revision > :cursor ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMost:
-SELECT id, revision FROM user_stats WHERE revision <= :cursor;
+SELECT id, revision FROM user_stats WHERE deleted_at IS NULL AND revision <= :cursor;
 
 -- User-scoped substrate variants — the per-user filtering the Exposed base applies
 -- via `(revision <cmp> cursor) AND user_id = userId`.
@@ -57,7 +57,7 @@ ORDER BY revision ASC LIMIT :limit;
 
 selectIdRevAtMostForUser:
 SELECT id, revision FROM user_stats
-WHERE user_id = :userId AND revision <= :cursor;
+WHERE user_id = :userId AND deleted_at IS NULL AND revision <= :cursor;
 
 -- Domain queries.
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/SeriesRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/SeriesRepositoryTest.kt
@@ -143,15 +143,17 @@ class SeriesRepositoryTest :
             }
         }
 
-        test("allIdRevisionsForTest returns all rows including soft-deleted") {
+        test("allIdRevisionsForTest returns only live rows (tombstones excluded), matching the digest") {
             withSqlDatabase {
                 val repo = SeriesRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
                 runTest {
                     val keep = repo.resolveOrCreate("Kept Series")
                     val gone = repo.resolveOrCreate("Gone Series")
                     repo.softDelete(gone)
+                    // The digest counts LIVE rows only (F1); the parity helper mirrors that set, so a
+                    // tombstoned series is excluded — feeding the client DigestComputer the same rows.
                     val ids = repo.allIdRevisionsForTest().map { it.first }
-                    ids shouldContainExactly listOf(keep.value, gone.value)
+                    ids shouldContainExactly listOf(keep.value)
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TagRepositoryDigestTest.kt
@@ -65,12 +65,16 @@ class TagRepositoryDigestTest :
             }
         }
 
-        test("digest includes soft-deleted rows") {
+        test("digest EXCLUDES soft-deleted rows (F1: symmetric with the client's tombstone-excluding digest)") {
             withSqlDatabase {
                 val repo = TagRepository(sql, ChangeBus(), SyncRegistry())
                 runTest {
                     repo.upsert(Tag("a", "alpha", "alpha", 0, 0))
+                    repo.upsert(Tag("b", "beta", "beta", 0, 0))
                     repo.softDelete("a")
+                    // The digest counts LIVE rows only — the tombstoned "a" drops out, leaving "b".
+                    // This is what lets a client that tombstoned "a" locally converge instead of
+                    // drifting forever (the deletion still reaches clients via catch-up / firehose).
                     val d = repo.digest(userId = null, cursor = Long.MAX_VALUE)
                     d.count shouldBe 1
                 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
@@ -80,7 +80,7 @@ internal interface ActivityDao {
     )
 
     /** All rows (including tombstones) with revision <= max, for digest computation. */
-    @Query("SELECT id AS id, revision FROM activities WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM activities WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** Ids of every live (non-tombstoned) activity — the access-gate's local-live set. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AdminUserRosterEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/AdminUserRosterEntity.kt
@@ -81,7 +81,7 @@ internal interface AdminUserRosterDao {
     )
 
     /** All rows (including tombstones) with [revision][AdminUserRosterEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM admin_user_roster WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM admin_user_roster WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.flow.Flow
  * tombstoned book never appears in a browse list. Point lookups by id (`getById`,
  * `getByIdWithContributors`, `observeByIdWithContributors`, the `*ByIds*` batch reads)
  * deliberately return the row regardless of tombstone state; the detail layer decides
- * how to react to a deleted book. [digestRows] also includes tombstones by design.
- * Use [softDelete] to apply a server tombstone; [deleteById] is a hard removal
+ * how to react to a deleted book. [digestRows] excludes tombstones — the digest counts only
+ * LIVE rows, symmetric with the server's tombstone-excluding digest, so a member who tombstoned
+ * a book locally still converges (F1). Use [softDelete] to apply a server tombstone; [deleteById] is a hard removal
  * for local-only cleanup scenarios.
  */
 @Dao
@@ -495,8 +496,8 @@ internal interface BookDao {
     @Query("SELECT DISTINCT bookId FROM book_documents")
     fun observeBookIdsWithDocuments(): Flow<List<String>>
 
-    /** All rows (including tombstones) with [revision][BookEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM books WHERE revision <= :max")
+    /** LIVE rows (tombstones excluded) with [revision][BookEntity.revision] <= [max], for digest computation. */
+    @Query("SELECT id AS id, revision FROM books WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CollectionDao.kt
@@ -89,7 +89,7 @@ internal interface CollectionDao {
     suspend fun deleteAll()
 
     /** All rows (including tombstones) with [revision][CollectionEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM collections WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM collections WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
@@ -174,7 +174,9 @@ internal interface CollectionBookDao {
      *
      * The synthetic id is `"$collectionId:$bookId"` — the same form the server uses on the wire.
      */
-    @Query("SELECT collectionId || ':' || bookId AS id, revision FROM collection_books WHERE revision <= :max")
+    @Query(
+        "SELECT collectionId || ':' || bookId AS id, revision FROM collection_books WHERE deletedAt IS NULL AND revision <= :max",
+    )
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /**
@@ -245,7 +247,7 @@ internal interface CollectionShareDao {
     suspend fun deleteAll()
 
     /** All rows (including tombstones) with [revision][CollectionShareEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM collection_shares WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM collection_shares WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
@@ -120,7 +120,7 @@ internal interface SeriesDao {
     )
 
     /** All rows (including tombstones) with [revision][SeriesEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM series WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM series WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
@@ -226,7 +226,7 @@ internal interface ContributorDao {
     )
 
     /** All rows (including tombstones) with [revision][ContributorEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM contributors WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM contributors WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/GenreDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/GenreDao.kt
@@ -145,7 +145,7 @@ internal interface GenreDao {
     suspend fun deleteAll()
 
     /** All rows (including tombstones) with [revision][GenreEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM genres WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM genres WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListeningEventEntity.kt
@@ -329,7 +329,7 @@ internal interface ListeningEventDao {
     ): List<BookDuration>
 
     /** All rows (including tombstones) with [revision][ListeningEventEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM listening_events WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM listening_events WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/MoodDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/MoodDao.kt
@@ -89,7 +89,7 @@ internal interface MoodDao {
     suspend fun deleteAll()
 
     /** All rows (including tombstones) with [revision][MoodEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM moods WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM moods WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
@@ -158,7 +158,9 @@ internal interface BookMoodDao {
      *
      * The synthetic id is `"$bookId:$moodId"` — the same form the server uses on the wire.
      */
-    @Query("SELECT bookId || ':' || moodId AS id, revision FROM book_moods WHERE revision <= :max")
+    @Query(
+        "SELECT bookId || ':' || moodId AS id, revision FROM book_moods WHERE deletedAt IS NULL AND revision <= :max",
+    )
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PublicProfileEntity.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PublicProfileEntity.kt
@@ -108,7 +108,7 @@ internal interface PublicProfileDao {
     )
 
     /** All rows (including tombstones) with [revision][PublicProfileEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM public_profiles WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM public_profiles WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfBookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfBookDao.kt
@@ -51,7 +51,7 @@ internal interface ShelfBookDao {
      *
      * The id is the synthetic `"$shelfId:$bookId"` — the same form the server uses on the wire.
      */
-    @Query("SELECT id AS id, revision FROM shelf_books WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM shelf_books WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with synthetic [id], tombstones included; null when never seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ShelfDao.kt
@@ -163,7 +163,7 @@ internal interface ShelfDao {
     suspend fun deleteAll()
 
     /** All rows (including tombstones) with [revision][ShelfEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM shelves WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM shelves WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TagDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TagDao.kt
@@ -87,7 +87,7 @@ internal interface TagDao {
     suspend fun deleteAll()
 
     /** All rows (including tombstones) with [revision][TagEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM tags WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM tags WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */
@@ -154,7 +154,7 @@ internal interface BookTagDao {
      *
      * The synthetic id is `"$bookId:$tagId"` — the same form the server uses on the wire.
      */
-    @Query("SELECT bookId || ':' || tagId AS id, revision FROM book_tags WHERE revision <= :max")
+    @Query("SELECT bookId || ':' || tagId AS id, revision FROM book_tags WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserStatsDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/UserStatsDao.kt
@@ -81,7 +81,7 @@ internal interface UserStatsDao {
     suspend fun count(): Int
 
     /** All rows (including tombstones) with [revision][UserStatsEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM user_stats WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM user_stats WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryDao.kt
@@ -65,7 +65,7 @@ internal interface LibraryDao {
     )
 
     /** All rows (including tombstones) with [revision][LibraryEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM libraries WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM libraries WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryFolderDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/dao/LibraryFolderDao.kt
@@ -72,7 +72,7 @@ internal interface LibraryFolderDao {
     )
 
     /** All rows (including tombstones) with [revision][LibraryFolderEntity.revision] <= [max], for digest computation. */
-    @Query("SELECT id AS id, revision FROM library_folders WHERE revision <= :max")
+    @Query("SELECT id AS id, revision FROM library_folders WHERE deletedAt IS NULL AND revision <= :max")
     suspend fun digestRows(max: Long): List<IdRevision>
 
     /** The stored revision of the row with [id], tombstones included; null when the row has never been seen. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncDomainHandler.kt
@@ -61,9 +61,10 @@ internal interface SyncDomainHandler<T : Any> {
     ): AppResult<Unit>
 
     /**
-     * The domain's local `(id, revision)` rows with `revision <= maxRevision`, INCLUDING
-     * soft-deleted rows — the exact set the server's digest covers. Used by the reconciler
-     * to fingerprint the domain and detect per-domain drift.
+     * The domain's local `(id, revision)` rows with `revision <= maxRevision`, EXCLUDING
+     * soft-deleted rows — the exact LIVE set the server's (tombstone-excluding) digest covers.
+     * Used by the reconciler to fingerprint the domain and detect per-domain drift; the
+     * tombstone exclusion is what lets a member who tombstoned a row locally converge (F1).
      *
      * Returns `null` for a domain that cannot be fingerprinted client-side (no local
      * `revision` column) — the reconciler skips such domains rather than re-pulling them

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
@@ -34,7 +34,8 @@ import com.calypsan.listenup.core.Timestamp
  * access is re-granted — then its `afterPrune` drops readership rows for the now-dead books.
  *
  * **Digest:** full participation — books are revision-fingerprintable, and
- * `digestRows` includes soft-deleted rows, matching the server's digest exactly.
+ * `digestRows` excludes soft-deleted rows, matching the server's (tombstone-excluding) digest
+ * exactly, so a member who tombstoned a book locally converges instead of drifting forever (F1).
  */
 internal fun booksDomain(
     database: ListenUpDatabase,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/DigestParticipation.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/DigestParticipation.kt
@@ -8,8 +8,9 @@ import com.calypsan.listenup.client.data.local.db.IdRevision
 internal sealed interface DigestParticipation {
     /**
      * The domain is fingerprintable: [rows] returns local `(id, revision)` pairs with
-     * `revision <= maxRevision`, INCLUDING soft-deleted rows — the exact set the
-     * server's digest covers.
+     * `revision <= maxRevision`, EXCLUDING soft-deleted rows — the exact LIVE set the
+     * server's (now tombstone-excluding) digest covers, so a locally-tombstoned row leaves
+     * both digests at once and the member converges (F1).
      */
     class Full(
         val rows: suspend (maxRevision: Long) -> List<Pair<String, Long>>,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
@@ -111,6 +111,12 @@ class ArchitectureTest :
                 // manufacture a sub-floor gap row, then proves reconcileAll repairs it. Same exemption
                 // class as DigestParityE2ETest — confined to jvmTest, not production.
                 .filter { "/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestReconcileGapE2ETest" !in it.path }
+                // F1 access-gated digest convergence E2E: drives the real server BookRepository +
+                // BookAccessPolicy against the client BookDao/DigestComputer to prove a member's client
+                // digest converges with the server member digest after a deletion/revoke, and that the
+                // access-filtered catch-up delivers tombstones. Same exemption class as DigestParityE2ETest
+                // — confined to jvmTest, not production.
+                .filter { "data/sync/AccessGatedDigestConvergenceE2ETest" !in it.path }
                 // Lifecycle-reconcile invariant E2E: boots real server in-process under FirehoseSuppressed
                 // to manufacture an above-cursor gap row, then proves lifecycleReconcile's forward catch-up
                 // lands it where forceReconcile cannot. Same exemption class — confined to jvmTest.

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/SeriesDigestRowsTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/SeriesDigestRowsTest.kt
@@ -9,18 +9,19 @@ import io.kotest.matchers.collections.shouldHaveSize
 import kotlinx.coroutines.test.runTest
 
 /**
- * Pins [SeriesDao.digestRows]: the query must return ALL rows (including soft-deleted
- * tombstones) whose `revision <= maxRevision`, mapped as `(id, revision)` pairs.
+ * Pins [SeriesDao.digestRows]: the query must return the LIVE rows (soft-deleted tombstones
+ * EXCLUDED) whose `revision <= maxRevision`, mapped as `(id, revision)` pairs.
  *
  * Three scenarios:
  *  1. Live rows within max → included.
- *  2. Tombstoned rows within max → included (digest covers deleted rows).
+ *  2. Tombstoned rows within max → EXCLUDED (the digest counts only live rows, so a client that
+ *     tombstoned a row locally converges with the server's tombstone-excluding digest — F1).
  *  3. Rows whose revision exceeds max → excluded.
  */
 class SeriesDigestRowsTest :
     FunSpec({
 
-        test("digestRows returns live and tombstoned rows bounded by maxRevision") {
+        test("digestRows returns live rows and EXCLUDES tombstones, bounded by maxRevision") {
             runTest {
                 val db = createInMemoryTestDatabase()
                 try {
@@ -28,20 +29,19 @@ class SeriesDigestRowsTest :
 
                     // revision 1 — live
                     dao.upsert(seriesEntityWithRevision("s-live-1", "Live Series One", revision = 1L))
-                    // revision 2 — soft-deleted (tombstone must still appear in digest)
+                    // revision 2 — soft-deleted (tombstone must NOT appear in the digest)
                     dao.upsert(seriesEntityWithRevision("s-dead-2", "Deleted Series", revision = 2L))
                     dao.softDelete(SeriesId("s-dead-2"), deletedAt = 1_000L, revision = 2L)
                     // revision 5 — live but above the max we'll query
                     dao.upsert(seriesEntityWithRevision("s-live-5", "Future Series", revision = 5L))
 
-                    // Query with max = 3 → should see s-live-1 (rev 1) and s-dead-2 (rev 2)
+                    // Query with max = 3 → should see only s-live-1 (rev 1); s-dead-2 is tombstoned.
                     val rows = dao.digestRows(max = 3L)
 
-                    rows shouldHaveSize 2
+                    rows shouldHaveSize 1
                     rows.map { it.id to it.revision } shouldContainExactlyInAnyOrder
                         listOf(
                             "s-live-1" to 1L,
-                            "s-dead-2" to 2L,
                         )
                 } finally {
                     db.close()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessGatedDigestConvergenceE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessGatedDigestConvergenceE2ETest.kt
@@ -1,0 +1,280 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.sync.BookSyncPayload
+import com.calypsan.listenup.client.data.local.db.BookEntityMapper
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.sync.domains.booksDomain
+import com.calypsan.listenup.client.data.sync.domains.toHandler
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.stubImageStorage
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.api.BookAccessPolicy
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import com.calypsan.listenup.server.db.sqldelight.DriverFactory
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase as ServerSqlDatabase
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.services.GenreRepository
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.SeriesRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.SyncRegistry
+import app.cash.sqldelight.db.SqlDriver
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+
+/**
+ * F1 — the deferred correctness item from the sync-core reviews.
+ *
+ * For an access-gated domain the client digest is tombstone-INCLUSIVE while the server's
+ * *member* digest is access-filtered and therefore tombstone-EXCLUSIVE (a deleted or
+ * inaccessible row falls out of `accessibleBookIdsSql`, which requires `deleted_at IS NULL`).
+ * After the client tombstones a row (via a delivered deletion, or the `AccessGate` prune on
+ * revoke) the two digests can never converge, so `reconcileAll` re-derives the whole domain
+ * (`repairDrift → catchUpTransient`) on EVERY reconcile edge, forever, for any member who ever
+ * witnessed a deletion.
+ *
+ * These tests reproduce non-convergence on `books` (the reference gated domain) against the
+ * REAL server repository + access policy, and prove:
+ *  1. a delivered deletion converges (client digest EQUALS the server member digest);
+ *  2. a share revoke (`AccessGate` prune) converges the same way;
+ *  3. the access-filtered catch-up delivers the tombstone for a MISSED live deletion, so a
+ *     member who was offline during the delete can still learn to remove the row and converge.
+ *
+ * The convergence assertion is `clientDigest == serverMemberDigest` at the same cursor — the
+ * exact comparison `SyncReconciler.reconcileOne` performs, so equality means `reconcileAll` is a
+ * stable no-op (no `catchUpTransient`) on the next pass.
+ */
+class AccessGatedDigestConvergenceE2ETest :
+    FunSpec({
+
+        test("delivered deletion: a member's client digest converges with the server member digest") {
+            withBooksServerAndClient { server, clientDb ->
+                runTest {
+                    val member = "m1"
+                    val role = UserRole.MEMBER
+                    server.seedAccessibleBook(bookId = "b1", collectionId = "c1", ownerId = member)
+
+                    val filter = server.policy.accessibleBookIdsSql(member, role).shouldNotBeNull()
+                    val handler =
+                        booksDomain(clientDb, BookEntityMapper(), stubImageStorage())
+                            .toHandler(RoomTransactionRunner(clientDb), ClientSyncDomainRegistry())
+
+                    // Member mirrors b1 (live) via the access-filtered catch-up.
+                    val page = server.bookRepo.pullSince(member, cursor = 0L, limit = 100, extraWhere = filter)
+                    page.items.forEach { handler.onCatchUpItem(it, isTombstone = it.deletedAt != null) }
+                    clientDb.bookDao().getById(BookId("b1")).shouldNotBeNull()
+
+                    // Book deleted server-side; the tombstone reaches the member (live firehose is
+                    // tombstone-ungated) and the member applies it locally.
+                    server.bookRepo.softDelete(BookId("b1"))
+                    handler.onCatchUpItem(server.tombstonePayloadOf("b1"), isTombstone = true)
+                    // getById returns rows regardless of tombstone state (point lookups ignore
+                    // soft-deletes by design), so assert the tombstone via deletedAt.
+                    clientDb
+                        .bookDao()
+                        .getById(BookId("b1"))
+                        .shouldNotBeNull()
+                        .deletedAt
+                        .shouldNotBeNull()
+
+                    // Convergence: the client digest must EQUAL the server member digest at the same
+                    // cursor — i.e. reconcileAll would find no drift and do NO catch-up on the next pass.
+                    val clientDigest =
+                        DigestComputer.compute(Long.MAX_VALUE, handler.localDigestRows(Long.MAX_VALUE).shouldNotBeNull())
+                    val serverMemberDigest = server.bookRepo.digest(member, Long.MAX_VALUE, filter)
+
+                    clientDigest.count shouldBe serverMemberDigest.count
+                    clientDigest.hash shouldBe serverMemberDigest.hash
+                }
+            }
+        }
+
+        test("revoke: after an AccessGate prune, the client digest converges with the server member digest") {
+            withBooksServerAndClient { server, clientDb ->
+                runTest {
+                    val member = "m1"
+                    val role = UserRole.MEMBER
+                    server.seedAccessibleBook(bookId = "b1", collectionId = "c1", ownerId = member)
+
+                    val filterBefore = server.policy.accessibleBookIdsSql(member, role).shouldNotBeNull()
+                    val handler =
+                        booksDomain(clientDb, BookEntityMapper(), stubImageStorage())
+                            .toHandler(RoomTransactionRunner(clientDb), ClientSyncDomainRegistry())
+
+                    val page = server.bookRepo.pullSince(member, cursor = 0L, limit = 100, extraWhere = filterBefore)
+                    page.items.forEach { handler.onCatchUpItem(it, isTombstone = it.deletedAt != null) }
+                    clientDb.bookDao().getById(BookId("b1")).shouldNotBeNull()
+
+                    // Share revoked: the collection membership is removed, so b1 leaves the member's
+                    // accessible set (the book itself stays live server-side). The AccessGate prune
+                    // tombstones the now-inaccessible local row (exactly bookDao().tombstoneByIds).
+                    server.revokeMembership(bookId = "b1", collectionId = "c1")
+                    clientDb.bookDao().tombstoneByIds(listOf("b1"), now = 999L)
+                    // getById returns rows regardless of tombstone state (point lookups ignore
+                    // soft-deletes by design), so assert the tombstone via deletedAt.
+                    clientDb
+                        .bookDao()
+                        .getById(BookId("b1"))
+                        .shouldNotBeNull()
+                        .deletedAt
+                        .shouldNotBeNull()
+
+                    val filterAfter = server.policy.accessibleBookIdsSql(member, role).shouldNotBeNull()
+                    val clientDigest =
+                        DigestComputer.compute(Long.MAX_VALUE, handler.localDigestRows(Long.MAX_VALUE).shouldNotBeNull())
+                    val serverMemberDigest = server.bookRepo.digest(member, Long.MAX_VALUE, filterAfter)
+
+                    clientDigest.count shouldBe serverMemberDigest.count
+                    clientDigest.hash shouldBe serverMemberDigest.hash
+                }
+            }
+        }
+
+        test("missed live deletion: the access-filtered catch-up delivers the tombstone, and the member converges") {
+            withBooksServerAndClient { server, clientDb ->
+                runTest {
+                    val member = "m1"
+                    val role = UserRole.MEMBER
+                    server.seedAccessibleBook(bookId = "b1", collectionId = "c1", ownerId = member)
+
+                    val filter = server.policy.accessibleBookIdsSql(member, role).shouldNotBeNull()
+                    val handler =
+                        booksDomain(clientDb, BookEntityMapper(), stubImageStorage())
+                            .toHandler(RoomTransactionRunner(clientDb), ClientSyncDomainRegistry())
+
+                    // Member mirrors b1 live, then goes OFFLINE.
+                    server.bookRepo
+                        .pullSince(member, cursor = 0L, limit = 100, extraWhere = filter)
+                        .items
+                        .forEach { handler.onCatchUpItem(it, isTombstone = it.deletedAt != null) }
+                    clientDb.bookDao().getById(BookId("b1")).shouldNotBeNull()
+
+                    // b1 deleted while the member is offline — the live tombstone is NEVER delivered.
+                    server.bookRepo.softDelete(BookId("b1"))
+
+                    // Reconcile catch-up: a transient access-filtered pull from cursor 0. It MUST carry
+                    // the b1 tombstone so the member can remove the row and converge — even though b1 is
+                    // no longer "accessible" (a tombstone leaks no content, mirroring the firehose rule).
+                    val catchUp = server.bookRepo.pullSince(member, cursor = 0L, limit = 100, extraWhere = filter)
+                    val tombstone = catchUp.items.firstOrNull { it.id == "b1" && it.deletedAt != null }
+                    tombstone.shouldNotBeNull()
+
+                    catchUp.items.forEach { handler.onCatchUpItem(it, isTombstone = it.deletedAt != null) }
+                    // getById returns rows regardless of tombstone state (point lookups ignore
+                    // soft-deletes by design), so assert the tombstone via deletedAt.
+                    clientDb
+                        .bookDao()
+                        .getById(BookId("b1"))
+                        .shouldNotBeNull()
+                        .deletedAt
+                        .shouldNotBeNull()
+
+                    val clientDigest =
+                        DigestComputer.compute(Long.MAX_VALUE, handler.localDigestRows(Long.MAX_VALUE).shouldNotBeNull())
+                    val serverMemberDigest = server.bookRepo.digest(member, Long.MAX_VALUE, filter)
+                    clientDigest.count shouldBe serverMemberDigest.count
+                    clientDigest.hash shouldBe serverMemberDigest.hash
+                }
+            }
+        }
+    })
+
+/** The server side wired for a single convergence run: the real books repo + access policy over a migrated DB. */
+private class BooksServerHarness(
+    val bookRepo: BookRepository,
+    val policy: BookAccessPolicy,
+    val driver: SqlDriver,
+) {
+    private var revisionSeed = 1L
+
+    /**
+     * Seeds a live book [bookId] that member-owner [ownerId] can see: a member-owned live
+     * collection [collectionId] containing the book (the pure-union visibility rule). Raw SQL
+     * because the tables are `internal`; mirrors the DigestParityE2ETest seeding style.
+     */
+    fun seedAccessibleBook(
+        bookId: String,
+        collectionId: String,
+        ownerId: String,
+    ) {
+        val now = System.currentTimeMillis()
+        driver.execute(
+            null,
+            "INSERT OR IGNORE INTO libraries(id, name, created_at, updated_at, revision) " +
+                "VALUES ('lib', 'Test Library', $now, $now, 0)",
+            0,
+        )
+        driver.execute(
+            null,
+            "INSERT INTO books(id, library_id, folder_id, title, total_duration, root_rel_path, " +
+                "scanned_at, revision, created_at, updated_at) " +
+                "VALUES ('$bookId', 'lib', 'folder', 'Book $bookId', 0, '$bookId', $now, ${revisionSeed++}, $now, $now)",
+            0,
+        )
+        driver.execute(
+            null,
+            "INSERT INTO collections(id, library_id, owner_id, name, type, created_at, updated_at, revision) " +
+                "VALUES ('$collectionId', 'lib', '$ownerId', 'Collection', 'NORMAL', $now, $now, ${revisionSeed++})",
+            0,
+        )
+        driver.execute(
+            null,
+            "INSERT INTO collection_books(id, collection_id, book_id, created_at, updated_at, revision) " +
+                "VALUES ('$collectionId:$bookId', '$collectionId', '$bookId', $now, $now, ${revisionSeed++})",
+            0,
+        )
+    }
+
+    /** Removes the book→collection membership (a share revoke) so the book leaves the member's accessible set. */
+    fun revokeMembership(
+        bookId: String,
+        collectionId: String,
+    ) {
+        val now = System.currentTimeMillis()
+        driver.execute(
+            null,
+            "UPDATE collection_books SET deleted_at = $now WHERE collection_id = '$collectionId' AND book_id = '$bookId'",
+            0,
+        )
+    }
+
+    /** The current server payload for [bookId], tombstone included — read via the unfiltered (admin) pull. */
+    suspend fun tombstonePayloadOf(bookId: String): BookSyncPayload =
+        bookRepo
+            .pullSince(userId = null, cursor = 0L, limit = 500, extraWhere = null)
+            .items
+            .first { it.id == bookId }
+}
+
+private fun withBooksServerAndClient(block: (BooksServerHarness, ListenUpDatabase) -> Unit) {
+    val tmp =
+        Files.createTempFile("listenup-f1-convergence-", ".db").toFile().apply { deleteOnExit() }
+    DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
+    val driver = DriverFactory().createDriver(tmp.absolutePath)
+    val sqlDb = ServerSqlDatabase(driver)
+    val bus = ChangeBus()
+    val registry = SyncRegistry()
+    val bookRepo =
+        BookRepository(
+            db = sqlDb,
+            bus = bus,
+            registry = registry,
+            driver = driver,
+            contributorRepository = ContributorRepository(sqlDb, bus, SyncRegistry()),
+            seriesRepository = SeriesRepository(sqlDb, bus, SyncRegistry()),
+            genreRepository = GenreRepository(sqlDb, bus, SyncRegistry()),
+        )
+    val policy = BookAccessPolicy(sqlDb, driver)
+    val clientDb = createInMemoryTestDatabase()
+    try {
+        block(BooksServerHarness(bookRepo, policy, driver), clientDb)
+    } finally {
+        clientDb.close()
+    }
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AdminUserRosterDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AdminUserRosterDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.adminUserRosterDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -110,7 +110,7 @@ class AdminUserRosterDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("user-deleted", revision = 1L)), isOwnEcho = false)
                 handler.onEvent(
@@ -123,8 +123,10 @@ class AdminUserRosterDomainTest :
                     .observeAll()
                     .first()
                     .none { it.id == "user-deleted" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation
-                db.adminUserRosterDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "user-deleted"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.adminUserRosterDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "user-deleted"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookMoodsDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.bookMoodsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -68,7 +68,7 @@ class BookMoodsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(junctionPayload("b1", "m1")), isOwnEcho = false)
                 handler.onEvent(
@@ -81,8 +81,10 @@ class BookMoodsDomainTest :
                     .observeForBook("b1")
                     .first()
                     .none { it.moodId == "m1" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation (synthetic "$bookId:$moodId" id)
-                db.bookMoodDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "b1:m1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation (synthetic "$bookId:$moodId" id)
+                db.bookMoodDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "b1:m1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BookTagsDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.bookTagsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -72,7 +72,7 @@ class BookTagsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(junctionPayload("b1", "t1", revision = 1L)), isOwnEcho = false)
                 handler.onEvent(
@@ -85,8 +85,10 @@ class BookTagsDomainTest :
                     .observeForBook("b1")
                     .first()
                     .none { it.tagId == "t1" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation (synthetic "$bookId:$tagId" id)
-                db.bookTagDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "b1:t1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation (synthetic "$bookId:$tagId" id)
+                db.bookTagDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "b1:t1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/BooksDomainTest.kt
@@ -37,7 +37,7 @@ import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -266,7 +266,7 @@ class BooksDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withTestHandler { handler, db ->
                 val initial = bookPayload(id = "b1")
                 handler.onEvent(created(initial), isOwnEcho = false)
@@ -276,8 +276,10 @@ class BooksDomainTest :
                 )
                 // getAllLive filters tombstones — invisible to reads
                 db.bookDao().getAllLive().none { it.id == BookId("b1") } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation
-                db.bookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "b1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.bookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "b1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionBooksDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.collectionBooksDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -71,7 +71,7 @@ class CollectionBooksDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(createdJunction(junctionPayload("c1", "b1", revision = 1L)), isOwnEcho = false)
                 handler.onEvent(SyncEvent.Deleted(id = "c1:b1", revision = 2L, occurredAt = 800L), isOwnEcho = false)
@@ -81,8 +81,10 @@ class CollectionBooksDomainTest :
                     .observeBookIds("c1")
                     .first()
                     .none { it == "b1" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation (synthetic "$collectionId:$bookId" id)
-                db.collectionBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "c1:b1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation (synthetic "$collectionId:$bookId" id)
+                db.collectionBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "c1:b1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionSharesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionSharesDomainTest.kt
@@ -10,7 +10,7 @@ import com.calypsan.listenup.client.data.sync.domains.collectionSharesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -58,12 +58,12 @@ class CollectionSharesDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(createdShare(sharePayload("s1", "c1")), isOwnEcho = false)
                 handler.onEvent(SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
                 db.collectionShareDao().getById("s1") shouldBe null
-                db.collectionShareDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1"
+                db.collectionShareDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "s1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/CollectionsDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -67,12 +67,12 @@ class CollectionsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(createdCollection(collectionPayload("c1")), isOwnEcho = false)
                 handler.onEvent(SyncEvent.Deleted(id = "c1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
                 db.collectionDao().getById("c1") shouldBe null
-                db.collectionDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "c1"
+                db.collectionDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "c1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ContributorsDomainTest.kt
@@ -21,7 +21,7 @@ import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -182,7 +182,7 @@ class ContributorsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("c1", "Brandon Sanderson")), isOwnEcho = false)
                 handler.onEvent(
@@ -191,8 +191,10 @@ class ContributorsDomainTest :
                 )
                 // observeById filters tombstones — invisible to reads
                 db.contributorDao().observeById("c1").first() shouldBe null
-                // but still fingerprinted for digest-drift reconciliation
-                db.contributorDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "c1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.contributorDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "c1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestParityE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/DigestParityE2ETest.kt
@@ -33,8 +33,9 @@ import kotlinx.coroutines.test.runTest
  * over the same `(id, revision)` rows.
  *
  * Seeds three series on the real server repository (two live, one soft-deleted so
- * the digest must include a tombstoned row), then computes both the server digest
- * and the client digest and asserts count AND hash equality.
+ * the digest must EXCLUDE the tombstoned row — the F1 tombstone-excluding contract),
+ * then computes both the server digest and the client digest and asserts count AND
+ * hash equality.
  *
  * If this test ever fails it means the two algorithms have drifted — do not weaken
  * the assertion; instead reconcile the implementations.
@@ -68,7 +69,9 @@ class DigestParityE2ETest :
             val repo = SeriesRepository(db = sqlDb, bus = ChangeBus(), registry = SyncRegistry())
 
             runTest {
-                // Seed: two live series + one that is immediately soft-deleted (tombstoned).
+                // Seed: two live series + one that is immediately soft-deleted (tombstoned). The
+                // tombstone must be EXCLUDED by both the server digest and the parity helper (F1),
+                // so the two sides still agree on the LIVE set.
                 repo.resolveOrCreate("Mistborn")
                 repo.resolveOrCreate("Stormlight")
                 val thirdId = repo.resolveOrCreate("Deleted Series")

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/GenresDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/GenresDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.genresDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -69,7 +69,7 @@ class GenresDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(genrePayload("g1", "Fantasy", "fantasy")), isOwnEcho = false)
                 handler.onEvent(
@@ -77,7 +77,7 @@ class GenresDomainTest :
                     isOwnEcho = false,
                 )
                 db.genreDao().getById("g1") shouldBe null
-                db.genreDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "g1"
+                db.genreDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "g1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibrariesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibrariesDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.librariesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -66,7 +66,7 @@ class LibrariesDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("lib1", "My Library")), isOwnEcho = false)
                 handler.onEvent(
@@ -74,7 +74,7 @@ class LibrariesDomainTest :
                     isOwnEcho = false,
                 )
                 db.libraryDao().findById("lib1") shouldBe null
-                db.libraryDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "lib1"
+                db.libraryDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "lib1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryFoldersDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/LibraryFoldersDomainTest.kt
@@ -10,7 +10,7 @@ import com.calypsan.listenup.client.data.sync.domains.libraryFoldersDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -70,7 +70,7 @@ class LibraryFoldersDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 seedLibrary(db, "lib1")
                 handler.onEvent(created(payload("f1", "lib1", "/audiobooks")), isOwnEcho = false)
@@ -80,8 +80,10 @@ class LibraryFoldersDomainTest :
                 )
                 // findAllForLibrary filters tombstones — invisible to reads
                 db.libraryFolderDao().findAllForLibrary("lib1").none { it.id == "f1" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation
-                db.libraryFolderDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "f1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.libraryFolderDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "f1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ListeningEventsDomainTest.kt
@@ -11,7 +11,7 @@ import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakeAuthSession
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -137,7 +137,7 @@ class ListeningEventsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("ev-6", "book-1")), isOwnEcho = false)
                 handler.onCatchUpItem(
@@ -150,8 +150,10 @@ class ListeningEventsDomainTest :
                     .observeEventsForBook("book-1")
                     .first()
                     .none { it.id == "ev-6" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation
-                db.listeningEventDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "ev-6"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.listeningEventDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "ev-6"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/MoodsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/MoodsDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.moodsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -71,7 +71,7 @@ class MoodsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(moodPayload("m1", "Feel-Good", "feel-good")), isOwnEcho = false)
                 handler.onEvent(
@@ -79,7 +79,7 @@ class MoodsDomainTest :
                     isOwnEcho = false,
                 )
                 db.moodDao().getById("m1") shouldBe null
-                db.moodDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "m1"
+                db.moodDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "m1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PublicProfilesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PublicProfilesDomainTest.kt
@@ -10,7 +10,7 @@ import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -94,10 +94,10 @@ class PublicProfilesDomainTest :
                         isOwnEcho = false,
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
 
-                // digestRows includes all rows; the tombstoned row must carry the updated revision
-                val allRows = db.publicProfileDao().digestRows(Long.MAX_VALUE)
-                val row = allRows.first { it.id == "user-deleted" }
-                row.revision shouldBe 2L
+                // The tombstoned row is retained (revision bumped) but EXCLUDED from the digest;
+                // read its revision via the tombstone-inclusive revisionOf, not digestRows.
+                db.publicProfileDao().revisionOf("user-deleted") shouldBe 2L
+                db.publicProfileDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "user-deleted"
                 // observeAll() only emits live rows; confirm the row is absent there
                 // (collect one emission — we're inside runTest so the Room Flow is synchronous)
                 val liveRows = db.publicProfileDao().observeAll().first()
@@ -105,7 +105,7 @@ class PublicProfilesDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("user-tomb-digest", revision = 1L)), isOwnEcho = false)
                 handler.onEvent(
@@ -114,8 +114,10 @@ class PublicProfilesDomainTest :
                 )
                 // observeById filters tombstones — invisible to reads
                 db.publicProfileDao().observeById("user-tomb-digest").first() shouldBe null
-                // but still fingerprinted for digest-drift reconciliation
-                db.publicProfileDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "user-tomb-digest"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.publicProfileDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "user-tomb-digest"
             }
         }
 
@@ -131,10 +133,10 @@ class PublicProfilesDomainTest :
                         isTombstone = true,
                     ).shouldBeInstanceOf<AppResult.Success<Unit>>()
 
-                // observeAll excludes tombstoned rows; digestRows includes them
-                val allRows = db.publicProfileDao().digestRows(Long.MAX_VALUE)
-                val row = allRows.first { it.id == "user-4" }
-                row.revision shouldBe 2L
+                // The row is retained (revision bumped) but EXCLUDED from the digest; read its
+                // revision via the tombstone-inclusive revisionOf, not digestRows.
+                db.publicProfileDao().revisionOf("user-4") shouldBe 2L
+                db.publicProfileDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "user-4"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SeriesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SeriesDomainTest.kt
@@ -12,7 +12,7 @@ import com.calypsan.listenup.client.data.sync.domains.seriesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -70,7 +70,7 @@ class SeriesDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("s1", "The Stormlight Archive")), isOwnEcho = false)
                 handler.onEvent(
@@ -79,8 +79,10 @@ class SeriesDomainTest :
                 )
                 // observeById filters tombstones — invisible to reads
                 db.seriesDao().observeById("s1").first() shouldBe null
-                // but still fingerprinted for digest-drift reconciliation
-                db.seriesDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.seriesDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "s1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelfBooksDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelfBooksDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.shelfBooksDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -73,7 +73,7 @@ class ShelfBooksDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(createdJunction(junctionPayload("s1", "b1", revision = 1L)), isOwnEcho = false)
                 handler.onEvent(SyncEvent.Deleted(id = "s1:b1", revision = 2L, occurredAt = 800L), isOwnEcho = false)
@@ -83,8 +83,10 @@ class ShelfBooksDomainTest :
                     .observeShelfBooks("s1")
                     .first()
                     .none { it == "b1" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation
-                db.shelfBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1:b1"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.shelfBookDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "s1:b1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelvesDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/ShelvesDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.shelvesDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -66,12 +66,12 @@ class ShelvesDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withShelfHandler { handler, db ->
                 handler.onEvent(createdShelf(shelfPayload("s1")), isOwnEcho = false)
                 handler.onEvent(SyncEvent.Deleted(id = "s1", revision = 2L, occurredAt = 500L), isOwnEcho = false)
                 db.shelfDao().getById("s1") shouldBe null
-                db.shelfDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "s1"
+                db.shelfDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "s1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/TagsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/TagsDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.tagsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -68,7 +68,7 @@ class TagsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(tagPayload("t1", "Sci-Fi", "sci-fi")), isOwnEcho = false)
                 handler.onEvent(
@@ -76,7 +76,7 @@ class TagsDomainTest :
                     isOwnEcho = false,
                 )
                 db.tagDao().getById("t1") shouldBe null
-                db.tagDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "t1"
+                db.tagDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "t1"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/UserStatsDomainTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/UserStatsDomainTest.kt
@@ -9,7 +9,7 @@ import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.data.sync.domains.userStatsDomain
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -93,7 +93,7 @@ class UserStatsDomainTest :
             }
         }
 
-        test("tombstoned row survives in digestRows — the digest covers deletes") {
+        test("tombstoned row is EXCLUDED from digestRows — the digest counts live rows only (F1)") {
             withHandler { handler, db ->
                 handler.onEvent(created(payload("user-tomb")), isOwnEcho = false)
                 handler.onCatchUpItem(
@@ -106,8 +106,10 @@ class UserStatsDomainTest :
                     .observeAll()
                     .first()
                     .none { it.id == "user-tomb" } shouldBe true
-                // but still fingerprinted for digest-drift reconciliation
-                db.userStatsDao().digestRows(Long.MAX_VALUE).map { it.id } shouldContain "user-tomb"
+                // and EXCLUDED from the digest — the digest counts live rows only, so a client that
+                // tombstoned this row locally converges (F1). Deletions still reach clients via the
+                // firehose and the tombstone-ungated access-filtered catch-up. Digest-drift reconciliation
+                db.userStatsDao().digestRows(Long.MAX_VALUE).map { it.id } shouldNotContain "user-tomb"
             }
         }
 


### PR DESCRIPTION
## F1 — the deferred correctness item from the sync-core reviews

> **Stacked on #1033** (branched off `refactor/sync-elegance` to build on its clean digest substrate). Merge #1033 first; the diff below includes #1033's commits until then.

Fixes the permanent digest non-convergence both adversarial reviews flagged: for an access-gated domain, the client digest (tombstone-**inclusive**) never matched the server's access-filtered member digest (tombstone-**exclusive**), so a member who witnessed any deletion/revocation triggered a full domain re-derive (`repairDrift → catchUpTransient`) on **every** reconcile edge, forever. Pre-existing in `books`/`collections`; activities inherited it.

### TDD — failing test first
New cross-stack E2E `AccessGatedDigestConvergenceE2ETest` (real server `BookRepository` + `BookAccessPolicy` vs the client `BookDao`/`DigestComputer`), three cases — **delivered deletion**, **revoke**, **missed live deletion** — all asserting `clientDigest == serverMemberDigest` (a stable reconcile no-op). All three failed first; the missed-live-deletion case failed at `tombstone.shouldNotBeNull()`, **proving part 3 was required**.

### The symmetric fix (uniform across all gated domains)
1. **Server digest excludes tombstones** — `deleted_at IS NULL` on the 21 `.sq` digest-slice queries (keeps ADMIN + non-gated domains symmetric with the client).
2. **Client `digestRows` excludes tombstones** — `WHERE deletedAt IS NULL` on the 20 client DAO digest queries.
3. **Access-filtered catch-up delivers tombstones ungated** — `selectIdRevAccessFiltered` gains `includeTombstones`: the pull path (`revision > cursor`) matches `id IN (<access>) OR deleted_at IS NOT NULL`; the digest path stays access-only. Mirrors the firehose's `isBookEventHidden` exactly, so a member who missed the live delete learns of it via catch-up and converges. **Content-leak-safe** — a tombstone carries only id/revision/deleted_at.

No schema/migration change (WHERE-clauses only) → golden snapshot unaffected.

### Test Plan
- [x] New convergence E2E (3 cases) green; the ~20 per-domain digest tests that *encoded the old behavior* flipped to tombstone-excluded (documented in-code — e.g. `TagRepositoryDigestTest` literally asserted "digest includes soft-deleted rows").
- [x] ADMIN/ROOT still sees everything; MEMBER sees only accessible live rows; only tombstones pass ungated (no content leak); `*CatchUp*`/`*Digest*`/`*Access*`/`*Firehose*` suites green.
- [x] Full `verifyLocal` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)