### PR TITLE
🐛 fix(iosApp): playback prepare hardening + collection member display names

### DIFF
--- a/iosApp/ListenUp/Features/Admin/Collections/AdminCollectionDetailObserver.swift
+++ b/iosApp/ListenUp/Features/Admin/Collections/AdminCollectionDetailObserver.swift
@@ -127,11 +127,14 @@ struct CollectionBookRowModel: Identifiable {
 struct CollectionShareRowModel: Identifiable {
     let id: String
     let userId: String
+    let displayName: String
     let permission: String
 
     init(from share: CollectionShareItem) {
         self.id = share.id
         self.userId = share.userId
+        // Resolved in the shared VM from the public_profiles mirror; falls back to the id until synced.
+        self.displayName = share.displayName
         self.permission = share.permission
     }
 }

--- a/iosApp/ListenUp/Features/Admin/Collections/AdminCollectionDetailView.swift
+++ b/iosApp/ListenUp/Features/Admin/Collections/AdminCollectionDetailView.swift
@@ -280,10 +280,10 @@ struct AdminCollectionDetailView: View {
         isRevoking: Bool
     ) -> some View {
         HStack(spacing: 12) {
-            InitialsAvatar(initials: initials(for: share.userId), size: 36)
+            InitialsAvatar(initials: initials(for: share.displayName), size: 36)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(share.userId)
+                Text(share.displayName)
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(.primary)
                 Text(share.permission.capitalized)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -162,6 +162,7 @@ internal val adminPresentationModule =
                 collectionRepository = get(),
                 adminRepository = get(),
                 userRepository = get(),
+                userProfileRepository = get(),
                 bookDao = get(),
                 searchRepository = get(),
                 imageStorage = get(),

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -105,7 +105,22 @@ class PlaybackPreparer internal constructor(
      *
      * @return a [PreparedPlayback] value, or `null` on any failure (logged).
      */
-    suspend fun prepare(bookId: BookId): PreparedPlayback? {
+    suspend fun prepare(bookId: BookId): PreparedPlayback? =
+        try {
+            prepareInternal(bookId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Contract (see KDoc): "null on any failure (logged)". An escaping throw — e.g. a
+            // transport exception from the streaming-prepare RPC when the book isn't downloaded
+            // (buildTimeline's `playbackService().prepare` is the one unguarded RPC) — otherwise
+            // crosses the Swift Export seam as an opaque `KotlinError`, and the player shows
+            // "Couldn't start playback" with no cause. Fold to null and log the real exception.
+            logger.error(e) { "Playback prepare failed for ${bookId.value}" }
+            null
+        }
+
+    private suspend fun prepareInternal(bookId: BookId): PreparedPlayback? {
         logger.info { "Preparing playback for book: ${bookId.value}" }
 
         // 1. Ensure fresh auth token

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModel.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModel.kt
@@ -16,6 +16,7 @@ import com.calypsan.listenup.client.domain.repository.AdminRepository
 import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.SearchRepository
+import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
@@ -26,6 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -52,6 +54,7 @@ class AdminCollectionDetailViewModel internal constructor(
     private val collectionRepository: CollectionRepository,
     private val adminRepository: AdminRepository,
     private val userRepository: UserRepository,
+    private val userProfileRepository: UserProfileRepository,
     private val bookDao: BookDao,
     private val searchRepository: SearchRepository,
     private val imageStorage: ImageStorage,
@@ -96,17 +99,18 @@ class AdminCollectionDetailViewModel internal constructor(
                         }
                         return@collect
                     }
+                    val shareItems = shares.map { it.toShareItem(resolveShareName(it.sharedWithUserId)) }
                     state.update { current ->
                         if (current is AdminCollectionDetailUiState.Ready) {
                             current.copy(
                                 collection = collection,
-                                shares = shares.map { it.toShareItem() },
+                                shares = shareItems,
                             )
                         } else {
                             AdminCollectionDetailUiState.Ready(
                                 collection = collection,
                                 editedName = collection.name,
-                                shares = shares.map { it.toShareItem() },
+                                shares = shareItems,
                             )
                         }
                     }
@@ -380,12 +384,26 @@ class AdminCollectionDetailViewModel internal constructor(
         }
     }
 
-    private fun CollectionShare.toShareItem() =
+    private fun CollectionShare.toShareItem(displayName: String) =
         CollectionShareItem(
             id = id,
             userId = sharedWithUserId,
+            displayName = displayName,
             permission = permission.name.lowercase(),
         )
+
+    /**
+     * Resolve a shared-with user's display name from the globally-synced `public_profiles` mirror,
+     * falling back to the raw user id only until that row syncs (or if the name is blank). A share
+     * record carries only the user id — names live in the separate `public_profiles` domain — so this
+     * resolution is what stops the UI from showing a bare UUID for a collection member.
+     */
+    private suspend fun resolveShareName(userId: String): String =
+        userProfileRepository
+            .observeProfile(userId)
+            .first()
+            ?.displayName
+            ?.ifBlank { null } ?: userId
 }
 
 /**
@@ -444,5 +462,7 @@ sealed interface AdminCollectionDetailUiState {
 data class CollectionShareItem(
     val id: String,
     val userId: String,
+    /** Resolved display name of the shared-with user; falls back to [userId] until the profile syncs. */
+    val displayName: String,
     val permission: String,
 )

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelSearchTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelSearchTest.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.client.domain.repository.AdminRepository
 import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.SearchRepository
+import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
@@ -143,6 +144,7 @@ class AdminCollectionDetailViewModelSearchTest :
             val repo: CollectionRepository = mock()
             val adminRepo: AdminRepository = mock()
             val userRepo: UserRepository = mock()
+            val userProfileRepo: UserProfileRepository = mock()
             val bookDao: BookDao = mock()
             val searchRepo: SearchRepository = mock()
             val imageStorage: ImageStorage = mock()
@@ -155,6 +157,7 @@ class AdminCollectionDetailViewModelSearchTest :
                 every { bookDao.observeByIdsWithContributors(any()) } returns flowOf(emptyList())
                 every { imageStorage.exists(any()) } returns false
                 every { imageStorage.getCoverPath(any()) } returns ""
+                every { userProfileRepo.observeProfile(any()) } returns flowOf(null)
             }
 
             fun build(): AdminCollectionDetailViewModel {
@@ -166,6 +169,7 @@ class AdminCollectionDetailViewModelSearchTest :
                     repo,
                     adminRepo,
                     userRepo,
+                    userProfileRepo,
                     bookDao,
                     searchRepo,
                     imageStorage,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/admin/AdminCollectionDetailViewModelTest.kt
@@ -13,6 +13,8 @@ import com.calypsan.listenup.client.domain.repository.AdminRepository
 import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.SearchRepository
+import com.calypsan.listenup.client.domain.model.CachedUserProfile
+import com.calypsan.listenup.client.domain.repository.UserProfileRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
@@ -114,6 +116,7 @@ class AdminCollectionDetailViewModelTest :
             val repo: CollectionRepository = mock()
             val adminRepo: AdminRepository = mock()
             val userRepo: UserRepository = mock()
+            val userProfileRepo: UserProfileRepository = mock()
             val bookDao: BookDao = mock()
             val searchRepo: SearchRepository = mock()
             val imageStorage: ImageStorage = mock()
@@ -126,6 +129,8 @@ class AdminCollectionDetailViewModelTest :
                 every { bookDao.observeByIdsWithContributors(any()) } returns flowOf(emptyList())
                 every { imageStorage.exists(any()) } returns false
                 every { imageStorage.getCoverPath(any()) } returns ""
+                // Default: no cached profile → share-name resolution falls back to the user id.
+                every { userProfileRepo.observeProfile(any()) } returns flowOf(null)
             }
 
             fun build(): AdminCollectionDetailViewModel {
@@ -137,6 +142,7 @@ class AdminCollectionDetailViewModelTest :
                     repo,
                     adminRepo,
                     userRepo,
+                    userProfileRepo,
                     bookDao,
                     searchRepo,
                     imageStorage,
@@ -164,6 +170,39 @@ class AdminCollectionDetailViewModelTest :
                 ready.collection.id shouldBe "c1"
                 ready.books.map { it.id } shouldBe listOf("b1", "b2")
                 ready.shares.map { it.userId } shouldBe listOf("u1")
+            }
+        }
+
+        // Regression: a collection member must show their name, not their UUID. A share record carries
+        // only the user id; the VM resolves the display name from the public_profiles mirror.
+        test("share row shows the member's resolved display name, not the raw user id") {
+            runTest(dispatcher) {
+                val f = Fixture()
+                every { f.userProfileRepo.observeProfile("u1") } returns
+                    flowOf(CachedUserProfile(id = "u1", displayName = "Alice Reader", avatarType = "initials", updatedAt = 0L))
+                f.sharesFlow.value = listOf(CollectionShare("s1", "c1", "u1", SharePermission.Read))
+
+                val vm = f.build()
+                advanceUntilIdle()
+
+                val ready = vm.state.value.shouldBeInstanceOf<AdminCollectionDetailUiState.Ready>()
+                ready.shares.first().displayName shouldBe "Alice Reader"
+                ready.shares.first().userId shouldBe "u1"
+            }
+        }
+
+        // Never-stranded fallback: before the profile row has synced (or if the name is blank), the id
+        // is shown rather than nothing — but the resolution path still runs.
+        test("share row falls back to the user id when no cached profile exists yet") {
+            runTest(dispatcher) {
+                val f = Fixture() // default stub: observeProfile → null
+                f.sharesFlow.value = listOf(CollectionShare("s1", "c1", "u-unsynced", SharePermission.Read))
+
+                val vm = f.build()
+                advanceUntilIdle()
+
+                val ready = vm.state.value.shouldBeInstanceOf<AdminCollectionDetailUiState.Ready>()
+                ready.shares.first().displayName shouldBe "u-unsynced"
             }
         }
 

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparerTest.kt
@@ -302,6 +302,33 @@ class PlaybackPreparerTest :
                 fakePlaybackService.prepareCallCount shouldBe 1
             }
         }
