### PR TITLE
🔒 fix(server): enforce All Books exclusivity — curating a book removes it from the everyone-collection

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookAccessPolicy.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookAccessPolicy.kt
@@ -26,9 +26,12 @@ import com.calypsan.listenup.server.sync.bindRaw
  * collection at all is denied. ROOT and ADMIN bypass the filter entirely — every live book,
  * including inbox and private ones.
  *
- * Public visibility is now expressed structurally: every member holds a default `ALL_BOOKS`
- * grant and every scanned book joins `ALL_BOOKS`, so the union rule reaches the same set the
- * old "uncollected = public" branch used to — without the special case.
+ * Public visibility is expressed structurally: every member holds a default `ALL_BOOKS` grant and
+ * every **uncollected** book sits in `ALL_BOOKS`. `ALL_BOOKS` is **exclusive** — a book leaves it
+ * the moment it is curated into a real collection and returns when its last real membership is
+ * removed (the invariant maintained by `CollectionServiceImpl.reconcileSystemMembership`). So the
+ * pure-union rule reaches exactly the set the old "uncollected = public" branch used to — a curated
+ * book is visible only to its collection's audience, not to everyone — without the special case.
  *
  * **System collections and book-level visibility:** `ALL_BOOKS` and `INBOX` are
  * server-managed substrate collections. They are excluded from the COLLECTION-domain sync

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -177,7 +177,15 @@ internal class CollectionServiceImpl(
         // a suspend repo call that opens its own SQLDelight transaction, so they run sequentially
         // (they cannot nest inside a non-suspend SQLDelight transaction body). Sequential
         // single-engine writes never contend for the lone SQLite write lock.
+        // Capture the live members BEFORE the cascade so we can re-home any book that loses its
+        // last real membership: deleting a collection must never strand a book with zero memberships.
+        val affectedBookIds = collectionBookRepo.findBookIdsForCollection(id.value)
         collectionBookRepo.softDeleteAllForCollection(id.value)
+        // A book whose only membership was this collection returns to ALL_BOOKS (reconcile bumps
+        // its revision + nudges ALL_BOOKS grant-holders so members re-derive the now-public book).
+        for (bookId in affectedBookIds) {
+            reconcileSystemMembership(bookId)
+        }
         for (grant in grantRepo.listActiveGrantsForCollection(id.value)) {
             grantRepo.softDelete(grant.id)
         }
@@ -211,6 +219,12 @@ internal class CollectionServiceImpl(
                 // Bump the book's revision so each member's incremental `revision > cursor` pull
                 // re-delivers the now-visible book — the access nudge alone never carries the row.
                 bookRevisionTouch.touchRevision(bookId)
+                // First real membership ⇒ the book leaves the everyone-visible ALL_BOOKS substrate.
+                // Adding directly to a system collection (ALL_BOOKS/INBOX) is a managed action, not
+                // reconciled — reconcile there would immediately undo the deliberate placement.
+                if (id.value !in collectionRepo.systemCollectionIds()) {
+                    reconcileSystemMembership(bookId.value)
+                }
                 AppResult.Success(Unit)
             }
 
@@ -237,6 +251,8 @@ internal class CollectionServiceImpl(
         // Bump the book's revision so each member's incremental `revision > cursor` pull re-evaluates
         // its now-changed visibility and prunes it when no access path remains.
         bookRevisionTouch.touchRevision(bookId)
+        // Removing the last real membership ⇒ the book returns to ALL_BOOKS (never stranded).
+        reconcileSystemMembership(bookId.value)
         return AppResult.Success(Unit)
     }
 
@@ -249,9 +265,10 @@ internal class CollectionServiceImpl(
 
         if (!bookExists(bookId.value)) return AppResult.Failure(CollectionError.BookNotFound())
 
-        // System collections (ALL_BOOKS, INBOX) are managed by the server — setBookCollections must
-        // never add or remove them. Exclude system ids from both sides of the diff so only NORMAL
-        // collection memberships are affected by this replace-set operation.
+        // System collections (ALL_BOOKS, INBOX) are server-managed — a client must never NAME one
+        // as a target. Exclude system ids from the caller-supplied set and from the diff so this
+        // replace-set only touches NORMAL memberships; ALL_BOOKS is then maintained by
+        // reconcileSystemMembership below (derived from the resulting real set), never named here.
         val systemIds = collectionRepo.systemCollectionIds()
 
         // Validate every distinct target up front — exists and live — before mutating:
@@ -294,6 +311,10 @@ internal class CollectionServiceImpl(
         if (added.isNotEmpty() || removed.isNotEmpty()) {
             bookRevisionTouch.touchRevision(bookId)
         }
+        // Derive ALL_BOOKS from the resulting real set: in ALL_BOOKS iff no real membership remains
+        // (and not held in INBOX). This drops a curated book out of the everyone-collection (the
+        // #680/#730 leak) and re-homes an empty target set into ALL_BOOKS instead of orphaning it.
+        reconcileSystemMembership(bookId.value)
         return AppResult.Success(Unit)
     }
 
@@ -587,20 +608,70 @@ internal class CollectionServiceImpl(
         for (bookId in assignments.keys) {
             bookRevisionTouch.touchRevision(BookId(bookId))
         }
+        // Maintain exclusivity from the post-release set: a book released into explicit targets must
+        // not linger in ALL_BOOKS (defensive tombstone of any stale junction); one released unsorted
+        // stays in ALL_BOOKS (the fallback added above). reconcile derives both.
+        for (bookId in assignments.keys) {
+            reconcileSystemMembership(bookId)
+        }
         return AppResult.Success(Unit)
     }
 
     /**
-     * Publishes a per-user [SyncControl.AccessChanged] nudge to every enumerable user whose
-     * visibility may have shifted because the membership of [collectionIds] changed — each
-     * collection's owner plus its active-share recipients. The single emission contract shared
-     * by every visibility-mutating method (add/remove book, [setBookCollections], [releaseBooks]).
+     * Enforces the exclusivity invariant between the everyone-visible ALL_BOOKS substrate and
+     * every regular collection: a book is in ALL_BOOKS **iff** it belongs to no other (non-system)
+     * collection and is not held in INBOX. Called after any junction mutation.
      *
-     * A nudged member re-derives their view and prunes any book they can no longer reach — the
-     * gated-out book/junction sync events alone would never tell them. Admins see everything, so
-     * they need no signal; the non-enumerable public↔private "everyone" edge converges on the next
-     * firehose catch-up (the documented 1b behavior).
+     * Derives the book's live memberships, then:
+     *  - `real.isEmpty() && !held` → ensures a live ALL_BOOKS junction via
+     *    [CollectionBookRepository.upsert], which **resurrects** a tombstoned row — unlike the
+     *    insert-only `writeSystemMembership`, which would skip an existing/tombstoned junction.
+     *  - otherwise → tombstones the live ALL_BOOKS junction if present.
+     *
+     * Only when ALL_BOOKS membership actually flips does it nudge that collection's grant-holders
+     * (every member holds a default ALL_BOOKS grant) and bump the book's revision, so each member
+     * re-derives their view and the visibility delta converges. Idempotent: a no-op flip emits
+     * nothing.
      */
+    private suspend fun reconcileSystemMembership(bookId: String) {
+        val libraryId = bookLibraryId(bookId) ?: return
+        val systemIds = collectionRepo.systemCollectionIds()
+        val liveMemberships = collectionBookRepo.findCollectionIdsForBook(bookId).toSet()
+        val real = liveMemberships - systemIds
+        val inboxId = collectionRepo.findInboxForLibrary(libraryId)?.id
+        val held = inboxId != null && inboxId in liveMemberships
+        val allBooksId = collectionRepo.findSystemCollection(libraryId, SYSTEM_TYPE_ALL_BOOKS)?.id
+        val allBooksLive = allBooksId != null && allBooksId in liveMemberships
+
+        if (real.isEmpty() && !held) {
+            if (allBooksLive) return
+            val id =
+                allBooksId
+                    ?: getOrCreateSystemCollection(libraryId, SystemCollectionType.ALL_BOOKS)
+                        .getOrElse { return }
+                        .id.value
+            collectionBookRepo.upsert(
+                CollectionBookSyncPayload(
+                    collectionId = id,
+                    bookId = bookId,
+                    createdAt = clock.now().toEpochMilliseconds(),
+                    revision = 0L,
+                    deletedAt = null,
+                ),
+            )
+            notifyAccessChanged(listOf(id))
+            bookRevisionTouch.touchRevision(BookId(bookId))
+        } else if (allBooksLive) {
+            collectionBookRepo.softDelete(collectionId = allBooksId!!, bookId = bookId)
+            notifyAccessChanged(listOf(allBooksId))
+            bookRevisionTouch.touchRevision(BookId(bookId))
+        }
+    }
+
+    /** The `books.library_id` for [bookId], or null when the book is absent — resolves its system collections. */
+    private suspend fun bookLibraryId(bookId: String): String? =
+        suspendTransaction(sql) { sql.booksQueries.selectLibraryIdById(bookId).executeAsOneOrNull() }
+
     private suspend fun notifyAccessChanged(collectionIds: Collection<String>) {
         val affectedUserIds =
             collectionIds
@@ -610,6 +681,9 @@ internal class CollectionServiceImpl(
                     if (owner != null) shareUsers + owner else shareUsers
                 }.toSet()
         for (affectedUserId in affectedUserIds) {
+            // The ALL_BOOKS/INBOX sentinel owner is not a real client — nudging it is pure noise.
+            // (ALL_BOOKS reaches its real audience via the per-member default grants enumerated above.)
+            if (affectedUserId == SYSTEM_OWNER_ID) continue
             bus.publishControl(SyncControl.AccessChanged, affectedUserId)
         }
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/SystemCollectionType.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/SystemCollectionType.kt
@@ -20,8 +20,10 @@ internal const val SYSTEM_OWNER_ID = "system"
  *
  * Identified by the server-only `collections.type` column (never on the wire). Member-facing
  * sync uses [com.calypsan.listenup.api.sync.CollectionSyncPayload.isInbox] / the access layer;
- * `type` is a server-internal discriminator that distinguishes the always-everything [ALL_BOOKS]
- * view from the quarantine [INBOX]. The enum name is the persisted column value.
+ * `type` is a server-internal discriminator that distinguishes the [ALL_BOOKS] substrate — the
+ * exclusive everyone-collection that holds a book **iff** it is in no other (non-system) collection —
+ * from the quarantine [INBOX]. Both are exclusive with regular collections. The enum name is the
+ * persisted column value.
  */
 internal enum class SystemCollectionType {
     ALL_BOOKS,

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Books.sq
@@ -272,6 +272,11 @@ SELECT EXISTS(SELECT 1 FROM books WHERE id = :id);
 existsLiveById:
 SELECT EXISTS(SELECT 1 FROM books WHERE id = :id AND deleted_at IS NULL);
 
+-- library_id for a single book — resolves the book's per-library system collections
+-- (ALL_BOOKS / INBOX) when reconciling its exclusive system-collection membership.
+selectLibraryIdById:
+SELECT library_id FROM books WHERE id = :id;
+
 -- (id, title) for a batch of LIVE books — the ShelfReadAssembler view projection.
 -- A tombstoned book yields no row, so it never appears in a shelf view.
 selectLiveTitlesByIds:

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessModelExclusivityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessModelExclusivityTest.kt
@@ -1,0 +1,381 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.CollectionId
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.UserPermissionPolicy
+import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.db.UserRoleColumn
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionGrantRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
+import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Enforces the definitive access model's exclusivity invariant (regression from #680/#730):
+ * **a book is in ALL_BOOKS IFF it belongs to no other (non-system) collection.** Curating a
+ * book into a real collection must remove it from the everyone-visible ALL_BOOKS substrate;
+ * removing its last real membership must return it.
+ *
+ * These tests drive the real [CollectionServiceImpl] over a real Flyway-migrated in-memory
+ * SQLite db and assert visibility through the real [BookAccessPolicy] — the money-shot proves
+ * a curated-out book is denied to a non-member who only holds the default ALL_BOOKS grant.
+ */
+class CollectionAccessModelExclusivityTest :
+    FunSpec({
+
+        val fixedClock = FixedClock(Instant.fromEpochMilliseconds(1_700_000_000_000L))
+
+        fun principalFor(
+            userId: String,
+            role: UserRole = UserRole.MEMBER,
+        ): PrincipalProvider =
+            PrincipalProvider {
+                UserPrincipal(UserId(userId), SessionId("session-$userId"), role)
+            }
+
+        data class Harness(
+            val service: CollectionServiceImpl,
+            val collectionRepo: CollectionRepository,
+            val collectionBookRepo: CollectionBookRepository,
+            val grantRepo: CollectionGrantRepository,
+            val bookAccessPolicy: BookAccessPolicy,
+        )
+
+        fun makeHarness(db: SqlTestDatabases): Harness {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val collectionRepo = CollectionRepository(db = db.sql, bus = bus, registry = registry, driver = db.driver)
+            val collectionBookRepo =
+                CollectionBookRepository(db = db.sql, bus = bus, registry = registry, driver = db.driver)
+            val grantRepo = CollectionGrantRepository(db = db.sql, bus = bus, registry = registry, driver = db.driver)
+            val accessPolicy = CollectionAccessPolicy(collectionRepo, grantRepo)
+            val service =
+                CollectionServiceImpl(
+                    collectionRepo = collectionRepo,
+                    collectionBookRepo = collectionBookRepo,
+                    grantRepo = grantRepo,
+                    accessPolicy = accessPolicy,
+                    bus = bus,
+                    sql = db.sql,
+                    clock = fixedClock,
+                    permissionPolicy = UserPermissionPolicy(db.sql),
+                    bookRevisionTouch = FakeBookRevisionTouch(),
+                    principal = principalFor("admin", UserRole.ADMIN),
+                )
+            return Harness(service, collectionRepo, collectionBookRepo, grantRepo, BookAccessPolicy(db.sql, db.driver))
+        }
+
+        fun CollectionServiceImpl.actAs(
+            userId: String,
+            role: UserRole = UserRole.MEMBER,
+        ): CollectionServiceImpl = copyWith(principalFor(userId, role))
+
+        /** Grants [userId] the default ALL_BOOKS grant every member holds at registration. */
+        suspend fun Harness.grantAllBooks(
+            allBooksId: String,
+            userId: String,
+        ) {
+            grantRepo.upsert(
+                CollectionShareSyncPayload(
+                    id = "grant-$allBooksId-$userId",
+                    collectionId = allBooksId,
+                    sharedWithUserId = userId,
+                    sharedByUserId = "system",
+                    permission = SharePermission.Read,
+                    revision = 0L,
+                    updatedAt = 0L,
+                    deletedAt = null,
+                ),
+            )
+        }
+
+        /** The live (non-system-excluded) collection ids the book currently belongs to. */
+        suspend fun Harness.liveMemberships(bookId: String): Set<String> = collectionBookRepo.findCollectionIdsForBook(bookId).toSet()
+
+        test("adding a book to a real collection removes it from ALL_BOOKS; removing the last returns it") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestBook("B")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B")) shouldBe AppResult.Success(Unit)
+                    h.liveMemberships("B") shouldContain allBooksId
+
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+
+                    // First real membership ⇒ auto-LEAVE ALL_BOOKS.
+                    admin.addBookToCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
+                    h.liveMemberships("B").let {
+                        it shouldContain c.data.id.value
+                        it shouldNotContain allBooksId
+                    }
+
+                    // Last real membership removed ⇒ auto-RETURN to ALL_BOOKS.
+                    admin.removeBookFromCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
+                    h.liveMemberships("B").let {
+                        it shouldContain allBooksId
+                        it shouldNotContain c.data.id.value
+                    }
+                }
+            }
+        }
+
+        test("setBookCollections([x]) leaves ALL_BOOKS; setBookCollections([]) returns to ALL_BOOKS") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestBook("B")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+
+                    admin.setBookCollections(BookId("B"), listOf(c.data.id)) shouldBe AppResult.Success(Unit)
+                    h.liveMemberships("B").let {
+                        it shouldContain c.data.id.value
+                        it shouldNotContain allBooksId
+                    }
+
+                    // Empty target set: the book must NOT be orphaned — it returns to ALL_BOOKS.
+                    admin.setBookCollections(BookId("B"), emptyList()) shouldBe AppResult.Success(Unit)
+                    h.liveMemberships("B").let {
+                        it shouldContain allBooksId
+                        it shouldNotContain c.data.id.value
+                    }
+                }
+            }
+        }
+
+        test("MONEY SHOT: curating a book out of ALL_BOOKS denies it to a non-member; removing restores access") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+                    h.grantAllBooks(allBooksId, "m")
+
+                    // Precondition: m sees B via the default ALL_BOOKS grant.
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
+
+                    // Admin curates B into a private collection C that m is NOT a member of.
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    admin.addBookToCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
+
+                    // B left ALL_BOOKS → m can no longer reach it (THIS FAILS BEFORE THE FIX).
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe false
+
+                    // Un-curate → B returns to ALL_BOOKS → m regains access.
+                    admin.removeBookFromCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
+                }
+            }
+        }
+
+        test("multi-collection union: book stays visible while any granted real membership remains") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+                    h.grantAllBooks(allBooksId, "m")
+
+                    // C1 (shared to m) and C2 (private). B ∈ C1 ∪ C2 ⇒ B leaves ALL_BOOKS.
+                    val c1 = admin.createCollection("test-library", "C1")
+                    val c2 = admin.createCollection("test-library", "C2")
+                    require(c1 is AppResult.Success)
+                    require(c2 is AppResult.Success)
+                    admin.addBookToCollection(c1.data.id, BookId("B"))
+                    admin.addBookToCollection(c2.data.id, BookId("B"))
+                    h.grantRepo.upsert(
+                        CollectionShareSyncPayload(
+                            id = "grant-c1-m",
+                            collectionId = c1.data.id.value,
+                            sharedWithUserId = "m",
+                            sharedByUserId = "admin",
+                            permission = SharePermission.Read,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    h.liveMemberships("B") shouldNotContain allBooksId
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
+
+                    // Remove C1: m loses the granted path, but B is still in C2 (not ALL_BOOKS) → invisible to m.
+                    admin.removeBookFromCollection(c1.data.id, BookId("B"))
+                    h.liveMemberships("B") shouldNotContain allBooksId
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe false
+
+                    // Remove C2 (last real membership) → B returns to ALL_BOOKS → visible to m again.
+                    admin.removeBookFromCollection(c2.data.id, BookId("B"))
+                    h.liveMemberships("B") shouldContain allBooksId
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
+                }
+            }
+        }
+
+        test("releaseBooks: released into a collection ⇒ not in INBOX, not in ALL_BOOKS; released unsorted ⇒ ALL_BOOKS only") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestBook("sorted")
+                sql.seedTestBook("unsorted")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val inbox = admin.getOrCreateInbox("test-library")
+                    require(inbox is AppResult.Success)
+                    val inboxId = inbox.data.id.value
+                    admin.addToInbox("sorted", "test-library") shouldBe AppResult.Success(Unit)
+                    admin.addToInbox("unsorted", "test-library") shouldBe AppResult.Success(Unit)
+
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+
+                    admin.releaseBooks(
+                        "test-library",
+                        mapOf("sorted" to listOf(c.data.id.value), "unsorted" to emptyList()),
+                    ) shouldBe AppResult.Success(Unit)
+
+                    val allBooksId =
+                        h.collectionRepo.findSystemCollection("test-library", SYSTEM_TYPE_ALL_BOOKS)?.id
+                            ?: error("ALL_BOOKS must exist after an unsorted release")
+
+                    h.liveMemberships("sorted").let {
+                        it shouldContain c.data.id.value
+                        it shouldNotContain inboxId
+                        it shouldNotContain allBooksId
+                    }
+                    h.liveMemberships("unsorted").let {
+                        it shouldContain allBooksId
+                        it shouldNotContain inboxId
+                    }
+                }
+            }
+        }
+
+        test("deleteCollection returns a book to ALL_BOOKS when the deleted collection was its only membership") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestBook("B")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    admin.addBookToCollection(c.data.id, BookId("B"))
+                    h.liveMemberships("B") shouldNotContain allBooksId
+
+                    // Deleting C removes B's only real membership → B must not be stranded.
+                    admin.deleteCollection(c.data.id) shouldBe AppResult.Success(Unit)
+                    h.liveMemberships("B").let {
+                        it shouldContain allBooksId
+                        it shouldNotContain c.data.id.value
+                    }
+                }
+            }
+        }
+
+        test("never-orphan: no add/remove/set/delete path ends with a book in ZERO collections") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestBook("B")
+                runTest {
+                    val h = makeHarness(db)
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    admin.addBookToCollection(allBooks.data.id, BookId("B"))
+
+                    val c1 = admin.createCollection("test-library", "C1")
+                    val c2 = admin.createCollection("test-library", "C2")
+                    require(c1 is AppResult.Success)
+                    require(c2 is AppResult.Success)
+
+                    admin.addBookToCollection(c1.data.id, BookId("B"))
+                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    admin.addBookToCollection(c2.data.id, BookId("B"))
+                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    admin.setBookCollections(BookId("B"), listOf(c2.data.id))
+                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    admin.removeBookFromCollection(c2.data.id, BookId("B"))
+                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    admin.setBookCollections(BookId("B"), emptyList())
+                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    admin.deleteCollection(c1.data.id)
+                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -141,7 +141,10 @@ class CollectionMembershipRevisionTest :
                         require(it is AppResult.Success)
                     }
 
