### PR TITLE
🐛 fix(shared): refresh presence on AccessChanged so revoked access drops in real time

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncEngine.kt
@@ -622,6 +622,14 @@ internal class SyncEngine(
                     }
                 }
             }
+            // End of this leader activation: re-fire every access-sensitive refreshed domain against the
+            // caller's NEW accessible set. Deliberately AFTER the loop, never before it: on GRANT, a
+            // refetch before the books delta landed would see a roster whose newly-granted row is dropped
+            // at the local enrichment join (presence does not re-emit when the books mirror later fills),
+            // leaving it stale until the poll. The leader single-flight flag is already cleared here (drain
+            // → None), so an access-sensitive refresh must be idempotent and concurrency-safe (a future
+            // Refetch domain would need its own single-flight). Fires once per leader activation.
+            refreshedRouter.refreshAccessSensitive()
         } finally {
             // Normal exit already cleared the flag under the lock (via drain → None). This fires only
             // on a thrown/cancelled reconcile, and — like the CursorStale cleanup — runs

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouter.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomainRouter.kt
@@ -42,6 +42,17 @@ internal class RefreshedDomainRouter(
         refreshed.forEach { runStrategy(it.refresh) }
     }
 
+    /**
+     * Re-run the declared refresh of every domain flagged [RefreshedDomain.refreshOnAccessChanged].
+     * The engine funnels every `AccessChanged` reconcile here (after the reconcile's own fetches
+     * complete) so a domain whose refresh reads an ACL-filtered RPC re-fetches the instant the caller's
+     * accessible set changes. Derived, not declared: a new access-sensitive domain heals the moment it
+     * sets the flag (see [RefreshedDomain.refreshOnAccessChanged] for the idempotency contract).
+     */
+    suspend fun refreshAccessSensitive() {
+        refreshed.filter { it.refreshOnAccessChanged }.forEach { runStrategy(it.refresh) }
+    }
+
     private suspend fun runStrategy(strategy: RefreshStrategy) {
         when (strategy) {
             is RefreshStrategy.Ping -> strategy.ping()

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomains.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/RefreshedDomains.kt
@@ -9,11 +9,18 @@ import com.calypsan.listenup.api.sync.SyncControl
  * `UserDeleted`, `LibraryDataChanged`) are NOT here — they stay engine callbacks.
  */
 
-/** Presence changed: ping the signal the social repos (currently-listening, book-readers) collect. */
+/**
+ * Presence changed: ping the signal the social repos (currently-listening, book-readers) collect.
+ *
+ * [refreshOnAccessChanged] is `true` because those RPCs are ACL-filtered at read time — an access
+ * change (a collection share granted or revoked) changes which sessions the caller may see, so it is
+ * a presence-visibility change that must re-fire this ping.
+ */
 internal fun presenceDomain(ping: () -> Unit): RefreshedDomain =
     RefreshedDomain(
         trigger = SyncControl.ActiveSessionsChanged::class,
         refresh = RefreshStrategy.Ping(ping),
+        refreshOnAccessChanged = true,
     )
 
 /** Server info changed (admin edited name / remote URL): re-fetch getServerInfo (persists the remote-URL fallback). */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainDescriptors.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainDescriptors.kt
@@ -46,8 +46,17 @@ internal class MirroredDomain<T : SyncPayload>(
  * The self-heal is derived, not declared: the lifecycle-reconcile edge re-runs every
  * refreshed domain's [refresh] through [RefreshedDomainRouter.refreshAll], so a dropped
  * trigger heals on the next foreground/reconnect with no per-domain recovery wiring.
+ *
+ * [refreshOnAccessChanged] is the second, orthogonal recovery edge: when `true`, the engine also
+ * re-runs this domain's [refresh] at the end of an `AccessChanged` reconcile (via
+ * [RefreshedDomainRouter.refreshAccessSensitive]). It declares "this refresh reads an ACL-filtered
+ * surface, so a change to what the caller can access is a change to what this refresh returns."
+ * The refresh runs after the reconcile's leader guard is released, so a flagged [refresh] must be
+ * idempotent and concurrency-safe — presence's `Ping` is; a `Refetch` would need its own single-flight.
+ * Defaults `false` — most refreshed domains (server info, preferences) are access-insensitive.
  */
 internal class RefreshedDomain(
     val trigger: KClass<out SyncControl>,
     val refresh: RefreshStrategy,
+    val refreshOnAccessChanged: Boolean = false,
 )

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/AccessChangedReconcileTest.kt
@@ -12,11 +12,13 @@ import com.calypsan.listenup.client.data.local.db.BookEntityMapper
 import com.calypsan.listenup.client.data.local.db.BookReadershipEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.sync.domains.RefreshedDomainRouter
 import com.calypsan.listenup.client.data.sync.domains.activitiesDomain
 import com.calypsan.listenup.client.data.sync.domains.booksDomain
 import com.calypsan.listenup.client.data.sync.domains.collectionBooksDomain
 import com.calypsan.listenup.client.data.sync.domains.collectionSharesDomain
 import com.calypsan.listenup.client.data.sync.domains.collectionsDomain
+import com.calypsan.listenup.client.data.sync.domains.presenceDomain
 import com.calypsan.listenup.client.data.sync.domains.toHandler
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.stubImageStorage
@@ -26,6 +28,7 @@ import com.calypsan.listenup.api.sync.AccessScope
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
 import com.calypsan.listenup.core.LibraryId
+import app.cash.turbine.test
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -381,6 +384,55 @@ class AccessChangedReconcileTest :
             }
         }
 
