### PR TITLE
🐛 fix(iosApp): iOS UI batch — long-press, popover anchor, leaderboard modes, book-detail envelope, padding

### DIFF
--- a/iosApp/CLAUDE.md
+++ b/iosApp/CLAUDE.md
@@ -73,7 +73,7 @@ inline below.
    - **Never `await` an `AppResult`-returning Kotlin suspend from Swift.** It traps in the Swift Export
      bridge (`__createProtocolWrapper(...) as! any AppResult` cast failure → frozen UI). Consume
      `AppResult` in Kotlin and expose a plain-typed `*OrNull` accessor (see `AppResult.valueOrNull` +
-     the `getInstanceOrNull`/`getResumeBookOrNull`/`downloadBookOrNull`/`ensureLocalPathOrNull`
+     the `getServerInfoOrNull`/`getResumeBookOrNull`/`downloadBookOrNull`/`ensureLocalPathOrNull`
      precedents); Swift `await`s the plain optional. Enforced by `scripts/check-no-appresult-await.sh`
      in the `Test (iOS)` CI job. (Plain-typed suspends — `String?`, domain types, `Flow`,
      fire-and-forget `Unit` — are fine.)

--- a/iosApp/ListenUp/Features/Admin/AdminView.swift
+++ b/iosApp/ListenUp/Features/Admin/AdminView.swift
@@ -526,7 +526,8 @@ private struct RegistrationPolicyCard: View {
             .pickerStyle(.segmented)
             .disabled(isBusy)
         }
