### PR TITLE
⚡ perf(sync): AccessChanged scoped delta — O(changed) access propagation, not O(library)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/sync/SyncControl.kt
@@ -49,13 +49,23 @@ sealed interface SyncControl {
      * Sent when the recipient's accessible set may have changed without a book row
      * itself mutating — e.g. a collection was shared/unshared with them, a share's
      * permission changed, or a book was released into a collection they can see.
-     * The client treats this as "re-derive your accessible library" and re-pulls
-     * the access-aware books digest. A bare signal is enough; no scope is carried.
+     *
+     * When [scope] is present, it names the affected entities (recipient-agnostic): the
+     * client does a targeted access-filtered fetch of just those ids — returned entities are
+     * upserted, requested-but-not-returned entities are tombstoned — turning the reconcile
+     * from O(library) into O(changed). When [scope] is `null` the client falls back to the
+     * coarse "re-derive your whole accessible library" pass (the pre-scope behavior, and the
+     * safe anchor for skew or frame loss). The `scope` field is additive: an older server
+     * omits it (→ `null` → coarse) and an older client ignores it (→ coarse), so the frame
+     * degrades gracefully in both skew directions.
      */
     @HiddenFromObjC
     @Serializable
     @SerialName("SyncControl.AccessChanged")
-    data object AccessChanged : SyncControl
+    data class AccessChanged(
+        @SerialName("scope")
+        val scope: AccessScope? = null,
+    ) : SyncControl
 
     /**
      * The authenticated user's account was deleted by an admin. The client clears auth (logout)
@@ -129,3 +139,26 @@ sealed interface SyncControl {
     @SerialName("SyncControl.LibraryDataChanged")
     data object LibraryDataChanged : SyncControl
 }
+
+/**
+ * The affected entities carried by a scoped [SyncControl.AccessChanged] frame — recipient-agnostic.
+ *
+ * The frame names *what changed*, not *who can now see it*: per-user truth is resolved at fetch
+ * time by the server's access filter. The client fetches these ids access-filtered — entities that
+ * come back are (still) accessible and are upserted; ids that were requested but not returned are no
+ * longer accessible and are tombstoned. This is what lets one recipient-agnostic payload serve every
+ * recipient without any per-user diffing on the server.
+ *
+ * @property collectionIds Collections whose membership or sharing changed.
+ * @property bookIds Books whose accessibility may have flipped (e.g. released into / removed from a
+ *   visible collection).
+ */
+@HiddenFromObjC
+@Serializable
+@SerialName("AccessScope")
+data class AccessScope(
+    @SerialName("collectionIds")
+    val collectionIds: List<String>,
+    @SerialName("bookIds")
+    val bookIds: List<String>,
+)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.api.error.CollectionError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.getOrElse
 import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.AccessScope
 import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
 import com.calypsan.listenup.api.sync.CollectionSyncPayload
 import com.calypsan.listenup.api.sync.SyncControl
@@ -33,6 +34,31 @@ import kotlin.time.Clock
 private const val LIST_BOOKS_MIN = 1
 private const val LIST_BOOKS_MAX = 1000
 private const val MAX_NAME_LENGTH = 200
+
+/**
+ * The largest scoped [AccessChanged][SyncControl.AccessChanged] delta the server will emit. Above
+ * it — too many affected collections or books — the frame degrades to coarse (scope = null) and the
+ * client re-derives its whole accessible library, which is cheaper than a huge targeted fetch. 200
+ * comfortably covers every realistic single collection mutation while capping the pathological case.
+ */
+internal const val DELTA_MAX_BOOKS = 200
+
+/**
+ * Builds the recipient-agnostic [AccessScope] naming the entities an access change touched, or
+ * `null` when the change is too large to delta ([maxBooks]) — the explicit, never-silent fallback to
+ * a coarse re-derive. A pure function of the affected ids, so the emission sites can build the scope
+ * without any per-user computation and a unit test can pin the threshold directly.
+ */
+internal fun accessScopeFor(
+    collectionIds: Collection<String>,
+    bookIds: Collection<String>,
+    maxBooks: Int = DELTA_MAX_BOOKS,
+): AccessScope? {
+    val cols = collectionIds.toSet()
+    val books = bookIds.toSet()
+    if (cols.size > maxBooks || books.size > maxBooks) return null
+    return AccessScope(collectionIds = cols.toList(), bookIds = books.toList())
+}
 
 /**
  * [CollectionService] implementation.
@@ -180,11 +206,14 @@ internal class CollectionServiceImpl(
         // Capture the live members BEFORE the cascade so we can re-home any book that loses its
         // last real membership: deleting a collection must never strand a book with zero memberships.
         val affectedBookIds = collectionBookRepo.findBookIdsForCollection(id.value)
-        // S2: nudge the collection's audience (owner + active grant recipients) BEFORE the grants are
-        // tombstoned — captured while the grants are still live, exactly like revokeShare. A member who
-        // could reach these books ONLY via this collection loses access in real time, not just on the
-        // next foreground reconcile.
-        notifyAccessChanged(listOf(id.value))
+        // S2: capture the collection's audience (owner + active grant recipients) and the scoped
+        // delta BEFORE the cascade — while the grants are still live — but PUBLISH the frame AFTER
+        // the cascade commits. Staging the audience keeps the "loses access in real time" guarantee
+        // for a member who could reach these books only via this collection; deferring the publish
+        // fixes the pre-existing race where the frame raced ahead of the membership/revision writes
+        // it points at, so a fast client could fetch stale rows.
+        val audience = accessChangedAudience(listOf(id.value))
+        val scope = accessScopeFor(listOf(id.value), affectedBookIds)
         collectionBookRepo.softDeleteAllForCollection(id.value)
         // A book whose only membership was this collection returns to ALL_BOOKS (reconcile bumps
         // its revision + nudges ALL_BOOKS grant-holders so members re-derive the now-public book).
@@ -199,6 +228,8 @@ internal class CollectionServiceImpl(
             grantRepo.softDelete(grant.id)
         }
         collectionRepo.softDelete(id.value)
+        // Cascade committed — now nudge the staged audience so no frame outruns its writes.
+        if (audience.isNotEmpty()) publishAccessChanged(audience, scope)
         return AppResult.Success(Unit)
     }
 
@@ -224,7 +255,7 @@ internal class CollectionServiceImpl(
             is AppResult.Success -> {
                 // Adding the book to this collection grants its visible users (owner + active-share
                 // recipients) a new access path — nudge each to re-derive, matching setBookCollections.
-                notifyAccessChanged(listOf(id.value))
+                notifyAccessChanged(listOf(id.value), listOf(bookId.value))
                 // Bump the book's revision so each member's incremental `revision > cursor` pull
                 // re-delivers the now-visible book — the access nudge alone never carries the row.
                 bookRevisionTouch.touchRevision(bookId)
@@ -256,7 +287,7 @@ internal class CollectionServiceImpl(
         collectionBookRepo.softDelete(collectionId = id.value, bookId = bookId.value)
         // Removing the book may have severed a visible user's only access path to it — nudge this
         // collection's visible users to re-derive (and prune if needed), matching setBookCollections.
-        notifyAccessChanged(listOf(id.value))
+        notifyAccessChanged(listOf(id.value), listOf(bookId.value))
         // Bump the book's revision so each member's incremental `revision > cursor` pull re-evaluates
         // its now-changed visibility and prunes it when no access path remains.
         bookRevisionTouch.touchRevision(bookId)
@@ -314,7 +345,7 @@ internal class CollectionServiceImpl(
         // gained the book) and each REMOVED collection (they may have lost their only access path) —
         // is nudged once to re-derive. The non-enumerable public↔private "everyone" edge converges on
         // the next firehose catch-up — the documented 1b behavior.
-        notifyAccessChanged(added + removed)
+        notifyAccessChanged(added + removed, listOf(bookId.value))
         // Bump the subject book's revision once when its membership actually changed, so each member's
         // incremental `revision > cursor` pull re-evaluates its visibility (delivering or pruning it).
         if (added.isNotEmpty() || removed.isNotEmpty()) {
@@ -362,8 +393,12 @@ internal class CollectionServiceImpl(
             )
         return when (val result = grantRepo.upsert(payload)) {
             is AppResult.Success -> {
-                // The newly-shared user's accessible set just grew — tell them to re-derive.
-                bus.publishControl(SyncControl.AccessChanged(), sharedWithUserId)
+                // The newly-shared user's accessible set just grew — tell them to re-derive, scoped
+                // to this collection and the books it currently holds (the ones they just gained).
+                publishAccessChanged(
+                    setOf(sharedWithUserId),
+                    accessScopeFor(listOf(id.value), collectionBookRepo.findBookIdsForCollection(id.value)),
+                )
                 AppResult.Success(result.data.toDto())
             }
 
@@ -389,8 +424,12 @@ internal class CollectionServiceImpl(
         val updated = existing.copy(permission = permission, updatedAt = clock.now().toEpochMilliseconds())
         return when (val result = grantRepo.upsert(updated)) {
             is AppResult.Success -> {
-                // The share's permission changed — the recipient must re-derive what they can do.
-                bus.publishControl(SyncControl.AccessChanged(), sharedWithUserId)
+                // The share's permission changed — the recipient must re-derive what they can do,
+                // scoped to this collection and its current books.
+                publishAccessChanged(
+                    setOf(sharedWithUserId),
+                    accessScopeFor(listOf(id.value), collectionBookRepo.findBookIdsForCollection(id.value)),
+                )
                 AppResult.Success(result.data.toDto())
             }
 
@@ -412,7 +451,12 @@ internal class CollectionServiceImpl(
         // idempotent — a no-op revoke satisfies the caller's intent. Only nudge the ex-target
         // when a live grant was actually removed: a no-op revoke didn't change their access.
         if (grantRepo.softDeleteGrant(id.value, sharedWithUserId) is AppResult.Success) {
-            bus.publishControl(SyncControl.AccessChanged(), sharedWithUserId)
+            // The ex-target lost this grant — scope the re-derive to this collection and the books
+            // it holds (the ones they may have just lost; per-user truth resolves at fetch time).
+            publishAccessChanged(
+                setOf(sharedWithUserId),
+                accessScopeFor(listOf(id.value), collectionBookRepo.findBookIdsForCollection(id.value)),
+            )
         }
         return AppResult.Success(Unit)
     }
@@ -611,7 +655,7 @@ internal class CollectionServiceImpl(
 
         // Every user who can see a target collection just gained access to the released books —
         // nudge each once to re-derive. ALL_BOOKS is included so its grant recipients re-derive.
-        notifyAccessChanged(explicitTargetIds + listOfNotNull(allBooksId))
+        notifyAccessChanged(explicitTargetIds + listOfNotNull(allBooksId), assignments.keys)
         // Bump each released book's revision so members' incremental `revision > cursor` pull
         // re-evaluates its now-changed visibility — the access nudge alone never carries the row.
         for (bookId in assignments.keys) {
@@ -668,11 +712,11 @@ internal class CollectionServiceImpl(
                     deletedAt = null,
                 ),
             )
-            notifyAccessChanged(listOf(id))
+            notifyAccessChanged(listOf(id), listOf(bookId))
             bookRevisionTouch.touchRevision(BookId(bookId))
         } else if (allBooksLive) {
             collectionBookRepo.softDelete(collectionId = allBooksId!!, bookId = bookId)
-            notifyAccessChanged(listOf(allBooksId))
+            notifyAccessChanged(listOf(allBooksId), listOf(bookId))
             bookRevisionTouch.touchRevision(BookId(bookId))
         }
     }
@@ -681,19 +725,47 @@ internal class CollectionServiceImpl(
     private suspend fun bookLibraryId(bookId: String): String? =
         suspendTransaction(sql) { sql.booksQueries.selectLibraryIdById(bookId).executeAsOneOrNull() }
 
-    private suspend fun notifyAccessChanged(collectionIds: Collection<String>) {
-        val affectedUserIds =
-            collectionIds
-                .flatMap { collectionId ->
-                    val owner = collectionRepo.findById(collectionId)?.ownerId
-                    val shareUsers = grantRepo.listActiveGrantsForCollection(collectionId).map { it.sharedWithUserId }
-                    if (owner != null) shareUsers + owner else shareUsers
-                }.toSet()
-        for (affectedUserId in affectedUserIds) {
-            // The ALL_BOOKS/INBOX sentinel owner is not a real client — nudging it is pure noise.
-            // (ALL_BOOKS reaches its real audience via the per-member default grants enumerated above.)
-            if (affectedUserId == SYSTEM_OWNER_ID) continue
-            bus.publishControl(SyncControl.AccessChanged(), affectedUserId)
+    /**
+     * Nudge the audience of an access change on [collectionIds] — each collection's owner + active
+     * grant recipients — to re-derive, carrying the [scoped delta][accessScopeFor] of the
+     * [affectedBookIds] (books whose accessibility may have flipped). [affectedBookIds] is
+     * **required**: an emission site that cannot enumerate the touched books passes the coarse
+     * `emptyList()` deliberately (there is no way to forget it silently), and a scope over
+     * [DELTA_MAX_BOOKS] entities degrades to coarse. The audience is resolved once here; the
+     * recipient-agnostic frame is published to every member (per-user truth resolves at fetch time).
+     */
+    private suspend fun notifyAccessChanged(
+        collectionIds: Collection<String>,
+        affectedBookIds: Collection<String>,
+    ) {
+        val audience = accessChangedAudience(collectionIds)
+        if (audience.isEmpty()) return
+        publishAccessChanged(audience, accessScopeFor(collectionIds, affectedBookIds))
+    }
+
+    /**
+     * The users to nudge for an access change on [collectionIds]: each collection's owner + its
+     * active grant recipients, minus the [SYSTEM_OWNER_ID] sentinel (not a real client — ALL_BOOKS
+     * reaches its real audience through the per-member default grants enumerated here). Captured
+     * separately from [publishAccessChanged] so a cascade (e.g. [deleteCollection]) can resolve the
+     * audience *before* it tombstones the grants, then publish *after* the writes commit.
+     */
+    private suspend fun accessChangedAudience(collectionIds: Collection<String>): Set<String> =
+        collectionIds
+            .flatMap { collectionId ->
+                val owner = collectionRepo.findById(collectionId)?.ownerId
+                val shareUsers = grantRepo.listActiveGrantsForCollection(collectionId).map { it.sharedWithUserId }
+                if (owner != null) shareUsers + owner else shareUsers
+            }.toSet()
+            .minus(SYSTEM_OWNER_ID)
+
+    /** Publishes the recipient-agnostic [AccessChanged][SyncControl.AccessChanged] frame carrying [scope] to each of [userIds]. */
+    private suspend fun publishAccessChanged(
+        userIds: Set<String>,
+        scope: AccessScope?,
+    ) {
+        for (userId in userIds) {
+            bus.publishControl(SyncControl.AccessChanged(scope), userId)
         }
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -363,7 +363,7 @@ internal class CollectionServiceImpl(
         return when (val result = grantRepo.upsert(payload)) {
             is AppResult.Success -> {
                 // The newly-shared user's accessible set just grew — tell them to re-derive.
-                bus.publishControl(SyncControl.AccessChanged, sharedWithUserId)
+                bus.publishControl(SyncControl.AccessChanged(), sharedWithUserId)
                 AppResult.Success(result.data.toDto())
             }
 
@@ -390,7 +390,7 @@ internal class CollectionServiceImpl(
         return when (val result = grantRepo.upsert(updated)) {
             is AppResult.Success -> {
                 // The share's permission changed — the recipient must re-derive what they can do.
-                bus.publishControl(SyncControl.AccessChanged, sharedWithUserId)
+                bus.publishControl(SyncControl.AccessChanged(), sharedWithUserId)
                 AppResult.Success(result.data.toDto())
             }
 
@@ -412,7 +412,7 @@ internal class CollectionServiceImpl(
         // idempotent — a no-op revoke satisfies the caller's intent. Only nudge the ex-target
         // when a live grant was actually removed: a no-op revoke didn't change their access.
         if (grantRepo.softDeleteGrant(id.value, sharedWithUserId) is AppResult.Success) {
-            bus.publishControl(SyncControl.AccessChanged, sharedWithUserId)
+            bus.publishControl(SyncControl.AccessChanged(), sharedWithUserId)
         }
         return AppResult.Success(Unit)
     }
@@ -693,7 +693,7 @@ internal class CollectionServiceImpl(
             // The ALL_BOOKS/INBOX sentinel owner is not a real client — nudging it is pure noise.
             // (ALL_BOOKS reaches its real audience via the per-member default grants enumerated above.)
             if (affectedUserId == SYSTEM_OWNER_ID) continue
-            bus.publishControl(SyncControl.AccessChanged, affectedUserId)
+            bus.publishControl(SyncControl.AccessChanged(), affectedUserId)
         }
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReads.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReads.kt
@@ -18,7 +18,9 @@ import com.calypsan.listenup.server.io.hashBytesSha256
  * same placeholder order, raw bind values instead of Exposed-typed pairs.
  *
  * **Bind-arg ordering is security-relevant and load-bearing.** The placeholders bind, in order:
- *  1. the revision cursor (the `?` in [revisionPredicate]) — bound first,
+ *  1. every [predicate] arg (the row-selection clause) — the revision cursor for a `revision > ?`
+ *     pull / `revision <= ?` digest slice, or the target ids for an `id IN (?, …)` /
+ *     `collection_id IN (?, …)` targeted fetch — bound first, in [SqlFragment.args] order,
  *  2. then every [SqlFragment.args] value of the spliced access subquery, in its existing order,
  *  3. then the optional trailing `LIMIT ?` ([limit]).
  *
@@ -31,19 +33,21 @@ import com.calypsan.listenup.server.io.hashBytesSha256
  * bind from `parameterIndex = 0`; the driver adds 1 internally).
  *
  * **Called only from inside an active SQLDelight transaction** (the
- * `suspendTransaction(db) { … }` opened by each aggregate's filtered `pullSince` / `digest`),
- * so the raw query runs on the same connection as the surrounding read.
+ * `suspendTransaction(db) { … }` opened by each aggregate's filtered `pullSince` / `digest` /
+ * `pullByIds`), so the raw query runs on the same connection as the surrounding read.
  *
  * @param table the aggregate's root table name (`"books"`, `"collections"`, …) — a closed,
  *   code-controlled string, never user input.
- * @param revisionPredicate the revision clause carrying exactly one `?` — `"revision > ?"` for a
- *   pull page, `"revision <= ?"` for a digest slice.
- * @param revisionArg the cursor value bound to [revisionPredicate]'s `?`.
- * @param extraWhere the access subquery to splice as `id IN (<sql>)`, with its ordered raw args.
+ * @param predicate the row-selection clause and its ordered args — `"revision > ?"` for a pull
+ *   page, `"revision <= ?"` for a digest slice, `"id IN (?, …)"` / `"collection_id IN (?, …)"` for
+ *   a targeted-by-ids fetch. The column names are code-controlled, never user input.
+ * @param extraWhere the access subquery to splice as `id IN (<sql>)`, with its ordered raw args;
+ *   `null` when the caller is unconstrained (an admin, or a targeted fetch by an all-seeing role) —
+ *   the access clause is then omitted entirely and every matched row (tombstones included) returns.
  * @param ascendingByRevision when true, append `ORDER BY revision ASC` (the pull-page ordering;
- *   the digest slice is unordered — it is sorted by id in Kotlin afterwards).
+ *   the digest slice and the targeted fetch are unordered — sorted by id in Kotlin if needed).
  * @param limit the page cap; when non-null a trailing `LIMIT ?` is appended and the value bound
- *   last (the pull path), null for the unbounded digest slice.
+ *   last (the pull path), null for the unbounded digest slice and targeted fetch.
  * @param includeTombstones when true, a tombstone (`deleted_at IS NOT NULL`) passes the access
  *   gate regardless of the subquery — the member needs to learn what to remove even for a row it
  *   can no longer "access" (a deleted row is never accessible: `accessibleBookIdsSql` requires
@@ -51,13 +55,13 @@ import com.calypsan.listenup.server.io.hashBytesSha256
  *   lets every `SyncEvent.Deleted` through) so catch-up and the live tail agree, and it leaks no
  *   content — a tombstone carries only id/revision/deleted_at. Set true on the pull path (catch-up
  *   must deliver deletions), false on the digest path (the digest counts only LIVE accessible rows,
- *   symmetric with the tombstone-excluding client digest).
+ *   symmetric with the tombstone-excluding client digest). Only meaningful when [extraWhere] is
+ *   non-null; with no access clause, every matched row already returns.
  */
 internal fun SqlDriver.selectIdRevAccessFiltered(
     table: String,
-    revisionPredicate: String,
-    revisionArg: Long,
-    extraWhere: SqlFragment,
+    predicate: SqlFragment,
+    extraWhere: SqlFragment?,
     ascendingByRevision: Boolean,
     limit: Int?,
     includeTombstones: Boolean,
@@ -67,17 +71,19 @@ internal fun SqlDriver.selectIdRevAccessFiltered(
             append("SELECT id, revision FROM ")
             append(table)
             append(" WHERE ")
-            append(revisionPredicate)
-            append(" AND (id IN (")
-            append(extraWhere.sql)
-            append(")")
-            if (includeTombstones) append(" OR deleted_at IS NOT NULL")
-            append(")")
+            append(predicate.sql)
+            if (extraWhere != null) {
+                append(" AND (id IN (")
+                append(extraWhere.sql)
+                append(")")
+                if (includeTombstones) append(" OR deleted_at IS NOT NULL")
+                append(")")
+            }
             if (ascendingByRevision) append(" ORDER BY revision ASC")
             if (limit != null) append(" LIMIT ?")
         }
-    // Placeholder count: 1 (revision) + access-subquery args + (1 if limited).
-    val parameterCount = 1 + extraWhere.args.size + if (limit != null) 1 else 0
+    // Placeholder count: predicate args + access-subquery args + (1 if limited).
+    val parameterCount = predicate.args.size + (extraWhere?.args?.size ?: 0) + if (limit != null) 1 else 0
     return executeQuery(
         identifier = null,
         sql = sql,
@@ -92,8 +98,8 @@ internal fun SqlDriver.selectIdRevAccessFiltered(
         binders = {
             // Bind in the exact placeholder order — the load-bearing invariant.
             var index = 0
-            bindLong(index++, revisionArg)
-            extraWhere.args.forEach { arg -> bindRaw(index++, arg) }
+            predicate.args.forEach { arg -> bindRaw(index++, arg) }
+            extraWhere?.args?.forEach { arg -> bindRaw(index++, arg) }
             if (limit != null) bindLong(index, limit.toLong())
         },
     ).value

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -487,8 +487,7 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                     extraWhere != null -> {
                         accessDriver().selectIdRevAccessFiltered(
                             table = rootTableName,
-                            revisionPredicate = "revision > ?",
-                            revisionArg = cursor,
+                            predicate = SqlFragment(sql = "revision > ?", args = listOf(cursor)),
                             extraWhere = extraWhere,
                             ascendingByRevision = true,
                             limit = limit,
@@ -516,6 +515,52 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                 hasMore = idsWithRev.size == limit,
             )
         }
+
+    /**
+     * Access-filtered targeted read: the aggregates whose [matchColumn] is in [matchValues] and
+     * which the caller can still see — the read half of the scoped `AccessChanged` delta.
+     *
+     * Where [pullSince] walks the revision axis, this walks an explicit id set. It is **always**
+     * access-filtered (via the same [selectIdRevAccessFiltered] path as the filtered [pullSince]),
+     * so a returned row is one the caller is entitled to; an id the client asked about but that does
+     * **not** come back is either gone or no longer accessible, and the client tombstones it. The
+     * result is therefore ⊆ what an unbounded `since = 0` catch-up would return — no new surface.
+     *
+     * [matchColumn] is a closed, code-controlled column name (`"id"` for the books/collections
+     * targeted fetch, `"collection_id"` for the collection-books-by-collection fetch), never user
+     * input — the same trust level as [rootTableName]. [matchValues] are bound positionally.
+     *
+     * Tombstones are included ([selectIdRevAccessFiltered]'s `includeTombstones = true`), matching
+     * the filtered [pullSince] catch-up contract: a deletion the client missed is delivered so it
+     * can converge. The page is un-paged — the caller (the sync route) caps the request size, so
+     * `nextCursor` is null and `hasMore` is false.
+     *
+     * When [extraWhere] is null (an all-seeing role) the access clause is dropped and every matched
+     * row returns. Only ever called on access-gated aggregates, which wire a [driver]; an ungated
+     * domain has none and [accessDriver] fails loud rather than silently degrading.
+     */
+    override suspend fun pullByIds(
+        userId: String?,
+        matchColumn: String,
+        matchValues: List<String>,
+        extraWhere: SqlFragment?,
+    ): Page<T> {
+        if (matchValues.isEmpty()) return Page(items = emptyList(), nextCursor = null, hasMore = false)
+        return suspendTransaction(db) {
+            val placeholders = matchValues.joinToString(separator = ", ") { "?" }
+            val idsWithRev =
+                accessDriver().selectIdRevAccessFiltered(
+                    table = rootTableName,
+                    predicate = SqlFragment(sql = "$matchColumn IN ($placeholders)", args = matchValues),
+                    extraWhere = extraWhere,
+                    ascendingByRevision = false,
+                    limit = null,
+                    includeTombstones = true,
+                )
+            val items = readPayloads(idsWithRev.map { it.id })
+            Page(items = items, nextCursor = null, hasMore = false)
+        }
+    }
 
     /**
      * Returns a [DomainDigest] over the LIVE rows with `revision <= cursor` — tombstones are
@@ -552,8 +597,7 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                     extraWhere != null -> {
                         accessDriver().selectIdRevAccessFiltered(
                             table = rootTableName,
-                            revisionPredicate = "revision <= ?",
-                            revisionArg = cursor,
+                            predicate = SqlFragment(sql = "revision <= ?", args = listOf(cursor)),
                             extraWhere = extraWhere,
                             ascendingByRevision = false,
                             limit = null,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -197,7 +197,12 @@ private fun accessFilterFor(
  * trailing comma or an empty param yields an empty list rather than a phantom `""` id.
  */
 private fun parseTargetedIds(raw: String): List<String>? {
-    val ids = raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+    val ids =
+        raw
+            .split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
     return if (ids.size > MAX_TARGETED_IDS) null else ids
 }
 
@@ -272,12 +277,13 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
 
         val page: Page<Any> =
             when {
-                idsParam != null ->
+                idsParam != null -> {
                     parseTargetedIds(idsParam)?.let { ids ->
                         typedRepo.pullByIds(userId, matchColumn = "id", matchValues = ids, extraWhere = extraWhere)
                     } ?: return@get call.respond(HttpStatusCode.BadRequest, "too many ids (max $MAX_TARGETED_IDS)")
+                }
 
-                collectionIdsParam != null ->
+                collectionIdsParam != null -> {
                     parseTargetedIds(collectionIdsParam)?.let { ids ->
                         typedRepo.pullByIds(
                             userId,
@@ -286,6 +292,7 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
                             extraWhere = extraWhere,
                         )
                     } ?: return@get call.respond(HttpStatusCode.BadRequest, "too many ids (max $MAX_TARGETED_IDS)")
+                }
 
                 else -> {
                     val since =

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncRoutes.kt
@@ -54,6 +54,12 @@ private const val ACTIVITIES_DOMAIN = "activities"
 private const val COLLECTION_SHARES_DOMAIN = "collection_shares"
 private const val COLLECTION_BOOKS_DOMAIN = "collection_books"
 
+// Cap on a single targeted `?ids=` / `?collectionIds=` fetch (the scoped AccessChanged delta).
+// The client chunks larger scopes into ≤ this many ids per request; the server rejects an
+// over-cap request rather than silently truncating — a truncated response would look to the
+// client like "these ids are no longer accessible" and wrongly tombstone them.
+private const val MAX_TARGETED_IDS = 100
+
 // Admin-only domain: a row carries an absolute server filesystem path (operator disk
 // topology), which members must never see. Unlike the per-row book/collection gates, this
 // is whole-domain by role — members hold no folder rows at all, so there is nothing for them
@@ -186,6 +192,16 @@ private fun accessFilterFor(
 ): SqlFragment? = ACCESS_FILTERS[domainName]?.fragment(userId, role, policy)
 
 /**
+ * Parses a targeted `?ids=` / `?collectionIds=` CSV into a de-duplicated id list, or `null` if it
+ * exceeds [MAX_TARGETED_IDS] (the caller turns that into a `400`). Blank segments are dropped so a
+ * trailing comma or an empty param yields an empty list rather than a phantom `""` id.
+ */
+private fun parseTargetedIds(raw: String): List<String>? {
+    val ids = raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+    return if (ids.size > MAX_TARGETED_IDS) null else ids
+}
+
+/**
  * The `activities` access fragment: selects the visible ACTIVITY ids — a row is visible iff its
  * `book_id` is null (public) or accessible. Returns null for ROOT/ADMIN (unconstrained). Extracted
  * so the catch-up/digest override, the firehose gate's sibling logic, and their tests all share one
@@ -236,13 +252,6 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
         val domainName =
             call.parameters["domain"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, "missing domain")
-        val since =
-            call.request.queryParameters["since"]?.toLongOrNull()
-                ?: return@get call.respond(HttpStatusCode.BadRequest, "since must be a Long")
-        val limit =
-            call.request.queryParameters["limit"]
-                ?.toIntOrNull()
-                ?.coerceIn(1, 5000) ?: 500
 
         val repo =
             registry.lookup(domainName)
@@ -254,8 +263,42 @@ fun Route.syncRoutes(heartbeatIntervalMillis: Long = 25_000L) {
 
         @Suppress("UNCHECKED_CAST")
         val typedRepo = repo as SyncableRepo<Any>
-        val page: Page<Any> = typedRepo.pullSince(userId, since, limit, extraWhere)
-        log.debug { "sync pull: domain=$domainName since=$since → ${page.items.size} rows userId=$userId" }
+
+        // Targeted scoped-delta fetch: `?ids=` matches the row's own id (books, collections),
+        // `?collectionIds=` matches its `collection_id` (collection_books). Both are access-
+        // filtered, capped, and un-paged. Absent both, fall back to the `?since=` catch-up page.
+        val idsParam = call.request.queryParameters["ids"]
+        val collectionIdsParam = call.request.queryParameters["collectionIds"]
+
+        val page: Page<Any> =
+            when {
+                idsParam != null ->
+                    parseTargetedIds(idsParam)?.let { ids ->
+                        typedRepo.pullByIds(userId, matchColumn = "id", matchValues = ids, extraWhere = extraWhere)
+                    } ?: return@get call.respond(HttpStatusCode.BadRequest, "too many ids (max $MAX_TARGETED_IDS)")
+
+                collectionIdsParam != null ->
+                    parseTargetedIds(collectionIdsParam)?.let { ids ->
+                        typedRepo.pullByIds(
+                            userId,
+                            matchColumn = "collection_id",
+                            matchValues = ids,
+                            extraWhere = extraWhere,
+                        )
+                    } ?: return@get call.respond(HttpStatusCode.BadRequest, "too many ids (max $MAX_TARGETED_IDS)")
+
+                else -> {
+                    val since =
+                        call.request.queryParameters["since"]?.toLongOrNull()
+                            ?: return@get call.respond(HttpStatusCode.BadRequest, "since must be a Long")
+                    val limit =
+                        call.request.queryParameters["limit"]
+                            ?.toIntOrNull()
+                            ?.coerceIn(1, 5000) ?: 500
+                    typedRepo.pullSince(userId, since, limit, extraWhere)
+                }
+            }
+        log.debug { "sync pull: domain=$domainName → ${page.items.size} rows userId=$userId" }
         // call.respond(page) would fail at runtime: kotlinx.serialization cannot
         // infer the concrete element serializer from the type-erased Page<Any>.
         // encodePageAsJson uses the concrete KSerializer<T> each repository provides.

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncableRepo.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SyncableRepo.kt
@@ -62,6 +62,21 @@ interface SyncableRepo<T : Any> {
     ): Page<T>
 
     /**
+     * Access-filtered targeted read: the aggregates whose [matchColumn] is in [matchValues] and
+     * the caller can still see — the read half of the scoped `AccessChanged` delta. The result is
+     * ⊆ what an unbounded `since = 0` catch-up would return; an asked-about id that does not come
+     * back is gone or no longer accessible and the client tombstones it. See the base override for
+     * the full tombstone / access / trust contract. [matchColumn] is code-controlled, never user
+     * input.
+     */
+    suspend fun pullByIds(
+        userId: String?,
+        matchColumn: String,
+        matchValues: List<String>,
+        extraWhere: SqlFragment? = null,
+    ): Page<T>
+
+    /**
      * Returns a [DomainDigest] over all rows with `revision <= cursor`,
      * soft-deleted rows included — the cheap drift-detection probe.
      */

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.error.CollectionError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.AccessScope
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.server.auth.PrincipalProvider
@@ -129,7 +130,7 @@ class AccessChangedEmissionTest :
                     }
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(), "u2"))
+                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())), "u2"))
                 }
             }
         }