+        // ---- Presence refresh on AccessChanged (the revoke-latency fix) --------------------------
+
+        test("presence refreshes exactly once, AFTER the access reconcile's domain fetches complete") {
+            withReconcileEngine { harness, _, _ ->
+                harness.presence.signal.test {
+                    // A direct (non-launched) call: when it returns, the reconcile loop AND the
+                    // end-of-loop presence refresh have both run.
+                    harness.engine.handleAccessChanged(null)
+
+                    // Exactly one presence refresh for the single leader activation.
+                    awaitItem()
+                    expectNoEvents()
+
+                    // Ordering proof: the refresh captured the FULL 5-domain coarse sweep already in the
+                    // recorded trail. If the refresh were placed before the reconcile (top of
+                    // handleAccessChanged), this snapshot would be empty and the assertion would fail.
+                    harness.coarseCallsAtPresenceRefresh.single().toSet() shouldBe
+                        setOf("books", "collections", "collection_books", "collection_shares", "activities")
+                }
+            }
+        }
+
+        test("presence refresh coalesces: two AccessChanged frames fold into one leader activation, one refresh") {
+            withReconcileEngine { harness, _, _ ->
+                harness.fakeCatchUp.returnedByDomain["books"] = setOf("ba", "bb", "bc")
+                val gate = CompletableDeferred<Unit>()
+                harness.fakeCatchUp.gate = gate
+
+                harness.presence.signal.test {
+                    coroutineScope {
+                        // Leader reconciles [ba] and parks on the gate at its books fetch.
+                        val leader = launch { harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("ba"))) }
+                        while (harness.fakeCatchUp.fetches.isEmpty()) yield()
+                        // Two more frames land while the leader is parked → they fold into its follow-up pass,
+                        // NOT their own leader activation (and NOT their own presence refresh).
+                        harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bb")))
+                        harness.engine.handleAccessChanged(AccessScope(emptyList(), listOf("bc")))
+                        gate.complete(Unit)
+                        leader.join()
+                    }
+
+                    // One leader activation drained [ba] then the unioned {bb, bc} follow-up; the presence
+                    // refresh fired once at the END of that single activation — coalesced, not once-per-frame.
+                    awaitItem()
+                    expectNoEvents()
+                }
+            }
+        }
+
         test("coalesce: two deltas arriving mid-reconcile fold into ONE unioned follow-up fetch") {
             withReconcileEngine { harness, _, _ ->
                 harness.fakeCatchUp.returnedByDomain["books"] = setOf("ba", "bb", "bc")
@@ -621,6 +673,14 @@ private class FakeReconcileSse : SseClient {
 private data class ReconcileHarness(
     val engine: SyncEngine,
     val fakeCatchUp: FakeReconcileCatchUp,
+    /** The presence signal the access-sensitive router pings — subscribe with Turbine to observe refreshes. */
+    val presence: PresenceRefreshSignal,
+    /**
+     * Snapshot of [FakeReconcileCatchUp.coarseCalls] captured at the instant each presence refresh fires.
+     * Because the refresh runs at the END of the reconcile loop, a snapshot here proves the reconcile's
+     * fetches already ran before the refresh — an empty snapshot would mean the refresh fired too early.
+     */
+    val coarseCallsAtPresenceRefresh: List<List<String>>,
 )
 
 private fun withReconcileEngine(block: suspend (ReconcileHarness, ListenUpDatabase, SyncCursorStore) -> Unit) =
@@ -656,6 +716,10 @@ private fun withReconcileEngine(block: suspend (ReconcileHarness, ListenUpDataba
                     cursorAdvance = { domain, rev -> store.setCursor(domain, rev) },
                 )
             val fakeCatchUp = FakeReconcileCatchUp()
+            val presence = PresenceRefreshSignal()
+            // Snapshot the coarse reconcile trail at the moment presence refreshes, so ordering
+            // (refresh AFTER the reconcile's fetches) is provable from the recorded sequence.
+            val coarseCallsAtPresenceRefresh = mutableListOf<List<String>>()
             val engine =
                 SyncEngine(
                     registry = registry,
@@ -666,10 +730,28 @@ private fun withReconcileEngine(block: suspend (ReconcileHarness, ListenUpDataba
                     sseClient = FakeReconcileSse(),
                     reconciler = noopSyncReconciler(registry, store, fakeCatchUp),
                     dispatcher = dispatcher,
-                    presenceRefreshSignal = PresenceRefreshSignal(),
+                    presenceRefreshSignal = presence,
                     scope = scope,
+                    // Presence is the access-sensitive refreshed domain: the engine re-fires it at the end
+                    // of an AccessChanged reconcile via refreshAccessSensitive(). Wire it so the test can
+                    // observe the refresh (via the signal) and the reconcile state at refresh time.
+                    refreshedRouter =
+                        RefreshedDomainRouter(
+                            listOf(
+                                presenceDomain(
+                                    ping = {
+                                        coarseCallsAtPresenceRefresh += fakeCatchUp.coarseCalls.toList()
+                                        presence.ping()
+                                    },
+                                ),
+                            ),
+                        ),
                 )
-            block(ReconcileHarness(engine, fakeCatchUp), db, store)
+            block(
+                ReconcileHarness(engine, fakeCatchUp, presence, coarseCallsAtPresenceRefresh),
+                db,
+                store,
+            )
         } finally {
             scope.cancel()
             db.close()

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/domains/SyncDomainCompletenessSpec.kt
@@ -217,6 +217,35 @@ class SyncDomainCompletenessSpec :
             }
         }
 
+        test("presence is the only access-sensitive refreshed domain (refreshOnAccessChanged frozen to presence)") {
+            val db = createInMemoryTestDatabase()
+            try {
+                val catalog =
+                    syncDomainCatalog(
+                        database = db,
+                        mapper = BookEntityMapper(),
+                        imageStorage = stubImageStorage(),
+                        authSession = FakeAuthSession(userId = "spec-user"),
+                        avatarDownloadRepository = StubAvatarDownloadRepository(),
+                        pingPresence = {},
+                        refetchServerInfo = {},
+                        refetchPreferences = {},
+                    )
+
+                // The presence RPCs (currently-listening / book-readers) are ACL-filtered at read time,
+                // so an access change is a presence-visibility change — presence is the one refreshed
+                // domain the engine re-fires at the end of an AccessChanged reconcile. Server-info and
+                // preferences are access-insensitive. Adding/removing an access-sensitive refresh domain
+                // must be a conscious edit here, not a silent side effect.
+                catalog.refreshed
+                    .filter { it.refreshOnAccessChanged }
+                    .map { it.trigger }
+                    .toSet() shouldBe setOf(SyncControl.ActiveSessionsChanged::class)
+            } finally {
+                db.close()
+            }
+        }
+
         test("declared delete and digest postures match the frozen rulebook") {
             val db = createInMemoryTestDatabase()
             try {


### PR DESCRIPTION
## Problem
When a user's collection access is **revoked**, the "What Others Are Listening To" / presence surface takes ~40s to drop the now-inaccessible book (it waits for presence's `PRESENCE_POLL_INTERVAL_MS = 60_000` backstop poll). Grant is already real-time. Net effect: a ~40s window where a member still sees others' listening presence on a book they can no longer access — a brief access-boundary staleness.

## Root cause
Presence is RPC-fetched (`SocialService.currentlyListening()`, ACL-filtered at read time) and refreshed by `PresenceRefreshSignal` (fast-path ping + slow backstop poll). On access change the server sends a per-user `SyncControl.AccessChanged` frame, but `SyncEngine.handleAccessChanged` never pinged presence — so revoke only converged on the backstop tick.

## Fix — structural, not a spot-patch
Access-sensitivity is now a **declared property** of a refreshed domain, so future ACL-filtered refresh surfaces get real-time access updates for free:

- `RefreshedDomain` gains `refreshOnAccessChanged: Boolean = false`.
- The presence descriptor sets it `true` (its RPCs are ACL-filtered).
- `RefreshedDomainRouter.refreshAccessSensitive()` re-runs every flagged domain's refresh, reusing the existing `runStrategy` guard (re-throws `CancellationException`).
- `SyncEngine.handleAccessChanged` calls it **after** the reconcile leader loop completes.

### Ordering is a correctness requirement
The refresh fires *after* the reconcile, never before: on **grant**, a presence refetch before the books delta lands would see a roster whose newly-granted row is dropped at the local enrichment join (presence doesn't re-emit when the books mirror later fills) — leaving it stale until the poll. A test asserts the refresh is observed after the reconcile's domain fetches, and fails if misplaced.

## Tests (TDD)
- Freeze: presence is the only `refreshOnAccessChanged` domain (adding another is a conscious spec edit).
- Ordering: presence refreshes exactly once, after the reconcile fetches (deterministic in-coroutine snapshot).
- Coalescing: two folded `AccessChanged` frames → one refresh.

## Scope
PR 1 of 2 on the access-change propagation asymmetry. PR 2 (the `reconcileDelta` registry-driven refactor for the activity-grant freshness gap) follows separately.

Verified: `:sharedLogic:jvmTest spotlessApply detekt` → BUILD SUCCESSFUL.