### PR TITLE
🐛 fix(iosApp): floor activity timestamp + Android-style duration wording; bust cover cache on coverHash

### DIFF
--- a/iosApp/ListenUp/DesignSystem/Components/BookCoverImage.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/BookCoverImage.swift
@@ -24,6 +24,10 @@ struct BookCoverImage: View {
     let bookId: String?
     let coverPath: String?
     let blurHash: String?
+    /// Content hash of the current cover, folded into the image cache key so a new cover at the same
+    /// stable path/URL busts the stale entry (mirrors Android's `"$bookId:$coverHash"` Coil key).
+    /// Nil when unknown — the cache then keys on the path/URL alone, as before.
+    let coverHash: String?
     /// VoiceOver label. When nil the cover is treated as decorative and hidden from VoiceOver
     /// (an unlabeled cover is noise — meaningful covers pass a label via `CoverAccessibility.label`).
     var accessibilityLabel: String?
@@ -37,6 +41,7 @@ struct BookCoverImage: View {
         self.bookId = book.idString
         self.coverPath = book.coverPath
         self.blurHash = book.coverBlurHash
+        self.coverHash = book.coverHash
         self.accessibilityLabel = CoverAccessibility.label(title: book.title, author: book.authorNames)
     }
 
@@ -45,6 +50,7 @@ struct BookCoverImage: View {
         self.bookId = book.id
         self.coverPath = book.coverPath
         self.blurHash = book.coverBlurHash
+        self.coverHash = book.coverHash
         self.accessibilityLabel = CoverAccessibility.label(title: book.title, author: book.authorNames)
     }
 
@@ -53,22 +59,31 @@ struct BookCoverImage: View {
         self.bookId = book.idString
         self.coverPath = book.coverPath
         self.blurHash = book.coverBlurHash
+        self.coverHash = book.coverHash
         self.accessibilityLabel = CoverAccessibility.label(title: book.title, author: book.authorNames)
     }
 
     /// Direct initializer with a book id, so the authenticated server URL can resolve.
-    init(bookId: String?, coverPath: String?, blurHash: String? = nil, accessibilityLabel: String? = nil) {
+    init(
+        bookId: String?,
+        coverPath: String?,
+        blurHash: String? = nil,
+        coverHash: String? = nil,
+        accessibilityLabel: String? = nil
+    ) {
         self.bookId = bookId
         self.coverPath = coverPath
         self.blurHash = blurHash
+        self.coverHash = coverHash
         self.accessibilityLabel = accessibilityLabel
     }
 
     /// Local-only initializer (no `bookId`): renders the downloaded file or a placeholder.
-    init(coverPath: String?, blurHash: String? = nil, accessibilityLabel: String? = nil) {
+    init(coverPath: String?, blurHash: String? = nil, coverHash: String? = nil, accessibilityLabel: String? = nil) {
         self.bookId = nil
         self.coverPath = coverPath
         self.blurHash = blurHash
+        self.coverHash = coverHash
         self.accessibilityLabel = accessibilityLabel
     }
 
@@ -98,11 +113,12 @@ struct BookCoverImage: View {
                 targetMaxPixels = px
             }
         }
-        .task(id: TaskKey(bookId: bookId, coverPath: coverPath, targetPixels: targetMaxPixels)) {
+        .task(id: TaskKey(bookId: bookId, coverPath: coverPath, coverHash: coverHash, targetPixels: targetMaxPixels)) {
             guard targetMaxPixels > 0 else { return }
             request = await CoverImageRequest.book(
                 bookId: bookId,
                 coverPath: coverPath,
+                coverHash: coverHash,
                 targetPixels: targetMaxPixels
             )
         }
@@ -116,6 +132,7 @@ struct BookCoverImage: View {
     private struct TaskKey: Equatable {
         let bookId: String?
         let coverPath: String?
+        let coverHash: String?
         let targetPixels: CGFloat
     }
 

--- a/iosApp/ListenUp/DesignSystem/Components/BookRow.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/BookRow.swift
@@ -22,6 +22,9 @@ struct BookRow: Identifiable, Equatable, Hashable {
     let hasDocuments: Bool
     let coverPath: String?
     let coverBlurHash: String?
+    /// Content hash of the cover, threaded into `BookCoverImage` so a cover change busts the stale
+    /// image cache (mirrors Android). Nil when unknown.
+    let coverHash: String?
     /// Total duration in ms — for cards that show it (e.g. the contributor/series book rows).
     let duration: Int64
     /// The book's sequence within a series, when shown in a series context (e.g. Series detail).
@@ -35,6 +38,7 @@ struct BookRow: Identifiable, Equatable, Hashable {
         hasDocuments: Bool,
         coverPath: String?,
         coverBlurHash: String?,
+        coverHash: String? = nil,
         duration: Int64 = 0,
         sequence: String? = nil
     ) {
@@ -44,6 +48,7 @@ struct BookRow: Identifiable, Equatable, Hashable {
         self.hasDocuments = hasDocuments
         self.coverPath = coverPath
         self.coverBlurHash = coverBlurHash
+        self.coverHash = coverHash
         self.duration = duration
         self.sequence = sequence
     }
@@ -58,6 +63,7 @@ struct BookRow: Identifiable, Equatable, Hashable {
         self.hasDocuments = item.hasDocuments
         self.coverPath = item.coverPath
         self.coverBlurHash = item.coverBlurHash
+        self.coverHash = item.coverHash
         self.duration = item.duration
         self.sequence = sequence
     }

--- a/iosApp/ListenUp/DesignSystem/Components/CoverImageRequest.swift
+++ b/iosApp/ListenUp/DesignSystem/Components/CoverImageRequest.swift
@@ -10,11 +10,17 @@ import Nuke
 /// re-downloads just because the access token rotated.
 enum CoverImageRequest {
     @MainActor
-    static func book(bookId: String?, coverPath: String?, targetPixels: CGFloat) async -> ImageRequest? {
+    static func book(
+        bookId: String?,
+        coverPath: String?,
+        coverHash: String?,
+        targetPixels: CGFloat
+    ) async -> ImageRequest? {
         let processors = AuthenticatedImageRequest.processors(targetPixels: targetPixels)
 
         if let coverPath, !coverPath.isEmpty {
-            return AuthenticatedImageRequest.localFile(coverPath, processors: processors)
+            let cacheKey = coverCacheKey(identity: bookId ?? coverPath, coverHash: coverHash)
+            return AuthenticatedImageRequest.localFile(coverPath, processors: processors, cacheKey: cacheKey)
         }
 
         guard let bookId, !bookId.isEmpty else { return nil }
@@ -29,6 +35,14 @@ enum CoverImageRequest {
               let url = URL(string: "\(base)/api/v1/covers/\(bookId)")
         else { return nil }
 
-        return await AuthenticatedImageRequest.authenticated(url: url, processors: processors)
+        let cacheKey = coverCacheKey(identity: bookId, coverHash: coverHash)
+        return await AuthenticatedImageRequest.authenticated(url: url, processors: processors, cacheKey: cacheKey)
+    }
+
+    /// Fold the cover content hash into Nuke's cache identity so a new cover at the same stable
+    /// path/URL busts the old entry — mirrors Android's `"$bookId:$coverHash"` Coil key. The key is
+    /// token-independent, so a cached cover still survives access-token rotation.
+    private static func coverCacheKey(identity: String, coverHash: String?) -> String {
+        "\(identity):\(coverHash ?? "cover")"
     }
 }

--- a/iosApp/ListenUp/Features/Admin/Collections/AdminCollectionDetailView.swift
+++ b/iosApp/ListenUp/Features/Admin/Collections/AdminCollectionDetailView.swift
@@ -219,7 +219,7 @@ struct AdminCollectionDetailView: View {
         isRemoving: Bool
     ) -> some View {
         ZStack(alignment: .topTrailing) {
-            BookCoverImage(bookId: book.id, coverPath: book.coverPath, blurHash: book.coverHash)
+            BookCoverImage(bookId: book.id, coverPath: book.coverPath, coverHash: book.coverHash)
                 .frame(width: 80, height: 80)
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .opacity(isRemoving ? 0.5 : 1)

--- a/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
+++ b/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
@@ -371,7 +371,7 @@ private struct InboxBookRow: View {
                 BookCoverImage(
                     bookId: book.id,
                     coverPath: book.coverPath,
-                    blurHash: book.coverHash,
+                    coverHash: book.coverHash,
                     accessibilityLabel: nil
                 )
                 .frame(width: 52, height: 52)

--- a/iosApp/ListenUp/Features/BookEdit/BookEditView.swift
+++ b/iosApp/ListenUp/Features/BookEdit/BookEditView.swift
@@ -60,7 +60,7 @@ struct BookEditView: View {
                 onPicked: { observer.onCoverPicked($0) },
                 onRemove: {}
             ) {
-                BookCoverImage(coverPath: observer.displayCoverPath, blurHash: observer.coverHash)
+                BookCoverImage(coverPath: observer.displayCoverPath, coverHash: observer.coverHash)
             }
             .padding(.top, 8)
 

--- a/iosApp/ListenUp/Features/Discover/ActivityFeedObserver.swift
+++ b/iosApp/ListenUp/Features/Discover/ActivityFeedObserver.swift
@@ -77,9 +77,6 @@ struct ActivityRowItem: Identifiable, Equatable {
     /// The book id, for navigation; nil for book-less activities.
     let bookId: String?
     let occurredAt: Date
-    /// Formatted listened duration ("54m" / "1h 5m") for `listening_session` activities;
-    /// nil for every other type and for zero-duration sessions.
-    let duration: String?
 
     init(from model: ActivityUiModel) {
         self.id = model.id
@@ -91,7 +88,6 @@ struct ActivityRowItem: Identifiable, Equatable {
         self.book = model.bookTitle
         self.bookId = model.bookId
         self.occurredAt = Date(timeIntervalSince1970: TimeInterval(model.occurredAt) / 1_000)
-        self.duration = ActivityRowItem.duration(for: model)
     }
 
     init(
@@ -103,8 +99,7 @@ struct ActivityRowItem: Identifiable, Equatable {
         action: String,
         book: String?,
         bookId: String?,
-        occurredAt: Date,
-        duration: String? = nil
+        occurredAt: Date
     ) {
         self.id = id
         self.userId = userId
@@ -115,7 +110,6 @@ struct ActivityRowItem: Identifiable, Equatable {
         self.book = book
         self.bookId = bookId
         self.occurredAt = occurredAt
-        self.duration = duration
     }
 
     /// Pure: map an activity's `type` (+ `isReread`) to its localized action phrase.
@@ -128,7 +122,7 @@ struct ActivityRowItem: Identifiable, Equatable {
         case "finished_book":
             String(localized: "discover.activity_finished")
         case "listening_session":
-            String(localized: "discover.activity_listened_to")
+            "\(String(localized: "discover.activity_listened_to")) \(durationWords(ms: model.durationMs)) of"
         case "streak_milestone":
             String(localized: "discover.activity_streak")
         case "listening_milestone":
@@ -142,11 +136,24 @@ struct ActivityRowItem: Identifiable, Equatable {
         }
     }
 
-    /// Pure: the formatted listened duration for a `listening_session` with real time on the
-    /// clock ("54m" / "1h 5m"), else nil. Other activity types and zero-duration sessions
-    /// carry no duration detail. Mirrors Android surfacing the session length on the row.
-    static func duration(for model: ActivityUiModel) -> String? {
-        guard model.type == "listening_session", model.durationMs > 0 else { return nil }
-        return DurationFormatting.hoursMinutes(ms: model.durationMs)
+    /// Pure: long-form session length woven into the listening-session phrase
+    /// ("30 seconds", "5 minutes", "1 hour", "1 hour 30 minutes"). Mirrors Android's
+    /// `formatDurationMinutes` verbatim — whole-minute rounding once past a minute, seconds
+    /// below that, singular/plural units — so the two platforms read identically.
+    private static func durationWords(ms: Int64) -> String {
+        let totalSeconds = Int(max(0, ms) / 1_000)
+        let totalMinutes = totalSeconds / 60
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+
+        if totalMinutes == 0 {
+            return "\(totalSeconds) second\(totalSeconds == 1 ? "" : "s")"
+        } else if hours == 0 {
+            return "\(minutes) minute\(minutes == 1 ? "" : "s")"
+        } else if minutes == 0 {
+            return "\(hours) hour\(hours == 1 ? "" : "s")"
+        } else {
+            return "\(hours) hour\(hours == 1 ? "" : "s") \(minutes) minute\(minutes == 1 ? "" : "s")"
+        }
     }
 }

--- a/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/ActivityRow.swift
@@ -12,17 +12,16 @@ struct ActivityRow: View {
         return formatter
     }()
 
+    /// Relative timestamp, floored to the past. A just-created event whose server `occurredAt` sits a
+    /// few seconds ahead of the device clock would otherwise read "in 3 seconds"; we clamp sub-minute
+    /// ages to "Just now" and never let the formatter phrase a future instant — matching Android's
+    /// floored `relativeTime`.
     private var timeLabel: String {
-        Self.relativeFormatter.localizedString(for: item.occurredAt, relativeTo: Date())
-    }
-
-    /// Timestamp, with the listened duration appended as a middot-separated detail when present
-    /// ("2h ago · 1h 5m").
-    private var detailLabel: String {
-        if let duration = item.duration {
-            return "\(timeLabel) · \(duration)"
+        let now = Date()
+        if item.occurredAt >= now.addingTimeInterval(-60) {
+            return String(localized: "discover.time_ago_now")
         }
-        return timeLabel
+        return Self.relativeFormatter.localizedString(for: min(item.occurredAt, now), relativeTo: now)
     }
 
     var body: some View {
@@ -59,7 +58,7 @@ struct ActivityRow: View {
                     .font(.subheadline)
                     .lineLimit(2)
 
-                Text(detailLabel)
+                Text(timeLabel)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -84,8 +83,8 @@ struct ActivityRow: View {
 
     private var accessibilityText: String {
         if let book = item.book, !book.isEmpty {
-            return "\(item.who) \(item.action) \(book), \(detailLabel)"
+            return "\(item.who) \(item.action) \(book), \(timeLabel)"
         }
-        return "\(item.who) \(item.action), \(detailLabel)"
+        return "\(item.who) \(item.action), \(timeLabel)"
     }
 }

--- a/iosApp/ListenUpTests/DiscoverObserverTests.swift
+++ b/iosApp/ListenUpTests/DiscoverObserverTests.swift
@@ -181,28 +181,40 @@ struct ActivityFeedObserverTests {
         #expect(item.action == "joined the server")
     }
 
-    @Test func listeningSessionCarriesFormattedDuration() {
-        // 1h 5m = 65 minutes = 3_900_000 ms
-        let item = ActivityRowItem(from: model(type: "listening_session", durationMs: 3_900_000))
-        #expect(item.duration == "1h 5m")
+    @Test func listeningSessionWeavesDurationIntoPhrase() {
+        // 1h 5m = 65 minutes = 3_900_000 ms — Android reads "listened to 1 hour 5 minutes of <book>".
+        #expect(
+            ActivityRowItem.action(for: model(type: "listening_session", durationMs: 3_900_000))
+                == "listened to 1 hour 5 minutes of"
+        )
     }
 
-    @Test func listeningSessionUnderAnHourShowsMinutesOnly() {
+    @Test func listeningSessionUnderAnHourReadsMinutesOnly() {
         // 54m = 3_240_000 ms
-        let item = ActivityRowItem(from: model(type: "listening_session", durationMs: 3_240_000))
-        #expect(item.duration == "54m")
+        #expect(
+            ActivityRowItem.action(for: model(type: "listening_session", durationMs: 3_240_000))
+                == "listened to 54 minutes of"
+        )
     }
 
-    @Test func zeroDurationListeningSessionHasNoDuration() {
-        let item = ActivityRowItem(from: model(type: "listening_session", durationMs: 0))
-        #expect(item.duration == nil)
+    @Test func listeningSessionRoundsToWholeHour() {
+        // Exactly 2h = 7_200_000 ms — no trailing "0 minutes", singular unit.
+        #expect(
+            ActivityRowItem.action(for: model(type: "listening_session", durationMs: 7_200_000))
+                == "listened to 2 hours of"
+        )
     }
 
-    @Test func nonListeningActivityHasNoDurationEvenWithMs() {
-        let started = ActivityRowItem(from: model(type: "started_book", durationMs: 3_900_000))
-        let finished = ActivityRowItem(from: model(type: "finished_book", durationMs: 3_900_000))
-        #expect(started.duration == nil)
-        #expect(finished.duration == nil)
+    @Test func zeroDurationListeningSessionReadsSeconds() {
+        #expect(
+            ActivityRowItem.action(for: model(type: "listening_session", durationMs: 0))
+                == "listened to 0 seconds of"
+        )
+    }
+
+    @Test func nonListeningActivityIgnoresDurationEvenWithMs() {
+        #expect(ActivityRowItem.action(for: model(type: "started_book", durationMs: 3_900_000)) == "started")
+        #expect(ActivityRowItem.action(for: model(type: "finished_book", durationMs: 3_900_000)) == "finished")
     }
 }
 


### PR DESCRIPTION
Two iOS-only fixes from the app-test bug-bash. **Verified: `xcodebuild build-for-testing` succeeds (compiles clean).** The iOS *test-run* lane is environmentally flaky right now (test-host bootstrap failures on both CI and a local Mac; app runs fine on-device) — CI iOS may need a re-run.

### #1 — activity row "in X seconds" + duration wording
- **Floored the timestamp:** `ActivityRow.timeLabel` now clamps `occurredAt` to the past and returns "Just now" (the already-present `discover.time_ago_now`) under a minute — never the unfloored future "in X seconds".
- **Android-exact duration wording:** for `listening_session`, the duration is now *in the sentence* — "Marcus **listened to 5 minutes of** Dune" (matches `ActivityFeedSection.kt`'s "listened to `<duration>` of `<book>`"), with a `durationWords()` mirroring Android's `formatDurationMinutes`. Removed the separate "· 4m" tail so it doesn't double up. `DiscoverObserverTests` updated.

### #6 — book cover doesn't update after a change (stale iOS cache)
Server + sync + Android are already correct; iOS just never keyed the Nuke cache on `coverHash`. Fix: thread `coverHash` into `CoverImageRequest.book(...)` → the existing `cacheKey:` override (`"<id>:<coverHash>"`, mirroring Android), and into `BookCoverImage` + its `TaskKey`. Also fixed 3 latent `coverHash`-passed-as-`blurHash` misuses.
- **Scope note:** busts the cache on the surfaces whose models expose `coverHash` — Library grid (`BookRow`), Series/Contributor/Facet/Tag, Book Detail, and the admin/edit/collection rows. **Follow-up:** ~12 secondary surfaces (Discover cards, Home, Search, Player/mini-player, Shelf) need `coverHash` added to their projection models first — tracked, best done with compiler feedback.

## Test Plan
- [x] `xcodebuild build-for-testing` (iOS Simulator) — **TEST BUILD SUCCEEDED**, 0 Swift errors (all init/signature changes verified).
- [ ] iOS test-run: environmentally flaky (host bootstrap) — via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)