### PR TITLE
🐛 fix(sync): stop the SSE firehose self-teardown loop + un-gate the outbox from SSE

### DIFF
--- a/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.android.kt
+++ b/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.android.kt
@@ -18,6 +18,9 @@ import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
+/** Finite connect timeout for streaming clients — a dead-server connect fails fast instead of hanging ~2min. */
+private const val STREAMING_CONNECT_TIMEOUT_SECONDS = 10
+
 /**
  * Android implementation of streaming HTTP client factory.
  *
@@ -39,8 +42,10 @@ internal actual suspend fun createStreamingHttpClient(
         // Configure OkHttp engine with infinite timeouts for streaming
         engine {
             config {
-                // 0 = infinite timeout in OkHttp
-                connectTimeout(0.seconds)
+                // Finite CONNECT timeout so a failed connect fails fast (~10s) instead of hanging on
+                // OkHttp's default while a dead server is retried; read/write stay infinite (0 =
+                // infinite) because an SSE stream holds the connection open indefinitely.
+                connectTimeout(STREAMING_CONNECT_TIMEOUT_SECONDS.seconds)
                 readTimeout(0.seconds)
                 writeTimeout(0.seconds)
             }
@@ -96,8 +101,10 @@ internal actual fun createUnauthenticatedStreamingHttpClient(serverUrl: ServerUr
         // Configure OkHttp engine with infinite timeouts for streaming
         engine {
             config {
-                // 0 = infinite timeout in OkHttp
-                connectTimeout(0.seconds)
+                // Finite CONNECT timeout so a failed connect fails fast (~10s) instead of hanging on
+                // OkHttp's default while a dead server is retried; read/write stay infinite (0 =
+                // infinite) because an SSE stream holds the connection open indefinitely.
+                connectTimeout(STREAMING_CONNECT_TIMEOUT_SECONDS.seconds)
                 readTimeout(0.seconds)
                 writeTimeout(0.seconds)
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinator.kt
@@ -123,7 +123,12 @@ class ConnectionCoordinator internal constructor(
                     if (connected && !wasConnected) {
                         if (hasConnectedOnce) {
                             logger.info { "Firehose reconnected; invalidating stale RPC proxy caches" }
-                            invalidator.invalidateAll()
+                            // SCOPED sweep: refresh the stale RPC proxies + request client, but spare the
+                            // streaming client. This reconnect edge fires FROM the streaming client itself;
+                            // closing it here would abort the in-flight SSE read and spin a self-teardown
+                            // loop (reconnect → invalidate → abort → reconnect …). A genuine host change
+                            // takes the full invalidateAll() path in observeActiveUrl() instead.
+                            invalidator.invalidateRequestCaches()
                         }
                         hasConnectedOnce = true
                     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -109,6 +109,19 @@ internal interface ApiClientFactory : RemoteCache {
     suspend fun getUnauthenticatedStreamingClient(): HttpClient
 
     /**
+     * Invalidate ONLY the request/RPC client, leaving the long-lived streaming clients open.
+     *
+     * The full [invalidate] (from [RemoteCache]) closes every cached client — including the
+     * streaming client the SSE firehose rides on. That is correct for a server-URL change, but
+     * fatal on a firehose *reconnect*: the reconnect sweep exists to refresh stale RPC proxies +
+     * the regular request client, NOT to abort the very SSE connection whose reconnect triggered
+     * it (closing it aborts the in-flight read → reconnect → sweep → abort … a self-teardown loop).
+     * This narrower path drops the request client (so the next RPC call — and the RPC proxies that
+     * derive their client from it — rebinds fresh) while the streaming client keeps streaming.
+     */
+    suspend fun invalidateRequestClientOnly()
+
+    /**
      * Eagerly create and cache the authenticated client without exposing it.
      *
      * Lets cross-module startup code prime the lazy client (so the first real request doesn't pay the
@@ -419,6 +432,15 @@ internal class KtorApiClientFactory(
             cachedStreamingClient = null
             cachedUnauthenticatedStreamingClient?.close()
             cachedUnauthenticatedStreamingClient = null
+        }
+    }
+
+    override suspend fun invalidateRequestClientOnly() {
+        mutex.withLock {
+            cachedClient?.close()
+            cachedClient = null
+            // Deliberately leave cachedStreamingClient / cachedUnauthenticatedStreamingClient open:
+            // the firehose-reconnect sweep must not abort the SSE connection it rode in on.
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCacheInvalidator.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCacheInvalidator.kt
@@ -15,9 +15,25 @@ private val logger = KotlinLogging.logger {}
  * source of truth for a server-URL change, replacing the hand-maintained two-cache
  * list that silently missed every other authed proxy.
  */
