### PR TITLE
🐛 fix(shared): bound startup library-setup check so an unreachable server can't strand the splash

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val logger = KotlinLogging.logger {}
 
@@ -159,6 +160,16 @@ class AppStartupViewModel(
         const val BACKGROUND_THRESHOLD_MS = 30 * 60 * 1000L // 30 minutes
 
         /**
+         * Overall bound on the startup library-setup check. Its RPC calls ride the `/api/rpc/authed`
+         * WebSocket, and Ktor's `HttpTimeout` does not catch a post-upgrade RPC stall on
+         * Darwin/URLSession (documented on `InstanceRpcFactory`) — so an unreachable server would
+         * otherwise hang the check forever, leaving `readiness` on `Checking` and the app stranded on
+         * the splash screen. On timeout the check falls through to the offline resolution. 12s mirrors
+         * the `InstanceRpcFactory` server-probe bound for the same transport.
+         */
+        const val SETUP_CHECK_TIMEOUT_MS = 12_000L
+
+        /**
          * How long the "Building your library" gate may go without scan progress advancing before it
          * is marked stalled and offers the never-stranded "Continue" escape. A healthy scan advances
          * progress far more often than this; only a stuck or crashed server scan reaches it.
@@ -257,25 +268,42 @@ class AppStartupViewModel(
     private fun runLibrarySetupCheck() {
         viewModelScope.launch {
             try {
-                val user = userRepository.refreshCurrentUser() ?: userRepository.getCurrentUser()
-                logger.info { "AppStartupViewModel: resolved user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
+                // Bound the whole server-hitting check: its RPC calls can stall indefinitely against an
+                // unreachable server (HttpTimeout doesn't catch a post-upgrade RPC stall on Darwin), which
+                // would leave readiness on Checking and strand the app on the splash. withTimeoutOrNull —
+                // not withTimeout — so a timeout returns null and falls through to the offline resolution
+                // rather than throwing a TimeoutCancellationException that the CancellationException guard
+                // below would re-raise.
+                val completed =
+                    withTimeoutOrNull(SETUP_CHECK_TIMEOUT_MS) {
+                        val user = userRepository.refreshCurrentUser() ?: userRepository.getCurrentUser()
+                        logger.info { "AppStartupViewModel: resolved user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
 
-                if (user?.isAdmin == true) {
-                    applyAdminSetupCheckResult(
-                        libraryAdminRpcFactory.get().getSetupStatus(),
-                    )
-                } else {
-                    logger.info {
-                        "AppStartupViewModel: not an admin (user=${user?.displayName}, isAdmin=${user?.isAdmin}) — " +
-                            "skipping library-setup check"
+                        if (user?.isAdmin == true) {
+                            applyAdminSetupCheckResult(
+                                libraryAdminRpcFactory.get().getSetupStatus(),
+                            )
+                        } else {
+                            logger.info {
+                                "AppStartupViewModel: not an admin (user=${user?.displayName}, isAdmin=${user?.isAdmin}) — " +
+                                    "skipping library-setup check"
+                            }
+                            state.value =
+                                state.value.copy(
+                                    isChecking = false,
+                                    needsLibrarySetup = false,
+                                    setupCheckFailed = false,
+                                    checkResolved = true,
+                                )
+                        }
                     }
-                    state.value =
-                        state.value.copy(
-                            isChecking = false,
-                            needsLibrarySetup = false,
-                            setupCheckFailed = false,
-                            checkResolved = true,
-                        )
+
+                if (completed == null) {
+                    logger.warn {
+                        "AppStartupViewModel: setup check did not complete within ${SETUP_CHECK_TIMEOUT_MS}ms " +
+                            "(server unreachable) — resolving offline"
+                    }
+                    resolveOfflineOrFail()
                 }
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                 throw e

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -12,6 +12,7 @@ import com.calypsan.listenup.client.domain.model.User
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.every
@@ -22,6 +23,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -487,6 +489,33 @@ class AppStartupViewModelTest :
                 viewModel.state.value.isChecking shouldBe false
                 viewModel.state.value.setupCheckFailed shouldBe true
                 viewModel.state.value.needsLibrarySetup shouldBe false
+                viewModel.readiness.value shouldBe LibraryReadiness.CheckFailed
+            }
+        }
+
+        // Regression: when the server is unreachable at cold start, the setup check's RPC calls
+        // (refreshCurrentUser / getSetupStatus over the /api/rpc/authed WebSocket) can hang forever —
+        // Ktor's HttpTimeout does not bound a post-WebSocket-upgrade RPC stall on Darwin/URLSession.
+        // Without an overall timeout the check never resolves, readiness stays Checking, and iOS shows
+        // the splash screen indefinitely. The check must bound itself and fall through to the offline
+        // resolution so the app is never stranded on the splash.
+        test("setup check that hangs against an unreachable server times out and resolves, not an infinite splash") {
+            runTest {
+                // Given - the current-user RPC never returns (the unreachable-server stall)
+                val userRepository = createMockUserRepository()
+                val factory = createMockLibraryAdminRpcFactory()
+                everySuspend { userRepository.refreshCurrentUser() } calls { awaitCancellation() }
+                everySuspend { userRepository.getCurrentUser() } returns null
+                val syncRepository = createMockSyncRepository(hasLocalLibrary = false)
+
+                // When
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), syncRepository)
+                advanceUntilIdle()
+
+                // Then - the check timed out and resolved offline instead of hanging on Checking. With
+                // no local library the honest CheckFailed wall shows (→ MainTabView), dismissing splash.
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.checkResolved shouldBe true
                 viewModel.readiness.value shouldBe LibraryReadiness.CheckFailed
             }
         }


### PR DESCRIPTION
## Problem

Both iOS and Android hang forever on the splash screen at cold start when the server is unreachable. The app authenticates, logs `"authenticated — running library-setup check"`, then never advances.

## Root cause

`AppStartupViewModel.runLibrarySetupCheck()` (commonMain) awaits two kotlinx.rpc WebSocket calls — `userRepository.refreshCurrentUser()` and `libraryAdminRpcFactory.get().getSetupStatus()`, both on `/api/rpc/authed` — with **no overall timeout**. Ktor's `HttpTimeout` does not bound a post-WebSocket-upgrade RPC stall (the codebase documents this on `InstanceRpcFactory`). Against an unreachable server the check never resolves, so the derived `readiness` StateFlow stays `LibraryReadiness.Checking`, and both platforms keep showing their loading gate forever (iOS `LaunchScreen()`, Android `FullScreenLoadingIndicator`). The existing `catch → resolveOfflineOrFail()` never fires because a *hang* never throws.

This is a "Never Stranded" violation on the launch path. It predates the recent SSE reconnect work (introduced with the readiness gate in #1020) and affects **both platforms** because the gate is shared `commonMain`.

## Fix

Bound the server-hitting block with `withTimeoutOrNull(SETUP_CHECK_TIMEOUT_MS)` (12s). On timeout it falls through to the **existing** `resolveOfflineOrFail()`, which resolves to `Ready` (a returning user with a cached local library opens offline) or `CheckFailed` (a fresh admin sees the retryable error wall). Both dismiss the splash on both platforms.

`withTimeoutOrNull` (not `withTimeout`) is deliberate: a `TimeoutCancellationException` would be re-raised by the existing `catch (CancellationException) { throw e }` guard and never reach the fallback. Real (non-timeout) coroutine cancellation still propagates and is re-thrown — verified end-to-end.

12s mirrors `InstanceRpcFactory.DEFAULT_REQUEST_TIMEOUT_MS`, which bounds the identical post-upgrade RPC stall over the identical transport.

## Tests

- New regression test in `AppStartupViewModelTest` — `refreshCurrentUser()` hangs (`awaitCancellation()`); under `runTest` virtual time the check must resolve (`CheckFailed`, no local library) instead of staying `Checking`. Verified **red** without the fix, **green** with it.
- Full `:sharedLogic:jvmTest` (17/17 startup cases), `spotlessCheck`, `detekt`, `compileCommonMainKotlinMetadata`, `:androidApp:assembleDebug`, `:sharedUI:testAndroidHostTest` — all green locally.

## Reviewed

Code-reviewed (verdict: ship it). Confirmed: real cancellation still propagates (rubric compliance), no double-resolution, timeout genuinely fires (nothing in the awaited chain swallows it), and no happy-path regression — a healthy server sets state inside the block exactly as before, with zero added latency.

## Note / known lever

The 12s budget now covers two *sequential* RPC round-trips (currentUser, then getSetupStatus for admins) rather than a single probe, so it's a little tighter on a genuinely slow-but-reachable server. Acceptable by construction — a false timeout degrades gracefully (offline for returning users, retryable wall for a fresh admin), never a strand. Worth revisiting only if field reports show false timeouts on slow servers.
