### PR TITLE
⚡️ perf(shared): local-first startup gate — instant launch when the library is cached

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -268,15 +268,35 @@ class AppStartupViewModel(
     private fun runLibrarySetupCheck() {
         viewModelScope.launch {
             try {
-                // Bound the whole server-hitting check: its RPC calls can stall indefinitely against an
-                // unreachable server (HttpTimeout doesn't catch a post-upgrade RPC stall on Darwin), which
-                // would leave readiness on Checking and strand the app on the splash. withTimeoutOrNull —
-                // not withTimeout — so a timeout returns null and falls through to the offline resolution
-                // rather than throwing a TimeoutCancellationException that the CancellationException guard
-                // below would re-raise.
+                // Offline-first: if the library is already in Room, the app is Ready the instant we can
+                // read local state — never block the splash on the network when there is content to show.
+                // Server work (user refresh, setup-status, and the delta sync driven separately by
+                // connectRealtime) is background reconciliation that can only upgrade the experience.
+                if (syncRepository.hasLocalLibrary()) {
+                    markReady()
+                    launchBackgroundUserRefresh()
+                    return@launch
+                }
+
+                // No local library. A non-admin has nothing to set up, so go straight to the (empty)
+                // shell that incremental sync fills — still no network on the critical path. isAdmin is
+                // read from the locally-cached user; only a not-yet-cached user needs the server for it.
+                val localUser = userRepository.getCurrentUser()
+                if (localUser != null && !localUser.isAdmin) {
+                    markReady()
+                    launchBackgroundUserRefresh()
+                    return@launch
+                }
+
+                // Genuine cold start: no local library and a (possibly) admin user. This is the only case
+                // that must consult the server to decide wizard-vs-shell — and the only case where there
+                // is nothing local to show anyway. Bound it so an unreachable server can't strand the
+                // splash (HttpTimeout doesn't catch a post-upgrade RPC stall on Darwin). withTimeoutOrNull
+                // — not withTimeout — so a timeout returns null and falls through to the offline
+                // resolution rather than throwing a TimeoutCancellationException that the guard re-raises.
                 val completed =
                     withTimeoutOrNull(SETUP_CHECK_TIMEOUT_MS) {
-                        val user = userRepository.refreshCurrentUser() ?: userRepository.getCurrentUser()
+                        val user = userRepository.refreshCurrentUser() ?: localUser
                         logger.info { "AppStartupViewModel: resolved user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
 
                         if (user?.isAdmin == true) {
@@ -288,13 +308,7 @@ class AppStartupViewModel(
                                 "AppStartupViewModel: not an admin (user=${user?.displayName}, isAdmin=${user?.isAdmin}) — " +
                                     "skipping library-setup check"
                             }
-                            state.value =
-                                state.value.copy(
-                                    isChecking = false,
-                                    needsLibrarySetup = false,
-                                    setupCheckFailed = false,
-                                    checkResolved = true,
-                                )
+                            markReady()
                         }
                     }
 
@@ -312,6 +326,27 @@ class AppStartupViewModel(
                 resolveOfflineOrFail()
             }
         }
+    }
+
+    /** Resolve the gate to Ready — library present or nothing to set up — so the shell mounts now. */
+    private fun markReady() {
+        state.value =
+            state.value.copy(
+                isChecking = false,
+                needsLibrarySetup = false,
+                setupCheckFailed = false,
+                checkResolved = true,
+            )
+    }
+
+    /**
+     * Best-effort background refresh of the current user after a local-first [markReady]. Keeps isAdmin
+     * / profile current without gating the splash: [UserRepository.refreshCurrentUser] already swallows
+     * transport failures to null (offline is fine) and re-raises CancellationException. It never touches
+     * [readiness] — a user with local content is already Ready.
+     */
+    private fun launchBackgroundUserRefresh() {
+        viewModelScope.launch { userRepository.refreshCurrentUser() }
     }
 
     /**
@@ -353,13 +388,7 @@ class AppStartupViewModel(
         val hasLocal = suspendRunCatching { syncRepository.hasLocalLibrary() }.getOrDefault { false }
         if (hasLocal) {
             logger.info { "library check failed but a local library exists — opening offline" }
-            state.value =
-                state.value.copy(
-                    isChecking = false,
-                    needsLibrarySetup = false,
-                    setupCheckFailed = false,
-                    checkResolved = true,
-                )
+            markReady()
         } else {
             logger.warn { "library check failed and no local library — surfacing retryable error" }
             state.value =

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 
@@ -303,8 +304,11 @@ class AppStartupViewModelTest :
 
         test("setup-check failure does NOT swallow CancellationException into setupCheckFailed") {
             runTest {
-                // Given - admin user, setup-status fails, and the local-library probe is cancelled
-                // mid-flight (the coroutine scope is being torn down).
+                // Given - admin user, no local library so the check flows to the server path; setup-status
+                // fails, and resolveOfflineOrFail's local-library re-probe is cancelled mid-flight (the
+                // coroutine scope is being torn down). The sequential stub makes the first probe (the
+                // local-first top check) report "no library" and the second (inside resolveOfflineOrFail)
+                // throw — so this exercises that resolveOfflineOrFail suspendRunCatching CE guard directly.
                 val userRepository = createMockUserRepository()
                 val service = mock<LibraryAdminService>()
                 val factory = createMockLibraryAdminRpcFactory(service)
@@ -314,7 +318,15 @@ class AppStartupViewModelTest :
                 everySuspend { service.getSetupStatus() } returns
                     AppResult.Failure(TransportError.NetworkUnavailable())
                 val sync = createMockSyncRepository()
-                everySuspend { sync.hasLocalLibrary() } throws CancellationException("scope cancelled")
+                var probed = false
+                everySuspend { sync.hasLocalLibrary() } calls {
+                    if (!probed) {
+                        probed = true
+                        false
+                    } else {
+                        throw CancellationException("scope cancelled")
+                    }
+                }
 
                 // When
                 val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), sync)
@@ -517,6 +529,38 @@ class AppStartupViewModelTest :
                 viewModel.state.value.isChecking shouldBe false
                 viewModel.state.value.checkResolved shouldBe true
                 viewModel.readiness.value shouldBe LibraryReadiness.CheckFailed
+            }
+        }
+
+        // Offline-first responsiveness: a returning user already has the library in Room, so the app
+        // is Ready the instant we can read local state — the splash must NOT wait on any server
+        // round-trip. Server work (user refresh, setup-status, delta sync) is background reconciliation
+        // that can only ever upgrade the experience, never gate it.
+        test("resolves Ready instantly from a local library without any server round-trip") {
+            runTest {
+                // Given - admin with a cached local library; the setup-status RPC would hang forever if
+                // the local-first path ever consulted it.
+                val userRepository = createMockUserRepository()
+                val service = mock<LibraryAdminService>()
+                val factory = createMockLibraryAdminRpcFactory(service)
+                val adminUser = createTestUser(isAdmin = true)
+                everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+                everySuspend { userRepository.getCurrentUser() } returns adminUser
+                everySuspend { service.getSetupStatus() } calls { awaitCancellation() }
+                val syncRepository = createMockSyncRepository(hasLocalLibrary = true)
+
+                // When - run only the work scheduled at the current instant; do NOT advance virtual time
+                // past any timeout.
+                val viewModel = AppStartupViewModel(userRepository, factory, createMockAuthSession(), syncRepository)
+                runCurrent()
+
+                // Then - Ready is resolved synchronously from local content, before (and without) the
+                // hanging server call. Pre-change the check would call getSetupStatus, hang, and stay
+                // Checking here — only reaching Ready after the full timeout.
+                viewModel.state.value.checkResolved shouldBe true
+                viewModel.state.value.isChecking shouldBe false
+                viewModel.state.value.needsLibrarySetup shouldBe false
+                viewModel.readiness.value shouldBe LibraryReadiness.Ready
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadinessTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/LibraryReadinessTest.kt
@@ -83,10 +83,15 @@ class LibraryReadinessTest :
         fun syncRepo(
             scanning: MutableStateFlow<Boolean>,
             progress: MutableStateFlow<ScanProgressState?> = MutableStateFlow(null),
+            hasLocalLibrary: Boolean = false,
         ): SyncRepository {
             val sync = mock<SyncRepository>()
             every { sync.isBuildingInitialLibrary } returns scanning
             every { sync.scanProgress } returns progress
+            // Local-first startup reads this before any server round-trip. Default false: a fresh admin
+            // and an in-progress initial population have no complete local library yet, so the setup
+            // check flows through the server path these specs drive. The relaunch-existing spec overrides.
+            everySuspend { sync.hasLocalLibrary() } returns hasLocalLibrary
             return sync
         }
 
@@ -161,7 +166,9 @@ class LibraryReadinessTest :
                         userRepoReturning(adminUser()),
                         adminFactory(service),
                         authSession(MutableStateFlow(authenticated)),
-                        syncRepo(MutableStateFlow(false)),
+                        // Existing library present in Room → local-first resolves Ready without the
+                        // server round-trip (the getSetupStatus stub above is intentionally unreached).
+                        syncRepo(MutableStateFlow(false), hasLocalLibrary = true),
                     )
 
                 vm.readiness.test {


### PR DESCRIPTION
## Why

Follow-up to #1058. That PR stopped an unreachable server from stranding the splash by bounding the startup check with a 12s timeout — but 12s is a band-aid: the splash was gated on a server round-trip at all, which is wrong for an offline-first app that already has the whole library in Room. This PR takes the network off the launch path.

## What

Make the startup gate **local-first** in `AppStartupViewModel.runLibrarySetupCheck()`:

1. **`hasLocalLibrary()` (a local Room read) → `markReady()` instantly** + a fire-and-forget background user refresh. No network on the critical path when there's content to show.
2. **No local library, known non-admin (from cached `getCurrentUser()`) → Ready instantly** too — a non-admin has nothing to set up.
3. **Only a no-local-library, admin-or-uncached user** falls through to the existing bounded `withTimeoutOrNull(12s)` server path (the one case that genuinely needs the server to decide wizard-vs-shell, and the one case where there's nothing local to show anyway).

Result: every returning launch is instant (Room speed) on **both platforms** — the gate and `readiness` are shared `commonMain`. The 12s bound survives only for a genuine first-run with no cached data. Server work (user refresh, setup-status) and delta sync (driven separately by `connectRealtime`) become background reconciliation that can only upgrade the experience, never block it.

Also DRYs `resolveOfflineOrFail()`'s local-library branch onto the new `markReady()` helper.

## Behavior change (acknowledged)

A returning admin whose server library was *deleted* while a device holds stale cache now mounts the shell (on stale books → emptied by sync) instead of auto-routing to the setup wizard. This is intentional and never-stranded: the admin re-adds a folder from **Settings → Administration → Library Settings** (an always-available screen, separate from the first-run wizard, that works on an empty library — verified on both iOS and Android). It also avoids the more common false-positive of forcing the wizard during a transient mid-scan empty state.

Residual to verify separately (server-side, not this change): if a deletion removes the library *record* entirely so `getLibrary()` fails (rather than returning a zero-folder library), the Library Settings screen errors — the never-stranded guarantee relies on the server still returning a Library object.

## Tests

- New: `resolves Ready instantly from a local library without any server round-trip` — hangs `getSetupStatus` and asserts Ready via `runCurrent()` (no virtual-time advance), proving the local path never touches the server. Red → green verified.
- Updated `LibraryReadinessTest` fixtures to stub the newly-called `hasLocalLibrary()` (fresh-admin/populating = false, relaunch-existing = true) — assertions unchanged.
- Preserved the `resolveOfflineOrFail` CancellationException-reraise coverage via a sequential stub (first probe succeeds → server path fails → the re-probe is the one cancelled).
- Full `:sharedLogic:jvmTest`, `spotlessCheck`, `detekt`, `compileCommonMainKotlinMetadata`, `:androidApp:assembleDebug`, `:sharedUI:testAndroidHostTest` — all green.

## Reviewed

Code-reviewed (verdict: ship-able). Confirmed the decision tree is correct for every user type, `markReady()` preserves `backgroundedAtMs`/`populatingDismissed`, the background refresh can't leak or crash the scope, and CancellationException handling holds end-to-end.
