### PR TITLE
🐛 fix(shared): bound SSE connect phase so iOS reconnects after server restart

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ReconnectionSupervisor.kt
@@ -111,7 +111,13 @@ internal class ReconnectionSupervisor(
     }
 
     private companion object {
-        const val DEFAULT_PROBE_INTERVAL_MS = 5_000L
+        /**
+         * Probe floor: how soon after the firehose drops we first re-check reachability, and the
+         * cadence we snap back to the moment the server answers again. Kept tight so recovery feels
+         * near-instant while the app is open; the interval escalates to [MAX_PROBE_INTERVAL_MS] on
+         * sustained failure so a long outage doesn't sweep mDNS every couple of seconds.
+         */
+        const val DEFAULT_PROBE_INTERVAL_MS = 2_000L
         const val MAX_PROBE_INTERVAL_MS = 60_000L
     }
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClient.kt
@@ -8,6 +8,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.header
 import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.HttpStatement
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpHeaders
 import io.ktor.utils.io.readLine
@@ -15,10 +17,13 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.pow
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -31,6 +36,13 @@ private val logger = KotlinLogging.logger {}
 internal const val INITIAL_RECONNECT_DELAY_MS = 1_000L
 internal const val MAX_RECONNECT_DELAY_MS = 60_000L
 internal const val RECONNECT_BACKOFF_MULTIPLIER = 2.0
+
+/**
+ * Upper bound on the connection-establishment phase. A connect that hasn't produced a response
+ * within this window is abandoned and retried, so a down/unreachable server can't wedge the loop on
+ * engines with no finite connect timeout (Darwin/URLSession). The streaming read stays unbounded.
+ */
+internal const val DEFAULT_CONNECT_TIMEOUT_MS = 5_000L
 private const val SSE_ENDPOINT = "/api/v1/sync/events"
 private const val HTTP_UNAUTHORIZED = 401
 private const val HTTP_FORBIDDEN = 403
