### PR TITLE
🐛 fix(iosApp): library multi-select — gesture, count, tab-bar collision

### DIFF
--- a/iosApp/ListenUp/Features/Discover/DiscoverView.swift
+++ b/iosApp/ListenUp/Features/Discover/DiscoverView.swift
@@ -45,7 +45,9 @@ struct DiscoverView: View {
         }
         .background(Color(.systemBackground))
         .navigationTitle(String(localized: "common.discover"))
-        .navigationBarTitleDisplayMode(.large)
+        // Collapse the large title while selecting so the selection toolbar's principal "N selected"
+        // count doesn't render alongside a large "Discover" title (Home is already .inline).
+        .navigationBarTitleDisplayMode(selection?.isSelecting == true ? .inline : .large)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 NavigationLink(value: UserProfileDestination()) {

--- a/iosApp/ListenUp/Features/Library/Content/BooksContent.swift
+++ b/iosApp/ListenUp/Features/Library/Content/BooksContent.swift
@@ -203,15 +203,17 @@ struct BooksContent: View {
             Button { selection.toggle(book.id) } label: { card }
                 .buttonStyle(.plain)
         } else {
+            // A plain value-based NavigationLink: a tap opens the book. Selection is entered via a
+            // native long-press → context menu → "Select", which iOS arbitrates against the link's
+            // own tap so the two never double-fire. (The old `.simultaneousGesture(LongPressGesture)`
+            // let a long-press *and* the link's tap-on-release both fire, so releasing navigated.)
             NavigationLink(value: BookDestination(id: book.id)) { card }
                 .buttonStyle(.plain)
-                // A long-press attached directly to a NavigationLink is swallowed by the link's
-                // own press recognizer and never fires. `simultaneousGesture` lets the long-press
-                // run alongside the tap: a quick tap still navigates, a hold enters selection.
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.4)
-                        .onEnded { _ in selection.enter(book.id) }
-                )
+                .contextMenu {
+                    Button(String(localized: "common.select"), systemImage: "checkmark.circle") {
+                        selection.enter(book.id)
+                    }
+                }
         }
     }
 

