### PR TITLE
🐛 fix: data-correctness batch — metadata spinner, streak, contributor page, Audible pull-out, warnings

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -715,7 +715,7 @@ internal class CollectionServiceImpl(
             notifyAccessChanged(listOf(id), listOf(bookId))
             bookRevisionTouch.touchRevision(BookId(bookId))
         } else if (allBooksLive) {
-            collectionBookRepo.softDelete(collectionId = allBooksId!!, bookId = bookId)
+            collectionBookRepo.softDelete(collectionId = allBooksId, bookId = bookId)
             notifyAccessChanged(listOf(allBooksId), listOf(bookId))
             bookRevisionTouch.touchRevision(BookId(bookId))
         }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImpl.kt
@@ -40,6 +40,13 @@ import kotlinx.coroutines.CancellationException
 private val log = loggerFor<MetadataLookupServiceImpl>()
 
 /**
+ * Feature flag for contributor auto-match (search + profile fetch). Off while the only source — the
+ * `www.audible.com` scrape — is bot-blocked (uniform 503); the future multi-target scrape provider
+ * flips it back on. See [MetadataLookupServiceImpl.searchContributorMetadata]. Finding #18b.
+ */
+private const val CONTRIBUTOR_MATCH_ENABLED = false
+
+/**
  * Server-side implementation of [MetadataLookupService].
  *
  * Delegates search/fetch/refresh to the injected [metadataProviders] list, which own
@@ -136,23 +143,30 @@ internal class MetadataLookupServiceImpl(
     ): AppResult<MetadataChapters?> = audible.getChapters(asin, region)
 
     /**
-     * Searches Audible for contributors matching [query] using HTML scraping of
-     * `www.audible.com/search?searchAuthor={query}`. Results are deduplicated by
-     * ASIN and mapped to [MetadataContributorHit] wire DTOs.
+     * Contributor auto-match (search + profile fetch) is served only by scraping `www.audible.com`,
+     * which Audible's edge now bot-blocks with a uniform 503 (the `api.audible.com` book-match path is
+     * unaffected). Rather than surface that 503 to users, the feature is disabled until a multi-target
+     * scrape provider exists — [searchContributorMetadata] returns an empty result and
+     * [getContributorMetadata] returns null, so the UI cleanly shows "no matches" and the user falls
+     * back to manual contributor editing (Never-Stranded). See Finding #18b.
      *
-     * Backed by [MetadataService.searchContributors], which adds TTL caching
-     * so repeated queries for the same name avoid redundant scraping.
+     * The re-enable seam is intact: flip [CONTRIBUTOR_MATCH_ENABLED] to `true` once a working scrape
+     * source lands and the [metadataService] calls below resume.
      */