@@ -158,7 +159,7 @@ class AccessChangedEmissionTest :
                     }
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(), "u2"))
+                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())), "u2"))
                 }
             }
         }
@@ -184,7 +185,7 @@ class AccessChangedEmissionTest :
                     owner.revokeShare(created.data.id, "u2") shouldBe AppResult.Success(Unit)
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(), "u2"))
+                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())), "u2"))
                 }
             }
         }
@@ -244,7 +245,10 @@ class AccessChangedEmissionTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
+                    frames.forEach {
+                        it.control shouldBe
+                            SyncControl.AccessChanged(AccessScope(listOf(target.data.id.value), listOf("book1")))
+                    }
                 }
             }
         }
@@ -273,7 +277,10 @@ class AccessChangedEmissionTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
+                    frames.forEach {
+                        it.control shouldBe
+                            SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), listOf("book1")))
+                    }
                 }
             }
         }
@@ -303,7 +310,10 @@ class AccessChangedEmissionTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
+                    frames.forEach {
+                        it.control shouldBe
+                            SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), listOf("book1")))
+                    }
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
@@ -129,7 +129,7 @@ class AccessChangedEmissionTest :
                     }
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged, "u2"))
+                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(), "u2"))
                 }
             }
         }
@@ -158,7 +158,7 @@ class AccessChangedEmissionTest :
                     }
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged, "u2"))
+                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(), "u2"))
                 }
             }
         }