-        .padding(.vertical, 4)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
     }
 
     private static func label(_ policy: RegistrationPolicy) -> String {

--- a/iosApp/ListenUp/Features/Admin/Import/ImportWizardTerminalContent.swift
+++ b/iosApp/ListenUp/Features/Admin/Import/ImportWizardTerminalContent.swift
@@ -8,6 +8,10 @@ import SwiftUI
 /// warning tells them what will be skipped rather than blocking them).
 struct ImportReviewContent: View {
     let review: ImportReviewModel
+    /// The ABS user whose target picker is open, if any. Bound to the parent so a single row's
+    /// popover is presented; the popover itself is attached to that row (below) so it anchors to
+    /// the tapped row rather than floating at the top of the screen.
+    @Binding var assigningUser: ImportUserRowModel?
     let onAccept: (ImportUserRowModel, String) -> Void
     let onAssign: (ImportUserRowModel) -> Void
     let onSkip: (ImportUserRowModel) -> Void
@@ -28,6 +32,9 @@ struct ImportReviewContent: View {
                             onSkip: { onSkip(user) },
                             onChange: { onAssign(user) }
                         )
+                        .popover(item: assignPopoverBinding(for: user)) { _ in
+                            assignPicker(for: user)
+                        }
                     }
                     if review.unresolvedCount > 0 {
                         warning
@@ -39,6 +46,33 @@ struct ImportReviewContent: View {
             }
             actionTray
         }
+    }
+
+    /// A binding that is non-nil only for the row whose picker is open, so the `.popover(item:)`
+    /// attached to each row presents on exactly that row (and thus anchors to it).
+    private func assignPopoverBinding(for user: ImportUserRowModel) -> Binding<ImportUserRowModel?> {
+        Binding(
+            get: { assigningUser?.absUserId == user.absUserId ? assigningUser : nil },
+            set: { assigningUser = $0 }
+        )
+    }
+
+    /// The target-user picker shown in the row popover. On a regular width it renders as a popover
+    /// anchored to the row; on a compact width SwiftUI adapts it to a sheet automatically.
+    private func assignPicker(for user: ImportUserRowModel) -> some View {
+        List(review.listenupUsers) { pickerUser in
+            Button {
+                onAccept(user, pickerUser.id)
+                assigningUser = nil
+            } label: {
+                Text(pickerUser.name)
+                    .foregroundStyle(.primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .listStyle(.plain)
+        .frame(minWidth: 260, idealWidth: 300, minHeight: 240, idealHeight: 320)
+        .presentationDetents([.medium, .large])
     }
 
     private var countHeader: some View {

--- a/iosApp/ListenUp/Features/Admin/Import/ImportWizardView.swift
+++ b/iosApp/ListenUp/Features/Admin/Import/ImportWizardView.swift
@@ -55,13 +55,6 @@ struct ImportWizardView: View {
             } message: { message in
                 Text(message)
             }
-            .confirmationDialog(
-                String(localized: "import.user_pick_user"),
-                isPresented: assignSheetPresented,
-                titleVisibility: .visible
-            ) {
-                assignButtons
-            }
         }
         .onAppear {
             if observer == nil {
@@ -101,6 +94,7 @@ struct ImportWizardView: View {
         case .review(let review):
             ImportReviewContent(
                 review: review,
+                assigningUser: $assigningUser,
                 onAccept: { observer.assignUser(absUserId: $0.absUserId, listenUpUserId: $1) },
                 onAssign: { assigningUser = $0 },
                 onSkip: { observer.skipUser(absUserId: $0.absUserId) },
@@ -193,21 +187,6 @@ struct ImportWizardView: View {
         }
     }
 
-    // MARK: - Assign picker
-
-    @ViewBuilder
-    private var assignButtons: some View {
-        if case .review(let review) = observer?.phase, let assigning = assigningUser {
-            ForEach(review.listenupUsers) { pickerUser in
-                Button(pickerUser.name) {
-                    observer?.assignUser(absUserId: assigning.absUserId, listenUpUserId: pickerUser.id)
-                    assigningUser = nil
-                }
-            }
-            Button(String(localized: "common.cancel"), role: .cancel) { assigningUser = nil }
-        }
-    }
-
     // MARK: - Derived flags
 
     private var isTerminal: Bool { observer?.phase.isTerminal ?? false }
@@ -222,10 +201,6 @@ struct ImportWizardView: View {
 
     private var pickErrorPresented: Binding<Bool> {
         Binding(get: { pickError != nil }, set: { if !$0 { pickError = nil } })
-    }
-
-    private var assignSheetPresented: Binding<Bool> {
-        Binding(get: { assigningUser != nil }, set: { if !$0 { assigningUser = nil } })
     }
 }
 

--- a/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
@@ -332,7 +332,7 @@ final class BookDetailObserver {
         // threw `EnvelopeMismatchException` on every book-detail load. `getServerInfo` is pure RPC
         // and carries the `remoteUrl` + `instanceId` the share link needs. The embedded `serverUrl`
         // is advisory (display / future connect), so the WAN `remoteUrl` is the right value.
-        guard let info = await Dependencies.shared.instanceRepository.getServerInfoOrNull(forceRefresh: false)
+        guard let info = try? await Dependencies.shared.instanceRepository.getServerInfoOrNull(forceRefresh: false)
         else { return }
         let trimmed = info.remoteUrl.map { $0.hasSuffix("/") ? String($0.dropLast()) : $0 }
         let raw = ShareLinkCodec.shared.encode(

--- a/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/ListenUp/Features/BookDetail/BookDetailObserver.swift
@@ -327,14 +327,18 @@ final class BookDetailObserver {
     }
 
     private func buildShareURL(bookId: String) async {
-        guard let instance = try? await Dependencies.shared.instanceRepository.getInstanceOrNull(forceRefresh: false)
+        // Use the RPC-backed server identity, not the legacy `getInstance` REST path: the Kotlin
+        // server responds a bare (non-enveloped) body there, so decoding it as `ApiResponse<Instance>`
+        // threw `EnvelopeMismatchException` on every book-detail load. `getServerInfo` is pure RPC
+        // and carries the `remoteUrl` + `instanceId` the share link needs. The embedded `serverUrl`
+        // is advisory (display / future connect), so the WAN `remoteUrl` is the right value.
+        guard let info = await Dependencies.shared.instanceRepository.getServerInfoOrNull(forceRefresh: false)
         else { return }
-        let baseUrl = instance.remoteUrl ?? instance.localUrl
-        let trimmed = baseUrl.map { $0.hasSuffix("/") ? String($0.dropLast()) : $0 }
+        let trimmed = info.remoteUrl.map { $0.hasSuffix("/") ? String($0.dropLast()) : $0 }
         let raw = ShareLinkCodec.shared.encode(
             target: ShareTargetBook(
                 bookId: BookId(value: bookId),
-                serverInstanceId: instance.id.value,
+                serverInstanceId: info.instanceId,
                 serverUrl: trimmed
             )
         )

--- a/iosApp/ListenUp/Features/Discover/Components/LeaderboardSectionView.swift
+++ b/iosApp/ListenUp/Features/Discover/Components/LeaderboardSectionView.swift
@@ -1,15 +1,35 @@
 import SwiftUI
 
-/// The Discover leaderboard section: a title, a Week / Month / All period control, and
-/// flat ranked rows. Renders loading / empty / data / error from the observer's phase.
+/// The Discover leaderboard section: a title, a Week / Month / All period control, a
+/// Time / Books / Streak metric control, and flat ranked rows. Renders loading / empty /
+/// data / error from the observer's phase.
 struct LeaderboardSectionView: View {
     let observer: LeaderboardObserver
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             header
+            metricPicker
             content
         }
+    }
+
+    // MARK: - Metric control
+
+    private var metricPicker: some View {
+        Picker(
+            String(localized: "discover.leaderboard"),
+            selection: Binding(
+                get: { observer.selectedMetric },
+                set: { observer.selectMetric($0) }
+            )
+        ) {
+            ForEach(LeaderboardMetric.allCases) { metric in
+                Text(String(localized: metric.titleKey)).tag(metric)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
     }
 
     // MARK: - Header

--- a/iosApp/ListenUp/Features/Discover/LeaderboardObserver.swift
+++ b/iosApp/ListenUp/Features/Discover/LeaderboardObserver.swift
@@ -2,9 +2,10 @@ import Foundation
 import Shared
 
 /// Observes `LeaderboardViewModel` — flattens the sealed `LeaderboardUiState` into a
-/// SwiftUI-native `LeaderboardPhase` for the Discover leaderboard. Surfaces only the
-/// **Time** category (the design shows no category tabs) and the period control
-/// (Week / Month / All).
+/// SwiftUI-native `LeaderboardPhase` for the Discover leaderboard. Surfaces the period
+/// control (Week / Month / All) and the metric control (Time / Books / Streak); the
+/// snapshot already carries all three category rankings, so switching metric is a pure
+/// state transformation with no upstream re-fetch.
 ///
 /// The current-user "(You)" highlight is resolved here: `LeaderboardEntry` carries no
 /// `isCurrentUser` flag, only a `userId`, so the screen passes the signed-in user's id
@@ -18,6 +19,7 @@ final class LeaderboardObserver {
 
     private(set) var phase: LeaderboardPhase = .loading
     private(set) var selectedPeriod: LeaderboardSelection = .week
+    private(set) var selectedMetric: LeaderboardMetric = .time
 
     // MARK: - Dependencies
 
@@ -45,6 +47,16 @@ final class LeaderboardObserver {
         viewModel.selectPeriod(p: selection.kmpPeriod)
     }
 
+    /// Switch the ranked metric (Time / Books / Streak). The snapshot already holds all three
+    /// lists, so this re-maps the latest snapshot locally; it also nudges the shared VM to keep
+    /// its category state in sync.
+    func selectMetric(_ metric: LeaderboardMetric) {
+        guard selectedMetric != metric else { return }
+        selectedMetric = metric
+        viewModel.selectCategory(c: metric.kmpCategory)
+        apply(latestState)
+    }
+
     /// Update the id used for the "(You)" highlight, re-tagging the current snapshot.
     func setCurrentUserId(_ id: String?) {
         guard currentUserId != id else { return }
@@ -62,7 +74,10 @@ final class LeaderboardObserver {
         case .empty:
             phase = .empty
         case .data(let data):
-            phase = .data(Self.rows(from: data.snapshot, currentUserId: currentUserId))
+            // The KMP state is `.data` when ANY category has entries; the selected metric's list
+            // can still be empty (e.g. Books/Streak for a bounded period), so fall to `.empty`.
+            let rows = Self.rows(from: data.snapshot, currentUserId: currentUserId, metric: selectedMetric)
+            phase = rows.isEmpty ? .empty : .data(rows)
         case .error(let error):
             phase = .error(isRetryable: error.isRetryable)
         case .unknown:
@@ -71,12 +86,51 @@ final class LeaderboardObserver {
         }
     }
 
-    /// Pure: map the snapshot's `time` ranking to display rows, tagging the current user.
-    /// `time` is the headline ranking the design surfaces; category tabs are not shown.
+    /// Pure: map the ranking for `metric` to display rows, tagging the current user.
     /// `nonisolated` because it touches no actor state — callable from tests off the main actor.
-    nonisolated static func rows(from snapshot: LeaderboardSnapshot, currentUserId: String?) -> [LeaderboardRow] {
-        snapshot.time.map { entry in
-            LeaderboardRow(from: entry, isCurrentUser: entry.userId == currentUserId)
+    nonisolated static func rows(
+        from snapshot: LeaderboardSnapshot,
+        currentUserId: String?,
+        metric: LeaderboardMetric = .time
+    ) -> [LeaderboardRow] {
+        metric.entries(in: snapshot).map { entry in
+            LeaderboardRow(from: entry, isCurrentUser: entry.userId == currentUserId, metric: metric)
+        }
+    }
+}
+
+// MARK: - Metric selection
+
+/// The three ranked metrics the leaderboard surfaces. Maps to the KMP `LeaderboardCategory`.
+enum LeaderboardMetric: CaseIterable, Identifiable {
+    case time
+    case books
+    case streak
+
+    var id: Self { self }
+
+    var kmpCategory: LeaderboardCategory {
+        switch self {
+        case .time: LeaderboardCategory.time
+        case .books: LeaderboardCategory.books
+        case .streak: LeaderboardCategory.streak
+        }
+    }
+
+    /// The snapshot ranking for this metric.
+    func entries(in snapshot: LeaderboardSnapshot) -> [LeaderboardEntry] {
+        switch self {
+        case .time: snapshot.time
+        case .books: snapshot.books
+        case .streak: snapshot.streak
+        }
+    }
+
+    var titleKey: String.LocalizationValue {
+        switch self {
+        case .time: "discover.leaderboard_category_time"
+        case .books: "discover.leaderboard_category_books"
+        case .streak: "discover.leaderboard_category_streak"
         }
     }
 }
@@ -132,12 +186,12 @@ struct LeaderboardRow: Identifiable, Equatable {
     let value: String
     let isCurrentUser: Bool
 
-    init(from entry: LeaderboardEntry, isCurrentUser: Bool) {
+    init(from entry: LeaderboardEntry, isCurrentUser: Bool, metric: LeaderboardMetric = .time) {
         self.id = entry.userId
         self.rank = Int(entry.rank)
         self.displayName = entry.displayName
         self.initials = Self.initials(from: entry.displayName)
-        self.value = Self.formatHours(seconds: entry.totalSeconds)
+        self.value = Self.value(for: entry, metric: metric)
         self.isCurrentUser = isCurrentUser
     }
 
@@ -155,6 +209,19 @@ struct LeaderboardRow: Identifiable, Equatable {
         let words = name.split(separator: " ").prefix(2)
         let letters = words.compactMap { $0.first.map(String.init) }
         return letters.joined().uppercased()
+    }
+
+    /// The value-column string for a metric: listen-time for Time, a book count for Books, a
+    /// day count for Streak (longest run, matching the Android leaderboard).
+    static func value(for entry: LeaderboardEntry, metric: LeaderboardMetric) -> String {
+        switch metric {
+        case .time:
+            return formatHours(seconds: entry.totalSeconds)
+        case .books:
+            return String(format: String(localized: "common.books_count"), entry.booksFinished)
+        case .streak:
+            return String(format: String(localized: "common.n_days"), String(entry.longestStreakDays))
+        }
     }
 
     /// Format a listen-time total as "14h 20m" / "48m" — matches the design's value column.

--- a/iosApp/ListenUp/Features/Discover/LeaderboardObserver.swift
+++ b/iosApp/ListenUp/Features/Discover/LeaderboardObserver.swift
@@ -111,9 +111,9 @@ enum LeaderboardMetric: CaseIterable, Identifiable {
 
     var kmpCategory: LeaderboardCategory {
         switch self {
-        case .time: LeaderboardCategory.time
-        case .books: LeaderboardCategory.books
-        case .streak: LeaderboardCategory.streak
+        case .time: LeaderboardCategory.Time
+        case .books: LeaderboardCategory.Books
+        case .streak: LeaderboardCategory.Streak
         }
     }
 

--- a/iosApp/ListenUp/Features/Library/Content/BooksContent.swift
+++ b/iosApp/ListenUp/Features/Library/Content/BooksContent.swift
@@ -205,7 +205,13 @@ struct BooksContent: View {
         } else {
             NavigationLink(value: BookDestination(id: book.id)) { card }
                 .buttonStyle(.plain)
-                .onLongPressGesture { selection.enter(book.id) }
+                // A long-press attached directly to a NavigationLink is swallowed by the link's
+                // own press recognizer and never fires. `simultaneousGesture` lets the long-press
+                // run alongside the tap: a quick tap still navigates, a hold enters selection.
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.4)
+                        .onEnded { _ in selection.enter(book.id) }
+                )
         }
     }
 

--- a/iosApp/ListenUp/Features/Selection/SelectableBookCard.swift
+++ b/iosApp/ListenUp/Features/Selection/SelectableBookCard.swift
@@ -25,7 +25,13 @@ struct SelectableBookCard<Label: View>: View {
         } else if let selection {
             NavigationLink(value: BookDestination(id: bookId)) { label() }
                 .buttonStyle(.pressScaleCard)
-                .onLongPressGesture { selection.enter(bookId) }
+                // A long-press attached directly to a NavigationLink is swallowed by the link's
+                // own press recognizer and never fires. `simultaneousGesture` lets the long-press
+                // run alongside the tap: a quick tap still navigates, a hold enters selection.
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.4)
+                        .onEnded { _ in selection.enter(bookId) }
+                )
         } else {
             NavigationLink(value: BookDestination(id: bookId)) { label() }
                 .buttonStyle(.pressScaleCard)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
@@ -44,6 +44,16 @@ interface InstanceRepository {
     suspend fun getServerInfo(forceRefresh: Boolean = false): AppResult<ServerInfo>
 
     /**
+     * iOS-safe accessor: the [ServerInfo] or `null` on failure (folded in Kotlin). Use from Swift —
+     * never `await` the `AppResult`-returning [getServerInfo] (Swift Export bridge trap). This is
+     * the RPC-backed replacement for [getInstanceOrNull] on the share-link / server-identity path.
+     */
+    suspend fun getServerInfoOrNull(forceRefresh: Boolean = false): ServerInfo? =
+        getServerInfo(forceRefresh).valueOrNull {
+            instanceRepositoryLogger.warn { "getServerInfoOrNull: ${it.debugInfo ?: it.message}" }
+        }
+
+    /**
      * Legacy REST fetch of the richer [Instance] aggregate.
      *
      * Retained only for admin/settings consumers that read fields absent from

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/InstanceRepository.kt
@@ -46,7 +46,7 @@ interface InstanceRepository {
     /**
      * iOS-safe accessor: the [ServerInfo] or `null` on failure (folded in Kotlin). Use from Swift —
      * never `await` the `AppResult`-returning [getServerInfo] (Swift Export bridge trap). This is
-     * the RPC-backed replacement for [getInstanceOrNull] on the share-link / server-identity path.
+     * the RPC-backed accessor for the share-link / server-identity path.
      */
     suspend fun getServerInfoOrNull(forceRefresh: Boolean = false): ServerInfo? =
         getServerInfo(forceRefresh).valueOrNull {
@@ -61,15 +61,6 @@ interface InstanceRepository {
      * GET surface exists. New code should prefer [getServerInfo].
      */
     suspend fun getInstance(forceRefresh: Boolean = false): AppResult<Instance>
-
-    /**
-     * iOS-safe accessor: the [Instance] or `null` on failure (folded in Kotlin). Use from Swift —
-     * never `await` the `AppResult`-returning [getInstance] (Swift Export bridge trap). Android/server use [getInstance].
-     */
-    suspend fun getInstanceOrNull(forceRefresh: Boolean = false): Instance? =
-        getInstance(forceRefresh).valueOrNull {
-            instanceRepositoryLogger.warn { "getInstanceOrNull: ${it.debugInfo ?: it.message}" }
-        }
 
     /**
      * Verifies a server URL is a valid ListenUp instance before authentication.


### PR DESCRIPTION
A batch of iOS-only fixes from the app-test pass, one commit each. iOS `xcodebuild build-for-testing` **SUCCEEDED**; the one shared change passes Linux `verifyLocal`; adversarially code-reviewed.

### #13 — library-tile long-press did nothing
`.onLongPressGesture` on a `NavigationLink` is swallowed by the link's own press recognizer. Fixed with `.simultaneousGesture(LongPressGesture(0.4))` so tap still navigates and hold enters multi-select — in both the library grid (`BooksContent`) and the identical carousel case (`SelectableBookCard`). The multiselect VM was already wired; this was purely gesture precedence.

### #16 — ABS-import assign popover anchored to screen-top
Was a `.confirmationDialog` on a detached full-screen container. Replaced with a per-row `.popover(item:)` keyed on the row's user, so it presents on and anchors to the tapped row (auto-adapts to a sheet on compact widths). Dead `assignButtons`/`assignSheetPresented` removed.

### #17 — leaderboard only showed Time
Added a Time/Books/Streak metric picker wired to the shared VM's `selectCategory`, mapped to KMP `LeaderboardCategory` (PascalCase cases), with per-metric formatting matching Android (hours / books / longest-streak days). Books/Streak populate for All-Time (bounded periods show the empty state, as Android does).

### #18a — book-detail `EnvelopeMismatchException` on every load
`buildShareURL()` called a legacy REST `getInstance` that decoded the dead `{v,…}` envelope the Kotlin server never emits — so it always failed and the share URL never built. Retired it for the working RPC `getServerInfo()` (via a new shared `getServerInfoOrNull`); dropped the now-orphaned `getInstanceOrNull`. This kills the recurring log **and restores iOS share-link generation**. (The match-spinner is a separate, already-merged shared fix.)

### #19 — admin registration card had no padding
Padded to match sibling cards (`ToggleRow`).

### #12 — invite-accept field capitalization
Investigated: **already correct** on this branch (fixed by #972) — `.words` on names, `.characters` on the code, `.never`/secure on password. No change made.

**Deferred:** #15 iOS backup/restore parity (a new admin screen, not a bug) — separate follow-up.

## Follow-up flagged by review (out of scope)
The same broken `/api/v1/instance` envelope contract still affects the **Android** book-detail share builder + Settings — logged for a follow-up (point them at `getServerInfo()` or fix the client/server envelope contract).

## Test Plan
- [x] `xcodebuild build-for-testing` (iOS sim) SUCCEEDED, 0 errors.
- [x] Linux `verifyLocal` green (the shared `getServerInfoOrNull` + orphan deletion).
- [x] Code-reviewed — ship-ready; no gesture regression, no popover state leak, correct leaderboard mapping, no CancellationException swallow.