### PR TITLE
🔒 fix: Batch-7 sync security & correctness (087, 088, 090, 094, 096, 101)

### DIFF
--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/CollectionError.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/CollectionError.kt
@@ -54,10 +54,11 @@ sealed interface CollectionError : AppError {
     }
 
     /**
-     * The caller attempted to rename or delete a system collection.
+     * The caller attempted to rename, delete, or change the sharing of a system collection.
      *
      * `ALL_BOOKS` and `INBOX` are server-managed system collections (created automatically
-     * per library, owned by the `"system"` sentinel) and may not be renamed or deleted.
+     * per library, owned by the `"system"` sentinel) and may not be renamed, deleted, or
+     * re-shared — their grants are managed exclusively by the server.
      */
     @Serializable
     @SerialName("CollectionError.SystemCollectionReadOnly")
@@ -65,7 +66,7 @@ sealed interface CollectionError : AppError {
         override val correlationId: String? = null,
         override val debugInfo: String? = null,
     ) : CollectionError {
-        override val message: String = "System collections can't be renamed or deleted."
+        override val message: String = "System collections can't be modified."
         override val code: String = "COLLECTION_SYSTEM_READ_ONLY"
         override val isRetryable: Boolean = false
     }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -222,10 +222,14 @@ internal class CollectionServiceImpl(
         // Every affected book's revision is touched regardless, so a member whose access just changed
         // re-derives visibility on their incremental `revision > cursor` pull (a book that stays in
         // other collections isn't reconciled but must still drop for this collection's lost audience).
+        val lookups = SystemMembershipLookups()
         for (bookId in affectedBookIds) {
-            reconcileSystemMembership(bookId)
-            bookRevisionTouch.touchRevision(BookId(bookId))
+            reconcileSystemMembership(bookId, lookups)
         }
+        // One batched revision bump for every affected book (one transaction, per-book revisions) —
+        // the reconcile above already bumps any book whose ALL_BOOKS membership flipped; this ensures
+        // every affected book advances so a member whose access just changed re-derives on their pull.
+        bookRevisionTouch.touchRevisions(affectedBookIds.map(::BookId))
         for (grant in grantRepo.listActiveGrantsForCollection(id.value)) {
             grantRepo.softDelete(grant.id)
         }
@@ -666,17 +670,61 @@ internal class CollectionServiceImpl(
         notifyAccessChanged(explicitTargetIds + listOfNotNull(allBooksId), assignments.keys)
         // Bump each released book's revision so members' incremental `revision > cursor` pull
         // re-evaluates its now-changed visibility — the access nudge alone never carries the row.
-        for (bookId in assignments.keys) {
-            bookRevisionTouch.touchRevision(BookId(bookId))
-        }
+        // One transaction, per-book revisions (never one shared revision — see touchRevisions).
+        bookRevisionTouch.touchRevisions(assignments.keys.map(::BookId))
         // Maintain exclusivity from the post-release set: a book released into explicit targets must
         // not linger in ALL_BOOKS (defensive tombstone of any stale junction); one released unsorted
-        // stays in ALL_BOOKS (the fallback added above). reconcile derives both.
+        // stays in ALL_BOOKS (the fallback added above). reconcile derives both. One memo hoists the
+        // loop-invariant system-collection lookups across the whole release.
+        val lookups = SystemMembershipLookups()
         for (bookId in assignments.keys) {
-            reconcileSystemMembership(bookId)
+            reconcileSystemMembership(bookId, lookups)
         }
         return AppResult.Success(Unit)
     }
+
+    /**
+     * Loop-invariant lookups for [reconcileSystemMembership], resolved at most once per bulk operation
+     * instead of once per book. The global system-id set and the per-library inbox id are stable for
+     * the duration of one operation; the ALL_BOOKS id is memoized only once FOUND, so the lazy-create
+     * fallback inside the reconcile still fires for the first book that materialises it —
+     * [noteAllBooksCreated] registers the fresh id (and adds it to the system-id set) so later books in
+     * the same loop see it exactly as a fresh per-book lookup would.
+     */
+    private inner class SystemMembershipLookups {
+        private var systemIds: MutableSet<String>? = null
+        private val inboxIdByLibrary = mutableMapOf<String, String?>()
+        private val allBooksIdByLibrary = mutableMapOf<String, String>()
+
+        suspend fun systemIds(): Set<String> =
+            systemIds ?: collectionRepo.systemCollectionIds().toMutableSet().also { systemIds = it }
+
+        suspend fun inboxId(libraryId: String): String? {
+            if (libraryId !in inboxIdByLibrary) {
+                inboxIdByLibrary[libraryId] = collectionRepo.findInboxForLibrary(libraryId)?.id
+            }
+            return inboxIdByLibrary[libraryId]
+        }
+
+        suspend fun allBooksId(libraryId: String): String? =
+            allBooksIdByLibrary[libraryId]
+                ?: collectionRepo
+                    .findSystemCollection(libraryId, SYSTEM_TYPE_ALL_BOOKS)
+                    ?.id
+                    ?.also { allBooksIdByLibrary[libraryId] = it }
+
+        fun noteAllBooksCreated(
+            libraryId: String,
+            id: String,
+        ) {
+            allBooksIdByLibrary[libraryId] = id
+            systemIds?.add(id)
+        }
+    }
+
+    /** Single-book entry point: reconciles [bookId] through a fresh one-shot [SystemMembershipLookups]. */
+    private suspend fun reconcileSystemMembership(bookId: String) =
+        reconcileSystemMembership(bookId, SystemMembershipLookups())
 
     /**
      * Enforces the exclusivity invariant between the everyone-visible ALL_BOOKS substrate and
@@ -693,15 +741,23 @@ internal class CollectionServiceImpl(
      * (every member holds a default ALL_BOOKS grant) and bump the book's revision, so each member
      * re-derives their view and the visibility delta converges. Idempotent: a no-op flip emits
      * nothing.
+     *
+     * [lookups] memoizes the loop-invariant lookups (system-id set, per-library inbox/ALL_BOOKS ids) so
+     * a bulk caller (deleteCollection / releaseBooks) resolves them once per operation rather than once
+     * per book; single-book callers delegate with a fresh memo. A mid-loop lazy-create of ALL_BOOKS is
+     * recorded via [SystemMembershipLookups.noteAllBooksCreated] so later books observe it.
      */
-    private suspend fun reconcileSystemMembership(bookId: String) {
+    private suspend fun reconcileSystemMembership(
+        bookId: String,
+        lookups: SystemMembershipLookups,
+    ) {
         val libraryId = bookLibraryId(bookId) ?: return
-        val systemIds = collectionRepo.systemCollectionIds()
+        val systemIds = lookups.systemIds()
         val liveMemberships = collectionBookRepo.findCollectionIdsForBook(bookId).toSet()
         val real = liveMemberships - systemIds
-        val inboxId = collectionRepo.findInboxForLibrary(libraryId)?.id
+        val inboxId = lookups.inboxId(libraryId)
         val held = inboxId != null && inboxId in liveMemberships
-        val allBooksId = collectionRepo.findSystemCollection(libraryId, SYSTEM_TYPE_ALL_BOOKS)?.id
+        val allBooksId = lookups.allBooksId(libraryId)
         val allBooksLive = allBooksId != null && allBooksId in liveMemberships
 
         if (real.isEmpty() && !held) {
@@ -711,6 +767,7 @@ internal class CollectionServiceImpl(
                     ?: getOrCreateSystemCollection(libraryId, SystemCollectionType.ALL_BOOKS)
                         .getOrElse { return }
                         .id.value
+                        .also { lookups.noteAllBooksCreated(libraryId, it) }
             collectionBookRepo.upsert(
                 CollectionBookSyncPayload(
                     collectionId = id,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -82,9 +82,11 @@ internal fun accessScopeFor(
  * the Koin singleton carries an unscoped placeholder that yields no principal.
  *
  * Sharing ([shareCollection], [updateShare], [revokeShare], [listShares]) is owner-only —
- * gated through [ownerGate] like rename/delete. The per-user `AccessChanged` reconcile
- * signal on share/unshare is Collections-1b (it depends on the book-visibility layer);
- * 1a just persists the share rows and emits the normal sync events.
+ * gated through [ownerGate] like rename/delete. System collections (ALL_BOOKS, INBOX) reject
+ * all three share mutations with [CollectionError.SystemCollectionReadOnly]; the default
+ * ALL_BOOKS grants are managed exclusively by [DefaultAllBooksGrantIssuer]. The per-user
+ * `AccessChanged` reconcile signal on share/unshare is Collections-1b (it depends on the
+ * book-visibility layer); 1a just persists the share rows and emits the normal sync events.
  */
 internal class CollectionServiceImpl(
     private val collectionRepo: CollectionRepository,
@@ -368,6 +370,8 @@ internal class CollectionServiceImpl(
         val caller = resolveCaller() ?: return noPrincipal()
         val decision = accessPolicy.decide(caller.userId, caller.role, id.value)
         ownerGate(decision, caller.role)?.let { return AppResult.Failure(it) }
+        val systemIds = collectionRepo.systemCollectionIds()
+        if (id.value in systemIds) return AppResult.Failure(CollectionError.SystemCollectionReadOnly())
         // canShare is an ADDITIONAL gate beyond ownership: a member must hold canShare AND own
         // (or admin-bypass) the collection to share it. ROOT/ADMIN pass the flag implicitly.
         permissionPolicy
@@ -416,6 +420,8 @@ internal class CollectionServiceImpl(
         val caller = resolveCaller() ?: return noPrincipal()
         val decision = accessPolicy.decide(caller.userId, caller.role, id.value)
         ownerGate(decision, caller.role)?.let { return AppResult.Failure(it) }
+        val systemIds = collectionRepo.systemCollectionIds()
+        if (id.value in systemIds) return AppResult.Failure(CollectionError.SystemCollectionReadOnly())
 
         val existing =
             grantRepo.findActiveGrant(id.value, sharedWithUserId)
@@ -446,6 +452,8 @@ internal class CollectionServiceImpl(
         val caller = resolveCaller() ?: return noPrincipal()
         val decision = accessPolicy.decide(caller.userId, caller.role, id.value)
         ownerGate(decision, caller.role)?.let { return AppResult.Failure(it) }
+        val systemIds = collectionRepo.systemCollectionIds()
+        if (id.value in systemIds) return AppResult.Failure(CollectionError.SystemCollectionReadOnly())
 
         // softDeleteGrant returns Failure(NotFound) when no live grant exists; revoke is
         // idempotent — a no-op revoke satisfies the caller's intent. Only nudge the ex-target

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/SyncModule.kt
@@ -62,8 +62,6 @@ fun syncModule(): Module =
                 genreRepository = get<GenreRepository>(),
                 tagRepository = getOrNull<TagRepository>(),
                 moodRepository = getOrNull<MoodRepository>(),
-                bookTagRepository = getOrNull<BookTagRepository>(),
-                bookMoodRepository = getOrNull<BookMoodRepository>(),
             )
         }
         // Collection aggregate — fully SQLDelight. The access-filtered catch-up/digest raw reads

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ActivitySyncRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ActivitySyncRepository.kt
@@ -103,6 +103,21 @@ class ActivitySyncRepository(
         return idStrs.mapNotNull { byId[it]?.toSyncPayload() }
     }
 
+    /** Tombstone projection — see [SqlSyncableRepository.minimizeTombstone]. */
+    override fun minimizeTombstone(payload: ActivitySyncPayload): ActivitySyncPayload =
+        payload.copy(
+            userId = "",
+            type = "",
+            bookId = null,
+            isReread = false,
+            durationMs = 0L,
+            milestoneValue = 0,
+            milestoneUnit = null,
+            shelfId = null,
+            shelfName = null,
+            occurredAt = 0L,
+        )
+
     override fun writePayload(
         value: ActivitySyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -244,6 +244,38 @@ class BookRepository(
     /** Batched hydration: fetches each child table once per id-chunk and assembles in input-id order. */
     override fun readPayloads(idStrs: List<String>): List<BookSyncPayload> = db.readBookPayloads(idStrs)
 
+    /** Tombstone projection — see [SqlSyncableRepository.minimizeTombstone]. */
+    override fun minimizeTombstone(payload: BookSyncPayload): BookSyncPayload =
+        payload.copy(
+            // libraryId/folderId are @JvmInline value classes with isNotBlank() init guards
+            // AND opaque UUIDs, not content — they stay. Everything content-bearing goes.
+            title = "",
+            sortTitle = null,
+            subtitle = null,
+            description = null,
+            publishYear = null,
+            publisher = null,
+            language = null,
+            isbn = null,
+            asin = null,
+            abridged = false,
+            explicit = false,
+            hasScanWarning = false,
+            totalDuration = 0L,
+            cover = null,
+            rootRelPath = "",
+            inode = null,
+            scannedAt = 0L,
+            contributors = emptyList(),
+            series = emptyList(),
+            genres = emptyList(),
+            audioFiles = emptyList(),
+            documents = emptyList(),
+            chapters = emptyList(),
+            chapterSource = ChapterSource.EMBEDDED,
+            userEditedFields = emptySet(),
+        )
+
     /**
      * Writes the full book aggregate inside the substrate's open SQLDelight transaction.
      *

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -953,8 +953,19 @@ class BookRepository(
      *
      * Finally, the orphan-purge cascade ([orphanParentPurger]) tombstones any contributor / series /
      * genre / tag / mood the removal left with zero live book children, so an orphaned parent stops
-     * appearing. The linked parents are captured BEFORE the removal (the tag/mood junctions are
-     * tombstoned by the cascade), then re-evaluated after it.
+     * appearing. The linked parents are captured BEFORE the removal (tombstone-inclusively, so the
+     * capture survives a resume run), then re-evaluated after it.
+     *
+     * **Crash-resume.** Each step above commits in its own transaction, so a crash mid-cascade leaves a
+     * half-cascaded book (tombstoned book, some live junctions, unpurged parents). Re-invoking
+     * `softDelete` on an already-tombstoned book is safe and completes any unfinished cascade: the base
+     * `softDelete` has no already-deleted early return, so it re-stamps the tombstone (bumping the
+     * revision and re-emitting a convergent [SyncEvent]); the junction cascades are live-select
+     * idempotent (already-tombstoned rows are skipped); and [OrphanParentPurger.captureParents] is
+     * tombstone-inclusive, so the orphan purge still fires even when the junctions are already dead.
+     * Caveat: nothing re-invokes this automatically today — the scan sweeps ([softDeleteAbsent] /
+     * [softDeleteAbsentByPaths]) select LIVE books only — so an interrupted cascade heals only on an
+     * explicit re-delete (a bulk folder-removal pass or a manual removal), never on its own.
      */
     override suspend fun softDelete(
         id: BookId,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRepository.kt
@@ -1407,6 +1407,29 @@ class BookRepository(
     }
 
     /**
+     * Batched [touchRevision]: bumps every book in [ids] in ONE transaction, assigning each row its
+     * own revision from the global counter — never one shared revision, because `pullSince` pages by
+     * `revision > cursor`, so equal revisions straddling a page boundary would be skipped. Missing ids
+     * are skipped (mirrors [reviveByIds]); an empty list is a no-op success. The bulk collection paths
+     * call this instead of looping [touchRevision] to collapse N transactions into one.
+     */
+    override suspend fun touchRevisions(ids: List<BookId>): AppResult<Unit> {
+        if (ids.isEmpty()) return AppResult.Success(Unit)
+        return suspendTransaction(db) {
+            for (id in ids) {
+                val idStr = idAsString(id)
+                val rev = nextRevision()
+                val now = clock.now().toEpochMilliseconds()
+                db.booksQueries.touchRevision(revision = rev, updated_at = now, id = idStr)
+                if (db.booksQueries.changes().executeAsOne() != 0L) {
+                    publishUpdatedAfterCommit(idStr, rev, now)
+                }
+            }
+            AppResult.Success(Unit)
+        }
+    }
+
+    /**
      * Resolves where [id]'s cover image lives for the cover-serving route. Delegates to
      * [ManagedCoverFiles.coverInfo]. Returns null when the book is absent or has no cover.
      */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRevisionTouch.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/BookRevisionTouch.kt
@@ -13,4 +13,17 @@ import com.calypsan.listenup.core.BookId
  */
 interface BookRevisionTouch {
     suspend fun touchRevision(id: BookId): AppResult<Unit>
+
+    /**
+     * Bumps every book in [ids] in a single transaction, assigning each row its own revision from the
+     * global counter — never one shared revision, because `pullSince` pages by `revision > cursor` and
+     * equal revisions straddling a page boundary would be skipped (silent client divergence). Missing
+     * ids are skipped (mirrors [BookRepository.reviveByIds]); an empty list is a no-op success. The
+     * default implementation loops [touchRevision] so existing implementations and fakes stay
+     * source-compatible; [BookRepository] overrides it with the batched, single-transaction form.
+     */
+    suspend fun touchRevisions(ids: List<BookId>): AppResult<Unit> {
+        for (id in ids) touchRevision(id)
+        return AppResult.Success(Unit)
+    }
 }

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ContributorRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/ContributorRepository.kt
@@ -204,6 +204,11 @@ class ContributorRepository(
      * Idempotent: a rescan of unchanged books re-resolves existing contributors with no event and
      * no revision bump.
      *
+     * A dedup hit on a TOMBSTONED row (a parent purged by [OrphanParentPurger] after its last
+     * live book was removed) is revived in place — `deleted_at` cleared, revision bumped,
+     * `SyncEvent.Updated` published — so re-ingesting the same name resurrects the parent under
+     * its original id. Live hits remain pure reads: no event, no revision bump.
+     *
      * The find-miss → create window is a benign race only under SQLite's single-writer model; the
      * single-threaded scan never triggers it.
      */
@@ -218,9 +223,11 @@ class ContributorRepository(
                 db.contributorsQueries
                     .selectByNormalizedName(normalized)
                     .executeAsOneOrNull()
-                    ?.id
             }
-        if (existing != null) return ContributorId(existing)
+        if (existing != null) {
+            if (existing.deleted_at != null) reviveTombstonedHit(existing.id)
+            return ContributorId(existing.id)
+        }
 
         val id = ContributorId(Uuid.random().toString())
         upsert(
@@ -257,6 +264,8 @@ class ContributorRepository(
      * @return a `Map<dedupKey, ContributorId>` keyed by [contributorDedupKey] — callers look an
      *   id up by recomputing that key for each book's contributors. Every supplied identity's key
      *   is present in the result.
+     *
+     * Tombstoned hits are revived; see [resolveOrCreate].
      */
     suspend fun resolveOrCreateAll(identities: Collection<Pair<String, String?>>): Map<String, ContributorId> {
         if (identities.isEmpty()) return emptyMap()
@@ -270,13 +279,19 @@ class ContributorRepository(
         }
 
         // One bulk SELECT for the existing rows — the bulk of the work, collapsed from N per-book reads.
-        val existing =
+        val existingRows =
             suspendTransaction(db) {
                 byKey.keys
                     .chunked(SQLITE_IN_CHUNK)
                     .flatMap { chunk -> db.contributorsQueries.selectByNormalizedNames(chunk).executeAsList() }
-                    .associate { it.normalized_name to ContributorId(it.id) }
             }
+        // Revive tombstoned dedup hits before handing their ids back: a purged parent returned by
+        // the dedup lookup must come back live (see reviveTombstonedHit). Rare — only ever after an
+        // orphan purge — so per-id upserts are fine here.
+        for (row in existingRows) {
+            if (row.deleted_at != null) reviveTombstonedHit(row.id)
+        }
+        val existing = existingRows.associate { it.normalized_name to ContributorId(it.id) }
 
         val resolved = LinkedHashMap<String, ContributorId>(byKey.size)
         for ((key, identity) in byKey) {
@@ -284,6 +299,20 @@ class ContributorRepository(
             resolved[key] = id
         }
         return resolved
+    }
+
+    /**
+     * Revives a tombstoned dedup hit in place: re-upserts the row's own read-back payload with
+     * `deletedAt = null`. The base `upsert` bumps the domain revision and publishes
+     * [com.calypsan.listenup.api.sync.SyncEvent.Updated]; [writePayload]'s update branch always
+     * clears `deleted_at`. The id stays stable, so junction rows written against it resolve again —
+     * the same revive semantics as [BookRepository.reviveById] (clear deleted_at + bump revision +
+     * publish Updated), composed from the existing substrate instead of a dedicated query.
+     * Enrichment columns survive because the payload is the row's own current content.
+     */
+    private suspend fun reviveTombstonedHit(idStr: String) {
+        val payload = findById(idStr) ?: return
+        upsert(payload.copy(deletedAt = null), clientOpId = null)
     }
 
     /** Reads a contributor by raw id outside substrate orchestration — test/diagnostic use. */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/LibraryFolderRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/LibraryFolderRepository.kt
@@ -124,6 +124,10 @@ class LibraryFolderRepository(
         return idStrs.mapNotNull { byId[it]?.toSyncPayload() }
     }
 
+    /** Tombstone projection — see [SqlSyncableRepository.minimizeTombstone]. */
+    override fun minimizeTombstone(payload: LibraryFolderSyncPayload): LibraryFolderSyncPayload =
+        payload.copy(libraryId = "", rootPath = "")
+
     override fun writePayload(
         value: LibraryFolderSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/OrphanParentPurger.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/OrphanParentPurger.kt
@@ -38,8 +38,11 @@ class LinkedParents(
  * live-book count has dropped to zero. Each count joins live books, so a lingering junction to the
  * now-dead book never keeps a parent alive.
  *
- * **Revival note.** A purged parent is not explicitly revived; a remove-then-rescan re-ingests the
- * book through `resolveOrCreate`, which resurrects the parent, so memberships return on re-scan.
+ * **Revival note.** A remove-then-rescan resurrects purged parents: contributors and series are
+ * revived IN PLACE by `resolveOrCreate` (a dedup hit on a tombstoned row clears `deleted_at`,
+ * bumps the revision, and publishes `SyncEvent.Updated`, keeping the id stable). Genres, tags,
+ * and moods are re-created as fresh rows instead — their slug lookups are live-only and their
+ * slug unique indexes are partial (`WHERE deleted_at IS NULL`), so a new id is minted.
  */
 class OrphanParentPurger(
     private val db: ListenUpDatabase,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/OrphanParentPurger.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/OrphanParentPurger.kt
@@ -5,14 +5,13 @@ import com.calypsan.listenup.core.GenreId
 import com.calypsan.listenup.core.SeriesId
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
-import com.calypsan.listenup.server.sync.BookMoodRepository
-import com.calypsan.listenup.server.sync.BookTagRepository
 import com.calypsan.listenup.server.sync.MoodRepository
 import com.calypsan.listenup.server.sync.TagRepository
 
 /**
- * The parent ids a book was linked to at the moment of its removal — captured while the book and
- * its junctions are still live so the post-cascade orphan check knows which parents to re-evaluate.
+ * The parent ids a book was ever linked to — captured tombstone-inclusively before its removal so the
+ * post-cascade orphan check knows which parents to re-evaluate, even on a crash-resume run where the
+ * junctions are already tombstoned.
  */
 class LinkedParents(
     val contributorIds: List<String>,
@@ -30,13 +29,17 @@ class LinkedParents(
  * appearing in browse lists with a phantom "0 books". This purger tombstones each such orphan so it
  * stops appearing; the parents are mirrored sync domains, so the tombstone propagates to clients.
  *
- * **Two-phase, by design.** [captureParents] reads the linked parent ids BEFORE the removal (the
- * `book_tags` / `book_moods` junctions are tombstoned by the book cascade, so their ids must be read
- * while still live; `book_contributors` / `book_series_memberships` / `book_genres` are hard-replace
- * child tables whose rows persist, but capturing all five together keeps the contract uniform).
- * [purgeOrphaned] runs AFTER the book + junction cascade and tombstones every captured parent whose
- * live-book count has dropped to zero. Each count joins live books, so a lingering junction to the
- * now-dead book never keeps a parent alive.
+ * **Two-phase, by design.** [captureParents] reads the linked parent ids BEFORE the removal, and reads
+ * them tombstone-inclusively — every parent EVER linked to the book, whether or not its junction is
+ * still live. All five parent tables are read the same way: `book_contributors` /
+ * `book_series_memberships` / `book_genres` are hard-replace child tables whose rows persist across the
+ * book tombstone, and `book_tags` / `book_moods` are read via `tagIdsForBook` / `moodIdsForBook`, which
+ * omit the `deleted_at IS NULL` guard. This makes capture resume-safe: a re-invoked `softDelete` after a
+ * crash that already tombstoned the junctions still nominates the tags and moods. [purgeOrphaned] runs
+ * AFTER the book + junction cascade and tombstones every captured parent whose live-book count has
+ * dropped to zero — the live-book-count query (joining live books through live junctions) is the SOLE
+ * decision-maker, so widening the capture can never wrongly purge a parent that still has any live
+ * junction-book pair.
  *
  * **Revival note.** A remove-then-rescan resurrects purged parents: contributors and series are
  * revived IN PLACE by `resolveOrCreate` (a dedup hit on a tombstoned row clears `deleted_at`,
@@ -51,24 +54,22 @@ class OrphanParentPurger(
     private val genreRepository: GenreRepository,
     private val tagRepository: TagRepository?,
     private val moodRepository: MoodRepository?,
-    private val bookTagRepository: BookTagRepository?,
-    private val bookMoodRepository: BookMoodRepository?,
 ) {
-    /** Reads the parent ids linked to [bookId] while it is still live — the orphan-check candidate set. */
-    suspend fun captureParents(bookId: String): LinkedParents {
-        val (contributorIds, seriesIds, genreIds) =
-            suspendTransaction(db) {
-                Triple(
-                    db.bookContributorsQueries.contributorIdsForBook(bookId).executeAsList(),
-                    db.bookSeriesMembershipsQueries.seriesIdsForBook(bookId).executeAsList(),
-                    db.bookGenresQueries.genreIdsForBook(bookId).executeAsList(),
-                )
-            }
-        // Tag/mood ids come from the junction repos' live reads (their `id` column is synthetic).
-        val tagIds = bookTagRepository?.findAllForBook(bookId)?.map { it.tagId }.orEmpty()
-        val moodIds = bookMoodRepository?.findAllForBook(bookId)?.map { it.moodId }.orEmpty()
-        return LinkedParents(contributorIds, seriesIds, genreIds, tagIds, moodIds)
-    }
+    /**
+     * Reads the parent ids ever linked to [bookId] — the orphan-check candidate set. Tombstone-inclusive
+     * across all five parent tables so a resume run (after a crash that already tombstoned the junctions)
+     * still nominates every parent; the live-book-count query in [purgeOrphaned] is the purge decision.
+     */
+    suspend fun captureParents(bookId: String): LinkedParents =
+        suspendTransaction(db) {
+            LinkedParents(
+                contributorIds = db.bookContributorsQueries.contributorIdsForBook(bookId).executeAsList(),
+                seriesIds = db.bookSeriesMembershipsQueries.seriesIdsForBook(bookId).executeAsList(),
+                genreIds = db.bookGenresQueries.genreIdsForBook(bookId).executeAsList(),
+                tagIds = db.bookTagsQueries.tagIdsForBook(bookId).executeAsList(),
+                moodIds = db.bookMoodsQueries.moodIdsForBook(bookId).executeAsList(),
+            )
+        }
 
     /** Tombstones every parent in [parents] that has zero live book children after the removal. */
     suspend fun purgeOrphaned(parents: LinkedParents) {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/services/SeriesRepository.kt
@@ -151,6 +151,11 @@ class SeriesRepository(
      * publishing `SyncEvent.Created`). Idempotent on the normalized name; the
      * display name preserves the first writer's casing.
      *
+     * A dedup hit on a TOMBSTONED row (a series purged by [OrphanParentPurger] after its last
+     * live book was removed) is revived in place — `deleted_at` cleared, revision bumped,
+     * `SyncEvent.Updated` published — so re-ingesting the same name resurrects the series under
+     * its original id. Live hits remain pure reads: no event, no revision bump.
+     *
      * The find-miss → create window is a benign race only under SQLite's
      * single-writer model; the single-threaded scan never triggers it.
      */
@@ -161,9 +166,11 @@ class SeriesRepository(
                 db.seriesQueries
                     .selectByNormalizedName(normalized)
                     .executeAsOneOrNull()
-                    ?.id
             }
-        if (existing != null) return SeriesId(existing)
+        if (existing != null) {
+            if (existing.deleted_at != null) reviveTombstonedHit(existing.id)
+            return SeriesId(existing.id)
+        }
 
         val id = SeriesId(Uuid.random().toString())
         upsert(
@@ -197,6 +204,8 @@ class SeriesRepository(
      *
      * @return a `Map<normalizedKey, SeriesId>` keyed by [normalizeForDedup] — callers look an id up
      *   by recomputing that key for each book's series. Every supplied name's key is present.
+     *
+     * Tombstoned hits are revived; see [resolveOrCreate].
      */
     suspend fun resolveOrCreateAll(names: Collection<String>): Map<String, SeriesId> {
         if (names.isEmpty()) return emptyMap()
@@ -209,19 +218,39 @@ class SeriesRepository(
         }
 
         // One bulk SELECT for the existing rows — the bulk of the work, collapsed from N per-book reads.
-        val existing =
+        val existingRows =
             suspendTransaction(db) {
                 byKey.keys
                     .chunked(SQLITE_IN_CHUNK)
                     .flatMap { chunk -> db.seriesQueries.selectByNormalizedNames(chunk).executeAsList() }
-                    .associate { it.normalized_name to SeriesId(it.id) }
             }
+        // Revive tombstoned dedup hits before handing their ids back: a purged series returned by
+        // the dedup lookup must come back live (see reviveTombstonedHit). Rare — only ever after an
+        // orphan purge — so per-id upserts are fine here.
+        for (row in existingRows) {
+            if (row.deleted_at != null) reviveTombstonedHit(row.id)
+        }
+        val existing = existingRows.associate { it.normalized_name to SeriesId(it.id) }
 
         val resolved = LinkedHashMap<String, SeriesId>(byKey.size)
         for ((key, name) in byKey) {
             resolved[key] = existing[key] ?: resolveOrCreate(name)
         }
         return resolved
+    }
+
+    /**
+     * Revives a tombstoned dedup hit in place: re-upserts the row's own read-back payload with
+     * `deletedAt = null`. The base `upsert` bumps the domain revision and publishes
+     * [com.calypsan.listenup.api.sync.SyncEvent.Updated]; [writePayload]'s update branch always
+     * clears `deleted_at`. The id stays stable, so junction rows written against it resolve again —
+     * the same revive semantics as [BookRepository.reviveById] (clear deleted_at + bump revision +
+     * publish Updated), composed from the existing substrate instead of a dedicated query.
+     * Enrichment columns survive because the payload is the row's own current content.
+     */
+    private suspend fun reviveTombstonedHit(idStr: String) {
+        val payload = findById(idStr) ?: return
+        upsert(payload.copy(deletedAt = null), clientOpId = null)
     }
 
     /** Reads a series by raw id outside substrate orchestration — test/diagnostic use. */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReads.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AccessFilteredReads.kt
@@ -52,11 +52,15 @@ import com.calypsan.listenup.server.io.hashBytesSha256
  *   gate regardless of the subquery — the member needs to learn what to remove even for a row it
  *   can no longer "access" (a deleted row is never accessible: `accessibleBookIdsSql` requires
  *   `deleted_at IS NULL`). This mirrors the firehose's tombstone-ungated rule (`isBookEventHidden`
- *   lets every `SyncEvent.Deleted` through) so catch-up and the live tail agree, and it leaks no
- *   content — a tombstone carries only id/revision/deleted_at. Set true on the pull path (catch-up
- *   must deliver deletions), false on the digest path (the digest counts only LIVE accessible rows,
- *   symmetric with the tombstone-excluding client digest). Only meaningful when [extraWhere] is
- *   non-null; with no access clause, every matched row already returns.
+ *   lets every `SyncEvent.Deleted` through) so catch-up and the live tail agree. This is an
+ *   *id-selection* rule: it lets the tombstoned row through ungated, and it leaks no content —
+ *   content safety is guaranteed downstream by [SqlSyncableRepository.minimizeTombstone], which
+ *   projects every tombstoned payload to identity + sync-discipline fields (id/revision/deleted_at
+ *   + timestamps) before it leaves [SqlSyncableRepository.pullSince] /
+ *   [SqlSyncableRepository.pullByIds]. Set true on the pull path
+ *   (catch-up must deliver deletions), false on the digest path (the digest counts only LIVE
+ *   accessible rows, symmetric with the tombstone-excluding client digest). Only meaningful when
+ *   [extraWhere] is non-null; with no access clause, every matched row already returns.
  */
 internal fun SqlDriver.selectIdRevAccessFiltered(
     table: String,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AdminUserRosterRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/AdminUserRosterRepository.kt
@@ -90,6 +90,17 @@ class AdminUserRosterRepository(
             .executeAsOneOrNull()
             ?.toSyncPayload()
 
+    /** Tombstone projection — see [SqlSyncableRepository.minimizeTombstone]. */
+    override fun minimizeTombstone(payload: AdminUserRosterSyncPayload): AdminUserRosterSyncPayload =
+        payload.copy(
+            email = "",
+            displayName = "",
+            role = "",
+            status = "",
+            canShare = false,
+            accountCreatedAt = 0L,
+        )
+
     override fun writePayload(
         value: AdminUserRosterSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionGrantRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionGrantRepository.kt
@@ -117,6 +117,15 @@ class CollectionGrantRepository(
         return idStrs.mapNotNull { byId[it]?.toSharePayload() }
     }
 
+    /** Tombstone projection — see [SqlSyncableRepository.minimizeTombstone]. */
+    override fun minimizeTombstone(payload: CollectionShareSyncPayload): CollectionShareSyncPayload =
+        payload.copy(
+            collectionId = "",
+            sharedWithUserId = "",
+            sharedByUserId = "",
+            permission = SharePermission.Read, // non-null enum: neutral placeholder
+        )
+
     override fun writePayload(
         value: CollectionShareSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionRepository.kt
@@ -121,6 +121,10 @@ class CollectionRepository(
         return idStrs.mapNotNull { byId[it]?.toSyncPayload() }
     }
 
+    /** Tombstone projection — see [SqlSyncableRepository.minimizeTombstone]. */
+    override fun minimizeTombstone(payload: CollectionSyncPayload): CollectionSyncPayload =
+        payload.copy(libraryId = "", ownerId = "", name = "", isInbox = false, isSystem = false)
+
     override fun writePayload(
         value: CollectionSyncPayload,
         rev: Long,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/SqlSyncableRepository.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.sync.DomainDigest
 import com.calypsan.listenup.api.sync.Page
 import com.calypsan.listenup.api.sync.SyncDomainKey
 import com.calypsan.listenup.api.sync.SyncEvent
+import com.calypsan.listenup.api.sync.Tombstoned
 import app.cash.sqldelight.TransactionCallbacks
 import app.cash.sqldelight.TransactionWithReturn
 import app.cash.sqldelight.db.SqlDriver
@@ -121,6 +122,30 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
      * transaction opened by [pullSince].
      */
     protected open fun readPayloads(idStrs: List<String>): List<T> = idStrs.mapNotNull { readPayload(it) }
+
+    /**
+     * Projects a soft-deleted aggregate to its wire-safe tombstone form: identity and
+     * sync-discipline fields (id, revision, deletedAt, timestamps — and, for junction
+     * domains, the composite-key components) preserved; every content field blanked.
+     *
+     * The pull path ([pullSince]/[pullByIds]) delivers tombstones ungated so every client
+     * can converge on deletions — including callers whose access filter would exclude the
+     * row were it live. A tombstone must therefore carry NO content: the live firehose's
+     * [SyncEvent.Deleted] already carries none, and clients apply catch-up tombstones by
+     * identity + revision + deletedAt alone. Applied to every pulled item whose `deletedAt`
+     * is non-null, for every caller (admins included — deleted content is useless by
+     * design and one rule is safer than a per-caller branch).
+     *
+     * Default is identity: an ungated domain, or one whose payload is already minimal
+     * (e.g. collection_books — pure junction identity), needs no override. Every domain
+     * registered with an access filter in SyncRoutes' ACCESS_FILTERS map MUST override
+     * this unless its payload provably carries no content beyond identity.
+     */
+    protected open fun minimizeTombstone(payload: T): T = payload
+
+    /** [minimizeTombstone] applied iff [payload] is a tombstone; identity otherwise. */
+    private fun minimizedIfTombstoned(payload: T): T =
+        if ((payload as? Tombstoned)?.deletedAt != null) minimizeTombstone(payload) else payload
 
     /**
      * Write the full aggregate (root row + children) inside the open transaction.
@@ -456,7 +481,10 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
      * Returns up to [limit] aggregates whose root row has `revision > cursor`,
      * ordered by revision ascending, each hydrated via [readPayloads] (child rows
      * included). Soft-deleted aggregates are returned so clients can apply
-     * tombstones. [Page.hasMore] is true when the result hit the limit.
+     * tombstones — in minimized form: content fields are blanked by
+     * [minimizeTombstone] before they leave this method, so a tombstone crosses the
+     * wire with identity + sync-discipline fields only. [Page.hasMore] is true when
+     * the result hit the limit.
      *
      * `nextCursor` advances using the queried revision (the last id/rev pair's
      * revision) rather than `items.last().revisionOf()` — a hard delete between the
@@ -508,7 +536,7 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                         substrate.selectIdsAboveRevision(cursor, limit.toLong())
                     }
                 }
-            val items = readPayloads(idsWithRev.map { it.id })
+            val items = readPayloads(idsWithRev.map { it.id }).map(::minimizedIfTombstoned)
             Page(
                 items = items,
                 nextCursor = idsWithRev.lastOrNull()?.revision,
@@ -557,7 +585,7 @@ abstract class SqlSyncableRepository<T : Any, ID : Any>(
                     limit = null,
                     includeTombstones = true,
                 )
-            val items = readPayloads(idsWithRev.map { it.id })
+            val items = readPayloads(idsWithRev.map { it.id }).map(::minimizedIfTombstoned)
             Page(items = items, nextCursor = null, hasMore = false)
         }
     }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookMoods.sq
@@ -90,6 +90,13 @@ SELECT id FROM book_moods WHERE mood_id = :mood_id AND deleted_at IS NULL;
 countLiveForMood:
 SELECT COUNT(*) FROM book_moods WHERE mood_id = :mood_id AND deleted_at IS NULL;
 
+-- Distinct mood ids ever linked to a book, tombstoned junctions included — the orphan-purge
+-- capture set. Tombstone-inclusive so a resume run (re-invoked softDelete after a crash that
+-- already tombstoned the junctions) still nominates the moods; liveBookCountForMood remains the
+-- sole purge decision-maker, so a mood with any live junction-book pair always survives.
+moodIdsForBook:
+SELECT DISTINCT mood_id FROM book_moods WHERE book_id = :book_id;
+
 -- Count of LIVE books linked to a mood via a LIVE junction — the orphan-purge decision for moods.
 liveBookCountForMood:
 SELECT COUNT(*) FROM book_moods bm

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookTags.sq
@@ -92,6 +92,13 @@ SELECT id FROM book_tags WHERE tag_id = :tag_id AND deleted_at IS NULL;
 countLiveForTag:
 SELECT COUNT(*) FROM book_tags WHERE tag_id = :tag_id AND deleted_at IS NULL;
 
+-- Distinct tag ids ever linked to a book, tombstoned junctions included — the orphan-purge
+-- capture set. Tombstone-inclusive so a resume run (re-invoked softDelete after a crash that
+-- already tombstoned the junctions) still nominates the tags; liveBookCountForTag remains the
+-- sole purge decision-maker, so a tag with any live junction-book pair always survives.
+tagIdsForBook:
+SELECT DISTINCT tag_id FROM book_tags WHERE book_id = :book_id;
+
 -- Count of LIVE books linked to a tag via a LIVE junction — the orphan-purge decision for tags.
 -- Both the junction and the book must be live; zero ⇒ orphaned tag → tombstone.
 liveBookCountForTag:

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Contributors.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Contributors.sq
@@ -63,10 +63,10 @@ selectByNormalizedName:
 SELECT * FROM contributors WHERE normalized_name = :normalized_name;
 
 -- Batch dedup lookup: resolveOrCreateAll resolves a whole scan's contributors in one
--- query. Projects (normalized_name, id) so the caller builds the dedup-key → id map
--- without re-reading every column.
+-- query. Projects (normalized_name, id, deleted_at) so the caller builds the
+-- dedup-key → id map without re-reading every column AND can revive tombstoned hits.
 selectByNormalizedNames:
-SELECT normalized_name, id FROM contributors WHERE normalized_name IN :normalized_names;
+SELECT normalized_name, id, deleted_at FROM contributors WHERE normalized_name IN :normalized_names;
 
 -- Live (non-tombstoned) id strings — OrphanImageCleanupTask uses these to keep
 -- images whose contributor still exists.

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Series.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/Series.sq
@@ -43,10 +43,10 @@ selectByNormalizedName:
 SELECT * FROM book_series WHERE normalized_name = :normalized_name;
 
 -- Batch dedup lookup: resolveOrCreateAll resolves a whole scan's series in one query.
--- Projects (normalized_name, id) so the caller builds the dedup-key → id map without
--- re-reading every column.
+-- Projects (normalized_name, id, deleted_at) so the caller builds the dedup-key → id
+-- map without re-reading every column AND can revive tombstoned hits.
 selectByNormalizedNames:
-SELECT normalized_name, id FROM book_series WHERE normalized_name IN :normalized_names;
+SELECT normalized_name, id, deleted_at FROM book_series WHERE normalized_name IN :normalized_names;
 
 -- Live (non-tombstoned) id strings — OrphanImageCleanupTask uses these to keep
 -- cover images whose series still exists.

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessModelExclusivityTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionAccessModelExclusivityTest.kt
@@ -243,4 +243,42 @@ class CollectionAccessModelExclusivityTest :
                 }
             }
         }
+
+        test("deleteCollection with multiple books returns each to a public ALL_BOOKS member") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("b1")
+                sql.seedTestBook("b2")
+                sql.seedTestBook("b3")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    val books = listOf("b1", "b2", "b3")
+                    books.forEach { admin.addBookToCollection(CollectionId(allBooksId), BookId(it)) }
+                    h.grantAllBooks(allBooksId, "m")
+
+                    // Curate all three into one private collection C (m is not a member) → each leaves ALL_BOOKS.
+                    val c = admin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+                    books.forEach { admin.addBookToCollection(c.data.id, BookId(it)) }
+                    books.forEach { h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, it).shouldBeFalse() }
+
+                    // C is their only home → deleting it returns all three to ALL_BOOKS → public access returns.
+                    admin.deleteCollection(c.data.id) shouldBe AppResult.Success(Unit)
+                    books.forEach { book ->
+                        h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, book).shouldBeTrue()
+                        h.junctionDiagnostic(book).let { j ->
+                            j shouldContain allBooksId
+                            j shouldNotContain c.data.id.value
+                        }
+                    }
+                }
+            }
+        }
     })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionMembershipRevisionTest.kt
@@ -27,6 +27,7 @@ import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import kotlin.time.Instant
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -226,6 +227,38 @@ class CollectionMembershipRevisionTest :
                     }
 
                     touch.touched shouldContainExactly listOf("b1")
+                }
+            }
+        }
+
+        test("deleteCollection touches every affected book's revision") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("u1")
+                sql.seedTestBook(bookId = "b1")
+                sql.seedTestBook(bookId = "b2")
+                sql.seedTestBook(bookId = "b3")
+                runTest(UnconfinedTestDispatcher()) {
+                    val touch = FakeBookRevisionTouch()
+                    val service = makeCollectionService(db, bookRevisionTouch = touch)
+                    val owner = service.actAs("u1")
+                    val created = owner.createCollection("test-library", "Shelf")
+                    require(created is AppResult.Success)
+                    listOf("b1", "b2", "b3").forEach { bookId ->
+                        owner.addBookToCollection(created.data.id, BookId(bookId)).let {
+                            require(it is AppResult.Success)
+                        }
+                    }
+                    touch.touched.clear()
+
+                    owner.deleteCollection(created.data.id).let {
+                        require(it is AppResult.Success)
+                    }
+
+                    // Deleting the collection returns each book to ALL_BOOKS and bumps its revision;
+                    // reconcile can legitimately double-bump a flipped book, so distinct() first.
+                    touch.touched.distinct() shouldContainExactlyInAnyOrder listOf("b1", "b2", "b3")
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SystemCollectionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SystemCollectionTest.kt
@@ -3,11 +3,14 @@
 package com.calypsan.listenup.server.api
 
 import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.api.dto.SharePermission
 import com.calypsan.listenup.api.dto.auth.SessionId
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.error.CollectionError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.CollectionId
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPermissionPolicy
 import com.calypsan.listenup.server.auth.UserPrincipal
@@ -20,10 +23,16 @@ import com.calypsan.listenup.server.sync.CollectionRepository
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.testing.FakeBookRevisionTouch
 import com.calypsan.listenup.server.testing.FixedClock
+import com.calypsan.listenup.server.testing.collectionAccessHarness
+import com.calypsan.listenup.server.testing.grantAllBooks
+import com.calypsan.listenup.server.testing.seedTestBook
 import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.seedTestUser
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.time.Instant
@@ -226,6 +235,83 @@ class SystemCollectionTest :
                     val result = service.actAs("admin").deleteCollection(allBooks.data.id)
                     require(result is AppResult.Failure)
                     result.error.shouldBeInstanceOf<CollectionError.SystemCollectionReadOnly>()
+                }
+            }
+        }
+
+        // ── System collection share guards (plan 090) ────────────────────────
+
+        test("revokeShare on ALL_BOOKS returns SystemCollectionReadOnly and preserves the member's default grant") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                sql.seedTestBook("B")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    admin.addBookToCollection(CollectionId(allBooksId), BookId("B"))
+                    h.grantAllBooks(allBooksId, "m")
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+
+                    val result = admin.revokeShare(CollectionId(allBooksId), "m")
+
+                    require(result is AppResult.Failure) {
+                        "expected SystemCollectionReadOnly but revoke returned $result — the default grant was deleted"
+                    }
+                    result.error.shouldBeInstanceOf<CollectionError.SystemCollectionReadOnly>()
+                    // The member's default grant and their library visibility survive.
+                    h.grantRepo.findActiveGrant(allBooksId, "m").shouldNotBeNull()
+                    h.bookAccessPolicy.canAccess("m", UserRole.MEMBER, "B").shouldBeTrue()
+                }
+            }
+        }
+
+        test("shareCollection on INBOX returns SystemCollectionReadOnly and creates no grant") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val inbox = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.INBOX)
+                    require(inbox is AppResult.Success)
+                    val inboxId = inbox.data.id.value
+
+                    val result = admin.shareCollection(CollectionId(inboxId), "m", SharePermission.Read)
+
+                    require(result is AppResult.Failure)
+                    result.error.shouldBeInstanceOf<CollectionError.SystemCollectionReadOnly>()
+                    h.grantRepo.findActiveGrant(inboxId, "m").shouldBeNull()
+                }
+            }
+        }
+
+        test("updateShare on ALL_BOOKS returns SystemCollectionReadOnly and keeps the grant at Read") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("m")
+                runTest {
+                    val h = collectionAccessHarness()
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    val allBooks = admin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    h.grantAllBooks(allBooksId, "m")
+
+                    val result = admin.updateShare(CollectionId(allBooksId), "m", SharePermission.Write)
+
+                    require(result is AppResult.Failure)
+                    result.error.shouldBeInstanceOf<CollectionError.SystemCollectionReadOnly>()
+                    h.grantRepo.findActiveGrant(allBooksId, "m")!!.permission shouldBe SharePermission.Read
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
@@ -49,8 +49,6 @@ class BookRemovalOrphanPurgeTest :
                     genreRepository = genreRepo,
                     tagRepository = tagRepo,
                     moodRepository = moodRepo,
-                    bookTagRepository = bookTagRepo,
-                    bookMoodRepository = bookMoodRepo,
                 )
             val bookRepo =
                 BookRepository(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
@@ -143,14 +143,30 @@ class BookRemovalOrphanPurgeTest :
 
                     // Removal purges the sole-linked parents (pinned by the neighbor tests above).
                     bookRepo.softDelete(BookId("book1"), clientOpId = null)
-                    sql.contributorsQueries.selectById(c1.value).executeAsOne().deleted_at.shouldNotBeNull()
-                    sql.seriesQueries.selectById(s1.value).executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.contributorsQueries
+                        .selectById(c1.value)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                    sql.seriesQueries
+                        .selectById(s1.value)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
 
                     // Re-ingest the same names — the scanner's resolve path — and both parents come back live.
                     contributorRepo.resolveOrCreate("Sole Author", "Author, Sole") shouldBe c1
                     seriesRepo.resolveOrCreate("Sole Saga") shouldBe s1
-                    sql.contributorsQueries.selectById(c1.value).executeAsOne().deleted_at.shouldBeNull()
-                    sql.seriesQueries.selectById(s1.value).executeAsOne().deleted_at.shouldBeNull()
+                    sql.contributorsQueries
+                        .selectById(c1.value)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
+                    sql.seriesQueries
+                        .selectById(s1.value)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRemovalOrphanPurgeTest.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -121,6 +122,35 @@ class BookRemovalOrphanPurgeTest :
                         .executeAsOne()
                         .deleted_at
                         .shouldNotBeNull()
+                }
+            }
+        }
+
+        test("re-adding a book after its sole parents were purged revives contributor and series under their original ids") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val (bookRepo, _, _) = buildRepo(sql, driver)
+                    val bus = ChangeBus()
+                    val registry = SyncRegistry()
+                    val contributorRepo = ContributorRepository(sql, bus, registry)
+                    val seriesRepo = SeriesRepository(sql, bus, registry)
+                    val c1 = contributorRepo.resolveOrCreate("Sole Author", "Author, Sole")
+                    val s1 = seriesRepo.resolveOrCreate("Sole Saga")
+                    sql.bookContributorsQueries.insert("book1", c1.value, "author", null, 0)
+                    sql.bookSeriesMembershipsQueries.insert("book1", s1.value, null, 0)
+
+                    // Removal purges the sole-linked parents (pinned by the neighbor tests above).
+                    bookRepo.softDelete(BookId("book1"), clientOpId = null)
+                    sql.contributorsQueries.selectById(c1.value).executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.seriesQueries.selectById(s1.value).executeAsOne().deleted_at.shouldNotBeNull()
+
+                    // Re-ingest the same names — the scanner's resolve path — and both parents come back live.
+                    contributorRepo.resolveOrCreate("Sole Author", "Author, Sole") shouldBe c1
+                    seriesRepo.resolveOrCreate("Sole Saga") shouldBe s1
+                    sql.contributorsQueries.selectById(c1.value).executeAsOne().deleted_at.shouldBeNull()
+                    sql.seriesQueries.selectById(s1.value).executeAsOne().deleted_at.shouldBeNull()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryTouchRevisionTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookRepositoryTouchRevisionTest.kt
@@ -63,6 +63,75 @@ class BookRepositoryTouchRevisionTest :
                 }
             }
         }
+
+        test("touchRevisions bumps every book in one call with distinct revisions") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook(bookId = "b1")
+                sql.seedTestBook(bookId = "b2")
+                sql.seedTestBook(bookId = "b3")
+                val repo = buildBookRepository(sql, driver)
+                runTest {
+                    val ids = listOf("b1", "b2", "b3")
+
+                    fun revOf(id: String): Long =
+                        sql.booksQueries
+                            .selectById(id)
+                            .executeAsOneOrNull()
+                            ?.revision
+                            ?: error("book $id not found")
+                    // Seed revisions don't track the global counter — establish a counter baseline first.
+                    ids.forEach { repo.touchRevision(BookId(it)) }
+                    val before = ids.associateWith { revOf(it) }
+
+                    val result = repo.touchRevisions(ids.map(::BookId))
+
+                    result shouldBe AppResult.Success(Unit)
+                    val after = ids.associateWith { revOf(it) }
+                    // Each row advanced past its pre-call revision.
+                    ids.forEach { after.getValue(it) shouldBeGreaterThan before.getValue(it) }
+                    // Every row got its OWN revision — the pagination-safety property (never one shared).
+                    after.values.toSet().size shouldBe after.values.size
+                }
+            }
+        }
+
+        test("touchRevisions skips missing ids and still bumps the rest") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook(bookId = "b1")
+                sql.seedTestBook(bookId = "b2")
+                val repo = buildBookRepository(sql, driver)
+                runTest {
+                    fun revOf(id: String): Long =
+                        sql.booksQueries
+                            .selectById(id)
+                            .executeAsOneOrNull()
+                            ?.revision
+                            ?: error("book $id not found")
+                    repo.touchRevision(BookId("b1"))
+                    repo.touchRevision(BookId("b2"))
+                    val b1Before = revOf("b1")
+                    val b2Before = revOf("b2")
+
+                    val result = repo.touchRevisions(listOf(BookId("b1"), BookId("nope"), BookId("b2")))
+
+                    result shouldBe AppResult.Success(Unit)
+                    revOf("b1") shouldBeGreaterThan b1Before
+                    revOf("b2") shouldBeGreaterThan b2Before
+                }
+            }
+        }
+
+        test("touchRevisions on an empty list is a no-op success") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                val repo = buildBookRepository(sql, driver)
+                runTest {
+                    repo.touchRevisions(emptyList()) shouldBe AppResult.Success(Unit)
+                }
+            }
+        }
     })
 
 /**

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
@@ -1,0 +1,276 @@
+package com.calypsan.listenup.server.services
+
+import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.BookMoodSyncPayload
+import com.calypsan.listenup.api.sync.BookTagSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.Mood
+import com.calypsan.listenup.api.sync.Tag
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.BookMoodRepository
+import com.calypsan.listenup.server.sync.BookTagRepository
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.MoodRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import com.calypsan.listenup.server.sync.TagRepository
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the partial-failure and crash-resume semantics of [BookRepository.softDelete] (plan 094).
+ *
+ * The cascade is deliberately multi-transaction: the book tombstone commits first, then each junction
+ * cascade (`book_tags`, `book_moods`, `collection_books`) commits in its own transaction, then the
+ * orphan-parent purge runs one transaction per parent. A crash between those steps leaves a
+ * half-cascaded book that NO scan sweep ever re-drives (they select live books only). These tests
+ * reproduce each crash boundary — via selective wiring (a null junction repo is a "committed nothing"
+ * for that step) and via a genuine mid-cascade throw — and prove that a re-invoked `softDelete`
+ * completes the unfinished cascade.
+ */
+class BookSoftDeleteCascadeResumeTest :
+    FunSpec({
+
+        // Full leaf-repo graph sharing one database; `bookRepo(...)` builds a BookRepository whose
+        // cascade wiring can be narrowed to reproduce a specific crash boundary (a null junction repo
+        // is a committed-nothing for that cascade step).
+        class CascadeGraph(
+            val sql: ListenUpDatabase,
+            val driver: SqlDriver,
+        ) {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val tagRepo = TagRepository(db = sql, bus = bus, registry = registry)
+            val moodRepo = MoodRepository(db = sql, bus = bus, registry = registry)
+            val bookTagRepo = BookTagRepository(db = sql, bus = bus, registry = registry)
+            val bookMoodRepo = BookMoodRepository(db = sql, bus = bus, registry = registry)
+            val collectionBookRepo = CollectionBookRepository(sql, bus, registry, driver = driver)
+            val contributorRepo = ContributorRepository(sql, bus, registry)
+            val seriesRepo = SeriesRepository(sql, bus, registry)
+            val genreRepo = GenreRepository(sql, bus, registry)
+            val purger =
+                OrphanParentPurger(
+                    db = sql,
+                    contributorRepository = contributorRepo,
+                    seriesRepository = seriesRepo,
+                    genreRepository = genreRepo,
+                    tagRepository = tagRepo,
+                    moodRepository = moodRepo,
+                    bookTagRepository = bookTagRepo,
+                    bookMoodRepository = bookMoodRepo,
+                )
+
+            // Each BookRepository registers its 'books' domain in the registry on construction, so the
+            // partial and resume instances need distinct registries (a shared one throws "already
+            // registered"). The cascade calls the leaf repos directly, not via the registry, so an
+            // isolated registry per instance is behaviourally transparent.
+            fun bookRepo(
+                wireTags: Boolean = true,
+                wireMoods: Boolean = true,
+                wireCollections: Boolean = true,
+                wirePurger: Boolean = true,
+            ): BookRepository =
+                BookRepository(
+                    db = sql,
+                    driver = driver,
+                    bus = bus,
+                    registry = SyncRegistry(),
+                    contributorRepository = contributorRepo,
+                    seriesRepository = seriesRepo,
+                    genreRepository = genreRepo,
+                    collectionBookRepository = if (wireCollections) collectionBookRepo else null,
+                    tagRepository = tagRepo,
+                    bookTagRepository = if (wireTags) bookTagRepo else null,
+                    bookMoodRepository = if (wireMoods) bookMoodRepo else null,
+                    orphanParentPurger = if (wirePurger) purger else null,
+                )
+        }
+
+        // Attaches a tag, a mood, and a NORMAL-collection membership to [bookId].
+        suspend fun CascadeGraph.attachTagMoodCollection(
+            bookId: String,
+            tagId: String,
+            moodId: String,
+            collectionId: String,
+        ) {
+            val now = System.currentTimeMillis()
+            sql.collectionsQueries.insert(
+                id = collectionId,
+                library_id = "test-library",
+                owner_id = "owner1",
+                name = "Faves-$collectionId",
+                type = "NORMAL",
+                created_at = now,
+                updated_at = now,
+                revision = 0L,
+                deleted_at = null,
+                client_op_id = null,
+            )
+            tagRepo.upsert(Tag(id = tagId, name = tagId, slug = tagId, revision = 0, updatedAt = 0))
+            moodRepo.upsert(Mood(id = moodId, name = moodId, slug = moodId, revision = 0, updatedAt = 0))
+            bookTagRepo.upsert(BookTagSyncPayload(bookId = bookId, tagId = tagId, createdAt = 1000L, revision = 0L))
+            bookMoodRepo.upsert(BookMoodSyncPayload(bookId = bookId, moodId = moodId, createdAt = 1000L, revision = 0L))
+            collectionBookRepo.upsert(
+                CollectionBookSyncPayload(collectionId = collectionId, bookId = bookId, createdAt = 1000L, revision = 0L),
+            )
+        }
+
+        test("boundary 2: crash after book tombstone, before any cascade, leaves junctions and parents live") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
+                    val soleAuthor = graph.contributorRepo.resolveOrCreate("Sole Author", "Author, Sole").value
+                    sql.bookContributorsQueries.insert("book1", soleAuthor, "author", null, 0)
+
+                    // No junction repos and no purger wired → every cascade step is a committed-nothing.
+                    graph.bookRepo(wireTags = false, wireMoods = false, wireCollections = false, wirePurger = false)
+                        .softDelete(BookId("book1"), clientOpId = null)
+
+                    // Book is tombstoned, but nothing downstream ran.
+                    sql.booksQueries.selectById("book1").executeAsOne().deleted_at.shouldNotBeNull()
+                    graph.bookTagRepo.findAllForBook("book1").shouldHaveSize(1)
+                    graph.bookMoodRepo.findAllForBook("book1").shouldHaveSize(1)
+                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldContainExactly("c1")
+                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldBeNull()
+                }
+            }
+        }
+
+        test("boundary 4: crash after tag+mood cascades, before collection_books, leaves membership live") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
+
+                    // Tag+mood repos wired, collections + purger not → cascade stops at collection_books.
+                    graph.bookRepo(wireTags = true, wireMoods = true, wireCollections = false, wirePurger = false)
+                        .softDelete(BookId("book1"), clientOpId = null)
+
+                    sql.booksQueries.selectById("book1").executeAsOne().deleted_at.shouldNotBeNull()
+                    graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
+                    graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
+                    // The uncascaded step: the book still sits in its collection.
+                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldContainExactly("c1")
+                }
+            }
+        }
+
+        test("resume from boundary 2 completes junction cascade, purges sole parents, spares shared ones") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
+                    // Sole parents (book1 only) and shared parents (book1 + book2, survive the removal).
+                    val soleAuthor = graph.contributorRepo.resolveOrCreate("Sole Author", "Author, Sole").value
+                    val sharedAuthor = graph.contributorRepo.resolveOrCreate("Shared Author", "Author, Shared").value
+                    sql.bookContributorsQueries.insert("book1", soleAuthor, "author", null, 0)
+                    sql.bookContributorsQueries.insert("book1", sharedAuthor, "author", null, 1)
+                    sql.bookContributorsQueries.insert("book2", sharedAuthor, "author", null, 0)
+                    val soleSeries = graph.seriesRepo.resolveOrCreate("Sole Series").value
+                    val sharedSeries = graph.seriesRepo.resolveOrCreate("Shared Series").value
+                    sql.bookSeriesMembershipsQueries.insert("book1", soleSeries, null, 0)
+                    sql.bookSeriesMembershipsQueries.insert("book1", sharedSeries, null, 1)
+                    sql.bookSeriesMembershipsQueries.insert("book2", sharedSeries, null, 0)
+
+                    // Partial: book tombstoned, nothing else (boundary 2).
+                    graph.bookRepo(wireTags = false, wireMoods = false, wireCollections = false, wirePurger = false)
+                        .softDelete(BookId("book1"), clientOpId = null)
+                    val revisionAfterPartial = sql.booksQueries.selectById("book1").executeAsOne().revision
+
+                    // Resume on the fully-wired repo.
+                    val result = graph.bookRepo().softDelete(BookId("book1"), clientOpId = null)
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+
+                    // Junctions now tombstoned.
+                    graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
+                    graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
+                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldBeEmpty()
+                    // Sole parents purged; shared parents (book2 still live) survive.
+                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.contributorsQueries.selectById(sharedAuthor).executeAsOne().deleted_at.shouldBeNull()
+                    sql.seriesQueries.selectById(soleSeries).executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.seriesQueries.selectById(sharedSeries).executeAsOne().deleted_at.shouldBeNull()
+                    // The re-stamp bumped the revision.
+                    sql.booksQueries.selectById("book1").executeAsOne().revision.shouldBeGreaterThan(revisionAfterPartial)
+                }
+            }
+        }
+
+        test("resume from boundary 4 tombstones the collection membership and purges the sole contributor") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
+                    val soleAuthor = graph.contributorRepo.resolveOrCreate("Sole Author", "Author, Sole").value
+                    sql.bookContributorsQueries.insert("book1", soleAuthor, "author", null, 0)
+
+                    // Partial: tags+moods cascaded, collections + purge did not (boundary 4).
+                    graph.bookRepo(wireTags = true, wireMoods = true, wireCollections = false, wirePurger = false)
+                        .softDelete(BookId("book1"), clientOpId = null)
+                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldContainExactly("c1")
+
+                    // Resume completes the collection cascade and the hard-replace-parent purge.
+                    val result = graph.bookRepo().softDelete(BookId("book1"), clientOpId = null)
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldBeEmpty()
+                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldNotBeNull()
+                }
+            }
+        }
+
+        test("a mid-cascade throw propagates, keeps the committed prefix, and resume completes after repair") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
+                    val soleAuthor = graph.contributorRepo.resolveOrCreate("Sole Author", "Author, Sole").value
+                    sql.bookContributorsQueries.insert("book1", soleAuthor, "author", null, 0)
+                    val bookRepo = graph.bookRepo()
+
+                    // Rip collection_books out from under the cascade: tag+mood cascades run first, so the
+                    // throw lands exactly at the collectionBookRepository step (boundary 4→5).
+                    driver.execute(null, "ALTER TABLE collection_books RENAME TO collection_books_bak", 0)
+
+                    shouldThrowAny { bookRepo.softDelete(BookId("book1"), clientOpId = null) }
+
+                    // Committed prefix: book + tags + moods tombstoned; purge did NOT run (contributor live).
+                    sql.booksQueries.selectById("book1").executeAsOne().deleted_at.shouldNotBeNull()
+                    graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
+                    graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
+                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldBeNull()
+
+                    // Repair and resume → completes the collection cascade and the hard-replace-parent purge.
+                    driver.execute(null, "ALTER TABLE collection_books_bak RENAME TO collection_books", 0)
+                    val result = bookRepo.softDelete(BookId("book1"), clientOpId = null)
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldBeEmpty()
+                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldNotBeNull()
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/BookSoftDeleteCascadeResumeTest.kt
@@ -69,8 +69,6 @@ class BookSoftDeleteCascadeResumeTest :
                     genreRepository = genreRepo,
                     tagRepository = tagRepo,
                     moodRepository = moodRepo,
-                    bookTagRepository = bookTagRepo,
-                    bookMoodRepository = bookMoodRepo,
                 )
 
             // Each BookRepository registers its 'books' domain in the registry on construction, so the
@@ -139,15 +137,27 @@ class BookSoftDeleteCascadeResumeTest :
                     sql.bookContributorsQueries.insert("book1", soleAuthor, "author", null, 0)
 
                     // No junction repos and no purger wired → every cascade step is a committed-nothing.
-                    graph.bookRepo(wireTags = false, wireMoods = false, wireCollections = false, wirePurger = false)
+                    graph
+                        .bookRepo(wireTags = false, wireMoods = false, wireCollections = false, wirePurger = false)
                         .softDelete(BookId("book1"), clientOpId = null)
 
                     // Book is tombstoned, but nothing downstream ran.
-                    sql.booksQueries.selectById("book1").executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.booksQueries
+                        .selectById("book1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
                     graph.bookTagRepo.findAllForBook("book1").shouldHaveSize(1)
                     graph.bookMoodRepo.findAllForBook("book1").shouldHaveSize(1)
-                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldContainExactly("c1")
-                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldBeNull()
+                    sql.collectionBooksQueries
+                        .liveCollectionIdsForBook("book1")
+                        .executeAsList()
+                        .shouldContainExactly("c1")
+                    sql.contributorsQueries
+                        .selectById(soleAuthor)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
                 }
             }
         }
@@ -161,14 +171,22 @@ class BookSoftDeleteCascadeResumeTest :
                     graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
 
                     // Tag+mood repos wired, collections + purger not → cascade stops at collection_books.
-                    graph.bookRepo(wireTags = true, wireMoods = true, wireCollections = false, wirePurger = false)
+                    graph
+                        .bookRepo(wireTags = true, wireMoods = true, wireCollections = false, wirePurger = false)
                         .softDelete(BookId("book1"), clientOpId = null)
 
-                    sql.booksQueries.selectById("book1").executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.booksQueries
+                        .selectById("book1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
                     graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
                     graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
                     // The uncascaded step: the book still sits in its collection.
-                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldContainExactly("c1")
+                    sql.collectionBooksQueries
+                        .liveCollectionIdsForBook("book1")
+                        .executeAsList()
+                        .shouldContainExactly("c1")
                 }
             }
         }
@@ -194,9 +212,14 @@ class BookSoftDeleteCascadeResumeTest :
                     sql.bookSeriesMembershipsQueries.insert("book2", sharedSeries, null, 0)
 
                     // Partial: book tombstoned, nothing else (boundary 2).
-                    graph.bookRepo(wireTags = false, wireMoods = false, wireCollections = false, wirePurger = false)
+                    graph
+                        .bookRepo(wireTags = false, wireMoods = false, wireCollections = false, wirePurger = false)
                         .softDelete(BookId("book1"), clientOpId = null)
-                    val revisionAfterPartial = sql.booksQueries.selectById("book1").executeAsOne().revision
+                    val revisionAfterPartial =
+                        sql.booksQueries
+                            .selectById("book1")
+                            .executeAsOne()
+                            .revision
 
                     // Resume on the fully-wired repo.
                     val result = graph.bookRepo().softDelete(BookId("book1"), clientOpId = null)
@@ -205,14 +228,37 @@ class BookSoftDeleteCascadeResumeTest :
                     // Junctions now tombstoned.
                     graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
                     graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
-                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldBeEmpty()
+                    sql.collectionBooksQueries
+                        .liveCollectionIdsForBook("book1")
+                        .executeAsList()
+                        .shouldBeEmpty()
                     // Sole parents purged; shared parents (book2 still live) survive.
-                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldNotBeNull()
-                    sql.contributorsQueries.selectById(sharedAuthor).executeAsOne().deleted_at.shouldBeNull()
-                    sql.seriesQueries.selectById(soleSeries).executeAsOne().deleted_at.shouldNotBeNull()
-                    sql.seriesQueries.selectById(sharedSeries).executeAsOne().deleted_at.shouldBeNull()
+                    sql.contributorsQueries
+                        .selectById(soleAuthor)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                    sql.contributorsQueries
+                        .selectById(sharedAuthor)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
+                    sql.seriesQueries
+                        .selectById(soleSeries)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                    sql.seriesQueries
+                        .selectById(sharedSeries)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
                     // The re-stamp bumped the revision.
-                    sql.booksQueries.selectById("book1").executeAsOne().revision.shouldBeGreaterThan(revisionAfterPartial)
+                    sql.booksQueries
+                        .selectById("book1")
+                        .executeAsOne()
+                        .revision
+                        .shouldBeGreaterThan(revisionAfterPartial)
                 }
             }
         }
@@ -228,15 +274,26 @@ class BookSoftDeleteCascadeResumeTest :
                     sql.bookContributorsQueries.insert("book1", soleAuthor, "author", null, 0)
 
                     // Partial: tags+moods cascaded, collections + purge did not (boundary 4).
-                    graph.bookRepo(wireTags = true, wireMoods = true, wireCollections = false, wirePurger = false)
+                    graph
+                        .bookRepo(wireTags = true, wireMoods = true, wireCollections = false, wirePurger = false)
                         .softDelete(BookId("book1"), clientOpId = null)
-                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldContainExactly("c1")
+                    sql.collectionBooksQueries
+                        .liveCollectionIdsForBook("book1")
+                        .executeAsList()
+                        .shouldContainExactly("c1")
 
                     // Resume completes the collection cascade and the hard-replace-parent purge.
                     val result = graph.bookRepo().softDelete(BookId("book1"), clientOpId = null)
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
-                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldBeEmpty()
-                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.collectionBooksQueries
+                        .liveCollectionIdsForBook("book1")
+                        .executeAsList()
+                        .shouldBeEmpty()
+                    sql.contributorsQueries
+                        .selectById(soleAuthor)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
                 }
             }
         }
@@ -259,17 +316,89 @@ class BookSoftDeleteCascadeResumeTest :
                     shouldThrowAny { bookRepo.softDelete(BookId("book1"), clientOpId = null) }
 
                     // Committed prefix: book + tags + moods tombstoned; purge did NOT run (contributor live).
-                    sql.booksQueries.selectById("book1").executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.booksQueries
+                        .selectById("book1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
                     graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
                     graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
-                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldBeNull()
+                    sql.contributorsQueries
+                        .selectById(soleAuthor)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
 
                     // Repair and resume → completes the collection cascade and the hard-replace-parent purge.
                     driver.execute(null, "ALTER TABLE collection_books_bak RENAME TO collection_books", 0)
                     val result = bookRepo.softDelete(BookId("book1"), clientOpId = null)
                     result.shouldBeInstanceOf<AppResult.Success<Unit>>()
-                    sql.collectionBooksQueries.liveCollectionIdsForBook("book1").executeAsList().shouldBeEmpty()
-                    sql.contributorsQueries.selectById(soleAuthor).executeAsOne().deleted_at.shouldNotBeNull()
+                    sql.collectionBooksQueries
+                        .liveCollectionIdsForBook("book1")
+                        .executeAsList()
+                        .shouldBeEmpty()
+                    sql.contributorsQueries
+                        .selectById(soleAuthor)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                }
+            }
+        }
+
+        test("resume purges a tag and mood orphaned by a crash before the purge ran (boundary 5)") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    graph.attachTagMoodCollection("book1", "t1", "m1", "c1")
+
+                    // Boundary 5: junction cascades ran, the purge did NOT (junctions tombstoned, parents live).
+                    graph.bookRepo(wirePurger = false).softDelete(BookId("book1"), clientOpId = null)
+                    graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
+                    graph.bookMoodRepo.findAllForBook("book1").shouldBeEmpty()
+
+                    // Resume on the fully-wired repo must still purge the now-orphaned tag and mood — the
+                    // capture has to nominate them even though their junctions are already tombstoned.
+                    graph.bookRepo().softDelete(BookId("book1"), clientOpId = null)
+                    sql.tagsQueries
+                        .selectById("t1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                    sql.moodsQueries
+                        .selectById("m1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldNotBeNull()
+                }
+            }
+        }
+
+        test("a tag still linked to another live book survives even when this book's junction was pre-tombstoned") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("book1")
+                sql.seedTestBook("book2")
+                runTest {
+                    val graph = CascadeGraph(sql, driver)
+                    // t1 linked to book1 AND book2 (both live).
+                    graph.tagRepo.upsert(Tag(id = "t1", name = "t1", slug = "t1", revision = 0, updatedAt = 0))
+                    graph.bookTagRepo.upsert(BookTagSyncPayload(bookId = "book1", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    graph.bookTagRepo.upsert(BookTagSyncPayload(bookId = "book2", tagId = "t1", createdAt = 1000L, revision = 0L))
+                    // The user detached t1 from book1 earlier: book1's junction is tombstoned BEFORE the removal.
+                    graph.bookTagRepo.softDeleteAllForBook("book1")
+                    graph.bookTagRepo.findAllForBook("book1").shouldBeEmpty()
+
+                    // Removing book1: the tombstone-inclusive capture nominates t1, but liveBookCountForTag > 0
+                    // (book2 still holds a live junction), so the purge decision-maker spares it.
+                    graph.bookRepo().softDelete(BookId("book1"), clientOpId = null)
+                    sql.tagsQueries
+                        .selectById("t1")
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ContributorRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ContributorRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -309,6 +310,63 @@ class ContributorRepositoryTest :
                     val digest = repo.digest(userId = null, cursor = cursor)
                     digest.count shouldBe 2
                     digest.hash.startsWith("sha256:") shouldBe true
+                }
+            }
+        }
+
+        // ── revive on tombstoned dedup hit (plan 088) ─────────────────────────────
+
+        test("resolveOrCreate revives a tombstoned dedup hit — same id, live, revision bumped, Updated published") {
+            withSqlDatabase {
+                val bus = ChangeBus()
+                val repo = ContributorRepository(db = sql, bus = bus, registry = SyncRegistry())
+                runTest {
+                    val id = repo.resolveOrCreate("Purged Author", sortName = null)
+                    repo.softDelete(id)
+                    val revisionAfterDelete =
+                        sql.contributorsQueries.selectById(id.value).executeAsOne().revision
+
+                    // Subscribe after the delete so the first observed event is the revive's.
+                    val deferred = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    val resolved = repo.resolveOrCreate("Purged Author", sortName = null)
+
+                    resolved shouldBe id // id stays stable — no re-mint
+                    val row = sql.contributorsQueries.selectById(id.value).executeAsOne()
+                    row.deleted_at.shouldBeNull() // FAILS before the fix: still tombstoned
+                    (row.revision > revisionAfterDelete) shouldBe true
+
+                    val busEvent = deferred.await()
+                    busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<ContributorSyncPayload>>()
+                }
+            }
+        }
+
+        test("resolveOrCreateAll revives tombstoned hits and leaves live hits untouched") {
+            withSqlDatabase {
+                val repo = ContributorRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    val purged = repo.resolveOrCreate("Purged Author", sortName = null)
+                    val live = repo.resolveOrCreate("Live Author", sortName = null)
+                    repo.softDelete(purged)
+                    val liveRevisionBefore =
+                        sql.contributorsQueries.selectById(live.value).executeAsOne().revision
+
+                    val resolved =
+                        repo.resolveOrCreateAll(
+                            listOf("Purged Author" to null, "Live Author" to null, "Brand New Author" to null),
+                        )
+
+                    resolved.values.toSet().size shouldBe 3
+                    resolved.values shouldContain purged // same id — no re-mint
+                    sql.contributorsQueries
+                        .selectById(purged.value)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull() // FAILS before the fix
+                    // Live hit stays a pure read — no gratuitous revision bump.
+                    sql.contributorsQueries.selectById(live.value).executeAsOne().revision shouldBe liveRevisionBefore
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ContributorRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/ContributorRepositoryTest.kt
@@ -324,10 +324,14 @@ class ContributorRepositoryTest :
                     val id = repo.resolveOrCreate("Purged Author", sortName = null)
                     repo.softDelete(id)
                     val revisionAfterDelete =
-                        sql.contributorsQueries.selectById(id.value).executeAsOne().revision
+                        sql.contributorsQueries
+                            .selectById(id.value)
+                            .executeAsOne()
+                            .revision
 
-                    // Subscribe after the delete so the first observed event is the revive's.
-                    val deferred = async { bus.subscribe().first() }
+                    // The bus replays the earlier Created/Deleted; the revive is the only Updated,
+                    // so filter for it rather than taking the replayed head.
+                    val deferred = async { bus.subscribe().first { it.event is SyncEvent.Updated<*> } }
                     advanceUntilIdle()
 
                     val resolved = repo.resolveOrCreate("Purged Author", sortName = null)
@@ -339,6 +343,7 @@ class ContributorRepositoryTest :
 
                     val busEvent = deferred.await()
                     busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<ContributorSyncPayload>>()
+                    busEvent.event.id shouldBe id.value
                 }
             }
         }
@@ -351,7 +356,10 @@ class ContributorRepositoryTest :
                     val live = repo.resolveOrCreate("Live Author", sortName = null)
                     repo.softDelete(purged)
                     val liveRevisionBefore =
-                        sql.contributorsQueries.selectById(live.value).executeAsOne().revision
+                        sql.contributorsQueries
+                            .selectById(live.value)
+                            .executeAsOne()
+                            .revision
 
                     val resolved =
                         repo.resolveOrCreateAll(
@@ -366,7 +374,10 @@ class ContributorRepositoryTest :
                         .deleted_at
                         .shouldBeNull() // FAILS before the fix
                     // Live hit stays a pure read — no gratuitous revision bump.
-                    sql.contributorsQueries.selectById(live.value).executeAsOne().revision shouldBe liveRevisionBefore
+                    sql.contributorsQueries
+                        .selectById(live.value)
+                        .executeAsOne()
+                        .revision shouldBe liveRevisionBefore
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/SeriesRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/SeriesRepositoryTest.kt
@@ -252,10 +252,14 @@ class SeriesRepositoryTest :
                     val id = repo.resolveOrCreate("Purged Saga")
                     repo.softDelete(id)
                     val revisionAfterDelete =
-                        sql.seriesQueries.selectById(id.value).executeAsOne().revision
+                        sql.seriesQueries
+                            .selectById(id.value)
+                            .executeAsOne()
+                            .revision
 
-                    // Subscribe after the delete so the first observed event is the revive's.
-                    val deferred = async { bus.subscribe().first() }
+                    // The bus replays the earlier Created/Deleted; the revive is the only Updated,
+                    // so filter for it rather than taking the replayed head.
+                    val deferred = async { bus.subscribe().first { it.event is SyncEvent.Updated<*> } }
                     advanceUntilIdle()
 
                     val resolved = repo.resolveOrCreate("Purged Saga")
@@ -267,6 +271,7 @@ class SeriesRepositoryTest :
 
                     val busEvent = deferred.await()
                     busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<SeriesSyncPayload>>()
+                    busEvent.event.id shouldBe id.value
                 }
             }
         }
@@ -279,7 +284,10 @@ class SeriesRepositoryTest :
                     val live = repo.resolveOrCreate("Live Saga")
                     repo.softDelete(purged)
                     val liveRevisionBefore =
-                        sql.seriesQueries.selectById(live.value).executeAsOne().revision
+                        sql.seriesQueries
+                            .selectById(live.value)
+                            .executeAsOne()
+                            .revision
 
                     val resolved =
                         repo.resolveOrCreateAll(listOf("Purged Saga", "Live Saga", "Brand New Saga"))
@@ -292,7 +300,10 @@ class SeriesRepositoryTest :
                         .deleted_at
                         .shouldBeNull() // FAILS before the fix
                     // Live hit stays a pure read — no gratuitous revision bump.
-                    sql.seriesQueries.selectById(live.value).executeAsOne().revision shouldBe liveRevisionBefore
+                    sql.seriesQueries
+                        .selectById(live.value)
+                        .executeAsOne()
+                        .revision shouldBe liveRevisionBefore
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/SeriesRepositoryTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/services/SeriesRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.SyncRegistry
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -237,6 +238,61 @@ class SeriesRepositoryTest :
                 runTest {
                     repo.resolveOrCreateAll(emptyList()) shouldBe emptyMap()
                     repo.listLiveIds() shouldBe emptySet()
+                }
+            }
+        }
+
+        // ── revive on tombstoned dedup hit (plan 088) ─────────────────────────────
+
+        test("resolveOrCreate revives a tombstoned dedup hit — same id, live, revision bumped, Updated published") {
+            withSqlDatabase {
+                val bus = ChangeBus()
+                val repo = SeriesRepository(db = sql, bus = bus, registry = SyncRegistry())
+                runTest {
+                    val id = repo.resolveOrCreate("Purged Saga")
+                    repo.softDelete(id)
+                    val revisionAfterDelete =
+                        sql.seriesQueries.selectById(id.value).executeAsOne().revision
+
+                    // Subscribe after the delete so the first observed event is the revive's.
+                    val deferred = async { bus.subscribe().first() }
+                    advanceUntilIdle()
+
+                    val resolved = repo.resolveOrCreate("Purged Saga")
+
+                    resolved shouldBe id // id stays stable — no re-mint
+                    val row = sql.seriesQueries.selectById(id.value).executeAsOne()
+                    row.deleted_at.shouldBeNull() // FAILS before the fix: still tombstoned
+                    (row.revision > revisionAfterDelete) shouldBe true
+
+                    val busEvent = deferred.await()
+                    busEvent.event.shouldBeInstanceOf<SyncEvent.Updated<SeriesSyncPayload>>()
+                }
+            }
+        }
+
+        test("resolveOrCreateAll revives tombstoned hits and leaves live hits untouched") {
+            withSqlDatabase {
+                val repo = SeriesRepository(db = sql, bus = ChangeBus(), registry = SyncRegistry())
+                runTest {
+                    val purged = repo.resolveOrCreate("Purged Saga")
+                    val live = repo.resolveOrCreate("Live Saga")
+                    repo.softDelete(purged)
+                    val liveRevisionBefore =
+                        sql.seriesQueries.selectById(live.value).executeAsOne().revision
+
+                    val resolved =
+                        repo.resolveOrCreateAll(listOf("Purged Saga", "Live Saga", "Brand New Saga"))
+
+                    resolved.values.toSet().size shouldBe 3
+                    resolved.values shouldContain purged // same id — no re-mint
+                    sql.seriesQueries
+                        .selectById(purged.value)
+                        .executeAsOne()
+                        .deleted_at
+                        .shouldBeNull() // FAILS before the fix
+                    // Live hit stays a pure read — no gratuitous revision bump.
+                    sql.seriesQueries.selectById(live.value).executeAsOne().revision shouldBe liveRevisionBefore
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TombstonePayloadMinimizationTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/sync/TombstonePayloadMinimizationTest.kt
@@ -1,0 +1,414 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.calypsan.listenup.server.sync
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.sync.ActivitySyncPayload
+import com.calypsan.listenup.api.sync.AdminUserRosterSyncPayload
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.api.sync.CollectionShareSyncPayload
+import com.calypsan.listenup.api.sync.CollectionSyncPayload
+import com.calypsan.listenup.api.sync.LibraryFolderSyncPayload
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.server.api.BookAccessPolicy
+import com.calypsan.listenup.server.services.ActivitySyncRepository
+import com.calypsan.listenup.server.services.BookRepository
+import com.calypsan.listenup.server.services.ContributorRepository
+import com.calypsan.listenup.server.services.GenreRepository
+import com.calypsan.listenup.server.services.LibraryFolderRepository
+import com.calypsan.listenup.server.services.SeriesRepository
+import com.calypsan.listenup.server.testing.SqlTestDatabases
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Reproduction + regression proof for plan 087: a tombstone delivered on the access-filtered pull
+ * path ([SqlSyncableRepository.pullSince] / [pullByIds]) must carry identity + sync-discipline
+ * fields ONLY — never the deleted row's content. The catch-up path deletes-ungated so every client
+ * converges (a member must learn to drop a row it could never access), but the payload it ships for
+ * that tombstone must be empty of content: the live firehose's `SyncEvent.Deleted` carries none.
+ *
+ * Before the fix, `readPayloads` hydrated the full deleted row, so a member's `since=0` pull leaked
+ * private book titles, folder `rootPath`s (absolute server paths), and roster emails/roles. Each
+ * test asserts BOTH that the tombstone still arrives (convergence) and that its content is blanked.
+ *
+ * Fixture wiring mirrors [BookCatchUpAccessTest] / [ActivityCatchUpAccessTest] /
+ * [LibraryFolderSyncAccessTest] in this directory.
+ */
+class TombstonePayloadMinimizationTest :
+    FunSpec({
+
+        fun SqlTestDatabases.fixture(): TombstoneFixture {
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val contributorRepo = ContributorRepository(db = sql, bus = bus, registry = registry)
+            val seriesRepo = SeriesRepository(db = sql, bus = bus, registry = registry)
+            return TombstoneFixture(
+                bookRepo =
+                    BookRepository(
+                        db = sql,
+                        driver = driver,
+                        bus = bus,
+                        registry = registry,
+                        contributorRepository = contributorRepo,
+                        seriesRepository = seriesRepo,
+                        genreRepository = GenreRepository(db = sql, bus = bus, registry = registry),
+                    ),
+                collectionRepo = CollectionRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                collectionBookRepo = CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                grantRepo = CollectionGrantRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                activityRepo = ActivitySyncRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                folderRepo = LibraryFolderRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                rosterRepo = AdminUserRosterRepository(db = sql, bus = bus, registry = registry, driver = driver),
+                policy = BookAccessPolicy(sql, driver),
+            )
+        }
+
+        test("books member pullSince delivers a private-book tombstone with blanked content") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("public-book")
+                sql.seedTestBook("private-book")
+                val f = fixture()
+                runTest {
+                    f.makePublic("public-book", memberId = "member")
+                    f.collectionRepo.upsert(collection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(membership("private-col", "private-book"))
+                    f.bookRepo.softDelete(BookId("private-book"))
+
+                    val extra = f.policy.accessibleBookIdsSql("member", UserRole.MEMBER)
+                    val page = f.bookRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = extra)
+
+                    val tomb = page.items.firstOrNull { it.id == "private-book" }.shouldNotBeNull()
+                    // Convergence contract: the tombstone arrives with identity + sync discipline.
+                    tomb.deletedAt shouldNotBe null
+                    (tomb.revision > 1L) shouldBe true
+                    // Leak proof: every content field is blanked (was "Test Book private-book").
+                    tomb.title shouldBe ""
+                    tomb.description shouldBe null
+                    tomb.rootRelPath shouldBe ""
+                    tomb.contributors shouldBe emptyList()
+                    tomb.series shouldBe emptyList()
+                    tomb.chapters shouldBe emptyList()
+                    tomb.audioFiles shouldBe emptyList()
+                }
+            }
+        }
+
+        test("books member pullByIds delivers a private-book tombstone with blanked content") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("private-book")
+                val f = fixture()
+                runTest {
+                    f.collectionRepo.upsert(collection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(membership("private-col", "private-book"))
+                    f.bookRepo.softDelete(BookId("private-book"))
+
+                    val extra = f.policy.accessibleBookIdsSql("member", UserRole.MEMBER)
+                    val page =
+                        f.bookRepo.pullByIds(
+                            userId = "member",
+                            matchColumn = "id",
+                            matchValues = listOf("private-book"),
+                            extraWhere = extra,
+                        )
+
+                    val tomb = page.items.firstOrNull { it.id == "private-book" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.title shouldBe ""
+                    tomb.contributors shouldBe emptyList()
+                }
+            }
+        }
+
+        test("books admin pullSince (null filter) also minimizes the tombstone") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestBook("doomed-book")
+                val f = fixture()
+                runTest {
+                    f.bookRepo.softDelete(BookId("doomed-book"))
+
+                    // Admin passes a null fragment → the ungated substrate path, which also returns tombstones.
+                    val adminExtra = f.policy.accessibleBookIdsSql("admin", UserRole.ADMIN)
+                    adminExtra shouldBe null
+                    val page = f.bookRepo.pullSince("admin", cursor = 0L, limit = 100, extraWhere = adminExtra)
+
+                    val tomb = page.items.firstOrNull { it.id == "doomed-book" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.title shouldBe ""
+                }
+            }
+        }
+
+        test("collections member pullSince delivers a stranger-collection tombstone with blanked content") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                val f = fixture()
+                runTest {
+                    f.collectionRepo.upsert(
+                        CollectionSyncPayload(
+                            id = "secret-plans",
+                            libraryId = "test-library",
+                            ownerId = "stranger",
+                            name = "Secret Plans",
+                            revision = 0L,
+                            updatedAt = 0L,
+                        ),
+                    )
+                    f.collectionRepo.softDelete("secret-plans")
+
+                    val extra = f.policy.accessibleCollectionIdsSql("member", UserRole.MEMBER)
+                    val page = f.collectionRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = extra)
+
+                    val tomb = page.items.firstOrNull { it.id == "secret-plans" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.name shouldBe ""
+                    tomb.ownerId shouldBe ""
+                }
+            }
+        }
+
+        test("collection_shares member pullSince delivers a foreign-grant tombstone with blanked content") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestUser("stranger") // FK: collection_grants.principal_id → users(id)
+                val f = fixture()
+                runTest {
+                    // FK: collection_grants.collection_id → collections(id). Owned by a stranger, so the
+                    // grant is one the member can never see — only the tombstone reaches them.
+                    f.collectionRepo.upsert(collection("some-collection", owner = "stranger"))
+                    f.grantRepo.upsert(
+                        CollectionShareSyncPayload(
+                            id = "secret-grant",
+                            collectionId = "some-collection",
+                            sharedWithUserId = "stranger",
+                            sharedByUserId = "system",
+                            permission = SharePermission.Read,
+                            revision = 0L,
+                            updatedAt = 0L,
+                        ),
+                    )
+                    f.grantRepo.softDelete("secret-grant")
+
+                    val extra = f.policy.visibleCollectionGrantIdsSql("member", UserRole.MEMBER)
+                    val page = f.grantRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = extra)
+
+                    val tomb = page.items.firstOrNull { it.id == "secret-grant" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.collectionId shouldBe ""
+                    tomb.sharedWithUserId shouldBe ""
+                    tomb.sharedByUserId shouldBe ""
+                }
+            }
+        }
+
+        test("activities member pullSince delivers an inaccessible-book activity tombstone with blanked content") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                val f = fixture()
+                runTest {
+                    f.activityRepo.upsert(
+                        ActivitySyncPayload(
+                            id = "doomed-activity",
+                            userId = "alice",
+                            type = "FINISHED_BOOK",
+                            bookId = "inaccessible-book",
+                            isReread = false,
+                            durationMs = 0L,
+                            milestoneValue = 0,
+                            milestoneUnit = null,
+                            shelfId = null,
+                            shelfName = null,
+                            occurredAt = 0L,
+                            revision = 0L,
+                            createdAt = 0L,
+                            updatedAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    f.activityRepo.softDelete("doomed-activity")
+
+                    val extra = activitiesAccessFilter(f.policy, "member", UserRole.MEMBER)
+                    val page = f.activityRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = extra)
+
+                    val tomb = page.items.firstOrNull { it.id == "doomed-activity" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.type shouldBe ""
+                    tomb.bookId shouldBe null
+                    tomb.userId shouldBe ""
+                }
+            }
+        }
+
+        test("library_folders member pullSince delivers a folder tombstone with blanked rootPath") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                val f = fixture()
+                runTest {
+                    f.folderRepo.upsert(
+                        LibraryFolderSyncPayload(
+                            id = "secret-folder",
+                            libraryId = "test-library",
+                            rootPath = "/srv/secret/audiobooks",
+                            revision = 0L,
+                            updatedAt = 0L,
+                            createdAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    f.folderRepo.softDelete(FolderId("secret-folder"))
+
+                    // Mirrors LIBRARY_FOLDERS_HIDDEN in SyncRoutes (private there): members see no folder rows.
+                    val hidden = SqlFragment(sql = "SELECT id FROM library_folders WHERE 1 = 0", args = emptyList())
+                    val page = f.folderRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = hidden)
+
+                    val tomb = page.items.firstOrNull { it.id == "secret-folder" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.rootPath shouldBe ""
+                }
+            }
+        }
+
+        test("admin_user_roster member pullSince delivers a roster tombstone with blanked PII") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                val f = fixture()
+                runTest {
+                    f.rosterRepo.upsert(
+                        AdminUserRosterSyncPayload(
+                            id = "doomed-user",
+                            email = "secret@example.com",
+                            displayName = "Secret Person",
+                            role = "MEMBER",
+                            status = "ACTIVE",
+                            canShare = true,
+                            accountCreatedAt = 123L,
+                            revision = 0L,
+                            updatedAt = 0L,
+                            createdAt = 0L,
+                            deletedAt = null,
+                        ),
+                    )
+                    f.rosterRepo.softDelete("doomed-user")
+
+                    // Mirrors ADMIN_USER_ROSTER_HIDDEN in SyncRoutes (private there): members see no roster rows.
+                    val hidden = SqlFragment(sql = "SELECT id FROM admin_user_roster WHERE 1 = 0", args = emptyList())
+                    val page = f.rosterRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = hidden)
+
+                    val tomb = page.items.firstOrNull { it.id == "doomed-user" }.shouldNotBeNull()
+                    tomb.deletedAt shouldNotBe null
+                    tomb.email shouldBe ""
+                    tomb.displayName shouldBe ""
+                    tomb.role shouldBe ""
+                    tomb.status shouldBe ""
+                }
+            }
+        }
+
+        test("collection_books tombstone keeps its junction identity (no minimization for this domain)") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("member")
+                sql.seedTestBook("some-book")
+                val f = fixture()
+                runTest {
+                    f.collectionRepo.upsert(collection("private-col", owner = "stranger"))
+                    f.collectionBookRepo.upsert(membership("private-col", "some-book"))
+                    f.collectionBookRepo.softDelete(collectionId = "private-col", bookId = "some-book")
+
+                    val extra = f.policy.accessibleCollectionBookIdsSql("member", UserRole.MEMBER)
+                    val page = f.collectionBookRepo.pullSince("member", cursor = 0L, limit = 100, extraWhere = extra)
+
+                    val tomb =
+                        page.items
+                            .firstOrNull { it.collectionId == "private-col" && it.bookId == "some-book" }
+                            .shouldNotBeNull()
+                    // The client applies the junction tombstone by (collectionId, bookId) — identity must survive.
+                    tomb.deletedAt shouldNotBe null
+                    tomb.collectionId shouldBe "private-col"
+                    tomb.bookId shouldBe "some-book"
+                }
+            }
+        }
+    })
+
+private data class TombstoneFixture(
+    val bookRepo: BookRepository,
+    val collectionRepo: CollectionRepository,
+    val collectionBookRepo: CollectionBookRepository,
+    val grantRepo: CollectionGrantRepository,
+    val activityRepo: ActivitySyncRepository,
+    val folderRepo: LibraryFolderRepository,
+    val rosterRepo: AdminUserRosterRepository,
+    val policy: BookAccessPolicy,
+)
+
+private fun collection(
+    id: String,
+    owner: String,
+): CollectionSyncPayload =
+    CollectionSyncPayload(
+        id = id,
+        libraryId = "test-library",
+        ownerId = owner,
+        name = id,
+        revision = 0L,
+        updatedAt = 0L,
+    )
+
+private fun membership(
+    collectionId: String,
+    bookId: String,
+): CollectionBookSyncPayload =
+    CollectionBookSyncPayload(
+        collectionId = collectionId,
+        bookId = bookId,
+        createdAt = 0L,
+        revision = 0L,
+    )
+
+private fun grant(
+    id: String,
+    collectionId: String,
+    memberId: String,
+): CollectionShareSyncPayload =
+    CollectionShareSyncPayload(
+        id = id,
+        collectionId = collectionId,
+        sharedWithUserId = memberId,
+        sharedByUserId = "system",
+        permission = SharePermission.Read,
+        revision = 0L,
+        updatedAt = 0L,
+    )
+
+/**
+ * Makes [bookId] publicly visible the pure-union way (ALL_BOOKS membership + a member USER grant) —
+ * mirrors [BookCatchUpAccessTest.makePublic].
+ */
+private suspend fun TombstoneFixture.makePublic(
+    bookId: String,
+    memberId: String,
+) {
+    collectionRepo.upsert(collection("all-books", owner = "system"))
+    collectionBookRepo.upsert(membership("all-books", bookId))
+    grantRepo.upsert(grant("grant-$bookId-$memberId", "all-books", memberId))
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessReconciler.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/AccessReconciler.kt
@@ -30,8 +30,10 @@ private val logger = KotlinLogging.logger {}
  *    neither is fetched here.
  *
  * A delta pass ends in exactly the state a coarse pass restricted to the scope would: same upserts,
- * same tombstones, no leak. Per-domain failures are logged and swallowed — one domain must not
- * strand the others; the next signal (or the coarse anchor) recovers. The persisted
+ * same tombstones, no leak. A per-domain failure never strands the others — the pass continues — but
+ * it is no longer swallowed: the failed remainder is reported to the caller via
+ * [AccessReconcileOutcome] so the engine can re-queue it for exactly one bounded retry. After that
+ * one retry, the reconnect / coarse anchor remains the convergence backstop. The persisted
  * [SyncCursorStore] is never touched: the live SSE/cursor path continues independently.
  */
 internal class AccessReconciler(
@@ -40,17 +42,18 @@ internal class AccessReconciler(
     private val now: () -> Long = { currentEpochMilliseconds() },
 ) {
     /** Re-derive access-gated domains: coarse when [scope] is null, otherwise a scoped delta. */
-    suspend fun reconcile(scope: AccessScope?) {
+    suspend fun reconcile(scope: AccessScope?): AccessReconcileOutcome =
         if (scope == null) reconcileCoarse() else reconcileDelta(scope)
-    }
 
     /**
      * Whole-library re-derive: every access-gated domain re-pulled from 0 and pruned to the
-     * returned accessible set. The semantic anchor — correct regardless of what changed.
+     * returned accessible set. The semantic anchor — correct regardless of what changed. A failed
+     * domain does not stop the others; if any failed, the whole pass is re-queued as coarse.
      */
-    private suspend fun reconcileCoarse() {
+    private suspend fun reconcileCoarse(): AccessReconcileOutcome {
         logger.info { "AccessChanged (coarse): re-deriving + pruning every access-gated domain" }
         val ts = now()
+        var anyFailure = false
         for (handler in registry.accessFilteredHandlers()) {
             @Suppress("UNCHECKED_CAST")
             val typed = handler as SyncDomainHandler<Any>
@@ -61,49 +64,62 @@ internal class AccessReconciler(
 
                 is AppResult.Failure -> {
                     logger.warn { "AccessChanged coarse reconcile failed for ${handler.domainName}: ${ids.error.code}" }
+                    anyFailure = true
                 }
             }
         }
+        return if (anyFailure) AccessReconcileOutcome.Requeue(null) else AccessReconcileOutcome.Clean
     }
 
     /**
      * Scoped delta: fetch + prune only the named entities, in dependency order so a collection's
      * membership is reconciled before the books it gates. Each step is independent — a failure logs
-     * and moves on; the coarse anchor backstops any gap.
+     * and moves on — but its ids are collected into the failed remainder so the engine can re-queue
+     * exactly that portion; the coarse anchor backstops any gap after the one retry.
      */
-    private suspend fun reconcileDelta(scope: AccessScope) {
+    private suspend fun reconcileDelta(scope: AccessScope): AccessReconcileOutcome {
         logger.info {
             "AccessChanged (delta): ${scope.collectionIds.size} collection(s), ${scope.bookIds.size} book(s)"
         }
         val ts = now()
-        fetchAndPruneById("collections", scope.collectionIds, ts)
-        fetchAndPruneCollectionBooks(scope, ts)
-        fetchAndPruneById("books", scope.bookIds, ts)
+        val failedCollectionIds = mutableSetOf<String>()
+        val failedBookIds = mutableSetOf<String>()
+        if (!fetchAndPruneById("collections", scope.collectionIds, ts)) failedCollectionIds += scope.collectionIds
+        if (!fetchAndPruneCollectionBooks(scope, ts)) failedCollectionIds += scope.collectionIds
+        if (!fetchAndPruneById("books", scope.bookIds, ts)) failedBookIds += scope.bookIds
+        return if (failedCollectionIds.isEmpty() && failedBookIds.isEmpty()) {
+            AccessReconcileOutcome.Clean
+        } else {
+            AccessReconcileOutcome.Requeue(AccessScope(failedCollectionIds.toList(), failedBookIds.toList()))
+        }
     }
 
     /**
      * Delta one own-id-keyed domain (`books` / `collections`): fetch [ids] access-filtered, upsert
      * what comes back, and [AccessFilteredSyncHandler.pruneWithin] the candidate set [ids] against
      * the returned accessible subset — so an id asked about but not returned is tombstoned, and
-     * every row outside [ids] is left untouched.
+     * every row outside [ids] is left untouched. Returns `true` when the step completed (including
+     * the no-op paths: empty ids or a non-access-gated handler), `false` only on a fetch failure.
      */
     private suspend fun fetchAndPruneById(
         domainName: String,
         ids: List<String>,
         ts: Long,
-    ) {
-        if (ids.isEmpty()) return
-        val handler = accessGatedHandler(domainName) ?: return
+    ): Boolean {
+        if (ids.isEmpty()) return true
+        val handler = accessGatedHandler(domainName) ?: return true
 
         @Suppress("UNCHECKED_CAST")
         val typed = handler as SyncDomainHandler<Any>
-        when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByIds(ids))) {
+        return when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByIds(ids))) {
             is AppResult.Success -> {
                 (handler as AccessFilteredSyncHandler).pruneWithin(ids.toSet(), returned.data, ts)
+                true
             }
 
             is AppResult.Failure -> {
                 logger.warn { "AccessChanged delta fetch failed for $domainName: ${returned.error.code}" }
+                false
             }
         }
     }
@@ -118,22 +134,24 @@ internal class AccessReconciler(
     private suspend fun fetchAndPruneCollectionBooks(
         scope: AccessScope,
         ts: Long,
-    ) {
-        if (scope.collectionIds.isEmpty()) return
-        val handler = accessGatedHandler("collection_books") ?: return
+    ): Boolean {
+        if (scope.collectionIds.isEmpty()) return true
+        val handler = accessGatedHandler("collection_books") ?: return true
         val gated = handler as AccessFilteredSyncHandler
 
         @Suppress("UNCHECKED_CAST")
         val typed = handler as SyncDomainHandler<Any>
         val scopeCols = scope.collectionIds.toSet()
         val candidateIds = gated.localLiveIds().filterTo(mutableSetOf()) { it.substringBefore(':') in scopeCols }
-        when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByCollectionIds(scope.collectionIds))) {
+        return when (val returned = catchUp.fetchTransient(typed, TargetedFetch.ByCollectionIds(scope.collectionIds))) {
             is AppResult.Success -> {
                 gated.pruneWithin(candidateIds, returned.data, ts)
+                true
             }
 
             is AppResult.Failure -> {
                 logger.warn { "AccessChanged delta fetch failed for collection_books: ${returned.error.code}" }
+                false
             }
         }
     }
@@ -147,4 +165,19 @@ internal class AccessReconciler(
         }
         return handler
     }
+}
+
+/**
+ * What an [AccessReconciler.reconcile] pass could not complete. The engine folds a
+ * [Requeue] back into its coalescer for exactly one follow-up attempt; a `null`
+ * [Requeue.retryScope] re-queues a coarse pass (the accumulator's poison semantics).
+ */
+internal sealed interface AccessReconcileOutcome {
+    /** Every fetch succeeded — nothing to retry. */
+    data object Clean : AccessReconcileOutcome
+
+    /** At least one fetch failed; [retryScope] is the failed remainder (`null` = coarse). */
+    data class Requeue(
+        val retryScope: AccessScope?,
+    ) : AccessReconcileOutcome
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -598,12 +598,28 @@ internal class SyncEngine(
         if (!leader) return
 
         try {
+            // One retry budget per leader activation: a failed scope is re-folded into the
+            // accumulator exactly once; if the retry fails too, the reconnect / next
+            // AccessChanged edge is the backstop (AccessReconciler KDoc). A fresh frame
+            // later starts a fresh leader with a fresh budget.
+            var requeueGranted = true
             while (true) {
                 val work = accessChangedMutex.withLock { drainAccumulatedAccessChange() }
-                when (work) {
-                    PendingAccessChange.None -> break
-                    PendingAccessChange.Coarse -> accessReconciler.reconcile(null)
-                    is PendingAccessChange.Delta -> accessReconciler.reconcile(work.scope)
+                val outcome =
+                    when (work) {
+                        PendingAccessChange.None -> break
+                        PendingAccessChange.Coarse -> accessReconciler.reconcile(null)
+                        is PendingAccessChange.Delta -> accessReconciler.reconcile(work.scope)
+                    }
+                if (outcome is AccessReconcileOutcome.Requeue) {
+                    if (requeueGranted) {
+                        requeueGranted = false
+                        accessChangedMutex.withLock { accumulateAccessChange(outcome.retryScope) }
+                    } else {
+                        logger.warn {
+                            "AccessChanged reconcile failed after retry — deferring to reconnect/coarse backstop"
+                        }
+                    }
                 }
             }
         } finally {

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -20,6 +20,7 @@ import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.stubImageStorage
+import com.calypsan.listenup.api.error.SyncError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.AccessScope
 import com.calypsan.listenup.core.BookId
@@ -450,6 +451,89 @@ class AccessChangedReconcileTest :
                 harness.fakeCatchUp.fetches[0].fetch shouldBe TargetedFetch.ByIds(listOf("bb"))
             }
         }
+
+        // ---- Transient-failure re-queue (plan 101) --------------------------------------------------
+
+        test("delta requeue: a failed scoped fetch is retried on the next drain and the prune completes") {
+            withReconcileEngine { harness, db, _ ->
+                val handler =
+                    booksDomain(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
+                handler.onCatchUpItem(bookPayload("b1"), isTombstone = false)
+                handler.onCatchUpItem(bookPayload("b2"), isTombstone = false)
+
+                // First books fetch fails (transient); the retry succeeds returning only b1.
+                harness.fakeCatchUp.failNextByDomain["books"] = 1
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = emptyList(), bookIds = listOf("b1", "b2")))
+
+                // Two attempts were made over the same scope...
+                harness.fakeCatchUp.fetches shouldHaveSize 2
+                (harness.fakeCatchUp.fetches[1].fetch as TargetedFetch.ByIds).ids.toSet() shouldBe setOf("b1", "b2")
+                // ...and the retry's prune actually evicted the revoked book.
+                db.bookDao().getById(BookId("b1"))!!.deletedAt shouldBe null
+                db.bookDao().getById(BookId("b2"))!!.deletedAt shouldNotBe null
+            }
+        }
+
+        test("coarse requeue: a failed coarse domain triggers ONE follow-up coarse pass that prunes") {
+            withReconcileEngine { harness, db, _ ->
+                val handler = collectionsDomain(db).toHandler(RoomTransactionRunner(db), ClientSyncDomainRegistry())
+                handler.onCatchUpItem(collectionPayload("c1"), isTombstone = false)
+                handler.onCatchUpItem(collectionPayload("c2"), isTombstone = false)
+
+                harness.fakeCatchUp.failNextByDomain["collections"] = 1
+                harness.fakeCatchUp.accessibleByDomain["collections"] = setOf("c1")
+                harness.engine.handleAccessChanged(null)
+
+                // The coarse sweep ran twice for collections (failed pass + retry pass).
+                harness.fakeCatchUp.coarseCalls.count { it == "collections" } shouldBe 2
+                db.collectionDao().getById("c1").shouldNotBeNull()
+                db.collectionDao().getById("c2") shouldBe null
+            }
+        }
+
+        test("delta requeue is bounded: persistent failure stops after ONE retry and a later frame still leads") {
+            withReconcileEngine { harness, db, _ ->
+                val handler =
+                    booksDomain(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                    ).toHandler(transactionRunner = RoomTransactionRunner(db), registry = ClientSyncDomainRegistry())
+                handler.onCatchUpItem(bookPayload("b1"), isTombstone = false)
+
+                // Every attempt fails: leader + exactly one retry, then give up (reconnect backstop owns it).
+                harness.fakeCatchUp.failNextByDomain["books"] = 10
+                harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("b1")))
+                harness.fakeCatchUp.fetches shouldHaveSize 2
+
+                // A fresh frame gets a fresh leader with a fresh retry budget — nothing is wedged.
+                harness.fakeCatchUp.fetches.clear()
+                harness.fakeCatchUp.failNextByDomain.clear()
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
+                harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("b1")))
+                harness.fakeCatchUp.fetches shouldHaveSize 1
+            }
+        }
+
+        test("delta requeue: only the FAILED domain's ids are refetched — the succeeded domain is not") {
+            withReconcileEngine { harness, _, _ ->
+                // collections succeeds; books fails once then succeeds.
+                harness.fakeCatchUp.returnedByDomain["collections"] = setOf("c1")
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("b1")
+                harness.fakeCatchUp.failNextByDomain["books"] = 1
+
+                harness.engine.handleAccessChanged(AccessScope(collectionIds = listOf("c1"), bookIds = listOf("b1")))
+
+                // Pass 1: collections + collection_books + books(FAILED). Pass 2 (requeue): books only.
+                harness.fakeCatchUp.fetches.map { it.domain } shouldBe
+                    listOf("collections", "collection_books", "books", "books")
+            }
+        }
     })
 
 /** A targeted fetch the fake observed, for assertions. */
