### PR TITLE
✨ feat: book-removal cascade — nuke a removed book everywhere + orphan-purge + client reactions

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookAccessPolicy.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BookAccessPolicy.kt
@@ -212,6 +212,12 @@ class BookAccessPolicy(
      *
      * The selected `cb.id` matches the synthetic key the junction's [SyncableRepository] stores,
      * so the substrate's `collection_books.id IN (<sql>)` splice lines up exactly.
+     *
+     * **Book-liveness-aware (belt-and-suspenders).** A junction pointing at a tombstoned book is
+     * excluded (`books.deleted_at IS NULL`), so even if the book-removal cascade somehow missed a
+     * junction it never surfaces a dead book to a member's collection view — the removal cascade
+     * tombstones the junction directly, and the client's `collection_books` access-gate prunes any
+     * that slip past. Redundant with the cascade by design, cheap to enforce here.
      */
     fun accessibleCollectionBookIdsSql(
         userId: String,
@@ -222,6 +228,7 @@ class BookAccessPolicy(
             """
             SELECT cb.id FROM collection_books cb
             WHERE cb.collection_id IN ($accessibleCollectionIdsSubquery)
+              AND EXISTS (SELECT 1 FROM books b WHERE b.id = cb.book_id AND b.deleted_at IS NULL)
             """.trimIndent()
         return SqlFragment(sql = sql, args = listOf(userId, userId))
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -180,11 +180,20 @@ internal class CollectionServiceImpl(
         // Capture the live members BEFORE the cascade so we can re-home any book that loses its
         // last real membership: deleting a collection must never strand a book with zero memberships.
         val affectedBookIds = collectionBookRepo.findBookIdsForCollection(id.value)
+        // S2: nudge the collection's audience (owner + active grant recipients) BEFORE the grants are
+        // tombstoned — captured while the grants are still live, exactly like revokeShare. A member who
+        // could reach these books ONLY via this collection loses access in real time, not just on the
+        // next foreground reconcile.
+        notifyAccessChanged(listOf(id.value))
         collectionBookRepo.softDeleteAllForCollection(id.value)
         // A book whose only membership was this collection returns to ALL_BOOKS (reconcile bumps
         // its revision + nudges ALL_BOOKS grant-holders so members re-derive the now-public book).
+        // Every affected book's revision is touched regardless, so a member whose access just changed
+        // re-derives visibility on their incremental `revision > cursor` pull (a book that stays in
+        // other collections isn't reconciled but must still drop for this collection's lost audience).
         for (bookId in affectedBookIds) {
             reconcileSystemMembership(bookId)
+            bookRevisionTouch.touchRevision(BookId(bookId))
         }
         for (grant in grantRepo.listActiveGrantsForCollection(id.value)) {
             grantRepo.softDelete(grant.id)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
@@ -136,6 +136,7 @@ fun booksModule(
                 collectionBookRepository = get(),
                 tagRepository = getOrNull<TagRepository>(),
                 bookTagRepository = getOrNull<BookTagRepository>(),
+                bookMoodRepository = getOrNull<BookMoodRepository>(),
                 homeDir = homeDir,
                 coverImageStore = get<CoverImageStore>(),
             )

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BooksModule.kt
@@ -49,6 +49,7 @@ import com.calypsan.listenup.server.services.ContributorRepository
 import com.calypsan.listenup.server.services.GenreAutoCreator
 import com.calypsan.listenup.server.services.GenreRepository
 import com.calypsan.listenup.server.services.LibraryRegistry
+import com.calypsan.listenup.server.services.OrphanParentPurger
 import com.calypsan.listenup.server.services.PendingGenrePromotion
 import com.calypsan.listenup.server.services.SearchReindexService
 import com.calypsan.listenup.server.services.SeriesRepository
@@ -137,6 +138,7 @@ fun booksModule(
                 tagRepository = getOrNull<TagRepository>(),
                 bookTagRepository = getOrNull<BookTagRepository>(),
                 bookMoodRepository = getOrNull<BookMoodRepository>(),
+                orphanParentPurger = get<OrphanParentPurger>(),
                 homeDir = homeDir,
                 coverImageStore = get<CoverImageStore>(),
             )

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
@@ -3,6 +3,8 @@ package com.calypsan.listenup.server.di
 import app.cash.sqldelight.db.SqlDriver
 import com.calypsan.listenup.server.api.BookAccessPolicy
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.services.GenreRepository
+import com.calypsan.listenup.server.services.OrphanParentPurger
 import com.calypsan.listenup.server.sync.BookMoodRepository
 import com.calypsan.listenup.server.sync.BookTagRepository
 import com.calypsan.listenup.server.sync.ChangeBus
@@ -49,6 +51,21 @@ fun syncModule(): Module =
         single(createdAtStart = true) { BookTagRepository(get<ListenUpDatabase>(), get(), get()) }
         single(createdAtStart = true) { MoodRepository(get<ListenUpDatabase>(), get(), get()) }
         single(createdAtStart = true) { BookMoodRepository(get<ListenUpDatabase>(), get(), get()) }
+        // Orphan-purge collaborator, co-located with the tag/mood/junction repos it reads: when a
+        // book removal leaves a parent (contributor/series/genre/tag/mood) with zero live children,
+        // BookRepository.softDelete captures the parents, then this tombstones the orphaned ones.
+        single {
+            OrphanParentPurger(
+                db = get<ListenUpDatabase>(),
+                contributorRepository = get(),
+                seriesRepository = get(),
+                genreRepository = get<GenreRepository>(),
+                tagRepository = getOrNull<TagRepository>(),
+                moodRepository = getOrNull<MoodRepository>(),
+                bookTagRepository = getOrNull<BookTagRepository>(),
+                bookMoodRepository = getOrNull<BookMoodRepository>(),
+            )
+        }
         // Collection aggregate — fully SQLDelight. The access-filtered catch-up/digest raw reads
         // now run engine-neutral over the shared [SqlDriver] (the firehose's runtime-built
         // `extraWhere` subquery carries plain raw args; see each repo's pullSince override), so

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -142,6 +142,7 @@ class BookRepository(
     private val tagRepository: com.calypsan.listenup.server.sync.TagRepository? = null,
     private val bookTagRepository: com.calypsan.listenup.server.sync.BookTagRepository? = null,
     private val bookMoodRepository: com.calypsan.listenup.server.sync.BookMoodRepository? = null,
+    private val orphanParentPurger: OrphanParentPurger? = null,
     private val homeDir: Path? = null,
     private val coverImageStore: CoverImageStore? = null,
 ) : SqlSyncableRepository<BookSyncPayload, BookId>(
@@ -917,17 +918,24 @@ class BookRepository(
      * memberships): a dead book no longer surfaces via any collection's list, count, or the
      * `accessibleBookIdsSql` grant branch. Each cascade opens its own transaction (matching the
      * per-row substrate contract), run after the book's own tombstone commits.
+     *
+     * Finally, the orphan-purge cascade ([orphanParentPurger]) tombstones any contributor / series /
+     * genre / tag / mood the removal left with zero live book children, so an orphaned parent stops
+     * appearing. The linked parents are captured BEFORE the removal (the tag/mood junctions are
+     * tombstoned by the cascade), then re-evaluated after it.
      */
     override suspend fun softDelete(
         id: BookId,
         clientOpId: String?,
         userId: String?,
     ): AppResult<Unit> {
+        val linkedParents = orphanParentPurger?.captureParents(id.value)
         val result = super.softDelete(id, clientOpId, userId)
         if (result is AppResult.Success) {
             bookTagRepository?.softDeleteAllForBook(id.value)
             bookMoodRepository?.softDeleteAllForBook(id.value)
             collectionBookRepository?.softDeleteAllForBook(id.value)
+            if (linkedParents != null) orphanParentPurger.purgeOrphaned(linkedParents)
         }
         return result
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -141,6 +141,7 @@ class BookRepository(
     private val collectionBookRepository: com.calypsan.listenup.server.sync.CollectionBookRepository? = null,
     private val tagRepository: com.calypsan.listenup.server.sync.TagRepository? = null,
     private val bookTagRepository: com.calypsan.listenup.server.sync.BookTagRepository? = null,
+    private val bookMoodRepository: com.calypsan.listenup.server.sync.BookMoodRepository? = null,
     private val homeDir: Path? = null,
     private val coverImageStore: CoverImageStore? = null,
 ) : SqlSyncableRepository<BookSyncPayload, BookId>(
@@ -909,8 +910,13 @@ class BookRepository(
     }
 
     /**
-     * Tombstones this book and cascade-soft-deletes all of its `book_tags` junction
-     * rows so clients receive per-row tombstones for the orphaned junctions.
+     * Tombstones this book and cascade-soft-deletes all of its junction rows — `book_tags`,
+     * `book_moods`, and `collection_books` — so clients receive per-row tombstones for the orphaned
+     * junctions. Tombstoning the `collection_books` rows is what makes a removed book leave every
+     * collection it was in (Continue-Listening/search/collection-visibility all key off live
+     * memberships): a dead book no longer surfaces via any collection's list, count, or the
+     * `accessibleBookIdsSql` grant branch. Each cascade opens its own transaction (matching the
+     * per-row substrate contract), run after the book's own tombstone commits.
      */
     override suspend fun softDelete(
         id: BookId,
@@ -920,6 +926,8 @@ class BookRepository(
         val result = super.softDelete(id, clientOpId, userId)
         if (result is AppResult.Success) {
             bookTagRepository?.softDeleteAllForBook(id.value)
+            bookMoodRepository?.softDeleteAllForBook(id.value)
+            collectionBookRepository?.softDeleteAllForBook(id.value)
         }
         return result
     }
@@ -1074,9 +1082,14 @@ class BookRepository(
                 }
             }
         }
-        // Symmetric with softDelete's tag tombstone cascade: restore each book's user tags (its own
-        // transaction, exactly as the tombstone cascade is a separate call after the book write).
-        bookTagRepository?.reviveAllForBooks(ids.map { it.value }, cascadeFloor)
+        // Symmetric with softDelete's junction tombstone cascade: restore each book's user tags,
+        // moods, and collection memberships (each its own transaction, exactly as the tombstone
+        // cascade is a separate call after the book write), floored on the folder-removal instant so
+        // a remove-then-rescan keeps a book's memberships instead of losing them.
+        val idValues = ids.map { it.value }
+        bookTagRepository?.reviveAllForBooks(idValues, cascadeFloor)
+        bookMoodRepository?.reviveAllForBooks(idValues, cascadeFloor)
+        collectionBookRepository?.reviveAllForBooks(idValues, cascadeFloor)
     }
 
     /**

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/OrphanParentPurger.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/OrphanParentPurger.kt
@@ -1,0 +1,104 @@
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.core.ContributorId
+import com.calypsan.listenup.core.GenreId
+import com.calypsan.listenup.core.SeriesId
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import com.calypsan.listenup.server.sync.BookMoodRepository
+import com.calypsan.listenup.server.sync.BookTagRepository
+import com.calypsan.listenup.server.sync.MoodRepository
+import com.calypsan.listenup.server.sync.TagRepository
+
+/**
+ * The parent ids a book was linked to at the moment of its removal — captured while the book and
+ * its junctions are still live so the post-cascade orphan check knows which parents to re-evaluate.
+ */
+class LinkedParents(
+    val contributorIds: List<String>,
+    val seriesIds: List<String>,
+    val genreIds: List<String>,
+    val tagIds: List<String>,
+    val moodIds: List<String>,
+)
+
+/**
+ * Deletion-based orphan purge for the metadata parents of a removed book (the user "nuke" directive).
+ *
+ * When a book is soft-deleted, a contributor / series / genre / tag / mood that was linked ONLY to
+ * that book is now an orphan — a parent with zero live book children that would otherwise keep
+ * appearing in browse lists with a phantom "0 books". This purger tombstones each such orphan so it
+ * stops appearing; the parents are mirrored sync domains, so the tombstone propagates to clients.
+ *
+ * **Two-phase, by design.** [captureParents] reads the linked parent ids BEFORE the removal (the
+ * `book_tags` / `book_moods` junctions are tombstoned by the book cascade, so their ids must be read
+ * while still live; `book_contributors` / `book_series_memberships` / `book_genres` are hard-replace
+ * child tables whose rows persist, but capturing all five together keeps the contract uniform).
+ * [purgeOrphaned] runs AFTER the book + junction cascade and tombstones every captured parent whose
+ * live-book count has dropped to zero. Each count joins live books, so a lingering junction to the
+ * now-dead book never keeps a parent alive.
+ *
+ * **Revival note.** A purged parent is not explicitly revived; a remove-then-rescan re-ingests the
+ * book through `resolveOrCreate`, which resurrects the parent, so memberships return on re-scan.
+ */
+class OrphanParentPurger(
+    private val db: ListenUpDatabase,
+    private val contributorRepository: ContributorRepository,
+    private val seriesRepository: SeriesRepository,
+    private val genreRepository: GenreRepository,
+    private val tagRepository: TagRepository?,
+    private val moodRepository: MoodRepository?,
+    private val bookTagRepository: BookTagRepository?,
+    private val bookMoodRepository: BookMoodRepository?,
+) {
+    /** Reads the parent ids linked to [bookId] while it is still live — the orphan-check candidate set. */
+    suspend fun captureParents(bookId: String): LinkedParents {
+        val (contributorIds, seriesIds, genreIds) =
+            suspendTransaction(db) {
+                Triple(
+                    db.bookContributorsQueries.contributorIdsForBook(bookId).executeAsList(),
+                    db.bookSeriesMembershipsQueries.seriesIdsForBook(bookId).executeAsList(),
+                    db.bookGenresQueries.genreIdsForBook(bookId).executeAsList(),
+                )
+            }
+        // Tag/mood ids come from the junction repos' live reads (their `id` column is synthetic).
+        val tagIds = bookTagRepository?.findAllForBook(bookId)?.map { it.tagId }.orEmpty()
+        val moodIds = bookMoodRepository?.findAllForBook(bookId)?.map { it.moodId }.orEmpty()
+        return LinkedParents(contributorIds, seriesIds, genreIds, tagIds, moodIds)
+    }
+
+    /** Tombstones every parent in [parents] that has zero live book children after the removal. */
+    suspend fun purgeOrphaned(parents: LinkedParents) {
+        for (id in parents.contributorIds) {
+            if (liveBookCount { bookContributorsQueries.liveBookCountForContributor(id).executeAsOne() } == 0L) {
+                contributorRepository.softDelete(ContributorId(id))
+            }
+        }
+        for (id in parents.seriesIds) {
+            if (liveBookCount { bookSeriesMembershipsQueries.liveBookCountForSeries(id).executeAsOne() } == 0L) {
+                seriesRepository.softDelete(SeriesId(id))
+            }
+        }
+        for (id in parents.genreIds) {
+            if (liveBookCount { bookGenresQueries.liveBookCountForGenre(id).executeAsOne() } == 0L) {
+                genreRepository.softDelete(GenreId(id))
+            }
+        }
+        tagRepository?.let { repo ->
+            for (id in parents.tagIds) {
+                if (liveBookCount { bookTagsQueries.liveBookCountForTag(id).executeAsOne() } == 0L) {
+                    repo.softDelete(id)
+                }
+            }
+        }
+        moodRepository?.let { repo ->
+            for (id in parents.moodIds) {
+                if (liveBookCount { bookMoodsQueries.liveBookCountForMood(id).executeAsOne() } == 0L) {
+                    repo.softDelete(id)
+                }
+            }
+        }
+    }
+
+    private suspend fun liveBookCount(query: ListenUpDatabase.() -> Long): Long = suspendTransaction(db) { db.query() }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/BookMoodRepository.kt
@@ -231,6 +231,51 @@ class BookMoodRepository(
         }
 
     /**
+     * Revives the tombstoned junction rows for the books in [bookIds] that were tombstoned at or after
+     * [cascadeFloor] — the cascade counterpart to [softDeleteAllForBook], run when a removed folder is
+     * re-added so a book's moods return with the book instead of being lost. [cascadeFloor] is the
+     * removed folder's own `deleted_at`, flooring the revival exactly as the book/tag revivals are
+     * floored. All revives run in ONE transaction; each row gets its own revision bump and an
+     * after-commit [SyncEvent.Updated] (deleted_at cleared) so clients reflow the mood as live.
+     * Returns the number of rows revived. A no-op (returns 0) when [bookIds] is empty.
+     */
+    suspend fun reviveAllForBooks(
+        bookIds: List<String>,
+        cascadeFloor: Long,
+    ): Int {
+        if (bookIds.isEmpty()) return 0
+        return suspendTransaction(db) {
+            var count = 0
+            for (chunk in bookIds.chunked(SQLITE_IN_CHUNK)) {
+                for (row in db.bookMoodsQueries.selectDeletedForBooksSince(chunk, cascadeFloor).executeAsList()) {
+                    val rev = nextRevision()
+                    val now = clock.now().toEpochMilliseconds()
+                    db.bookMoodsQueries.reviveById(revision = rev, updated_at = now, id = row.id)
+                    emitAfterCommit(
+                        event =
+                            SyncEvent.Updated(
+                                id = row.id,
+                                revision = rev,
+                                occurredAt = now,
+                                clientOpId = null,
+                                payload =
+                                    BookMoodSyncPayload(
+                                        bookId = row.book_id,
+                                        moodId = row.mood_id,
+                                        createdAt = row.created_at,
+                                        revision = rev,
+                                        deletedAt = null,
+                                    ),
+                            ),
+                    )
+                    count++
+                }
+            }
+            count
+        }
+    }
+
+    /**
      * Tombstones each synthetic id in [syntheticIds] with its own revision bump, inside
      * the caller's open transaction, and registers a per-row after-commit
      * [SyncEvent.Deleted]. The shared body of [softDeleteAllForBook] / [softDeleteAllForMood].

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
@@ -237,6 +237,87 @@ class CollectionBookRepository(
             live.size
         }
 
+    /**
+     * Bulk soft-deletes all junction rows for [bookId] — the book-removal cascade counterpart to
+     * [softDeleteAllForCollection]. Called from [com.calypsan.listenup.server.services.BookRepository.softDelete]
+     * so a removed book leaves every collection it was in and clients receive per-row tombstones
+     * (the membership no longer surfaces the dead book in any collection's list/count). Each row gets
+     * its own revision bump and after-commit [SyncEvent.Deleted]. Returns the number of rows tombstoned.
+     */
+    suspend fun softDeleteAllForBook(bookId: String): Int =
+        suspendTransaction(db) {
+            val live = db.collectionBooksQueries.liveIdsForBook(bookId).executeAsList()
+            for (syntheticId in live) {
+                val rev = nextRevision()
+                val now = clock.now().toEpochMilliseconds()
+                db.collectionBooksQueries.softDeleteById(
+                    revision = rev,
+                    updated_at = now,
+                    deleted_at = now,
+                    client_op_id = null,
+                    id = syntheticId,
+                )
+                emitAfterCommit(
+                    event =
+                        SyncEvent.Deleted(
+                            id = syntheticId,
+                            revision = rev,
+                            occurredAt = now,
+                            clientOpId = null,
+                        ),
+                    userId = null,
+                )
+            }
+            live.size
+        }
+
+    /**
+     * Revives the tombstoned junction rows for the books in [bookIds] tombstoned at or after
+     * [cascadeFloor] — the cascade counterpart to [softDeleteAllForBook], run when a removed folder is
+     * re-added so a book's collection memberships return with the book instead of being lost.
+     * [cascadeFloor] is the removed folder's own `deleted_at`, flooring the revival exactly as the
+     * book/tag revivals are floored: only memberships tombstoned BY the folder removal return, never a
+     * membership the user removed manually before the removal. All revives run in ONE transaction; each
+     * row gets its own revision bump and an after-commit [SyncEvent.Updated] (deleted_at cleared).
+     * Returns the number of rows revived. A no-op (returns 0) when [bookIds] is empty.
+     */
+    suspend fun reviveAllForBooks(
+        bookIds: List<String>,
+        cascadeFloor: Long,
+    ): Int {
+        if (bookIds.isEmpty()) return 0
+        return suspendTransaction(db) {
+            var count = 0
+            for (chunk in bookIds.chunked(SQLITE_IN_CHUNK)) {
+                for (row in db.collectionBooksQueries.selectDeletedForBooksSince(chunk, cascadeFloor).executeAsList()) {
+                    val rev = nextRevision()
+                    val now = clock.now().toEpochMilliseconds()
+                    db.collectionBooksQueries.reviveById(revision = rev, updated_at = now, id = row.id)
+                    emitAfterCommit(
+                        event =
+                            SyncEvent.Updated(
+                                id = row.id,
+                                revision = rev,
+                                occurredAt = now,
+                                clientOpId = null,
+                                payload =
+                                    CollectionBookSyncPayload(
+                                        collectionId = row.collection_id,
+                                        bookId = row.book_id,
+                                        createdAt = row.created_at,
+                                        revision = rev,
+                                        deletedAt = null,
+                                    ),
+                            ),
+                        userId = null,
+                    )
+                    count++
+                }
+            }
+            count
+        }
+    }
+
     /** Maps a generated [Collection_books] row to the wire [CollectionBookSyncPayload] DTO. */
     private fun Collection_books.toSyncPayload(): CollectionBookSyncPayload =
         CollectionBookSyncPayload(

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookContributors.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookContributors.sq
@@ -96,3 +96,16 @@ relinkByCreditedAs:
 UPDATE book_contributors
 SET contributor_id = :to_id, credited_as = NULL
 WHERE contributor_id = :from_id AND credited_as = :alias_name;
+
+-- Distinct contributor ids linked to a book — the orphan-purge capture set (read while the book
+-- is still live). book_contributors is a hard-replace child table, so a soft-deleted book's rows
+-- persist; the count below joins live books to decide orphanhood.
+contributorIdsForBook:
+SELECT DISTINCT contributor_id FROM book_contributors WHERE book_id = :book_id;
+
+-- Count of LIVE books linked to a contributor (dead books excluded via the join). Zero ⇒ the
+-- contributor is orphaned by a book removal and is tombstoned by the orphan-purge cascade.
+liveBookCountForContributor:
+SELECT COUNT(DISTINCT bc.book_id) FROM book_contributors bc
+JOIN books b ON b.id = bc.book_id AND b.deleted_at IS NULL
+WHERE bc.contributor_id = :contributor_id;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookGenres.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookGenres.sq
@@ -102,3 +102,13 @@ DELETE FROM book_genres WHERE genre_id = :genre_id;
 relinkGenreCopy:
 INSERT OR IGNORE INTO book_genres (book_id, genre_id)
 SELECT book_id, :to_id FROM book_genres WHERE genre_id = :from_id;
+
+-- Distinct genre ids linked to a book — the orphan-purge capture set (see BookContributors).
+genreIdsForBook:
+SELECT DISTINCT genre_id FROM book_genres WHERE book_id = :book_id;
+
+-- Count of LIVE books linked to a genre (dead books excluded). Zero ⇒ orphaned genre → tombstone.
+liveBookCountForGenre:
+SELECT COUNT(DISTINCT bg.book_id) FROM book_genres bg
+JOIN books b ON b.id = bg.book_id AND b.deleted_at IS NULL
+WHERE bg.genre_id = :genre_id;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
@@ -71,6 +71,16 @@ WHERE book_id = :book_id AND mood_id = :mood_id;
 selectLiveIdsForBook:
 SELECT id FROM book_moods WHERE book_id = :book_id AND deleted_at IS NULL;
 
+-- Tombstoned junction rows for a batch of books at or after :floor — the revive counterpart to
+-- selectLiveIdsForBook, floored on the folder-removal cascade instant (mirrors BookTags): only
+-- moods tombstoned BY the folder removal return with the book on re-add.
+selectDeletedForBooksSince:
+SELECT * FROM book_moods WHERE book_id IN :book_ids AND deleted_at IS NOT NULL AND deleted_at >= :floor;
+
+-- Revives a tombstoned junction (clears deleted_at, bumps revision) so clients reflow the mood as live.
+reviveById:
+UPDATE book_moods SET revision = :revision, updated_at = :updated_at, deleted_at = NULL WHERE id = :id;
+
 selectLiveIdsForMood:
 SELECT id FROM book_moods WHERE mood_id = :mood_id AND deleted_at IS NULL;
 

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
@@ -89,3 +89,9 @@ SELECT id FROM book_moods WHERE mood_id = :mood_id AND deleted_at IS NULL;
 -- `BookMoodsTable.selectAll().where { moodId eq … and deletedAt.isNull() }.count()`.
 countLiveForMood:
 SELECT COUNT(*) FROM book_moods WHERE mood_id = :mood_id AND deleted_at IS NULL;
+
+-- Count of LIVE books linked to a mood via a LIVE junction — the orphan-purge decision for moods.
+liveBookCountForMood:
+SELECT COUNT(*) FROM book_moods bm
+JOIN books b ON b.id = bm.book_id AND b.deleted_at IS NULL
+WHERE bm.mood_id = :mood_id AND bm.deleted_at IS NULL;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookSeriesMemberships.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookSeriesMemberships.sq
@@ -56,3 +56,13 @@ DELETE FROM book_series_memberships WHERE series_id = :series_id;
 -- IS the intended semantic.
 relinkSeries:
 UPDATE book_series_memberships SET series_id = :to_id WHERE series_id = :from_id;
+
+-- Distinct series ids linked to a book — the orphan-purge capture set (see BookContributors).
+seriesIdsForBook:
+SELECT DISTINCT series_id FROM book_series_memberships WHERE book_id = :book_id;
+
+-- Count of LIVE books linked to a series (dead books excluded). Zero ⇒ orphaned series → tombstone.
+liveBookCountForSeries:
+SELECT COUNT(DISTINCT bsm.book_id) FROM book_series_memberships bsm
+JOIN books b ON b.id = bsm.book_id AND b.deleted_at IS NULL
+WHERE bsm.series_id = :series_id;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
@@ -91,3 +91,10 @@ SELECT id FROM book_tags WHERE tag_id = :tag_id AND deleted_at IS NULL;
 -- `BookTagsTable.selectAll().where { tagId eq … and deletedAt.isNull() }.count()`.
 countLiveForTag:
 SELECT COUNT(*) FROM book_tags WHERE tag_id = :tag_id AND deleted_at IS NULL;
+
+-- Count of LIVE books linked to a tag via a LIVE junction — the orphan-purge decision for tags.
+-- Both the junction and the book must be live; zero ⇒ orphaned tag → tombstone.
+liveBookCountForTag:
+SELECT COUNT(*) FROM book_tags bt
+JOIN books b ON b.id = bt.book_id AND b.deleted_at IS NULL
+WHERE bt.tag_id = :tag_id AND bt.deleted_at IS NULL;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionBooks.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/CollectionBooks.sq
@@ -69,25 +69,46 @@ selectLiveByCollectionAndBook:
 SELECT * FROM collection_books
 WHERE collection_id = :collection_id AND book_id = :book_id AND deleted_at IS NULL;
 
--- Live book ids in a collection.
+-- Live book ids in a collection. Book-liveness-aware (belt-and-suspenders): a stale junction
+-- pointing at a tombstoned book must never surface a dead id — even if the book-removal cascade
+-- somehow missed the junction, the JOIN filters it out so counts/lists never inflate.
 liveBookIdsForCollection:
-SELECT book_id FROM collection_books
-WHERE collection_id = :collection_id AND deleted_at IS NULL;
+SELECT cb.book_id FROM collection_books cb
+JOIN books b ON b.id = cb.book_id AND b.deleted_at IS NULL
+WHERE cb.collection_id = :collection_id AND cb.deleted_at IS NULL;
 
 -- Live collection ids that contain a book.
 liveCollectionIdsForBook:
 SELECT collection_id FROM collection_books
 WHERE book_id = :book_id AND deleted_at IS NULL;
 
--- Count of live junction rows for a collection.
+-- Count of live junction rows for a collection, book-liveness-aware (see liveBookIdsForCollection):
+-- a junction whose book is tombstoned is not counted, so CollectionSummary.bookCount matches the list.
 countLiveForCollection:
-SELECT COUNT(*) FROM collection_books
-WHERE collection_id = :collection_id AND deleted_at IS NULL;
+SELECT COUNT(*) FROM collection_books cb
+JOIN books b ON b.id = cb.book_id AND b.deleted_at IS NULL
+WHERE cb.collection_id = :collection_id AND cb.deleted_at IS NULL;
 
 -- Live synthetic ids for a collection — the cascade set for softDeleteAllForCollection.
 liveIdsForCollection:
 SELECT id FROM collection_books
 WHERE collection_id = :collection_id AND deleted_at IS NULL;
+
+-- Live synthetic ids for a book — the cascade set for softDeleteAllForBook (book-removal cascade).
+liveIdsForBook:
+SELECT id FROM collection_books
+WHERE book_id = :book_id AND deleted_at IS NULL;
+
+-- Tombstoned junction rows for a batch of books at or after :floor — the revive counterpart to
+-- liveIdsForBook, floored on the folder-removal cascade instant (mirrors BookTags.selectDeletedForBooksSince):
+-- only memberships tombstoned BY the folder removal return with the book on re-add; a membership the
+-- user removed manually before the removal (an older tombstone) stays dead.
+selectDeletedForBooksSince:
+SELECT * FROM collection_books WHERE book_id IN :book_ids AND deleted_at IS NOT NULL AND deleted_at >= :floor;
+
+-- Revives a tombstoned junction (clears deleted_at, bumps revision) so clients reflow the membership as live.
+reviveById:
+UPDATE collection_books SET revision = :revision, updated_at = :updated_at, deleted_at = NULL WHERE id = :id;
 
 insert:
 INSERT INTO collection_books (id, collection_id, book_id, created_at, updated_at, revision, deleted_at, client_op_id)

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
@@ -1,0 +1,127 @@
+package com.calypsan.listenup.server.services
+
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.sync.BookMoodRepository
+import com.calypsan.listenup.server.sync.BookTagRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.MoodRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.sync.TagRepository
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Verifies the deletion-based orphan purge in [BookRepository.softDelete] (the user "nuke" directive):
+ * removing a book tombstones any contributor / tag left with zero live book children, while a parent
+ * still linked to another live book survives.
+ */
+class BookRemovalOrphanPurgeTest :
+    FunSpec({
+
+        fun buildRepo(
+            sql: com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase,
+            driver: app.cash.sqldelight.db.SqlDriver,
+        ): Triple<BookRepository, TagRepository, BookTagRepository> {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+            val moodRepo = MoodRepository(db = sql, bus = bus, registry = registry)
+            val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+            val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = registry)
+            val collectionBookRepo = CollectionBookRepository(sql, bus, registry, driver = driver)
+            val contributorRepo = ContributorRepository(sql, bus, registry)
+            val seriesRepo = SeriesRepository(sql, bus, registry)
+            val genreRepo = GenreRepository(sql, bus, registry)
+            val purger =
+                OrphanParentPurger(
+                    db = sql,
+                    contributorRepository = contributorRepo,
+                    seriesRepository = seriesRepo,
+                    genreRepository = genreRepo,
+                    tagRepository = tagRepo,
+                    moodRepository = moodRepo,
+                    bookTagRepository = bookTagRepo,
+                    bookMoodRepository = bookMoodRepo,
+                )
+            val bookRepo =
+                BookRepository(
+                    db = sql,
+                    driver = driver,
+                    bus = bus,
+                    registry = registry,
+                    contributorRepository = contributorRepo,
+                    seriesRepository = seriesRepo,
+                    genreRepository = genreRepo,
+                    collectionBookRepository = collectionBookRepo,
+                    tagRepository = tagRepo,
+                    bookTagRepository = bookTagRepo,
+                    bookMoodRepository = bookMoodRepo,
+                    orphanParentPurger = purger,
+                )
+            return Triple(bookRepo, tagRepo, bookTagRepo)
+        }
+
+        test("removing a book with a sole contributor purges the orphan contributor but keeps a shared one") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                runTest {
+                    val (bookRepo, _, _) = buildRepo(sql, driver)
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val contributorRepo = ContributorRepository(sql, bus, registry)
+                    // c1 → book1 only (will orphan); c2 → book1 + book2 (survives).
+                    val c1 = contributorRepo.resolveOrCreate("Sole Author", "Author, Sole").value
+                    val c2 = contributorRepo.resolveOrCreate("Shared Author", "Author, Shared").value
+                    sql.bookContributorsQueries.insert("book1", c1, "author", null, 0)
+                    sql.bookContributorsQueries.insert("book1", c2, "author", null, 1)
+                    sql.bookContributorsQueries.insert("book2", c2, "author", null, 0)
+
+                    bookRepo.softDelete(BookId("book1"), clientOpId = null)
+
+                    // c1 is orphaned (its only book is gone) → tombstoned; c2 survives (book2 lives).
+                    sql.contributorsQueries
+                        .selectById(c1)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                    sql.contributorsQueries
+                        .selectById(c2)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
+                }
+            }
+        }
+
+        test("removing a book with a sole tag purges the orphan tag") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val (bookRepo, tagRepo, bookTagRepo) = buildRepo(sql, driver)
+                    tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
+                    bookTagRepo.upsert(
+                        BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L),
+                    )
+
+                    bookRepo.softDelete(BookId("book1"), clientOpId = null)
+
+                    sql.tagsQueries
+                        .selectById("t1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositorySoftDeleteCascadeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositorySoftDeleteCascadeTest.kt
@@ -1,10 +1,16 @@
 package com.calypsan.listenup.server.services
 
+import com.calypsan.listenup.api.sync.BookMoodSyncPayload
 import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.Mood
 import com.calypsan.listenup.api.sync.Tag
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.sync.BookMoodRepository
 import com.calypsan.listenup.server.sync.BookTagRepository
 import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.MoodRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.sync.TagRepository
 import com.calypsan.listenup.server.testing.seedTestBook
@@ -12,6 +18,8 @@ import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -60,6 +68,123 @@ class BookRepositorySoftDeleteCascadeTest :
                     // Junction should now be tombstoned — findAllForBook returns live rows only.
                     val after = bookTagRepo.findAllForBook("book1")
                     after.shouldBeEmpty()
+                }
+            }
+        }
+
+        test("softDelete tombstones collection_books and book_moods junctions") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                // A regular (NORMAL) collection the book belongs to.
+                val now = System.currentTimeMillis()
+                sql.collectionsQueries.insert(
+                    id = "c1",
+                    library_id = "test-library",
+                    owner_id = "owner1",
+                    name = "Faves",
+                    type = "NORMAL",
+                    created_at = now,
+                    updated_at = now,
+                    revision = 0L,
+                    deleted_at = null,
+                    client_op_id = null,
+                )
+                runTest {
+                    val bus = ChangeBus()
+                    val syncRegistry = SyncRegistry()
+                    val moodRepo = MoodRepository(db = sql, bus = bus, registry = syncRegistry)
+                    val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = syncRegistry)
+                    val collectionBookRepo =
+                        CollectionBookRepository(db = sql, bus = bus, registry = syncRegistry, driver = driver)
+
+                    val bookRepo =
+                        BookRepository(
+                            db = sql,
+                            driver = driver,
+                            bus = bus,
+                            registry = syncRegistry,
+                            contributorRepository = ContributorRepository(sql, bus, syncRegistry),
+                            seriesRepository = SeriesRepository(sql, bus, syncRegistry),
+                            genreRepository = GenreRepository(sql, bus, syncRegistry),
+                            collectionBookRepository = collectionBookRepo,
+                            bookMoodRepository = bookMoodRepo,
+                        )
+
+                    // Attach a mood and a collection membership to book1.
+                    moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
+                    bookMoodRepo.upsert(
+                        BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
+                    )
+                    collectionBookRepo.upsert(
+                        CollectionBookSyncPayload(collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
+                    )
+
+                    check(collectionBookRepo.findBookIdsForCollection("c1") == listOf("book1"))
+                    check(bookMoodRepo.findAllForBook("book1").size == 1)
+
+                    bookRepo.softDelete(BookId("book1"), clientOpId = null)
+
+                    // Both junctions are tombstoned — the dead book leaves the collection and its moods.
+                    collectionBookRepo.findBookIdsForCollection("c1").shouldBeEmpty()
+                    bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
+                }
+            }
+        }
+
+        test("reviveByIds restores collection_books and book_moods memberships tombstoned by the removal") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                val now = System.currentTimeMillis()
+                sql.collectionsQueries.insert(
+                    id = "c1",
+                    library_id = "test-library",
+                    owner_id = "owner1",
+                    name = "Faves",
+                    type = "NORMAL",
+                    created_at = now,
+                    updated_at = now,
+                    revision = 0L,
+                    deleted_at = null,
+                    client_op_id = null,
+                )
+                runTest {
+                    val bus = ChangeBus()
+                    val syncRegistry = SyncRegistry()
+                    val moodRepo = MoodRepository(db = sql, bus = bus, registry = syncRegistry)
+                    val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = syncRegistry)
+                    val collectionBookRepo =
+                        CollectionBookRepository(db = sql, bus = bus, registry = syncRegistry, driver = driver)
+
+                    val bookRepo =
+                        BookRepository(
+                            db = sql,
+                            driver = driver,
+                            bus = bus,
+                            registry = syncRegistry,
+                            contributorRepository = ContributorRepository(sql, bus, syncRegistry),
+                            seriesRepository = SeriesRepository(sql, bus, syncRegistry),
+                            genreRepository = GenreRepository(sql, bus, syncRegistry),
+                            collectionBookRepository = collectionBookRepo,
+                            bookMoodRepository = bookMoodRepo,
+                        )
+
+                    moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
+                    bookMoodRepo.upsert(
+                        BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L),
+                    )
+                    collectionBookRepo.upsert(
+                        CollectionBookSyncPayload(collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
+                    )
+
+                    // Remove (tombstones book + its junctions), then re-add (revive) with floor 0.
+                    bookRepo.softDelete(BookId("book1"), clientOpId = null)
+                    bookRepo.reviveByIds(listOf(BookId("book1")), cascadeFloor = 0L)
+
+                    // Memberships return with the book.
+                    collectionBookRepo.findBookIdsForCollection("c1").shouldContainExactly("book1")
+                    bookMoodRepo.findAllForBook("book1").shouldHaveSize(1)
                 }
             }
         }

