### PR TITLE
✅ test(server): collections access-invariant guard suite — make the #680 regression class unshippable

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRemovalDispositions.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRemovalDispositions.kt
@@ -1,0 +1,81 @@
+package com.calypsan.listenup.server.services
+
+/**
+ * How a `book_id`-owning table behaves when its parent book is **soft-removed** ([BookRepository.softDelete]).
+ *
+ * This registry is the declared companion to the removal cascade. `BookRepositorySoftDeleteCascadeTest`
+ * proves the *behaviour*; [BookCascadeRegistryParityTest] proves this **map stays complete** — schema
+ * introspection fails the build the moment a new `book_id` table is added without a considered
+ * disposition here. That parity is the guard that would have caught the moods/collection_books cascade
+ * gap directly: a new table can no longer silently escape the removal decision.
+ */
+internal enum class RemovalDisposition {
+    /**
+     * A user-facing membership junction whose live rows are **tombstoned** by
+     * [BookRepository.softDelete] and **revived** by [BookRepository.reviveByIds] (floored on the
+     * removal instant), so clients receive per-row tombstones and a remove-then-rescan restores the
+     * membership. The dead book must leave these — visibility, counts, and the access union all key
+     * off live rows here. Verified behaviourally per table by [BookCascadeRegistryParityTest].
+     */
+    CASCADE_TOMBSTONED,
+
+    /**
+     * A child owned by the book aggregate (FK `ON DELETE CASCADE`), rewritten wholesale on every
+     * rescan. It is **not** an independent soft-delete cascade target: under a tombstoned parent its
+     * rows are unreachable (the parent hides them) and they are rebuilt on re-ingest. Adding one of
+     * these is a book-aggregate change, not an access change.
+     */
+    HARD_CHILD,
+
+    /**
+     * User-owned data keyed by `book_id` that **deliberately survives** a book removal — playback
+     * positions, read history, listening events, activity, shelf placement, active sessions. It is
+     * not a cascade target: a re-added book keeps the user's position and history (the never-stranded
+     * contract), and a dead book never surfaces because every read path gates on live books.
+     */
+    USER_DATA,
+
+    /**
+     * The FTS5 search-index shadow keyed by `book_id`. Maintained by the search-index write path
+     * ([com.calypsan.listenup.server.services.BookFtsWriter]) — a rowid↔book_id map, not a removal
+     * cascade target. A tombstoned book is filtered from search results by the book-liveness join +
+     * access gate, so its stale map row is inert and is overwritten (rowid reused) on re-ingest.
+     */
+    SEARCH_SHADOW,
+}
+
+/**
+ * The authoritative disposition of **every** table that carries a `book_id` column, keyed by table
+ * name. [BookCascadeRegistryParityTest] asserts this key set equals the set discovered by live schema
+ * introspection — in **both** directions — so a new `book_id` table forces an explicit entry here (and,
+ * if [RemovalDisposition.CASCADE_TOMBSTONED], a wired soft-delete/revive proven by that same test).
+ *
+ * Note on the search tables: the FTS5 virtual table `book_search` tracks books by `rowid`, not a
+ * `book_id` column (recreated contentless in V21), so it is not a `book_id` table. Its persistent
+ * rowid↔book_id map `book_search_map` (V9) **does** carry `book_id` and is the [RemovalDisposition
+ * .SEARCH_SHADOW] entry below.
+ */
+internal val bookIdTableDispositions: Map<String, RemovalDisposition> =
+    mapOf(
+        // ── Membership junctions the removal cascade tombstones + revives ──
+        "book_tags" to RemovalDisposition.CASCADE_TOMBSTONED,
+        "book_moods" to RemovalDisposition.CASCADE_TOMBSTONED,
+        "collection_books" to RemovalDisposition.CASCADE_TOMBSTONED,
+        // ── Book-aggregate children, rewritten on rescan (FK ON DELETE CASCADE) ──
+        "book_audio_files" to RemovalDisposition.HARD_CHILD,
+        "book_chapters" to RemovalDisposition.HARD_CHILD,
+        "book_contributors" to RemovalDisposition.HARD_CHILD,
+        "book_series_memberships" to RemovalDisposition.HARD_CHILD,
+        "book_genres" to RemovalDisposition.HARD_CHILD,
+        "book_documents" to RemovalDisposition.HARD_CHILD,
+        "pending_book_genres" to RemovalDisposition.HARD_CHILD,
+        // ── User-owned data that survives removal (never-stranded) ──
+        "playback_positions" to RemovalDisposition.USER_DATA,
+        "book_reads" to RemovalDisposition.USER_DATA,
+        "listening_events" to RemovalDisposition.USER_DATA,
+        "activities" to RemovalDisposition.USER_DATA,
+        "shelf_books" to RemovalDisposition.USER_DATA,
+        "active_sessions" to RemovalDisposition.USER_DATA,
+        // ── FTS5 search-index shadow (rowid↔book_id map) ──
+        "book_search_map" to RemovalDisposition.SEARCH_SHADOW,
+    )

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessInvariantMatrixTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessInvariantMatrixTest.kt
@@ -1,0 +1,423 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.CollectionId
+import com.calypsan.listenup.server.db.UserRoleColumn
+import com.calypsan.listenup.server.sync.SqlFragment
+import com.calypsan.listenup.server.testing.AccessModelOracle
+import com.calypsan.listenup.server.testing.CollectionAccessHarness
+import com.calypsan.listenup.server.testing.actAs
+import com.calypsan.listenup.server.testing.collectionAccessHarness
+import com.calypsan.listenup.server.testing.grantAllBooks
+import com.calypsan.listenup.server.testing.junctionDiagnostic
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The **access-seam invariant matrix** — the guard that would have caught #680/#730.
+ *
+ * Every row asserts the user-visible access *invariant* through the single funnel every byte and
+ * sync surface routes through — [BookAccessPolicy.canAccess] / [BookAccessPolicy.accessibleBookIds]
+ * and the access-filtered `pullSince` / `digest` — **never** through a `collection_books` junction
+ * read. That inversion is the whole point: #680/#730 slipped because the tests pinned junction state
+ * (the mechanism), which is legitimately rewritten during a refactor, while the invariant (what a
+ * member can actually reach) broke silently. Here a junction read is at most a `// mechanism
+ * diagnostic` that makes a failure legible; weakening any row means editing a line that reads as an
+ * access-control decision, cross-checked against the independent [AccessModelOracle].
+ *
+ * Rows:
+ *  - **I1** exclusivity — curating a book into a real collection removes it from ALL_BOOKS (the #680 hole).
+ *  - **I2** union — a book stays visible while any reachable containing collection is granted.
+ *  - **I3** removal — a soft-deleted book is denied to member AND root; the tombstone is delivered.
+ *  - **I4** inbox — a quarantined book is hidden from members, visible to root, released back into reach.
+ *  - **I5** ALL_BOOKS grant — revoking one member's default grant hides uncollected books from them only.
+ *  - **I6** dead relationships grant nothing — a tombstoned junction / collection / grant each deny.
+ *  - **I7** deleteCollection — sole membership returns to everyone; multi keeps the surviving audience.
+ *  - **I8** route parity — the HTTP surfaces funnel through the same policy; pinned by the existing
+ *    `SeamLeakE2ETest` + `BookRoutesTest` rather than re-derived here (see the note at the tail).
+ */
+class AccessInvariantMatrixTest :
+    FunSpec({
+
+        /** The member's access-filtered live book-id set — the ids a real catch-up would deliver. */
+        suspend fun CollectionAccessHarness.visibleLiveBooks(userId: String): List<String> {
+            val extra: SqlFragment? = bookAccessPolicy.accessibleBookIdsSql(userId, UserRole.MEMBER)
+            val page = bookRepo.pullSince(userId, cursor = 0L, limit = 1000, extraWhere = extra)
+            return page.items.filter { it.deletedAt == null }.map { it.id }
+        }
+
+        /** Creates a collection owned by [ownerId] (create is not admin-gated; owner = the caller). */
+        suspend fun CollectionServiceImpl.createCollectionAsOwner(
+            ownerId: String,
+            name: String,
+        ): CollectionId {
+            val created = actAs(ownerId).createCollection("test-library", name)
+            require(created is AppResult.Success) { "createCollection failed for $ownerId: $created" }
+            return created.data.id
+        }
+
+        // ─────────────────────────────── I1: exclusivity ───────────────────────────────
+        test("I1 exclusivity: curating a book into a real collection denies it to a non-member (the #680 hole)") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    admin.addBookToCollection(CollectionId(allBooks.data.id.value), BookId("B"))
+                    h.grantAllBooks(allBooks.data.id.value, "m")
+
+                    // Precondition: m reaches B via the default ALL_BOOKS grant (oracle + policy agree).
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.visibleLiveBooks("m") shouldContain "B"
+
+                    // Curate B into a private collection C that m is NOT a member of.
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    admin.addBookToCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
+
+                    // THE INVARIANT: B left ALL_BOOKS → m can no longer reach it, via the funnel AND catch-up.
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+                    h.visibleLiveBooks("m") shouldNotContain "B"
+                    // mechanism diagnostic — the junction moved, but it is NOT what this row asserts.
+                    h.junctionDiagnostic("B") shouldNotContain allBooks.data.id.value
+                }
+            }
+        }
+
+        // ─────────────────────────────── I2: union ───────────────────────────────
+        test("I2 union: granting a containing collection restores access; revoking removes it") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    admin.addBookToCollection(c.data.id, BookId("B"))
+
+                    // No grant → invisible.
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+
+                    // Grant C to m → visible (union: any one reachable containing collection wins).
+                    val grantId = "grant-c-m"
+                    h.grantRepo.upsert(
+                        CollectionShareSyncPayload(
+                            id = grantId,
+                            collectionId = c.data.id.value,
+                            sharedWithUserId = "m",
+                            sharedByUserId = "admin",
+                            permission = SharePermission.Read,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.visibleLiveBooks("m") shouldContain "B"
+
+                    // Revoke → invisible again.
+                    h.grantRepo.softDelete(grantId, clientOpId = null)
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+                }
+            }
+        }
+
+        // ─────────────────────────────── I3: removal ───────────────────────────────
+        test("I3 removal: a soft-deleted book is denied to member AND root, and the tombstone is delivered") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    admin.addBookToCollection(CollectionId(allBooks.data.id.value), BookId("B"))
+                    h.grantAllBooks(allBooks.data.id.value, "m")
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+
+                    // Remove the book through the real removal cascade.
+                    h.bookRepo.softDelete(BookId("B"), clientOpId = null) shouldBe AppResult.Success(Unit)
+
+                    // Denied to the member (oracle agrees) AND to root — bookExists requires deleted_at IS NULL.
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+                    h.bookAccessPolicy.canAccess("root", UserRole.ROOT, "B").shouldBeFalse()
+
+                    // Catch-up delivers the tombstone (so the member converges), but no LIVE row remains;
+                    // the digest excludes it going forward.
+                    val extra = h.bookAccessPolicy.accessibleBookIdsSql("m", UserRole.MEMBER)
+                    val page = h.bookRepo.pullSince("m", cursor = 0L, limit = 1000, extraWhere = extra)
+                    page.items.filter { it.deletedAt == null }.map { it.id } shouldNotContain "B"
+                    page.items.any { it.id == "B" && it.deletedAt != null }.shouldBeTrue()
+                    h.bookRepo.digest("m", cursor = 1_000_000L, extraWhere = extra).count shouldBe 0
+                }
+            }
+        }
+
+        // ─────────────────────────────── I4: inbox ───────────────────────────────
+        test("I4 inbox: a quarantined book is hidden from members, visible to root, and reachable once released") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    admin.getOrCreateInbox("test-library")
+                    admin.addToInbox("B", "test-library") shouldBe AppResult.Success(Unit)
+
+                    // In INBOX (not ALL_BOOKS) → hidden from a member, visible to root.
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+                    h.bookAccessPolicy.canAccess("root", UserRole.ROOT, "B").shouldBeTrue()
+
+                    // Release into a collection m is granted → reachable.
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    h.grantRepo.upsert(
+                        CollectionShareSyncPayload(
+                            id = "grant-c-m",
+                            collectionId = c.data.id.value,
+                            sharedWithUserId = "m",
+                            sharedByUserId = "admin",
+                            permission = SharePermission.Read,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    admin.releaseBooks("test-library", mapOf("B" to listOf(c.data.id.value))) shouldBe AppResult.Success(Unit)
+
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                }
+            }
+        }
+
+        // ─────────────────────────────── I5: ALL_BOOKS grant ───────────────────────────────
+        test("I5 ALL_BOOKS grant: revoking one member's default grant hides uncollected books from them only") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m1")
+                sql.seedTestUser("m2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    admin.addBookToCollection(CollectionId(allBooks.data.id.value), BookId("B"))
+                    h.grantAllBooks(allBooks.data.id.value, "m1")
+                    h.grantAllBooks(allBooks.data.id.value, "m2")
+                    h.bookAccessPolicy.canAccess("m1", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.bookAccessPolicy.canAccess("m2", UserRole.MEMBER, "B").shouldBeTrue()
+
+                    // Revoke m1's ALL_BOOKS grant only.
+                    h.grantRepo.softDelete("grant-${allBooks.data.id.value}-m1", clientOpId = null)
+
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m1", listOf("B"))
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m2", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m1", UserRole.MEMBER, "B").shouldBeFalse()
+                    h.bookAccessPolicy.canAccess("m2", UserRole.MEMBER, "B").shouldBeTrue()
+                }
+            }
+        }
+
+        // ─────────────────────────────── I6: dead relationships grant nothing ───────────────────────────────
+        test("I6 dead relationships grant nothing: a tombstoned junction, collection, or grant each deny") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("Bj") // dead junction
+                sql.seedTestBook("Bc") // dead collection
+                sql.seedTestBook("Bg") // dead grant
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    // (a) tombstoned junction: m owns C1, Bj was in it, junction tombstoned → deny.
+                    val c1 = admin.createCollectionAsOwner("m", "C1")
+                    admin.addBookToCollection(c1, BookId("Bj"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "Bj").shouldBeTrue() // control
+                    h.collectionBookRepo.softDelete(collectionId = c1.value, bookId = "Bj")
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "Bj").shouldBeFalse()
+
+                    // (b) tombstoned collection: m owns C2 holding Bc (live junction), but C2 is tombstoned → deny.
+                    val c2 = admin.createCollectionAsOwner("m", "C2")
+                    admin.addBookToCollection(c2, BookId("Bc"))
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "Bc").shouldBeTrue() // control
+                    h.collectionRepo.softDelete(c2.value, clientOpId = null)
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "Bc").shouldBeFalse()
+
+                    // (c) tombstoned grant: stranger owns C3 holding Bg; m's grant on C3 tombstoned → deny.
+                    val c3 = admin.createCollectionAsOwner("stranger", "C3")
+                    admin.addBookToCollection(c3, BookId("Bg"))
+                    h.grantRepo.upsert(
+                        CollectionShareSyncPayload(
+                            id = "grant-c3-m",
+                            collectionId = c3.value,
+                            sharedWithUserId = "m",
+                            sharedByUserId = "stranger",
+                            permission = SharePermission.Read,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "Bg").shouldBeTrue() // control
+                    h.grantRepo.softDelete("grant-c3-m", clientOpId = null)
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "Bg").shouldBeFalse()
+
+                    AccessModelOracle.assertAccessInvariants(
+                        h.bookAccessPolicy,
+                        h.db,
+                        h.driver,
+                        "m",
+                        listOf("Bj", "Bc", "Bg"),
+                    )
+                }
+            }
+        }
+
+        // ─────────────────────────────── I7: deleteCollection ───────────────────────────────
+        test("I7 deleteCollection sole membership: the book returns to everyone via ALL_BOOKS") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m1")
+                sql.seedTestUser("m2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    // Establish ALL_BOOKS + both members' default grants first.
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    h.grantAllBooks(allBooks.data.id.value, "m1")
+                    h.grantAllBooks(allBooks.data.id.value, "m2")
+
+                    // B lives ONLY in C (m1 granted). It left ALL_BOOKS, so m2 (only ALL_BOOKS) can't see it.
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    admin.addBookToCollection(c.data.id, BookId("B"))
+                    h.grantRepo.upsert(
+                        CollectionShareSyncPayload(
+                            id = "grant-c-m1",
+                            collectionId = c.data.id.value,
+                            sharedWithUserId = "m1",
+                            sharedByUserId = "admin",
+                            permission = SharePermission.Read,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    h.bookAccessPolicy.canAccess("m1", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.bookAccessPolicy.canAccess("m2", UserRole.MEMBER, "B").shouldBeFalse()
+
+                    // Delete C (B's only real membership) → B returns to ALL_BOOKS → visible to EVERYONE.
+                    admin.deleteCollection(c.data.id) shouldBe AppResult.Success(Unit)
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m1", listOf("B"))
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m2", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m1", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.bookAccessPolicy.canAccess("m2", UserRole.MEMBER, "B").shouldBeTrue()
+                }
+            }
+        }
+
+        test("I7 deleteCollection multi membership: the book drops only for the deleted collection's audience") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m1")
+                sql.seedTestUser("m2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    // B in C1 (m1 granted) and C2 (m2 granted). Union → both see it.
+                    val c1 = admin.createCollection("test-library", "C1")
+                    val c2 = admin.createCollection("test-library", "C2")
+                    require(c1 is AppResult.Success && c2 is AppResult.Success)
+                    admin.addBookToCollection(c1.data.id, BookId("B"))
+                    admin.addBookToCollection(c2.data.id, BookId("B"))
+                    for ((cid, member) in listOf(c1.data.id.value to "m1", c2.data.id.value to "m2")) {
+                        h.grantRepo.upsert(
+                            CollectionShareSyncPayload(
+                                id = "grant-$cid-$member",
+                                collectionId = cid,
+                                sharedWithUserId = member,
+                                sharedByUserId = "admin",
+                                permission = SharePermission.Read,
+                                revision = 0L,
+                                updatedAt = 0L,
+                                deletedAt = null,
+                            ),
+                        )
+                    }
+                    h.bookAccessPolicy.canAccess("m1", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.bookAccessPolicy.canAccess("m2", UserRole.MEMBER, "B").shouldBeTrue()
+
+                    // Delete C1: B still lives in C2 (never returns to ALL_BOOKS) → only m1 loses it.
+                    admin.deleteCollection(c1.data.id) shouldBe AppResult.Success(Unit)
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m1", listOf("B"))
+                    AccessModelOracle.assertAccessInvariants(h.bookAccessPolicy, h.db, h.driver, "m2", listOf("B"))
+                    h.bookAccessPolicy.canAccess("m1", UserRole.MEMBER, "B").shouldBeFalse()
+                    h.bookAccessPolicy.canAccess("m2", UserRole.MEMBER, "B").shouldBeTrue()
+                }
+            }
+        }
+
+        // ─────────────────────────────── I8: route parity — pinned by existing E2E, not duplicated ───────────────────────────────
+        // The HTTP byte/metadata surfaces all funnel through BookAccessPolicy.canAccess, which I1–I7
+        // exercise directly. Proving the *routes actually call the funnel* needs the full module, and
+        // that is already pinned comprehensively for a curated-out / private book by:
+        //   • SeamLeakE2ETest — getBook, search, audio, cover, catch-up, digest, AND the SSE firehose,
+        //     each with a visible public control, for a book unreachable to a member (the spec's SKIP
+        //     note names this test as the route-level pin), and
+        //   • BookRoutesTest — "GET /api/v1/books/{id} returns 404 when a member can't reach a private book".
+        // A third full-module testApplication here would duplicate those (and is library-alignment
+        // fragile: reconcile keys off books.library_id, so the book, ALL_BOOKS, and the member's default
+        // grant must share one library — the exact trap SeamLeak's library-aware makeBookPublic avoids).
+        // Per CLAUDE.md's no-redundant-coverage rule, I8 is deferred to those pins rather than re-derived.
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessEmissionContractTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessEmissionContractTest.kt
@@ -1,0 +1,346 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
+import com.calypsan.listenup.api.sync.SyncControl
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.CollectionId
+import com.calypsan.listenup.server.db.UserRoleColumn
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.konsist.stripComments
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.testing.CollectionAccessHarness
+import com.calypsan.listenup.server.testing.actAs
+import com.calypsan.listenup.server.testing.collectionAccessHarness
+import com.calypsan.listenup.server.testing.grantAllBooks
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The **emission-contract guard** for the per-user `AccessChanged` fan-out. Every visibility-changing
+ * collection mutation must nudge **exactly** the set of users whose access it changed — no member
+ * missed (they'd be stranded with stale visibility until the next foreground reconcile), no
+ * [SYSTEM_OWNER_ID] noise (the ALL_BOOKS/INBOX sentinel is not a real client). Each case computes its
+ * expected recipient set **before** the mutation and asserts the captured [SyncControl.AccessChanged]
+ * frames equal it exactly.
+ *
+ * `deleteCollection` is the S2 money-shot: its audience must be captured while the grants are still
+ * live (before the cascade tombstones them), so a member who reached the books *only* through the
+ * deleted collection is told to re-derive in real time. Moving that nudge after the grant tombstone
+ * drops the audience — this guard fires.
+ *
+ * A Konsist **completeness backstop** (bottom) proves the case list is exhaustive: every
+ * `CollectionServiceImpl` function that mutates `collection_books` / grants must appear as a case
+ * here or be allowlisted with a reason, so a new membership mutation can't ship without an emission
+ * contract.
+ */
+class CollectionAccessEmissionContractTest :
+    FunSpec({
+
+        /** Seeds an ADMIN `admin` plus each of [memberIds] as a MEMBER. */
+        fun ListenUpDatabase.seedAdminAndMembers(vararg memberIds: String) {
+            seedTestUser("admin", UserRoleColumn.ADMIN)
+            memberIds.forEach { seedTestUser(it) }
+        }
+
+        /** Materialises the library's ALL_BOOKS system collection and returns its id. */
+        suspend fun CollectionServiceImpl.allBooksId(): String {
+            val result = getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+            return (result as AppResult.Success).data.id.value
+        }
+
+        /** Creates a normal collection named [name] and returns its id. */
+        suspend fun CollectionServiceImpl.newCollection(name: String): CollectionId {
+            val result = createCollection("test-library", name)
+            return (result as AppResult.Success).data.id
+        }
+
+        /** A live USER read grant for [userId] on [collectionId]. */
+        suspend fun CollectionAccessHarness.shareTo(
+            collectionId: String,
+            userId: String,
+        ) {
+            grantRepo.upsert(
+                CollectionShareSyncPayload(
+                    id = "grant-$collectionId-$userId",
+                    collectionId = collectionId,
+                    sharedWithUserId = userId,
+                    sharedByUserId = "admin",
+                    permission = SharePermission.Read,
+                    revision = 0L,
+                    updatedAt = 0L,
+                    deletedAt = null,
+                ),
+            )
+        }
+
+        // ── addBookToCollection: target audience + the ALL_BOOKS grant-holders the flip-out reaches ──
+        test("addBookToCollection nudges the target audience AND the ALL_BOOKS holders it flips the book away from") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s1", "m1", "m2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val allBooks = admin.allBooksId()
+                    admin.addBookToCollection(CollectionId(allBooks), BookId("B"))
+                    h.grantAllBooks(allBooks, "m1")
+                    h.grantAllBooks(allBooks, "m2")
+                    val c = admin.newCollection("C")
+                    h.shareTo(c.value, "s1")
+
+                    h.revisionTouch.touched.clear()
+                    val recipients = captureAccessChanged(h.bus) { admin.addBookToCollection(c, BookId("B")) }
+
+                    recipients shouldBe setOf("admin", "s1", "m1", "m2")
+                    h.revisionTouch.touched shouldContain "B"
+                }
+            }
+        }
+
+        // ── removeBookFromCollection: target audience + ALL_BOOKS holders the flip-back reaches ──
+        test("removeBookFromCollection nudges the target audience AND the ALL_BOOKS holders it flips the book back to") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s1", "m1", "m2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val allBooks = admin.allBooksId()
+                    h.grantAllBooks(allBooks, "m1")
+                    h.grantAllBooks(allBooks, "m2")
+                    val c = admin.newCollection("C")
+                    h.shareTo(c.value, "s1")
+                    admin.addBookToCollection(c, BookId("B")) // B now curated out of ALL_BOOKS
+
+                    h.revisionTouch.touched.clear()
+                    val recipients = captureAccessChanged(h.bus) { admin.removeBookFromCollection(c, BookId("B")) }
+
+                    recipients shouldBe setOf("admin", "s1", "m1", "m2")
+                    h.revisionTouch.touched shouldContain "B"
+                }
+            }
+        }
+
+        // ── setBookCollections: the union of the added and removed audiences ──
+        test("setBookCollections nudges the union of the added and removed collection audiences") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s1", "s2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val c1 = admin.newCollection("C1")
+                    val c2 = admin.newCollection("C2")
+                    h.shareTo(c1.value, "s1")
+                    h.shareTo(c2.value, "s2")
+                    admin.addBookToCollection(c1, BookId("B"))
+
+                    h.revisionTouch.touched.clear()
+                    val recipients = captureAccessChanged(h.bus) { admin.setBookCollections(BookId("B"), listOf(c2)) }
+
+                    recipients shouldBe setOf("admin", "s1", "s2")
+                    h.revisionTouch.touched shouldContain "B"
+                }
+            }
+        }
+
+        // ── shareCollection: only the newly-shared user ──
+        test("shareCollection nudges only the newly-shared user") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s3")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val c = admin.newCollection("C")
+
+                    val recipients = captureAccessChanged(h.bus) { admin.shareCollection(c, "s3", SharePermission.Read) }
+
+                    recipients shouldBe setOf("s3")
+                }
+            }
+        }
+
+        // ── updateShare: only the affected recipient ──
+        test("updateShare nudges only the recipient whose permission changed") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s4")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val c = admin.newCollection("C")
+                    admin.shareCollection(c, "s4", SharePermission.Read)
+
+                    val recipients = captureAccessChanged(h.bus) { admin.updateShare(c, "s4", SharePermission.Write) }
+
+                    recipients shouldBe setOf("s4")
+                }
+            }
+        }
+
+        // ── revokeShare: only the ex-target, and only because a live grant existed ──
+        test("revokeShare nudges only the ex-target when a live grant existed") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s5")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val c = admin.newCollection("C")
+                    admin.shareCollection(c, "s5", SharePermission.Read)
+
+                    val recipients = captureAccessChanged(h.bus) { admin.revokeShare(c, "s5") }
+
+                    recipients shouldBe setOf("s5")
+                }
+            }
+        }
+
+        // ── deleteCollection (S2): audience captured BEFORE grants tombstone + ALL_BOOKS re-home holders ──
+        test("deleteCollection nudges the pre-delete audience (S2) AND the ALL_BOOKS holders a re-homed book returns to") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s6", "m1", "m2")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val allBooks = admin.allBooksId()
+                    h.grantAllBooks(allBooks, "m1")
+                    h.grantAllBooks(allBooks, "m2")
+                    val c = admin.newCollection("C")
+                    h.shareTo(c.value, "s6")
+                    admin.addBookToCollection(c, BookId("B")) // sole membership → will re-home to ALL_BOOKS
+
+                    h.revisionTouch.touched.clear()
+                    val recipients = captureAccessChanged(h.bus) { admin.deleteCollection(c) }
+
+                    // s6 is present ONLY because the audience was captured while the grant was still live (S2).
+                    recipients shouldBe setOf("admin", "s6", "m1", "m2")
+                    h.revisionTouch.touched shouldContain "B"
+                }
+            }
+        }
+
+        // ── releaseBooks: every target-collection audience + ALL_BOOKS holders for the unsorted release ──
+        test("releaseBooks nudges every target audience and the ALL_BOOKS holders for the unsorted release") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedAdminAndMembers("s7", "m1", "m2")
+                sql.seedTestBook("B")
+                sql.seedTestBook("U")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+                    val allBooks = admin.allBooksId()
+                    h.grantAllBooks(allBooks, "m1")
+                    h.grantAllBooks(allBooks, "m2")
+                    admin.getOrCreateInbox("test-library")
+                    admin.addToInbox("B", "test-library")
+                    admin.addToInbox("U", "test-library")
+                    val c = admin.newCollection("C")
+                    h.shareTo(c.value, "s7")
+
+                    h.revisionTouch.touched.clear()
+                    val recipients =
+                        captureAccessChanged(h.bus) {
+                            admin.releaseBooks("test-library", mapOf("B" to listOf(c.value), "U" to emptyList()))
+                        }
+
+                    recipients shouldBe setOf("admin", "s7", "m1", "m2")
+                    h.revisionTouch.touched shouldContain "B"
+                    h.revisionTouch.touched shouldContain "U"
+                }
+            }
+        }
+
+        // ── Completeness backstop: no membership/grant mutation escapes an emission case ──
+        test("every CollectionServiceImpl membership/grant mutation has an emission case (or an allowlist reason)") {
+            val serviceFns =
+                Konsist
+                    .scopeFromProduction()
+                    .classes()
+                    .filter { it.name == "CollectionServiceImpl" }
+                    .flatMap { it.functions() }
+            require(serviceFns.isNotEmpty()) { "CollectionServiceImpl not found in production scope — check the Konsist scope" }
+
+            val uncovered =
+                serviceFns
+                    .filter { fn ->
+                        val body = stripComments(fn.text)
+                        "collectionBookRepo.upsert(" in body ||
+                            "collectionBookRepo.softDelete" in body ||
+                            "grantRepo.upsert(" in body ||
+                            "grantRepo.softDelete" in body
+                    }.map { it.name }
+                    .distinct()
+                    .filterNot { it in EMISSION_CASE_FUNCTIONS || it in EMISSION_ALLOWLIST }
+                    .map { "$it mutates collection_books/grants but has no emission contract case — add a case or allowlist it" }
+            uncovered.shouldBeEmpty()
+        }
+    }) {
+    companion object {
+        /** The membership/grant mutations whose AccessChanged fan-out is pinned by a case above. */
+        val EMISSION_CASE_FUNCTIONS =
+            setOf(
+                "addBookToCollection",
+                "removeBookFromCollection",
+                "setBookCollections",
+                "shareCollection",
+                "updateShare",
+                "revokeShare",
+                "deleteCollection",
+                "releaseBooks",
+            )
+
+        /**
+         * Functions that touch the mutation tokens but legitimately emit nothing here:
+         *  - `reconcileSystemMembership` — the private flip helper, exercised through the add/remove cases.
+         *  - `addToInbox` — quarantine by placement; hidden via delivery-time `canAccess`, no proactive nudge.
+         */
+        val EMISSION_ALLOWLIST = setOf("reconcileSystemMembership", "addToInbox")
+    }
+}
+
+/**
+ * Subscribes to [bus]'s control channel, runs [action], and returns the set of user ids that received
+ * an [SyncControl.AccessChanged] frame. The collector starts UNDISPATCHED so it is subscribed before
+ * [action] emits (the control channel has no replay); [runCurrent] then drains the buffered frames.
+ */
+private suspend fun TestScope.captureAccessChanged(
+    bus: ChangeBus,
+    action: suspend () -> Unit,
+): Set<String> {
+    val recipients = mutableListOf<String>()
+    val collector =
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.subscribeControl().collect { frame ->
+                if (frame.control == SyncControl.AccessChanged) recipients += frame.userId
+            }
+        }
+    action()
+    runCurrent()
+    collector.cancel()
+    return recipients.toSet()
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessModelExclusivityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessModelExclusivityTest.kt
@@ -2,35 +2,25 @@
 
 package com.calypsan.listenup.server.api
 