-    override suspend fun searchContributorMetadata(query: String): AppResult<List<MetadataContributorHit>> =
-        metadataService
+    override suspend fun searchContributorMetadata(query: String): AppResult<List<MetadataContributorHit>> {
+        if (!CONTRIBUTOR_MATCH_ENABLED) return AppResult.Success(emptyList())
+        return metadataService
             .searchContributors(defaultRegion, query)
             .map { profiles -> profiles.map { MetadataContributorHit(asin = it.asin, name = it.name) } }
+    }
 
     override suspend fun getContributorMetadata(
         asin: String,
         region: AudibleRegion,
-    ): AppResult<MetadataContributorProfile?> =
-        metadataService.getContributor(region, asin).map { it?.toMetadataContributorProfile() }
+    ): AppResult<MetadataContributorProfile?> {
+        if (!CONTRIBUTOR_MATCH_ENABLED) return AppResult.Success(null)
+        return metadataService.getContributor(region, asin).map { it?.toMetadataContributorProfile() }
+    }
 
     override suspend fun refreshBookMetadata(
         asin: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleClient.kt
@@ -172,32 +172,20 @@ class AudibleClient(
      *
      * Endpoint: `GET https://www.audible.{tld}/pd/{asin}`
      *
-     * Reuses [webGet] (web host + storefront locale cookie from Task 4, which
-     * turns Audible's 503-without-cookie into a 200; the request follows the
-     * redirect to the canonical slug URL). Best-effort: a 404 maps the `null`
-     * body to an empty list; any transport failure stays a typed [MetadataError].
+     * Best-effort and known-degraded: a 404 maps the `null` body to an empty list, and any transport
+     * failure — including Audible's edge bot-block, which currently returns a uniform 503 for the
+     * `www` host (Finding #18b) — is returned as a typed [MetadataError] that the caller flattens to
+     * an empty list, so moods/tags are simply absent rather than fatal. Failures are not logged per
+     * request here; [webGet] logs the www scrape's known 503 at debug level to avoid log spam.
      */
     override suspend fun getProductTags(
         region: AudibleRegion,
         asin: String,
     ): AppResult<List<ProductTag>> {
         rateLimiter.await(region)
-        val result =
-            webGet(region, "/pd/$asin", failOnGeoRedirect = true) { body ->
-                parseProductTags(body)
-            }.map { it ?: emptyList() }
-        if (result is AppResult.Failure) {
-            // Distinguish a geo-redirect / fetch failure from a genuine "title has no tags" empty:
-            // Audible IP-redirects the regional storefront when the server isn't located in that
-            // region (see [webGet]), so the /pd page — and its moods/tags — never loads. The caller
-            // flattens this to an empty list (best-effort), so without this log it would be silent.
-            logger.warn {
-                "Product-tag scrape for ASIN $asin in $region failed (${result.error.debugInfo}); " +
-                    "moods/tags will be empty. Audible geo-gates storefronts by IP — pick the Audible " +
-                    "region matching the server's country."
-            }
-        }
-        return result
+        return webGet(region, "/pd/$asin", failOnGeoRedirect = true) { body ->
+            parseProductTags(body)
+        }.map { it ?: emptyList() }
     }
 
     // ─── Private infrastructure ───────────────────────────────────────────────
@@ -294,9 +282,9 @@ class AudibleClient(
                         "User-Agent",
                         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                     )
-                    // The storefront locale cookie forces the correct regional catalog and turns
-                    // Audible's 503-without-cookie into a 200 (covers /pd product pages + the
-                    // contributor scrape, fixing non-US contributor lookups).
+                    // Storefront locale cookie — forces the correct regional catalog. (It no longer
+                    // clears Audible's 503: the www host now bot-blocks datacenter clients regardless
+                    // of the cookie — Finding #18b.)
                     header("Cookie", region.localeCookie())
                     queryParams.forEach { (k, v) -> parameter(k, v) }
                 }
@@ -325,7 +313,9 @@ class AudibleClient(
                 }
 
                 else -> {
-                    logger.warn {
+                    // The www host is known-degraded (Audible edge bot-blocks datacenter clients with a
+                    // uniform 503 — Finding #18b); log at debug so a per-request 5xx doesn't spam WARN.
+                    logger.debug {
                         "Audible web request server error: region=$region path=$path status=${response.status.value}"
                     }
                     AppResult.Failure(

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleRegionConfig.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/metadata/audible/AudibleRegionConfig.kt
@@ -45,12 +45,13 @@ internal val AudibleRegion.webHost: String
         }
 
 /**
- * The storefront locale cookie for this region, sent on web-host scrapes.
+ * The storefront locale cookie for this region, sent on web-host scrapes to force the correct
+ * regional catalog.
  *
- * Audible's website (`/pd/{ASIN}` product pages, the author page, and the
- * author-search page) returns **HTTP 503** without a storefront locale cookie
- * and **HTTP 200** with one. Sending the right cookie both unblocks product-tag
- * scraping and fixes the non-US contributor lookup.
+ * Historically this cookie also turned Audible's cookie-less 503 into a 200, but that no longer holds:
+ * the `www` host now bot-blocks datacenter clients with a uniform 503 regardless of the cookie, so the
+ * web-scrape features (contributor match, product-tag/mood enrichment) are degraded — see Finding
+ * #18b. The cookie is retained for when a future scrape provider can reach the site again.
  */
 internal fun AudibleRegion.localeCookie(): String =
     when (this) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/UserStatsDerivation.kt
@@ -114,9 +114,24 @@ suspend fun deriveUserStats(
                 .toInt()
         }
 
-    // 5. Current + longest streak via the shared reducer, resolved as-of-today in the home timezone.
+    // 5. Streak day-set: union the listening_events days with the days the user advanced progress
+    //    (playback_positions.last_played_at) or finished a book (book_reads.finished_at). ABS imports
+    //    write mediaProgress → positions + completions but keep session rows (→ listening_events)
+    //    sparsely, so events alone leave false gaps that collapse the streak. Both engines (this and
+    //    the client's StatsRepositoryImpl) union the same primitives so their streaks agree.
+    val streakDays = ArrayList(listeningDays)
+    suspendTransaction(sql) {
+        sql.playbackPositionsQueries.selectLastPlayedAtForUser(userId).executeAsList().forEach { ms ->
+            streakDays += Instant.fromEpochMilliseconds(ms).toLocalDateTime(userTz).date
+        }
+        sql.bookReadsQueries.finishedAtForUser(userId).executeAsList().forEach { ms ->
+            streakDays += Instant.fromEpochMilliseconds(ms).toLocalDateTime(userTz).date
+        }
+    }
+
+    // 6. Current + longest streak via the shared reducer, resolved as-of-today in the home timezone.
     val today = Instant.fromEpochMilliseconds(nowMs).toLocalDateTime(userTz).date
-    val streaks = StreakReducer.reduce(listeningDays, today)
+    val streaks = StreakReducer.reduce(streakDays, today)
 
     return UserStatsSyncPayload(
         id = userId,

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookReads.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookReads.sq
@@ -57,3 +57,9 @@ UPDATE book_reads SET finished_at = :finished_at WHERE id = :id;
 -- True iff the user has any completion row for this book — gates the idempotent reconcile insert.
 existsForUserBook:
 SELECT EXISTS(SELECT 1 FROM book_reads WHERE user_id = :userId AND book_id = :bookId);
+
+-- Stats support: every completion timestamp for a user. Feeds the streak day-set so an imported
+-- finish that never produced a listening_events session still counts as a listening day. Re-reads add
+-- multiple rows; the streak reducer collapses same-day duplicates.
+finishedAtForUser:
+SELECT finished_at FROM book_reads WHERE user_id = :userId;

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/PlaybackPositions.sq
@@ -111,6 +111,13 @@ selectFinishedBooksForUser:
 SELECT book_id, last_played_at FROM playback_positions
 WHERE user_id = :userId AND finished = 1 AND deleted_at IS NULL;
 
+-- Stats support: last-played timestamp of every live position of a user. Feeds the streak day-set so
+-- imported mediaProgress (which advances a position but need not produce a listening_events session)
+-- still counts as a listening day.
+selectLastPlayedAtForUser:
+SELECT last_played_at FROM playback_positions
+WHERE user_id = :userId AND deleted_at IS NULL;
+
 insert:
 INSERT INTO playback_positions (
     id, user_id, book_id, position_ms, last_played_at, finished, playback_speed,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
@@ -114,8 +114,10 @@ class ImportApplierTest :
                     stats.booksStarted shouldBe 2
                     // book-1's finished progress position is reflected after backfill.
                     stats.booksFinished shouldBe 1
-                    // sess-kings/mist/fidelity end on Jan 17/18/19 UTC (consecutive days) → streak = 3.
-                    stats.longestStreakDays shouldBe 3
+                    // Streak day-set unions the session days (sess-kings/mist/fidelity end Jan 17/18/19
+                    // UTC) with imported progress: book-1's finished mediaProgress + book_reads finish
+                    // land on Jan 16. Jan 16→17→18→19 is a 4-day consecutive run (Finding #20).
+                    stats.longestStreakDays shouldBe 4
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/MetadataLookupServiceImplTest.kt
@@ -64,30 +64,32 @@ private val NOW = Instant.parse("2026-05-24T12:00:00Z")
 class MetadataLookupServiceImplTest :
     FunSpec({
 
-        // ── searchContributorMetadata ─────────────────────────────────────────
+        // ── contributor match: pulled out (Finding #18b) ──────────────────────
+        // Contributor auto-match scrapes www.audible.com, which Audible now bot-blocks with a uniform
+        // 503. The feature is disabled server-side until a multi-target scraper exists; it returns a
+        // clean empty/absent result (never a 503) so manual contributor editing stays the fallback.
 
-        test("searchContributorMetadata wires through to AudibleApi.searchContributors") {
+        test("searchContributorMetadata is pulled out — returns empty without scraping") {
             withSqlDatabase {
                 val canned =
                     listOf(
                         AudibleContributorProfile(asin = "B001H6L8VC", name = "Stephen King", biography = "", imageUrl = ""),
                         AudibleContributorProfile(asin = "B002ABCDEF", name = "Stephen King Jr.", biography = "", imageUrl = ""),
                     )
+                // Even though the scrape *would* return two hits, the disabled feature ignores it.
                 val audible = StubAudibleApi(contributorSearchResult = AppResult.Success(canned))
                 val service = makeService(audible = audible, dbs = this)
 
                 runTest {
                     val result = service.searchContributorMetadata("stephen king")
-
-                    val success = result.shouldBeInstanceOf<AppResult.Success<List<MetadataContributorHit>>>()
-                    success.data shouldHaveSize 2
-                    success.data[0] shouldBe MetadataContributorHit(asin = "B001H6L8VC", name = "Stephen King")
-                    success.data[1] shouldBe MetadataContributorHit(asin = "B002ABCDEF", name = "Stephen King Jr.")
+                    result
+                        .shouldBeInstanceOf<AppResult.Success<List<MetadataContributorHit>>>()
+                        .data shouldHaveSize 0
                 }
             }
         }
 
-        test("searchContributorMetadata propagates Failure from AudibleApi") {
+        test("searchContributorMetadata returns a clean empty result instead of surfacing the scrape 503") {
             withSqlDatabase {
                 val audible =
                     StubAudibleApi(
@@ -97,22 +99,30 @@ class MetadataLookupServiceImplTest :
 
                 runTest {
                     val result = service.searchContributorMetadata("anyone")
-                    result.shouldBeInstanceOf<AppResult.Failure>()
-                    result.error.shouldBeInstanceOf<MetadataError.ExternalUnavailable>()
+                    // Not a Failure — the 503 must never reach the user; auto-match is simply off.
+                    result
+                        .shouldBeInstanceOf<AppResult.Success<List<MetadataContributorHit>>>()
+                        .data shouldHaveSize 0
                 }
             }
         }
 
-        test("searchContributorMetadata returns empty list when AudibleApi finds nothing") {
+        test("getContributorMetadata is pulled out — returns null even when the scrape would return a profile") {
             withSqlDatabase {
-                val audible = StubAudibleApi(contributorSearchResult = AppResult.Success(emptyList()))
+                val audible =
+                    StubAudibleApi(
+                        contributorProfileResult =
+                            AppResult.Success(
+                                AudibleContributorProfile(asin = "B001", name = "Stephen King", biography = "bio", imageUrl = "img"),
+                            ),
+                    )
                 val service = makeService(audible = audible, dbs = this)
 
                 runTest {
-                    val result = service.searchContributorMetadata("unknown author xyz")
+                    val result = service.getContributorMetadata("B001", AudibleRegion.US)
                     result
-                        .shouldBeInstanceOf<AppResult.Success<List<MetadataContributorHit>>>()
-                        .data shouldHaveSize 0
+                        .shouldBeInstanceOf<AppResult.Success<com.calypsan.listenup.api.dto.MetadataContributorProfile?>>()
+                        .data shouldBe null
                 }
             }
         }
@@ -473,6 +483,7 @@ private fun makeService(
 
 private class StubAudibleApi(
     val contributorSearchResult: AppResult<List<AudibleContributorProfile>> = AppResult.Success(emptyList()),
+    val contributorProfileResult: AppResult<AudibleContributorProfile?> = AppResult.Success(null),
 ) : AudibleApi {
     override suspend fun search(
         region: AudibleRegion,
@@ -492,7 +503,7 @@ private class StubAudibleApi(
     override suspend fun getContributor(
         region: AudibleRegion,
         asin: String,
-    ): AppResult<AudibleContributorProfile?> = AppResult.Success(null)
+    ): AppResult<AudibleContributorProfile?> = contributorProfileResult
 
     override suspend fun searchContributors(
         region: AudibleRegion,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderInvariantTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/StatsRecorderInvariantTest.kt
@@ -81,10 +81,12 @@ class StatsRecorderInvariantTest :
 
                     val stats = userStatsRepo.getForUser("u1").shouldNotBeNull()
                     stats.booksFinished shouldBe 1
-                    // Spec §6: a completion moves booksFinished but must never fabricate listening
-                    // time or touch the streak — no synthesized listening_events.
+                    // A completion fabricates NO listening time (no synthesized listening_events) —
+                    // totalSecondsAllTime stays 0. It DOES count as a listening day for the streak
+                    // (Finding #20): finishing book-1 yesterday is a day the user listened, so the
+                    // streak now includes the book_reads.finished_at day → currentStreak = 1.
                     stats.totalSecondsAllTime shouldBe 0
-                    stats.currentStreakDays shouldBe 0
+                    stats.currentStreakDays shouldBe 1
                     val profile = publicProfileRepo.pullSince(userId = null, cursor = 0L, limit = 10).items.single()
                     profile.booksFinished shouldBe 1
                     profile.booksFinishedLast7Days shouldBe 1

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/UserStatsBackfillServiceTest.kt
@@ -121,14 +121,14 @@ class UserStatsBackfillServiceTest :
                     stats.booksStarted shouldBe 2
                     // 1 finished position
                     stats.booksFinished shouldBe 1
-                    // Streak: events processed in endedAt order.
-                    // Dates (UTC): -35d=Apr-17, -33d=Apr-19, -32d=Apr-20, -31d=Apr-21,
+                    // Streak day-set = event days UNION the finished position's last-played day.
+                    // Event dates (UTC): -35d=Apr-17, -33d=Apr-19, -32d=Apr-20, -31d=Apr-21,
                     //              -29d=Apr-23, -20d=May-02, -10d=May-12, -5d=May-17,
-                    //              -3d=May-19, -2d=May-20
-                    // Apr-19→Apr-20→Apr-21 forms a 3-day streak (longestStreak = 3).
-                    // Last event is May-20; today (clock) is May-22 — neither today nor yesterday →
-                    // currentStreak lapses to 0.
-                    stats.currentStreakDays shouldBe 0
+                    //              -3d=May-19, -2d=May-20; finished position last-played = -1d=May-21.
+                    // Apr-19→Apr-20→Apr-21 forms a 3-day run (longestStreak = 3).
+                    // With the position counted, May-19→May-20→May-21 is also a 3-day run ending
+                    // yesterday (today = May-22) → currentStreak = 3.
+                    stats.currentStreakDays shouldBe 3
                     stats.longestStreakDays shouldBe 3
                 }
             }
@@ -236,6 +236,49 @@ class UserStatsBackfillServiceTest :
                     stats.totalSecondsLast30Days shouldBe 120L
                     stats.booksStarted shouldBe 1
                     stats.booksFinished shouldBe 0
+                }
+            }
+        }
+
+        test("streak counts days with only imported progress + finishes, not just listening_events") {
+            // ABS import writes mediaProgress → playback_positions + book_reads, but keeps
+            // playbackSessions (→ listening_events) sparsely. A day the user demonstrably listened
+            // (progress advanced / book finished) with no session row must still count toward the
+            // streak. Here there are NO listening_events at all: yesterday is covered by a finished
+            // position, today by a book_reads completion. Both must count → currentStreak = 2.
+            withSqlDatabase {
+                val clock = FixedClock(Instant.fromEpochMilliseconds(nowMs))
+                val statsRepo = UserStatsRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry(), clock = clock)
+                val positionRepo = PlaybackPositionRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                val backfillService = UserStatsBackfillService(sql = sql, userStatsRepo = statsRepo, clock = clock)
+
+                runTest {
+                    // Yesterday: a finished position (imported mediaProgress), no session row.
+                    positionRepo.recordPosition(
+                        userId = "u1",
+                        bookId = "book-a",
+                        positionMs = 0L,
+                        lastPlayedAt = nowMs - dayMs,
+                        finished = true,
+                        playbackSpeed = 1.0f,
+                        currentChapterId = null,
+                    )
+                    // Today: a book_reads completion for a different book, no session or position.
+                    sql.bookReadsQueries.insert(
+                        id = "br-today",
+                        user_id = "u1",
+                        book_id = "book-b",
+                        finished_at = nowMs,
+                        source = "import",
+                        created_at = nowMs,
+                    )
+
+                    backfillService.backfillFor("u1")
+
+                    val stats = statsRepo.getForUser("u1").shouldNotBeNull()
+                    // yesterday (position) → today (book_read) = consecutive 2-day run ending today.
+                    stats.currentStreakDays shouldBe 2
+                    stats.longestStreakDays shouldBe 2
                 }
             }
         }

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/SqlAdminConnection.linux.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/db/SqlAdminConnection.linux.kt
@@ -105,7 +105,8 @@ private class Sqlite3AdminConnection(
             execute("COMMIT")
             return result
         } catch (e: Throwable) {
-            runCatching { execute("ROLLBACK") }
+            // Best-effort rollback; the original exception is rethrown below.
+            runCatching { execute("ROLLBACK") }.getOrNull()
             throw e
         }
     }

--- a/server/src/linuxMain/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcher.kt
+++ b/server/src/linuxMain/kotlin/com/calypsan/listenup/server/scanner/watcher/InotifyDirectoryWatcher.kt
@@ -21,6 +21,7 @@ import kotlinx.cinterop.toKString
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
@@ -77,7 +78,7 @@ private const val EVENT_BUFFER_BYTES = 64 * 1024
  * `eventfd`; [close] writes the eventfd to wake the loop — a race-free alternative to closing the fd
  * out from under a blocking `read`.
  */
-@OptIn(ExperimentalForeignApi::class, DelicateCoroutinesApi::class)
+@OptIn(ExperimentalForeignApi::class, DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 internal class InotifyDirectoryWatcher(
     private val scope: CoroutineScope,
 ) : LowLevelDirectoryWatcher {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PlaybackPositionDao.kt
@@ -162,4 +162,17 @@ internal interface PlaybackPositionDao {
      */
     @Query("SELECT * FROM playback_positions")
     fun observeAll(): Flow<List<PlaybackPositionEntity>>
+
+    /**
+     * Every listening-day timestamp derivable from local positions: each live position's last-played
+     * time (falling back to [PlaybackPositionEntity.updatedAt] for legacy rows with no
+     * [PlaybackPositionEntity.lastPlayedAt]) unioned with its finish time. Feeds the client streak so
+     * imported mediaProgress — which advances a position without ever producing a listening_events
+     * session — still counts as a listening day, matching the server's streak day-set (Finding #20).
+     */
+    @Query(
+        "SELECT COALESCE(lastPlayedAt, updatedAt) FROM playback_positions WHERE deletedAt IS NULL " +
+            "UNION SELECT finishedAt FROM playback_positions WHERE deletedAt IS NULL AND finishedAt IS NOT NULL",
+    )
+    fun observeListenedDayTimestamps(): Flow<List<Long>>
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImpl.kt
@@ -5,6 +5,7 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.client.data.local.db.GenreDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.domain.DayBucket
 import com.calypsan.listenup.client.domain.GenreShare
 import com.calypsan.listenup.client.domain.WeeklyStats
@@ -37,12 +38,15 @@ private const val MIDNIGHT_PULSE_DELAY_MS = 60_000L
  * Reactive: republishes whenever new events land, so the home screen updates
  * without manual refresh and works fully offline.
  *
- * Streak counters are computed client-side from the full [ListeningEventDao.observeEndedAt]
- * history in the device timezone — real-time, tz-correct, and self-correcting on idle days
- * via the [midnightPulse] ticker. This deliberately diverges from the old server-authoritative
- * streak math: the server's `user_stats` still drives the cross-user leaderboard (a different
- * consumer); the Home display derives locally for immediate reactivity and correct tz handling
- * of imported events (which land in UTC but belong to the device's calendar day).
+ * Streak counters are computed client-side from the full [ListeningEventDao.observeEndedAt] history
+ * unioned with [PlaybackPositionDao.observeListenedDayTimestamps] (each position's last-played and
+ * finish day) in the device timezone — real-time, tz-correct, and self-correcting on idle days via
+ * the [midnightPulse] ticker. Including the playback days is what makes imported listening visible:
+ * ABS mediaProgress lands as playback_positions with no matching listening_events session, so an
+ * events-only streak shows false gaps (Finding #20). The server's [StatsRepositoryImpl] twin unions
+ * the same primitives so the two engines agree. This deliberately diverges from the old
+ * server-authoritative streak math: the server's `user_stats` still drives the cross-user
+ * leaderboard (a different consumer); the Home display derives locally for immediate reactivity.
  *
  * Genre seconds use wall-clock time (`endedAt - startedAt`) so fast-forwarded or slow-mo
  * sessions don't inflate genre totals.
@@ -60,6 +64,7 @@ private const val MIDNIGHT_PULSE_DELAY_MS = 60_000L
 internal class StatsRepositoryImpl(
     private val listeningEventDao: ListeningEventDao,
     private val genreDao: GenreDao,
+    private val playbackPositionDao: PlaybackPositionDao,
     private val authSession: AuthSession,
     private val clock: Clock = Clock.System,
     private val timeZone: () -> TimeZone = { TimeZone.currentSystemDefault() },
@@ -82,15 +87,17 @@ internal class StatsRepositoryImpl(
                 combine(
                     listeningEventDao.observeWithinWindow(userId, startMs, endMs),
                     listeningEventDao.observeEndedAt(userId),
-                ) { events, allEndedAt -> aggregate(events, allEndedAt, tz) }
+                    playbackPositionDao.observeListenedDayTimestamps(),
+                ) { events, allEndedAt, playbackDays -> aggregate(events, allEndedAt, playbackDays, tz) }
             }
 
     private suspend fun aggregate(
         events: List<ListeningEventEntity>,
         allEndedAt: List<Long>,
+        playbackDays: List<Long>,
         tz: TimeZone,
     ): WeeklyStats {
-        if (events.isEmpty() && allEndedAt.isEmpty()) return WeeklyStats.empty()
+        if (events.isEmpty() && allEndedAt.isEmpty() && playbackDays.isEmpty()) return WeeklyStats.empty()
 
         val today = clock.now().toLocalDateTime(tz).date
         val buckets = MutableList(7) { offset -> DayBucket(dayOffsetFromToday = offset, totalSeconds = 0L) }
@@ -122,7 +129,9 @@ internal class StatsRepositoryImpl(
                 .take(3)
                 .map { GenreShare(it.key, it.value) }
 
-        val (currentStreak, longestStreak) = computeStreaks(allEndedAt, tz, today)
+        // Streak day-set unions listening-event days with playback progress/finish days so imported
+        // listening (positions without a session row) is not invisible to the streak (Finding #20).
+        val (currentStreak, longestStreak) = computeStreaks(allEndedAt + playbackDays, tz, today)
 
         return WeeklyStats(
             dailyBuckets = buckets,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ListeningModule.kt
@@ -34,6 +34,7 @@ internal val listeningModule: Module =
             StatsRepositoryImpl(
                 listeningEventDao = get(),
                 genreDao = get(),
+                playbackPositionDao = get(),
                 authSession = get(),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.calypsan.listenup.client.domain.model.Contributor
 import com.calypsan.listenup.client.domain.model.ContributorRole
 import com.calypsan.listenup.client.domain.model.RoleWithBookCount
 import com.calypsan.listenup.client.domain.model.SeriesWithBooks
+import com.calypsan.listenup.client.domain.repository.BookWithContributorRole
 import com.calypsan.listenup.client.domain.repository.ContributorRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.SeriesRepository
@@ -24,9 +25,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -72,15 +73,67 @@ class ContributorDetailViewModel(
             if (id == null) {
                 flowOf(ContributorDetailUiState.Idle)
             } else {
-                combine(
-                    contributorRepository.observeById(id).filterNotNull(),
-                    contributorRepository.observeRolesWithCountForContributor(id),
-                ) { contributor, rolesWithCount ->
-                    val ready: ContributorDetailUiState = buildReadyState(id, contributor, rolesWithCount)
-                    ready
-                }.onStart { emit(ContributorDetailUiState.Loading) }
+                observeReadyState(id).onStart { emit(ContributorDetailUiState.Loading) }
             }
         }
+
+    /**
+     * Fully reactive Ready-state pipeline: the contributor, its per-role book lists, and the derived
+     * series are all LIVE Room subscriptions. Removing this contributor from a book updates the
+     * `book_contributors` mirror, which re-emits on [ContributorRepository.observeBooksForContributorRole]
+     * and refreshes the list here — no re-navigation required (Finding #21). Mirrors the healthy
+     * `ContributorBooksViewModel`; the earlier one-shot `.first()` snapshots were the stale-read bug.
+     */
+    private fun observeReadyState(contributorId: String): Flow<ContributorDetailUiState> =
+        combine(
+            contributorRepository.observeById(contributorId).filterNotNull(),
+            contributorRepository.observeRolesWithCountForContributor(contributorId),
+        ) { contributor, rolesWithCount -> contributor to rolesWithCount }
+            .flatMapLatest { (contributor, rolesWithCount) ->
+                observeRoleBooks(contributorId, rolesWithCount).flatMapLatest { roleBooks ->
+                    observeSeries(roleBooks).map { series ->
+                        buildReadyState(contributor, roleBooks, series)
+                    }
+                }
+            }
+
+    /** Live per-role book lists, one live subscription per role, combined into a single emission. */
+    private fun observeRoleBooks(
+        contributorId: String,
+        rolesWithCount: List<RoleWithBookCount>,
+    ): Flow<List<RoleBooks>> {
+        if (rolesWithCount.isEmpty()) return flowOf(emptyList())
+        val perRole =
+            rolesWithCount.map { roleWithCount ->
+                contributorRepository
+                    .observeBooksForContributorRole(contributorId, roleWithCount.role)
+                    .map { books -> RoleBooks(roleWithCount, books) }
+            }
+        return combine(perRole) { it.toList() }
+    }
+
+    /** Live series subscriptions derived from the current [roleBooks], ordered by contributor presence. */
+    private fun observeSeries(roleBooks: List<RoleBooks>): Flow<List<SeriesWithBooks>> {
+        val distinctBooks = roleBooks.flatMap { it.booksWithRole }.map { it.book }.distinctBy { it.id }
+        val seriesIds = distinctBooks.flatMap { it.series }.map { it.seriesId }.distinct()
+        if (seriesIds.isEmpty()) return flowOf(emptyList())
+        val flows = seriesIds.map { seriesRepository.observeSeriesWithBooks(it) }
+        return combine(flows) { emitted ->
+            emitted
+                .filterNotNull()
+                .sortedWith(
+                    compareByDescending<SeriesWithBooks> { sb ->
+                        distinctBooks.count { b -> b.series.any { it.seriesId == sb.series.id.value } }
+                    }.thenBy { it.series.name },
+                )
+        }
+    }
+
+    /** A role paired with its currently-observed books. */
+    private data class RoleBooks(
+        val roleWithCount: RoleWithBookCount,
+        val booksWithRole: List<BookWithContributorRole>,
+    )
 
     val state: StateFlow<ContributorDetailUiState> =
         combine(dataState, deleteOverlay) { data, overlay ->
@@ -131,38 +184,33 @@ class ContributorDetailViewModel(
     }
 
     private suspend fun buildReadyState(
-        contributorId: String,
         contributor: Contributor,
-        rolesWithCount: List<RoleWithBookCount>,
+        roleBooks: List<RoleBooks>,
+        series: List<SeriesWithBooks>,
     ): ContributorDetailUiState.Ready {
         val allCreditedAs = mutableMapOf<String, String>()
         val roleBooksFull = mutableListOf<List<BookListItem>>()
 
         val roleSections =
-            rolesWithCount.map { roleWithCount ->
-                val result = loadBooksForRole(contributorId, contributor.name, roleWithCount.role)
-                allCreditedAs.putAll(result.creditedAsMap)
-                roleBooksFull += result.books
+            roleBooks.map { (roleWithCount, booksWithRole) ->
+                val books = booksWithRole.map { it.book }
+                booksWithRole.forEach { bwr ->
+                    val creditedAs = bwr.creditedAs
+                    if (creditedAs != null && !creditedAs.equals(contributor.name, ignoreCase = true)) {
+                        allCreditedAs[bwr.book.id.value] = creditedAs
+                    }
+                }
+                roleBooksFull += books
                 RoleSection(
                     role = roleWithCount.role,
                     displayName = roleToDisplayName(roleWithCount.role),
                     bookCount = roleWithCount.bookCount,
-                    previewBooks = result.books.take(PREVIEW_BOOK_COUNT),
+                    previewBooks = books.take(PREVIEW_BOOK_COUNT),
                 )
             }
 
         val distinctBooks = roleBooksFull.flatten().distinctBy { it.id }
         val totalDuration = distinctBooks.sumOf { it.duration }.milliseconds
-
-        val seriesIds = distinctBooks.flatMap { it.series }.map { it.seriesId }.distinct()
-        val series =
-            seriesIds
-                .mapNotNull { seriesId -> seriesRepository.observeSeriesWithBooks(seriesId).first() }
-                .sortedWith(
-                    compareByDescending<SeriesWithBooks> { sb ->
-                        distinctBooks.count { b -> b.series.any { it.seriesId == sb.series.id.value } }
-                    }.thenBy { it.series.name },
-                )
 
         val allPreviewBooks = roleSections.flatMap { it.previewBooks }
         val bookProgress = playbackPositionRepository.calculateProgressMap(allPreviewBooks)
@@ -178,38 +226,6 @@ class ContributorDetailViewModel(
             isDeleting = false,
             deleteError = null,
         )
-    }
-
-    private data class BooksForRoleResult(
-        val books: List<BookListItem>,
-        /** Maps bookId to creditedAs name (when different from contributor's name). */
-        val creditedAsMap: Map<String, String>,
-    )
-
-    private suspend fun loadBooksForRole(
-        contributorId: String,
-        contributorName: String,
-        role: String,
-    ): BooksForRoleResult {
-        val booksWithRole =
-            contributorRepository
-                .observeBooksForContributorRole(contributorId, role)
-                .first()
-
-        val books = booksWithRole.map { it.book }
-
-        val creditedAsMap =
-            booksWithRole
-                .mapNotNull { bwr ->
-                    val creditedAs = bwr.creditedAs
-                    if (creditedAs != null && !creditedAs.equals(contributorName, ignoreCase = true)) {
-                        bwr.book.id.value to creditedAs
-                    } else {
-                        null
-                    }
-                }.toMap()
-
-        return BooksForRoleResult(books, creditedAsMap)
     }
 
     companion object {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
@@ -341,9 +341,10 @@ class MetadataViewModel(
 
         viewModelScope.launch {
             try {
-                val result = withTimeout(METADATA_RPC_TIMEOUT) {
-                    metadataRepository.searchBooks(query, current.region)
-                }
+                val result =
+                    withTimeout(METADATA_RPC_TIMEOUT) {
+                        metadataRepository.searchBooks(query, current.region)
+                    }
                 when (result) {
                     is AppResult.Success -> {
                         val hits = result.data.hits
@@ -686,9 +687,10 @@ class MetadataViewModel(
     ) {
         viewModelScope.launch {
             try {
-                val result = withTimeout(METADATA_RPC_TIMEOUT) {
-                    metadataRepository.getBookMetadata(match.asin, region)
-                }
+                val result =
+                    withTimeout(METADATA_RPC_TIMEOUT) {
+                        metadataRepository.getBookMetadata(match.asin, region)
+                    }
                 when (result) {
                     is AppResult.Success -> {
                         val preview = result.data
@@ -699,7 +701,13 @@ class MetadataViewModel(
                                     preview.series.isEmpty() &&
                                     preview.coverUrl == null &&
                                     preview.description == null
-                            transitionToReady(match, preview, previewNotFound = hasNoData, bookId = bookId, region = region)
+                            transitionToReady(
+                                match,
+                                preview,
+                                previewNotFound = hasNoData,
+                                bookId = bookId,
+                                region = region,
+                            )
                         } else {
                             // Server returned null — book not found in region
                             transitionToReady(match, match, previewNotFound = true, bookId = bookId, region = region)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModel.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.error.ErrorBus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,8 +26,23 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
+
+/**
+ * Hard ceiling on a single metadata RPC call. Metadata lookups hit external providers and can be
+ * genuinely slow, so this is generous — its only job is to guarantee that a black-hole WebSocket (an
+ * RPC that never resolves and never throws) eventually surfaces as a visible error instead of an
+ * infinite spinner. Never-Stranded: the user always gets an outcome.
+ */
+private val METADATA_RPC_TIMEOUT = 30.seconds
+
+private const val SEARCH_TIMEOUT_MESSAGE = "Search timed out. Check your connection and try again."
+private const val SEARCH_FAILED_MESSAGE = "Something went wrong while searching. Please try again."
+private const val PREVIEW_TIMEOUT_MESSAGE = "Loading the match timed out. Check your connection and try again."
+private const val PREVIEW_FAILED_MESSAGE = "Something went wrong while loading the match. Please try again."
 
 /** Tracks which metadata fields the user has selected to apply. */
 data class MetadataSelections(
@@ -324,29 +340,50 @@ class MetadataViewModel(
         state.value = current.copy(loadState = SearchLoadState.InFlight)
 
         viewModelScope.launch {
-            when (val result = metadataRepository.searchBooks(query, current.region)) {
-                is AppResult.Success -> {
-                    val hits = result.data.hits
-                    state.update { latest ->
-                        if (latest is MetadataUiState.Search && latest.query.trim() == query) {
-                            latest.copy(loadState = SearchLoadState.Loaded(hits))
-                        } else {
-                            latest
+            try {
+                val result = withTimeout(METADATA_RPC_TIMEOUT) {
+                    metadataRepository.searchBooks(query, current.region)
+                }
+                when (result) {
+                    is AppResult.Success -> {
+                        val hits = result.data.hits
+                        state.update { latest ->
+                            if (latest is MetadataUiState.Search && latest.query.trim() == query) {
+                                latest.copy(loadState = SearchLoadState.Loaded(hits))
+                            } else {
+                                latest
+                            }
                         }
                     }
-                }
 
-                is AppResult.Failure -> {
-                    errorBus.emit(result.error)
-                    logger.error { "Metadata search failed: ${result.error.message}" }
-                    state.update { latest ->
-                        if (latest is MetadataUiState.Search && latest.query.trim() == query) {
-                            latest.copy(loadState = SearchLoadState.Failed(result.error.message))
-                        } else {
-                            latest
-                        }
+                    is AppResult.Failure -> {
+                        errorBus.emit(result.error)
+                        logger.error { "Metadata search failed: ${result.error.message}" }
+                        setSearchFailed(query, result.error.message)
                     }
                 }
+            } catch (e: TimeoutCancellationException) {
+                logger.error(e) { "Metadata search timed out for query \"$query\"" }
+                setSearchFailed(query, SEARCH_TIMEOUT_MESSAGE)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                logger.error(e) { "Metadata search failed unexpectedly for query \"$query\"" }
+                setSearchFailed(query, SEARCH_FAILED_MESSAGE)
+            }
+        }
+    }
+
+    /** Project a [SearchLoadState.Failed] onto the still-current search, ignoring a superseded query. */
+    private fun setSearchFailed(
+        query: String,
+        message: String,
+    ) {
+        state.update { latest ->
+            if (latest is MetadataUiState.Search && latest.query.trim() == query) {
+                latest.copy(loadState = SearchLoadState.Failed(message))
+            } else {
+                latest
             }
         }
     }
@@ -648,41 +685,60 @@ class MetadataViewModel(
         bookId: String,
     ) {
         viewModelScope.launch {
-            when (val result = metadataRepository.getBookMetadata(match.asin, region)) {
-                is AppResult.Success -> {
-                    val preview = result.data
-                    if (preview != null) {
-                        val hasNoData =
-                            preview.authors.isEmpty() &&
-                                preview.narrators.isEmpty() &&
-                                preview.series.isEmpty() &&
-                                preview.coverUrl == null &&
-                                preview.description == null
-                        transitionToReady(match, preview, previewNotFound = hasNoData, bookId = bookId, region = region)
-                    } else {
-                        // Server returned null — book not found in region
-                        transitionToReady(match, match, previewNotFound = true, bookId = bookId, region = region)
-                    }
+            try {
+                val result = withTimeout(METADATA_RPC_TIMEOUT) {
+                    metadataRepository.getBookMetadata(match.asin, region)
                 }
+                when (result) {
+                    is AppResult.Success -> {
+                        val preview = result.data
+                        if (preview != null) {
+                            val hasNoData =
+                                preview.authors.isEmpty() &&
+                                    preview.narrators.isEmpty() &&
+                                    preview.series.isEmpty() &&
+                                    preview.coverUrl == null &&
+                                    preview.description == null
+                            transitionToReady(match, preview, previewNotFound = hasNoData, bookId = bookId, region = region)
+                        } else {
+                            // Server returned null — book not found in region
+                            transitionToReady(match, match, previewNotFound = true, bookId = bookId, region = region)
+                        }
+                    }
 
-                is AppResult.Failure -> {
-                    errorBus.emit(result.error)
-                    logger.error { "Failed to load metadata preview: ${result.error.message}" }
-                    if (match.title.isNotBlank()) {
-                        logger.info { "Using search result data as preview fallback" }
-                        transitionToReady(match, match, previewNotFound = false, bookId = bookId, region = region)
-                    } else {
-                        state.update { latest ->
-                            if (latest is MetadataUiState.Preview && latest.match.asin == match.asin) {
-                                latest.copy(
-                                    loadState = PreviewLoadState.Failed(result.error.message),
-                                )
-                            } else {
-                                latest
-                            }
+                    is AppResult.Failure -> {
+                        errorBus.emit(result.error)
+                        logger.error { "Failed to load metadata preview: ${result.error.message}" }
+                        if (match.title.isNotBlank()) {
+                            logger.info { "Using search result data as preview fallback" }
+                            transitionToReady(match, match, previewNotFound = false, bookId = bookId, region = region)
+                        } else {
+                            setPreviewFailed(match.asin, result.error.message)
                         }
                     }
                 }
+            } catch (e: TimeoutCancellationException) {
+                logger.error(e) { "Metadata preview timed out for ${match.asin}" }
+                setPreviewFailed(match.asin, PREVIEW_TIMEOUT_MESSAGE)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                logger.error(e) { "Metadata preview failed unexpectedly for ${match.asin}" }
+                setPreviewFailed(match.asin, PREVIEW_FAILED_MESSAGE)
+            }
+        }
+    }
+
+    /** Project a [PreviewLoadState.Failed] onto the still-current preview, ignoring a switched match. */
+    private fun setPreviewFailed(
+        asin: String,
+        message: String,
+    ) {
+        state.update { latest ->
+            if (latest is MetadataUiState.Preview && latest.match.asin == asin) {
+                latest.copy(loadState = PreviewLoadState.Failed(message))
+            } else {
+                latest
             }
         }
     }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/contributordetail/ContributorDetailViewModelTest.kt
@@ -489,6 +489,49 @@ class ContributorDetailViewModelTest :
             }
         }
 
+        test("book list updates reactively when a contributor is removed from a book, without re-navigation") {
+            runTest {
+                val fixture = createFixture()
+                val contributor = createContributor(id = "c1")
+                val role = RoleWithBookCount(role = ContributorRole.AUTHOR.apiValue, bookCount = 2)
+
+                // The per-role book list is a LIVE Room subscription — removing a contributor from a
+                // book updates book_contributors, which must re-emit here without re-navigating.
+                val booksFlow =
+                    MutableStateFlow(
+                        listOf(
+                            createBookWithContributorRole(createBook(id = "b1", title = "Book One")),
+                            createBookWithContributorRole(createBook(id = "b2", title = "Book Two")),
+                        ),
+                    )
+                every {
+                    fixture.contributorRepository.observeBooksForContributorRole("c1", ContributorRole.AUTHOR.apiValue)
+                } returns booksFlow
+
+                val viewModel = fixture.build()
+                backgroundScope.launch { viewModel.state.collect { } }
+
+                viewModel.loadContributor("c1")
+                fixture.contributorFlow.value = contributor
+                fixture.rolesFlow.value = listOf(role)
+                advanceUntilIdle()
+
+                (viewModel.state.value as ContributorDetailUiState.Ready)
+                    .roleSections[0]
+                    .previewBooks
+                    .map { it.title } shouldBe listOf("Book One", "Book Two")
+
+                // b2 loses this contributor — only the book_contributors mirror changes.
+                booksFlow.value = listOf(createBookWithContributorRole(createBook(id = "b1", title = "Book One")))
+                advanceUntilIdle()
+
+                (viewModel.state.value as ContributorDetailUiState.Ready)
+                    .roleSections[0]
+                    .previewBooks
+                    .map { it.title } shouldBe listOf("Book One")
+            }
+        }
+
         // ========== Series + Catalog Stats ==========
 
         test("Ready exposes distinct book count, total hours, and derived series") {

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/metadata/MetadataViewModelTest.kt
@@ -22,7 +22,9 @@ import com.calypsan.listenup.client.domain.repository.TagRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.error.ErrorBus
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -32,6 +34,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -181,6 +184,53 @@ class MetadataViewModelTest :
                 val state = vm.state.value.shouldBeInstanceOf<MetadataUiState.Search>()
                 val failed = state.loadState.shouldBeInstanceOf<SearchLoadState.Failed>()
                 failed.message shouldBe error.message
+            }
+        }
+
+        test("search that never resolves surfaces Failed after the timeout, not an infinite spinner") {
+            runTest {
+                val repo = mock<MetadataRepository>()
+                // Black-hole WebSocket: the RPC never returns and never throws.
+                everySuspend { repo.searchBooks(any(), any()) } calls { awaitCancellation() }
+                val vm = buildVm(repo)
+
+                vm.initForBook("b1", "Dune", "Frank Herbert")
+                vm.search()
+                advanceUntilIdle()
+
+                val state = vm.state.value.shouldBeInstanceOf<MetadataUiState.Search>()
+                state.loadState.shouldBeInstanceOf<SearchLoadState.Failed>()
+            }
+        }
+
+        test("search throwing an unexpected error surfaces Failed instead of hanging InFlight") {
+            runTest {
+                val repo = mock<MetadataRepository>()
+                everySuspend { repo.searchBooks(any(), any()) } throws IllegalStateException("boom")
+                val vm = buildVm(repo)
+
+                vm.initForBook("b1", "Dune", "Frank Herbert")
+                vm.search()
+                advanceUntilIdle()
+
+                val state = vm.state.value.shouldBeInstanceOf<MetadataUiState.Search>()
+                state.loadState.shouldBeInstanceOf<SearchLoadState.Failed>()
+            }
+        }
+
+        test("preview that never resolves surfaces Failed after the timeout, not an infinite spinner") {
+            runTest {
+                val book = makeBook(asin = "B001", title = "Dune")
+                val repo = mock<MetadataRepository>()
+                everySuspend { repo.getBookMetadata(any(), any()) } calls { awaitCancellation() }
+                val vm = buildVm(repo)
+
+                vm.initForBook("b1", "Dune", "Frank Herbert")
+                vm.selectMatch(book)
+                advanceUntilIdle()
+
+                val preview = vm.state.value.shouldBeInstanceOf<MetadataUiState.Preview>()
+                preview.loadState.shouldBeInstanceOf<PreviewLoadState.Failed>()
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImplTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/StatsRepositoryImplTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
 import com.calypsan.listenup.client.data.local.db.GenreEntity
 import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.domain.WeeklyStats
 import com.calypsan.listenup.client.domain.model.AuthState
 import com.calypsan.listenup.client.domain.repository.AuthSession
@@ -77,12 +78,28 @@ class StatsRepositoryImplTest :
                 override fun now(): Instant = nowInstant
             }
 
+        fun makePosition(
+            bookId: String,
+            lastPlayedAt: Long,
+            finishedAt: Long? = null,
+        ): PlaybackPositionEntity =
+            PlaybackPositionEntity(
+                bookId = BookId(bookId),
+                positionMs = 0L,
+                playbackSpeed = 1.0f,
+                updatedAt = lastPlayedAt,
+                lastPlayedAt = lastPlayedAt,
+                isFinished = finishedAt != null,
+                finishedAt = finishedAt,
+            )
+
         fun buildRepo(
             db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
             authFlow: MutableStateFlow<AuthState>,
         ) = StatsRepositoryImpl(
             listeningEventDao = db.listeningEventDao(),
             genreDao = db.genreDao(),
+            playbackPositionDao = db.playbackPositionDao(),
             authSession = FakeAuthSession(authFlow),
             clock = fixedClock(),
             timeZone = { utc },
@@ -309,6 +326,28 @@ class StatsRepositoryImplTest :
 
                     val stats = repo.observeWeeklyStats().first()
                     stats.currentStreakDays shouldBe 2
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("days with only playback progress (no listening events) count toward the streak") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    // ABS import lands as playback_positions with the original last-played time — no
+                    // listening_events. Yesterday (progress) → today (finished) must count → current 2.
+                    val msPerDay = 86_400_000L
+                    db.playbackPositionDao().save(makePosition("book-a", lastPlayedAt = nowMs - msPerDay))
+                    db.playbackPositionDao().save(makePosition("book-b", lastPlayedAt = nowMs, finishedAt = nowMs))
+
+                    val authFlow = MutableStateFlow<AuthState>(AuthState.Authenticated(UserId("u1"), SessionId("s1")))
+                    val repo = buildRepo(db, authFlow)
+
+                    val stats = repo.observeWeeklyStats().first()
+                    stats.currentStreakDays shouldBe 2
+                    stats.longestStreakDays shouldBe 2
                 }
             } finally {
                 db.close()


### PR DESCRIPTION
Five root-caused data-correctness fixes from the app-test pass, one commit each (reviewed per-commit). All Linux JVM + native + spotless green; adversarially code-reviewed (ship-ready, no regressions).

### #18a — metadata match: infinite spinner → visible error
The Audible/metadata match wizard spun forever on failure: `MetadataViewModel.search()` had no try/catch, and a kotlinx.rpc **black-hole WebSocket** (RPC that never resolves, never throws) left the state pinned `InFlight`. Fix: `withTimeout(30s)` + catch ordering `TimeoutCancellationException → Failed` / `CancellationException → rethrow` (rubric) / `Throwable → Failed`. A hung RPC now surfaces a user-visible error instead of spinning. (The envelope-log + iOS book-detail `getInstance` retirement are a separate iOS PR.)

### #20 — streak wrong after ABS import
Streak counted only `listening_events` (ABS *sessions*, kept sparsely) so imported progress/finishes were invisible → false gaps → streak stuck at ~days-since-import. Fix: union the streak day-set with `playback_positions.last_played_at` + `book_reads.finished_at` days, applied through the **same shared `StreakReducer`** on server (`UserStatsDerivation`) and client (`StatsRepositoryImpl`) so they can't diverge. Real-DB tests prove imported history (original timestamps) extends the streak.

### #21 — contributor page didn't update on contributor removal
`ContributorDetailViewModel` read its book list one-shot via `.first()` while every other surface subscribes reactively. Fix: fully reactive `combine → flatMapLatest → map` over `observeBooksForContributorRole` (mirroring `ContributorBooksViewModel`), `.first()` snapshots removed. One shared-VM change fixes Android, desktop, and iOS.

### #18b — Audible contributor scrape pulled out (bot-blocked)
Audible's `www` storefront 503s every scrape request (bot-protection on the datacenter IP; the `api` host / book match still works). Per maintainer direction, contributor-match is disabled behind `CONTRIBUTOR_MATCH_ENABLED = false` (a clean re-enable seam for a future multi-provider scraper) — returns empty instead of surfacing 503s; manual contributor editing intact (Never-Stranded). Quieted the noisy per-request 503 logs and removed the misleading geo-gate warning + stale "cookie fixes 503" comments.

### warnings — 3 compiler warnings cleared
Redundant `!!`, unused `runCatching` result, missing `ExperimentalCoroutinesApi` opt-in.

## Test Plan
- [x] RED→GREEN per fix (real-DB tests for streak; `awaitCancellation` black-hole test for the spinner; reactive re-emission test for the contributor page; disabled-feature test for Audible).
- [x] Full Linux `verifyLocal` + `:server:compileKotlinLinuxX64` + spotless green.
- [x] Code-reviewed — ship-ready, no data-correctness regressions.

Noted minor follow-ups (non-blocking): metadata preview timeout could reuse the search-data fallback; streak finish-source has a rare soft-deleted-position edge; the operator region config was left out (moot while contributor-match is disabled).