@@ -184,7 +184,7 @@ class AccessChangedEmissionTest :
                     owner.revokeShare(created.data.id, "u2") shouldBe AppResult.Success(Unit)
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged, "u2"))
+                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(), "u2"))
                 }
             }
         }
@@ -244,7 +244,7 @@ class AccessChangedEmissionTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged }
+                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
                 }
             }
         }
@@ -273,7 +273,7 @@ class AccessChangedEmissionTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged }
+                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
                 }
             }
         }
@@ -303,7 +303,7 @@ class AccessChangedEmissionTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged }
+                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessChangedEmissionTest.kt
@@ -130,7 +130,13 @@ class AccessChangedEmissionTest :
                     }
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())), "u2"))
+                    frames shouldContainExactlyInAnyOrder
+                        listOf(
+                            ControlFrame(
+                                SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())),
+                                "u2",
+                            ),
+                        )
                 }
             }
         }
@@ -159,7 +165,13 @@ class AccessChangedEmissionTest :
                     }
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())), "u2"))
+                    frames shouldContainExactlyInAnyOrder
+                        listOf(
+                            ControlFrame(
+                                SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())),
+                                "u2",
+                            ),
+                        )
                 }
             }
         }
@@ -185,7 +197,13 @@ class AccessChangedEmissionTest :
                     owner.revokeShare(created.data.id, "u2") shouldBe AppResult.Success(Unit)
                     drainControlFrames()
 
-                    frames shouldContainExactlyInAnyOrder listOf(ControlFrame(SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())), "u2"))
+                    frames shouldContainExactlyInAnyOrder
+                        listOf(
+                            ControlFrame(
+                                SyncControl.AccessChanged(AccessScope(listOf(created.data.id.value), emptyList())),
+                                "u2",
+                            ),
+                        )
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessScopeForTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/AccessScopeForTest.kt
@@ -1,0 +1,62 @@
+package com.calypsan.listenup.server.api
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the pure [accessScopeFor] threshold: a small change yields a scoped delta; a change over
+ * [DELTA_MAX_BOOKS] entities degrades to `null` (coarse). The null is the never-silent fallback — an
+ * emission site that produces it consciously hands the client a whole-library re-derive rather than
+ * an oversized targeted fetch.
+ */
+class AccessScopeForTest :
+    FunSpec({
+
+        test("a small change yields a scoped, de-duplicated delta") {
+            val scope =
+                accessScopeFor(
+                    collectionIds = listOf("c1", "c1", "c2"),
+                    bookIds = listOf("b1", "b2"),
+                )
+            scope.shouldNotBeNull()
+            scope.collectionIds shouldContainExactlyInAnyOrder listOf("c1", "c2")
+            scope.bookIds shouldContainExactlyInAnyOrder listOf("b1", "b2")
+        }
+
+        test("an empty change is a valid (non-null) empty scope") {
+            val scope = accessScopeFor(collectionIds = emptyList(), bookIds = emptyList())
+            scope.shouldNotBeNull()
+            scope.collectionIds shouldBe emptyList()
+            scope.bookIds shouldBe emptyList()
+        }
+
+        test("more than DELTA_MAX_BOOKS affected books degrades to coarse (null)") {
+            val scope =
+                accessScopeFor(
+                    collectionIds = listOf("c1"),
+                    bookIds = (1..DELTA_MAX_BOOKS + 1).map { "b$it" },
+                )
+            scope shouldBe null
+        }
+
+        test("more than DELTA_MAX_BOOKS affected collections degrades to coarse (null)") {
+            val scope =
+                accessScopeFor(
+                    collectionIds = (1..DELTA_MAX_BOOKS + 1).map { "c$it" },
+                    bookIds = listOf("b1"),
+                )
+            scope shouldBe null
+        }
+
+        test("exactly DELTA_MAX_BOOKS books is still a scoped delta") {
+            val scope =
+                accessScopeFor(
+                    collectionIds = listOf("c1"),
+                    bookIds = (1..DELTA_MAX_BOOKS).map { "b$it" },
+                )
+            scope.shouldNotBeNull()
+            scope.bookIds.size shouldBe DELTA_MAX_BOOKS
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
@@ -314,7 +314,14 @@ class CollectionServiceImplSetBookCollectionsTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2", "u3")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
+                    // Recipient-agnostic scope: every frame names both touched collections and the book.
+                    frames.forEach { frame ->
+                        val control = frame.control
+                        require(control is SyncControl.AccessChanged)
+                        control.scope!!.collectionIds shouldContainExactlyInAnyOrder
+                            listOf(c1.data.id.value, c2.data.id.value)
+                        control.scope!!.bookIds shouldBe listOf("book1")
+                    }
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionServiceImplSetBookCollectionsTest.kt
@@ -314,7 +314,7 @@ class CollectionServiceImplSetBookCollectionsTest :
                     drainControlFrames()
 
                     frames.map { it.userId } shouldContainExactlyInAnyOrder listOf("u1", "u2", "u3")
-                    frames.forEach { it.control shouldBe SyncControl.AccessChanged }
+                    frames.forEach { it.control shouldBe SyncControl.AccessChanged() }
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/PullByIdsAccessTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/PullByIdsAccessTest.kt
@@ -1,0 +1,225 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
+import com.calypsan.listenup.server.api.BookAccessPolicy
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.services.GenreRepository
+import com.calypsan.listenup.server.services.SeriesRepository
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the read half of the scoped `AccessChanged` delta: [SqlSyncableRepository.pullByIds] on the
+ * access-gated `books` and `collection_books` domains. The invariant — a returned id is one the
+ * caller can still see; an asked-about id that does not come back is gone or no longer accessible
+ * (the client's cue to tombstone it) — is what makes the delta a sound, leak-free replacement for a
+ * full re-derive. Exercised directly on the repositories, independent of the HTTP layer.
+ */
+class PullByIdsAccessTest :
+    FunSpec({
+
+        fun SqlTestDatabases.pbiFixture(): PbiFixture {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val contributorRepo = ContributorRepository(db = sql, bus = bus, registry = registry)
+            val seriesRepo = SeriesRepository(db = sql, bus = bus, registry = registry)
+            return PbiFixture(
+                bookRepo =
+                    BookRepository(
+                        db = sql,
+                        driver = driver,
+                        bus = bus,
+                        registry = registry,
+                        contributorRepository = contributorRepo,
+                        seriesRepository = seriesRepo,
+                        genreRepository = GenreRepository(db = sql, bus = bus, registry = registry),
+                    ),
+                collectionRepo = CollectionRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                collectionBookRepo = CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                grantRepo = CollectionGrantRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                policy = BookAccessPolicy(sql, driver),
+            )
+        }
+
+        test("books pullByIds returns an accessible book and omits an inaccessible one") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("public-book")
+                sql.seedTestBook("private-book")
+                val f = pbiFixture()
+                runTest {
+                    f.pbiMakePublic("public-book", memberId = "member")
+                    f.collectionRepo.upsert(pbiCollection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(pbiMembership("private-col", "private-book"))
+
+                    val extra = f.policy.accessibleBookIdsSql("member", UserRole.MEMBER)
+                    val page =
+                        f.bookRepo.pullByIds(
+                            userId = "member",
+                            matchColumn = "id",
+                            matchValues = listOf("public-book", "private-book"),
+                            extraWhere = extra,
+                        )
+                    val ids = page.items.map { it.id }
+
+                    // public-book comes back (upsert); private-book does not (client tombstones it).
+                    ids shouldContain "public-book"
+                    ids shouldNotContain "private-book"
+                }
+            }
+        }
+
+        test("books pullByIds delivers a tombstone so a missed deletion converges") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("doomed-book")
+                val f = pbiFixture()
+                runTest {
+                    f.pbiMakePublic("doomed-book", memberId = "member")
+                    f.bookRepo.softDelete(BookId("doomed-book"))
+
+                    val extra = f.policy.accessibleBookIdsSql("member", UserRole.MEMBER)
+                    val page =
+                        f.bookRepo.pullByIds(
+                            userId = "member",
+                            matchColumn = "id",
+                            matchValues = listOf("doomed-book"),
+                            extraWhere = extra,
+                        )
+
+                    // A soft-deleted row is not "accessible", but includeTombstones delivers it so the
+                    // client learns to remove it — the catch-up tombstone contract, unchanged.
+                    page.items.map { it.id } shouldContain "doomed-book"
+                }
+            }
+        }
+
+        test("books pullByIds for an admin (null filter) returns every requested row") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("public-book")
+                sql.seedTestBook("private-book")
+                val f = pbiFixture()
+                runTest {
+                    f.pbiMakePublic("public-book", memberId = "member")
+                    f.collectionRepo.upsert(pbiCollection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(pbiMembership("private-col", "private-book"))
+
+                    val adminExtra = f.policy.accessibleBookIdsSql("admin", UserRole.ADMIN)
+                    val page =
+                        f.bookRepo.pullByIds(
+                            userId = "admin",
+                            matchColumn = "id",
+                            matchValues = listOf("public-book", "private-book"),
+                            extraWhere = adminExtra,
+                        )
+
+                    page.items.map { it.id } shouldContainExactlyInAnyOrder listOf("public-book", "private-book")
+                }
+            }
+        }
+
+        test("collection_books pullByIds by collection_id returns only accessible memberships") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("owned-book")
+                sql.seedTestBook("private-book")
+                val f = pbiFixture()
+                runTest {
+                    f.collectionRepo.upsert(pbiCollection("owned-col", owner = "member"))
+                    f.collectionBookRepo.upsert(pbiMembership("owned-col", "owned-book"))
+                    f.collectionRepo.upsert(pbiCollection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(pbiMembership("private-col", "private-book"))
+
+                    val extra = f.policy.accessibleCollectionBookIdsSql("member", UserRole.MEMBER)
+                    val page =
+                        f.collectionBookRepo.pullByIds(
+                            userId = "member",
+                            matchColumn = "collection_id",
+                            matchValues = listOf("owned-col", "private-col"),
+                            extraWhere = extra,
+                        )
+
+                    val memberships = page.items.map { it.collectionId to it.bookId }
+                    memberships shouldContain ("owned-col" to "owned-book")
+                    memberships shouldNotContain ("private-col" to "private-book")
+                }
+            }
+        }
+    })
+
+private data class PbiFixture(
+    val bookRepo: BookRepository,
+    val collectionRepo: CollectionRepository,
+    val collectionBookRepo: CollectionBookRepository,
+    val grantRepo: CollectionGrantRepository,
+    val policy: BookAccessPolicy,
+)
+
+private fun pbiCollection(
+    id: String,
+    owner: String,
+): CollectionSyncPayload =
+    CollectionSyncPayload(
+        id = id,
+        libraryId = "test-library",
+        ownerId = owner,
+        name = id,
+        revision = 0L,
+        updatedAt = 0L,
+    )
+
+private fun pbiMembership(
+    collectionId: String,
+    bookId: String,
+): CollectionBookSyncPayload =
+    CollectionBookSyncPayload(
+        collectionId = collectionId,
+        bookId = bookId,
+        createdAt = 0L,
+        revision = 0L,
+    )
+
+private fun pbiGrant(
+    id: String,
+    collectionId: String,
+    memberId: String,
+): CollectionShareSyncPayload =
+    CollectionShareSyncPayload(
+        id = id,
+        collectionId = collectionId,
+        sharedWithUserId = memberId,
+        sharedByUserId = "system",
+        permission = SharePermission.Read,
+        revision = 0L,
+        updatedAt = 0L,
+    )
+
+private suspend fun PbiFixture.pbiMakePublic(
+    bookId: String,
+    memberId: String,
+) {
+    collectionRepo.upsert(pbiCollection("all-books", owner = "system"))
+    collectionBookRepo.upsert(pbiMembership("all-books", bookId))
+    grantRepo.upsert(pbiGrant("grant-$bookId-$memberId", "all-books", memberId))
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncCatchUpRouteTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/SyncCatchUpRouteTest.kt
@@ -39,4 +39,21 @@ class SyncCatchUpRouteTest :
                 response.status shouldBe HttpStatusCode.BadRequest
             }
         }
