### PR TITLE
🔒 fix: Batch-7 backup/restore hardening (091, 089, 095)

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/ApplicationStartup.kt
@@ -71,6 +71,13 @@ internal fun Application.startBackgroundTasks(
     val statsFreshnessSweepTask by inject<StatsFreshnessSweepTask>()
     statsFreshnessSweepTask.start(scope)
 
+    // Heal any ABS import whose apply was interrupted by a crash: re-running is idempotent and
+    // restores stats + the client nudge. A path-less boot is a no-op (the imports dir is absent).
+    // Never fatal to startup.
+    scope.launchNeverFatal("interrupted-import resume failed") {
+        koinGet<com.calypsan.listenup.server.absimport.InterruptedImportResumer>().resumeAll()
+    }
+
     val rescanOnStartup = environment.config.rescanOnStartup()
     scope.launch {
         runCatching {
@@ -119,6 +126,21 @@ internal fun Application.startBackgroundTasks(
                 logger.warn(e) { "mDNS advertisement failed to start — server keeps running" }
             }
         }
+    }
+}
+
+/**
+ * Launches [task] as a fire-and-forget startup job that must never break server boot: any
+ * non-cancellation failure is logged (prefixed with [description]) and swallowed.
+ * [kotlinx.coroutines.CancellationException] is re-raised to honor structured concurrency.
+ */
+private fun CoroutineScope.launchNeverFatal(
+    description: String,
+    task: suspend () -> Unit,
+) = launch {
+    runCatching { task() }.onFailure { e ->
+        if (e is kotlinx.coroutines.CancellationException) throw e
+        logger.error(e) { "$description — server keeps running" }
     }
 }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
@@ -57,6 +57,11 @@ private val logger = loggerFor<ImportApplier>()
  * history). Re-applying the same import therefore produces no duplicate events and leaves stats
  * unchanged.
  *
+ * **Interrupted applies self-heal.** Apply persists an `.applying` marker before writing any row;
+ * a crash or failure mid-burst leaves that marker without the completion `.applied` marker. At
+ * server boot [InterruptedImportResumer] re-runs every such import — idempotency makes the re-run
+ * converge the partial state (rows complete, stats recompute, clients get the owed nudge).
+ *
  * Unmapped users and unresolved items are **skipped, not errored** — a partial library overlap is
  * the normal case, not a failure. A mapped user's books that aren't in this library are surfaced
  * as [ImportResult.booksNotInLibrary]; unmapped-user history is excluded by the admin, not counted.