+
+        // ── test 4: streaming-prepare RPC THROWS + not downloaded → null (never propagate) ──────
+        test("prepare RPC throws and files not downloaded — prepare() returns null, does not propagate") {
+            runTest {
+                val fakePlaybackService =
+                    FakePlaybackService(
+                        prepareResult = AppResult.Failure(InternalError(debugInfo = "unused")),
+                        prepareThrows = RuntimeException("RPC transport failure (e.g. dead WebSocket)"),
+                    )
+                val fakeFactory = FakePlaybackRpcFactory(fakePlaybackService)
+
+                val downloadService: DownloadService = mock()
+                everySuspend { downloadService.getLocalPath(any()) } returns null
+                everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+
+                val preparer = buildPreparer(downloadService, fakeFactory)
+
+                // The streaming-prepare RPC throws a transport-level exception (not an AppResult.Failure)
+                // — exactly the "started book A (downloaded), played book B (streaming), it failed" case.
+                // prepare() must fold it to null per its contract, NOT let it escape across the Swift
+                // Export seam as an opaque KotlinError. Pre-fix this line threw; post-fix it returns null.
+                val result = preparer.prepare(bookId)
+
+                result.shouldBeNull()
+                fakePlaybackService.prepareCallCount shouldBe 1
+            }
+        }
     })
 
 // ── Test doubles ──────────────────────────────────────────────────────────────────────────────