@@ -107,6 +119,7 @@ internal class SyncSseClient(
     private val state: SyncEngineState,
     private val scope: CoroutineScope,
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    private val connectTimeoutMillis: Long = DEFAULT_CONNECT_TIMEOUT_MS,
 ) : SseClient {
     private val frameBus =
         MutableSharedFlow<ParsedSseFrame>(
@@ -222,33 +235,11 @@ internal class SyncSseClient(
     private suspend fun runOnce(): ConnectAttempt {
         val serverUrl = serverUrlProvider() ?: return ConnectAttempt.GracefulClose
         return try {
-            val httpClient = streamingClientProvider()
-            httpClient
-                .prepareGet("$serverUrl$SSE_ENDPOINT") {
+            val request =
+                streamingClientProvider().prepareGet("$serverUrl$SSE_ENDPOINT") {
                     lastEventId?.let { header(HttpHeaders.LastEventID, it.toString()) }
-                }.execute { response ->
-                    state.setConnection(ConnectionState.Connected(lastEventId))
-                    state.recordSuccess(nowMillis())
-                    val channel = response.bodyAsChannel()
-                    val buffer = StringBuilder()
-                    while (!channel.isClosedForRead) {
-                        val line = channel.readLine() ?: break
-                        if (line.isEmpty()) {
-                            // Append an empty trailing line so parseSseStream commits the frame.
-                            val parsed = parseSseStream(buffer.lineSequence().plus(""))
-                            for (frame in parsed) {
-                                frame.id?.let { lastEventId = it }
-                                frameBus.emit(frame)
-                                state.setConnection(ConnectionState.Connected(lastEventId))
-                            }
-                            buffer.clear()
-                        } else {
-                            if (buffer.isNotEmpty()) buffer.append('\n')
-                            buffer.append(line)
-                        }
-                    }
-                    ConnectAttempt.Connected
                 }
+            connectBounded(request)
         } catch (e: CancellationException) {
             throw e
         } catch (e: ResponseException) {
@@ -262,6 +253,60 @@ internal class SyncSseClient(
             logger.warn(e) { "SSE connection error" }
             ConnectAttempt.Reconnect
         }
+    }
+
+    /**
+     * Runs one connection attempt, bounding only the *connect* phase: if the server hasn't produced
+     * a response within [connectTimeoutMillis], the attempt is abandoned and mapped to
+     * [ConnectAttempt.Reconnect] so the outer loop can back off and retry. Once connected, the
+     * streaming read ([streamFrames]) runs unbounded — a live-but-idle SSE stream must never be torn
+     * down, and both servers heartbeat well within any read window.
+     *
+     * Without this bound, a connect against a down/unreachable server hangs forever on engines with
+     * no finite connect timeout (Darwin/URLSession): [runOnce] never returns, the state never leaves
+     * `Connecting`, and every downstream recovery mechanism stays wedged.
+     */
+    private suspend fun connectBounded(request: HttpStatement): ConnectAttempt =
+        coroutineScope {
+            val connected = CompletableDeferred<Unit>()
+            val reader =
+                async {
+                    request.execute { response ->
+                        connected.complete(Unit)
+                        streamFrames(response)
+                    }
+                }
+            if (withTimeoutOrNull(connectTimeoutMillis) { connected.await() } == null) {
+                reader.cancel()
+                ConnectAttempt.Reconnect
+            } else {
+                reader.await()
+            }
+        }
+
+    /** Read and dispatch SSE frames until the stream closes. Returns [ConnectAttempt.Connected] on EOF. */
+    private suspend fun streamFrames(response: HttpResponse): ConnectAttempt {
+        state.setConnection(ConnectionState.Connected(lastEventId))
+        state.recordSuccess(nowMillis())
+        val channel = response.bodyAsChannel()
+        val buffer = StringBuilder()
+        while (!channel.isClosedForRead) {
+            val line = channel.readLine() ?: break
+            if (line.isEmpty()) {
+                // Append an empty trailing line so parseSseStream commits the frame.
+                val parsed = parseSseStream(buffer.lineSequence().plus(""))
+                for (frame in parsed) {
+                    frame.id?.let { lastEventId = it }
+                    frameBus.emit(frame)
+                    state.setConnection(ConnectionState.Connected(lastEventId))
+                }
+                buffer.clear()
+            } else {
+                if (buffer.isNotEmpty()) buffer.append('\n')
+                buffer.append(line)
+            }
+        }
+        return ConnectAttempt.Connected
     }
 
     private enum class ConnectAttempt { Connected, Reconnect, AuthFailed, GracefulClose }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientConnectTimeoutTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/SyncSseClientConnectTimeoutTest.kt
@@ -1,0 +1,86 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Pins the connect-phase timeout that lets the SSE reconnect loop recover after
+ * the server goes down or unreachable.
+ *
+ * Regression this prevents: the iOS (Darwin/URLSession) streaming client had
+ * infinite timeouts on every phase including connect, so a reconnect attempt
+ * against a down server hung inside `execute {}` forever — [SyncSseClient.runOnce]
+ * never returned, the connection state never left `Connecting`, and the
+ * `ReconnectionSupervisor` (gated on not-connected) never ran. The user-visible
+ * symptom: iOS never reconnects after the server comes back, while Android (a
+ * finite OkHttp connect timeout) does.
+ *
+ * The fix moves the connect bound into commonMain so both platforms behave
+ * identically: a connection that doesn't produce a response within
+ * `connectTimeoutMillis` is abandoned and classified as `Reconnect`, so the loop
+ * cycles. The streaming read itself stays unbounded — a live-but-idle SSE stream
+ * must not be torn down (both servers heartbeat well within any read window).
+ *
+ * Simulated with a `MockEngine` handler that never responds
+ * ([awaitCancellation]) — a server that accepts the socket but never sends the
+ * response, the exact shape that used to hang forever on Darwin.
+ */
+class SyncSseClientConnectTimeoutTest :
+    FunSpec({
+        test("a connect that never produces a response is abandoned and drives a reconnect, not an infinite hang") {
+            runBlocking {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                val hangingClient =
+                    HttpClient(MockEngine { _ -> awaitCancellation() }) {
+                        installListenUpErrorHandling()
+                    }
+
+                try {
+                    val state = SyncEngineState()
+                    val sse =
+                        SyncSseClient(
+                            serverUrlProvider = { "" },
+                            streamingClientProvider = { hangingClient },
+                            state = state,
+                            scope = scope,
+                            connectTimeoutMillis = CONNECT_TIMEOUT_MS,
+                        )
+
+                    sse.connect()
+
+                    // Pre-fix this hangs at Connecting forever (the Darwin infinite-timeout
+                    // bug), so awaiting the reconnecting state times out. Post-fix the connect
+                    // watchdog fires after CONNECT_TIMEOUT_MS and the loop enters its backoff.
+                    val reconnecting =
+                        withTimeout(GUARD_TIMEOUT) {
+                            state
+                                .observe()
+                                .filter {
+                                    (it.connection as? ConnectionState.Disconnected)?.reason == RECONNECTING
+                                }.first()
+                        }
+                    (reconnecting.connection as ConnectionState.Disconnected).reason shouldBe RECONNECTING
+                } finally {
+                    scope.cancel()
+                    hangingClient.close()
+                }
+            }
+        }
+    })
+
+private const val RECONNECTING = "reconnecting"
+private const val CONNECT_TIMEOUT_MS = 300L
+private val GUARD_TIMEOUT = 10.seconds


### PR DESCRIPTION
## Problem

iOS did not automatically reconnect to the server after the server went down and came back up. Android did. On WiFi that stays up while only the server bounces, iOS stayed stranded until an app restart.

## Root cause

The entire reconnect state machine (`SyncSseClient` backoff loop + `ReconnectionSupervisor`) is shared `commonMain` and runs identically on both platforms. The only connection-relevant divergence was the streaming HTTP engine config:

- **Android (OkHttp)** keeps a finite 10s connect timeout, so a reconnect attempt against a down server fails fast and the shared loop cycles.
- **iOS (Darwin/URLSession)** set `setTimeoutInterval` / `timeoutIntervalForRequest` / `timeoutIntervalForResource` all to `POSITIVE_INFINITY` — every phase, including connect.

So on iOS the reconnect attempt hung forever inside `prepareGet(...).execute {}`. `SyncSseClient.runOnce()` never returned → connection state never left `Connecting` → `ReconnectionSupervisor.recoveryLoop()` (gated on *not-connected*) never ran → even a foreground `connectRealtime()` no-op'd because the wedged job was still `isActive`.

`NetworkMonitor` is not involved: when only the server bounces, neither platform's monitor emits a transition.

## Fix

Rather than patch per-platform engine config, the connect bound moves into `commonMain` so both platforms behave identically and the logic is unit-testable:

- **`SyncSseClient`** — `runOnce()` now delegates to `connectBounded()`, which wraps `execute {}` in a `coroutineScope` and bounds **only** the connection-establishment phase via `withTimeoutOrNull(connectTimeoutMillis) { connected.await() }` (default 5s). On timeout the reader is cancelled and the attempt is mapped to `Reconnect`; once connected, `streamFrames()` reads **unbounded** — a live-but-idle SSE stream must never be torn down (both servers heartbeat every 25–30s). This removes the platform divergence entirely.
- **`ReconnectionSupervisor`** — probe-floor default lowered 5s → 2s so, once un-wedged, recovery of an already-open app feels near-instant (the supervisor's `reconnectNow()` short-circuits the backoff the moment the server answers).

## Tests

- New regression test `SyncSseClientConnectTimeoutTest` — a `MockEngine` that never responds (`awaitCancellation()`, the exact "socket accepted, no response" shape that hung on Darwin). Verified **red** first (hung at `Connecting` → guard timeout) then **green** after the watchdog.
- Full `:sharedLogic:jvmTest`, `spotlessCheck`, `detekt`, `compileCommonMainKotlinMetadata`, `:androidApp:assembleDebug` — all green locally. The auth-transient (401/403) and `reconnectNow` paths that the restructure touches still pass.

## Reviewed

Code-reviewed for coroutine correctness: fast-fail `ResponseException` → `AuthFailed`, clean timeout → `Reconnect`, external cancel re-thrown as `CancellationException`, no coroutine/request leaks. No blocking findings.

## Notes / caveats

- **On-device confirmation recommended.** The shared logic is unit-tested via a cancellation-honoring `MockEngine`; the fix assumes Ktor's Darwin engine aborts the URLSession task when the reader coroutine is cancelled (it does). A one-time simulator check — server up → kill server → confirm iOS leaves `Connecting` within ~5s and recovers when the server returns — is the final real-world verification. The CI `Test (iOS)` lane also gates this.
- **Android connect ceiling** is now effectively 5s (the commonMain watchdog) rather than OkHttp's prior 10s — deliberate, generous for LAN, and serves the snappier-recovery goal.
- **Known residual (both platforms, pre-existing, out of scope):** a half-open established stream that dies with no FIN isn't detected until the next heartbeat gap, since neither engine sets a read/idle timeout. The reported bug (reconnect after the server returns) is the connect path, which this fixes.