-import com.calypsan.listenup.api.dto.SharePermission
-import com.calypsan.listenup.api.dto.auth.SessionId
-import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.result.AppResult
-import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.CollectionId
-import com.calypsan.listenup.server.auth.PrincipalProvider
-import com.calypsan.listenup.server.auth.UserPermissionPolicy
-import com.calypsan.listenup.server.auth.UserPrincipal
 import com.calypsan.listenup.server.db.UserRoleColumn
-import com.calypsan.listenup.server.sync.ChangeBus
-import com.calypsan.listenup.server.sync.CollectionBookRepository
-import com.calypsan.listenup.server.sync.CollectionGrantRepository
-import com.calypsan.listenup.server.sync.CollectionRepository
-import com.calypsan.listenup.server.sync.SyncRegistry
-import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
-import com.calypsan.listenup.server.testing.FixedClock
-import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.actAs
+import com.calypsan.listenup.server.testing.collectionAccessHarness
+import com.calypsan.listenup.server.testing.grantAllBooks
+import com.calypsan.listenup.server.testing.junctionDiagnostic
 import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.seedTestUser
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
-import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -39,111 +29,52 @@ import kotlinx.coroutines.test.runTest
  * book into a real collection must remove it from the everyone-visible ALL_BOOKS substrate;
  * removing its last real membership must return it.
  *