-fun interface RpcCacheInvalidator {
-    /** Invalidate every registered [RemoteCache]. */
+interface RpcCacheInvalidator {
+    /**
+     * Invalidate every registered [RemoteCache] — including the SSE streaming client.
+     *
+     * The full sweep: use it when the connection's *identity* changed (logout, user switch, or a
+     * genuine server-URL/host change), so every transport — request client, RPC proxies, AND the
+     * streaming client — rebuilds against the new identity on its next use.
+     */
     suspend fun invalidateAll()
+
+    /**
+     * Invalidate the RPC proxy caches + the regular request client, but NOT the SSE streaming client.
+     *
+     * The scoped sweep for a firehose *reconnect to the same server*: refresh the stale kotlinx.rpc
+     * proxies (and the request client they derive from) so the next RPC call rebinds to the live
+     * connection, while sparing the streaming client — closing it would abort the very SSE read whose
+     * reconnect triggered the sweep, spinning a self-teardown loop.
+     */
+    suspend fun invalidateRequestCaches()
 }
 
 /**
@@ -30,7 +46,16 @@ internal class DefaultRpcCacheInvalidator(
     internal val caches: List<RemoteCache>,
 ) : RpcCacheInvalidator {
     override suspend fun invalidateAll() {
-        logger.debug { "Invalidating ${caches.size} remote connection cache(s)" }
+        logger.debug { "Invalidating ${caches.size} remote connection cache(s) (incl. streaming)" }
         caches.forEach { it.invalidate() }
+    }
+
+    override suspend fun invalidateRequestCaches() {
+        logger.debug { "Invalidating ${caches.size} remote connection cache(s) (sparing streaming client)" }
+        // The ApiClientFactory is the only cache holding a streaming client; every other RemoteCache
+        // (RPC proxy caches) has no streaming concern, so a full invalidate() is correct for them.
+        caches.forEach { cache ->
+            if (cache is ApiClientFactory) cache.invalidateRequestClientOnly() else cache.invalidate()
+        }
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImpl.kt
@@ -61,7 +61,12 @@ internal class AdminRepositoryImpl(
     private val libraryAdminRpc: LibraryAdminRpcFactory,
     private val serverConfig: ServerConfig,
     private val adminUserRosterDao: AdminUserRosterDao,
-    private val rpcCacheInvalidator: RpcCacheInvalidator = RpcCacheInvalidator {},
+    private val rpcCacheInvalidator: RpcCacheInvalidator =
+        object : RpcCacheInvalidator {
+            override suspend fun invalidateAll() = Unit
+
+            override suspend fun invalidateRequestCaches() = Unit
+        },
 ) : AdminRepository {
     // ═══════════════════════════════════════════════════════════════════════
     // USER MANAGEMENT

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -2,8 +2,11 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
+import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.core.currentEpochMilliseconds
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CompletableDeferred
@@ -56,6 +59,14 @@ internal class SyncEngine(
     private val dispatcher: SyncEventDispatcher,
     private val presenceRefreshSignal: PresenceRefreshSignal,
     private val scope: CoroutineScope,
+    // Gates the outbox drain on device reachability rather than the SSE firehose. The outbox pushes
+    // over the RPC/request transport, which is independent of the inbound SSE stream — so a new op
+    // (playback position, listening event, offline edit) must drain whenever the device is online,
+    // even while the firehose is down. Gating on `isOnline()` (not "SSE Connected") is the fix; it
+    // also spares the retry budget when the device is genuinely offline (no drain, no burned
+    // attempts). Defaults to an always-online monitor so existing call sites that don't drive
+    // connectivity (tests) need no change; production wires the live monitor.
+    private val networkMonitor: NetworkMonitor = AlwaysOnlineNetworkMonitor,
     // The refreshed tier's router. The lifecycle-reconcile pass re-runs every refreshed domain's
     // declared refresh through it, so a dropped refresh trigger self-heals on the next foreground/reconnect
     // edge — derived from the catalog, no per-domain recovery wiring (Plan §6a).
@@ -684,7 +695,14 @@ internal class SyncEngine(
                         .observeEnqueueSignal()
                         .onSubscription { ready.complete(Unit) }
                         .drop(1) // ignore the StateFlow's replayed current value
-                        .filter { state.value.connection is ConnectionState.Connected }
+                        // Gate on device reachability, NOT the SSE firehose. The outbox pushes over the
+                        // RPC/request transport, which is independent of the inbound SSE stream — so a new
+                        // op must drain whenever the device is online, even while the firehose is down (its
+                        // reconnect loop, an outage, etc.). Gating on SSE-Connected silently stranded
+                        // playback progress + edits whenever the firehose wasn't up. When offline we skip
+                        // the drain so the op's retry budget isn't burned against an unreachable server;
+                        // the connection-up trigger + reconnection supervisor recover it on the next edge.
+                        .filter { networkMonitor.isOnline() }
                         .collect { runDrain() }
                 }
             ready.await()
@@ -840,4 +858,17 @@ internal class SyncEngine(
         // edge, wasteful at 1 Hz. force = true (reconnect, LibraryDataChanged) bypasses it.
         const val LIFECYCLE_RECONCILE_MIN_INTERVAL_MS = 30_000L
     }
+}
+
+/**
+ * Fallback [NetworkMonitor] that always reports online. Defaults [SyncEngine]'s monitor so unit tests
+ * that don't exercise offline gating need no change; production always wires the live platform
+ * monitor via Koin.
+ */
+private object AlwaysOnlineNetworkMonitor : NetworkMonitor {
+    override fun isOnline(): Boolean = true
+
+    override val isOnlineFlow: StateFlow<Boolean> = MutableStateFlow(true)
+
+    override val isOnUnmeteredNetworkFlow: StateFlow<Boolean> = MutableStateFlow(true)
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -273,6 +273,9 @@ internal val clientSyncModule =
                 dispatcher = get(),
                 presenceRefreshSignal = get(),
                 scope = get(qualifier = named(APP_SCOPE)),
+                // Outbox liveness rides device reachability, not the SSE firehose — so local-first writes
+                // push over RPC even while the firehose is down.
+                networkMonitor = get(),
                 // The refreshed tier's router — the lifecycle-reconcile pass re-runs every refreshed
                 // domain's refresh through it so a dropped refresh trigger self-heals on the next
                 // foreground/reconnect edge (Plan §6a).

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionCoordinatorTest.kt
@@ -30,10 +30,18 @@ import kotlinx.coroutines.test.advanceUntilIdle
 class ConnectionCoordinatorTest :
     FunSpec({
         class FakeInvalidator : RpcCacheInvalidator {
-            var count = 0
+            /** Full sweeps (incl. streaming client) — the URL/identity-change path. */
+            var allCount = 0
+
+            /** Scoped sweeps (sparing streaming client) — the firehose-reconnect path. */
+            var requestOnlyCount = 0
 
             override suspend fun invalidateAll() {
-                count++
+                allCount++
+            }
+
+            override suspend fun invalidateRequestCaches() {
+                requestOnlyCount++
             }
         }
 
@@ -254,7 +262,7 @@ class ConnectionCoordinatorTest :
             verifySuspend { instance.findReachableUrl(any()) }
         }
 
-        test("a firehose reconnect invalidates stale RPC proxy caches, but the initial connect does not") {
+        test("a firehose reconnect sweeps stale RPC proxies WITHOUT closing the streaming client, but the initial connect does not") {
             val scope = TestScope(StandardTestDispatcher())
             val online = MutableStateFlow(true)
             val invalidator = FakeInvalidator()
@@ -291,17 +299,23 @@ class ConnectionCoordinatorTest :
             // Initial connect: no stale proxies yet → no sweep.
             engineState.setConnection(ConnectionState.Connected(lastEventId = null))
             scope.testScheduler.advanceUntilIdle()
-            invalidator.count shouldBe 0
+            invalidator.requestOnlyCount shouldBe 0
+            invalidator.allCount shouldBe 0
 
             // Drop, then reconnect to the same server: the cached proxies are now bound to a dead
             // RpcClient and must be swept so the next RPC call rebinds.
             engineState.setConnection(ConnectionState.Disconnected(reason = "network blip"))
             scope.testScheduler.advanceUntilIdle()
-            invalidator.count shouldBe 0
+            invalidator.requestOnlyCount shouldBe 0
+            invalidator.allCount shouldBe 0
 
             engineState.setConnection(ConnectionState.Connected(lastEventId = 7L))
             scope.testScheduler.advanceUntilIdle()
-            invalidator.count shouldBe 1
+            // Reconnect must use the SCOPED sweep — closing the streaming client here would abort the
+            // very SSE read whose reconnect triggered this, spinning a self-teardown loop. So the
+            // request-only path fires and the full (streaming-closing) path must NOT.
+            invalidator.requestOnlyCount shouldBe 1
+            invalidator.allCount shouldBe 0
         }
 
         test("invalidates when the active URL host changes") {
@@ -328,10 +342,13 @@ class ConnectionCoordinatorTest :
                 }
             ConnectionCoordinator(serverConfig, instance, idleDiscovery(), networkMonitor, invalidator, scope).start()
             scope.testScheduler.advanceUntilIdle()
-            invalidator.count shouldBe 0
+            invalidator.allCount shouldBe 0
 
             active.value = ServerUrl(remote)
             scope.testScheduler.advanceUntilIdle()
-            invalidator.count shouldBe 1
+            // A genuine host change SHOULD rebuild the streaming client (it must point at the new URL),
+            // so the FULL sweep fires here — not the scoped one.
+            invalidator.allCount shouldBe 1
+            invalidator.requestOnlyCount shouldBe 0
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactoryStreamingCacheTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactoryStreamingCacheTest.kt
@@ -1,0 +1,69 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.ServerUrl
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the streaming-client lifecycle that keeps the SSE firehose alive across a reconnect sweep.
+ *
+ * [ApiClientFactory.invalidateRequestClientOnly] must drop the request client (so RPC proxies
+ * rebind) while leaving the cached streaming client untouched — closing it would abort the very SSE
+ * read whose reconnect triggered the sweep, spinning a self-teardown loop. The full [ApiClientFactory.invalidate]
+ * (URL/identity change) still rebuilds everything, streaming included.
+ */
+class ApiClientFactoryStreamingCacheTest :
+    FunSpec({
+
+        fun factory(): KtorApiClientFactory {
+            val serverConfig =
+                mock<ServerConfig> {
+                    everySuspend { getActiveUrl() } returns ServerUrl("https://server.example.com")
+                }
+            // MockEngine backs the request client; the streaming client builds its real (idle) engine.
+            // No request is ever issued, so the handler is never invoked.
+            val engine = MockEngine { respondOk() }
+            return KtorApiClientFactory(
+                serverConfig = serverConfig,
+                authSession = mock<AuthSession>(),
+                refreshAccessToken = { error("token refresh not used") },
+                engine = engine,
+            )
+        }
+
+        test("invalidateRequestClientOnly rebuilds the request client but preserves the streaming client") {
+            runTest {
+                val factory = factory()
+                val streaming1 = factory.getStreamingClient()
+                val request1 = factory.getClient()
+
+                factory.invalidateRequestClientOnly()
+
+                // The streaming client — the one the SSE firehose rides — is the SAME instance.
+                factory.getStreamingClient() shouldBeSameInstanceAs streaming1
+                // The request client was dropped, so a fresh one is built.
+                factory.getClient() shouldNotBeSameInstanceAs request1
+            }
+        }
+
+        test("full invalidate rebuilds the streaming client too") {
+            runTest {
+                val factory = factory()
+                val streaming1 = factory.getStreamingClient()
+
+                factory.invalidate()
+
+                // A genuine URL/identity change must repoint the streaming client — new instance.
+                factory.getStreamingClient() shouldNotBeSameInstanceAs streaming1
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcCacheInvalidatorTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcCacheInvalidatorTest.kt
@@ -1,0 +1,81 @@
+package com.calypsan.listenup.client.data.remote
+
+import io.ktor.client.HttpClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins how [DefaultRpcCacheInvalidator] dispatches its two sweeps:
+ *
+ *  - [RpcCacheInvalidator.invalidateAll] drops EVERY cache with a full [RemoteCache.invalidate] —
+ *    including the [ApiClientFactory]'s streaming client. Correct for a URL/identity change.
+ *  - [RpcCacheInvalidator.invalidateRequestCaches] drops the RPC proxy caches with a full
+ *    `invalidate()` but routes the [ApiClientFactory] through the scoped
+ *    [ApiClientFactory.invalidateRequestClientOnly] so the SSE streaming client survives — the fix
+ *    for the firehose self-teardown loop.
+ */
+class RpcCacheInvalidatorTest :
+    FunSpec({
+
+        /** Records which invalidation entry point was hit, without touching a real HttpClient. */
+        class RecordingApiClientFactory : ApiClientFactory {
+            var fullInvalidations = 0
+            var requestOnlyInvalidations = 0
+
+            override suspend fun getClient(): HttpClient = error("not used")
+
+            override suspend fun getStreamingClient(): HttpClient = error("not used")
+
+            override suspend fun getUnauthenticatedStreamingClient(): HttpClient = error("not used")
+
+            override suspend fun warmUp() = Unit
+
+            override suspend fun invalidate() {
+                fullInvalidations++
+            }
+
+            override suspend fun invalidateRequestClientOnly() {
+                requestOnlyInvalidations++
+            }
+        }
+
+        class RecordingRpcCache : RemoteCache {
+            var invalidations = 0
+
+            override suspend fun invalidate() {
+                invalidations++
+            }
+        }
+
+        test("invalidateAll closes the streaming client (full invalidate) on the ApiClientFactory") {
+            runTest {
+                val apiClient = RecordingApiClientFactory()
+                val rpcCache = RecordingRpcCache()
+                val invalidator = DefaultRpcCacheInvalidator(caches = listOf(apiClient, rpcCache))
+
+                invalidator.invalidateAll()
+
+                apiClient.fullInvalidations shouldBe 1
+                apiClient.requestOnlyInvalidations shouldBe 0
+                rpcCache.invalidations shouldBe 1
+            }
+        }
+
+        test("invalidateRequestCaches spares the streaming client but still sweeps RPC proxy caches") {
+            runTest {
+                val apiClient = RecordingApiClientFactory()
+                val rpcCache = RecordingRpcCache()
+                val invalidator = DefaultRpcCacheInvalidator(caches = listOf(apiClient, rpcCache))
+
+                invalidator.invalidateRequestCaches()
+
+                // ApiClientFactory takes the scoped path — the streaming client is NOT closed.
+                apiClient.requestOnlyInvalidations shouldBe 1
+                apiClient.fullInvalidations shouldBe 0
+                // Every other RemoteCache (the RPC proxy caches) still gets a full invalidate so the
+                // next RPC call rebinds to the live connection.
+                rpcCache.invalidations shouldBe 1
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AdminRepositoryImplUserTest.kt
@@ -268,7 +268,16 @@ class AdminRepositoryImplUserTest :
                     libraryAdminRpc = mock(),
                     serverConfig = mock<com.calypsan.listenup.client.domain.repository.ServerConfig>(),
                     adminUserRosterDao = mock(),
-                    rpcCacheInvalidator = { invalidations++ },
+                    rpcCacheInvalidator =
+                        object : com.calypsan.listenup.client.data.remote.RpcCacheInvalidator {
+                            override suspend fun invalidateAll() {
+                                invalidations++
+                            }
+
+                            override suspend fun invalidateRequestCaches() {
+                                invalidations++
+                            }
+                        },
                 )
 
             (repo.getUsers() is AppResult.Failure) shouldBe true

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BackupRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BackupRepositoryImplTest.kt
@@ -110,6 +110,8 @@ class BackupRepositoryImplTest :
             override suspend fun warmUp() = Unit
 
             override suspend fun invalidate() = Unit
+
+            override suspend fun invalidateRequestClientOnly() = Unit
         }
 
         /**
@@ -135,6 +137,8 @@ class BackupRepositoryImplTest :
             override suspend fun warmUp() = Unit
 
             override suspend fun invalidate() = Unit
+
+            override suspend fun invalidateRequestClientOnly() = Unit
         }
 
         fun buildRepo(service: BackupService): BackupRepositoryImpl =

--- a/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.jvm.kt
+++ b/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.jvm.kt
@@ -15,6 +15,9 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.time.Duration.Companion.seconds
 
+/** Finite connect timeout for streaming clients — a dead-server connect fails fast instead of hanging ~2min. */
+private const val STREAMING_CONNECT_TIMEOUT_SECONDS = 10
+
 /**
  * JVM desktop implementation of streaming HTTP client factory.
  *
@@ -36,8 +39,10 @@ internal actual suspend fun createStreamingHttpClient(
         // Configure OkHttp engine with infinite timeouts for streaming
         engine {
             config {
-                // 0 = infinite timeout in OkHttp
-                connectTimeout(0.seconds)
+                // Finite CONNECT timeout so a failed connect fails fast (~10s) instead of hanging on
+                // OkHttp's default while a dead server is retried; read/write stay infinite (0 =
+                // infinite) because an SSE stream holds the connection open indefinitely.
+                connectTimeout(STREAMING_CONNECT_TIMEOUT_SECONDS.seconds)
                 readTimeout(0.seconds)
                 writeTimeout(0.seconds)
             }
@@ -93,8 +98,10 @@ internal actual fun createUnauthenticatedStreamingHttpClient(serverUrl: ServerUr
         // Configure OkHttp engine with infinite timeouts for streaming
         engine {
             config {
-                // 0 = infinite timeout in OkHttp
-                connectTimeout(0.seconds)
+                // Finite CONNECT timeout so a failed connect fails fast (~10s) instead of hanging on
+                // OkHttp's default while a dead server is retried; read/write stay infinite (0 =
+                // infinite) because an SSE stream holds the connection open indefinitely.
+                connectTimeout(STREAMING_CONNECT_TIMEOUT_SECONDS.seconds)
                 readTimeout(0.seconds)
                 writeTimeout(0.seconds)
             }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PendingQueueDrainSchedulingTest.kt
@@ -267,6 +267,91 @@ class PendingQueueDrainSchedulingTest :
             }
         }
 
+        test("an op enqueued while the SSE firehose is DOWN still drains when the device is online") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val sent = MutableSharedFlow<String>(replay = 64)
+                    val sender =
+                        PendingOperationSender { op ->
+                            sent.tryEmit(op.clientOpId)
+                            AppResult.Success(Unit)
+                        }
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                        )
+                    val state = SyncEngineState()
+                    // Firehose never connects; the outbox rides the RPC/request transport, which is up.
+                    val sse = NeverConnectingSseClient(state)
+                    val engine =
+                        buildEngine(db, queue, state, sse, scope, networkMonitor = FakeNetworkMonitor(online = true))
+
+                    engine.start(currentUserId = "u1")
+
+                    // The firehose is observably NOT connected — proving the drain is not riding an SSE
+                    // Connected edge. Playback progress etc. must still push over RPC.
+                    (state.value.connection is ConnectionState.Connected) shouldBe false
+
+                    val opId = queue.enqueue(tagsChannel, "t-offline-sse", OpKind.Upsert, "{}", "u1")
+
+                    withTimeout(TIMEOUT_SECONDS.seconds) {
+                        sent.first { it == opId }
+                    }
+                    db.pendingOperationV2Dao().get(opId) shouldBe null
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
+        test("an op enqueued while the device is OFFLINE does not drain (retry budget preserved)") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val db = createInMemoryTestDatabase()
+                try {
+                    val attempts = AtomicInteger(0)
+                    val sender =
+                        PendingOperationSender { _ ->
+                            attempts.incrementAndGet()
+                            AppResult.Failure(TransportError.NetworkUnavailable())
+                        }
+                    val queue =
+                        PendingOperationQueue(
+                            dao = db.pendingOperationV2Dao(),
+                            sender = sender,
+                        )
+                    val state = SyncEngineState()
+                    val sse = NeverConnectingSseClient(state)
+                    // Device offline: draining now would only burn the op's retry budget against an
+                    // unreachable server — the outbox must hold until connectivity returns.
+                    val engine =
+                        buildEngine(db, queue, state, sse, scope, networkMonitor = FakeNetworkMonitor(online = false))
+
+                    engine.start(currentUserId = "u1")
+
+                    val opId = queue.enqueue(tagsChannel, "t-offline", OpKind.Upsert, "{}", "u1")
+
+                    // Give the engine ample time to (wrongly) attempt a drain.
+                    delay(POLL_DELAY_MILLIS * 10)
+
+                    attempts.get() shouldBe 0
+                    // The op is still queued, its retry budget untouched, ready for the next online edge.
+                    db.pendingOperationV2Dao().get(opId)?.failureCount shouldBe 0
+                } finally {
+                    scope.cancel()
+                    scope.coroutineContext.job.children
+                        .forEach { it.join() }
+                    db.close()
+                }
+            }
+        }
+
         test("a multi-op backlog for one entity fully drains after a single Connected transition") {
             runBlocking {
                 val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -313,6 +398,7 @@ private fun buildEngine(
     sse: SseClient,
     scope: CoroutineScope,
     retryBackoffMillis: Long = 1_000L,
+    networkMonitor: com.calypsan.listenup.client.domain.repository.NetworkMonitor = FakeNetworkMonitor(online = true),
 ): SyncEngine {
     val registry = ClientSyncDomainRegistry()
     registry.register(NoopTagHandler)
@@ -335,8 +421,47 @@ private fun buildEngine(
         dispatcher = dispatcher,
         presenceRefreshSignal = PresenceRefreshSignal(),
         scope = scope,
+        networkMonitor = networkMonitor,
         retryBackoffMillis = retryBackoffMillis,
     )
+}
+
+/** [NetworkMonitor] whose online state is fixed for the lifetime of a test. */
+private class FakeNetworkMonitor(
+    private val online: Boolean,
+) : com.calypsan.listenup.client.domain.repository.NetworkMonitor {
+    override fun isOnline(): Boolean = online
+
+    override val isOnlineFlow = kotlinx.coroutines.flow.MutableStateFlow(online)
+    override val isOnUnmeteredNetworkFlow = kotlinx.coroutines.flow.MutableStateFlow(online)
+}
+
+/**
+ * SSE client that NEVER reaches [ConnectionState.Connected] — `connect()` leaves the firehose
+ * Disconnected. Models the outage the fix targets: the firehose is down, but the RPC/request
+ * transport the outbox rides is healthy.
+ */
+private class NeverConnectingSseClient(
+    private val state: SyncEngineState,
+) : SseClient {
+    private val flow = MutableSharedFlow<ParsedSseFrame>()
+    override val frames: SharedFlow<ParsedSseFrame> = flow.asSharedFlow()
+
+    override fun seedLastEventId(initial: Long?) = Unit
+
+    override fun connect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "firehose down"))
+    }
+
+    override fun disconnect() {
+        state.setConnection(ConnectionState.Disconnected(reason = "firehose down"))
+    }
+
+    override fun currentLastEventId(): Long? = null
+
+    override suspend fun reseed(newLastEventId: Long?) = Unit
+
+    override fun reconnectNow() = Unit
 }
 
 private object NoopCatchUp : CatchUp {


### PR DESCRIPTION
## The ghost: live sync never propagated — and playback progress was silently not saving

Diagnosed on a real device (clean server + clean install) via logcat, then confirmed in code. Two coupled defects the in-process E2Es can't surface (they never exercise the real streaming transport).

### 1. SSE firehose self-teardown loop (why adds/removes didn't propagate)
`ConnectionCoordinator.observeFirehoseReconnect` fires on every firehose **reconnect** and calls `invalidator.invalidateAll()` to refresh stale RPC proxies — but `invalidateAll()` → `ApiClientFactory.invalidate()` also closes `cachedStreamingClient`, **the exact HTTP client the SSE firehose is riding**. So a reconnect closed the connection out from under itself → `ClosedByteChannelException: Software caused connection abort` → reconnect → sweep → abort → **infinite loop; the firehose never stayed up → no live events.** (It also defeated the deliberate streaming-client caching.)

**Fix — scoped invalidation:** added `ApiClientFactory.invalidateRequestClientOnly()` (closes the request client, leaves the streaming clients open) and split `RpcCacheInvalidator` into `invalidateAll()` (full, incl. streaming — kept for genuine URL/host changes) vs `invalidateRequestCaches()`. The firehose-reconnect sweep now uses the request-only path, so RPC proxies still rebind while the SSE stream survives.

### 2. Outbox gated on SSE (silently losing playback progress — cardinal-rule violation)
The outbox drain trigger filtered on `ConnectionState.Connected`, which is set **only** by `SyncSseClient`. So while the firehose was down, playback positions / listening events / offline edits / profile+preference patches **never pushed — even though the RPC channel they ride was healthy.** That silently loses the user's position.

**Fix:** the outbox now drains whenever the device is **online** (via `NetworkMonitor`), independent of the inbound SSE state. Deliberately *not* a blanket un-gate — draining while genuinely offline would burn the op's retry budget into dead-letter; the network gate drains online-but-SSE-down (the fix) and holds when offline.

### 3. Finite connect timeout
Streaming client `connectTimeout(0)` (infinite → ~2min hangs on a bad connect) → **10s** on Android/JVM (read/write stay infinite for SSE). Darwin deferred (URLSession has no separate connect timeout).

**Decision (from investigation):** keep SSE, do **not** migrate to RPC — the transport was fine; the coordinator was sabotaging it, and web/HTMX rides SSE. Deferred fast-follows: SSE idle-watchdog, SSE URL-fallback, decouple `ServerReachability` from SSE, Darwin connect timeout.

## Test Plan
- [x] `ConnectionCoordinatorTest`: a firehose **reconnect** invalidates request-only (streaming survives); a **host change** still full-invalidates. RED observed first.
- [x] `ApiClientFactoryStreamingCacheTest`: `invalidateRequestClientOnly` preserves the streaming client instance; full `invalidate` rebuilds it.
- [x] `RpcCacheInvalidatorTest`: request-caches path routes ApiClientFactory to request-only while still sweeping RPC proxies.
- [x] `PendingQueueDrainSchedulingTest`: op enqueued while **SSE down but online** drains (RED first); op enqueued while **offline** does not (retry budget preserved).
- [x] Full Linux `verifyLocal` green (spotless + detekt + all JVM tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)