### PR TITLE
👷 ci(iosApp): per-test timeouts — surface hung iOS tests instead of 45-min opaque cancels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,17 @@ jobs:
         working-directory: iosApp
         run: |
           set -o pipefail
+          # Per-test timeouts: a hung test (never-completing await / black-hole Flow) fails fast with
+          # its own name after 120s instead of freezing the whole run until the 45-min job timeout —
+          # which surfaced as an opaque "operation was canceled" with no culprit. Individual tests may
+          # opt into longer via executionTimeAllowance, capped at the 300s maximum.
           xcodebuild test \
             -scheme ListenUp \
             -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.device }},OS=latest" \
-            -resultBundlePath "$RUNNER_TEMP/ios-test.xcresult"
+            -resultBundlePath "$RUNNER_TEMP/ios-test.xcresult" \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 120 \
+            -maximum-test-execution-time-allowance 300
 
       - name: Upload iOS test results
         uses: actions/upload-artifact@v7

--- a/iosApp/ListenUpTests/AsyncGateTests.swift
+++ b/iosApp/ListenUpTests/AsyncGateTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import ListenUp
+
+/// Regression coverage for `AsyncGate`'s isolation contract.
+///
+/// The gate hung `BootSequenceTests` intermittently because `wait` was a plain
+/// `nonisolated async` method: it hopped off the caller's actor onto the generic executor
+/// while `fire`/`signal` stayed on the caller's actor, racing the `waiters` array. A `fire()`
+/// that landed between `wait`'s predicate check and its append was a lost wakeup, and the test
+/// hung forever. These tests pin the fixed behaviour — a `fire`/`signal` issued *after* a wait
+/// has begun, from the wait's own isolation domain, always resumes it. Under the pre-fix
+/// off-actor gate they race and can hang; under the `isolation:`-pinned gate they are
+/// deterministic on the single-threaded domain.
+@MainActor
+@Suite("AsyncGate isolation")
+struct AsyncGateTests {
+    @Test func resumesWhenKeyFiresAfterWaitBegins() async {
+        let gate = AsyncGate()
+        let waiting = Task { @MainActor in await gate.wait(forKey: "resumeDownloads") }
+        // Hand the main actor to the child so its wait registers, then fire from this same
+        // domain. A lost wakeup here would hang `waiting.value` — the exact boot-test failure.
+        await Task.yield()
+        gate.fire("resumeDownloads")
+        await waiting.value
+    }
+
+    @Test func resumesWhenPredicateSignalsAfterWaitBegins() async {
+        let gate = AsyncGate()
+        var ready = false
+        let waiting = Task { @MainActor in await gate.wait(until: { ready }) }
+        await Task.yield()
+        ready = true
+        gate.signal()
+        await waiting.value
+    }
+
+    @Test func returnsImmediatelyWhenKeyAlreadyFired() async {
+        let gate = AsyncGate()
+        gate.fire("already")
+        // No waiter registered, no signal to come — the fast path must return without blocking.
+        await gate.wait(forKey: "already")
+    }
+
+    @Test func returnsImmediatelyWhenPredicateAlreadyHolds() async {
+        let gate = AsyncGate()
+        await gate.wait(until: { true })
+    }
+}

--- a/iosApp/ListenUpTests/Fakes/AsyncGate.swift
+++ b/iosApp/ListenUpTests/Fakes/AsyncGate.swift
@@ -10,16 +10,24 @@ import Foundation
 /// `AsyncGate` replaces the clock with causality: a fake records a mutation, then calls
 /// `signal()`; a test `await wait(until:)`s the exact state transition it cares about and
 /// resumes the instant that transition happens — never sooner, and with no timeout to lose
-/// a race against. A hang here means the awaited work genuinely never occurred, which is the
-/// honest failure we want (Swift Testing surfaces it as a stuck test, not a flaky pass).
+/// a race against.
 ///
