### PR TITLE
✨ feat(iosApp): frost bulk picker sheets + inline create-collection

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
+++ b/build-logic/convention/src/main/kotlin/com/calypsan/listenup/gradle/SwiftExportSourcePatcher.kt
@@ -386,7 +386,7 @@ object SwiftExportSourcePatcher {
             "com.calypsan.listenup.client.presentation.bookdetail.BookReadersUiState" to 4,
             "com.calypsan.listenup.client.presentation.bookedit.BookEditNavAction" to 2,
             "com.calypsan.listenup.client.presentation.bookedit.BookEditUiEvent" to 42,
-            "com.calypsan.listenup.client.presentation.books.BookMultiSelectEvent" to 3,
+            "com.calypsan.listenup.client.presentation.books.BookMultiSelectEvent" to 4,
             "com.calypsan.listenup.client.presentation.books.SelectionMode" to 2,
             "com.calypsan.listenup.client.presentation.browsefacet.BrowseFacetUiState" to 3,
             "com.calypsan.listenup.client.presentation.browsegenre.BrowseGenreUiState" to 3,

--- a/iosApp/ListenUp/Features/Selection/BookSelectionObserver.swift
+++ b/iosApp/ListenUp/Features/Selection/BookSelectionObserver.swift
@@ -108,4 +108,5 @@ final class BookSelectionObserver {
     func addToShelf(shelfId: String) { viewModel.addSelectedToShelf(shelfId: shelfId) }
     func createShelfAndAdd(name: String) { viewModel.createShelfAndAddBooks(name: name) }
     func addToCollection(collectionId: String) { viewModel.addSelectedToCollection(collectionId: collectionId) }
+    func createCollectionAndAdd(name: String) { viewModel.createCollectionAndAddBooks(name: name) }
 }

--- a/iosApp/ListenUp/Features/Selection/BulkCollectionPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkCollectionPickerSheet.swift
@@ -2,19 +2,23 @@ import SwiftUI
 
 /// Sheet body for filing the multi-selected books into one of the admin's collections.
 ///
-/// Mirrors `CollectionPickerSheet` but is bound to `BookSelectionObserver` and operates on the
-/// whole selection: a leading count line states how many books will be added, and each collection
-/// is a plain tappable row. There is no inline "New Collection…" affordance here — the shared VM
-/// exposes no bulk create-collection action, matching the Compose multi-select picker
-/// (`canCreate = false`); this sheet is additive-to-existing only. Admin-gated (the whole sheet is
-/// only presented for admins). Failures surface on the global `ErrorBus`; on success the VM clears
-/// the selection and emits an event the observer reacts to by dismissing this sheet.
+/// Mirrors `BulkShelfPickerSheet` but is bound to `BookSelectionObserver` and operates on the whole
+/// selection: a leading count line states how many books will be added, each collection is a plain
+/// tappable row, and an inline "New Collection…" affordance creates a collection and files every
+/// selected book into it in one step. The create affordance is always present — an admin with zero
+/// collections still needs a way to make the first one — so the empty state is a hint row above it,
+/// not a full-screen `ContentUnavailableView`. Admin-gated (the whole sheet is only presented for
+/// admins). Failures surface on the global `ErrorBus`; on success the VM clears the selection and
+/// emits an event the observer reacts to by dismissing this sheet.
 struct BulkCollectionPickerSheet: View {
     let observer: BookSelectionObserver
     /// Number of books currently selected — shown in the count line.
     let count: Int
     /// Invoked by the Done button; the assembly screen flips the sheet binding.
     let onClose: () -> Void
+
+    @State private var isCreatingCollection = false
+    @State private var newCollectionName = ""
 
     var body: some View {
         NavigationStack {
@@ -25,7 +29,9 @@ struct BulkCollectionPickerSheet: View {
                         .foregroundStyle(.secondary)
                 }
                 collectionsSection
+                newCollectionSection
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle(String(localized: "book.detail_collection_picker_title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -39,18 +45,20 @@ struct BulkCollectionPickerSheet: View {
                 }
             }
             .presentationDetents([.medium, .large])
+            .presentationBackground(.thickMaterial)
         }
     }
 
-    // MARK: - Collections
+    // MARK: - Existing collections
 
     @ViewBuilder
     private var collectionsSection: some View {
         if observer.allCollections.isEmpty {
-            ContentUnavailableView(
-                String(localized: "book.detail_no_collections"),
-                systemImage: "rectangle.stack"
-            )
+            Section {
+                Text(String(localized: "book.detail_no_collections"))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
         } else {
             Section {
                 ForEach(observer.allCollections) { collection in
@@ -63,5 +71,52 @@ struct BulkCollectionPickerSheet: View {
                 }
             }
         }
+    }
+
+    // MARK: - New collection
+
+    @ViewBuilder
+    private var newCollectionSection: some View {
+        Section {
+            if isCreatingCollection {
+                TextField(String(localized: "common.collection_name_hint"), text: $newCollectionName)
+                    .submitLabel(.done)
+                    .onSubmit(createCollection)
+
+                HStack {
+                    Button(String(localized: "common.cancel")) {
+                        isCreatingCollection = false
+                        newCollectionName = ""
+                    }
+                    .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button(String(localized: "common.create"), action: createCollection)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.listenUpOrange)
+                        .disabled(trimmedName.isEmpty || observer.isAddingToCollection)
+                }
+            } else {
+                Button { isCreatingCollection = true } label: {
+                    Label(String(localized: "book.detail_new_collection"), systemImage: "plus")
+                        .foregroundStyle(Color.listenUpOrange)
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private var trimmedName: String {
+        newCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func createCollection() {
+        let name = trimmedName
+        guard !name.isEmpty else { return }
+        observer.createCollectionAndAdd(name: name)
+        newCollectionName = ""
+        isCreatingCollection = false
     }
 }

--- a/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
@@ -29,6 +29,7 @@ struct BulkShelfPickerSheet: View {
                 shelvesSection
                 newShelfSection
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle(String(localized: "book.detail_add_to_shelf"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -42,6 +43,7 @@ struct BulkShelfPickerSheet: View {
                 }
             }
             .presentationDetents([.medium, .large])
+            .presentationBackground(.thickMaterial)
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CollectionModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CollectionModule.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.data.repository.InboxRepositoryImpl
 import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.InboxRepository
 import com.calypsan.listenup.client.domain.usecase.collection.AddBooksToCollectionUseCase
+import com.calypsan.listenup.client.domain.usecase.collection.CreateCollectionUseCase
 import org.koin.core.module.Module
 import org.koin.dsl.bind
 import org.koin.dsl.binds
@@ -57,4 +58,7 @@ internal val collectionModule: Module =
 
         // AddBooksToCollectionUseCase — bulk add for multi-select flows
         factory { AddBooksToCollectionUseCase(get()) }
+
+        // CreateCollectionUseCase — create-and-add for the multi-select collection picker
+        factory { CreateCollectionUseCase(get(), get()) }
     }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -261,6 +261,7 @@ internal val libraryPresentationModule =
                 addBooksToShelfUseCase = get(),
                 addBooksToCollectionUseCase = get(),
                 createShelfUseCase = get(),
+                createCollectionUseCase = get(),
                 errorBus = get(),
             )
         }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/collection/CreateCollectionUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/domain/usecase/collection/CreateCollectionUseCase.kt
@@ -1,0 +1,54 @@
+package com.calypsan.listenup.client.domain.usecase.collection
+
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.result.validationError
+import com.calypsan.listenup.client.domain.model.Collection
+import com.calypsan.listenup.client.domain.repository.CollectionRepository
+import com.calypsan.listenup.client.domain.repository.LibraryRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.first
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Creates a new collection with the given name in the current library.
+ *
+ * Collections are library-scoped, but ListenUp's admin model is single-library-per-server, so the
+ * library id is sourced from the first library observed via [LibraryRepository] — the same source
+ * the admin collections screen uses. Validates that the name is not blank before calling the
+ * repository. Admin-gated at the call site (collections are admin-managed).
+ *
+ * Usage:
+ * ```kotlin
+ * val result = createCollectionUseCase(name = "Staff Picks")
+ * ```
+ */
+open class CreateCollectionUseCase(
+    private val collectionRepository: CollectionRepository,
+    private val libraryRepository: LibraryRepository,
+) {
+    /**
+     * Create a new collection.
+     *
+     * @param name The collection name (required, will be trimmed).
+     * @return Result containing the created collection or a failure.
+     */
+    open suspend operator fun invoke(name: String): AppResult<Collection> {
+        val trimmedName = name.trim()
+        if (trimmedName.isBlank()) {
+            return validationError("Collection name is required")
+        }
+
+        val libraryId =
+            libraryRepository
+                .observeAll()
+                .first()
+                .firstOrNull()
+                ?.id
+                ?: return validationError("No library available")
+
+        logger.info { "Creating collection: $trimmedName" }
+
+        return collectionRepository.create(libraryId, trimmedName)
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModel.kt
@@ -9,6 +9,7 @@ import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.domain.usecase.collection.AddBooksToCollectionUseCase
+import com.calypsan.listenup.client.domain.usecase.collection.CreateCollectionUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.core.BookId
@@ -50,6 +51,7 @@ class BookMultiSelectViewModel(
     private val addBooksToShelfUseCase: AddBooksToShelfUseCase,
     private val addBooksToCollectionUseCase: AddBooksToCollectionUseCase,
     private val createShelfUseCase: CreateShelfUseCase,
+    private val createCollectionUseCase: CreateCollectionUseCase,
     private val errorBus: ErrorBus,
 ) : ViewModel() {
     // ═══════════════════════════════════════════════════════════════════════
@@ -228,6 +230,52 @@ class BookMultiSelectViewModel(
         }
     }
 
+    /**
+     * Create a new collection and add all selected books to it. Creates the collection, then adds
+     * the books. Clears the selection on success; surfaces the error on the [errorBus] and keeps
+     * the selection on any failure. Admin only (the collection picker is admin-gated).
+     *
+     * @param name The name for the new collection.
+     */
+    fun createCollectionAndAddBooks(name: String) {
+        val selectedIds = currentSelectedIds()
+        if (selectedIds.isEmpty()) return
+
+        viewModelScope.launch {
+            isAddingToCollection.value = true
+            val bookIds = selectedIds.toList()
+
+            when (val createResult = createCollectionUseCase(name)) {
+                is AppResult.Success -> {
+                    val newCollection = createResult.data
+                    logger.info { "Created collection '${newCollection.name}' with id ${newCollection.id}" }
+
+                    when (val addResult = addBooksToCollectionUseCase(newCollection.id, bookIds)) {
+                        is AppResult.Success -> {
+                            logger.info { "Added ${bookIds.size} books to new collection ${newCollection.id}" }
+                            eventsChannel.send(
+                                BookMultiSelectEvent.CollectionCreatedAndBooksAdded(newCollection.name, bookIds.size),
+                            )
+                            clearSelection()
+                        }
+
+                        is AppResult.Failure -> {
+                            logger.error { "Failed to add books to new collection: ${addResult.message}" }
+                            errorBus.emit(addResult.error)
+                        }
+                    }
+                }
+
+                is AppResult.Failure -> {
+                    logger.error { "Failed to create collection: ${createResult.message}" }
+                    errorBus.emit(createResult.error)
+                }
+            }
+
+            isAddingToCollection.value = false
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // SHELF ACTIONS (all users)
     // ═══════════════════════════════════════════════════════════════════════
@@ -357,6 +405,12 @@ sealed interface BookMultiSelectEvent {
     /** A new shelf was created and books were added to it. */
     data class ShelfCreatedAndBooksAdded(
         val shelfName: String,
+        val bookCount: Int,
+    ) : BookMultiSelectEvent
+
+    /** A new collection was created and books were added to it. */
+    data class CollectionCreatedAndBooksAdded(
+        val collectionName: String,
         val bookCount: Int,
     ) : BookMultiSelectEvent
 }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/CollectionModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/CollectionModuleVerifyTest.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.client.data.local.db.CollectionBookDao
 import com.calypsan.listenup.client.data.local.db.CollectionDao
 import com.calypsan.listenup.client.data.local.db.CollectionShareDao
 import com.calypsan.listenup.client.data.remote.ApiClientFactory
+import com.calypsan.listenup.client.domain.repository.LibraryRepository
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.kotest.core.spec.style.FunSpec
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -19,6 +20,7 @@ import org.koin.test.verify.verify
  *  - [CollectionDao] — owned by `persistenceModule`.
  *  - [CollectionBookDao] — owned by `persistenceModule`.
  *  - [CollectionShareDao] — owned by `persistenceModule`.
+ *  - [LibraryRepository] — owned by `libraryModule` (CreateCollectionUseCase resolves the library id).
  */
 @OptIn(KoinExperimentalAPI::class)
 class CollectionModuleVerifyTest :
@@ -33,6 +35,7 @@ class CollectionModuleVerifyTest :
                         CollectionShareDao::class,
                         ApiClientFactory::class,
                         ServerConfig::class,
+                        LibraryRepository::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryPresentationModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/LibraryPresentationModuleVerifyTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.SyncStatusRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.domain.usecase.collection.AddBooksToCollectionUseCase
+import com.calypsan.listenup.client.domain.usecase.collection.CreateCollectionUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.core.error.ErrorBus
@@ -41,6 +42,7 @@ import org.koin.test.verify.verify
  *  - [AddBooksToShelfUseCase] — owned by `shelfModule`.
  *  - [AddBooksToCollectionUseCase] — owned by `collectionModule`.
  *  - [CreateShelfUseCase] — owned by `shelfModule`.
+ *  - [CreateCollectionUseCase] — owned by `collectionModule`.
  *  - [ErrorBus] — owned by `appCoreModule`.
  *  - [SearchRepository] — owned by `searchModule`.
  */
@@ -66,6 +68,7 @@ class LibraryPresentationModuleVerifyTest :
                         AddBooksToShelfUseCase::class,
                         AddBooksToCollectionUseCase::class,
                         CreateShelfUseCase::class,
+                        CreateCollectionUseCase::class,
                         ErrorBus::class,
                         SearchRepository::class,
                     ),

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/collection/CreateCollectionUseCaseTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/domain/usecase/collection/CreateCollectionUseCaseTest.kt
@@ -1,0 +1,99 @@
+package com.calypsan.listenup.client.domain.usecase.collection
+
+import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.error.ValidationError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.model.AccessMode
+import com.calypsan.listenup.client.domain.model.Collection
+import com.calypsan.listenup.client.domain.model.Library
+import com.calypsan.listenup.client.domain.repository.CollectionRepository
+import com.calypsan.listenup.client.domain.repository.LibraryRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifyNoMoreCalls
+import dev.mokkery.verifySuspend
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+
+class CreateCollectionUseCaseTest :
+    FunSpec({
+        fun library(id: String = "lib-1"): Library =
+            Library(
+                id = id,
+                name = "My Library",
+                metadataPrecedence = "audible",
+                accessMode = AccessMode.OPEN,
+                createdByUserId = null,
+                createdAt = 1704067200000L,
+                revision = 1L,
+            )
+
+        fun collection(
+            id: String = "col-1",
+            name: String = "Staff Picks",
+        ): Collection =
+            Collection(
+                id = id,
+                name = name,
+                ownerId = "user-1",
+                isInbox = false,
+                isSystem = false,
+                bookCount = 0,
+                callerPermission = SharePermission.Write,
+                isOwner = true,
+            )
+
+        test("trims the name and creates the collection in the first library") {
+            runTest {
+                val collectionRepo: CollectionRepository = mock()
+                val libraryRepo: LibraryRepository = mock()
+                val created = collection(name = "Staff Picks")
+                every { libraryRepo.observeAll() } returns flowOf(listOf(library("lib-1")))
+                everySuspend { collectionRepo.create(any(), any()) } returns AppResult.Success(created)
+                val useCase = CreateCollectionUseCase(collectionRepo, libraryRepo)
+
+                val result = useCase("  Staff Picks  ")
+
+                result.shouldBeInstanceOf<AppResult.Success<Collection>>().data shouldBe created
+                verifySuspend { collectionRepo.create("lib-1", "Staff Picks") }
+            }
+        }
+
+        test("returns validation failure and never touches the repository for a blank name") {
+            runTest {
+                val collectionRepo: CollectionRepository = mock()
+                val libraryRepo: LibraryRepository = mock()
+                val useCase = CreateCollectionUseCase(collectionRepo, libraryRepo)
+
+                val result = useCase("   ")
+
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<ValidationError>()
+                failure.message shouldBe "Collection name is required"
+                verifyNoMoreCalls(collectionRepo)
+            }
+        }
+
+        test("returns validation failure when no library is available") {
+            runTest {
+                val collectionRepo: CollectionRepository = mock()
+                val libraryRepo: LibraryRepository = mock()
+                every { libraryRepo.observeAll() } returns flowOf(emptyList())
+                val useCase = CreateCollectionUseCase(collectionRepo, libraryRepo)
+
+                val result = useCase("Staff Picks")
+
+                val failure = result.shouldBeInstanceOf<AppResult.Failure>()
+                failure.error.shouldBeInstanceOf<ValidationError>()
+                failure.message shouldBe "No library available"
+                verifySuspend(mode = VerifyMode.not) { collectionRepo.create(any(), any()) }
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/books/BookMultiSelectViewModelTest.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.domain.usecase.collection.AddBooksToCollectionUseCase
+import com.calypsan.listenup.client.domain.usecase.collection.CreateCollectionUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
 import com.calypsan.listenup.core.error.ErrorBus
@@ -57,6 +58,7 @@ class BookMultiSelectViewModelTest :
             val addBooksToShelfUseCase: AddBooksToShelfUseCase = mock()
             val addBooksToCollectionUseCase: AddBooksToCollectionUseCase = mock()
             val createShelfUseCase: CreateShelfUseCase = mock()
+            val createCollectionUseCase: CreateCollectionUseCase = mock()
             val errorBus = ErrorBus()
 
             val userFlow = MutableStateFlow<User?>(null)
@@ -71,6 +73,7 @@ class BookMultiSelectViewModelTest :
                     addBooksToShelfUseCase = addBooksToShelfUseCase,
                     addBooksToCollectionUseCase = addBooksToCollectionUseCase,
                     createShelfUseCase = createShelfUseCase,
+                    createCollectionUseCase = createCollectionUseCase,
                     errorBus = errorBus,
                 )
         }
@@ -413,6 +416,109 @@ class BookMultiSelectViewModelTest :
 
                 fixture.errorBus.errors.test {
                     viewModel.createShelfAndAddBooks("My New Shelf")
+                    advanceUntilIdle()
+                    awaitItem() shouldBe error
+                }
+
+                events.shouldBeEmpty()
+                viewModel.selectionMode.value.shouldBeInstanceOf<SelectionMode.Active>()
+            }
+        }
+
+        // ========== createCollectionAndAddBooks ==========
+
+        fun createCollection(
+            id: String = "collection-1",
+            name: String = "My Collection",
+        ): Collection =
+            Collection(
+                id = id,
+                name = name,
+                ownerId = "user-1",
+                isInbox = false,
+                isSystem = false,
+                bookCount = 0,
+                callerPermission = SharePermission.Write,
+                isOwner = true,
+            )
+
+        test("createCollectionAndAddBooks does nothing when no books selected") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                advanceUntilIdle()
+
+                viewModel.createCollectionAndAddBooks("New Collection")
+                advanceUntilIdle()
+
+                viewModel.isAddingToCollection.value shouldBe false
+                verifySuspend(mode = VerifyMode.not) { fixture.createCollectionUseCase(any()) }
+                verifySuspend(mode = VerifyMode.not) { fixture.addBooksToCollectionUseCase(any(), any()) }
+            }
+        }
+
+        test("createCollectionAndAddBooks creates the collection, adds the books, emits event, clears selection") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                viewModel.enterSelectionMode("book-1")
+                val newCollection = createCollection(id = "new-collection", name = "My New Collection")
+                everySuspend { fixture.createCollectionUseCase(any()) } returns AppResult.Success(newCollection)
+                everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns AppResult.Success(Unit)
+                advanceUntilIdle()
+
+                viewModel.events.test {
+                    viewModel.createCollectionAndAddBooks("My New Collection")
+                    advanceUntilIdle()
+                    awaitItem().shouldBeInstanceOf<BookMultiSelectEvent.CollectionCreatedAndBooksAdded>()
+                }
+
+                verifySuspend { fixture.createCollectionUseCase("My New Collection") }
+                verifySuspend { fixture.addBooksToCollectionUseCase("new-collection", listOf("book-1")) }
+                viewModel.selectionMode.value shouldBe SelectionMode.None
+            }
+        }
+
+        test("createCollectionAndAddBooks creation failure surfaces on errorBus, no event, keeps selection, never adds") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                viewModel.enterSelectionMode("book-1")
+                val error = ValidationError(message = "Failed to create collection")
+                everySuspend { fixture.createCollectionUseCase(any()) } returns AppResult.Failure(error)
+
+                // Capture the success-only events channel to prove no event fires on failure.
+                val events = mutableListOf<BookMultiSelectEvent>()
+                backgroundScope.launch { viewModel.events.collect { events += it } }
+
+                fixture.errorBus.errors.test {
+                    viewModel.createCollectionAndAddBooks("New Collection")
+                    advanceUntilIdle()
+                    awaitItem() shouldBe error
+                }
+
+                events.shouldBeEmpty()
+                viewModel.selectionMode.value.shouldBeInstanceOf<SelectionMode.Active>()
+                verifySuspend(mode = VerifyMode.not) { fixture.addBooksToCollectionUseCase(any(), any()) }
+            }
+        }
+
+        test("createCollectionAndAddBooks add-books failure surfaces on errorBus, no event, keeps selection") {
+            runTest {
+                val fixture = createFixture()
+                val viewModel = fixture.build()
+                viewModel.enterSelectionMode("book-1")
+                val newCollection = createCollection(id = "new-collection", name = "My New Collection")
+                val error = ValidationError(message = "Failed to add books")
+                everySuspend { fixture.createCollectionUseCase(any()) } returns AppResult.Success(newCollection)
+                everySuspend { fixture.addBooksToCollectionUseCase(any(), any()) } returns AppResult.Failure(error)
+
+                // Capture the success-only events channel to prove no event fires on failure.
+                val events = mutableListOf<BookMultiSelectEvent>()
+                backgroundScope.launch { viewModel.events.collect { events += it } }
+
+                fixture.errorBus.errors.test {
+                    viewModel.createCollectionAndAddBooks("My New Collection")
                     advanceUntilIdle()
                     awaitItem() shouldBe error
                 }

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BookSelectionScaffold.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BookSelectionScaffold.kt
@@ -159,6 +159,16 @@ private fun BookSelectionFeedback(
                     val bookText = if (event.bookCount == 1) "1 book" else "${event.bookCount} books"
                     scope.launch { snackbarHostState.showSnackbar("Created \"${event.shelfName}\" with $bookText") }
                 }
+
+                is BookMultiSelectEvent.CollectionCreatedAndBooksAdded -> {
+                    onCollectionActionHandled()
+                    val bookText = if (event.bookCount == 1) "1 book" else "${event.bookCount} books"
+                    scope.launch {
+                        snackbarHostState.showSnackbar(
+                            "Created \"${event.collectionName}\" with $bookText",
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Improves the multi-select bulk **Add to Shelf** / **Add to Collection** picker sheets, per user feedback after the multi-select arc.

## Part A — Frost the sheets
Both `BulkShelfPickerSheet` and `BulkCollectionPickerSheet` now set `.scrollContentBackground(.hidden)` on the `List` + `.presentationBackground(.thickMaterial)` on the `NavigationStack`. System material only (never hand-rolled blur), so Reduce Transparency / Increase Contrast keep working. `.thickMaterial` is the starting point — final strength is a device-eyeball call.

## Part B — Create a new collection from the picker (mirrors shelf)
- **Shared:** `CreateCollectionUseCase` (wraps `CollectionRepository.create`, resolving the library id via `LibraryRepository.observeAll().first().firstOrNull()` — the established `AdminCollectionsViewModel` idiom); `BookMultiSelectViewModel.createCollectionAndAddBooks(name)` mirroring `createShelfAndAddBooks`; new `BookMultiSelectEvent.CollectionCreatedAndBooksAdded` variant; DI in `CollectionModule` + `PresentationModule`.
- **iOS:** `BookSelectionObserver.createCollectionAndAdd(name:)` + a `newCollectionSection` in the collection sheet. The empty state was restructured to a footnote hint so an admin with **zero collections** can still create the first one.
- No new localization keys (all reused).

## Tests
- `CreateCollectionUseCaseTest` (trim+create, blank-name short-circuit, no-library).
- 4 new `BookMultiSelectViewModelTest` cases for `createCollectionAndAddBooks`.
- Both affected `*ModuleVerifyTest`s updated.

## Verification
- Linux lane: spotless, detekt, verifyStrings, `:sharedLogic:jvmTest`, host tests, `androidApp:assembleDebug` ✅
- Mac (via Tailscale): `xcodebuild build` (Release) + `build-for-testing` ✅ — includes the Swift Export baseline + sealed-subtype drift guard (bumped `BookMultiSelectEvent` 3→4 in `SwiftExportSourcePatcher`).
- Superpowers code review: clean (one Critical drift-guard miss caught and fixed).
- **Pending:** on-device visual check of frost strength + the create-collection flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)