+
+        test("a targeted ?ids= fetch over the 100-id cap returns 400") {
+            withTestApplication {
+                // The cap is enforced before the repo read, so it fires on any registered domain.
+                val ids = (1..101).joinToString(",") { "id-$it" }
+                val response = client.get("/api/v1/sync/tags?ids=$ids")
+                response.status shouldBe HttpStatusCode.BadRequest
+            }
+        }
+
+        test("a targeted ?collectionIds= fetch over the 100-id cap returns 400") {
+            withTestApplication {
+                val ids = (1..101).joinToString(",") { "col-$it" }
+                val response = client.get("/api/v1/sync/tags?collectionIds=$ids")
+                response.status shouldBe HttpStatusCode.BadRequest
+            }
+        }
     })

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ActivityDao.kt
@@ -100,6 +100,23 @@ internal interface ActivityDao {
     )
 
     /**
+     * Soft-delete every live activity whose gating book is gone or tombstoned — the activities half of
+     * the books access-gate `afterPrune` cascade. A scoped `AccessChanged` delta only fetches the
+     * `books`/`collections`/`collection_books` domains, so an activity whose book was just revoked
+     * would otherwise linger live locally while the server's access-filtered activities digest no
+     * longer counts it → permanent digest drift. Tombstoning it here (soft, like [tombstoneByIds] —
+     * `activities` is a cursored domain, so a hard delete would itself drift the digest) converges the
+     * two sides; a re-grant re-delivers the row live via catch-up. Book-less activities (`bookId IS
+     * NULL`) are always visible and are left untouched.
+     */
+    @Query(
+        "UPDATE activities SET deletedAt = :now " +
+            "WHERE deletedAt IS NULL AND bookId IS NOT NULL " +
+            "AND bookId NOT IN (SELECT id FROM books WHERE deletedAt IS NULL)",
+    )
+    suspend fun tombstoneWhereBookNotLive(now: Long)
+
+    /**
      * Insert or update an activity entity.
      * If an activity with the same ID exists, it will be updated.
      *

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessFilteredSyncHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessFilteredSyncHandler.kt
@@ -27,8 +27,31 @@ internal interface AccessFilteredSyncHandler {
      * Soft-delete (tombstone) every live local row whose id is NOT in [accessibleIds].
      * [now] is the tombstone timestamp. Rows already accessible are left untouched so the
      * UI never flickers; rows already tombstoned stay tombstoned.
+     *
+     * Whole-domain sweep — correct for a coarse re-derive ([catchUpTransient] returned the caller's
+     * entire accessible set). For a scoped delta, use [pruneWithin] instead, which never touches a
+     * row outside the scope.
      */
     suspend fun pruneTo(
+        accessibleIds: Set<String>,
+        now: Long,
+    )
+
+    /**
+     * Scoped prune: soft-delete every live local row that is BOTH in [candidateIds] AND absent from
+     * [accessibleIds] — the removal half of the scoped `AccessChanged` delta.
+     *
+     * Restricting the doomed set to [candidateIds] IS the substrate protection: a live row OUTSIDE
+     * the scope — e.g. a public `ALL_BOOKS` book the client mirrors but that a targeted delta never
+     * named — is never a candidate, so a scoped delta can never tombstone it. This is the structural
+     * difference from [pruneTo], which sweeps every live row not in [accessibleIds] and so is only
+     * sound when [accessibleIds] is the caller's WHOLE accessible set, not a targeted subset.
+     *
+     * [now] is the tombstone timestamp; already-tombstoned rows stay tombstoned, accessible rows are
+     * left untouched (no UI flicker).
+     */
+    suspend fun pruneWithin(
+        candidateIds: Set<String>,
         accessibleIds: Set<String>,
         now: Long,
     )

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessReconciler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessReconciler.kt
@@ -1,0 +1,150 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.AccessScope
+import com.calypsan.listenup.core.currentEpochMilliseconds
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Re-derives and prunes the caller's access-gated domains after a `SyncControl.AccessChanged`
+ * signal — the client half of the scoped-delta design. Extracted from [SyncEngine] (file-per-
+ * concern) so the reconcile logic lives apart from the engine's lifecycle/coalesce plumbing.
+ *
+ * Two modes, chosen by the frame's [AccessScope]:
+ *
+ *  - **Coarse** ([reconcile] with `null`): the pre-scope behavior and the safe anchor for skew or
+ *    frame loss. Every access-gated domain is re-derived from cursor 0 via
+ *    [CatchUp.catchUpTransient] (server-access-filtered, so it returns exactly what the caller may
+ *    now see) and [AccessFilteredSyncHandler.pruneTo] evicts every locally-live row not in that set.
+ *
+ *  - **Delta** ([reconcile] with a scope): O(changed) instead of O(library). Only the named
+ *    entities are fetched — access-filtered — and pruned within the scope
+ *    ([AccessFilteredSyncHandler.pruneWithin]), so a row the server returns is upserted and one it
+ *    asked about but did not return is tombstoned, while a live row OUTSIDE the scope is never
+ *    touched. Domains run in dependency order `collections → collection_books → books`; the books
+ *    prune's `afterPrune` cascade drops readership + Continue-Listening positions for the now-dead
+ *    books. `collection_shares` is revision-cursored and rides the coarse anchor / live tail;
+ *    `activities` gains ride the digest backstop and losses ride the books `afterPrune` cascade —
+ *    neither is fetched here.
+ *
+ * A delta pass ends in exactly the state a coarse pass restricted to the scope would: same upserts,
+ * same tombstones, no leak. Per-domain failures are logged and swallowed — one domain must not
+ * strand the others; the next signal (or the coarse anchor) recovers. The persisted
+ * [SyncCursorStore] is never touched: the live SSE/cursor path continues independently.
+ */
+internal class AccessReconciler(
+    private val registry: ClientSyncDomainRegistry,
+    private val catchUp: CatchUp,
+    private val now: () -> Long = { currentEpochMilliseconds() },
+) {
+    /** Re-derive access-gated domains: coarse when [scope] is null, otherwise a scoped delta. */
+    suspend fun reconcile(scope: AccessScope?) {
+        if (scope == null) reconcileCoarse() else reconcileDelta(scope)
+    }
+
+    /**
+     * Whole-library re-derive: every access-gated domain re-pulled from 0 and pruned to the
+     * returned accessible set. The semantic anchor — correct regardless of what changed.
+     */
+    private suspend fun reconcileCoarse() {
+        logger.info { "AccessChanged (coarse): re-deriving + pruning every access-gated domain" }
+        val ts = now()
+        for (handler in registry.accessFilteredHandlers()) {
+            @Suppress("UNCHECKED_CAST")
+            val typed = handler as SyncDomainHandler<Any>
+            when (val ids = catchUp.catchUpTransient(typed)) {
+                is AppResult.Success -> {
+                    (handler as AccessFilteredSyncHandler).pruneTo(ids.data, ts)
+                }
+
+                is AppResult.Failure -> {
+                    logger.warn { "AccessChanged coarse reconcile failed for ${handler.domainName}: ${ids.error.code}" }
+                }
+            }
+        }
+    }
+
+    /**
+     * Scoped delta: fetch + prune only the named entities, in dependency order so a collection's
+     * membership is reconciled before the books it gates. Each step is independent — a failure logs
+     * and moves on; the coarse anchor backstops any gap.
+     */
+    private suspend fun reconcileDelta(scope: AccessScope) {
+        logger.info {
+            "AccessChanged (delta): ${scope.collectionIds.size} collection(s), ${scope.bookIds.size} book(s)"
+        }
+        val ts = now()
+        fetchAndPruneById("collections", scope.collectionIds, ts)
+        fetchAndPruneCollectionBooks(scope, ts)
+        fetchAndPruneById("books", scope.bookIds, ts)
+    }
+
+    /**
+     * Delta one own-id-keyed domain (`books` / `collections`): fetch [ids] access-filtered, upsert
+     * what comes back, and [AccessFilteredSyncHandler.pruneWithin] the candidate set [ids] against
+     * the returned accessible subset — so an id asked about but not returned is tombstoned, and
+     * every row outside [ids] is left untouched.
+     */
+    private suspend fun fetchAndPruneById(
+        domainName: String,
+        ids: List<String>,
+        ts: Long,
+    ) {
+        if (ids.isEmpty()) return
+        val handler = accessGatedHandler(domainName) ?: return
+
+        @Suppress("UNCHECKED_CAST")
+        val typed = handler as SyncDomainHandler<Any>
+        when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByIds(ids))) {
+            is AppResult.Success -> {
+                (handler as AccessFilteredSyncHandler).pruneWithin(ids.toSet(), returned.data, ts)
+            }
+
+            is AppResult.Failure -> {
+                logger.warn { "AccessChanged delta fetch failed for $domainName: ${returned.error.code}" }
+            }
+        }
+    }
+
+    /**
+     * Delta the `collection_books` domain by the scope's collections: fetch every membership of the
+     * affected collections (access-filtered), then prune the LOCAL memberships of just those
+     * collections against what came back. The candidate set is the local live membership rows whose
+     * `collectionId` is in scope — derived from the synthetic `"$collectionId:$bookId"` wire id — so
+     * a membership in a collection the delta never named can never be tombstoned.
+     */
+    private suspend fun fetchAndPruneCollectionBooks(
+        scope: AccessScope,
+        ts: Long,
+    ) {
+        if (scope.collectionIds.isEmpty()) return
+        val handler = accessGatedHandler("collection_books") ?: return
+        val gated = handler as AccessFilteredSyncHandler
+
+        @Suppress("UNCHECKED_CAST")
+        val typed = handler as SyncDomainHandler<Any>
+        val scopeCols = scope.collectionIds.toSet()
+        val candidateIds = gated.localLiveIds().filterTo(mutableSetOf()) { it.substringBefore(':') in scopeCols }
+        when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByCollectionIds(scope.collectionIds))) {
+            is AppResult.Success -> {
+                gated.pruneWithin(candidateIds, returned.data, ts)
+            }
+
+            is AppResult.Failure -> {
+                logger.warn { "AccessChanged delta fetch failed for collection_books: ${returned.error.code}" }
+            }
+        }
+    }
+
+    /** The registered handler for [domainName] if it is an [AccessFilteredSyncHandler]; else null (logged). */
+    private fun accessGatedHandler(domainName: String): SyncDomainHandler<*>? {
+        val handler = registry.lookup(domainName)
+        if (handler !is AccessFilteredSyncHandler) {
+            logger.warn { "AccessChanged delta: '$domainName' is not an access-gated handler; skipping" }
+            return null
+        }
+        return handler
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
@@ -30,5 +30,35 @@ internal interface CatchUp {
      */
     suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>>
 
+    /**
+     * Targeted, access-filtered fetch of just the rows named by [fetch] — the read half of the
+     * scoped `AccessChanged` delta, [catchUpTransient] minus the from-0 paging. Each returned row is
+     * applied through [SyncDomainHandler.onCatchUpItem], so it inherits the same ServerWins /
+     * EchoShielded no-lost-update guard as paged catch-up. Returns the non-tombstone ids that came
+     * back — for [TargetedFetch.ByIds] that is the still-accessible subset of the requested ids (the
+     * requested-but-not-returned remainder is what the caller prunes); the persisted
+     * [SyncCursorStore] is deliberately untouched, exactly like [catchUpTransient].
+     *
+     * The default returns the empty set: only the production [SyncCatchUpClient] performs the real
+     * HTTP fetch; a test fake that does not drive the delta path can leave this default.
+     */
+    suspend fun <T : Any> fetchTransient(
+        handler: SyncDomainHandler<T>,
+        fetch: TargetedFetch,
+    ): AppResult<Set<String>> = AppResult.Success(emptySet())
+
     suspend fun domains(): AppResult<List<String>>
+}
+
+/**
+ * A targeted, cursor-agnostic fetch of a subset of an access-gated domain — names WHICH rows to
+ * pull for the scoped `AccessChanged` delta. The server access-filters the result regardless, so a
+ * returned row is one the caller may still see.
+ */
+internal sealed interface TargetedFetch {
+    /** Match rows by their own wire id — books and collections. */
+    data class ByIds(val ids: List<String>) : TargetedFetch
+
+    /** Match rows by their `collection_id` — collection_books, to pull a set of collections' memberships. */
+    data class ByCollectionIds(val collectionIds: List<String>) : TargetedFetch
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CatchUp.kt
@@ -57,8 +57,12 @@ internal interface CatchUp {
  */
 internal sealed interface TargetedFetch {
     /** Match rows by their own wire id — books and collections. */
-    data class ByIds(val ids: List<String>) : TargetedFetch
+    data class ByIds(
+        val ids: List<String>,
+    ) : TargetedFetch
 
     /** Match rows by their `collection_id` — collection_books, to pull a set of collections' memberships. */
-    data class ByCollectionIds(val collectionIds: List<String>) : TargetedFetch
+    data class ByCollectionIds(
+        val collectionIds: List<String>,
+    ) : TargetedFetch
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncCatchUpClient.kt
@@ -22,6 +22,11 @@ private val logger = KotlinLogging.logger {}
 private const val PAGE_LIMIT = 100
 private const val SERVER_URL_NOT_CONFIGURED = "Server URL not configured"
 
+// Per-request cap on a targeted `?ids=` / `?collectionIds=` fetch — matches the server's
+// MAX_TARGETED_IDS. A scope larger than this is chunked, never truncated: a truncated response
+// would read to the client as "these ids are gone" and wrongly tombstone still-accessible rows.
+private const val TARGETED_FETCH_LIMIT = 100
+
 /**
  * Drives REST `?since=<rev>` per-domain pagination for client sync catch-up.
  *
@@ -147,6 +152,49 @@ internal class SyncCatchUpClient(
                 if (!page.hasMore) break
             }
             accessibleIds
+        }
+
+    /**
+     * Targeted access-filtered fetch of just [fetch]'s ids WITHOUT advancing [SyncCursorStore] —
+     * the read half of the scoped `AccessChanged` delta. Chunks the id set under
+     * [TARGETED_FETCH_LIMIT] (the server's per-request cap) so a large scope never truncates,
+     * applies each returned row via [SyncDomainHandler.onCatchUpItem] (inheriting the same
+     * ServerWins/EchoShielded guard as paged catch-up), and returns the non-tombstone ids that came
+     * back — the still-accessible subset the caller diffs against to prune.
+     */
+    override suspend fun <T : Any> fetchTransient(
+        handler: SyncDomainHandler<T>,
+        fetch: TargetedFetch,
+    ): AppResult<Set<String>> =
+        suspendRunCatching {
+            val baseUrl = serverUrlProvider() ?: error(SERVER_URL_NOT_CONFIGURED)
+            val httpClient = httpClientProvider()
+            val (paramName, values) =
+                when (fetch) {
+                    is TargetedFetch.ByIds -> "ids" to fetch.ids
+                    is TargetedFetch.ByCollectionIds -> "collectionIds" to fetch.collectionIds
+                }
+            val returnedIds = mutableSetOf<String>()
+            for (chunk in values.distinct().chunked(TARGETED_FETCH_LIMIT)) {
+                val csv = chunk.joinToString(",")
+                val element: JsonElement =
+                    httpClient
+                        .get("$baseUrl/api/v1/sync/${handler.domainName}?$paramName=$csv")
+                        .body()
+                val page: Page<T> =
+                    contractJson.decodeFromJsonElement(
+                        Page.serializer(handler.payloadSerializer),
+                        element,
+                    )
+                transactionRunner.atomically {
+                    for (item in page.items) {
+                        val isTomb = (item as? Tombstoned)?.deletedAt != null
+                        handler.onCatchUpItem(item, isTomb)
+                        if (!isTomb) returnedIds += handler.syncId(item)
+                    }
+                }
+            }
+            returnedIds
         }
 
     /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -3,7 +3,7 @@ package com.calypsan.listenup.client.data.sync
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
 import com.calypsan.listenup.client.domain.repository.NetworkMonitor
-import com.calypsan.listenup.core.currentEpochMilliseconds
+import com.calypsan.listenup.api.sync.AccessScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -121,6 +121,24 @@ internal class SyncEngine(
     // satisfied by a pass that began after it registered (and the pending flag guarantees that pass
     // runs), the caller suspends exactly until a catch-up pass covering its request has drained.
     private val cursorStaleWaiters = mutableListOf<CompletableDeferred<Unit>>()
+
+    // The access-gated re-derive/prune half of AccessChanged, extracted to its own concern.
+    // Built from the engine's existing registry + catchUp, so wiring is unchanged.
+    private val accessReconciler = AccessReconciler(registry, catchUp)
+
+    // Serializes + coalesces AccessChanged reconciles. A single access mutation fans out one frame
+    // per affected recipient, and a bulk action (release, delete) can fan out a burst — routing each
+    // straight into a reconcile would overlap N access-filtered fetches. This guard runs at most one
+    // reconcile at a time and folds a burst into a SINGLE follow-up: the pending scopes UNION, and a
+    // coarse frame (or a union that outgrows the delta budget) POISONS the follow-up to one coarse
+    // pass (cheaper than a huge targeted fetch, and the safe anchor). Same shape as the CursorStale
+    // coalesce, minus the completion waiters — no caller awaits an AccessChanged reconcile.
+    private val accessChangedMutex = Mutex()
+    private var accessChangedRunning = false
+    private var accessChangedDirty = false
+    private var pendingAccessCoarse = false
+    private val pendingAccessCollectionIds = mutableSetOf<String>()
+    private val pendingAccessBookIds = mutableSetOf<String>()
 
     // Serializes + debounces the standing lifecycle reconcile — the one recovery pass every
     // lifecycle edge (app-foreground via connectRealtime, firehose reconnect) funnels into.
@@ -552,43 +570,103 @@ internal class SyncEngine(
     }
 
     /**
-     * Recover from an `AccessChanged` control signal: the caller's accessible set may have
-     * changed without a book row mutating (a collection was shared/unshared with them, a share's
-     * permission changed, or a book was released into a collection they can see).
+     * Recover from an `AccessChanged` control signal: the caller's accessible set may have changed
+     * without a book row mutating (a collection shared/unshared, a share's permission changed, a book
+     * released into a collection they can see). [scope] names the affected entities for a targeted
+     * delta, or is `null` for a coarse whole-library re-derive (the safe anchor). The actual
+     * re-derive/prune lives in [AccessReconciler]; this method is the coalescer in front of it.
      *
-     * For each access-gated domain (`books`, `activities`, and the three collection domains) this **re-derives
-     * and prunes** (approach B — always re-derive, no digest gate):
-     *  1. Run a TRANSIENT access-filtered catch-up from cursor 0 via [CatchUp.catchUpTransient].
-     *     The server's `pullSince` for these domains is access-filtered, so the pass upserts
-     *     exactly the rows the caller may now see and returns their ids. It deliberately does
-     *     NOT touch [SyncCursorStore] — the live SSE/cursor path continues independently.
-     *  2. [AccessFilteredSyncHandler.pruneTo] soft-deletes every locally-live row NOT in that
-     *     accessible set — the load-bearing security step that evicts a revoked share's now
-     *     inaccessible books from Room (closing the gap a plain catch-up would leave open).
-     *
-     * For an admin, the access-filtered catch-up returns everything, so `pruneTo` deletes
-     * nothing — the same code is correct for both members and admins.
-     *
-     * Unlike [handleCursorStale] this does not tear down the SSE connection: the live tail is
-     * still valid (no cursor was lost), only the *visibility* of existing rows shifted. A failed
-     * re-derive for one domain is logged and swallowed — the next signal (or a manual refresh)
-     * recovers, and one domain's failure must not strand the others.
+     * Coalesce: a single access mutation fans out one frame per recipient and a bulk action a whole
+     * burst, so an unguarded reconcile would overlap N access-filtered fetches. At most one reconcile
+     * runs at a time; frames that arrive while one is in flight FOLD into a single follow-up — their
+     * scopes union, and a coarse frame (or a union that outgrows the delta budget) poisons the
+     * follow-up to one coarse pass. Unlike [handleCursorStale] the SSE tail is never torn down (no
+     * cursor was lost, only visibility shifted); and no caller awaits this, so there are no
+     * completion waiters — a fire-and-forget signal.
      */
-    internal suspend fun handleAccessChanged() {
-        logger.info { "AccessChanged: re-deriving + pruning access-gated domains" }
-        for (handler in registry.accessFilteredHandlers()) {
-            @Suppress("UNCHECKED_CAST")
-            val typed = handler as SyncDomainHandler<Any>
-            when (val ids = catchUp.catchUpTransient(typed)) {
-                is AppResult.Success -> {
-                    (handler as AccessFilteredSyncHandler).pruneTo(ids.data, currentEpochMilliseconds())
+    internal suspend fun handleAccessChanged(scope: AccessScope?) {
+        val leader =
+            accessChangedMutex.withLock {
+                accumulateAccessChange(scope)
+                if (accessChangedRunning) {
+                    false
+                } else {
+                    accessChangedRunning = true
+                    true
                 }
+            }
+        if (!leader) return
 
-                is AppResult.Failure -> {
-                    logger.warn { "AccessChanged reconcile failed for ${handler.domainName}: ${ids.error.code}" }
+        try {
+            while (true) {
+                val work = accessChangedMutex.withLock { drainAccumulatedAccessChange() }
+                when (work) {
+                    PendingAccessChange.None -> break
+                    PendingAccessChange.Coarse -> accessReconciler.reconcile(null)
+                    is PendingAccessChange.Delta -> accessReconciler.reconcile(work.scope)
+                }
+            }
+        } finally {
+            // Normal exit already cleared the flag under the lock (via drain → None). This fires only
+            // on a thrown/cancelled reconcile, and — like the CursorStale cleanup — runs
+            // NonCancellable so a contended withLock on the cancellation path can't strand
+            // accessChangedRunning = true and wedge every future AccessChanged.
+            if (accessChangedRunning) {
+                withContext(NonCancellable) {
+                    accessChangedMutex.withLock { resetAccessChangeState() }
                 }
             }
         }
+    }
+
+    /** Fold [scope] into the pending accumulator. `null` poisons the follow-up to coarse. MUST hold [accessChangedMutex]. */
+    private fun accumulateAccessChange(scope: AccessScope?) {
+        accessChangedDirty = true
+        if (scope == null) {
+            pendingAccessCoarse = true
+        } else {
+            pendingAccessCollectionIds += scope.collectionIds
+            pendingAccessBookIds += scope.bookIds
+        }
+    }
+
+    /**
+     * Take the accumulated pending work and clear it, choosing coarse vs delta. Returns
+     * [PendingAccessChange.None] (and clears `accessChangedRunning`) when nothing is pending — the
+     * leader's loop-exit under the lock. A union that outgrows [ACCESS_DELTA_MAX_BOOKS], or any
+     * coarse frame, collapses to one coarse pass. MUST hold [accessChangedMutex].
+     */
+    private fun drainAccumulatedAccessChange(): PendingAccessChange {
+        if (!accessChangedDirty) {
+            accessChangedRunning = false
+            return PendingAccessChange.None
+        }
+        accessChangedDirty = false
+        val coarse =
+            pendingAccessCoarse ||
+                pendingAccessCollectionIds.size > ACCESS_DELTA_MAX_BOOKS ||
+                pendingAccessBookIds.size > ACCESS_DELTA_MAX_BOOKS
+        val result =
+            if (coarse) {
+                PendingAccessChange.Coarse
+            } else {
+                PendingAccessChange.Delta(
+                    AccessScope(pendingAccessCollectionIds.toList(), pendingAccessBookIds.toList()),
+                )
+            }
+        pendingAccessCoarse = false
+        pendingAccessCollectionIds.clear()
+        pendingAccessBookIds.clear()
+        return result
+    }
+
+    /** Clear all AccessChanged coalesce state after an abnormal exit. MUST hold [accessChangedMutex]. */
+    private fun resetAccessChangeState() {
+        accessChangedRunning = false
+        accessChangedDirty = false
+        pendingAccessCoarse = false
+        pendingAccessCollectionIds.clear()
+        pendingAccessBookIds.clear()
     }
 
     /** Stop SSE and wait until the frame collector is fully cancelled. Used by tests and deterministic shutdown paths. */
@@ -858,6 +936,27 @@ internal class SyncEngine(
         // edge, wasteful at 1 Hz. force = true (reconnect, LibraryDataChanged) bypasses it.
         const val LIFECYCLE_RECONCILE_MIN_INTERVAL_MS = 30_000L
     }
+}
+
+/**
+ * The largest coalesced AccessChanged scope the client will still fetch as a delta. A pending union
+ * bigger than this collapses to one coarse re-derive — cheaper than an enormous targeted fetch, and
+ * the safe anchor. Mirrors the server's `DELTA_MAX_BOOKS`.
+ */
+private const val ACCESS_DELTA_MAX_BOOKS = 200
+
+/** The coalesced AccessChanged work the leader loop pulls each pass: nothing, a coarse re-derive, or a scoped delta. */
+private sealed interface PendingAccessChange {
+    /** No pending work — the leader loop exits. */
+    data object None : PendingAccessChange
+
+    /** A coarse whole-library re-derive (a coarse frame arrived, or the union outgrew the delta budget). */
+    data object Coarse : PendingAccessChange
+
+    /** A scoped delta over the unioned affected entities. */
+    data class Delta(
+        val scope: AccessScope,
+    ) : PendingAccessChange
 }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -65,7 +65,7 @@ internal class SyncEventDispatcher(
                 state.recordError(control.error)
             }
 
-            SyncControl.AccessChanged -> {
+            is SyncControl.AccessChanged -> {
                 logger.info { "AccessChanged received; re-deriving accessible set via catch-up" }
                 onAccessChanged()
             }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEventDispatcher.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.api.contractJson
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.AccessScope
 import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.api.sync.SyncEvent
 import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
@@ -27,7 +28,7 @@ internal class SyncEventDispatcher(
     private val cursorAdvance: suspend (domainName: String, revision: Long) -> Unit,
     private val refreshedRouter: RefreshedDomainRouter = RefreshedDomainRouter(emptyList()),
     private val onCursorStale: suspend () -> Unit = {},
-    private val onAccessChanged: suspend () -> Unit = {},
+    private val onAccessChanged: suspend (scope: AccessScope?) -> Unit = {},
     private val onUserDeleted: suspend (reason: String?) -> Unit = {},
     private val onLibraryDataChanged: suspend () -> Unit = {},
 ) {
@@ -66,8 +67,12 @@ internal class SyncEventDispatcher(
             }
 
             is SyncControl.AccessChanged -> {
-                logger.info { "AccessChanged received; re-deriving accessible set via catch-up" }
-                onAccessChanged()
+                logger.info {
+                    val shape =
+                        control.scope?.let { "delta(${it.collectionIds.size}c/${it.bookIds.size}b)" } ?: "coarse"
+                    "AccessChanged received ($shape); re-deriving accessible set"
+                }
+                onAccessChanged(control.scope)
             }
 
             is SyncControl.UserDeleted -> {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/AccessGate.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/AccessGate.kt
@@ -18,8 +18,20 @@ internal class AccessGate(
     val liveIds: suspend () -> List<String>,
     /** Tombstone the given live local rows by wire id (called per bounded chunk). */
     val tombstoneByIds: suspend (ids: List<String>, now: Long) -> Unit,
-    /** Optional cascade run once after the prune completes (e.g. books' readership cleanup). */
+    /**
+     * Optional cascade run once after ANY prune (coarse or scoped) completes — the sweep for pure
+     * caches that have no sync domain of their own (e.g. books' readership + Continue-Listening
+     * positions). Safe to run in both paths because these rows are re-fetched, never digested.
+     */
     val afterPrune: suspend () -> Unit = {},
+    /**
+     * Optional cascade run once after a SCOPED prune ([AccessFilteredSyncHandler.pruneWithin]) only,
+     * receiving that prune's tombstone timestamp. Reserved for dependents that ARE their own
+     * access-gated sync domain — e.g. `activities`, which the coarse path re-derives authoritatively
+     * via its own prune, but a scoped delta never fetches. Running this in the coarse path would
+     * double-tombstone against that domain's own re-derivation, so it fires on the delta path alone.
+     */
+    val afterScopedPrune: suspend (now: Long) -> Unit = {},
 )
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/BooksDomain.kt
@@ -86,6 +86,11 @@ internal fun booksDomain(
                     database.bookReadershipDao().deleteWhereBookNotLive()
                     database.playbackPositionDao().deleteWhereBookNotLive()
                 },
+                // Delta-only: a scoped AccessChanged never fetches the activities domain, so an
+                // activity gating on a now-revoked book must be tombstoned here for the access-filtered
+                // activities digest to converge. Soft-delete — activities is a cursored domain. The
+                // coarse path re-derives activities via their own prune, so this must NOT run there.
+                afterScopedPrune = { now -> database.activityDao().tombstoneWhereBookNotLive(now) },
             ),
     )
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandler.kt
@@ -169,6 +169,20 @@ internal class AccessFilteredComposedSyncDomainHandler<T : SyncPayload>(
         doomed.chunked(SQLITE_IN_CHUNK).forEach { chunk -> gate.tombstoneByIds(chunk, now) }
         gate.afterPrune()
     }
+
+    override suspend fun pruneWithin(
+        candidateIds: Set<String>,
+        accessibleIds: Set<String>,
+        now: Long,
+    ) {
+        // Doomed = candidates that are still live locally but did NOT come back accessible. The
+        // intersection with the candidate set is the substrate protection: a live row outside the
+        // scope is never a candidate, so a scoped delta can never tombstone it. Same Kotlin-side
+        // diff + bounded chunking as pruneTo, so the bind-variable ceiling stays closed.
+        val doomed = (candidateIds intersect gate.liveIds().toSet()) - accessibleIds
+        doomed.chunked(SQLITE_IN_CHUNK).forEach { chunk -> gate.tombstoneByIds(chunk, now) }
+        gate.afterPrune()
+    }
 }
 
 /** Compile a descriptor into the runtime handler the engine speaks. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/ComposedSyncDomainHandler.kt
@@ -182,6 +182,10 @@ internal class AccessFilteredComposedSyncDomainHandler<T : SyncPayload>(
         val doomed = (candidateIds intersect gate.liveIds().toSet()) - accessibleIds
         doomed.chunked(SQLITE_IN_CHUNK).forEach { chunk -> gate.tombstoneByIds(chunk, now) }
         gate.afterPrune()
+        // Scoped-only: cascade to dependents that ARE their own access-gated domain (activities). The
+        // coarse path re-derives them via their own prune, but a delta never fetches them — so this
+        // fires here, not in pruneTo, to keep the activities digest converging after a scoped delta.
+        gate.afterScopedPrune(now)
     }
 }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -192,7 +192,7 @@ internal val clientSyncModule =
                 // AccessChanged re-derives the accessible set via catch-up without tearing down
                 // the live tail — same lazy-SyncEngine resolution as onCursorStale to break the
                 // construction cycle.
-                onAccessChanged = { get<SyncEngine>().handleAccessChanged() },
+                onAccessChanged = { scope -> get<SyncEngine>().handleAccessChanged(scope) },
                 // Account deleted by an admin: clear auth (soft logout → NeedsLogin),
                 // the same path the 401 fallback uses. Resolved lazily to avoid pulling
                 // AuthSession into the dispatcher's construction graph. The reason is logged

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/sync/SyncControlContractTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/api/sync/SyncControlContractTest.kt
@@ -26,11 +26,43 @@ class SyncControlContractTest :
             (decoded.error as InternalError).correlationId shouldBe "cid-xyz"
         }
 
-        test("AccessChanged round-trips") {
-            val original: SyncControl = SyncControl.AccessChanged
+        test("AccessChanged (bare, no scope) round-trips to scope=null — coarse") {
+            val original: SyncControl = SyncControl.AccessChanged()
             val json = contractJson.encodeToString(SyncControl.serializer(), original)
             val decoded = contractJson.decodeFromString(SyncControl.serializer(), json)
-            decoded shouldBe SyncControl.AccessChanged
+            decoded shouldBe SyncControl.AccessChanged(scope = null)
+        }
+
+        test("a legacy bare AccessChanged frame (no scope key) decodes to scope=null") {
+            // An older server emits the frame with no `scope` field — the additive default
+            // must degrade to coarse, never fail to decode.
+            val legacy = """{"type":"SyncControl.AccessChanged"}"""
+            val decoded = contractJson.decodeFromString(SyncControl.serializer(), legacy)
+            decoded shouldBe SyncControl.AccessChanged(scope = null)
+        }
+
+        test("scoped AccessChanged round-trips carrying affected entity ids") {
+            val original: SyncControl =
+                SyncControl.AccessChanged(
+                    scope =
+                        AccessScope(
+                            collectionIds = listOf("col-1", "col-2"),
+                            bookIds = listOf("book-9"),
+                        ),
+                )
+            val json = contractJson.encodeToString(SyncControl.serializer(), original)
+            val decoded = contractJson.decodeFromString(SyncControl.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("an AccessChanged frame with an unknown key still decodes (forward-compat)") {
+            val forward =
+                """{"type":"SyncControl.AccessChanged","scope":{"collectionIds":["c"],"bookIds":[],"future":42}}"""
+            val decoded = contractJson.decodeFromString(SyncControl.serializer(), forward)
+            decoded shouldBe
+                SyncControl.AccessChanged(
+                    scope = AccessScope(collectionIds = listOf("c"), bookIds = emptyList()),
+                )
         }
 
         test("UserDeleted round-trips") {
@@ -43,7 +75,7 @@ class SyncControlContractTest :
         test("Stable discriminators") {
             val stale: SyncControl = SyncControl.CursorStale(0)
             val streamErr: SyncControl = SyncControl.StreamError(InternalError())
-            val accessChanged: SyncControl = SyncControl.AccessChanged
+            val accessChanged: SyncControl = SyncControl.AccessChanged()
             contractJson
                 .encodeToString(SyncControl.serializer(), stale)
                 .contains("\"type\":\"SyncControl.CursorStale\"") shouldBe true

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FetchTransientTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FetchTransientTest.kt
@@ -150,8 +150,7 @@ private class InMemoryCursorDao : SyncCursorDao {
         cursors[entity.domainName] = entity.revision
     }
 
-    override suspend fun all(): List<SyncCursorEntity> =
-        cursors.map { (domain, rev) -> SyncCursorEntity(domainName = domain, revision = rev) }
+    override suspend fun all(): List<SyncCursorEntity> = cursors.map { (domain, rev) -> SyncCursorEntity(domainName = domain, revision = rev) }
 
     override suspend fun deleteAll() {
         cursors.clear()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FetchTransientTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/FetchTransientTest.kt
@@ -1,0 +1,159 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.Page
+import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.client.data.local.db.SyncCursorDao
+import com.calypsan.listenup.client.data.local.db.SyncCursorEntity
+import com.calypsan.listenup.client.test.db.passThroughTransactionRunner
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins [SyncCatchUpClient.fetchTransient] — the read half of the scoped `AccessChanged` delta:
+ * it hits the targeted `?ids=` / `?collectionIds=` endpoint, applies each returned row, returns the
+ * non-tombstone ids that came back, chunks over the per-request cap, and never advances the cursor.
+ */
+class FetchTransientTest :
+    FunSpec({
+
+        fun mockClient(record: MutableList<Url>): HttpClient =
+            HttpClient(
+                MockEngine { req ->
+                    record += req.url
+                    // Echo back a Page whose items are exactly the requested ids (all live), so the
+                    // test can assert the URL carried them and the returned set is what came back.
+                    val requested =
+                        (req.url.parameters["ids"] ?: req.url.parameters["collectionIds"] ?: "")
+                            .split(",")
+                            .filter { it.isNotBlank() }
+                    val page =
+                        Page(
+                            items = requested.map { Tag(it, it, it, 1L, 10L) },
+                            nextCursor = null,
+                            hasMore = false,
+                        )
+                    respond(
+                        content = contractJson.encodeToString(Page.serializer(Tag.serializer()), page),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+                    )
+                },
+            ) {
+                install(ContentNegotiation) { json(contractJson) }
+            }
+
+        fun tagHandler(seen: MutableList<Tag>): SyncDomainHandler<Tag> =
+            object : SyncDomainHandler<Tag> {
+                override val domainName = "tags"
+                override val payloadSerializer = Tag.serializer()
+
+                override fun syncId(item: Tag): String = item.id
+
+                override suspend fun onEvent(
+                    event: SyncEvent<Tag>,
+                    isOwnEcho: Boolean,
+                ): AppResult<Unit> = AppResult.Success(Unit)
+
+                override suspend fun onCatchUpItem(
+                    item: Tag,
+                    isTombstone: Boolean,
+                ): AppResult<Unit> {
+                    seen += item
+                    return AppResult.Success(Unit)
+                }
+
+                override suspend fun localDigestRows(maxRevision: Long): List<Pair<String, Long>> = emptyList()
+            }
+
+        fun client(
+            http: HttpClient,
+            dao: SyncCursorDao,
+        ): SyncCatchUpClient =
+            SyncCatchUpClient(
+                httpClientProvider = { http },
+                serverUrlProvider = { "http://test" },
+                store = SyncCursorStore(dao),
+                transactionRunner = passThroughTransactionRunner(),
+            )
+
+        test("ByIds hits ?ids=, applies returned rows, and returns their ids") {
+            runTest {
+                val urls = mutableListOf<Url>()
+                val seen = mutableListOf<Tag>()
+                val dao = InMemoryCursorDao()
+                dao.setCursor(SyncCursorEntity("tags", 99L))
+                val catchUp = client(mockClient(urls), dao)
+
+                val result = catchUp.fetchTransient(tagHandler(seen), TargetedFetch.ByIds(listOf("a", "b")))
+
+                result.shouldBeInstanceOf<AppResult.Success<Set<String>>>()
+                result.data shouldContainExactlyInAnyOrder setOf("a", "b")
+                seen.map { it.id } shouldContainExactlyInAnyOrder listOf("a", "b")
+                urls.single().encodedPath shouldBe "/api/v1/sync/tags"
+                urls.single().parameters["ids"] shouldBe "a,b"
+                // The persisted cursor is never touched by a transient fetch.
+                dao.getCursor("tags") shouldBe 99L
+            }
+        }
+
+        test("ByCollectionIds hits ?collectionIds=") {
+            runTest {
+                val urls = mutableListOf<Url>()
+                val catchUp = client(mockClient(urls), InMemoryCursorDao())
+
+                catchUp.fetchTransient(tagHandler(mutableListOf()), TargetedFetch.ByCollectionIds(listOf("c1")))
+
+                urls.single().encodedPath shouldBe "/api/v1/sync/tags"
+                urls.single().parameters["collectionIds"] shouldBe "c1"
+            }
+        }
+
+        test("a scope over the per-request cap is chunked, never truncated") {
+            runTest {
+                val urls = mutableListOf<Url>()
+                val seen = mutableListOf<Tag>()
+                val catchUp = client(mockClient(urls), InMemoryCursorDao())
+                val ids = (1..250).map { "id$it" }
+
+                val result = catchUp.fetchTransient(tagHandler(seen), TargetedFetch.ByIds(ids))
+
+                result.shouldBeInstanceOf<AppResult.Success<Set<String>>>()
+                // 250 ids / 100-per-request cap = 3 requests; every id comes back (no truncation).
+                urls.size shouldBe 3
+                result.data shouldContainExactly ids.toSet()
+            }
+        }
+    })
+
+private class InMemoryCursorDao : SyncCursorDao {
+    private val cursors = mutableMapOf<String, Long>()
+
+    override suspend fun getCursor(domainName: String): Long? = cursors[domainName]
+
+    override suspend fun setCursor(entity: SyncCursorEntity) {
+        cursors[entity.domainName] = entity.revision
+    }
+
+    override suspend fun all(): List<SyncCursorEntity> =
+        cursors.map { (domain, rev) -> SyncCursorEntity(domainName = domain, revision = rev) }
+
+    override suspend fun deleteAll() {
+        cursors.clear()
+    }
+}

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncReconcilerTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncReconcilerTest.kt
@@ -276,4 +276,12 @@ private fun accessGatedHandler(
         ) {
             prunedTo += accessibleIds
         }
+
+        override suspend fun pruneWithin(
+            candidateIds: Set<String>,
+            accessibleIds: Set<String>,
+            now: Long,
+        ) {
+            prunedTo += (candidateIds intersect accessibleIds)
+        }
     }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedDeltaE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedDeltaE2ETest.kt
@@ -1,0 +1,244 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.BookAudioFilePayload
+import com.calypsan.listenup.api.sync.BookChapterPayload
+import com.calypsan.listenup.api.sync.BookContributorPayload
+import com.calypsan.listenup.api.sync.BookSeriesPayload
+import com.calypsan.listenup.api.sync.BookSyncPayload
+import com.calypsan.listenup.client.data.local.db.BookReadershipEntity
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
+import com.calypsan.listenup.client.data.sync.testing.COLLECTION_E2E_MEMBER_ID
+import com.calypsan.listenup.client.data.sync.testing.CollectionSyncEngineScope
+import com.calypsan.listenup.client.data.sync.testing.withCollectionSyncEngineAgainstServer
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.CollectionId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+
+private val ROUND_TRIP_TIMEOUT = 30.seconds
+
+/**
+ * Tier-3 E2E for the scoped `AccessChanged` DELTA against the real `:server` routes + SSE firehose +
+ * the member's client [SyncEngine] (see
+ * [withCollectionSyncEngineAgainstServer][com.calypsan.listenup.client.data.sync.testing.withCollectionSyncEngineAgainstServer]).
+ *
+ * The oracle is **access-filtered digest parity**: after the reconcile settles, the member's local
+ * (tombstone-exclusive) `books` digest must EQUAL the server's `accessibleBookIdsSql`-filtered member
+ * digest at the same cursor — the exact comparison `SyncReconciler.reconcileOne` performs, so parity
+ * means a follow-up reconcile is a stable no-op. Complements the unit-level coalesce/prune coverage in
+ * [AccessChangedReconcileTest] by proving the whole stack — the server emits a correctly-scoped frame
+ * and the member converges through the real transports.
+ *
+ * Two proofs:
+ *  1. **Grant** — the member gains the book, the digests converge, and the member's persisted `books`
+ *     cursor is UNCHANGED (share touches no book revision, so the book arrives purely via the cursor-
+ *     untouched delta fetch — never a from-0 re-pull).
+ *  2. **Revoke** — the scoped book is tombstoned and its readership + Continue-Listening position
+ *     cascade away, WHILE a book the member holds through a different collection (outside the revoked
+ *     scope) SURVIVES — the substrate-protection invariant end-to-end — and the digests converge.
+ */
+class AccessChangedDeltaE2ETest :
+    FunSpec({
+
+        test("grant: member gains the book, digests converge, and the books cursor is unchanged")
+            .config(timeout = 2.minutes) {
+                withCollectionSyncEngineAgainstServer {
+                    serverBookRepository.upsert(bookPayload("book-private")).requireSuccess()
+                    val collectionId = adminCollections.createPrivateCollection("Private", "book-private")
+
+                    engine.start(currentUserId = COLLECTION_E2E_MEMBER_ID)
+
+                    // Pre-grant: the private book is invisible, and the books cursor is at its start value.
+                    clientDatabase.bookDao().getById(BookId("book-private")).shouldBeNull()
+                    val cursorBeforeGrant = clientDatabase.syncCursorDao().getCursor("books")
+
+                    adminCollections
+                        .shareCollection(collectionId, COLLECTION_E2E_MEMBER_ID, SharePermission.Read)
+                        .requireSuccess()
+
+                    awaitLiveBook(clientDatabase, "book-private")
+
+                    // Convergence oracle: the member's local books digest EQUALS the server's
+                    // access-filtered member digest — the reconcile landed exactly the accessible set.
+                    assertBooksDigestsConverge(this)
+
+                    // The delta fetch never advances the persisted cursor: the book arrived scoped, not
+                    // via a cursor-moving full re-pull.
+                    clientDatabase.syncCursorDao().getCursor("books") shouldBe cursorBeforeGrant
+                }
+            }
+
+        test("revoke: scoped book is tombstoned + cascaded, a book outside the scope survives, digests converge")
+            .config(timeout = 2.minutes) {
+                withCollectionSyncEngineAgainstServer {
+                    serverBookRepository.upsert(bookPayload("book-scoped")).requireSuccess()
+                    serverBookRepository.upsert(bookPayload("book-substrate")).requireSuccess()
+
+                    // Two independent private collections shared with the member: revoking one must not
+                    // touch the book held through the other (the substrate the naive design would nuke).
+                    val scopedCollection = adminCollections.createPrivateCollection("Scoped", "book-scoped")
+                    val substrateCollection = adminCollections.createPrivateCollection("Substrate", "book-substrate")
+
+                    engine.start(currentUserId = COLLECTION_E2E_MEMBER_ID)
+
+                    adminCollections
+                        .shareCollection(scopedCollection, COLLECTION_E2E_MEMBER_ID, SharePermission.Read)
+                        .requireSuccess()
+                    adminCollections
+                        .shareCollection(substrateCollection, COLLECTION_E2E_MEMBER_ID, SharePermission.Read)
+                        .requireSuccess()
+
+                    awaitLiveBook(clientDatabase, "book-scoped")
+                    awaitLiveBook(clientDatabase, "book-substrate")
+
+                    // Seed readership + a Continue-Listening position for the scoped book, so the revoke's
+                    // afterPrune cascade is observable.
+                    clientDatabase.bookReadershipDao().upsertAll(listOf(readershipRow("book-scoped", "reader")))
+                    clientDatabase.playbackPositionDao().save(positionRow("book-scoped"))
+
+                    // Revoke only the scoped collection → the server emits an AccessChanged delta scoped
+                    // to book-scoped alone.
+                    adminCollections.revokeShare(scopedCollection, COLLECTION_E2E_MEMBER_ID).requireSuccess()
+
+                    withTimeout(ROUND_TRIP_TIMEOUT) {
+                        while (clientDatabase.bookDao().getById(BookId("book-scoped"))?.deletedAt == null) {
+                            // poll until the scoped prune tombstones the book
+                        }
+                    }
+
+                    // The scoped book is pruned, and its dependents cascade away.
+                    clientDatabase
+                        .bookDao()
+                        .getById(BookId("book-scoped"))!!
+                        .deletedAt
+                        .shouldNotBeNull()
+                    clientDatabase
+                        .bookReadershipDao()
+                        .observeForBook("book-scoped")
+                        .first()
+                        .shouldBeEmpty()
+                    clientDatabase.playbackPositionDao().get(BookId("book-scoped")).shouldBeNull()
+
+                    // The substrate-protection invariant, end-to-end: the book held through the OTHER
+                    // collection is outside the revoked scope, so it is never a prune candidate.
+                    clientDatabase.bookDao().getById(BookId("book-substrate")).shouldNotBeNull()
+                    clientDatabase.bookDao().getById(BookId("book-substrate"))!!.deletedAt shouldBe null
+
+                    assertBooksDigestsConverge(this)
+                }
+            }
+    })
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Polls the member's Room until [bookId] is present AND live (non-tombstoned), or fails after timeout. */
+private suspend fun awaitLiveBook(
+    database: com.calypsan.listenup.client.data.local.db.ListenUpDatabase,
+    bookId: String,
+) = withTimeout(ROUND_TRIP_TIMEOUT) {
+    while (database.bookDao().getById(BookId(bookId)).let { it == null || it.deletedAt != null }) {
+        // poll until the AccessChanged delta upserts the book live
+    }
+}
+
+/**
+ * Asserts the member's local `books` digest equals the server's access-filtered member digest — the
+ * convergence oracle. The client digest is tombstone-exclusive (`bookDao.digestRows`); the server's
+ * is filtered through `accessibleBookIdsSql`, which itself excludes tombstones.
+ */
+private suspend fun assertBooksDigestsConverge(scope: CollectionSyncEngineScope) {
+    val filter =
+        scope.serverBookAccessPolicy
+            .accessibleBookIdsSql(COLLECTION_E2E_MEMBER_ID, UserRole.MEMBER)
+            .shouldNotBeNull()
+    val serverDigest = scope.serverBookRepository.digest(COLLECTION_E2E_MEMBER_ID, Long.MAX_VALUE, filter)
+    val clientRows =
+        scope.clientDatabase
+            .bookDao()
+            .digestRows(Long.MAX_VALUE)
+            .map { it.id to it.revision }
+    val clientDigest = DigestComputer.compute(Long.MAX_VALUE, clientRows)
+
+    clientDigest.count shouldBe serverDigest.count
+    clientDigest.hash shouldBe serverDigest.hash
+}
+
+/** Creates a private collection owned by the acting (admin) caller and adds [bookId]; returns its id. */
+private suspend fun com.calypsan.listenup.api.CollectionService.createPrivateCollection(
+    name: String,
+    bookId: String,
+): CollectionId {
+    val created = createCollection("test-library", name).requireSuccess()
+    addBookToCollection(created.id, BookId(bookId)).requireSuccess()
+    return created.id
+}
+
+private fun <T> AppResult<T>.requireSuccess(): T {
+    require(this is AppResult.Success) { "expected Success but got $this" }
+    return data
+}
+
+private fun readershipRow(
+    bookId: String,
+    userId: String,
+): BookReadershipEntity =
+    BookReadershipEntity(
+        bookId = bookId,
+        userId = userId,
+        displayName = "Reader $userId",
+        avatarType = "auto",
+        currentProgressPct = null,
+        finishesJson = "",
+        observedAt = 1L,
+    )
+
+private fun positionRow(bookId: String): PlaybackPositionEntity =
+    PlaybackPositionEntity(
+        bookId = BookId(bookId),
+        positionMs = 1_000L,
+        playbackSpeed = 1.0f,
+        updatedAt = 1L,
+    )
+
+private fun bookPayload(id: String): BookSyncPayload =
+    BookSyncPayload(
+        id = id,
+        libraryId = LibraryId("test-library"),
+        folderId = FolderId("test-folder"),
+        title = "Book $id",
+        sortTitle = "Book $id",
+        subtitle = null,
+        description = null,
+        publishYear = null,
+        publisher = null,
+        language = null,
+        isbn = null,
+        asin = null,
+        abridged = false,
+        explicit = false,
+        totalDuration = 3_600_000L,
+        cover = null,
+        rootRelPath = "books/$id",
+        inode = null,
+        scannedAt = 1L,
+        contributors = emptyList<BookContributorPayload>(),
+        series = emptyList<BookSeriesPayload>(),
+        audioFiles = emptyList<BookAudioFilePayload>(),
+        chapters = emptyList<BookChapterPayload>(),
+        revision = 1L,
+        updatedAt = 100L,
+        createdAt = 1L,
+        deletedAt = null,
+    )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -344,6 +344,31 @@ class AccessChangedReconcileTest :
             }
         }
 
+        test("delta: revoking a scoped book cascades to activities — its activity is tombstoned, a book-less one survives") {
+            withReconcileEngine { harness, db, _ ->
+                val books =
+                    booksDomain(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
+                val activities = activitiesDomain(db).toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
+                books.onCatchUpItem(bookPayload("b2"), isTombstone = false)
+                activities.onCatchUpItem(activityPayload("a2", bookId = "b2"), isTombstone = false)
+                // A book-less activity has no gating book, so the cascade must leave it live.
+                activities.onCatchUpItem(activityPayload("aNoBook", bookId = null), isTombstone = false)
+
+                // b2 revoked → the delta only touches books, but the books afterPrune cascade must
+                // tombstone a2 so the access-filtered activities digest converges (the delta never
+                // fetches the activities domain).
+                harness.fakeCatchUp.returnedByDomain["books"] = emptySet()
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b2")))
+
+                db.activityDao().getById("a2")!!.deletedAt shouldNotBe null
+                db.activityDao().getById("aNoBook")!!.deletedAt shouldBe null
+            }
+        }
+
         test("coarse frame re-derives every access-gated domain — the 5-domain sweep") {
             withReconcileEngine { harness, _, _ ->
                 harness.engine.handleAccessChanged(null)

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -21,6 +21,7 @@ import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.stubImageStorage
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.AccessScope
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
@@ -30,15 +31,21 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 
 /**
  * The load-bearing security piece: on `AccessChanged`, the engine
@@ -68,7 +75,7 @@ class AccessChangedReconcileTest :
 
                 // Server now reports only b1 accessible — b2's share was revoked.
                 harness.fakeCatchUp.accessibleByDomain["books"] = setOf("b1")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.bookDao().getById(BookId("b1"))!!.deletedAt shouldBe null
                 db.bookDao().getById(BookId("b2"))!!.deletedAt shouldNotBe null
@@ -91,7 +98,7 @@ class AccessChangedReconcileTest :
 
                 // Server now reports only b1 accessible — b2's share was revoked.
                 harness.fakeCatchUp.accessibleByDomain["books"] = setOf("b1")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.bookReadershipDao().observeForBook("b1").first() shouldHaveSize 1
                 db
@@ -109,7 +116,7 @@ class AccessChangedReconcileTest :
                 handler.onCatchUpItem(collectionPayload("c2"), isTombstone = false)
 
                 harness.fakeCatchUp.accessibleByDomain["collections"] = setOf("c1")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.collectionDao().getById("c1").shouldNotBeNull()
                 // getById filters tombstones, so a pruned (soft-deleted) row reads as null.
@@ -125,7 +132,7 @@ class AccessChangedReconcileTest :
 
                 // Admin: access-filtered catch-up returns everything → pruneTo deletes nothing.
                 harness.fakeCatchUp.accessibleByDomain["collections"] = setOf("c1", "c2")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.collectionDao().getById("c1").shouldNotBeNull()
                 db.collectionDao().getById("c2").shouldNotBeNull()
@@ -142,7 +149,7 @@ class AccessChangedReconcileTest :
                 // Member lost ALL access — access-filtered catch-up returns the empty set.
                 // The reconcile must evict EVERY local row; nothing may remain readable.
                 harness.fakeCatchUp.accessibleByDomain["collections"] = emptySet()
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.collectionDao().liveIds().shouldBeEmpty()
                 db.collectionDao().getById("c1") shouldBe null
@@ -161,7 +168,7 @@ class AccessChangedReconcileTest :
                 // The access-filtered catch-up now returns only a1 — b2 was deleted / its share revoked,
                 // so a2 dropped out of the member's accessible set.
                 harness.fakeCatchUp.accessibleByDomain["activities"] = setOf("a1")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 // a2 is tombstoned (soft-deleted), a1 remains live — same shape as books/collections.
                 db.activityDao().getById("a1")!!.deletedAt shouldBe null
@@ -178,13 +185,13 @@ class AccessChangedReconcileTest :
 
                 // First reconcile prunes a2 to match the server's accessible set.
                 harness.fakeCatchUp.accessibleByDomain["activities"] = setOf("a1")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
                 val digestAfterFirst = db.activityDao().digestRows(Long.MAX_VALUE).toSet()
 
                 // Second reconcile against the SAME accessible set must change nothing: the digest the
                 // server would compare against is now stable, so `activities` converges exactly like
                 // `books` — no row flip-flops, no permanent (id, revision) drift.
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.activityDao().digestRows(Long.MAX_VALUE).toSet() shouldBe digestAfterFirst
                 db.activityDao().liveIds() shouldBe listOf("a1")
@@ -198,7 +205,7 @@ class AccessChangedReconcileTest :
 
                 // Share revoked → the prune tombstones a1 (it dropped out of the accessible set).
                 harness.fakeCatchUp.accessibleByDomain["activities"] = emptySet()
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
                 db.activityDao().getById("a1")!!.deletedAt shouldNotBe null
 
                 // Share restored → catch-up re-delivers the SAME activity LIVE (deletedAt = null).
@@ -222,7 +229,7 @@ class AccessChangedReconcileTest :
                 // Only the first 10 stay accessible; the other 990 must all be tombstoned.
                 val accessible = (0 until 10).map { "a$it" }.toSet()
                 harness.fakeCatchUp.accessibleByDomain["activities"] = accessible
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 db.activityDao().liveIds().toSet() shouldBe accessible
             }
@@ -240,16 +247,209 @@ class AccessChangedReconcileTest :
                 store.setCursor("books", 42L)
 
                 harness.fakeCatchUp.accessibleByDomain["books"] = setOf("b1")
-                harness.engine.handleAccessChanged()
+                harness.engine.handleAccessChanged(null)
 
                 store.getCursor("books") shouldBe 42L
             }
         }
+
+        // ---- Scoped delta path -------------------------------------------------------------------
+
+        test("delta: fetches exactly the scoped ids — collections + collection_books + books, in dependency order") {
+            withReconcileEngine { harness, _, _ ->
+                // A returned set per domain so the prune step is a no-op; we assert only the fetch shape.
+                harness.fakeCatchUp.returnedByDomain["collections"] = setOf("c1")
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
+
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = listOf("c1"), bookIds = listOf("b1")))
+
+                harness.fakeCatchUp.fetches shouldBe
+                    listOf(
+                        RecordedFetch("collections", TargetedFetch.ByIds(listOf("c1"))),
+                        RecordedFetch("collection_books", TargetedFetch.ByCollectionIds(listOf("c1"))),
+                        RecordedFetch("books", TargetedFetch.ByIds(listOf("b1"))),
+                    )
+                // A scoped delta never re-derives the whole library — the coarse sweep must not run.
+                harness.fakeCatchUp.coarseCalls.shouldBeEmpty()
+            }
+        }
+
+        test("delta: a requested book that does not come back is tombstoned; the returned one stays live") {
+            withReconcileEngine { harness, db, _ ->
+                val handler =
+                    booksDomain(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
+                handler.onCatchUpItem(bookPayload("b1"), isTombstone = false)
+                handler.onCatchUpItem(bookPayload("b2"), isTombstone = false)
+
+                // Both are in scope, but only b1 comes back accessible — b2's share was revoked.
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b1", "b2")))
+
+                db.bookDao().getById(BookId("b1"))!!.deletedAt shouldBe null
+                db.bookDao().getById(BookId("b2"))!!.deletedAt shouldNotBe null
+            }
+        }
+
+        test("delta: a live book OUTSIDE the scope is NEVER touched — the substrate-protection invariant") {
+            withReconcileEngine { harness, db, _ ->
+                val handler =
+                    booksDomain(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
+                // b1 is the scoped, now-revoked book. bSubstrate is a live public ALL_BOOKS book the
+                // client mirrors but the delta never names — it MUST survive the prune.
+                handler.onCatchUpItem(bookPayload("b1"), isTombstone = false)
+                handler.onCatchUpItem(bookPayload("bSubstrate"), isTombstone = false)
+
+                // b1 revoked → returns nothing. The scope names ONLY b1, so bSubstrate is not a candidate.
+                harness.fakeCatchUp.returnedByDomain["books"] = emptySet()
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b1")))
+
+                db.bookDao().getById(BookId("b1"))!!.deletedAt shouldNotBe null
+                // The load-bearing assertion: a book outside the delta scope is untouched — no over-prune.
+                db.bookDao().getById(BookId("bSubstrate")).shouldNotBeNull()
+                db.bookDao().getById(BookId("bSubstrate"))!!.deletedAt shouldBe null
+            }
+        }
+
+        test("delta: the books prune cascades — readership for a revoked scoped book is dropped") {
+            withReconcileEngine { harness, db, _ ->
+                val handler =
+                    booksDomain(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
+                handler.onCatchUpItem(bookPayload("b1"), isTombstone = false)
+                handler.onCatchUpItem(bookPayload("b2"), isTombstone = false)
+                db.bookReadershipDao().upsertAll(
+                    listOf(readershipRow("b1", "u1"), readershipRow("b2", "u1")),
+                )
+
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b1", "b2")))
+
+                db.bookReadershipDao().observeForBook("b1").first() shouldHaveSize 1
+                db
+                    .bookReadershipDao()
+                    .observeForBook("b2")
+                    .first()
+                    .shouldBeEmpty()
+            }
+        }
+
+        test("coarse frame re-derives every access-gated domain — the 5-domain sweep") {
+            withReconcileEngine { harness, _, _ ->
+                harness.engine.handleAccessChanged(null)
+
+                harness.fakeCatchUp.coarseCalls.toSet() shouldBe
+                    setOf("books", "collections", "collection_books", "collection_shares", "activities")
+                // Coarse never issues a targeted fetch.
+                harness.fakeCatchUp.fetches.shouldBeEmpty()
+            }
+        }
+
+        test("coalesce: two deltas arriving mid-reconcile fold into ONE unioned follow-up fetch") {
+            withReconcileEngine { harness, _, _ ->
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("ba", "bb", "bc")
+                val gate = CompletableDeferred<Unit>()
+                harness.fakeCatchUp.gate = gate
+
+                coroutineScope {
+                    // Leader pass reconciles [ba] and parks on the gate at its books fetch.
+                    val leader = launch { harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("ba"))) }
+                    while (harness.fakeCatchUp.fetches.isEmpty()) yield()
+                    // Two frames land while the leader is parked → they accumulate together.
+                    harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bb")))
+                    harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bc")))
+                    gate.complete(Unit)
+                    leader.join()
+                }
+
+                // Exactly two passes: the leader's [ba], then ONE follow-up over the union {bb, bc}.
+                harness.fakeCatchUp.fetches shouldHaveSize 2
+                harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("ba"))
+                (harness.fakeCatchUp.fetches[1].fetch as TargetedFetch.ByIds).ids.toSet() shouldBe setOf("bb", "bc")
+            }
+        }
+
+        test("coalesce: a coarse frame arriving mid-delta POISONS the follow-up to a single coarse pass") {
+            withReconcileEngine { harness, _, _ ->
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("ba")
+                val gate = CompletableDeferred<Unit>()
+                harness.fakeCatchUp.gate = gate
+
+                coroutineScope {
+                    val leader = launch { harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("ba"))) }
+                    while (harness.fakeCatchUp.fetches.isEmpty()) yield()
+                    // A coarse frame AND another delta land — coarse must win the follow-up.
+                    harness.engine.handleAccessChanged(null)
+                    harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bb")))
+                    gate.complete(Unit)
+                    leader.join()
+                }
+
+                // Only the leader's single delta fetch ran; the follow-up was a coarse 5-domain sweep,
+                // NOT a targeted fetch of bb.
+                harness.fakeCatchUp.fetches shouldHaveSize 1
+                harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("ba"))
+                harness.fakeCatchUp.coarseCalls shouldHaveSize 5
+            }
+        }
+
+        test("a cancelled reconcile does not wedge the coalesce mutex — the next frame still leads") {
+            withReconcileEngine { harness, _, _ ->
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("ba", "bb")
+                val gate = CompletableDeferred<Unit>()
+                harness.fakeCatchUp.gate = gate
+
+                coroutineScope {
+                    val leader = launch { harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("ba"))) }
+                    while (harness.fakeCatchUp.fetches.isEmpty()) yield()
+                    // Cancel mid-reconcile (parked on the gate). The NonCancellable finally must reset the flags.
+                    leader.cancelAndJoin()
+                }
+
+                // If accessChangedRunning were stranded true, this frame would find a "running" leader and
+                // no-op — no fetch. It leading + fetching proves the mutex state was cleaned up.
+                harness.fakeCatchUp.fetches.clear()
+                harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bb")))
+
+                harness.fakeCatchUp.fetches shouldHaveSize 1
+                harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("bb"))
+            }
+        }
     })
 
-/** Fake [CatchUp] whose transient pass returns a controlled accessible id set per domain. */
+/** A targeted fetch the fake observed, for assertions. */
+private data class RecordedFetch(
+    val domain: String,
+    val fetch: TargetedFetch,
+)
+
+/**
+ * Fake [CatchUp]: the coarse pass ([catchUpTransient]) returns a controlled accessible set per
+ * domain; the delta pass ([fetchTransient]) records each targeted fetch and returns a controlled
+ * "still-accessible returned" set per domain (defaulting to the accessible set). A latch lets a test
+ * hold one reconcile mid-flight to exercise the coalescer.
+ */
 private class FakeReconcileCatchUp : CatchUp {
     val accessibleByDomain: MutableMap<String, Set<String>> = mutableMapOf()
+    val returnedByDomain: MutableMap<String, Set<String>> = mutableMapOf()
+    val fetches: MutableList<RecordedFetch> = mutableListOf()
+
+    /** The domain names the coarse pass ([catchUpTransient]) re-derived, in order — for the 5-domain sweep assertion. */
+    val coarseCalls: MutableList<String> = mutableListOf()
+
+    /** When set, the FIRST fetchTransient awaits this before returning — a hook to interleave a second frame. */
+    @Volatile
+    var gate: CompletableDeferred<Unit>? = null
 
     override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
 
@@ -258,8 +458,22 @@ private class FakeReconcileCatchUp : CatchUp {
     override suspend fun catchUpAll(registry: ClientSyncDomainRegistry): AppResult<Unit> = AppResult.Success(Unit)
 
     override suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>> {
+        coarseCalls += handler.domainName
         val ids = accessibleByDomain[handler.domainName] ?: emptySet()
         return AppResult.Success(ids)
+    }
+
+    override suspend fun <T : Any> fetchTransient(
+        handler: SyncDomainHandler<T>,
+        fetch: TargetedFetch,
+    ): AppResult<Set<String>> {
+        fetches += RecordedFetch(handler.domainName, fetch)
+        gate?.let {
+            gate = null
+            it.await()
+        }
+        val returned = returnedByDomain[handler.domainName] ?: accessibleByDomain[handler.domainName] ?: emptySet()
+        return AppResult.Success(returned)
     }
 
     override suspend fun domains(): AppResult<List<String>> = AppResult.Success(emptyList())

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PruneWithinTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/PruneWithinTest.kt
@@ -1,0 +1,99 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
+import com.calypsan.listenup.client.data.sync.domains.toHandler
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Pins the scoped prune primitive [AccessFilteredSyncHandler.pruneWithin] — the removal half of the
+ * scoped `AccessChanged` delta. The load-bearing property is the **substrate protection**: a live
+ * row outside the scope is never a candidate, so a targeted delta can never tombstone it, no matter
+ * what the accessible set says. Without that, a scoped revoke would nuke the public library the
+ * client mirrors but never enumerates.
+ */
+class PruneWithinTest :
+    FunSpec({
+
+        fun handler(db: com.calypsan.listenup.client.data.local.db.ListenUpDatabase) =
+            collectionsDomain(db).toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
+                as AccessFilteredSyncHandler
+
+        test("prunes a candidate that is no longer accessible") {
+            runBlocking {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val h = handler(db)
+                    (h as SyncDomainHandler<CollectionSyncPayload>).onCatchUpItem(collectionPayload("c1"), false)
+                    h.onCatchUpItem(collectionPayload("c2"), false)
+
+                    // c2 is a candidate that did NOT come back accessible → doomed.
+                    (h as AccessFilteredSyncHandler)
+                        .pruneWithin(candidateIds = setOf("c1", "c2"), accessibleIds = setOf("c1"), now = 1L)
+
+                    db.collectionDao().getById("c1").shouldNotBeNull()
+                    db.collectionDao().getById("c2") shouldBe null
+                } finally {
+                    db.close()
+                }
+            }
+        }
+
+        test("a live row OUTSIDE the scope is never touched, even when it is not in the accessible set") {
+            runBlocking {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val h = handler(db)
+                    val typed = h as SyncDomainHandler<CollectionSyncPayload>
+                    typed.onCatchUpItem(collectionPayload("in-scope"), false)
+                    // 'substrate' is a live row the client mirrors but the delta never names.
+                    typed.onCatchUpItem(collectionPayload("substrate"), false)
+
+                    // Scope names only 'in-scope'; accessibleIds is empty (in-scope was revoked).
+                    // 'substrate' is NOT a candidate, so it must survive despite being absent from
+                    // accessibleIds — this is the assertion the whole design turns on.
+                    (h as AccessFilteredSyncHandler)
+                        .pruneWithin(candidateIds = setOf("in-scope"), accessibleIds = emptySet(), now = 1L)
+
+                    db.collectionDao().getById("in-scope") shouldBe null
+                    db.collectionDao().getById("substrate").shouldNotBeNull()
+                } finally {
+                    db.close()
+                }
+            }
+        }
+
+        test("an empty candidate set is a no-op") {
+            runBlocking {
+                val db = createInMemoryTestDatabase()
+                try {
+                    val h = handler(db)
+                    (h as SyncDomainHandler<CollectionSyncPayload>).onCatchUpItem(collectionPayload("c1"), false)
+
+                    (h as AccessFilteredSyncHandler)
+                        .pruneWithin(candidateIds = emptySet(), accessibleIds = emptySet(), now = 1L)
+
+                    db.collectionDao().getById("c1").shouldNotBeNull()
+                } finally {
+                    db.close()
+                }
+            }
+        }
+    })
+
+private fun collectionPayload(id: String): CollectionSyncPayload =
+    CollectionSyncPayload(
+        id = id,
+        libraryId = "lib1",
+        ownerId = "u1",
+        name = "Collection $id",
+        isInbox = false,
+        revision = 1L,
+        updatedAt = 100L,
+        deletedAt = null,
+    )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouterTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouterTest.kt
@@ -74,7 +74,7 @@ class RefreshedDomainRouterTest :
                         listOf(presenceDomain(ping = {})),
                     )
 
-                router.dispatch(SyncControl.AccessChanged) shouldBe false
+                router.dispatch(SyncControl.AccessChanged()) shouldBe false
                 router.dispatch(SyncControl.LibraryDataChanged) shouldBe false
             }
         }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
@@ -94,6 +94,9 @@ internal data class CollectionSyncEngineScope(
     val adminCollections: CollectionService,
     val serverBookRepository: BookRepository,
     val clientDatabase: ListenUpDatabase,
+    // The server's access policy, exposed so a test can build the member's access-filtered book
+    // digest (`accessibleBookIdsSql(member, MEMBER)`) — the convergence oracle for the scoped delta.
+    val serverBookAccessPolicy: BookAccessPolicy,
 )
 
 /**
@@ -241,6 +244,7 @@ internal fun withCollectionSyncEngineAgainstServer(block: suspend CollectionSync
                     adminCollections = adminCollections,
                     serverBookRepository = bookRepo,
                     clientDatabase = clientDb,
+                    serverBookAccessPolicy = bookAccessPolicy,
                 ).block()
             } finally {
                 engine.stopAndJoin()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithCollectionSyncEngineAgainstServer.kt
@@ -303,8 +303,8 @@ private fun buildMemberSyncEngine(
             onCursorStale = {
                 checkNotNull(engineRef) { "SyncEngine not yet constructed" }.handleCursorStale()
             },
-            onAccessChanged = {
-                checkNotNull(engineRef) { "SyncEngine not yet constructed" }.handleAccessChanged()
+            onAccessChanged = { scope ->
+                checkNotNull(engineRef) { "SyncEngine not yet constructed" }.handleAccessChanged(scope)
             },
         )
 


### PR DESCRIPTION
## Collections propagation: 20-30s → sub-second

A collection/access change propagated in **20-30s** because the client responded to a **contentless `AccessChanged` nudge** by re-deriving its *entire* accessible library across 5 domains from cursor 0, serially, with no coalescing — it *was* a full library resync, because it literally was one.

This makes the frame **carry the affected entity ids**, and the client does a **targeted access-filtered fetch** of just those: `returned → upsert`, `requested-but-not-returned → tombstone`. **O(library) → O(changed).** Additions and removals converge through one mechanism, per-user-correct by construction, with zero server-side per-user diffing.

**Additive and wire-safe:** the frame evolves in place (`AccessChanged(scope: AccessScope? = null)`, same `@SerialName`); an old-server frame or any unhandled shape decodes to `scope = null` → the **coarse full re-derive**, which is kept verbatim as the semantic anchor and frame-loss backstop.

## Phases (6 commits)
1. Contract: `AccessChanged` carries an optional `AccessScope(collectionIds, bookIds)`.
2. Server: `pullByIds` targeted access-filtered read + `GET /api/v1/sync/{domain}?ids=`/`?collectionIds=`.
3. Server: build the scope at every access-mutation site (`affectedBookIds` is a *required* param — a site can't forget a gain; >200 books → coarse). Includes a bonus `deleteCollection` stage-then-publish split that fixes a pre-existing publish-before-cascade race.
4. Client: `CatchUp.fetchTransient` + `pruneWithin` (tombstones only `candidateIds ∩ live − accessible` — a book outside the scope can never be pruned).
5. Client: `AccessReconciler` (delta + coarse paths) + coalescing engine coordinator.
6. E2E + activities `afterPrune` cascade.

## Test Plan
- [x] 19 reconcile unit tests + 2 real-server E2E. The **substrate-protection** invariant is asserted at three altitudes (prune primitive, reconciler flow, E2E: a book held via a second collection survives a revoke with server-digest parity). The E2E also proves a grant delivers the gain **with digest parity AND the book-domain cursor unchanged** (no from-0 re-pull).
- [x] Full Linux `verifyLocal` green.
- [x] **Adversarially code-reviewed — SOUND, no critical findings.** All four critical failure classes (silent-drop of a gain, over-prune outside scope, RevisionGuard bypass, coalescer deadlock) traced to ground and structurally prevented.

Non-blocking notes from review: the cross-frame coalescer is a latent safety net under today's inline SSE dispatch (per-frame bursts run sequentially — correct + idempotent, just not the ≤2-pass path; server emits one big-scope frame per mutation so it rarely matters); targeted-fetch CSV relies on URL-safe ids (true today).