### PR TITLE
🐛 fix(server): unbreak main — match AccessChanged frames by type, not equality

### DIFF
--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessEmissionContractTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessEmissionContractTest.kt
@@ -336,7 +336,7 @@ private suspend fun TestScope.captureAccessChanged(
     val collector =
         launch(start = CoroutineStart.UNDISPATCHED) {
             bus.subscribeControl().collect { frame ->
-                if (frame.control == SyncControl.AccessChanged) recipients += frame.userId
+                if (frame.control is SyncControl.AccessChanged) recipients += frame.userId
             }
         }
     action()


### PR DESCRIPTION
## main is red — a semantic collision between two merged PRs

`CollectionAccessEmissionContractTest` (added by **#1041**, the guard suite) matched `AccessChanged` frames with `frame.control == SyncControl.AccessChanged` — equality against what was then a `data object` singleton. **#1044** (AccessChanged scoped delta) changed `AccessChanged` from a `data object` to a `data class(scope: AccessScope?)`, so every emitted frame is now a distinct instance (`AccessChanged(scope=…)`) that never `==` the bare reference → the collector captured **zero** recipients → all 8 emission tests fail.

Each PR passed its own CI in isolation; the break only appeared once both merged to main. Classic semantic merge conflict the compiler can't catch.

## Fix
One line: `==` → `is` (match any `AccessChanged` frame by type, regardless of its scope payload):
```kotlin
if (frame.control is SyncControl.AccessChanged) recipients += frame.userId
```

## Test Plan
- [x] `CollectionAccessEmissionContractTest` — 9/9 green (was 8/9 failing on main).
- [x] Full guard suite (G1 matrix, G3 registry parity, G5 routing) + AccessChanged emission/reconcile + detekt all green — confirms the collision is fully resolved and nothing else broke.

Merging this makes `main` green again; the other open PRs (#1042/#1043/#1046) will pass on re-run once they see the fixed base.