@@ -476,6 +560,16 @@ private class FakeReconcileCatchUp : CatchUp {
     @Volatile
     var gate: CompletableDeferred<Unit>? = null
 
+    /** Domains whose next N calls (targeted or coarse) fail with a retryable SyncError. Decremented per call. */
+    val failNextByDomain: MutableMap<String, Int> = mutableMapOf()
+
+    private fun consumeFailure(domain: String): Boolean {
+        val remaining = failNextByDomain[domain] ?: return false
+        if (remaining <= 0) return false
+        failNextByDomain[domain] = remaining - 1
+        return true
+    }
+
     override suspend fun <T : Any> catchUp(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
 
     override suspend fun <T : Any> catchUpFromZero(handler: SyncDomainHandler<T>): AppResult<Unit> = AppResult.Success(Unit)
@@ -484,6 +578,7 @@ private class FakeReconcileCatchUp : CatchUp {
 
     override suspend fun <T : Any> catchUpTransient(handler: SyncDomainHandler<T>): AppResult<Set<String>> {
         coarseCalls += handler.domainName
+        if (consumeFailure(handler.domainName)) return AppResult.Failure(SyncError.SyncFailed())
         val ids = accessibleByDomain[handler.domainName] ?: emptySet()
         return AppResult.Success(ids)
     }
@@ -497,6 +592,7 @@ private class FakeReconcileCatchUp : CatchUp {
             gate = null
             it.await()
         }
+        if (consumeFailure(handler.domainName)) return AppResult.Failure(SyncError.SyncFailed())
         val returned = returnedByDomain[handler.domainName] ?: accessibleByDomain[handler.domainName] ?: emptySet()
         return AppResult.Success(returned)
     }


### PR DESCRIPTION
Batch-7 audit — the P1 sync security & correctness cluster. Six plans, each reproduction-first TDD, adversarially code-reviewed (no critical/blocking findings; all six confirmed sound).

### 🔒 087 — tombstone payload leak (top finding, SECURITY)
The access-filtered sync pull delivered tombstones ungated (correct) but **hydrated full payloads** for them — any member's `since=0` pull got complete metadata of DELETED rows they never had access to: private titles/contributors/chapters, deleted-collection names, foreign sharing graph, **deleted admin-roster rows (emails/roles)**, and **folder rows (absolute server paths)**. Fix: `minimizeTombstone` blanks all content for tombstoned rows across all 6 access-filtered domains (junction domain keeps its identity-only key), applied at both `pullSince` and `pullByIds`. Reproduction test proves every field is blanked; client still converges on minimized tombstones.

### 🔒 090 — system-collection share guard (SECURITY)
`shareCollection`/`updateShare`/`revokeShare` lacked the system-collection guard that rename/delete have — so `revokeShare(ALL_BOOKS, member)` permanently deleted the member's default grant, **blanking their whole library**. Fix: reject share mutations on system collections; regression test pins that the default grant survives.

### 🐛 088 — revive orphan-purged parents
`resolveOrCreate` returned orphan-purged tombstoned contributor/series parents inert → a re-added book referenced a permanently hidden parent. Fix: revive-in-place (un-tombstone + bump revision) on a tombstoned dedup hit; live hits stay pure reads.

### 🐛 094 — removal-cascade crash-resume
An interrupted cascade stranded orphan parents forever (capture read live-only junctions, empty once tombstoned). Fix: tombstone-inclusive orphan capture (`tagIdsForBook`/`moodIdsForBook`) so a resumed cascade still purges them; the purge *decision* still uses live-book-count so it can't over-purge. 7 resume tests.

### ⚡ 096 — hoist reconcile lookups (perf)
`reconcileSystemMembership` re-queried loop-invariant system-collection ids per book (~5–6k txns for a 1000-book collection). Hoisted the invariants; behavior identical (lazy ALL_BOOKS creation threaded back into the memo).

### 🐛 101 — AccessChanged delta requeue (client)
The delta drained the pending scope before reconciling and swallowed per-domain fetch failures → a transient blip stranded a revoked book. Fix: report failures via `AccessReconcileOutcome`, re-queue the failed scope once (bounded), then defer to the coarse backstop; can't wedge the mutex; CancellationException propagates.

## Test Plan
- [x] Every plan RED→GREEN (reproduction-first).
- [x] Full Linux `verifyLocal` green (server + client + native + lint).
- [x] Adversarial code-review — no critical/blocking findings; all six confirmed sound, no cross-plan interference.