--- a/iosApp/ListenUp/Features/Library/LibraryView.swift
+++ b/iosApp/ListenUp/Features/Library/LibraryView.swift
@@ -19,6 +19,10 @@ struct LibraryView: View {
 
     private var user: User? { userObserver.user }
 
+    /// True while the Books tab is in multi-select mode — drives the inline title, the tab-bar hide,
+    /// and the action bar. Only the Books tab is selectable (Series/Authors/Narrators aren't).
+    private var isSelecting: Bool { selection?.isSelecting == true && selectedTab == .books }
+
     var body: some View {
         Group {
             if let observer, let selection {
@@ -28,8 +32,12 @@ struct LibraryView: View {
             }
         }
         .navigationTitle(String(localized: "common.library"))
-        .navigationBarTitleDisplayMode(.large)
+        // While selecting, collapse the large "Library" title so the toolbar's principal item shows
+        // the live "N selected" count (Photos idiom); the tab bar hides so the bottom action bar owns
+        // the bottom strip instead of colliding with the floating Library/Search tab pills.
+        .navigationBarTitleDisplayMode(isSelecting ? .inline : .large)
         .toolbar { libraryToolbar }
+        .toolbar(isSelecting ? .hidden : .automatic, for: .tabBar)
         .modifier(SelectionSheets(selection: selection))
         .onAppear {
             if observer == nil {
@@ -60,7 +68,15 @@ struct LibraryView: View {
         // Multi-select on the Books tab is entered by long-pressing a cover (see BooksContent),
         // so the toolbar surfaces only a "Done" exit + the action bar once selecting — no idle
         // "Select" button cluttering the nav bar beside the profile avatar.
-        if let selection, selectedTab == .books, selection.isSelecting {
+        if let selection, isSelecting {
+            // The live count sits in the title (principal) slot, not a bottom-bar item — a bare
+            // `Text` in `.bottomBar` becomes a Liquid Glass capsule that truncated to "1 sel…" and
+            // read as a broken button. The bottom bar carries only the real actions.
+            ToolbarItem(placement: .principal) {
+                Text(String(format: String(localized: "selection.n_selected"),
+                            selection.selectedBookIds.count))
+                    .font(.headline)
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 Button(String(localized: "common.done")) { selection.exit() }
             }
@@ -72,13 +88,6 @@ struct LibraryView: View {
                           systemImage: "rectangle.stack.badge.plus")
                 }
                 .disabled(selection.selectedBookIds.isEmpty)
-
-                Spacer()
-
-                Text(String(format: String(localized: "selection.n_selected"),
-                            selection.selectedBookIds.count))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
 
                 Spacer()
 

--- a/iosApp/ListenUp/Features/Library/LibraryView.swift
+++ b/iosApp/ListenUp/Features/Library/LibraryView.swift
@@ -69,38 +69,10 @@ struct LibraryView: View {
         // so the toolbar surfaces only a "Done" exit + the action bar once selecting — no idle
         // "Select" button cluttering the nav bar beside the profile avatar.
         if let selection, isSelecting {
-            // The live count sits in the title (principal) slot, not a bottom-bar item — a bare
-            // `Text` in `.bottomBar` becomes a Liquid Glass capsule that truncated to "1 sel…" and
-            // read as a broken button. The bottom bar carries only the real actions.
-            ToolbarItem(placement: .principal) {
-                Text(String(format: String(localized: "selection.n_selected"),
-                            selection.selectedBookIds.count))
-                    .font(.headline)
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                Button(String(localized: "common.done")) { selection.exit() }
-            }
-            ToolbarItemGroup(placement: .bottomBar) {
-                Button {
-                    selection.showShelfPicker = true
-                } label: {
-                    Label(String(localized: "book.detail_add_to_shelf"),
-                          systemImage: "rectangle.stack.badge.plus")
-                }
-                .disabled(selection.selectedBookIds.isEmpty)
-
-                Spacer()
-
-                if selection.isAdmin {
-                    Button {
-                        selection.showCollectionPicker = true
-                    } label: {
-                        Label(String(localized: "book.detail_add_to_collection"),
-                              systemImage: "folder.badge.plus")
-                    }
-                    .disabled(selection.selectedBookIds.isEmpty)
-                }
-            }
+            // The Books-tab selection surface reuses the same toolbar as the Home/Discover chrome
+            // (BookSelectionToolbar) so the two never drift; the inline-title switch below keeps the
+            // principal "N selected" count from sitting under the large "Library" title.
+            BookSelectionToolbar(selection: selection)
         }
     }
 

--- a/iosApp/ListenUp/Features/Selection/BookSelectionScreenChrome.swift
+++ b/iosApp/ListenUp/Features/Selection/BookSelectionScreenChrome.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
-/// Screen-level multi-select chrome — a "Done" toolbar button, the bottom action bar
-/// (Add to Shelf / count / admin-only Add to Collection), and the two bulk picker sheets — hosted
+/// Screen-level multi-select chrome — a "N selected" title item, a "Done" toolbar button, the bottom
+/// action bar (Add to Shelf / admin-only Add to Collection), and the two bulk picker sheets — hosted
 /// over a books-bearing screen. Keeps that wiring in one place instead of re-rolling it per screen.
 ///
-/// Entry into selection is **long-press a cover** (`SelectableBookCard.onLongPressGesture`); there
-/// is deliberately no idle "Select" button here — on Home/Discover it collided with the profile
-/// avatar in the top bar. The toolbar surfaces only once selecting, as a "Done" exit. (The Library
-/// grid keeps its own explicit Select button — it's the natural bulk surface.)
+/// Entry into selection is a native **long-press a cover → context menu → "Select"**
+/// (`SelectableBookCard`); iOS arbitrates the long-press against the card's `NavigationLink` tap, so
+/// browsing and selecting never conflict. There is deliberately no idle "Select" button — on
+/// Home/Discover it collided with the profile avatar. The toolbar surfaces only once selecting, and
+/// the tab bar hides so the action bar owns the bottom.
 ///
 /// `selection` is optional so the screen's `@State` (constructed in `.onAppear`) can be passed
 /// straight through; when `nil` the chrome is a no-op.
@@ -18,6 +19,9 @@ struct BookSelectionScreenChrome: ViewModifier {
         if let selection {
             content
                 .toolbar { toolbar(selection) }
+                // Hide the floating tab bar while selecting so the bottom action bar owns the bottom
+                // strip instead of colliding with the tab pills (matches LibraryView).
+                .toolbar(selection.isSelecting ? .hidden : .automatic, for: .tabBar)
                 .sheet(isPresented: Binding(
                     get: { selection.showShelfPicker },
                     set: { selection.showShelfPicker = $0 }
@@ -44,6 +48,13 @@ struct BookSelectionScreenChrome: ViewModifier {
     @ToolbarContentBuilder
     private func toolbar(_ selection: BookSelectionObserver) -> some ToolbarContent {
         if selection.isSelecting {
+            // Count in the title (principal) slot, not a bottom-bar `Text` — the latter became a
+            // Liquid Glass capsule that truncated and read as a broken button. Mirrors LibraryView.
+            ToolbarItem(placement: .principal) {
+                Text(String(format: String(localized: "selection.n_selected"),
+                            selection.selectedBookIds.count))
+                    .font(.headline)
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 Button(String(localized: "common.done")) { selection.exit() }
             }
@@ -55,13 +66,6 @@ struct BookSelectionScreenChrome: ViewModifier {
                           systemImage: "rectangle.stack.badge.plus")
                 }
                 .disabled(selection.selectedBookIds.isEmpty)
-
-                Spacer()
-
-                Text(String(format: String(localized: "selection.n_selected"),
-                            selection.selectedBookIds.count))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
 
                 Spacer()
 

--- a/iosApp/ListenUp/Features/Selection/BookSelectionScreenChrome.swift
+++ b/iosApp/ListenUp/Features/Selection/BookSelectionScreenChrome.swift
@@ -48,44 +48,60 @@ struct BookSelectionScreenChrome: ViewModifier {
     @ToolbarContentBuilder
     private func toolbar(_ selection: BookSelectionObserver) -> some ToolbarContent {
         if selection.isSelecting {
-            // Count in the title (principal) slot, not a bottom-bar `Text` — the latter became a
-            // Liquid Glass capsule that truncated and read as a broken button. Mirrors LibraryView.
-            ToolbarItem(placement: .principal) {
-                Text(String(format: String(localized: "selection.n_selected"),
-                            selection.selectedBookIds.count))
-                    .font(.headline)
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                Button(String(localized: "common.done")) { selection.exit() }
-            }
-            ToolbarItemGroup(placement: .bottomBar) {
-                Button {
-                    selection.showShelfPicker = true
-                } label: {
-                    Label(String(localized: "book.detail_add_to_shelf"),
-                          systemImage: "rectangle.stack.badge.plus")
-                }
-                .disabled(selection.selectedBookIds.isEmpty)
+            BookSelectionToolbar(selection: selection)
+        }
+    }
+}
 
+/// The shared selection toolbar — a "N selected" title, a Done exit, and the bottom action bar
+/// (Add to Shelf; admin-only Add to Collection). Extracted so the Library grid and the Home/Discover
+/// chrome render the *same* toolbar instead of two copies that can silently drift apart.
+///
+/// The count lives in the `.principal` (title) slot rather than a `.bottomBar` `Text`: a bare `Text`
+/// in a bottom bar becomes a Liquid Glass capsule that truncated to "1 sel…" and read as a broken
+/// button. Hosts are responsible for collapsing their title to `.inline` while selecting so this
+/// principal count doesn't sit under a large title.
+struct BookSelectionToolbar: ToolbarContent {
+    let selection: BookSelectionObserver
+
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .principal) {
+            Text(String(format: String(localized: "selection.n_selected"),
+                        selection.selectedBookIds.count))
+                .font(.headline)
+        }
+        ToolbarItem(placement: .topBarTrailing) {
+            Button(String(localized: "common.done")) { selection.exit() }
+        }
+        ToolbarItemGroup(placement: .bottomBar) {
+            Button {
+                selection.showShelfPicker = true
+            } label: {
+                Label(String(localized: "book.detail_add_to_shelf"),
+                      systemImage: "rectangle.stack.badge.plus")
+            }
+            .disabled(selection.selectedBookIds.isEmpty)
+
+            // The Spacer + Add-to-Collection are admin-only; a non-admin sees just Add-to-Shelf, so
+            // don't emit a trailing Spacer that would strand the lone button off to one side.
+            if selection.isAdmin {
                 Spacer()
 
-                if selection.isAdmin {
-                    Button {
-                        selection.showCollectionPicker = true
-                    } label: {
-                        Label(String(localized: "book.detail_add_to_collection"),
-                              systemImage: "folder.badge.plus")
-                    }
-                    .disabled(selection.selectedBookIds.isEmpty)
+                Button {
+                    selection.showCollectionPicker = true
+                } label: {
+                    Label(String(localized: "book.detail_add_to_collection"),
+                          systemImage: "folder.badge.plus")
                 }
+                .disabled(selection.selectedBookIds.isEmpty)
             }
         }
     }
 }
 
 extension View {
-    /// Hosts the screen-level multi-select chrome (Select/Done toolbar, bottom action bar, and bulk
-    /// picker sheets) bound to a screen-wide `BookSelectionObserver`. A no-op when `selection` is nil.
+    /// Hosts the screen-level multi-select chrome (Done toolbar, bottom action bar, and bulk picker
+    /// sheets) bound to a screen-wide `BookSelectionObserver`. A no-op when `selection` is nil.
     func bookSelectionChrome(_ selection: BookSelectionObserver?) -> some View {
         modifier(BookSelectionScreenChrome(selection: selection))
     }

--- a/iosApp/ListenUp/Features/Selection/SelectableBookCard.swift
+++ b/iosApp/ListenUp/Features/Selection/SelectableBookCard.swift
@@ -23,15 +23,17 @@ struct SelectableBookCard<Label: View>: View {
             Button { selection.toggle(bookId) } label: { label() }
                 .buttonStyle(.pressScaleCard)
         } else if let selection {
+            // Plain value-based NavigationLink (a tap opens the book); selection is entered via a
+            // native long-press → context menu → "Select". iOS arbitrates the long-press (menu)
+            // against the link's tap, so — unlike the old `.simultaneousGesture` — a long-press
+            // release never also navigates. Mirrors the library grid's `bookCell` (BooksContent).
             NavigationLink(value: BookDestination(id: bookId)) { label() }
                 .buttonStyle(.pressScaleCard)
-                // A long-press attached directly to a NavigationLink is swallowed by the link's
-                // own press recognizer and never fires. `simultaneousGesture` lets the long-press
-                // run alongside the tap: a quick tap still navigates, a hold enters selection.
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.4)
-                        .onEnded { _ in selection.enter(bookId) }
-                )
+                .contextMenu {
+                    Button(String(localized: "common.select"), systemImage: "checkmark.circle") {
+                        selection.enter(bookId)
+                    }
+                }
         } else {
             NavigationLink(value: BookDestination(id: bookId)) { label() }
                 .buttonStyle(.pressScaleCard)

--- a/iosApp/ListenUp/Features/Selection/SelectableBookCard.swift
+++ b/iosApp/ListenUp/Features/Selection/SelectableBookCard.swift
@@ -12,7 +12,9 @@ import SwiftUI
 ///      NavigationLink(navigate)+long-press based on the screen-wide `BookSelectionObserver`.
 ///
 /// `selection` is optional: when `nil` the card renders a plain `NavigationLink` and the chrome is a
-/// no-op, so callers that don't participate in multi-select stay unchanged.
+/// no-op, so callers that don't participate in multi-select stay unchanged. A host that passes a
+/// **non-nil** `selection` must also install `.bookSelectionChrome(selection)` (or otherwise surface a
+/// Done exit) — the card can *enter* selection mode but has no way to leave it on its own.
 struct SelectableBookCard<Label: View>: View {
     let bookId: String
     let selection: BookSelectionObserver?


### PR DESCRIPTION
Phase 1 of the iOS multi-select / collections work. Fixes three reported defects in the native library multi-select.

## Problems
1. **Long-press to select also navigated into the book.** The long-press was a `.simultaneousGesture` on the cell's `NavigationLink` — "simultaneous" lets the link fire its tap on release too, so you got selection *and* navigation.
2. **The "N selected" count was malformed.** A bare `Text` in a `.bottomBar` group becomes an iOS 26 Liquid Glass capsule that truncated to "1 sel…" and read as a broken button.
3. **The selection bar collided with the floating tab bar** (Library + Search tab pills), making the Add-to-Shelf / Add-to-Collection actions undiscoverable.

## Fix
- Selection is now entered via a native **long-press → context menu → "Select"** (`.contextMenu`); iOS arbitrates long-press (menu) vs tap (navigate), so no double-fire. `NavigationLink` stays intact for normal taps. Applied to the library grid **and** the Home/Discover carousel cards.
- Count moved into the toolbar **`.principal` (title)** slot; bottom bar carries only the two real actions.
- **Tab bar hidden** during selection so the action bar owns the bottom strip.
- Extracted a shared `BookSelectionToolbar` so `LibraryView` and the Home/Discover chrome can't drift; fixed a Discover large-title collision and the non-admin lone-button layout (surfaced in code review).

Swift-only; no shared/Kotlin changes. `xcodebuild build` **BUILD SUCCEEDED** on Xcode 26.5.

## Needs on-device verification (can't be settled on a headless/unconfigured simulator)
- Selection-mode visuals: title count, streamlined bottom bar, tab-bar hide, context-menu "Select".
- Mini-player anchoring while audio plays and you enter selection (bottom bar vs. mini-player overlap).