- * These tests drive the real [CollectionServiceImpl] over a real Flyway-migrated in-memory
- * SQLite db and assert visibility through the real [BookAccessPolicy] — the money-shot proves
- * a curated-out book is denied to a non-member who only holds the default ALL_BOOKS grant.
+ * These tests drive the real [CollectionServiceImpl] over a real Flyway-migrated in-memory SQLite
+ * db via the shared [collectionAccessHarness]. Every case now carries a **load-bearing**
+ * [BookAccessPolicy.canAccess] assertion — what a member actually sees — while the junction-state
+ * check is demoted to a `junctionDiagnostic(...)` *mechanism diagnostic* that only makes a failure
+ * legible. That inversion is deliberate: #680/#730 slipped because the tests pinned junction state,
+ * which is legitimately rewritten during a refactor, while the visible-access invariant broke
+ * silently. The canonical exclusivity money-shot (curate-out denies a non-member) and the union
+ * case now live in `AccessInvariantMatrixTest` (rows I1/I2); these cover the remaining mutation
+ * paths — setBookCollections, releaseBooks, deleteCollection, and the never-orphan sweep.
  */
 class CollectionAccessModelExclusivityTest :
     FunSpec({
 
-        val fixedClock = FixedClock(Instant.fromEpochMilliseconds(1_700_000_000_000L))
-
-        fun principalFor(
-            userId: String,
-            role: UserRole = UserRole.MEMBER,
-        ): PrincipalProvider =
-            PrincipalProvider {
-                UserPrincipal(UserId(userId), SessionId("session-$userId"), role)
-            }
-
-        data class Harness(
-            val service: CollectionServiceImpl,
-            val collectionRepo: CollectionRepository,
-            val collectionBookRepo: CollectionBookRepository,
-            val grantRepo: CollectionGrantRepository,
-            val bookAccessPolicy: BookAccessPolicy,
-        )
-
-        fun makeHarness(db: SqlTestDatabases): Harness {
-            val bus = ChangeBus()
-            val registry = SyncRegistry()
-            val collectionRepo = CollectionRepository(db = db.sql, bus = bus, registry = registry, driver = db.driver)
-            val collectionBookRepo =
-                CollectionBookRepository(db = db.sql, bus = bus, registry = registry, driver = db.driver)
-            val grantRepo = CollectionGrantRepository(db = db.sql, bus = bus, registry = registry, driver = db.driver)
-            val accessPolicy = CollectionAccessPolicy(collectionRepo, grantRepo)
-            val service =
-                CollectionServiceImpl(
-                    collectionRepo = collectionRepo,
-                    collectionBookRepo = collectionBookRepo,
-                    grantRepo = grantRepo,
-                    accessPolicy = accessPolicy,
-                    bus = bus,
-                    sql = db.sql,
-                    clock = fixedClock,
-                    permissionPolicy = UserPermissionPolicy(db.sql),
-                    bookRevisionTouch = FakeBookRevisionTouch(),
-                    principal = principalFor("admin", UserRole.ADMIN),
-                )
-            return Harness(service, collectionRepo, collectionBookRepo, grantRepo, BookAccessPolicy(db.sql, db.driver))
-        }
-
-        fun CollectionServiceImpl.actAs(
-            userId: String,
-            role: UserRole = UserRole.MEMBER,
-        ): CollectionServiceImpl = copyWith(principalFor(userId, role))
-
-        /** Grants [userId] the default ALL_BOOKS grant every member holds at registration. */
-        suspend fun Harness.grantAllBooks(
-            allBooksId: String,
-            userId: String,
-        ) {
-            grantRepo.upsert(
-                CollectionShareSyncPayload(
-                    id = "grant-$allBooksId-$userId",
-                    collectionId = allBooksId,
-                    sharedWithUserId = userId,
-                    sharedByUserId = "system",
-                    permission = SharePermission.Read,
-                    revision = 0L,
-                    updatedAt = 0L,
-                    deletedAt = null,
-                ),
-            )
-        }
-
-        /** The live (non-system-excluded) collection ids the book currently belongs to. */
-        suspend fun Harness.liveMemberships(bookId: String): Set<String> = collectionBookRepo.findCollectionIdsForBook(bookId).toSet()
-
-        test("adding a book to a real collection removes it from ALL_BOOKS; removing the last returns it") {
+        test("adding a book to a real collection denies it to an ALL_BOOKS member; removing the last restores it") {
             withSqlDatabase {
-                val db = this
                 sql.seedTestLibraryAndFolder()
                 sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
                 sql.seedTestBook("B")
                 runTest {
-                    val h = makeHarness(db)
+                    val h = collectionAccessHarness()
                     val admin = h.service.actAs("admin", UserRole.ADMIN)
 
                     val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
                     require(allBooks is AppResult.Success)
                     val allBooksId = allBooks.data.id.value
                     admin.addBookToCollection(CollectionId(allBooksId), BookId("B")) shouldBe AppResult.Success(Unit)
-                    h.liveMemberships("B") shouldContain allBooksId
+                    h.grantAllBooks(allBooksId, "m")
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
 
                     val c = admin.createCollection("test-library", "C")
                     require(c is AppResult.Success)
 
-                    // First real membership ⇒ auto-LEAVE ALL_BOOKS.
+                    // First real membership ⇒ auto-LEAVE ALL_BOOKS ⇒ the ALL_BOOKS member loses access.
                     admin.addBookToCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
-                    h.liveMemberships("B").let {
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+                    // mechanism diagnostic — not the invariant this test asserts.
+                    h.junctionDiagnostic("B").let {
                         it shouldContain c.data.id.value
                         it shouldNotContain allBooksId
                     }
 
-                    // Last real membership removed ⇒ auto-RETURN to ALL_BOOKS.
+                    // Last real membership removed ⇒ auto-RETURN to ALL_BOOKS ⇒ access restored.
                     admin.removeBookFromCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
-                    h.liveMemberships("B").let {
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.junctionDiagnostic("B").let {
                         it shouldContain allBooksId
                         it shouldNotContain c.data.id.value
                     }
@@ -151,33 +82,36 @@ class CollectionAccessModelExclusivityTest :
             }
         }
 
-        test("setBookCollections([x]) leaves ALL_BOOKS; setBookCollections([]) returns to ALL_BOOKS") {
+        test("setBookCollections([x]) denies an ALL_BOOKS member; setBookCollections([]) restores access") {
             withSqlDatabase {
-                val db = this
                 sql.seedTestLibraryAndFolder()
                 sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
                 sql.seedTestBook("B")
                 runTest {
-                    val h = makeHarness(db)
+                    val h = collectionAccessHarness()
                     val admin = h.service.actAs("admin", UserRole.ADMIN)
 
                     val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
                     require(allBooks is AppResult.Success)
                     val allBooksId = allBooks.data.id.value
                     admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+                    h.grantAllBooks(allBooksId, "m")
 
                     val c = admin.createCollection("test-library", "C")
                     require(c is AppResult.Success)
 
                     admin.setBookCollections(BookId("B"), listOf(c.data.id)) shouldBe AppResult.Success(Unit)
-                    h.liveMemberships("B").let {
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
+                    h.junctionDiagnostic("B").let {
                         it shouldContain c.data.id.value
                         it shouldNotContain allBooksId
                     }
 
-                    // Empty target set: the book must NOT be orphaned — it returns to ALL_BOOKS.
+                    // Empty target set: the book must NOT be orphaned — it returns to ALL_BOOKS and access returns.
                     admin.setBookCollections(BookId("B"), emptyList()) shouldBe AppResult.Success(Unit)
-                    h.liveMemberships("B").let {
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.junctionDiagnostic("B").let {
                         it shouldContain allBooksId
                         it shouldNotContain c.data.id.value
                     }
@@ -185,102 +119,15 @@ class CollectionAccessModelExclusivityTest :
             }
         }
 
-        test("MONEY SHOT: curating a book out of ALL_BOOKS denies it to a non-member; removing restores access") {
+        test("releaseBooks: a sorted book is hidden from an ungranted member; an unsorted book stays public") {
             withSqlDatabase {
-                val db = this
                 sql.seedTestLibraryAndFolder()
                 sql.seedTestUser("admin", UserRoleColumn.ADMIN)
                 sql.seedTestUser("m")
-                sql.seedTestBook("B")
-                runTest {
-                    val h = makeHarness(db)
-                    val admin = h.service.actAs("admin", UserRole.ADMIN)
-
-                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
-                    require(allBooks is AppResult.Success)
-                    val allBooksId = allBooks.data.id.value
-                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
-                    h.grantAllBooks(allBooksId, "m")
-
-                    // Precondition: m sees B via the default ALL_BOOKS grant.
-                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
-
-                    // Admin curates B into a private collection C that m is NOT a member of.
-                    val c = admin.createCollection("test-library", "C")
-                    require(c is AppResult.Success)
-                    admin.addBookToCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
-
-                    // B left ALL_BOOKS → m can no longer reach it (THIS FAILS BEFORE THE FIX).
-                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe false
-
-                    // Un-curate → B returns to ALL_BOOKS → m regains access.
-                    admin.removeBookFromCollection(c.data.id, BookId("B")) shouldBe AppResult.Success(Unit)
-                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
-                }
-            }
-        }
-
-        test("multi-collection union: book stays visible while any granted real membership remains") {
-            withSqlDatabase {
-                val db = this
-                sql.seedTestLibraryAndFolder()
-                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
-                sql.seedTestUser("m")
-                sql.seedTestBook("B")
-                runTest {
-                    val h = makeHarness(db)
-                    val admin = h.service.actAs("admin", UserRole.ADMIN)
-
-                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
-                    require(allBooks is AppResult.Success)
-                    val allBooksId = allBooks.data.id.value
-                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
-                    h.grantAllBooks(allBooksId, "m")
-
-                    // C1 (shared to m) and C2 (private). B ∈ C1 ∪ C2 ⇒ B leaves ALL_BOOKS.
-                    val c1 = admin.createCollection("test-library", "C1")
-                    val c2 = admin.createCollection("test-library", "C2")
-                    require(c1 is AppResult.Success)
-                    require(c2 is AppResult.Success)
-                    admin.addBookToCollection(c1.data.id, BookId("B"))
-                    admin.addBookToCollection(c2.data.id, BookId("B"))
-                    h.grantRepo.upsert(
-                        CollectionShareSyncPayload(
-                            id = "grant-c1-m",
-                            collectionId = c1.data.id.value,
-                            sharedWithUserId = "m",
-                            sharedByUserId = "admin",
-                            permission = SharePermission.Read,
-                            revision = 0L,
-                            updatedAt = 0L,
-                            deletedAt = null,
-                        ),
-                    )
-                    h.liveMemberships("B") shouldNotContain allBooksId
-                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
-
-                    // Remove C1: m loses the granted path, but B is still in C2 (not ALL_BOOKS) → invisible to m.
-                    admin.removeBookFromCollection(c1.data.id, BookId("B"))
-                    h.liveMemberships("B") shouldNotContain allBooksId
-                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe false
-
-                    // Remove C2 (last real membership) → B returns to ALL_BOOKS → visible to m again.
-                    admin.removeBookFromCollection(c2.data.id, BookId("B"))
-                    h.liveMemberships("B") shouldContain allBooksId
-                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B") shouldBe true
-                }
-            }
-        }
-
-        test("releaseBooks: released into a collection ⇒ not in INBOX, not in ALL_BOOKS; released unsorted ⇒ ALL_BOOKS only") {
-            withSqlDatabase {
-                val db = this
-                sql.seedTestLibraryAndFolder()
-                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
                 sql.seedTestBook("sorted")
                 sql.seedTestBook("unsorted")
                 runTest {
-                    val h = makeHarness(db)
+                    val h = collectionAccessHarness()
                     val admin = h.service.actAs("admin", UserRole.ADMIN)
 
                     val inbox = admin.getOrCreateInbox("test-library")
@@ -300,13 +147,18 @@ class CollectionAccessModelExclusivityTest :
                     val allBooksId =
                         h.collectionRepo.findSystemCollection("test-library", SYSTEM_TYPE_ALL_BOOKS)?.id
                             ?: error("ALL_BOOKS must exist after an unsorted release")
+                    h.grantAllBooks(allBooksId, "m")
 
-                    h.liveMemberships("sorted").let {
+                    // Released into a private collection m can't reach ⇒ hidden; released unsorted ⇒ public.
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "sorted").shouldBeFalse()
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "unsorted").shouldBeTrue()
+
+                    h.junctionDiagnostic("sorted").let {
                         it shouldContain c.data.id.value
                         it shouldNotContain inboxId
                         it shouldNotContain allBooksId
                     }
-                    h.liveMemberships("unsorted").let {
+                    h.junctionDiagnostic("unsorted").let {
                         it shouldContain allBooksId
                         it shouldNotContain inboxId
                     }
@@ -314,29 +166,31 @@ class CollectionAccessModelExclusivityTest :
             }
         }
 
-        test("deleteCollection returns a book to ALL_BOOKS when the deleted collection was its only membership") {
+        test("deleteCollection returns a book to a public ALL_BOOKS member when the deleted collection was its only home") {
             withSqlDatabase {
-                val db = this
                 sql.seedTestLibraryAndFolder()
                 sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
                 sql.seedTestBook("B")
                 runTest {
-                    val h = makeHarness(db)
+                    val h = collectionAccessHarness()
                     val admin = h.service.actAs("admin", UserRole.ADMIN)
 
                     val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
                     require(allBooks is AppResult.Success)
                     val allBooksId = allBooks.data.id.value
                     admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+                    h.grantAllBooks(allBooksId, "m")
 
                     val c = admin.createCollection("test-library", "C")
                     require(c is AppResult.Success)
                     admin.addBookToCollection(c.data.id, BookId("B"))
-                    h.liveMemberships("B") shouldNotContain allBooksId
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeFalse()
 
-                    // Deleting C removes B's only real membership → B must not be stranded.
+                    // Deleting C removes B's only real membership → B must not be stranded → access returns.
                     admin.deleteCollection(c.data.id) shouldBe AppResult.Success(Unit)
-                    h.liveMemberships("B").let {
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                    h.junctionDiagnostic("B").let {
                         it shouldContain allBooksId
                         it shouldNotContain c.data.id.value
                     }
@@ -344,37 +198,48 @@ class CollectionAccessModelExclusivityTest :
             }
         }
 
-        test("never-orphan: no add/remove/set/delete path ends with a book in ZERO collections") {
+        test("never-stranded: no add/remove/set/delete path leaves a book unreachable to the public") {
             withSqlDatabase {
-                val db = this
                 sql.seedTestLibraryAndFolder()
                 sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
                 sql.seedTestBook("B")
                 runTest {
-                    val h = makeHarness(db)
+                    val h = collectionAccessHarness()
                     val admin = h.service.actAs("admin", UserRole.ADMIN)
 
                     val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
                     require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
                     admin.addBookToCollection(allBooks.data.id, BookId("B"))
+                    h.grantAllBooks(allBooksId, "m")
 
                     val c1 = admin.createCollection("test-library", "C1")
                     val c2 = admin.createCollection("test-library", "C2")
                     require(c1 is AppResult.Success)
                     require(c2 is AppResult.Success)
 
+                    // Through every mutation the book keeps ≥1 live membership (mechanism diagnostic) …
                     admin.addBookToCollection(c1.data.id, BookId("B"))
-                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    h.junctionDiagnostic("B").isNotEmpty() shouldBe true
                     admin.addBookToCollection(c2.data.id, BookId("B"))
-                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    h.junctionDiagnostic("B").isNotEmpty() shouldBe true
                     admin.setBookCollections(BookId("B"), listOf(c2.data.id))
-                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    h.junctionDiagnostic("B").isNotEmpty() shouldBe true
                     admin.removeBookFromCollection(c2.data.id, BookId("B"))
-                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    h.junctionDiagnostic("B").isNotEmpty() shouldBe true
+
+                    // … and when it lands uncollected it is reachable by the public — the never-stranded
+                    // ACCESS consequence, load-bearing: the book returned to ALL_BOOKS, not into a void.
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+
                     admin.setBookCollections(BookId("B"), emptyList())
-                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    h.junctionDiagnostic("B").isNotEmpty() shouldBe true
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+
                     admin.deleteCollection(c1.data.id)
-                    h.liveMemberships("B").isNotEmpty() shouldBe true
+                    h.junctionDiagnostic("B").isNotEmpty() shouldBe true
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/CollectionMembershipRoutingRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/CollectionMembershipRoutingRule.kt
@@ -1,0 +1,51 @@
+package com.calypsan.listenup.server.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * The **reconcile-routing tripwire** for the ALL_BOOKS exclusivity invariant (#680/#730).
+ *
+ * Every production function that mutates a `collection_books` membership through the
+ * `collectionBookRepo` — `collectionBookRepo.upsert(` / `collectionBookRepo.softDelete(` — must also
+ * call `reconcileSystemMembership(` in the same declaration, so a book is dropped out of (or returned
+ * to) the everyone-visible ALL_BOOKS substrate on **every** membership change. #680 shipped because a
+ * membership mutation forgot exactly this. A text-based tripwire is a cheap *early* signal — the
+ * semantic backstop is `AccessInvariantMatrixTest` (G1) — but it fires at the exact line a future
+ * membership mutation is written, before any access test even runs.
+ *
+ * Allowlisted (matches the token, legitimately does NOT reconcile):
+ *  - `reconcileSystemMembership` — it *is* the reconcile.
+ *  - `addToInbox` — quarantine by placement; the book is hidden via the firehose's delivery-time
+ *    `canAccess`, not by ALL_BOOKS exclusivity, so a reconcile there would undo the quarantine.
+ *  - `writeSystemMembership` — the scanner's atomic new-book insert; a brand-new book's ALL_BOOKS/INBOX
+ *    membership is authored directly, not reconciled.
+ */
+class CollectionMembershipRoutingRule :
+    FunSpec({
+        test("every collection_books membership mutation also calls reconcileSystemMembership (#680 exclusivity)") {
+            val scope = Konsist.scopeFromProduction()
+            // Gather class-member functions (the precedent shape — `KoScope.functions()` alone does
+            // not descend into classes) plus any top-level ones, so no membership mutation escapes.
+            val allFunctions = scope.classes().flatMap { it.functions() } + scope.functions()
+            val offenders =
+                allFunctions
+                    .filter { fn ->
+                        val body = stripComments(fn.text)
+                        "collectionBookRepo.upsert(" in body || "collectionBookRepo.softDelete(" in body
+                    }.filterNot { it.name in ALLOWLIST }
+                    .filterNot { "reconcileSystemMembership(" in stripComments(it.text) }
+                    .map {
+                        "${it.name} @ ${it.path} — mutates collection_books without reconcileSystemMembership; " +
+                            "ALL_BOOKS exclusivity (#680) must be maintained by every membership mutation, " +
+                            "or allowlist with a reason"
+                    }
+            offenders.shouldBeEmpty()
+        }
+    }) {
+    companion object {
+        /** Functions that touch the token but legitimately do not reconcile — see the class KDoc. */
+        val ALLOWLIST = setOf("reconcileSystemMembership", "addToInbox", "writeSystemMembership")
+    }
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/CollectionMembershipRoutingRule.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/konsist/CollectionMembershipRoutingRule.kt
@@ -7,20 +7,37 @@ import io.kotest.matchers.collections.shouldBeEmpty
 /**
  * The **reconcile-routing tripwire** for the ALL_BOOKS exclusivity invariant (#680/#730).
  *
- * Every production function that mutates a `collection_books` membership through the
- * `collectionBookRepo` — `collectionBookRepo.upsert(` / `collectionBookRepo.softDelete(` — must also
- * call `reconcileSystemMembership(` in the same declaration, so a book is dropped out of (or returned
- * to) the everyone-visible ALL_BOOKS substrate on **every** membership change. #680 shipped because a
+ * Every production function that mutates a `collection_books` membership must also call
+ * `reconcileSystemMembership(` in the same declaration, so a book is dropped out of (or returned to)
+ * the everyone-visible ALL_BOOKS substrate on **every** membership change. #680 shipped because a
  * membership mutation forgot exactly this. A text-based tripwire is a cheap *early* signal — the
  * semantic backstop is `AccessInvariantMatrixTest` (G1) — but it fires at the exact line a future
  * membership mutation is written, before any access test even runs.
  *
- * Allowlisted (matches the token, legitimately does NOT reconcile):
+ * Coverage — the full `CollectionBookRepository` mutation surface, so a bulk re-home can't slip past:
+ *  - the two generic mutators (`.upsert(` / `.softDelete(`) are scoped to the known receiver field
+ *    names (`collectionBookRepo` **and** `collectionBookRepository` — `BookRepository` uses the long
+ *    spelling) so we don't over-match `grantRepo.upsert` / `collectionRepo.softDelete`;
+ *  - the three bulk mutators (`softDeleteAllForCollection` / `softDeleteAllForBook` /
+ *    `reviveAllForBooks`) are matched receiver-agnostically — those names are unique to
+ *    `CollectionBookRepository`, so no scoping is needed and no other repo collides.
+ *
+ * NOTE ON COUPLING: this is a text tripwire, so a mutation via a *newly-named* helper or a fourth bulk
+ * method would need adding here. That is the accepted cost of an early tripwire; G1's `canAccess`
+ * assertions are the receiver-name-agnostic semantic guard that catches the escape regardless.
+ *
+ * Allowlisted (matches a token, legitimately does NOT reconcile):
  *  - `reconcileSystemMembership` — it *is* the reconcile.
  *  - `addToInbox` — quarantine by placement; the book is hidden via the firehose's delivery-time
  *    `canAccess`, not by ALL_BOOKS exclusivity, so a reconcile there would undo the quarantine.
  *  - `writeSystemMembership` — the scanner's atomic new-book insert; a brand-new book's ALL_BOOKS/INBOX
  *    membership is authored directly, not reconciled.
+ *  - `softDelete` — `BookRepository.softDelete`'s removal cascade (`softDeleteAllForBook`): the book is
+ *    tombstoned *entirely*, not re-homed between collections, so ALL_BOOKS exclusivity is moot.
+ *  - `reviveByIds` — `BookRepository.reviveByIds`'s revival (`reviveAllForBooks`): restores the book's
+ *    prior membership set verbatim (deletedAt-floored), so there is nothing to reconcile.
+ *  ( `deleteCollection` is NOT allowlisted — it matches `softDeleteAllForCollection` but already loops
+ *    `reconcileSystemMembership` per affected book, so the reconcile filter clears it correctly. )
  */
 class CollectionMembershipRoutingRule :
     FunSpec({
@@ -33,7 +50,15 @@ class CollectionMembershipRoutingRule :
                 allFunctions
                     .filter { fn ->
                         val body = stripComments(fn.text)
-                        "collectionBookRepo.upsert(" in body || "collectionBookRepo.softDelete(" in body
+                        // Generic mutators — scope to the known receiver fields (both spellings).
+                        "collectionBookRepo.upsert(" in body ||
+                            "collectionBookRepository.upsert(" in body ||
+                            "collectionBookRepo.softDelete(" in body ||
+                            "collectionBookRepository.softDelete(" in body ||
+                            // Bulk mutators — names unique to CollectionBookRepository, receiver-agnostic.
+                            ".softDeleteAllForCollection(" in body ||
+                            ".softDeleteAllForBook(" in body ||
+                            ".reviveAllForBooks(" in body
                     }.filterNot { it.name in ALLOWLIST }
                     .filterNot { "reconcileSystemMembership(" in stripComments(it.text) }
                     .map {
@@ -46,6 +71,13 @@ class CollectionMembershipRoutingRule :
     }) {
     companion object {
         /** Functions that touch the token but legitimately do not reconcile — see the class KDoc. */
-        val ALLOWLIST = setOf("reconcileSystemMembership", "addToInbox", "writeSystemMembership")
+        val ALLOWLIST =
+            setOf(
+                "reconcileSystemMembership",
+                "addToInbox",
+                "writeSystemMembership",
+                "softDelete",
+                "reviveByIds",
+            )
     }
 }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookCascadeRegistryParityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookCascadeRegistryParityTest.kt
@@ -1,0 +1,178 @@
+package com.calypsan.listenup.server.services
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.api.sync.BookMoodSyncPayload
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.Mood
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.sync.BookMoodRepository
+import com.calypsan.listenup.server.sync.BookTagRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.MoodRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.sync.TagRepository
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The **cascade-registry parity guard** — the check that would have caught the moods/collection_books
+ * cascade gap directly. Instead of a hand-maintained list, it discovers the truth by **schema
+ * introspection** (`sqlite_master` + `PRAGMA table_info`) and holds it against the declared
+ * [bookIdTableDispositions] registry, in both directions. A new `book_id` table therefore cannot slip
+ * in without a considered [RemovalDisposition] — and every [RemovalDisposition.CASCADE_TOMBSTONED]
+ * table must actually tombstone-on-remove and revive-on-readd, proven behaviourally below.
+ */
+class BookCascadeRegistryParityTest :
+    FunSpec({
+
+        // ── Assertion 1: the declared registry matches the live schema, both directions ──
+        test("every book_id table is declared in the disposition registry (and vice versa)") {
+            withSqlDatabase {
+                val introspected = driver.tablesWithBookIdColumn()
+                val declared = bookIdTableDispositions.keys
+
+                val undeclared = introspected - declared
+                val stale = declared - introspected
+
+                withClue(
+                    "book_id tables missing from bookIdTableDispositions: $undeclared — decide each one's " +
+                        "cascade behaviour and, if CASCADE_TOMBSTONED, wire softDelete/reviveByIds for it",
+                ) {
+                    undeclared shouldBe emptySet()
+                }
+                withClue(
+                    "bookIdTableDispositions names a table with no book_id column (schema drift): $stale",
+                ) {
+                    stale shouldBe emptySet()
+                }
+            }
+        }
+
+        // ── Assertion 2: every CASCADE_TOMBSTONED table is tombstoned by remove and revived by re-add ──
+        test("every CASCADE_TOMBSTONED table is tombstoned by softDelete and revived by reviveByIds") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                val now = System.currentTimeMillis()
+                sql.collectionsQueries.insert(
+                    id = "c1",
+                    library_id = "test-library",
+                    owner_id = "owner1",
+                    name = "Faves",
+                    type = "NORMAL",
+                    created_at = now,
+                    updated_at = now,
+                    revision = 0L,
+                    deleted_at = null,
+                    client_op_id = null,
+                )
+                runTest {
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val moodRepo = MoodRepository(db = sql, bus = bus, registry = registry)
+                    val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+                    val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = registry)
+                    val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+                    val collectionBookRepo =
+                        CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver)
+
+                    val bookRepo =
+                        BookRepository(
+                            db = sql,
+                            driver = driver,
+                            bus = bus,
+                            registry = registry,
+                            contributorRepository = ContributorRepository(sql, bus, registry),
+                            seriesRepository = SeriesRepository(sql, bus, registry),
+                            genreRepository = GenreRepository(sql, bus, registry),
+                            collectionBookRepository = collectionBookRepo,
+                            bookTagRepository = bookTagRepo,
+                            bookMoodRepository = bookMoodRepo,
+                        )
+
+                    // A live row per CASCADE_TOMBSTONED table, keyed to a book-liveness lambda so a new
+                    // cascade table forces a probe here (the map key set must equal the registry's
+                    // CASCADE_TOMBSTONED set — checked below).
+                    tagRepo.upsert(Tag(id = "t1", name = "Sci-Fi", slug = "sci-fi", revision = 0, updatedAt = 0))
+                    moodRepo.upsert(Mood(id = "m1", name = "Tense", slug = "tense", revision = 0, updatedAt = 0))
+                    bookTagRepo.upsert(BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    bookMoodRepo.upsert(BookMoodSyncPayload(bookId = "book1", moodId = "m1", createdAt = 1000L, revision = 0L))
+                    collectionBookRepo.upsert(
+                        CollectionBookSyncPayload(collectionId = "c1", bookId = "book1", createdAt = 1000L, revision = 0L),
+                    )
+
+                    // live-row count for "book1" per CASCADE_TOMBSTONED table.
+                    val liveCount: Map<String, suspend () -> Int> =
+                        mapOf(
+                            "book_tags" to { bookTagRepo.findAllForBook("book1").size },
+                            "book_moods" to { bookMoodRepo.findAllForBook("book1").size },
+                            "collection_books" to { collectionBookRepo.findCollectionIdsForBook("book1").size },
+                        )
+
+                    val cascadeTables =
+                        bookIdTableDispositions
+                            .filterValues { it == RemovalDisposition.CASCADE_TOMBSTONED }
+                            .keys
+                    withClue("a CASCADE_TOMBSTONED table has no behavioural probe wired in this test") {
+                        liveCount.keys shouldBe cascadeTables
+                    }
+
+                    // Precondition: every probe row is live.
+                    for ((table, count) in liveCount) {
+                        withClue("$table should have a live row before removal") { count() shouldBe 1 }
+                    }
+
+                    // Remove → every CASCADE_TOMBSTONED table's live row is tombstoned.
+                    bookRepo.softDelete(BookId("book1"), clientOpId = null)
+                    for ((table, count) in liveCount) {
+                        withClue("$table must be tombstoned by BookRepository.softDelete") { count() shouldBe 0 }
+                    }
+
+                    // Re-add → every CASCADE_TOMBSTONED table's row is revived (floor 0 covers the removal).
+                    bookRepo.reviveByIds(listOf(BookId("book1")), cascadeFloor = 0L)
+                    for ((table, count) in liveCount) {
+                        withClue("$table must be revived by BookRepository.reviveByIds") { count() shouldBe 1 }
+                    }
+                }
+            }
+        }
+    })
+
+/** The set of tables that carry a `book_id` column, by live schema introspection (excludes `sqlite_%`). */
+private fun SqlDriver.tablesWithBookIdColumn(): Set<String> =
+    queryStrings(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+        column = 0,
+    ).filter { table -> "book_id" in columnNames(table) }
+        .toSet()
+
+/** Column names of [table] via `PRAGMA table_info` (name is column index 1). Table name is schema-sourced, not user input. */
+private fun SqlDriver.columnNames(table: String): List<String> = queryStrings("PRAGMA table_info('$table')", column = 1)
+
+/** Runs [sql] and collects the string value of result [column] from every row. */
+private fun SqlDriver.queryStrings(
+    sql: String,
+    column: Int,
+): List<String> =
+    executeQuery(
+        identifier = null,
+        sql = sql,
+        mapper = { cursor ->
+            val out = mutableListOf<String>()
+            while (cursor.next().value) {
+                cursor.getString(column)?.let { out += it }
+            }
+            QueryResult.Value(out.toList())
+        },
+        parameters = 0,
+    ).value

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/AccessModelOracle.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/AccessModelOracle.kt
@@ -28,6 +28,15 @@ import io.kotest.matchers.shouldBe
  * holds a live USER grant on.* No "uncollected is public" branch, no global-access branch — public
  * visibility is structural (the `ALL_BOOKS` substrate collection + the member's default grant), so
  * the union rule alone reaches exactly the intended set.
+ *
+ * **Scope of what this oracle catches — do not over-trust it.** It guards *production visibility-rule
+ * drift* (e.g. a reintroduced "uncollected is public" branch in [BookAccessPolicy]): [naiveVisible]
+ * and `canAccess` would then disagree, and the guard fires. It does **not**, by itself, catch the
+ * #680 *membership-maintenance* bug (a mutation that forgets `reconcileSystemMembership`), because
+ * both sides read the same junction state and would agree "visible." That specific regression is
+ * caught by the explicit `canAccess(...).shouldBeFalse()` + `pullSince` assertions in
+ * `AccessInvariantMatrixTest` (row I1) and by `CollectionMembershipRoutingRule` — so those must not be
+ * deleted on the assumption the oracle covers them.
  */
 object AccessModelOracle {
     /**

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/AccessModelOracle.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/AccessModelOracle.kt
@@ -1,0 +1,109 @@
+package com.calypsan.listenup.server.testing
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.server.api.BookAccessPolicy
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The independent, executable specification of the **book-level access model** — the single
+ * invariant the #680/#730 regression violated: a book is visible to a member IFF the pure-union
+ * rule reaches it.
+ *
+ * **Why this file exists (read before touching an expectation here).** #680/#730 shipped and went
+ * uncaught for ~two weeks because the tests pinned the *mechanism* (junction-table state) rather
+ * than the *invariant* (user-visible access). Mechanism tests get legitimately rewritten during a
+ * refactor; the invariant broke silently underneath them. This oracle re-derives the visibility
+ * rule **independently of production** — [naiveVisible] does NOT call [BookAccessPolicy] and does
+ * NOT share its SQL — so a guard built on it (G1's access-invariant matrix, and the G2 property
+ * test) can never drift in lockstep with the code it guards. Changing an expectation here is an
+ * **access-model change** and requires explicit sign-off — it is not a mechanical test fixup.
+ *
+ * The rule, stated as prose and encoded once in [naiveVisible]: *a live book is visible to a member
+ * iff at least one live `collection_books` junction links it to a live collection the member owns or
+ * holds a live USER grant on.* No "uncollected is public" branch, no global-access branch — public
+ * visibility is structural (the `ALL_BOOKS` substrate collection + the member's default grant), so
+ * the union rule alone reaches exactly the intended set.
+ */
+object AccessModelOracle {
+    /**
+     * Independently re-derives whether member [userId] can see [bookId] under the pure-union rule,
+     * querying the raw schema over [driver] — deliberately **not** via [BookAccessPolicy] and
+     * deliberately a different SQL shape (an inner `JOIN` chain, not the policy's `EXISTS`
+     * subquery) so the two definitions cannot drift together. If production's rule regresses, this
+     * still encodes the intended answer and the guard fires.
+     *
+     * Member semantics only: an admin/root sees every live book unconditionally, which is not the
+     * union invariant this oracle guards.
+     */
+    suspend fun naiveVisible(
+        db: ListenUpDatabase,
+        driver: SqlDriver,
+        userId: String,
+        bookId: String,
+    ): Boolean =
+        suspendTransaction(db) {
+            val sql =
+                """
+                SELECT 1
+                FROM books b
+                JOIN collection_books cb ON cb.book_id = b.id AND cb.deleted_at IS NULL
+                JOIN collections c ON c.id = cb.collection_id AND c.deleted_at IS NULL
+                WHERE b.id = ? AND b.deleted_at IS NULL
+                  AND (
+                    c.owner_id = ?
+                    OR EXISTS (
+                      SELECT 1 FROM collection_grants g
+                      WHERE g.collection_id = c.id AND g.principal_type = 'USER'
+                        AND g.principal_id = ? AND g.deleted_at IS NULL
+                    )
+                  )
+                LIMIT 1
+                """.trimIndent()
+            driver
+                .executeQuery(
+                    identifier = null,
+                    sql = sql,
+                    mapper = { cursor -> QueryResult.Value(cursor.next().value) },
+                    parameters = 3,
+                    binders = {
+                        bindString(0, bookId)
+                        bindString(1, userId)
+                        bindString(2, userId)
+                    },
+                ).value
+        }
+
+    /**
+     * Asserts the load-bearing access invariant for [member]: for every book in [bookIds] the
+     * production [BookAccessPolicy.canAccess] verdict agrees **exactly** with the independent
+     * [naiveVisible] oracle. Weakening any guard that routes through this helper means editing a
+     * line that reads as an access-control decision (`canAccess … shouldBe true/false`), not a
+     * mechanism tweak — that is the whole point.
+     *
+     * Member semantics ([UserRole.MEMBER] by default); the oracle does not model admin god-view.
+     */
+    suspend fun assertAccessInvariants(
+        policy: BookAccessPolicy,
+        db: ListenUpDatabase,
+        driver: SqlDriver,
+        member: String,
+        bookIds: List<String>,
+        role: UserRole = UserRole.MEMBER,
+    ) {
+        for (bookId in bookIds) {
+            val expected = naiveVisible(db, driver, member, bookId)
+            val actual = policy.canAccess(member, role, bookId)
+            withClue(
+                "access-model invariant violated for member=$member book=$bookId " +
+                    "— oracle(naiveVisible)=$expected but BookAccessPolicy.canAccess=$actual",
+            ) {
+                actual shouldBe expected
+            }
+        }
+    }
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/CollectionAccessHarness.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/CollectionAccessHarness.kt
@@ -1,0 +1,157 @@
+package com.calypsan.listenup.server.testing
+
+import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
+import com.calypsan.listenup.server.api.BookAccessPolicy
+import com.calypsan.listenup.server.api.CollectionAccessPolicy
+import com.calypsan.listenup.server.api.CollectionServiceImpl
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.UserPermissionPolicy
+import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.services.GenreRepository
+import com.calypsan.listenup.server.services.SeriesRepository
+import com.calypsan.listenup.server.sync.BookMoodRepository
+import com.calypsan.listenup.server.sync.BookTagRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionGrantRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import kotlin.time.Instant
+
+/**
+ * The shared fixture behind the collection access-model guard suite (G0–G5). Wires a real
+ * [CollectionServiceImpl] over a Flyway-migrated in-memory SQLite db, alongside the single
+ * [BookAccessPolicy] visibility seam and a [BookRepository] armed with the removal-cascade repos
+ * — so every guard drives the same production seams a client would, and asserts through
+ * `canAccess` / `pullSince` (the invariant) rather than junction-table reads (the mechanism).
+ *
+ * Extracted from `CollectionAccessModelExclusivityTest` so the exclusivity tests, the
+ * `AccessInvariantMatrixTest`, and the emission-contract test share one wiring — a drift in how
+ * the service is constructed can't leave one guard testing a different graph than another.
+ *
+ * @property bookRepo a [BookRepository] wired with the `book_tags` / `book_moods` /
+ *   `collection_books` cascade repos, so a guard can drive real book removal
+ *   ([BookRepository.softDelete]) and re-add ([BookRepository.reviveByIds]) and observe the
+ *   access consequence. Uses the default (stepping) `Clock.System` so a revive's
+ *   `deletedAt >= floor` window is honoured.
+ * @property revisionTouch the [FakeBookRevisionTouch] the service bumps — exposed so a guard can
+ *   assert which books a membership change touched, without a real book repo in the service graph.
+ */
+internal data class CollectionAccessHarness(
+    val service: CollectionServiceImpl,
+    val collectionRepo: CollectionRepository,
+    val collectionBookRepo: CollectionBookRepository,
+    val grantRepo: CollectionGrantRepository,
+    val bookAccessPolicy: BookAccessPolicy,
+    val bookRepo: BookRepository,
+    val bus: ChangeBus,
+    val db: ListenUpDatabase,
+    val driver: SqlDriver,
+    val revisionTouch: FakeBookRevisionTouch,
+)
+
+/** The fixed clock the collection service runs on — deterministic membership timestamps. */
+val harnessFixedClock: FixedClock = FixedClock(Instant.fromEpochMilliseconds(1_700_000_000_000L))
+
+/** A [PrincipalProvider] yielding [userId] with [role] — the per-caller binding the service copies in. */
+fun principalFor(
+    userId: String,
+    role: UserRole = UserRole.MEMBER,
+): PrincipalProvider =
+    PrincipalProvider {
+        UserPrincipal(UserId(userId), SessionId("session-$userId"), role)
+    }
+
+/**
+ * Builds the shared [CollectionAccessHarness] over this migrated test db. The [bus] and
+ * [SyncRegistry] are shared across every repo (matching production), so the collection service and
+ * the book repo publish onto the same change bus.
+ */
+internal fun SqlTestDatabases.collectionAccessHarness(): CollectionAccessHarness {
+    val bus = ChangeBus()
+    val registry = SyncRegistry()
+    val collectionRepo = CollectionRepository(db = sql, bus = bus, registry = registry, driver = driver)
+    val collectionBookRepo = CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver)
+    val grantRepo = CollectionGrantRepository(db = sql, bus = bus, registry = registry, driver = driver)
+    val accessPolicy = CollectionAccessPolicy(collectionRepo, grantRepo)
+    val revisionTouch = FakeBookRevisionTouch()
+    val service =
+        CollectionServiceImpl(
+            collectionRepo = collectionRepo,
+            collectionBookRepo = collectionBookRepo,
+            grantRepo = grantRepo,
+            accessPolicy = accessPolicy,
+            bus = bus,
+            sql = sql,
+            clock = harnessFixedClock,
+            permissionPolicy = UserPermissionPolicy(sql),
+            bookRevisionTouch = revisionTouch,
+            principal = principalFor("admin", UserRole.ADMIN),
+        )
+    val bookRepo =
+        BookRepository(
+            db = sql,
+            driver = driver,
+            bus = bus,
+            registry = registry,
+            contributorRepository = ContributorRepository(sql, bus, registry),
+            seriesRepository = SeriesRepository(sql, bus, registry),
+            genreRepository = GenreRepository(sql, bus, registry),
+            collectionBookRepository = collectionBookRepo,
+            bookTagRepository = BookTagRepository(db = sql, bus = bus, registry = registry),
+            bookMoodRepository = BookMoodRepository(db = sql, bus = bus, registry = registry),
+        )
+    return CollectionAccessHarness(
+        service = service,
+        collectionRepo = collectionRepo,
+        collectionBookRepo = collectionBookRepo,
+        grantRepo = grantRepo,
+        bookAccessPolicy = BookAccessPolicy(sql, driver),
+        bookRepo = bookRepo,
+        bus = bus,
+        db = sql,
+        driver = driver,
+        revisionTouch = revisionTouch,
+    )
+}
+
+/** Returns a copy of the service scoped to [userId] with [role] — how a route binds the caller. */
+internal fun CollectionServiceImpl.actAs(
+    userId: String,
+    role: UserRole = UserRole.MEMBER,
+): CollectionServiceImpl = copyWith(principalFor(userId, role))
+
+/** Grants [userId] the default `ALL_BOOKS` read grant every member holds at registration. */
+internal suspend fun CollectionAccessHarness.grantAllBooks(
+    allBooksId: String,
+    userId: String,
+) {
+    grantRepo.upsert(
+        CollectionShareSyncPayload(
+            id = "grant-$allBooksId-$userId",
+            collectionId = allBooksId,
+            sharedWithUserId = userId,
+            sharedByUserId = "system",
+            permission = SharePermission.Read,
+            revision = 0L,
+            updatedAt = 0L,
+            deletedAt = null,
+        ),
+    )
+}
+
+/**
+ * The raw live-collection-id set the book currently belongs to — a **mechanism diagnostic**, never
+ * a load-bearing assertion. A guard reads this only to make a failure legible; the invariant is
+ * asserted through [BookAccessPolicy.canAccess] / `pullSince`, which is what a user actually sees.
+ */
+internal suspend fun CollectionAccessHarness.junctionDiagnostic(bookId: String): Set<String> =
+    collectionBookRepo.findCollectionIdsForBook(bookId).toSet()


### PR DESCRIPTION
## Why
A severe collections access-control regression (#680/#730) went uncaught for ~2 weeks because our tests pinned the **mechanism** (junction-table state) rather than the **invariant** (user-visible access) — so when the mechanism changed, the tests were legitimately rewritten and the access invariant broke silently. This suite makes that entire regression **class** unshippable.

## The guards (25 tests, all red-proofed — each broken → confirmed it catches the regression → restored)
- **G0 `AccessModelOracle`** — an *independent* re-derivation of the union visibility rule (does NOT call/share SQL with `BookAccessPolicy`), so a guard built on it can't drift in lockstep with the code it guards.
- **G1 access-invariant matrix** — asserts the model's rules ONLY through the real seam (`canAccess`/`accessibleBookIds`/`pullSince`+`digest`), never junction reads. Row I1 is the #680 money-shot; the old mechanism-pinned tests are generalized to carry a load-bearing `canAccess` assertion (junction reads demoted to labeled diagnostics).
- **G3 cascade-registry parity** — schema-introspects every `book_id` table (17 today) and asserts each has a declared removal disposition + a real tombstone+revive behavioral check for `CASCADE_TOMBSTONED`. A new junction that isn't cascaded fails the build. (New production file `BookRemovalDispositions.kt`.)
- **G4 emission-contract** — every visibility-changing mutation emits `AccessChanged` to exactly the right recipients, with a completeness backstop.
- **G5 reconcile-routing Konsist rule** — any function mutating `collection_books` must call `reconcileSystemMembership` or be allowlisted-with-reason. Covers the full `CollectionBookRepository` mutation surface (both generic + the three bulk mutators, both receiver spellings).

## Code review applied
Adversarial code-review found no critical defects (push-ready) but flagged one teeth-gap: G5 originally matched only two mutators/one receiver name, blind to the three bulk methods — a future bulk re-home could skip reconcile undetected (the exact #680 shape). **Fixed in the final commit**: widened to the full mutation surface + both receiver spellings, allowlisted the book-lifecycle exempt paths, and clarified the oracle's scope KDoc so a future maintainer can't over-trust it and delete the real #680 assertion.

## Test Plan
- [x] 25 guard tests green; each red-proofed.
- [x] Full Linux `verifyLocal` green (spotless + detekt + all JVM tests).