-                    touch.touched shouldContainExactly listOf("b1")
+                    // Removing the last real membership returns the book to ALL_BOOKS (exclusivity
+                    // invariant), so its revision is bumped again by that restore — only b1 is ever
+                    // touched. `distinct` tolerates the legitimate second bump for the same book.
+                    touch.touched.distinct() shouldContainExactly listOf("b1")
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
@@ -221,7 +221,7 @@ class CollectionServiceImplSetBookCollectionsTest :
             }
         }
 
-        test("setBookCollections preserves ALL_BOOKS membership when it is not in the target set") {
+        test("setBookCollections removes ALL_BOOKS when real collections are set, and restores it on an empty set") {
             withSqlDatabase {
                 val db = this
                 sql.seedTestLibraryAndFolder()
@@ -245,23 +245,34 @@ class CollectionServiceImplSetBookCollectionsTest :
                     }
 
                     // Create a NORMAL collection and set the book's collections to [normal only].
-                    // ALL_BOOKS is deliberately NOT included in the target set.
+                    // Under the exclusivity invariant, curating the book OUT of the everyone-collection
+                    // must drop its ALL_BOOKS membership (the #680/#730 leak fix) — even though the
+                    // caller never names ALL_BOOKS in the target set.
                     val normal = admin.createCollection("test-library", "Normal")
                     require(normal is AppResult.Success)
                     val normalId = normal.data.id
 
                     admin.setBookCollections(BookId("book1"), listOf(normalId)) shouldBe AppResult.Success(Unit)
 
-                    // The book must still be in ALL_BOOKS — system memberships are never touched.
+                    // The book must have LEFT ALL_BOOKS — it now lives only in its explicit collection.
                     admin.listCollectionBooks(allBooksId).let {
+                        require(it is AppResult.Success)
+                        it.data shouldHaveSize 0
+                    }
+                    admin.listCollectionBooks(normalId).let {
                         require(it is AppResult.Success)
                         it.data shouldBe listOf(BookId("book1"))
                     }
 
-                    // The book must also be in the NORMAL collection.
-                    admin.listCollectionBooks(normalId).let {
+                    // Clearing every real membership must RETURN the book to ALL_BOOKS (never orphaned).
+                    admin.setBookCollections(BookId("book1"), emptyList()) shouldBe AppResult.Success(Unit)
+                    admin.listCollectionBooks(allBooksId).let {
                         require(it is AppResult.Success)
                         it.data shouldBe listOf(BookId("book1"))
+                    }
+                    admin.listCollectionBooks(normalId).let {
+                        require(it is AppResult.Success)
+                        it.data shouldHaveSize 0
                     }
                 }
             }


### PR DESCRIPTION
## Closes the collection access-control leak (a regression from #680/#730)

**The intended model:** collections *are* the ACL — "All Books" is an **exclusive** implicit system collection, so a book is in All Books **iff it belongs to no other real collection.** Curating a book into a collection *is* the single-step act of protecting it. This worked by construction before #680 (which had an explicit "uncollected = public" access branch); #680 moved to a materialized ALL_BOOKS collection but only wired the *join* side, and #730 sealed the last path that still removed it — so a curated book stayed reachable by every member via their default ALL_BOOKS grant.

**Fix — restore the leave/return maintenance** (no revert; implement the invariant on the current substrate). A single idempotent `reconcileSystemMembership(bookId)` runs after every membership mutation: `real = live non-system memberships`, `held = live Inbox`; if `real.isEmpty() && !held` → ensure the ALL_BOOKS junction (via `CollectionBookRepository.upsert`, which resurrects tombstones), else tombstone it; on an actual flip it `notifyAccessChanged(ALL_BOOKS)` + touches the book revision so clients converge. Wired into `addBookToCollection`, `removeBookFromCollection`, `setBookCollections`, `releaseBooks`, and the `deleteCollection` cascade (enumerate-before, reconcile-after → books whose last collection is deleted return to All Books, never stranded). Scanner insert path unchanged (already exclusive).

`BookAccessPolicy.accessibleBookIdsSql` is **not** touched — pure union is already correct under exclusive maintenance; only the stale prose in `BookAccessPolicy`/`SystemCollectionType` was updated. No migration; no data-repair sweep (nuke-and-pave in dev re-seeds correctly).

## Test Plan (TDD — 5/7 new tests failed pre-fix)
- [x] **Money-shot:** a member with only the default All Books grant is **denied** a book an admin curates into a collection they're not in; regains it when the book is removed from that collection. (Failed before fix.)
- [x] Round-trip add/remove + `setBookCollections([x])`→`([])`; multi-collection union; release-to-target (in target, not Inbox, not All Books); `deleteCollection` returns the book to All Books; never-orphan across all paths.
- [x] Flipped the old-model tests (`setBookCollections` "preserves ALL_BOOKS" → "removes it when collected"); full `verifyLocal` green (incl. the client↔server sync E2E harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)