### PR TITLE
✅ test(collections): JVM + native RPC E2E for collection create-and-add

### DIFF
--- a/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/collections/CollectionCreateNativeRpcTest.kt
+++ b/server/src/linuxX64Test/kotlin/com/calypsan/listenup/server/collections/CollectionCreateNativeRpcTest.kt
@@ -1,0 +1,180 @@
+package com.calypsan.listenup.server.collections
+
+import com.calypsan.listenup.api.CollectionService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.api.collectionServiceScopedTo
+import com.calypsan.listenup.server.api.createCollectionService
+import com.calypsan.listenup.server.auth.JwtConfiguration
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.auth.UserPrincipal
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import com.calypsan.listenup.server.db.sqldelight.DriverFactory
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase as ServerSqlDatabase
+import com.calypsan.listenup.server.foundation.FoundationDeps
+import com.calypsan.listenup.server.foundation.foundationServer
+import com.calypsan.listenup.server.io.readEnv
+import com.calypsan.listenup.server.rpcguard.CollectionServiceGuarded
+import com.calypsan.listenup.server.services.BookRevisionTouch
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionGrantRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO as ClientCIO
+import io.ktor.client.plugins.websocket.WebSockets as ClientWebSockets
+import io.ktor.server.routing.routing
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.client.rpcConfig
+import kotlinx.rpc.krpc.ktor.server.rpc
+import kotlinx.rpc.krpc.serialization.json.json
+import kotlinx.rpc.registerService
+import kotlinx.rpc.withService
+
+/**
+ * Native (linuxX64) proof for the create-collection RPC — the exact Kotlin/Native kotlinx.rpc
+ * transport that `server.kexe` and the iOS client run, which the JVM harness cannot exercise.
+ *
+ * Regression guard for the "create collection/shelf from the bulk picker is a silent no-op"
+ * bug (found on device 2026-07-06, PR #1055). The JVM RPC E2E
+ * ([com.calypsan.listenup.client.collections.CreateAndAddRpcE2ETest]) proved the create path
+ * works end-to-end over the JVM transport, isolating the defect to the Kotlin/Native stack.
+ * This drives the real native [CollectionService] (over a real native SQLite DB) across the
+ * native CIO/krpc WebSocket transport — if the create RPC (complex `CollectionSummary` return)
+ * fails on native, it reproduces HERE, on Linux, where it can be fixed.
+ *
+ * Structure mirrors [com.calypsan.listenup.server.rpcguard.RpcGuardNativeTest]: `kotlin.test.@Test`
+ * + `runBlocking` (Kotest's FunSpec is invisible to the K/N test runner), a real [foundationServer]
+ * over the native CIO engine, and a native CIO/krpc client opening the service proxy.
+ */
+class CollectionCreateNativeRpcTest {
+    private val jwt = JwtConfiguration("x".repeat(JWT_SECRET_LEN), "listenup", "listenup-client")
+
+    @Test
+    fun createCollectionRoundTripsOverNativeKrpc(): Unit =
+        runBlocking {
+            // A real, writable, ABSOLUTE dir under $HOME (the native test runner has no usable temp
+            // dir — see NativeServerBootTest). Absolute so MigrationRunner's admin connection and
+            // SQLiter's driver resolve to the SAME file: a bare filename sends SQLiter to its default
+            // dir while the admin connection opens it cwd-relative, and the two never meet
+            // (DriverFactory.linux splits name/basePath).
+            val home = readEnv("HOME")?.takeIf { it.isNotBlank() } ?: "."
+            val dir = "$home/.lu-collection-native-test"
+            SystemFileSystem.createDirectories(Path(dir))
+            val dbPath = "$dir/create-${Random.nextInt(1, Int.MAX_VALUE).toString(HEX_RADIX)}.db"
+            DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:$dbPath"))
+            val driver = DriverFactory().createDriver(dbPath)
+            val db = ServerSqlDatabase(driver)
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+
+            // FK targets for the collection insert + owner principal.
+            driver.execute(
+                null,
+                "INSERT INTO libraries(id, name, created_at, updated_at, revision) " +
+                    "VALUES ('test-library', 'Test Library', 1, 1, 0)",
+                0,
+            )
+            driver.execute(
+                null,
+                "INSERT INTO library_folders(id, library_id, root_path, created_at, updated_at, revision) " +
+                    "VALUES ('test-folder', 'test-library', '/tmp/test-library', 1, 1, 0)",
+                0,
+            )
+            driver.execute(
+                null,
+                "INSERT INTO users(id, email, email_normalized, password_hash, role, display_name, status, " +
+                    "created_at, updated_at) VALUES " +
+                    "('admin', 'admin@x', 'admin@x', 'x', 'ROOT', 'admin', 'ACTIVE', 1, 1)",
+                0,
+            )
+
+            val collectionRepo = CollectionRepository(db, bus, registry, driver = driver)
+            val collectionBookRepo = CollectionBookRepository(db, bus, registry, driver = driver)
+            val grantRepo = CollectionGrantRepository(db, bus, registry, driver = driver)
+            val noopRevisionTouch =
+                object : BookRevisionTouch {
+                    override suspend fun touchRevision(id: BookId): AppResult<Unit> = AppResult.Success(Unit)
+                }
+            val collectionService =
+                createCollectionService(
+                    collectionRepo = collectionRepo,
+                    collectionBookRepo = collectionBookRepo,
+                    grantRepo = grantRepo,
+                    bus = bus,
+                    sql = db,
+                    bookRevisionTouch = noopRevisionTouch,
+                )
+
+            val server =
+                foundationServer(port = 0, deps = FoundationDeps(jwt) { true }) {
+                    routing {
+                        rpc("/api/rpc/public") {
+                            rpcConfig { serialization { json(contractJson) } }
+                            registerService<CollectionService> {
+                                CollectionServiceGuarded(
+                                    collectionServiceScopedTo(
+                                        collectionService,
+                                        PrincipalProvider {
+                                            UserPrincipal(UserId("admin"), SessionId("s-admin"), UserRole.ROOT)
+                                        },
+                                    ),
+                                )
+                            }
+                        }
+                    }
+                }
+            server.start(wait = false)
+            try {
+                val port =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
+                val rpcClient =
+                    HttpClient(ClientCIO) {
+                        install(ClientWebSockets)
+                        installKrpc()
+                    }
+                try {
+                    val collections =
+                        rpcClient
+                            .rpc("ws://127.0.0.1:$port/api/rpc/public") {
+                                rpcConfig { serialization { json(contractJson) } }
+                            }.withService<CollectionService>()
+
+                    // The decisive native probe: does the create RPC (complex `CollectionSummary`
+                    // return) round-trip over the native krpc transport and yield a Success?
+                    val result = collections.createCollection("test-library", "Staff Picks")
+                    val created = result.shouldBeInstanceOf<AppResult.Success<*>>()
+                    created.data.shouldBeInstanceOf<com.calypsan.listenup.api.dto.CollectionSummary>()
+                } finally {
+                    rpcClient.close()
+                }
+            } finally {
+                server.stop(0, 0)
+                driver.close()
+                listOf(dbPath, "$dbPath-wal", "$dbPath-shm").forEach {
+                    SystemFileSystem.delete(Path(it), mustExist = false)
+                }
+            }
+        }
+
+    private companion object {
+        const val JWT_SECRET_LEN = 32
+        const val HEX_RADIX = 16
+    }
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/architecture/ArchitectureTest.kt
@@ -129,6 +129,10 @@ class ArchitectureTest :
                 // in-process to prove the admin backup routes return domain-typed results (not a
                 // transport 404). Same exemption class as the Profile E2E — confined to jvmTest.
                 .filter { "/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/admin/" !in it.path }
+                // Create-and-add RPC E2E: drives the client CollectionRepository through the real
+                // CollectionService in-process to prove the collection create path round-trips over the
+                // kotlinx.rpc transport. Same exemption class as the Backup RPC E2E — confined to jvmTest.
+                .filter { "/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/" !in it.path }
                 // Sync-domain completeness spec: boots the real server module in-process and reads
                 // GET /api/v1/sync/domains to assert contract ↔ client catalog ↔ server registrations
                 // are exactly 1:1:1. Asserting against the real production DI graph is the whole point,

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/CreateAndAddRpcE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/CreateAndAddRpcE2ETest.kt
@@ -1,0 +1,150 @@
+package com.calypsan.listenup.client.collections
+
+import com.calypsan.listenup.api.CollectionService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.CollectionBookDao
+import com.calypsan.listenup.client.data.local.db.CollectionDao
+import com.calypsan.listenup.client.data.local.db.CollectionShareDao
+import com.calypsan.listenup.client.data.repository.CollectionRepositoryImpl
+import com.calypsan.listenup.client.data.sync.testing.TestCollectionRpcFactory
+import com.calypsan.listenup.client.data.sync.testing.testAuth
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.api.collectionServiceScopedTo
+import com.calypsan.listenup.server.api.createCollectionService
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import com.calypsan.listenup.server.db.sqldelight.DriverFactory
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase as ServerSqlDatabase
+import com.calypsan.listenup.server.plugins.JWT_PROVIDER
+import com.calypsan.listenup.server.plugins.userPrincipalOrNull
+import com.calypsan.listenup.server.rpcguard.guard
+import com.calypsan.listenup.server.services.BookRevisionTouch
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionGrantRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.server.Krpc as ServerKrpc
+import kotlinx.rpc.krpc.ktor.server.rpc as serverRpc
+import kotlinx.rpc.krpc.serialization.json.json as krpcJson
+import kotlinx.rpc.registerService
+
+/**
+ * Cross-module E2E: the client's [CollectionRepositoryImpl] drives the real `:server`
+ * [CollectionService] in-process over the live kotlinx.rpc WebSocket transport — the exact
+ * seam `CreateCollectionUseCase` → `BookMultiSelectViewModel.createCollectionAndAddBooks`
+ * consumes in production.
+ *
+ * This is the regression guard for the "create collection/shelf from the bulk picker is a
+ * silent no-op" bug (found on device 2026-07-06, PR #1055). The create flow returns a complex
+ * object (`CollectionSummary`) where add returns `Unit`; add-to-existing was proven working,
+ * so the create RPC round-trip is the suspect. No test exercised this seam before — that
+ * coverage gap is why the bug shipped.
+ *
+ * Wiring mirrors [com.calypsan.listenup.client.admin.BackupRpcE2ETest]: [testAuth] mints a
+ * ROOT principal under [JWT_PROVIDER]; the route scopes the service per-request via
+ * [collectionServiceScopedTo] and wraps it with the KSP-generated [guard] decorator, exactly
+ * as production `RpcRoutes` does; [TestCollectionRpcFactory] opens the proxy against the
+ * in-process `ws://localhost/api/rpc/authed`.
+ */
+class CreateAndAddRpcE2ETest :
+    FunSpec({
+
+        test("client repository create() drives the real CollectionService RPC and returns Success") {
+            val tmp =
+                Files.createTempFile("listenup-createadd-e2e-", ".db").toFile().apply { deleteOnExit() }
+            DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
+            val serverDriver = DriverFactory().createDriver(tmp.absolutePath)
+            val serverSqlDb = ServerSqlDatabase(serverDriver)
+            val bus = ChangeBus()
+            val syncRegistry = SyncRegistry()
+
+            val now = System.currentTimeMillis()
+            serverDriver.execute(
+                null,
+                "INSERT INTO libraries(id, name, created_at, updated_at, revision) " +
+                    "VALUES ('test-library', 'Test Library', $now, $now, 0)",
+                0,
+            )
+            serverDriver.execute(
+                null,
+                "INSERT INTO library_folders(id, library_id, root_path, created_at, updated_at, revision) " +
+                    "VALUES ('test-folder', 'test-library', '/tmp/test-library', $now, $now, 0)",
+                0,
+            )
+            serverDriver.execute(
+                null,
+                "INSERT INTO users(id, email, email_normalized, password_hash, role, display_name, status, " +
+                    "created_at, updated_at) VALUES " +
+                    "('test-user', 'test-user@x', 'test-user@x', 'x', 'ROOT', 'test-user', 'ACTIVE', $now, $now)",
+                0,
+            )
+
+            val collectionRepo = CollectionRepository(serverSqlDb, bus, syncRegistry, driver = serverDriver)
+            val collectionBookRepo = CollectionBookRepository(serverSqlDb, bus, syncRegistry, driver = serverDriver)
+            val grantRepo = CollectionGrantRepository(serverSqlDb, bus, syncRegistry, driver = serverDriver)
+            val noopRevisionTouch =
+                object : BookRevisionTouch {
+                    override suspend fun touchRevision(id: BookId): AppResult<Unit> = AppResult.Success(Unit)
+                }
+            val collectionService =
+                createCollectionService(
+                    collectionRepo = collectionRepo,
+                    collectionBookRepo = collectionBookRepo,
+                    grantRepo = grantRepo,
+                    bus = bus,
+                    sql = serverSqlDb,
+                    bookRevisionTouch = noopRevisionTouch,
+                )
+
+            testApplication {
+                application {
+                    install(ServerKrpc)
+                    install(Authentication) { testAuth(defaultUserId = "test-user") }
+                    routing {
+                        authenticate(JWT_PROVIDER) {
+                            serverRpc("/api/rpc/authed") {
+                                rpcConfig { serialization { krpcJson(contractJson) } }
+                                registerService<CollectionService> {
+                                    val principal =
+                                        call.userPrincipalOrNull() ?: error("authed RPC mount reached without a principal")
+                                    guard(collectionServiceScopedTo(collectionService, PrincipalProvider { principal }))
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val rpcClient = createClient { installKrpc() }
+                val repository =
+                    CollectionRepositoryImpl(
+                        collectionDao = mock<CollectionDao>(MockMode.autofill),
+                        collectionBookDao = mock<CollectionBookDao>(MockMode.autofill),
+                        collectionShareDao = mock<CollectionShareDao>(MockMode.autofill),
+                        rpcFactory = TestCollectionRpcFactory(rpcClient),
+                    )
+
+                runTest {
+                    // The decisive probe: does the create RPC (complex `CollectionSummary` return)
+                    // round-trip over the real transport and map to a Success? A silent no-op on the
+                    // client would surface here as a Failure.
+                    val created = repository.create("test-library", "Staff Picks")
+                    created.shouldBeInstanceOf<AppResult.Success<*>>()
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## What

Adds the RPC-transport E2E coverage that never existed for the collection create path — the missing net that let the *"create collection/shelf from the bulk picker is a silent no-op"* bug (found on device during #1055) ship green through CI.

- **`CreateAndAddRpcE2ETest`** (`:sharedLogic:jvmTest`) — drives the real `CollectionRepositoryImpl.create` over the live kotlinx.rpc WebSocket transport against an in-process `CollectionService`. Green.
- **`CollectionCreateNativeRpcTest`** (`:server:linuxX64Test`) — drives the real native `CollectionService.createCollection` over the native CIO/krpc transport against a real native SQLite DB — `server.kexe`'s exact stack. Green.

## Why

Systematic debugging of the picker no-op **eliminated** the shared VM logic, the server service, and the RPC transport on **both** the JVM and native (linuxX64) stacks — all return `Success`. The defect is isolated to the **iosArm64 client runtime**, which cannot be built or run on Linux. These tests are the permanent nets for the layers that *can* be verified here; the iOS-side fix is tracked separately (needs a Mac). Full writeup lives in the (non-repo) findings doc `docs/create-from-picker-ios-findings-2026-07-07.md`.

JVM E2E structurally cannot catch an iosArm64-only bug — the durable fix for that class of gap is an Apple-target RPC smoke in the macOS CI lane (noted follow-up), alongside symmetric shelf RPC coverage.

## Test

- `./gradlew :sharedLogic:jvmTest --tests 'com.calypsan.listenup.client.collections.CreateAndAddRpcE2ETest'` → green (1 test)
- `./gradlew :server:linuxX64Test --tests 'com.calypsan.listenup.server.collections.CollectionCreateNativeRpcTest'` → green (1 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