--- a/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
+++ b/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
@@ -18,6 +18,7 @@ import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.SearchRepository
 import com.calypsan.listenup.client.domain.repository.SeriesRepository
@@ -82,6 +83,8 @@ class KoinModuleVerifyTest :
                         PlaybackPreferences::class,
                         NetworkMonitor::class,
                         DocumentRepository::class,
+                        DownloadRepository::class,
+                        PlaybackPositionRepository::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
@@ -124,6 +124,19 @@ internal interface BookDao {
     fun observeByIdWithContributors(id: BookId): Flow<BookWithContributors?>
 
     /**
+     * Observe whether a book is currently live (present and not tombstoned) in the local mirror.
+     *
+     * Emits `false` when the row is absent OR soft-deleted (`deletedAt` non-null) — the signal the
+     * now-playing teardown watches so a revoked/removed book stops streaming while a downloaded,
+     * in-progress copy is honoured (offline grace).
+     *
+     * @param id The type-safe book ID
+     * @return Flow emitting `true` while the book is live, `false` once it is gone or tombstoned
+     */
+    @Query("SELECT COUNT(*) > 0 FROM books WHERE id = :id AND deletedAt IS NULL")
+    fun observeIsLive(id: BookId): Flow<Boolean>
+
+    /**
      * Get multiple books by IDs with their contributors in a single batched query.
      *
      * Uses Room Relations to efficiently load books and their contributors,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
@@ -176,6 +176,7 @@ internal interface ContributorDao {
         SELECT c.*, COUNT(bc.bookId) as bookCount
         FROM contributors c
         INNER JOIN book_contributors bc ON c.id = bc.contributorId
+        INNER JOIN books b ON b.id = bc.bookId AND b.deletedAt IS NULL
         WHERE bc.role = :role AND c.deletedAt IS NULL
         GROUP BY c.id
         ORDER BY c.name ASC
@@ -202,6 +203,7 @@ internal interface ContributorDao {
         """
         SELECT bc.role, COUNT(bc.bookId) as bookCount
         FROM book_contributors bc
+        INNER JOIN books b ON b.id = bc.bookId AND b.deletedAt IS NULL
         WHERE bc.contributorId = :contributorId
         GROUP BY bc.role
         ORDER BY bc.role ASC

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
@@ -106,6 +106,20 @@ internal interface PlaybackPositionDao {
     )
 
     /**
+     * Drop every position whose book is gone or tombstoned — the Continue-Listening
+     * counterpart to the readership sweep, run from the books access-gate `afterPrune`.
+     *
+     * When a book leaves the local mirror (a real removal tombstone, or an access-loss
+     * prune), its lingering position would otherwise keep the book on the Home
+     * "Continue Listening" shelf and re-surface a book the user can no longer reach.
+     * The server still holds the row for an access-only loss, so a later re-grant
+     * re-syncs the position — this is a local hard-delete of a now-unreachable cache
+     * entry, not a destructive server write.
+     */
+    @Query("DELETE FROM playback_positions WHERE bookId NOT IN (SELECT id FROM books WHERE deletedAt IS NULL)")
+    suspend fun deleteWhereBookNotLive()
+
+    /**
      * Get recently played books for "Continue Listening" section.
      * Returns positions ordered by most recently played, limited to specified count.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/SearchDao.kt
@@ -53,6 +53,7 @@ internal interface SearchDao {
         FROM books_fts fts
         INNER JOIN books b ON fts.bookId = b.id
         WHERE books_fts MATCH :query
+          AND b.deletedAt IS NULL
         ORDER BY bm25(books_fts)
         LIMIT :limit
     """,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
@@ -218,6 +218,8 @@ internal class BookRepositoryImpl(
             .map { it.toListItem(imageStorage) }
     }
 
+    override fun observeIsBookLive(id: String): Flow<Boolean> = bookDao.observeIsLive(BookId(id))
+
     override fun observeBookListItems(ids: List<String>): Flow<List<BookListItem>> {
         if (ids.isEmpty()) return kotlinx.coroutines.flow.flowOf(emptyList())
         return bookDao

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMirrorApply.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BookMirrorApply.kt
@@ -66,6 +66,11 @@ internal class BookMirrorApply(
         // is no longer live (this one included; the stamp above precedes the sweep
         // inside the same write transaction).
         database.bookReadershipDao().deleteWhereBookNotLive()
+        // A removed book must leave Continue Listening too: drop the playback_positions for any
+        // now-dead book (this one included). This is the direct-tombstone counterpart to the books
+        // access-gate afterPrune positions sweep — a server removal arrives as a tombstone, not an
+        // AccessChanged. Local cache drop only; the server retains the row for an access re-grant.
+        database.playbackPositionDao().deleteWhereBookNotLive()
     }
 
     override suspend fun tombstoneFromItem(item: BookSyncPayload) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
@@ -31,7 +31,8 @@ import com.calypsan.listenup.core.Timestamp
  * accessible set, so an `AccessChanged` reconcile must prune local rows the user can
  * no longer see. The [AccessGate] tombstones (not hard-deletes) every live row outside
  * the accessible set — revoked books disappear from view but restore losslessly if
- * access is re-granted — then its `afterPrune` drops readership rows for the now-dead books.
+ * access is re-granted — then its `afterPrune` drops readership rows AND `playback_positions`
+ * for the now-dead books, so a revoked or removed book leaves Continue Listening too.
  *
  * **Digest:** full participation — books are revision-fingerprintable, and
  * `digestRows` excludes soft-deleted rows, matching the server's (tombstone-excluding) digest
@@ -77,9 +78,14 @@ internal fun booksDomain(
             AccessGate(
                 liveIds = database.bookDao()::liveIds,
                 tombstoneByIds = database.bookDao()::tombstoneByIds,
-                // Readership rows follow their book's liveness: once the prune tombstones the
-                // revoked books, drop the reader rows that now point at a non-live book.
-                afterPrune = database.bookReadershipDao()::deleteWhereBookNotLive,
+                // Readership rows AND Continue-Listening positions follow their book's liveness:
+                // once the prune tombstones the revoked/removed books, drop the reader rows and the
+                // playback_positions that now point at a non-live book (so the book leaves Continue
+                // Listening — #9B). Access-only losses re-sync from the server on re-grant.
+                afterPrune = {
+                    database.bookReadershipDao().deleteWhereBookNotLive()
+                    database.playbackPositionDao().deleteWhereBookNotLive()
+                },
             ),
     )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
@@ -25,6 +25,8 @@ internal val playbackPresentationModule =
                 playbackPreferences = get(),
                 networkMonitor = get(),
                 documentRepository = get(),
+                downloadRepository = get(),
+                playbackPositionRepository = get(),
             )
         }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookRepository.kt
@@ -36,6 +36,12 @@ interface BookRepository {
     fun observeChapters(bookId: String): Flow<List<Chapter>>
 
     /**
+     * Observe whether [id] is currently live (present, not tombstoned) in the local mirror.
+     * Emits `false` once the book is removed/revoked. Drives the now-playing teardown.
+     */
+    fun observeIsBookLive(id: String): Flow<Boolean>
+
+    /**
      * Observe random unstarted books for discovery.
      *
      * Used for "Discover Something New" section.

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -5,11 +5,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DocumentRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.playback.ContributorPickerType
 import com.calypsan.listenup.client.playback.NowPlayingOverlay
@@ -34,6 +37,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -78,6 +82,8 @@ class NowPlayingViewModel(
     private val playbackPreferences: PlaybackPreferences,
     private val networkMonitor: NetworkMonitor,
     private val documentRepository: DocumentRepository,
+    private val downloadRepository: DownloadRepository,
+    private val playbackPositionRepository: PlaybackPositionRepository,
 ) : ViewModel() {
     private companion object {
         const val FADE_DURATION_MS = 3000L
@@ -221,6 +227,12 @@ class NowPlayingViewModel(
                 }
         }
 
+        // Side effect: tear down the player when the currently-playing book leaves the local mirror
+        // (a removal tombstone or an access revoke), with ONE offline-grace exception — a DOWNLOADED,
+        // IN-PROGRESS copy keeps playing (never-stranded). A streaming (not-downloaded) book stops
+        // (the server already 404s its stream); a downloaded-but-not-in-progress book also drops.
+        watchNowPlayingLiveness()
+
         // Side effect: handle sleep timer fade-out events.
         // The try/catch ensures onFadeCompleted() (which resets state to Inactive) is
         // always called — even when fadeOutAndPause() throws or when viewModelScope is
@@ -239,6 +251,48 @@ class NowPlayingViewModel(
                     sleepTimerManager.onFadeCompleted()
                 }
             }
+        }
+    }
+
+    /**
+     * Observe the now-playing book's liveness in the local mirror and tear the player down when the
+     * book is gone (removed or access-revoked) — honouring the offline-grace exception.
+     *
+     * The decision per book: tear down when the book is NOT live AND it is NOT the protected case of
+     * being both downloaded AND in-progress. A streaming book (not downloaded) stops the moment access
+     * is lost; a downloaded book the user has meaningfully started keeps playing offline; a downloaded
+     * book at position 0 (never really started) drops. [closeBook] resets `currentBookId`, so the
+     * [flatMapLatest] re-subscribes to `null` and the effect quiesces — no teardown loop.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun watchNowPlayingLiveness() {
+        viewModelScope.launch {
+            playbackManager.currentBookId
+                .flatMapLatest { bookId ->
+                    if (bookId == null) {
+                        flowOf(false)
+                    } else {
+                        combine(
+                            bookRepository.observeIsBookLive(bookId.value),
+                            downloadRepository.observeBookStatus(bookId),
+                            playbackPositionRepository.observeAll(),
+                        ) { isLive, downloadStatus, positions ->
+                            val downloaded = downloadStatus is BookDownloadStatus.Completed
+                            val position = positions[bookId]
+                            val inProgress = position != null && position.positionMs > 0 && !position.isFinished
+                            !isLive && !(downloaded && inProgress)
+                        }
+                    }
+                }.distinctUntilChanged()
+                .collect { shouldTearDown ->
+                    if (shouldTearDown) {
+                        logger.info {
+                            "Now-playing book left the local mirror (removed/revoked) and is not a " +
+                                "downloaded in-progress copy — tearing down the player."
+                        }
+                        closeBook()
+                    }
+                }
         }
     }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
@@ -66,6 +66,7 @@ class NowPlayingProgressIsolationTest :
             every { playbackPreferences.observeDefaultPlaybackSpeed() } returns flowOf(1.0f)
             everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
             everySuspend { bookRepository.getBookListItem(any()) } returns sampleBook()
+            every { bookRepository.observeIsBookLive(any()) } returns flowOf(true)
             every { documentRepository.observeDocuments(any()) } returns flowOf(emptyList())
             every { playbackController.acquire() } returns Unit
             return NowPlayingViewModel(
@@ -76,6 +77,8 @@ class NowPlayingProgressIsolationTest :
                 playbackPreferences = playbackPreferences,
                 networkMonitor = networkMonitor,
                 documentRepository = documentRepository,
+                downloadRepository = com.calypsan.listenup.client.test.fake.FakeDownloadRepository(),
+                playbackPositionRepository = com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository(),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
@@ -77,8 +77,12 @@ class NowPlayingProgressIsolationTest :
                 playbackPreferences = playbackPreferences,
                 networkMonitor = networkMonitor,
                 documentRepository = documentRepository,
-                downloadRepository = com.calypsan.listenup.client.test.fake.FakeDownloadRepository(),
-                playbackPositionRepository = com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository(),
+                downloadRepository =
+                    com.calypsan.listenup.client.test.fake
+                        .FakeDownloadRepository(),
+                playbackPositionRepository =
+                    com.calypsan.listenup.client.test.fake
+                        .FakePlaybackPositionRepository(),
             )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
@@ -1,0 +1,170 @@
+package com.calypsan.listenup.client.presentation.nowplaying
+
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.client.domain.model.BookContributor
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.BookListItem
+import com.calypsan.listenup.client.domain.model.PlaybackPosition
+import com.calypsan.listenup.client.domain.repository.DocumentRepository
+import com.calypsan.listenup.client.domain.repository.NetworkMonitor
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.playback.PlaybackController
+import com.calypsan.listenup.client.playback.SleepTimerManager
+import com.calypsan.listenup.client.test.fake.FakeBookRepository
+import com.calypsan.listenup.client.test.fake.FakeDownloadRepository
+import com.calypsan.listenup.client.test.fake.FakePlaybackManager
+import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
+import com.calypsan.listenup.core.Timestamp
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+/**
+ * Now-playing teardown: when the currently-playing book leaves the local mirror (removed or
+ * access-revoked), the player tears down — EXCEPT for the offline-grace case of a downloaded,
+ * in-progress copy, which keeps playing (never-stranded).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NowPlayingTeardownTest :
+    FunSpec({
+        val testDispatcher = StandardTestDispatcher()
+        beforeTest { Dispatchers.setMain(testDispatcher) }
+        afterTest { Dispatchers.resetMain() }
+
+        val bookId = BookId("b1")
+
+        fun sampleBook() =
+            BookListItem(
+                id = bookId,
+                libraryId = LibraryId("lib"),
+                folderId = FolderId("folder"),
+                title = "Playing Book",
+                authors = listOf(BookContributor(id = "a1", name = "Author", roles = listOf("Author"))),
+                narrators = emptyList(),
+                duration = 100_000L,
+                coverPath = null,
+                addedAt = Timestamp(epochMillis = 1L),
+                updatedAt = Timestamp(epochMillis = 1L),
+            )
+
+        fun inProgressPosition() =
+            PlaybackPosition(
+                bookId = bookId.value,
+                positionMs = 42_000L,
+                playbackSpeed = 1.0f,
+                hasCustomSpeed = false,
+                updatedAtMs = 10L,
+                syncedAtMs = null,
+                lastPlayedAtMs = 10L,
+                isFinished = false,
+            )
+
+        fun buildVm(
+            bookRepository: FakeBookRepository,
+            downloadRepository: FakeDownloadRepository,
+            positionRepository: FakePlaybackPositionRepository,
+            fakePm: FakePlaybackManager,
+        ): NowPlayingViewModel {
+            val playbackController: PlaybackController = mock()
+            val playbackPreferences: PlaybackPreferences = mock()
+            val networkMonitor: NetworkMonitor = mock()
+            val documentRepository: DocumentRepository = mock()
+            every { playbackController.acquire() } returns Unit
+            every { playbackController.stop() } returns Unit
+            every { playbackPreferences.observeDefaultPlaybackSpeed() } returns flowOf(1.0f)
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+            every { documentRepository.observeDocuments(any()) } returns flowOf(emptyList())
+            return NowPlayingViewModel(
+                playbackManager = fakePm,
+                bookRepository = bookRepository,
+                sleepTimerManager = SleepTimerManager(CoroutineScope(Job())),
+                playbackController = playbackController,
+                playbackPreferences = playbackPreferences,
+                networkMonitor = networkMonitor,
+                documentRepository = documentRepository,
+                downloadRepository = downloadRepository,
+                playbackPositionRepository = positionRepository,
+            )
+        }
+
+        test("streaming now-playing book that leaves the mirror tears down the player") {
+            runTest {
+                val bookRepo = FakeBookRepository(initialBooks = listOf(sampleBook()))
+                val downloadRepo = FakeDownloadRepository() // NotDownloaded
+                val positionRepo = FakePlaybackPositionRepository()
+                val fakePm = FakePlaybackManager()
+                fakePm.currentBookIdFlow.value = bookId
+
+                buildVm(bookRepo, downloadRepo, positionRepo, fakePm)
+                advanceUntilIdle()
+
+                // Book is revoked/removed — drops out of the mirror.
+                bookRepo.setBooks(emptyList())
+                advanceUntilIdle()
+
+                fakePm.clearPlaybackCalls shouldBe 1
+            }
+        }
+
+        test("downloaded in-progress book that leaves the mirror keeps playing (offline grace)") {
+            runTest {
+                val bookRepo = FakeBookRepository(initialBooks = listOf(sampleBook()))
+                val downloadRepo =
+                    FakeDownloadRepository(
+                        initialStatuses =
+                            mapOf(bookId.value to BookDownloadStatus.Completed(bookId.value, totalBytes = 1_000L)),
+                    )
+                val positionRepo =
+                    FakePlaybackPositionRepository(initialPositions = mapOf(bookId.value to inProgressPosition()))
+                val fakePm = FakePlaybackManager()
+                fakePm.currentBookIdFlow.value = bookId
+
+                buildVm(bookRepo, downloadRepo, positionRepo, fakePm)
+                advanceUntilIdle()
+
+                bookRepo.setBooks(emptyList())
+                advanceUntilIdle()
+
+                fakePm.clearPlaybackCalls shouldBe 0
+            }
+        }
+
+        test("downloaded but not-in-progress book that leaves the mirror drops") {
+            runTest {
+                val bookRepo = FakeBookRepository(initialBooks = listOf(sampleBook()))
+                val downloadRepo =
+                    FakeDownloadRepository(
+                        initialStatuses =
+                            mapOf(bookId.value to BookDownloadStatus.Completed(bookId.value, totalBytes = 1_000L)),
+                    )
+                // No saved position → not in progress.
+                val positionRepo = FakePlaybackPositionRepository()
+                val fakePm = FakePlaybackManager()
+                fakePm.currentBookIdFlow.value = bookId
+
+                buildVm(bookRepo, downloadRepo, positionRepo, fakePm)
+                advanceUntilIdle()
+
+                bookRepo.setBooks(emptyList())
+                advanceUntilIdle()
+
+                fakePm.clearPlaybackCalls shouldBe 1
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -102,8 +102,12 @@ class NowPlayingViewModelTest :
                     playbackPreferences = playbackPreferences,
                     networkMonitor = networkMonitor,
                     documentRepository = documentRepository,
-                    downloadRepository = com.calypsan.listenup.client.test.fake.FakeDownloadRepository(),
-                    playbackPositionRepository = com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository(),
+                    downloadRepository =
+                        com.calypsan.listenup.client.test.fake
+                            .FakeDownloadRepository(),
+                    playbackPositionRepository =
+                        com.calypsan.listenup.client.test.fake
+                            .FakePlaybackPositionRepository(),
                 )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -83,6 +83,8 @@ class NowPlayingViewModelTest :
                 // Default: bookRepository.getBookListItem returns null (no metadata).
                 // bookFlow tolerates null; pure mapToNowPlayingState handles it.
                 everySuspend { bookRepository.getBookListItem(any()) } returns null
+                // Default: the now-playing book stays live, so the liveness teardown never fires.
+                every { bookRepository.observeIsBookLive(any()) } returns flowOf(true)
                 // Default: documentRepository.observeDocuments returns empty list (no documents).
                 every { documentRepository.observeDocuments(any()) } returns flowOf(emptyList())
                 // NowPlayingViewModel's init block calls playbackController.acquire() to
@@ -100,6 +102,8 @@ class NowPlayingViewModelTest :
                     playbackPreferences = playbackPreferences,
                     networkMonitor = networkMonitor,
                     documentRepository = documentRepository,
+                    downloadRepository = com.calypsan.listenup.client.test.fake.FakeDownloadRepository(),
+                    playbackPositionRepository = com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository(),
                 )
         }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeBookRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeBookRepository.kt
@@ -42,6 +42,10 @@ class FakeBookRepository(
 
     override fun observeChapters(bookId: String): Flow<List<Chapter>> = flowOf(chaptersByBookId[bookId].orEmpty())
 
+    /** A book is "live" in this fake when it is present in the current [books] list. */
+    override fun observeIsBookLive(id: String): Flow<Boolean> =
+        books.asStateFlow().map { list -> list.any { it.id == BookId(id) } }
+
     override fun observeRandomUnstartedBooks(limit: Int): Flow<List<DiscoveryBook>> =
         books.asStateFlow().map { list -> list.take(limit).map(::toDiscoveryBook) }
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeDownloadRepository.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeDownloadRepository.kt
@@ -1,0 +1,84 @@
+package com.calypsan.listenup.client.test.fake
+
+import com.calypsan.listenup.api.error.DownloadError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import com.calypsan.listenup.client.domain.model.Download
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.domain.model.DownloadStatus
+import com.calypsan.listenup.client.domain.model.DownloadedBookSummary
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.core.BookId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+/**
+ * In-memory [DownloadRepository] fake for seam tests. Only the read side used by the now-playing
+ * teardown ([observeBookStatus]) is stateful and controllable; the write/orchestration side returns
+ * benign defaults. Seed per-book statuses via [setStatus] and observers re-emit.
+ */
+class FakeDownloadRepository(
+    initialStatuses: Map<String, BookDownloadStatus> = emptyMap(),
+) : DownloadRepository {
+    private val statuses = MutableStateFlow(initialStatuses)
+
+    /** Test helper: set a book's aggregated download status, emitting to observers. */
+    fun setStatus(
+        bookId: String,
+        status: BookDownloadStatus,
+    ) {
+        statuses.value = statuses.value + (bookId to status)
+    }
+
+    override fun observeForBook(bookId: BookId): Flow<List<Download>> = flowOf(emptyList())
+
+    override fun observeAll(): Flow<List<Download>> = flowOf(emptyList())
+
+    override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
+        statuses.map { it[bookId.value] ?: BookDownloadStatus.NotDownloaded(bookId.value) }
+
+    override fun observeAllStatuses(): Flow<Map<String, BookDownloadStatus>> = statuses
+
+    override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> = flowOf(emptyList())
+
+    override suspend fun getLocalPath(audioFileId: String): String? = null
+
+    override suspend fun getStateForAudioFile(audioFileId: String): DownloadStatus? = null
+
+    override suspend fun markDownloading(
+        audioFileId: String,
+        startedAt: Long,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun updateProgress(
+        audioFileId: String,
+        downloadedBytes: Long,
+        totalBytes: Long,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun markCompleted(
+        audioFileId: String,
+        localPath: String,
+        completedAt: Long,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun markPaused(audioFileId: String): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun markCancelled(audioFileId: String): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun markFailed(
+        audioFileId: String,
+        error: DownloadError,
+    ): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun enqueueForBook(bookId: BookId): AppResult<DownloadOutcome> =
+        AppResult.Success(DownloadOutcome.Started)
+
+    override suspend fun cancelForBook(bookId: BookId): AppResult<Unit> = AppResult.Success(Unit)
+
+    override suspend fun deleteForBook(bookId: String) = Unit
+
+    override suspend fun resumeIncompleteDownloads(): AppResult<Unit> = AppResult.Success(Unit)
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/FakeRepositories.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/voice/FakeRepositories.kt
@@ -136,6 +136,8 @@ class FakeBookRepository : BookRepository {
 
     override fun observeChapters(bookId: String): Flow<List<Chapter>> = flowOf(chapters[bookId].orEmpty())
 
+    override fun observeIsBookLive(id: String): Flow<Boolean> = flowOf(true)
+
     override fun observeRandomUnstartedBooks(limit: Int): Flow<List<DiscoveryBook>> = flowOf(emptyList())
 
     override fun observeRecentlyAddedBooks(limit: Int): Flow<List<DiscoveryBook>> = flowOf(emptyList())

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -327,6 +327,8 @@ private class FakeBookRepository : BookRepository {
 
     override fun observeChapters(bookId: String): Flow<List<Chapter>> = flowOf(emptyList())
 
+    override fun observeIsBookLive(id: String): Flow<Boolean> = flowOf(true)
+
     override fun observeRandomUnstartedBooks(limit: Int): Flow<List<DiscoveryBook>> = flowOf(emptyList())
 
     override fun observeRecentlyAddedBooks(limit: Int): Flow<List<DiscoveryBook>> = flowOf(emptyList())


### PR DESCRIPTION
When a book is removed (scan-path removal / soft-delete) or a user loses access, everything downstream must react. This completes the "nuke" — the book disappears from every surface, and orphaned parents are purged.

## Server
- **`BookRepository.softDelete` cascade** now tombstones `collection_books` + `book_moods` (previously only `book_tags`), with symmetric revival in `reviveByIds` (deletedAt-floored) so remove-then-rescan keeps memberships.
- **Book-liveness-aware queries** — collection member/count queries + `accessibleCollectionBookIdsSql` exclude books with `deleted_at IS NOT NULL`, so a stale junction can't surface a dead book (inflated counts / dead ids).
- **Orphan purge (`OrphanParentPurger`)** — when a removal leaves a contributor / series / genre / tag / mood with zero live book children, the orphaned parent is tombstoned. Captures linked parents before soft-delete, purges the childless ones after.
- **S2** — `deleteCollection` now emits `AccessChanged` so members re-derive visibility.

## Client (`sharedLogic`)
- **Book-derived surfaces react** to removal / access-prune: `playback_positions` pruned for now-dead books (a removed/revoked book leaves Continue Listening), contributor counts join book-liveness, search backstops on `deletedAt`.
- **Playback teardown with offline grace** — when the currently-playing book leaves the local mirror, the player tears down **except** for a downloaded, in-progress copy (never-stranded). This is why `NowPlayingViewModel` now takes `DownloadRepository` + `PlaybackPositionRepository` (declared in `playbackPresentationModule.verify`).

## Test Plan
- [x] Orphan-purge tests (`BookRemovalOrphanPurgeTest`, 2/2) + cascade behavioral tests pass isolated.
- [x] DI `module.verify()` green (caught two missing cross-module deps; both declared).
- [x] detekt / compile / Koin graph green.
- [ ] **Full `:server:jvmTest` deferred to CI** — the local machine was under load 40+ (IDE), crashing test workers / hanging the scanner E2E suite (unrelated to this change; scan path untouched). CI runs the authoritative full gate on a clean box.

Stacked conceptually on #1038 (All-Books exclusivity — merged); uses its `reconcileSystemMembership`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)