### PR TITLE
✨ feat(iosApp): match Audible metadata for inbox books

### DIFF
--- a/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
+++ b/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
@@ -19,6 +19,8 @@ struct AdminInboxView: View {
     /// The inbox book currently being edited in the BookEdit sheet (metadata + admin collections),
     /// so an admin can review and assign collections before releasing. `nil` when no sheet is open.
     @State private var editingBook: InboxEditTarget?
+    /// The inbox book currently being matched against Audible metadata. `nil` when no sheet is open.
+    @State private var metadataBook: InboxMetadataTarget?
 
     private var isRegularWidth: Bool { horizontalSizeClass == .regular }
 
@@ -36,6 +38,9 @@ struct AdminInboxView: View {
         .toolbar { selectToolbarItem }
         .sheet(item: $editingBook) { target in
             BookEditView(bookId: target.id)
+        }
+        .sheet(item: $metadataBook) { target in
+            MetadataMatchView(bookId: target.id, title: target.title, author: target.author, asin: nil)
         }
         .onAppear {
             if observer == nil {
@@ -126,7 +131,8 @@ struct AdminInboxView: View {
                     isSelected: ready.selectedBookIds.contains(book.id),
                     isSelecting: ready.hasSelection,
                     onTap: { observer.toggleBookSelection(bookId: book.id) },
-                    onEdit: { editingBook = InboxEditTarget(id: book.id) }
+                    onEdit: { editingBook = InboxEditTarget(id: book.id) },
+                    onFindMetadata: { metadataBook = InboxMetadataTarget(book: book) }
                 )
             }
             .padding(.horizontal, 20)
@@ -156,7 +162,8 @@ struct AdminInboxView: View {
                             isSelected: ready.selectedBookIds.contains(b.id),
                             isSelecting: ready.hasSelection,
                             onTap: { observer.toggleBookSelection(bookId: b.id) },
-                            onEdit: { editingBook = InboxEditTarget(id: b.id) }
+                            onEdit: { editingBook = InboxEditTarget(id: b.id) },
+                            onFindMetadata: { metadataBook = InboxMetadataTarget(book: b) }
                         )
                     }
                 }
@@ -369,17 +376,32 @@ private struct InboxEditTarget: Identifiable {
     let id: String
 }
 
+/// Identifiable wrapper carrying the fields `MetadataMatchView` needs to seed its Audible search.
+private struct InboxMetadataTarget: Identifiable {
+    let id: String
+    let title: String
+    let author: String
+
+    init(book: InboxBookRowModel) {
+        self.id = book.id
+        self.title = book.title
+        self.author = book.author ?? ""
+    }
+}
+
 private struct InboxBookRow: View {
     let book: InboxBookRowModel
     let isSelected: Bool
     let isSelecting: Bool
     let onTap: () -> Void
     let onEdit: () -> Void
+    let onFindMetadata: () -> Void
 
     var body: some View {
         // Two independent hit targets: the main content toggles select-for-release, the trailing
-        // pencil opens BookEdit. A single row-spanning Button can't host a nested Button, so the two
-        // sit side by side. A long-press context menu offers the same Edit for discoverability.
+        // ellipsis menu hosts the per-book actions (edit, find metadata). A single row-spanning
+        // Button can't host a nested control, so the two sit side by side. A long-press context menu
+        // mirrors the same actions for discoverability.
         HStack(spacing: 8) {
             Button(action: onTap) {
                 HStack(spacing: 13) {
@@ -416,28 +438,36 @@ private struct InboxBookRow: View {
             .accessibilityLabel(book.title)
             .accessibilityAddTraits(isSelected ? .isSelected : [])
 
-            editButton
+            actionsMenu
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 11)
         .background(isSelected ? Color.luTint.opacity(0.08) : Color.clear)
         .animation(.easeInOut(duration: 0.15), value: isSelected)
-        .contextMenu {
-            Button(String(localized: "admin.inbox_review_edit"), systemImage: "square.and.pencil", action: onEdit)
-        }
+        .contextMenu { rowActions }
     }
 
-    /// Visible per-row affordance to review/edit the book (metadata + collections) before release.
-    private var editButton: some View {
-        Button(action: onEdit) {
-            Image(systemName: "square.and.pencil")
+    /// Visible per-row actions: review/edit (metadata fields + collections) or match against Audible —
+    /// both before releasing. A `Menu` so the two share one discoverable, HIG-standard affordance; the
+    /// long-press context menu mirrors it via the same `rowActions`.
+    private var actionsMenu: some View {
+        Menu {
+            rowActions
+        } label: {
+            Image(systemName: "ellipsis.circle")
                 .font(.body)
                 .foregroundStyle(Color.luTint)
                 .frame(width: 44, height: 44)   // HIG minimum tap target
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(String(localized: "admin.inbox_review_edit"))
+        .accessibilityLabel(String(localized: "common.more_actions"))
+    }
+
+    @ViewBuilder
+    private var rowActions: some View {
+        Button(String(localized: "admin.inbox_review_edit"), systemImage: "square.and.pencil", action: onEdit)
+        Button(String(localized: "book.detail_find_metadata"), systemImage: "sparkle.magnifyingglass", action: onFindMetadata)
     }
 
     private var selectionIndicator: some View {

--- a/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
+++ b/iosApp/ListenUp/Features/Admin/Inbox/AdminInboxView.swift
@@ -467,7 +467,9 @@ private struct InboxBookRow: View {
     @ViewBuilder
     private var rowActions: some View {
         Button(String(localized: "admin.inbox_review_edit"), systemImage: "square.and.pencil", action: onEdit)
-        Button(String(localized: "book.detail_find_metadata"), systemImage: "sparkle.magnifyingglass", action: onFindMetadata)
+        // Same label + icon as BookDetail's "Match on Audible" — one canonical affordance for the
+        // shared MetadataMatchView flow across both entry points.
+        Button(String(localized: "metadata.match_on_audible"), systemImage: "sparkles", action: onFindMetadata)
     }
 
     private var selectionIndicator: some View {

--- a/iosApp/ListenUp/Resources/Localizable.xcstrings
+++ b/iosApp/ListenUp/Resources/Localizable.xcstrings
@@ -4771,6 +4771,16 @@
         }
       }
     },
+    "common.more_actions": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More actions"
+          }
+        }
+      }
+    },
     "common.my_profile": {
       "localizations": {
         "en": {

--- a/sharedLogic/src/commonMain/resources/strings/en.json
+++ b/sharedLogic/src/commonMain/resources/strings/en.json
@@ -59,6 +59,7 @@
     "member": "Member",
     "members": "Members",
     "menu": "Menu",
+    "more_actions": "More actions",
     "my_profile": "My Profile",
     "n_days": "%1$s days",
     "name": "Name",

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -478,6 +478,7 @@ One beautiful library.</string>
     <string name="common_member">Member</string>
     <string name="common_members">Members</string>
     <string name="common_menu">Menu</string>
+    <string name="common_more_actions">More actions</string>
     <string name="common_my_profile">My Profile</string>
     <string name="common_n_days">%1$s days</string>
     <string name="common_name">Name</string>


### PR DESCRIPTION
Phase 3 of the iOS inbox arc. Makes the existing iOS metadata-match flow reachable from the Admin Inbox, so an admin can fetch/match metadata before releasing a book — the second half of the original "no way to add to a collection **or fetch metadata** before releasing" report.

> **Stacked on #1053** (`feat/ios-inbox-collections`). Until #1053 merges, this PR's diff also shows the Phase-2 commits; it'll shrink to just the Phase-3 commits once #1053 lands. Review/merge #1053 first.

## What & why
`MetadataMatchView` (Audible search → preview → apply) already existed and was reachable only from BookDetail. This wires it into the inbox with **no new screen** — just an entry point:
- The inbox row's single pencil button becomes an **ellipsis menu** (`ellipsis.circle`) hosting the now-two per-row actions: **Review & edit** and **Match on Audible**. The long-press context menu mirrors the same actions (shared `rowActions` builder).
- "Match on Audible" presents `MetadataMatchView` seeded with the row's title/author, exactly as BookDetail does.
- Aligned the label + icon with BookDetail ("Match on Audible" / `sparkles`) so the same flow reads identically from both entry points (code-review pattern-uniformity fix).

One new shared string (`common.more_actions`, for the menu's a11y label) sourced in `en.json` and regenerated; otherwise reuses existing keys.

## Verification
- `xcodebuild build` **BUILD SUCCEEDED** on Xcode 26.5; `verifyStrings` green.
- Superpowers code review: no Critical/Important blockers; applied the label/icon alignment.
- **Needs on-device check**: inbox row → ⋯ → Match on Audible → apply, before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)