### PR TITLE
🐛 fix: create shelves/collections reliably from multi-select + book detail (iOS + Android)

### DIFF
--- a/iosApp/ListenUp/Features/BookDetail/Components/CollectionPickerSheet.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/CollectionPickerSheet.swift
@@ -99,6 +99,11 @@ struct CollectionPickerSheet: View {
                         .foregroundStyle(Color.listenUpOrange)
                         .disabled(trimmedName.isEmpty || observer.isAddingToCollection)
                 }
+                // Give each button its own hit target. Without .borderless, two default
+                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
+                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
+                // which no-ops on the empty-name guard — a silent create failure.
+                .buttonStyle(.borderless)
             } else {
                 Button { isCreatingCollection = true } label: {
                     Label(String(localized: "book.detail_new_collection"), systemImage: "plus")

--- a/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/BookDetail/Components/ShelfPickerSheet.swift
@@ -97,6 +97,11 @@ struct ShelfPickerSheet: View {
                         .foregroundStyle(Color.listenUpOrange)
                         .disabled(trimmedName.isEmpty || observer.isAddingToShelf)
                 }
+                // Give each button its own hit target. Without .borderless, two default
+                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
+                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
+                // which no-ops on the empty-name guard — a silent create failure.
+                .buttonStyle(.borderless)
             } else {
                 Button { isCreatingShelf = true } label: {
                     Label(String(localized: "book.detail_new_shelf"), systemImage: "plus")

--- a/iosApp/ListenUp/Features/Selection/BulkCollectionPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkCollectionPickerSheet.swift
@@ -97,6 +97,11 @@ struct BulkCollectionPickerSheet: View {
                         .foregroundStyle(Color.listenUpOrange)
                         .disabled(trimmedName.isEmpty || observer.isAddingToCollection)
                 }
+                // Give each button its own hit target. Without .borderless, two default
+                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
+                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
+                // which no-ops on the empty-name guard — a silent create failure.
+                .buttonStyle(.borderless)
             } else {
                 Button { isCreatingCollection = true } label: {
                     Label(String(localized: "book.detail_new_collection"), systemImage: "plus")

--- a/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
+++ b/iosApp/ListenUp/Features/Selection/BulkShelfPickerSheet.swift
@@ -86,6 +86,11 @@ struct BulkShelfPickerSheet: View {
                         .foregroundStyle(Color.listenUpOrange)
                         .disabled(trimmedName.isEmpty || observer.isAddingToShelf)
                 }
+                // Give each button its own hit target. Without .borderless, two default
+                // buttons in a List row make the whole row tappable for BOTH: a tap anywhere
+                // outside the tiny "Create" text fires Cancel (clearing the name) then Create,
+                // which no-ops on the empty-name guard — a silent create failure.
+                .buttonStyle(.borderless)
             } else {
                 Button { isCreatingShelf = true } label: {
                     Label(String(localized: "book.detail_new_shelf"), systemImage: "plus")

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.dto.CollectionShareDto
 import com.calypsan.listenup.api.dto.CollectionSummary
 import com.calypsan.listenup.api.dto.SharePermission
+import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.client.data.local.db.CollectionBookDao
+import com.calypsan.listenup.client.data.local.db.CollectionEntity
 import com.calypsan.listenup.client.data.local.db.CollectionShareDao
 import com.calypsan.listenup.client.data.local.db.CollectionShareEntity
 import com.calypsan.listenup.client.data.local.db.CollectionWithBookCount
@@ -16,14 +18,20 @@ import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.CollectionId
+import com.calypsan.listenup.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.core.error.ErrorMapper
 import com.calypsan.listenup.api.result.map
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withTimeout
 
 private val logger = KotlinLogging.logger {}
+
+/** Upper bound on a single collection RPC. Guards against a black-holed WebSocket that never resolves. */
+private const val RPC_TIMEOUT_MS = 15_000L
 
 /**
  * Collection repository — Room-backed reads, RPC-dispatched mutations.
@@ -63,7 +71,10 @@ internal class CollectionRepositoryImpl(
     override suspend fun create(
         libraryId: String,
         name: String,
-    ): AppResult<Collection> = rpcCall { rpcFactory.get().createCollection(libraryId, name) }.map { it.toDomain() }
+    ): AppResult<Collection> =
+        rpcCall { rpcFactory.get().createCollection(libraryId, name) }
+            .also { if (it is AppResult.Success) mirrorCreatedCollection(libraryId, it.data) }
+            .map { it.toDomain() }
 
     override suspend fun rename(
         id: String,
@@ -119,16 +130,45 @@ internal class CollectionRepositoryImpl(
      */
     private suspend fun <T> rpcCall(block: suspend () -> WireAppResult<T>): AppResult<T> =
         try {
-            when (val result = block()) {
+            when (val result = withTimeout(RPC_TIMEOUT_MS) { block() }) {
                 is WireAppResult.Success -> AppResult.Success(result.data)
                 is WireAppResult.Failure -> AppResult.Failure(result.error)
             }
+        } catch (e: TimeoutCancellationException) {
+            logger.warn(e) { "Collection RPC timed out after ${RPC_TIMEOUT_MS}ms" }
+            AppResult.Failure(TransportError.Timeout())
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
             logger.warn(e) { "Collection RPC failed" }
             AppResult.Failure(ErrorMapper.map(e))
         }
+
+    /**
+     * Optimistically mirror a just-created collection into Room so it appears immediately, without
+     * waiting for the SSE echo (offline-first / never-stranded). Insert-if-absent at revision 0: the
+     * authoritative echo (revision >= 1) always wins via the domain's ServerWins/RevisionGuard, and a
+     * digest reconcile self-heals if the echo landed first — so this never overwrites an echoed row.
+     */
+    private suspend fun mirrorCreatedCollection(
+        libraryId: String,
+        summary: CollectionSummary,
+    ) {
+        if (collectionDao.revisionOf(summary.id.value) != null) return
+        collectionDao.upsert(
+            CollectionEntity(
+                id = summary.id.value,
+                libraryId = libraryId,
+                ownerId = summary.ownerId.value,
+                name = summary.name,
+                isInbox = summary.isInbox,
+                isSystem = summary.isSystem,
+                revision = 0,
+                deletedAt = null,
+                updatedAt = currentEpochMilliseconds(),
+            ),
+        )
+    }
 }
 
 private fun CollectionWithBookCount.toDomain(): Collection =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
@@ -3,10 +3,12 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.shelf.DiscoveredShelf
 import com.calypsan.listenup.api.dto.shelf.ShelfDetail as ShelfDetailDto
+import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
 import com.calypsan.listenup.client.core.error.ErrorMapper
 import com.calypsan.listenup.client.data.local.db.ShelfDao
+import com.calypsan.listenup.client.data.local.db.ShelfEntity
 import com.calypsan.listenup.client.data.local.db.ShelfWithBookCount
 import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.remote.ShelfRpcFactory
@@ -16,12 +18,18 @@ import com.calypsan.listenup.client.domain.model.ShelfDetail
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ShelfId
+import com.calypsan.listenup.core.currentEpochMilliseconds
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withTimeout
 
 private val logger = KotlinLogging.logger {}
+
+/** Upper bound on a single shelf RPC. Guards against a black-holed WebSocket that never resolves. */
+private const val RPC_TIMEOUT_MS = 15_000L
 
 /**
  * Shelf repository — substrate-Room-backed reads, [com.calypsan.listenup.api.ShelfService]
@@ -105,7 +113,8 @@ internal class ShelfRepositoryImpl(
                 description = description ?: "",
                 isPrivate = isPrivate,
             )
-        }.map { it.toDomain() }
+        }.also { if (it is AppResult.Success) mirrorCreatedShelf(it.data) }
+            .map { it.toDomain() }
 
     override suspend fun updateShelf(
         shelfId: ShelfId,
@@ -193,13 +202,38 @@ internal class ShelfRepositoryImpl(
      */
     private suspend fun <T> rpcCall(block: suspend () -> AppResult<T>): AppResult<T> =
         try {
-            block()
+            withTimeout(RPC_TIMEOUT_MS) { block() }
+        } catch (e: TimeoutCancellationException) {
+            logger.warn(e) { "Shelf RPC timed out after ${RPC_TIMEOUT_MS}ms" }
+            AppResult.Failure(TransportError.Timeout())
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
             logger.warn(e) { "Shelf RPC failed" }
             AppResult.Failure(ErrorMapper.map(e))
         }
+
+    /**
+     * Optimistically mirror a just-created shelf into Room so it appears immediately, without waiting
+     * for the SSE echo (offline-first / never-stranded). Insert-if-absent at revision 0: the
+     * authoritative echo (revision >= 1) always wins via the domain's ServerWins/RevisionGuard, and a
+     * digest reconcile self-heals if the echo landed first — so this never overwrites an echoed row.
+     */
+    private suspend fun mirrorCreatedShelf(shelf: com.calypsan.listenup.api.dto.shelf.Shelf) {
+        if (dao.revisionOf(shelf.id.value) != null) return
+        dao.upsert(
+            ShelfEntity(
+                id = shelf.id.value,
+                name = shelf.name,
+                description = shelf.description,
+                isPrivate = shelf.isPrivate,
+                revision = 0,
+                deletedAt = null,
+                updatedAt = shelf.updatedAt,
+                createdAt = shelf.updatedAt,
+            ),
+        )
+    }
 }
 
 private fun com.calypsan.listenup.api.dto.shelf.Shelf.toDomain(): Shelf =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -122,8 +122,38 @@ class BookDetailViewModel(
             bookIdFlow
                 .filterNotNull()
                 .flatMapLatest { id -> loadBookFlow(id) }
-                .collect { state.value = it }
+                .collect { built -> state.value = built.preservingTransientOverlays(state.value) }
         }
+    }
+
+    /**
+     * Carry user-driven transient overlay state (open pickers, in-flight action flags, inline
+     * errors) forward when [loadBookFlow] rebuilds [BookDetailUiState.Ready] from Room/availability.
+     *
+     * Those flows re-emit on every table invalidation (an SSE firehose frame the sync engine
+     * applies, a download progress tick, a reachability flip) — each rebuild resets these overlay
+     * fields to their defaults. Without preserving them, any background emission would silently close
+     * an open shelf/collection picker (and its create dialog) mid-interaction — the create-from-book-
+     * detail bug. Only carried between two [Ready]s for the *same* load; a book switch emits [Loading]
+     * first (breaking the chain), so overlays never leak across books.
+     *
+     * NOTE: when adding a new user-transient field to [Ready], add it here too.
+     */
+    private fun BookDetailUiState.preservingTransientOverlays(previous: BookDetailUiState): BookDetailUiState {
+        if (this !is BookDetailUiState.Ready || previous !is BookDetailUiState.Ready) return this
+        return copy(
+            isMarkingComplete = previous.isMarkingComplete,
+            isDiscardingProgress = previous.isDiscardingProgress,
+            isRestarting = previous.isRestarting,
+            isLoadingTags = previous.isLoadingTags,
+            showTagPicker = previous.showTagPicker,
+            showShelfPicker = previous.showShelfPicker,
+            isAddingToShelf = previous.isAddingToShelf,
+            shelfError = previous.shelfError,
+            showCollectionPicker = previous.showCollectionPicker,
+            isAddingToCollection = previous.isAddingToCollection,
+            collectionError = previous.collectionError,
+        )
     }
 
     /**

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImplTest.kt
@@ -15,10 +15,14 @@ import com.calypsan.listenup.client.data.local.db.CollectionDao
 import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.CollectionId
+import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -39,7 +43,8 @@ class CollectionRepositoryImplTest :
     FunSpec({
 
         fun repo(
-            collectionDao: CollectionDao = mock(),
+            // autofill: create() now reads revisionOf() and calls upsert() for the optimistic mirror.
+            collectionDao: CollectionDao = mock(MockMode.autofill),
             bookDao: CollectionBookDao = mock(),
             shareDao: CollectionShareDao = mock(),
             service: CollectionService = mock(),
@@ -146,6 +151,38 @@ class CollectionRepositoryImplTest :
                 val service = mock<CollectionService>()
                 everySuspend { service.deleteCollection(CollectionId("c1")) } returns WireAppResult.Success(Unit)
                 repo(service = service).delete("c1").shouldBeInstanceOf<AppResult.Success<*>>()
+            }
+        }
+
+        // Offline-first visibility: a created collection is written to Room immediately so it shows in
+        // the list without waiting for the SSE echo (which may be delayed or offline).
+        test("create optimistically mirrors the new collection into Room before the SSE echo") {
+            runTest {
+                val dao = mock<CollectionDao>(MockMode.autofill)
+                everySuspend { dao.revisionOf("c-new") } returns null // not yet echoed
+                val service = mock<CollectionService>()
+                everySuspend { service.createCollection("lib1", "New") } returns
+                    WireAppResult.Success(summary("c-new", "New"))
+
+                repo(collectionDao = dao, service = service).create("lib1", "New")
+
+                verifySuspend { dao.upsert(any()) }
+            }
+        }
+
+        // Idempotency: the optimistic write is insert-if-absent — it must never clobber a row the
+        // authoritative SSE echo already applied (which carries the real, higher revision).
+        test("create does not overwrite an already-echoed collection row") {
+            runTest {
+                val dao = mock<CollectionDao>(MockMode.autofill)
+                everySuspend { dao.revisionOf("c-new") } returns 9L // echo already applied
+                val service = mock<CollectionService>()
+                everySuspend { service.createCollection("lib1", "New") } returns
+                    WireAppResult.Success(summary("c-new", "New"))
+
+                repo(collectionDao = dao, service = service).create("lib1", "New")
+
+                verifySuspend(mode = VerifyMode.not) { dao.upsert(any()) }
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
@@ -18,11 +18,14 @@ import com.calypsan.listenup.client.data.remote.ShelfRpcFactory
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.core.Timestamp
+import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -57,7 +60,8 @@ class ShelfRepositoryImplTest :
             )
 
         fun repo(
-            shelfDao: ShelfDao = mock(),
+            // autofill: createShelf() now reads revisionOf() and calls upsert() for the optimistic mirror.
+            shelfDao: ShelfDao = mock(MockMode.autofill),
             userDao: UserDao = mock { everySuspend { getCurrentUser() } returns user() },
             service: ShelfService = mock(),
         ): ShelfRepositoryImpl {
@@ -141,6 +145,41 @@ class ShelfRepositoryImplTest :
                     }
                 val result = repo(service = service).createShelf("Dup", null, isPrivate = false)
                 result.shouldBeInstanceOf<AppResult.Failure>()
+            }
+        }
+
+        // Offline-first visibility: a created shelf is written to Room immediately so it shows in the
+        // list without waiting for the SSE echo.
+        test("createShelf optimistically mirrors the new shelf into Room before the SSE echo") {
+            runTest {
+                val dao = mock<ShelfDao>(MockMode.autofill)
+                everySuspend { dao.revisionOf("s-new") } returns null // not yet echoed
+                val service =
+                    mock<ShelfService> {
+                        everySuspend { createShelf("New", "", false) } returns
+                            AppResult.Success(summary("s-new", "New"))
+                    }
+
+                repo(shelfDao = dao, service = service).createShelf("New", null, isPrivate = false)
+
+                verifySuspend { dao.upsert(any()) }
+            }
+        }
+
+        // Idempotency: insert-if-absent must never clobber a row the SSE echo already applied.
+        test("createShelf does not overwrite an already-echoed shelf row") {
+            runTest {
+                val dao = mock<ShelfDao>(MockMode.autofill)
+                everySuspend { dao.revisionOf("s-new") } returns 9L // echo already applied
+                val service =
+                    mock<ShelfService> {
+                        everySuspend { createShelf("New", "", false) } returns
+                            AppResult.Success(summary("s-new", "New"))
+                    }
+
+                repo(shelfDao = dao, service = service).createShelf("New", null, isPrivate = false)
+
+                verifySuspend(mode = VerifyMode.not) { dao.upsert(any()) }
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/CreateAndAddRpcE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/CreateAndAddRpcE2ETest.kt
@@ -36,7 +36,7 @@ import io.ktor.server.auth.authenticate
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import java.nio.file.Files
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import kotlinx.rpc.krpc.ktor.client.installKrpc
 import kotlinx.rpc.krpc.ktor.server.Krpc as ServerKrpc
 import kotlinx.rpc.krpc.ktor.server.rpc as serverRpc
@@ -138,7 +138,10 @@ class CreateAndAddRpcE2ETest :
                         rpcFactory = TestCollectionRpcFactory(rpcClient),
                     )
 
-                runTest {
+                // runBlocking (real wall-clock), not runTest: the repo's rpcCall now bounds each call
+                // with withTimeout, whose clock is virtual under runTest — runTest would auto-advance
+                // past the 15s bound before the real WebSocket I/O completes and spuriously time out.
+                runBlocking {
                     // The decisive probe: does the create RPC (complex `CollectionSummary` return)
                     // round-trip over the real transport and map to a Success? A silent no-op on the
                     // client would surface here as a Failure.

--- a/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BookSelectionScaffold.kt
+++ b/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/BookSelectionScaffold.kt
@@ -86,8 +86,7 @@ fun BookSelectionScaffold(
     }
 
     // Collection picker sheet. Collections are admin-managed — gate the picker
-    // presentation on isAdmin as defense-in-depth. The multi-select flow adds existing
-    // collections only; inline create lives on the Book Detail picker (canCreate = false here).
+    // presentation (and the inline-create affordance) on isAdmin as defense-in-depth.
     if (showCollectionPicker && isAdmin) {
         CollectionPickerSheet(
             collections = collections,
@@ -95,7 +94,10 @@ fun BookSelectionScaffold(
             onCollectionSelected = { collectionId ->
                 multiSelect.addSelectedToCollection(collectionId)
             },
-            onCreateAndAddToCollection = {},
+            onCreateAndAddToCollection = { name ->
+                multiSelect.createCollectionAndAddBooks(name)
+            },
+            canCreate = isAdmin,
             onDismiss = { showCollectionPicker = false },
             isLoading = isAddingToCollection,
         )


### PR DESCRIPTION
## Why creating shelves/collections kept failing

Deep multi-agent investigation (shared + iOS + Android, fable) found this was **not one bug** — it was **several stacked defects that differ per platform**, which is exactly why 2-3 prior fixes (#1055 wired iOS only; #1057 added RPC tests) never stuck. Each verified independently:

| # | Defect | Where |
|---|--------|-------|
| **A** | Create tap fires **Cancel-then-Create** (Cancel clears the name → Create no-ops on the empty guard). Two default `Button`s in a SwiftUI `List` row with no `.buttonStyle(.borderless)` → the whole row is tappable for both. **Empirically reproduced on the iOS 26 simulator.** | iOS, all 4 sheets |
| **B** | Multi-select **create-collection was unwired** (`onCreateAndAddToCollection = {}`, `canCreate` never passed) | Android Compose |
| **C** | Book-detail **picker state clobbered** — `state.value = it` replaced the whole `Ready` (picker flags live inside it) on every Room re-emission (SSE frame, download tick) → sheet/dialog vanish mid-use | Shared VM (hit Android) |
| **D** | Shelf/collection `rpcCall` had **no timeout** → a black-holed WebSocket could hang create forever | Shared |
| **E** | **No optimistic write** — a created entity was only visible once the SSE echo landed in Room (no test covered create→visibility) | Shared |

## Fixes (all in this PR)

- **A** — `.buttonStyle(.borderless)` on the create-row buttons in all four sheets (`BulkShelf`/`BulkCollection`/book-detail `Shelf`/`Collection` picker sheets) so each button gets its own hit target.
- **B** — wired multi-select create-collection in `BookSelectionScaffold` (`canCreate = isAdmin` + real `createCollectionAndAddBooks`).
- **C** — `BookDetailViewModel` now preserves user-driven transient overlay state (open pickers, in-flight flags, inline errors) across data re-emissions; a book switch still resets cleanly (it emits `Loading` first).
- **D** — `withTimeout(15s)` on shelf/collection `rpcCall`; a timeout maps to `TransportError.Timeout` (surfaced as a normal failure, not a hang).
- **E** — optimistic **insert-if-absent** Room write on create at revision 0. The authoritative SSE echo (revision ≥ 1) always wins via the domain's `ServerWins`/`RevisionGuard`, and digest reconcile self-heals if the echo landed first — so it never clobbers an echoed row (no flicker/double-apply).

## Tests

- New repo tests (both `Collection` + `Shelf`): create optimistically mirrors into Room **before** the echo; and does **not** overwrite an already-echoed row (idempotency, `VerifyMode.not`).
- Fixed `CreateAndAddRpcE2ETest` to `runBlocking` (the new `withTimeout` uses a virtual clock under `runTest`, which auto-advanced past the real WebSocket I/O and spuriously timed out).
- Full `:sharedLogic:jvmTest` (3115+), `spotlessCheck`, `detekt`, `:sharedUI:testAndroidHostTest`, `:androidApp:assembleDebug` — all green. The native `CollectionCreateNativeRpcTest` already uses `runBlocking` (unaffected).

## Verification notes / follow-ups

- **iOS (A)** is a SwiftUI hit-testing fix — not unit-testable; verified by the agent's simulator repro + this standard idiom. CI's `Build (iOS)` / `Test (iOS)` lanes compile-verify it; a one-tap on-device check is the final confirmation.
- **Deferred (recommended follow-up):** the iOS **bulk** (multi-select) sheets route failures to the Kotlin `errorBus`, which iOS doesn't consume — so a genuine *failure* there is still silent (success now works). Per `iosApp` rule 10 this should surface natively at the observer boundary (the book-detail sheets already render inline errors). Not required for the create path to work, but worth doing for "never silent."