@@ -92,6 +97,13 @@ class ImportApplier internal constructor(
                     ?: return@withContext AppResult.Failure(
                         ImportError.ApplyFailed(debugInfo = "No confirmed mapping for import ${importId.value}."),
                     )
+
+            // Record that writing is about to start — after the guards (so a never-analyzed /
+            // never-mapped import can never be flagged interrupted) and before any DB write or the
+            // backup read (so even a read crash is re-driven at boot). The marker persists across a
+            // crash or failure and is only cleared by markApplied, so ".applying without .applied"
+            // is the durable signature of an interrupted apply.
+            store.markApplying(importId)
 
             try {
                 val effectiveBooks = effectiveBookMap(resolved.itemMatches, mapping.bookOverrides)

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportApplier.kt
@@ -98,14 +98,15 @@ class ImportApplier internal constructor(
                         ImportError.ApplyFailed(debugInfo = "No confirmed mapping for import ${importId.value}."),
                     )
 
-            // Record that writing is about to start — after the guards (so a never-analyzed /
-            // never-mapped import can never be flagged interrupted) and before any DB write or the
-            // backup read (so even a read crash is re-driven at boot). The marker persists across a
-            // crash or failure and is only cleared by markApplied, so ".applying without .applied"
-            // is the durable signature of an interrupted apply.
-            store.markApplying(importId)
-
             try {
+                // Record that writing is about to start — after the guards (so a never-analyzed /
+                // never-mapped import can never be flagged interrupted) and before any DB write or the
+                // backup read (so even a read crash is re-driven at boot). Inside the try so a
+                // marker-write failure surfaces as a typed ApplyFailed, not an escaping throwable. The
+                // marker persists across a crash or failure and is only cleared by markApplied, so
+                // ".applying without .applied" is the durable signature of an interrupted apply.
+                store.markApplying(importId)
+
                 val effectiveBooks = effectiveBookMap(resolved.itemMatches, mapping.bookOverrides)
                 val (progress, sessions) =
                     reader

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportPaths.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportPaths.kt
@@ -42,6 +42,9 @@ class ImportPaths(
     /** The marker file written once apply has completed for the import [id]. */
     fun appliedMarkerFor(id: String): Path = Path(dirFor(id), ".applied")
 
+    /** Marker touched when apply starts writing; cleared by a successful apply (see ImportStore). */
+    fun applyingMarkerFor(id: String): Path = Path(dirFor(id), ".applying")
+
     /** The small upload-time metadata sidecar (`meta.json`) for the import [id]. */
     fun metaFor(id: String): Path = Path(dirFor(id), "meta.json")
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportStore.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/ImportStore.kt
@@ -27,7 +27,8 @@ import kotlinx.serialization.json.Json
  * files present in its working directory under [ImportPaths.dirFor]. [ImportStore] is the single
  * place that reads and writes those files — enumerating jobs, deriving their
  * [ImportStatus] from which staging files exist, and persisting/reading the
- * `analysis.json` and `mapping.json` sidecars.
+ * `analysis.json` and `mapping.json` sidecars. It also owns the `.applying`/`.applied`
+ * apply markers, whose combination detects an interrupted apply (see [hasInterruptedApply]).
  *
  * All file I/O runs on [fileIoDispatcher].
  */
@@ -108,10 +109,52 @@ class ImportStore(
             if (SystemFileSystem.exists(file)) json.decodeFromString<StoredMapping>(file.readText()) else null
         }
 
-    /** Touches the `.applied` marker, recording that apply has completed for [id]. */
+    /**
+     * Touches the `.applying` marker, recording that apply has started writing rows for [id]. A
+     * marker that persists without `.applied` means an apply was interrupted (crash or failure)
+     * after possibly committing partial rows — see [hasInterruptedApply] and
+     * [InterruptedImportResumer].
+     */
+    suspend fun markApplying(id: ImportId) =
+        onIo {
+            paths.applyingMarkerFor(id.value).writeText("")
+        }
+
+    /**
+     * Touches the `.applied` marker, recording that apply has completed for [id], and clears the
+     * in-flight `.applying` marker so a completed import can never look interrupted.
+     */
     suspend fun markApplied(id: ImportId) =
         onIo {
             paths.appliedMarkerFor(id.value).writeText("")
+            SystemFileSystem.delete(paths.applyingMarkerFor(id.value), mustExist = false)
+        }
+
+    /**
+     * True when an apply started for [id] but never completed: the `.applying` marker exists and
+     * `.applied` does not. Partial rows may be committed and per-user stats may be stale until the
+     * apply is re-run (idempotent).
+     */
+    suspend fun hasInterruptedApply(id: ImportId): Boolean =
+        onIo {
+            SystemFileSystem.exists(paths.applyingMarkerFor(id.value)) &&
+                !SystemFileSystem.exists(paths.appliedMarkerFor(id.value))
+        }
+
+    /** Every staged import whose apply was interrupted (see [hasInterruptedApply]). */
+    suspend fun listInterruptedApplies(): List<ImportId> =
+        onIo {
+            val root = paths.importsDir
+            if (!SystemFileSystem.exists(root)) return@onIo emptyList()
+            SystemFileSystem
+                .list(root)
+                .filter { entry ->
+                    SystemFileSystem.metadataOrNull(entry)?.isDirectory == true && entry.name != paths.tmpDir.name
+                }.map { ImportId(it.name) }
+                .filter { id ->
+                    SystemFileSystem.exists(paths.applyingMarkerFor(id.value)) &&
+                        !SystemFileSystem.exists(paths.appliedMarkerFor(id.value))
+                }
         }
 
     /** Derives the lifecycle status of [id] from which staging files exist. */

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/InterruptedImportResumer.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/absimport/InterruptedImportResumer.kt
@@ -1,0 +1,49 @@
+package com.calypsan.listenup.server.absimport
+
+import com.calypsan.listenup.api.dto.imports.ImportEvent
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.server.logging.loggerFor
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+private val logger = loggerFor<InterruptedImportResumer>()
+
+/**
+ * Boot-time healer for ABS imports whose apply was interrupted (server crash or failure mid-burst):
+ * any import directory carrying an `.applying` marker without `.applied` is re-applied. Apply is
+ * idempotent (stable session ids, last-played-wins positions, full-history stats recompute — see
+ * [ImportApplier]), so re-running converges the partial state: rows complete, stats recompute,
+ * `.applied` lands, and connected clients get the LibraryDataChanged nudge they were owed.
+ *
+ * Failures are logged and skipped — one attempt per boot, never fatal to startup. Progress events go
+ * to the shared import event bus, mirroring
+ * [com.calypsan.listenup.server.api.ImportServiceImpl.apply].
+ */
+class InterruptedImportResumer(
+    private val store: ImportStore,
+    private val applier: ImportApplier,
+    private val eventBus: MutableSharedFlow<ImportEvent>,
+) {
+    /** Re-applies every interrupted import. Returns the ids it attempted. */
+    suspend fun resumeAll(): List<String> {
+        val interrupted = store.listInterruptedApplies()
+        if (interrupted.isEmpty()) return emptyList()
+        logger.warn { "found ${interrupted.size} interrupted import apply(s) — resuming" }
+        return interrupted.map { id ->
+            when (val result = applier.apply(id) { eventBus.tryEmit(it) }) {
+                is AppResult.Success -> {
+                    logger.info {
+                        "resumed interrupted import ${id.value}: " +
+                            "${result.data.importedCount} positions, ${result.data.sessionsImported} sessions"
+                    }
+                }
+
+                is AppResult.Failure -> {
+                    logger.error {
+                        "resume of interrupted import ${id.value} failed (${result.error.code}) — will retry next boot"
+                    }
+                }
+            }
+            id.value
+        }
+    }
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BackupServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/BackupServiceImpl.kt
@@ -14,6 +14,7 @@ import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.backup.BackupArchive
 import com.calypsan.listenup.server.backup.BackupPaths
 import com.calypsan.listenup.server.backup.RestoreOrchestrator
+import com.calypsan.listenup.server.backup.isSafeBackupId
 import com.calypsan.listenup.server.io.fileIoDispatcher
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -84,6 +85,9 @@ class BackupServiceImpl(
     override suspend fun getBackup(id: BackupId): AppResult<BackupSummary> {
         requireAdmin()?.let { return it }
         return withContext(fileIoDispatcher) {
+            if (!isSafeBackupId(id.value)) {
+                return@withContext AppResult.Failure(BackupError.BackupNotFound())
+            }
             val archivePath = paths.archiveFor(id.value)
             if (!SystemFileSystem.exists(archivePath)) {
                 return@withContext AppResult.Failure(BackupError.BackupNotFound())
@@ -95,6 +99,9 @@ class BackupServiceImpl(
     override suspend fun deleteBackup(id: BackupId): AppResult<Unit> {
         requireAdmin()?.let { return it }
         return withContext(fileIoDispatcher) {
+            if (!isSafeBackupId(id.value)) {
+                return@withContext AppResult.Failure(BackupError.BackupNotFound())
+            }
             val archivePath = paths.archiveFor(id.value)
             val existed = SystemFileSystem.exists(archivePath)
             SystemFileSystem.delete(archivePath, mustExist = false)
@@ -108,6 +115,7 @@ class BackupServiceImpl(
 
     override suspend fun restoreBackup(id: BackupId): AppResult<RestoreResult> {
         requireAdmin()?.let { return it }
+        if (!isSafeBackupId(id.value)) return AppResult.Failure(BackupError.BackupNotFound())
         return restoreOrchestrator.restore(id)
     }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/BackupPaths.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/BackupPaths.kt
@@ -50,3 +50,17 @@ class BackupPaths(
         }
     }
 }
+
+/**
+ * True when [id] is safe to use as a backup archive filename stem: non-blank, and free of
+ * path separators (`/`, `\`) and `..` traversal sequences. Checked before any filesystem
+ * access so a caller-supplied backup id cannot escape the backups directory. Shared by the
+ * REST download route and the RPC [com.calypsan.listenup.server.api.BackupServiceImpl] methods
+ * so both surfaces reject identical input.
+ */
+fun isSafeBackupId(id: String): Boolean {
+    if (id.isBlank()) return false
+    if (id.contains('/') || id.contains('\\')) return false
+    if (id.contains("..")) return false
+    return true
+}

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/RestoreOrchestrator.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/backup/RestoreOrchestrator.kt
@@ -4,12 +4,14 @@ import com.calypsan.listenup.api.dto.backup.BackupEvent
 import com.calypsan.listenup.api.dto.backup.RestoreResult
 import com.calypsan.listenup.api.error.BackupError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.core.BackupId
 import com.calypsan.listenup.server.db.DatabaseHandle
 import com.calypsan.listenup.server.io.copyDirectoryRecursively
 import com.calypsan.listenup.server.io.deleteRecursively
 import com.calypsan.listenup.server.io.fileIoDispatcher
 import com.calypsan.listenup.server.logging.loggerFor
+import com.calypsan.listenup.server.sync.ChangeBus
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -34,6 +36,7 @@ class RestoreOrchestrator(
     private val dbHandle: DatabaseHandle,
     private val maintenance: MaintenanceState,
     private val eventBus: MutableSharedFlow<BackupEvent>,
+    private val changeBus: ChangeBus,
 ) {
     suspend fun restore(id: BackupId): AppResult<RestoreResult> =
         withContext(fileIoDispatcher) {
@@ -101,6 +104,13 @@ class RestoreOrchestrator(
                         val migratedTo = dbHandle.migrate() ?: manifest.schemaVersion
 
                         eventBus.tryEmit(BackupEvent.RestoreComplete(manifest.includesImages))
+
+                        // The DB was swapped wholesale; connected devices' cursors are AHEAD of the
+                        // restored revision counter, so neither forward catch-up nor CursorStale can
+                        // see the change. Broadcast the digest-reconcile accelerator so every
+                        // connected client re-derives, exactly like ImportApplier's bulk path.
+                        changeBus.broadcastControl(SyncControl.LibraryDataChanged)
+
                         deleteRecursively(paths.rollbackDir)
                         deleteRecursively(paths.stagingDir)
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BackupModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/BackupModule.kt
@@ -31,6 +31,9 @@ import org.koin.dsl.module
  *
  * The [InstanceIdentity] is resolved from the mDNS module (mdnsModule must be
  * installed in the same Koin container). [DatabaseHandle] is resolved from [authModule].
+ * The [com.calypsan.listenup.server.sync.ChangeBus] singleton — resolved from `syncModule`
+ * — is threaded into [RestoreOrchestrator] so a completed restore broadcasts a
+ * re-baseline nudge to every connected device.
  */
 fun backupModule(
     homeDir: Path,
@@ -85,6 +88,7 @@ fun backupModule(
                 dbHandle = get(),
                 maintenance = get(),
                 eventBus = get(EventBusQualifiers.BackupEvents),
+                changeBus = get(),
             )
         }
 

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ImportModule.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/di/ImportModule.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.server.absimport.ImportAnalyzer
 import com.calypsan.listenup.server.absimport.ImportApplier
 import com.calypsan.listenup.server.absimport.ImportPaths
 import com.calypsan.listenup.server.absimport.ImportStore
+import com.calypsan.listenup.server.absimport.InterruptedImportResumer
 import com.calypsan.listenup.server.absimport.MappingValidator
 import com.calypsan.listenup.server.absimport.SessionConverter
 import com.calypsan.listenup.server.absimport.UserMatcher
@@ -32,6 +33,7 @@ import org.koin.dsl.module
  *  - [ImportApplier] — write listening progress + sessions, then recompute per-user stats via
  *    [com.calypsan.listenup.server.services.StatsRecorder].
  *  - [MutableSharedFlow]<[ImportEvent]> — process-wide progress event bus.
+ *  - [InterruptedImportResumer] — boot-time healer that re-applies any import interrupted mid-burst.
  *  - [ImportService] / [ImportServiceImpl] — admin-only RPC surface.
  *
  * [com.calypsan.listenup.server.db.DatabaseHandle], [com.calypsan.listenup.server.services.LibraryRegistry],
@@ -79,6 +81,14 @@ fun importModule(homeDir: Path): Module =
         // MutableSharedFlow<ImportEvent> would collide with the scan/backup event buses.
         single<MutableSharedFlow<ImportEvent>>(EventBusQualifiers.ImportEvents) {
             MutableSharedFlow(replay = 0, extraBufferCapacity = 64)
+        }
+
+        single {
+            InterruptedImportResumer(
+                store = get(),
+                applier = get(),
+                eventBus = get(EventBusQualifiers.ImportEvents),
+            )
         }
 
         single<ImportService> {

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/BackupRoutes.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/routes/BackupRoutes.kt
@@ -10,6 +10,7 @@ import com.calypsan.listenup.core.BackupId
 import com.calypsan.listenup.server.backup.BackupArchive
 import com.calypsan.listenup.server.backup.BackupManifest
 import com.calypsan.listenup.server.backup.BackupPaths
+import com.calypsan.listenup.server.backup.isSafeBackupId
 import com.calypsan.listenup.server.io.createTempFileIn
 import com.calypsan.listenup.server.io.respondSeekable
 import com.calypsan.listenup.server.io.streamFirstFilePartTo
@@ -76,7 +77,7 @@ fun Route.backupRoutes(
 
         val rawId = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
         // Reject ids containing path separators or traversal sequences before doing any I/O.
-        if (!rawId.isSafeBackupId()) {
+        if (!isSafeBackupId(rawId)) {
             return@get call.respond(HttpStatusCode.BadRequest, "invalid backup id")
         }
 
@@ -166,18 +167,6 @@ private suspend fun ApplicationCall.validateUpload(
         respondBareAppError(BackupError.CorruptArchive(debugInfo = e.message))
         null
     }
-
-/**
- * Returns true if [this] string is safe to use as a backup archive filename stem: no path
- * separators, no `..` traversal sequences, and non-blank. This is checked before any file
- * I/O to rule out path-traversal attacks at the earliest possible point.
- */
-private fun String.isSafeBackupId(): Boolean {
-    if (isBlank()) return false
-    if (contains('/') || contains('\\')) return false
-    if (contains("..")) return false
-    return true
-}
 
 /**
  * Derives a filesystem-safe backup id from the manifest's [BackupManifest.createdAt] epoch-

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/absimport/ImportApplierTest.kt
@@ -1,6 +1,8 @@
 package com.calypsan.listenup.server.absimport
 
 import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.imports.ImportEvent
+import com.calypsan.listenup.api.dto.imports.ImportStatus
 import com.calypsan.listenup.api.error.ImportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.sync.SyncControl
@@ -33,6 +35,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -458,6 +461,136 @@ class ImportApplierTest :
                             bookOverrides = mapOf(AbsItemId("book-1") to BookId(LU_KINGS)),
                         )
                     error.shouldBeNull()
+                }
+            }
+        }
+
+        test("an interrupted apply is detectable and a re-apply converges it") {
+            withSqlDatabase {
+                val dbs = this
+                runTest {
+                    val staged = stageAnalyzedImport(dbs)
+                    val applier = applierFor(staged)
+                    confirmSimonMapping(staged.paths, staged.importId)
+                    val store = ImportStore(staged.paths)
+
+                    // Inject a mid-burst failure: throw on the FIRST Applying event only. The catch
+                    // path re-invokes onEvent with ImportEvent.Failed, so a throw-always callback
+                    // would explode inside the catch block; the single-shot guard leaves ≥1 row
+                    // committed with the burst aborted — a true partial state, no mocks.
+                    var thrown = false
+                    val result =
+                        applier.apply(staged.importId) { event ->
+                            if (event is ImportEvent.Applying && !thrown) {
+                                thrown = true
+                                throw IllegalStateException("simulated crash mid-apply")
+                            }
+                        }
+                    result.shouldBeInstanceOf<AppResult.Failure>()
+
+                    // Partial state: rows committed, but the import is not marked applied.
+                    store.statusOf(staged.importId) shouldBe ImportStatus.MAPPED
+                    store.hasInterruptedApply(staged.importId) shouldBe true
+
+                    // Re-apply with a normal sink: converges.
+                    val second = applier.apply(staged.importId) {}
+                    second.shouldBeInstanceOf<AppResult.Success<*>>()
+                    store.statusOf(staged.importId) shouldBe ImportStatus.APPLIED
+                    store.hasInterruptedApply(staged.importId) shouldBe false
+                    staged.repo
+                        .getPosition(LU_USER, LU_KINGS)
+                        .shouldNotBeNull()
+                        .finished shouldBe true
+                    staged.statsRepo
+                        .getForUser(LU_USER)
+                        .shouldNotBeNull()
+                        .totalSecondsAllTime shouldBe 5_460L
+                }
+            }
+        }
+
+        test("a successful apply leaves no interrupted-apply marker") {
+            withSqlDatabase {
+                val dbs = this
+                runTest {
+                    val staged = stageAnalyzedImport(dbs)
+                    val applier = applierFor(staged)
+                    confirmSimonMapping(staged.paths, staged.importId)
+                    val store = ImportStore(staged.paths)
+
+                    applier.apply(staged.importId) {}
+
+                    store.hasInterruptedApply(staged.importId) shouldBe false
+                    store.statusOf(staged.importId) shouldBe ImportStatus.APPLIED
+                }
+            }
+        }
+
+        test("boot-time resume converges an interrupted apply: applied, stats, broadcast") {
+            withSqlDatabase {
+                val dbs = this
+                runTest(UnconfinedTestDispatcher()) {
+                    val staged = stageAnalyzedImport(dbs)
+                    val applier = applierFor(staged)
+                    confirmSimonMapping(staged.paths, staged.importId)
+                    val store = ImportStore(staged.paths)
+
+                    // Interrupt the first apply (same seam as the detection test).
+                    var thrown = false
+                    applier.apply(staged.importId) { event ->
+                        if (event is ImportEvent.Applying && !thrown) {
+                            thrown = true
+                            throw IllegalStateException("boom")
+                        }
+                    }
+                    store.hasInterruptedApply(staged.importId) shouldBe true
+
+                    // Collect control frames like the existing LibraryDataChanged test.
+                    val frames = mutableListOf<ControlFrame>()
+                    staged.bus
+                        .subscribeControl()
+                        .onEach { frames += it }
+                        .launchIn(backgroundScope)
+                    repeat(8) { yield() } // ensure the collector is subscribed before resume publishes
+
+                    val resumer =
+                        InterruptedImportResumer(
+                            store = store,
+                            applier = applier,
+                            eventBus = MutableSharedFlow(extraBufferCapacity = 64),
+                        )
+                    resumer.resumeAll() shouldBe listOf(staged.importId.value)
+                    repeat(8) { yield() } // let the post-apply broadcast drain to the collector
+
+                    store.statusOf(staged.importId) shouldBe ImportStatus.APPLIED
+                    store.hasInterruptedApply(staged.importId) shouldBe false
+                    staged.statsRepo
+                        .getForUser(LU_USER)
+                        .shouldNotBeNull()
+                        .totalSecondsAllTime shouldBe 5_460L
+                    frames.map { it.control } shouldContain SyncControl.LibraryDataChanged
+                }
+            }
+        }
+
+        test("resumer is a no-op when nothing was interrupted") {
+            withSqlDatabase {
+                val dbs = this
+                runTest {
+                    val staged = stageAnalyzedImport(dbs)
+                    confirmSimonMapping(staged.paths, staged.importId)
+                    val store = ImportStore(staged.paths)
+
+                    // Mapped but never applied → no `.applying` marker exists to heal.
+                    val resumer =
+                        InterruptedImportResumer(
+                            store = store,
+                            applier = applierFor(staged),
+                            eventBus = MutableSharedFlow(extraBufferCapacity = 64),
+                        )
+                    resumer.resumeAll() shouldBe emptyList<String>()
+                    store.statusOf(staged.importId) shouldBe ImportStatus.MAPPED
+                    staged.repo.getPosition(LU_USER, LU_KINGS).shouldBeNull()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BackupServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BackupServiceTest.kt
@@ -18,6 +18,7 @@ import com.calypsan.listenup.server.backup.RestoreOrchestrator
 import com.calypsan.listenup.server.backup.backupTestFixture
 import com.calypsan.listenup.server.backup.execSql
 import com.calypsan.listenup.server.backup.queryScalarInt
+import com.calypsan.listenup.server.sync.ChangeBus
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -65,6 +66,7 @@ class BackupServiceTest :
                     dbHandle = fixture.handle,
                     maintenance = maintenance,
                     eventBus = eventBus,
+                    changeBus = ChangeBus(),
                 )
             return BackupServiceImpl(
                 paths = fixture.paths,
@@ -181,6 +183,7 @@ class BackupServiceTest :
                             dbHandle = fixture.handle,
                             maintenance = maintenance,
                             eventBus = eventBus,
+                            changeBus = ChangeBus(),
                         )
                     val svc =
                         BackupServiceImpl(
@@ -214,6 +217,7 @@ class BackupServiceTest :
                             dbHandle = fixture.handle,
                             maintenance = maintenance,
                             eventBus = eventBus,
+                            changeBus = ChangeBus(),
                         )
                     val svc =
                         BackupServiceImpl(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BackupServiceTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/BackupServiceTest.kt
@@ -6,8 +6,10 @@ import com.calypsan.listenup.api.dto.auth.UserRole
 import com.calypsan.listenup.api.dto.backup.BackupEvent
 import com.calypsan.listenup.api.dto.backup.BackupSummary
 import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.BackupError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.streaming.RpcEvent
+import com.calypsan.listenup.core.BackupId
 import com.calypsan.listenup.server.auth.PrincipalProvider
 import com.calypsan.listenup.server.auth.UserPrincipal
 import com.calypsan.listenup.server.backup.BackupTestFixture
@@ -25,6 +27,8 @@ import app.cash.turbine.test
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.buffered
+import kotlinx.io.files.SystemFileSystem
 
 /**
  * Happy-path tests for [BackupServiceImpl].
@@ -223,6 +227,43 @@ class BackupServiceTest :
                     // emptyFlow() completes immediately — toList() returns [] without blocking
                     val events = svc.observeProgress().toList()
                     events.shouldBeEmpty()
+                }
+            }
+        }
+
+        test("deleteBackup rejects a path-traversal id and does not delete files outside backupsDir") {
+            runTest {
+                backupTestFixture(withImages = false).use { fixture ->
+                    val svc = buildService(fixture, rootPrincipalProvider())
+
+                    // A traversal id `../secret` resolves via archiveFor to
+                    // <homeDir>/backups/../secret.listenup.zip == <homeDir>/secret.listenup.zip,
+                    // i.e. OUTSIDE backupsDir. Plant a sentinel there.
+                    val sentinel = fixture.paths.archiveFor("../secret")
+                    SystemFileSystem.createDirectories(fixture.paths.backupsDir)
+                    SystemFileSystem.sink(sentinel).buffered().use { it.write(byteArrayOf(1, 2, 3)) }
+
+                    val result = svc.deleteBackup(BackupId("../secret"))
+
+                    // Secure behaviour: typed failure, and the sentinel survives.
+                    result
+                        .shouldBeInstanceOf<AppResult.Failure>()
+                        .error
+                        .shouldBeInstanceOf<BackupError.BackupNotFound>()
+                    SystemFileSystem.exists(sentinel) shouldBe true
+                }
+            }
+        }
+
+        test("getBackup rejects a path-traversal id with BackupNotFound") {
+            runTest {
+                backupTestFixture(withImages = false).use { fixture ->
+                    val svc = buildService(fixture, rootPrincipalProvider())
+                    svc
+                        .getBackup(BackupId("../secret"))
+                        .shouldBeInstanceOf<AppResult.Failure>()
+                        .error
+                        .shouldBeInstanceOf<BackupError.BackupNotFound>()
                 }
             }
         }

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/RestoreBroadcastE2ETest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/RestoreBroadcastE2ETest.kt
@@ -1,0 +1,158 @@
+package com.calypsan.listenup.server.backup
+
+import com.calypsan.listenup.api.BackupService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.AuthSession
+import com.calypsan.listenup.api.dto.auth.RegisterRequest
+import com.calypsan.listenup.api.dto.backup.BackupSummary
+import com.calypsan.listenup.api.dto.backup.RestoreResult
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncControl
+import com.calypsan.listenup.server.module
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.client.rpcConfig
+import kotlinx.rpc.krpc.serialization.json.json as krpcJson
+import kotlinx.rpc.withService
+
+/**
+ * Cross-device E2E for the restore re-baseline broadcast (Plan 089).
+ *
+ * WHY this exists: a restore swaps the server's entire SQLite DB in-process. The admin device
+ * that triggered the restore resyncs explicitly, but *every other connected device* used to get
+ * no signal at all — the orchestrator emitted only backup-progress events (admin-only) and never
+ * touched the cross-domain sync firehose. Those devices hold cursors AHEAD of the rewound
+ * revision counter, so neither forward catch-up nor `CursorStale` fires, and they silently
+ * diverge until a lucky reconnect. The fix broadcasts `SyncControl.LibraryDataChanged` on the
+ * firehose after a successful restore, so a second device re-derives live.
+ *
+ * This test pins the SERVER half end-to-end: a second device's open `GET /api/v1/sync/events`
+ * session receives the `LibraryDataChanged` control frame when an admin-triggered restore
+ * completes against the full server module. The client-side reaction to that frame
+ * (`lifecycleReconcile(force = true)` → digest reconcile) is already pinned by
+ * `SyncEventDispatcherTest` and the digest-convergence E2Es — that half is out of scope here.
+ *
+ * Timing note: the open SSE session counts as an in-flight request, so the restore stalls the
+ * full ~10 s `MaintenanceState.drain()` timeout before swapping the DB. The 30 s await budgets
+ * for that stall.
+ */
+class RestoreBroadcastE2ETest :
+    FunSpec({
+
+        test("a connected firehose subscriber receives LibraryDataChanged when a restore completes") {
+            val serverHomeDir = Files.createTempDirectory("restore-broadcast-e2e-")
+            try {
+                testApplication {
+                    environment {
+                        val tmpDb =
+                            Files
+                                .createTempFile("restore-broadcast-e2e-", ".db")
+                                .toFile()
+                                .apply { deleteOnExit() }
+                        val libDir = Files.createTempDirectory("restore-broadcast-e2e-lib-")
+                        config =
+                            MapApplicationConfig(
+                                "database.jdbcUrl" to "jdbc:sqlite:${tmpDb.absolutePath}",
+                                "auth.refreshPepper" to "x".repeat(32),
+                                "jwt.secret" to "x".repeat(32),
+                                "jwt.issuer" to "listenup",
+                                "jwt.audience" to "listenup-client",
+                                "registration.policy" to "OPEN",
+                                "mdns.enabled" to "false",
+                                "listenup.home" to serverHomeDir.toString(),
+                                "scanner.libraryPath" to libDir.toString(),
+                            )
+                    }
+                    application { module() }
+
+                    val restClient = createClient { install(ContentNegotiation) { json(contractJson) } }
+                    val accessToken = restClient.setupRoot()
+
+                    // Admin device: open a BackupService RPC proxy and create a backup to restore.
+                    val rpcClient = createClient { installKrpc() }
+                    val backupService =
+                        rpcClient
+                            .rpc("ws://localhost/api/rpc/authed") {
+                                rpcConfig { serialization { krpcJson(contractJson) } }
+                                bearerAuth(accessToken)
+                            }.withService<BackupService>()
+
+                    val summary =
+                        backupService
+                            .createBackup(includeImages = false)
+                            .shouldBeInstanceOf<AppResult.Success<BackupSummary>>()
+                            .data
+
+                    // Device B: subscribe to the firehose BEFORE the restore, then trigger the restore
+                    // from inside the session so the collector and the restore run concurrently.
+                    val sseClient = createClient { install(SSE) }
+                    sseClient.sse("/api/v1/sync/events", request = { bearerAuth(accessToken) }) {
+                        coroutineScope {
+                            val controlFrame =
+                                async {
+                                    incoming.first { frame ->
+                                        frame.event == "control" &&
+                                            frame.data?.let {
+                                                runCatching {
+                                                    contractJson.decodeFromString(SyncControl.serializer(), it)
+                                                }.getOrNull()
+                                            } is SyncControl.LibraryDataChanged
+                                    }
+                                }
+
+                            // Let the server-side firehose control-subscriber register before the
+                            // restore emits — the control channel has replay = 0, so a broadcast
+                            // emitted before subscription would be missed.
+                            delay(500)
+
+                            backupService
+                                .restoreBackup(summary.id)
+                                .shouldBeInstanceOf<AppResult.Success<RestoreResult>>()
+
+                            // The 30 s budget covers the ~10 s drain stall (the open SSE session
+                            // counts as in-flight) before the swap + broadcast.
+                            val frame = withTimeout(30_000) { controlFrame.await() }
+                            frame.event shouldBe "control"
+                        }
+                    }
+                }
+            } finally {
+                serverHomeDir.toFile().deleteRecursively()
+            }
+        }
+    })
+
+/**
+ * Registers the first user as ROOT via `/api/v1/auth/setup` and returns the access token.
+ * Mirrors the `setupRootForBackup` helper in `BackupUploadRestoreE2ETest`.
+ */
+private suspend fun HttpClient.setupRoot(): String {
+    val result =
+        post("/api/v1/auth/setup") {
+            contentType(ContentType.Application.Json)
+            setBody(RegisterRequest(email = "root@restore-broadcast.test", password = "password1234", displayName = "Root"))
+        }.body<AppResult<AuthSession>>()
+    return (result as AppResult.Success<AuthSession>).data.accessToken.value
+}

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/RestoreOrchestratorTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/backup/RestoreOrchestratorTest.kt
@@ -4,14 +4,21 @@ import com.calypsan.listenup.api.dto.backup.BackupEvent
 import com.calypsan.listenup.api.dto.backup.RestoreResult
 import com.calypsan.listenup.api.error.BackupError
 import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.SyncControl
 import com.calypsan.listenup.core.BackupId
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.ControlFrame
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
@@ -35,6 +42,7 @@ class RestoreOrchestratorTest :
             fixture: BackupTestFixture,
             maintenance: MaintenanceState = MaintenanceState(),
             eventBus: MutableSharedFlow<BackupEvent> = MutableSharedFlow(extraBufferCapacity = 64),
+            changeBus: ChangeBus = ChangeBus(),
         ): RestoreOrchestrator =
             RestoreOrchestrator(
                 paths = fixture.paths,
@@ -42,6 +50,7 @@ class RestoreOrchestratorTest :
                 dbHandle = fixture.handle,
                 maintenance = maintenance,
                 eventBus = eventBus,
+                changeBus = changeBus,
             )
 
         test("round-trip restore: db returns to pre-backup state after restore") {
@@ -71,6 +80,38 @@ class RestoreOrchestratorTest :
 
                     // row A is back, row B is gone
                     fixture.handle.queryScalarString("SELECT v FROM restore_test") shouldBe "row-A"
+                }
+            }
+        }
+
+        test("successful restore broadcasts SyncControl.LibraryDataChanged to the firehose") {
+            runTest {
+                backupTestFixture(withImages = false).use { fixture ->
+                    // Subscribe BEFORE the restore: the control channel has replay = 0, so a frame
+                    // emitted before subscription would be missed. UNDISPATCHED runs the collector
+                    // up to its first suspension (the subscribe) synchronously, guaranteeing it is
+                    // registered on the bus before restore emits.
+                    val changeBus = ChangeBus()
+                    val received = mutableListOf<ControlFrame>()
+                    val collector =
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            changeBus.subscribeControl().toList(received)
+                        }
+
+                    fixture.handle.execSql(
+                        "CREATE TABLE IF NOT EXISTS restore_test(v TEXT)",
+                        "INSERT INTO restore_test(v) VALUES ('row-A')",
+                    )
+                    fixture.archive.create("bcast1", includeImages = false, onEvent = {})
+
+                    val orchestrator = buildOrchestrator(fixture, changeBus = changeBus)
+                    orchestrator
+                        .restore(BackupId("bcast1"))
+                        .shouldBeInstanceOf<AppResult.Success<RestoreResult>>()
+
+                    testScheduler.advanceUntilIdle()
+                    received shouldBe listOf(ControlFrame(SyncControl.LibraryDataChanged, ChangeBus.BROADCAST))
+                    collector.cancel()
                 }
             }
         }
@@ -136,6 +177,66 @@ class RestoreOrchestratorTest :
                     // Connections must be resumed: a normal DB query must work, and row B is still there
                     // (rollback restored the original db).
                     fixture.handle.queryScalarString("SELECT v FROM rollback_test") shouldBe "row-B"
+                }
+            }
+        }
+
+        test("rolled-back restore does not broadcast: the DB is back to its pre-restore state") {
+            runTest {
+                backupTestFixture(withImages = false).use { fixture ->
+                    val changeBus = ChangeBus()
+                    val received = mutableListOf<ControlFrame>()
+                    val collector =
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            changeBus.subscribeControl().toList(received)
+                        }
+
+                    fixture.handle.execSql(
+                        "CREATE TABLE IF NOT EXISTS no_bcast_test(v TEXT)",
+                        "INSERT INTO no_bcast_test(v) VALUES ('row-B')",
+                    )
+
+                    // Malicious archive: garbage db bytes with a matching checksum (validate passes)
+                    // and schemaVersion "0" (not rejected as incompatible), so the swap fails and the
+                    // orchestrator rolls back — the rollback path must NOT broadcast.
+                    val garbageBytes = "not-a-sqlite-database-at-all".toByteArray()
+                    val manifest =
+                        BackupManifest(
+                            formatVersion = BackupManifest.FORMAT_VERSION,
+                            serverId = "srv-test",
+                            createdAt = System.currentTimeMillis(),
+                            appVersion = "0.0.0-test",
+                            schemaVersion = "0",
+                            includesImages = false,
+                            checksums = mapOf("db" to sha256OfBytes(garbageBytes)),
+                            bookCount = 0,
+                            userCount = 0,
+                        )
+                    fixture.paths.ensureDirs()
+                    val archivePath = fixture.paths.archiveFor("no-bcast1")
+                    ZipOutputStream(
+                        Files.newOutputStream(
+                            java.nio.file.Path
+                                .of(archivePath.toString()),
+                        ),
+                    ).use { zip ->
+                        zip.putNextEntry(ZipEntry("listenup.db"))
+                        zip.write(garbageBytes)
+                        zip.closeEntry()
+                        zip.putNextEntry(ZipEntry("manifest.json"))
+                        zip.write(manifest.toJson().toByteArray())
+                        zip.closeEntry()
+                    }
+
+                    val orchestrator = buildOrchestrator(fixture, changeBus = changeBus)
+                    val result = orchestrator.restore(BackupId("no-bcast1"))
+
+                    val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                    failure.error.shouldBeInstanceOf<BackupError.RestoreFailed>()
+
+                    testScheduler.advanceUntilIdle()
+                    received.shouldBeEmpty()
+                    collector.cancel()
                 }
             }
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/RestoreBackupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/RestoreBackupViewModel.kt
@@ -93,10 +93,11 @@ class RestoreBackupViewModel(
         viewModelScope.launch {
             when (val result = backupRepository.restoreBackup(BackupId(backupId))) {
                 is AppResult.Success -> {
-                    // The server swapped its entire DB in-process and does NOT publish to the
-                    // cross-domain sync firehose, so the client's Room is now stale and a delta
-                    // sync can't reconcile a wholesale swap. Force a full resync before showing
-                    // success, so the UI reflects the restored server data.
+                    // The server swapped its entire DB in-process. It broadcasts
+                    // SyncControl.LibraryDataChanged to all connected devices (digest reconcile),
+                    // but this initiating device also resyncs explicitly so the success state is
+                    // only shown once local data is fresh — and so the FTS index is rebuilt,
+                    // which the broadcast-triggered reconcile does not do.
                     when (val resync = syncRepository.forceFullResync()) {
                         is AppResult.Success -> {
                             state.value = RestoreBackupUiState.Completed(result.data)

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ControlChannelIsNotADataPathRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/ControlChannelIsNotADataPathRule.kt
@@ -107,6 +107,7 @@ internal object ControlChannelDetector {
         mapOf(
             "ImportApplier.kt" to setOf("LibraryDataChanged"),
             "BookPersister.kt" to setOf("LibraryDataChanged"),
+            "RestoreOrchestrator.kt" to setOf("LibraryDataChanged"),
             "AdminSettingsServiceImpl.kt" to setOf("ServerInfoChanged"),
             "UserPreferencesServiceImpl.kt" to setOf("PreferencesChanged"),
             "CollectionServiceImpl.kt" to setOf("AccessChanged"),

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/BackupRpcE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/BackupRpcE2ETest.kt
@@ -24,6 +24,7 @@ import com.calypsan.listenup.server.db.DatabaseHandle
 import com.calypsan.listenup.server.plugins.JWT_PROVIDER
 import com.calypsan.listenup.server.plugins.userPrincipalOrNull
 import com.calypsan.listenup.server.rpcguard.guard
+import com.calypsan.listenup.server.sync.ChangeBus
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
@@ -112,6 +113,7 @@ class BackupRpcE2ETest :
                     dbHandle = handle,
                     maintenance = MaintenanceState(),
                     eventBus = eventBus,
+                    changeBus = ChangeBus(),
                 )
             val service =
                 BackupServiceImpl(


### PR DESCRIPTION
Batch-7 audit — backup/restore hardening. Three plans, reproduction-first TDD, adversarially code-reviewed (no critical findings; all three confirmed sound).

### 🔒 091 — RPC backup path-traversal (SECURITY)
`getBackup`/`deleteBackup`/`restoreBackup` passed `BackupId` unsanitized to `archiveFor()` while REST rejected `/`,`\`,`..`. The reproduction actually **deleted a file outside the backup dir** pre-fix. Fix: a single public `isSafeBackupId` (BackupPaths) used by both REST and RPC — the divergence can't recur; unsafe ids return a typed `BackupNotFound` (no info leak). Admin-gated, so defense-in-depth against a crafted-id admin.

### 🐛 089 — multi-device restore re-baseline (the audit's worst backup gap)
`RestoreOrchestrator` only resynced the *initiating* device; other connected devices held cursors past the rewound-to-snapshot state and silently diverged. Fix: broadcast `SyncControl.LibraryDataChanged` on the **success path only** → every connected device re-baselines via digest reconcile (2-device E2E proves it). Rollback path deliberately doesn't broadcast. Client cursor-reset scoped out by design (digest reconcile gives parity).

### 🐛 095 — ABS import crash-resume
Import apply was non-transactional (row-by-row; markApplied/broadcast only at the end) — a mid-apply crash left partial positions + stale stats silently. Fix: durable `.applying` marker + a boot-time `InterruptedImportResumer` that re-drives partial applies idempotently (positions upsert last-played-wins, sessions keyed `abs:<id>`, final `BulkRecompute`) — converges, can't double-count. Per review: `markApplying` moved inside the try so a marker-write failure surfaces as a typed `ApplyFailed`.

## Test Plan
- [x] Every plan RED→GREEN (091's traversal actually deleted an out-of-dir file; 089's 2-device E2E; 095's interrupted-apply reproduction).
- [x] Full Linux `verifyLocal` green.
- [x] Adversarial code-review — no critical findings; the one non-blocking contract nit (markApplying placement) fixed.