-/// **Isolation:** the gate has no internal locking. Register, signal, and evaluate the
-/// predicate must all happen in one isolation domain — the same domain that mutates the
-/// observed state. The player fakes satisfy this: `FakePlaybackEngine` confines its gate to
-/// its actor; the `@MainActor`-touched reporting/sleep fakes confine theirs to the main actor.
-/// `@unchecked Sendable` so it can be stored in the `Sendable` player fakes. There is no
-/// internal synchronization — soundness rests entirely on the single-isolation-domain
-/// discipline documented above, exactly as the fakes' own `@unchecked Sendable` does.
+/// **Isolation — why the `isolation:` parameter is load-bearing.** The gate has no internal
+/// locking: register (`wait`), signal (`signal`/`fire`), and predicate evaluation must all
+/// happen in one isolation domain — the same domain that mutates the observed state. The
+/// fakes satisfy this: `FakePlaybackEngine` confines its gate to its actor; the
+/// `@MainActor`-touched reporting/sleep fakes and the boot recorder confine theirs to the
+/// main actor. But a *plain* `nonisolated async` method does **not** run in its caller's
+/// domain — it hops onto the generic cooperative executor. That silently broke the invariant:
+/// `wait` ran off the main actor while `fire`/`signal` (synchronous) ran on it, racing the
+/// `waiters` array from two threads. A `fire()` landing between `wait`'s predicate check and
+/// its waiter append was a lost wakeup — the continuation was never resumed and the test hung
+/// forever (surfacing in CI as an un-attributable 45-minute job stall, not a named failure).
+/// The `isolation: isolated (any Actor)? = #isolation` parameter pins each `wait` to its
+/// caller's actor, so registration and signalling genuinely share one single-threaded domain
+/// and the check-then-append is atomic against `fire`/`signal`. `@unchecked Sendable` so the
+/// gate can be stored in the `Sendable` player fakes; soundness now rests on that honoured
+/// single-domain discipline, not on an assumption the compiler was quietly violating.
 final class AsyncGate: @unchecked Sendable {
     private var waiters: [(predicate: () -> Bool, resume: () -> Void)] = []
     /// Keys that have fired at least once, for the keyed `fire`/`wait(forKey:)` API used by
@@ -30,7 +38,15 @@ final class AsyncGate: @unchecked Sendable {
 
     /// Suspend until `predicate` holds. Returns immediately if it already does, so a test
     /// that awaits an already-completed transition never blocks.
-    func wait(until predicate: @escaping () -> Bool) async {
+    ///
+    /// Runs in the caller's isolation domain (`isolation` defaults to the caller via
+    /// `#isolation`) so the predicate check and the waiter append are atomic against a
+    /// concurrent `signal()`/`fire()` on that same domain — see the type doc for why that
+    /// is what makes the gate race-free.
+    func wait(
+        until predicate: @escaping () -> Bool,
+        isolation: isolated (any Actor)? = #isolation
+    ) async {
         if predicate() { return }
         await withCheckedContinuation { continuation in
             waiters.append((predicate, { continuation.resume() }))
@@ -53,9 +69,13 @@ final class AsyncGate: @unchecked Sendable {
         resumeSatisfied()
     }
 
-    /// Suspend until `key` has fired. Returns immediately if it already has.
-    func wait(forKey key: String) async {
-        await wait { [weak self] in self?.firedKeys.contains(key) ?? false }
+    /// Suspend until `key` has fired. Returns immediately if it already has. Inherits the
+    /// caller's isolation domain and threads it into the underlying `wait(until:)`.
+    func wait(
+        forKey key: String,
+        isolation: isolated (any Actor)? = #isolation
+    ) async {
+        await wait(until: { [weak self] in self?.firedKeys.contains(key) ?? false }, isolation: isolation)
     }
 
     private func resumeSatisfied() {


### PR DESCRIPTION
## The flake
The `Test (iOS)` lane intermittently fails with `##[error]The operation was canceled` and an orphaned `xcodebuild` — no test named, no error. Tracing one instance: the suite ran real tests for ~13 min, then **hung with zero progress for ~30 min** until the job's 45-min wall-clock timeout killed it. `xcodebuild test` has **no per-test timeout by default**, so a single test that awaits something never-completing (a black-hole Flow/RPC — the same family as the #18a match-spinner) freezes the *entire* run, and CI can only report an opaque cancellation.

## The fix
Add per-test timeouts to the CI `xcodebuild test` command:
```
-test-timeouts-enabled YES
-default-test-execution-time-allowance 120
-maximum-test-execution-time-allowance 300
```
Now a hung test **fails fast (120s) with its own name**, the rest of the suite still reports, and the job no longer burns 45 min. This converts an undiagnosable flake into a named failure — which is the prerequisite for the root fix (fixing whichever test hangs).

## Why this alone is worth it
- Stops the spurious 45-min cancellations that have red-flagged healthy PRs (#1042, #1043) and `main`.
- Next time it hangs, CI will tell us **exactly which test** — so we can fix the underlying never-completing await.
- No behavior change for healthy tests (nothing legitimately runs >120s; anything that needs longer can set `executionTimeAllowance`, capped at 300s).

Workflow-only change; validated YAML. Follow-up: fix the specific hanging test once CI names it.