@@ -314,12 +341,14 @@ private val stubFailure = AppResult.Failure(InternalError(debugInfo = "stub"))
  */
 private class FakePlaybackService(
     private val prepareResult: AppResult<ContractPreparedPlayback>,
+    private val prepareThrows: Throwable? = null,
 ) : PlaybackService {
     var prepareCallCount = 0
         private set
 
     override suspend fun prepare(bookId: BookId): AppResult<ContractPreparedPlayback> {
         prepareCallCount++
+        prepareThrows?.let { throw it }
         return prepareResult
     }
 

--- a/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
+++ b/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
@@ -5802,7 +5802,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5826,7 +5826,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-client-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-client",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5850,7 +5850,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5874,7 +5874,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-ktor-client",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5898,7 +5898,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-ktor-core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5922,7 +5922,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-logging-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-logging",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5946,7 +5946,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-core-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-serialization-core",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5970,7 +5970,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "krpc-serialization-json",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",
@@ -5994,7 +5994,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-rpc-utils-jvm",
-            "artifactVersion": "0.11.0-grpc-188",
+            "artifactVersion": "0.11.0-grpc-189",
             "name": "utils",
             "description": "kotlinx.rpc, a Kotlin library for adding asynchronous RPC services to your applications.",
             "website": "https://github.com/Kotlin/kotlinx-rpc",


### PR DESCRIPTION
Two independent, user-reported iOS bug fixes.

## 1. Playback: switching books surfaced an opaque `KotlinError error 1`

**Symptom:** start book A, play book B → "Couldn't start playback"; log shows `PlaybackPreparer.prepare failed … KotlinRuntimeSupport.KotlinError error 1`.

**Root cause:** `PlaybackPreparer.prepare` is *contracted* to return `null` on failure (logged), but its `buildTimeline` step calls the streaming-prepare RPC **only for a not-fully-downloaded book** and — unlike `fetchBookFromServer` — leaves that RPC **unguarded**. A transport-level throw (e.g. a stale/black-holed RPC WebSocket) escapes `prepare`, and Swift Export surfaces it as an opaque `KotlinError`. Book A played from a local download (no RPC); book B streamed → its prepare RPC threw. Same RPC-robustness family as the recent create-shelf fix.

**Fix:** wrap `prepare` so any escaping exception folds to a logged `null` (re-throwing `CancellationException`) — honoring the documented contract and surfacing the *real* exception instead of an opaque seam error. New regression test: the streaming RPC throwing yields `null`, not a propagated throw.

> **Honest scope:** this makes the failure graceful and *diagnosable* — it does not, by itself, make a streaming book B *play* when its RPC is genuinely failing. The deeper fix is RPC-transport reconnection (`RpcProxyCache` never re-establishes a dead/expired WebSocket — the same root behind the create-shelf black-hole and the startup hang). That's a focused shared follow-up; the new logging will confirm the exact transport error on the next repro.

## 2. Collections: a member showed their UUID instead of their name

**Symptom:** adding a user to a collection shows their UUID, not their display name (iOS).

**Root cause:** a share record carries only `sharedWithUserId`; names live in the globally-synced `public_profiles` mirror. Android was fixed (`5f9c2a443`) to resolve the name in its UI row, but iOS still rendered `Text(share.userId)`, and the shared `CollectionShareItem` carried no name.

**Fix (per iosApp rule 6 — converge in shared):** resolve the name **once in the shared `AdminCollectionDetailViewModel`** from `UserProfileRepository`, add `displayName` to `CollectionShareItem` (fallback to the id until the profile syncs), and render it on iOS (row title + avatar initials). iOS now consumes a plain `String` — no per-row Flow bridging. Android keeps working (its own resolution is now redundant but harmless; it can adopt the shared field later). New VM tests: resolves the name from `public_profiles`, and falls back to the id when unsynced.

## Verification

- Full `:sharedLogic:jvmTest` (incl. the new playback + collection tests), `spotlessCheck`, `detekt`, `:androidApp:assembleDebug` — all green. CI's iOS lanes compile-verify the Swift changes.
