### PR TITLE
✨ feat(shared): bounded self-healing RPC transport recovery (RpcProxyCache.call)

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/core/error/ErrorMapper.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.api.error.AuthError
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
+import com.calypsan.listenup.client.data.remote.RpcFailureClassifier
 import com.calypsan.listenup.client.data.remote.ServerUrlNotConfiguredException
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
@@ -24,15 +25,23 @@ import kotlinx.serialization.SerializationException
  */
 internal object ErrorMapper {
     fun map(exception: Throwable): AppError =
-        when (exception) {
-            is ConnectTimeoutException,
-            is SocketTimeoutException,
-            is HttpRequestTimeoutException,
-            -> {
+        when {
+            // A handshake-401 WebSocketException is a stale-session signal from the `/api/rpc/authed`
+            // upgrade. After RpcProxyCache's one bounded token-refresh + retry, a SECOND 401 reaches
+            // here — surface it typed as SessionExpired so the global auth observer drives to login,
+            // instead of a generic InternalError. Checked first: it is a WebSocketException, which the
+            // arms below would otherwise fold into the InternalError catch-all.
+            RpcFailureClassifier.isWsHandshake401(exception) -> {
+                AuthError.SessionExpired(debugInfo = exception.message)
+            }
+
+            exception is ConnectTimeoutException ||
+                exception is SocketTimeoutException ||
+                exception is HttpRequestTimeoutException -> {
                 TransportError.Timeout(debugInfo = exception.message)
             }
 
-            is ResponseException -> {
+            exception is ResponseException -> {
                 val status = exception.response.status.value
                 when {
                     // 401 means the session is stale/invalid — type it as an auth error at the
@@ -53,25 +62,25 @@ internal object ErrorMapper {
                 }
             }
 
-            is SerializationException -> {
+            exception is SerializationException -> {
                 TransportError.DataMalformed(
                     detail = exception.message ?: "deserialization failed",
                     debugInfo = exception.message,
                 )
             }
 
-            is IOException -> {
+            exception is IOException -> {
                 TransportError.NetworkUnavailable(debugInfo = exception.message)
             }
 
             // "No server configured yet" is an expected pre-connection state (fresh / signed-out
             // install), not a fault — type it as a transport-unavailable so the boundary folds it
             // quietly instead of surfacing a generic InternalError "server error".
-            is ServerUrlNotConfiguredException -> {
+            exception is ServerUrlNotConfiguredException -> {
                 TransportError.NetworkUnavailable(debugInfo = exception.message)
             }
 
-            is IllegalArgumentException -> {
+            exception is IllegalArgumentException -> {
                 ValidationError(
                     message = exception.message ?: "Invalid input.",
                     debugInfo = exception.message,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.CollectionService
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.withService
@@ -17,6 +18,14 @@ internal interface CollectionRpcFactory {
     /** Returns the cached [CollectionService] proxy, connecting on first use. */
     suspend fun get(): CollectionService
 
+    /**
+     * Run [block] against the [CollectionService] proxy through the bounded, self-healing recovery
+     * engine, folding the outcome into an [AppResult]. The canonical mutation/query path — a dead
+     * socket heals invisibly, a surviving fault surfaces typed, a business failure passes through
+     * untouched.
+     */
+    suspend fun <T> callResult(block: suspend (CollectionService) -> AppResult<T>): AppResult<T>
+
     /** Drop the cached proxy and the RPC-flavored HttpClient. */
     suspend fun invalidate()
 }
@@ -29,14 +38,18 @@ internal interface CollectionRpcFactory {
 internal class KtorCollectionRpcFactory(
     apiClientFactory: ApiClientFactory,
     serverConfig: ServerConfig,
+    authRecovery: RpcAuthRecovery = RpcAuthRecovery.None,
 ) : CollectionRpcFactory,
     RemoteCache {
     private val cache =
-        RpcProxyCache(apiClientFactory, serverConfig) { client, baseUrl ->
+        RpcProxyCache(apiClientFactory, serverConfig, authRecovery) { client, baseUrl ->
             client.rpc("$baseUrl/api/rpc/authed").withService<CollectionService>()
         }
 
     override suspend fun get(): CollectionService = cache.get()
+
+    override suspend fun <T> callResult(block: suspend (CollectionService) -> AppResult<T>): AppResult<T> =
+        cache.rpcCall(block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/CollectionRpcFactory.kt
@@ -49,7 +49,7 @@ internal class KtorCollectionRpcFactory(
     override suspend fun get(): CollectionService = cache.get()
 
     override suspend fun <T> callResult(block: suspend (CollectionService) -> AppResult<T>): AppResult<T> =
-        cache.rpcCall(block)
+        cache.rpcCall(block = block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
@@ -25,7 +25,7 @@ interface PlaybackRpcFactory {
      * Run [block] against the [PlaybackService] proxy through the bounded, self-healing recovery
      * engine, folding the outcome into an [AppResult].
      *
-     * The default here only provides the boundary (throw → typed [AppResult.Failure]); the
+     * The default here only provides the boundary (a thrown fault becomes a typed [AppResult.Failure]); the
      * production [KtorPlaybackRpcFactory] overrides it to add the bounded reconnect + retry.
      * Test doubles inherit the default and get faithful throw→Failure semantics without a socket.
      */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
@@ -55,7 +55,7 @@ internal class KtorPlaybackRpcFactory(
     override suspend fun playbackService(): PlaybackService = cache.get()
 
     override suspend fun <T> callResult(block: suspend (PlaybackService) -> AppResult<T>): AppResult<T> =
-        cache.rpcCall(block)
+        cache.rpcCall(block = block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/PlaybackRpcFactory.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.PlaybackService
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.withService
@@ -20,6 +21,17 @@ interface PlaybackRpcFactory {
     /** Returns the cached [PlaybackService] proxy, connecting on first use. */
     suspend fun playbackService(): PlaybackService
 
+    /**
+     * Run [block] against the [PlaybackService] proxy through the bounded, self-healing recovery
+     * engine, folding the outcome into an [AppResult].
+     *
+     * The default here only provides the boundary (throw → typed [AppResult.Failure]); the
+     * production [KtorPlaybackRpcFactory] overrides it to add the bounded reconnect + retry.
+     * Test doubles inherit the default and get faithful throw→Failure semantics without a socket.
+     */
+    suspend fun <T> callResult(block: suspend (PlaybackService) -> AppResult<T>): AppResult<T> =
+        catchingRpcResult { block(playbackService()) }
+
     /** Drop the cached proxy and the RPC-flavored HttpClient. */
     suspend fun invalidate()
 }
@@ -32,14 +44,18 @@ interface PlaybackRpcFactory {
 internal class KtorPlaybackRpcFactory(
     apiClientFactory: ApiClientFactory,
     serverConfig: ServerConfig,
+    authRecovery: RpcAuthRecovery = RpcAuthRecovery.None,
 ) : PlaybackRpcFactory,
     RemoteCache {
     private val cache =
-        RpcProxyCache(apiClientFactory, serverConfig) { client, baseUrl ->
+        RpcProxyCache(apiClientFactory, serverConfig, authRecovery) { client, baseUrl ->
             client.rpc("$baseUrl/api/rpc/authed").withService<PlaybackService>()
         }
 
     override suspend fun playbackService(): PlaybackService = cache.get()
+
+    override suspend fun <T> callResult(block: suspend (PlaybackService) -> AppResult<T>): AppResult<T> =
+        cache.rpcCall(block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcAuthRecovery.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcAuthRecovery.kt
@@ -1,0 +1,44 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Recovers RPC authentication when the `/api/rpc/authed` WebSocket handshake is rejected with 401 —
+ * the bearer token that authorized the upgrade expired. It refreshes the token via the shared
+ * [RefreshAccessToken] seam and rebuilds the request client so its Bearer provider re-reads the new
+ * token (the streaming/SSE client is deliberately spared via [ApiClientFactory.invalidateRequestClientOnly]).
+ *
+ * Single-flighted, so a burst of 401s across many cached proxies triggers exactly ONE refresh.
+ */
+internal interface RpcAuthRecovery {
+    /** @return true if a fresh token is now in place (retry the handshake); false if re-auth is required. */
+    suspend fun refreshAndRebuild(): Boolean
+
+    /** No-op recovery for the unauthenticated `/api/rpc/public` mount — it must never trigger a refresh. */
+    object None : RpcAuthRecovery {
+        override suspend fun refreshAndRebuild(): Boolean = false
+    }
+}
+
+internal class RpcAuthRecoveryImpl(
+    private val authSession: AuthSession,
+    private val refreshAccessToken: RefreshAccessToken,
+    private val apiClientFactory: ApiClientFactory,
+) : RpcAuthRecovery {
+    private val mutex = Mutex()
+
+    override suspend fun refreshAndRebuild(): Boolean =
+        mutex.withLock {
+            // refreshAuthTokens saves the new tokens into AuthSession and returns them (null on failure,
+            // clearing tokens on an invalid refresh token so the global auth observer routes to login).
+            val refreshed = refreshAuthTokens(authSession, refreshAccessToken) != null
+            if (refreshed) {
+                // Rebuild ONLY the request client so its Bearer provider re-reads the refreshed token;
+                // the long-lived streaming/SSE client is untouched.
+                apiClientFactory.invalidateRequestClientOnly()
+            }
+            refreshed
+        }
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcAuthRecovery.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcAuthRecovery.kt
@@ -10,7 +10,10 @@ import kotlinx.coroutines.sync.withLock
  * [RefreshAccessToken] seam and rebuilds the request client so its Bearer provider re-reads the new
  * token (the streaming/SSE client is deliberately spared via [ApiClientFactory.invalidateRequestClientOnly]).
  *
- * Single-flighted, so a burst of 401s across many cached proxies triggers exactly ONE refresh.
+ * A [Mutex] serializes concurrent refreshes so they don't race the token store or stampede the
+ * refresh endpoint; it does not deduplicate them into a single call across factories (each 401
+ * still enters, and a later one may refresh an already-fresh token). That is acceptable — refresh
+ * is idempotent and cheap relative to the failure it recovers.
  */
 internal interface RpcAuthRecovery {
     /** @return true if a fresh token is now in place (retry the handshake); false if re-auth is required. */

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCall.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCall.kt
@@ -1,0 +1,42 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.core.error.ErrorMapper
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Run [run] and fold its outcome into an [AppResult] at the RPC boundary.
+ *
+ * A business [AppResult.Failure] returned by [run] is a VALUE — it passes straight through and
+ * never enters the catch clauses, so it can never be mistaken for a transport fault. Only a thrown
+ * failure is translated: our [TransportError.Timeout] bound trips to a typed timeout, a genuine
+ * caller [CancellationException] re-raises (kotlinx.coroutines canonical rule), and every other
+ * throwable maps once through [ErrorMapper].
+ *
+ * Shared by [RpcProxyCache.rpcCall] (production) and the test RPC-factory doubles, so repository
+ * unit tests exercise the real boundary rather than a re-implementation of it.
+ */
+internal suspend fun <T> catchingRpcResult(run: suspend () -> AppResult<T>): AppResult<T> =
+    try {
+        run()
+    } catch (e: TimeoutCancellationException) {
+        AppResult.Failure(TransportError.Timeout(debugInfo = e.message))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        AppResult.Failure(ErrorMapper.map(e))
+    }
+
+/**
+ * Run [block] against the cached service proxy through the bounded, self-healing [RpcProxyCache.call]
+ * engine, folding the outcome into an [AppResult].
+ *
+ * This is the single repository-facing RPC shape: transport deaths heal invisibly (one bounded
+ * reconnect + retry), a surviving fault surfaces as a typed [AppResult.Failure], and a business
+ * failure returned by the service passes through untouched — a `ValidationError` never triggers a
+ * reconnect.
+ */
+internal suspend fun <S : Any, T> RpcProxyCache<S>.rpcCall(block: suspend (S) -> AppResult<T>): AppResult<T> =
+    catchingRpcResult { call { block(it) } }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCall.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCall.kt
@@ -25,6 +25,10 @@ internal suspend fun <T> catchingRpcResult(run: suspend () -> AppResult<T>): App
         run()
     } catch (e: TimeoutCancellationException) {
         AppResult.Failure(TransportError.Timeout(debugInfo = e.message))
+    } catch (e: RpcOutcomeUnknownException) {
+        // The frame was sent but the response was lost — outcome unknown. Surface as a typed transport
+        // failure (not a re-raised cancellation) so the caller can honestly report it and decide.
+        AppResult.Failure(TransportError.Timeout(debugInfo = e.message))
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCall.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcCall.kt
@@ -5,6 +5,8 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.core.error.ErrorMapper
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Run [run] and fold its outcome into an [AppResult] at the RPC boundary.
@@ -38,5 +40,7 @@ internal suspend fun <T> catchingRpcResult(run: suspend () -> AppResult<T>): App
  * failure returned by the service passes through untouched — a `ValidationError` never triggers a
  * reconnect.
  */
-internal suspend fun <S : Any, T> RpcProxyCache<S>.rpcCall(block: suspend (S) -> AppResult<T>): AppResult<T> =
-    catchingRpcResult { call { block(it) } }
+internal suspend fun <S : Any, T> RpcProxyCache<S>.rpcCall(
+    timeout: Duration = 15.seconds,
+    block: suspend (S) -> AppResult<T>,
+): AppResult<T> = catchingRpcResult { call(timeout) { block(it) } }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifier.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifier.kt
@@ -1,0 +1,39 @@
+package com.calypsan.listenup.client.data.remote
+
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.websocket.WebSocketException
+
+/**
+ * Classifies a throwable that escaped a kotlinx.rpc call so [RpcProxyCache.call] can decide whether
+ * to recover the connection and — critically — whether it is safe to auto-retry.
+ *
+ * The retry contract is **at-most-once**: a call is retried ONLY when the failure proves the RPC
+ * frame was never delivered (the WebSocket never opened, or no connection was established). Anything
+ * that could have reached a server handler — our own request timeout, a post-connect socket timeout,
+ * a serialization or business error — is never retried, so a non-idempotent mutation (createShelf,
+ * createCollection) can't double-apply.
+ */
+internal object RpcFailureClassifier {
+    /**
+     * A WebSocket handshake that failed with 401: the `/api/rpc/authed` upgrade carried an expired
+     * bearer token, so the server answered 401 instead of 101 and Ktor threw a [WebSocketException]
+     * ("...expected status code 101 but was 401"). The request never reached a handler — recovery
+     * (refresh token → reconnect → retry) is safe.
+     *
+     * Matching on the exception message is legitimate here: this is a Ktor transport exception, not
+     * an [com.calypsan.listenup.api.error.AppError] (the "never substring-match on message" rubric
+     * rule governs AppError bodies, not third-party exceptions).
+     */
+    fun isWsHandshake401(t: Throwable): Boolean =
+        t is WebSocketException && (t.message?.contains("401") == true)
+
+    /**
+     * A transport failure that proves the RPC frame was never delivered — the WebSocket handshake
+     * failed ([WebSocketException]) or the connection was never established ([ConnectTimeoutException]).
+     * Safe to invalidate the dead proxy and retry once, even for a non-idempotent mutation.
+     * Deliberately excludes post-connect socket timeouts, our own request-timeout, serialization, and
+     * business `ResponseException`s — those could have reached a handler.
+     */
+    fun isPreDeliveryTransportFailure(t: Throwable): Boolean =
+        t is WebSocketException || t is ConnectTimeoutException
+}

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifier.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifier.kt
@@ -24,8 +24,7 @@ internal object RpcFailureClassifier {
      * an [com.calypsan.listenup.api.error.AppError] (the "never substring-match on message" rubric
      * rule governs AppError bodies, not third-party exceptions).
      */
-    fun isWsHandshake401(t: Throwable): Boolean =
-        t is WebSocketException && (t.message?.contains("401") == true)
+    fun isWsHandshake401(t: Throwable): Boolean = t is WebSocketException && t.message?.contains("401") == true
 
     /**
      * A transport failure that proves the RPC frame was never delivered — the WebSocket handshake
@@ -34,8 +33,7 @@ internal object RpcFailureClassifier {
      * Deliberately excludes post-connect socket timeouts, our own request-timeout, serialization, and
      * business `ResponseException`s — those could have reached a handler.
      */
-    fun isPreDeliveryTransportFailure(t: Throwable): Boolean =
-        t is WebSocketException || t is ConnectTimeoutException
+    fun isPreDeliveryTransportFailure(t: Throwable): Boolean = t is WebSocketException || t is ConnectTimeoutException
 
     /**
      * The cached `RpcClient` (its WebSocket) died — the server restarted, the socket dropped, or the

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifier.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifier.kt
@@ -36,4 +36,19 @@ internal object RpcFailureClassifier {
      */
     fun isPreDeliveryTransportFailure(t: Throwable): Boolean =
         t is WebSocketException || t is ConnectTimeoutException
+
+    /**
+     * The cached `RpcClient` (its WebSocket) died — the server restarted, the socket dropped, or the
+     * client was otherwise torn down — so kotlinx.rpc refuses the next call, throwing "RpcClient was
+     * cancelled". In this kotlinx.rpc version that surfaces as a plain [IllegalStateException] (NOT a
+     * [kotlin.coroutines.cancellation.CancellationException]), so the caller-cancellation heuristic
+     * can't catch it. The frame was rejected before delivery — invalidate the dead proxy and retry
+     * once is safe even for a non-idempotent mutation.
+     *
+     * Matching on the message is legitimate: this is a kotlinx.rpc transport exception, not an
+     * [com.calypsan.listenup.api.error.AppError] (the "never substring-match on message" rule governs
+     * AppError bodies, not third-party exceptions).
+     */
+    fun isDeadRpcClient(t: Throwable): Boolean =
+        t.message?.contains("RpcClient was cancelled", ignoreCase = true) == true
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcOutcomeUnknownException.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcOutcomeUnknownException.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.client.data.remote
+
+/**
+ * Signals that an RPC frame was **sent** but its outcome could not be observed — the connection
+ * dropped after delivery, while awaiting the response.
+ *
+ * kotlinx.rpc surfaces a post-delivery drop as a bare `CancellationException("Client cancelled")`
+ * thrown from below when it closes the *pending* (already-sent) request channel. [RpcProxyCache]
+ * must NOT auto-retry this: the server may have received, handled, and committed a non-idempotent
+ * mutation, so a retry would double-apply it. It also must not re-raise the raw
+ * `CancellationException` — that would silently cancel the caller's ViewModel job ("honest over
+ * silent"). Instead the engine converts it to this typed, non-cancellation signal, which
+ * [com.calypsan.listenup.client.core.error.ErrorMapper]-adjacent boundary code
+ * ([catchingRpcResult]) folds into a typed [com.calypsan.listenup.api.result.AppResult.Failure]
+ * (an outcome-unknown transport failure) the caller can surface honestly.
+ *
+ * Not a `CancellationException` on purpose: it must survive the `catch (CancellationException)`
+ * re-raise at the boundary and become a value instead.
+ */
+internal class RpcOutcomeUnknownException(
+    cause: Throwable,
+) : Exception("RPC frame was sent but its outcome is unknown — the response was lost.", cause)

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
@@ -1,27 +1,51 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isPreDeliveryTransportFailure
+import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isWsHandshake401
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import kotlinx.rpc.krpc.ktor.client.installKrpc
 import kotlinx.rpc.krpc.serialization.json.json
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Upper bound on a single RPC. Guards against a black-holed WebSocket that never resolves. */
+private val DEFAULT_RPC_TIMEOUT = 15.seconds
 
 /**
  * The shared stateful body of every post-login RPC factory: a Mutex-guarded,
- * invalidate-able cache of one kotlinx.rpc service proxy plus the RPC-flavored
- * [HttpClient] it rides on.
+ * invalidate-able, **self-healing** cache of one kotlinx.rpc service proxy plus the
+ * RPC-flavored [HttpClient] it rides on.
  *
  * `rpc(url)` returns a cold [kotlinx.rpc.krpc.ktor.client.KtorRpcClient] that opens
- * its WebSocket on the first message, so the proxy is cached and reused. [invalidate]
- * drops both the cached proxy and the derived [HttpClient] — they are principal-bound
- * and must not survive a logout, re-login, or server-URL change ([RpcCacheInvalidator]
- * sweeps every [RemoteCache] for exactly that reason).
+ * its WebSocket on the first message, so the proxy is cached and reused. When that
+ * socket later dies (server restart, token expiry, network blip) kotlinx.rpc rejects
+ * the next call — with a `CancellationException("RpcClient was cancelled")`, a
+ * handshake [io.ktor.client.plugins.websocket.WebSocketException], or a connect
+ * timeout. [call] centralizes bounded, single-flight recovery for exactly those
+ * cases: it invalidates the dead proxy and retries **at most once** on a freshly
+ * reconnected proxy, so a transient death heals invisibly instead of surfacing as a
+ * silent no-op or an unbounded hang.
+ *
+ * [invalidate] drops both the cached proxy and the derived [HttpClient] — they are
+ * principal-bound and must not survive a logout, re-login, or server-URL change
+ * ([RpcCacheInvalidator] sweeps every [RemoteCache] for exactly that reason).
  *
  * [connect] is where reification lives: `withService<T>()` needs a reified type
  * parameter, so each factory supplies a lambda like
  * `{ client, baseUrl -> client.rpc("$baseUrl/api/rpc/authed").withService<FooService>() }`.
+ *
+ * [authRecovery] refreshes the bearer token and rebuilds the request client when the
+ * `/api/rpc/authed` handshake is rejected with 401; the unauthenticated public mount
+ * passes [RpcAuthRecovery.None].
  *
  * Wire serialization is the contract-layer [contractJson] — one wire format, two
  * transports.
@@ -29,29 +53,138 @@ import kotlinx.rpc.krpc.serialization.json.json
 internal class RpcProxyCache<T : Any>(
     private val apiClientFactory: ApiClientFactory,
     private val serverConfig: ServerConfig,
+    private val authRecovery: RpcAuthRecovery = RpcAuthRecovery.None,
     private val connect: suspend (rpcClient: HttpClient, wsBaseUrl: String) -> T,
 ) : RemoteCache {
     private val mutex = Mutex()
     private var cachedRpcClient: HttpClient? = null
     private var cachedProxy: T? = null
 
+    /**
+     * Monotonic connection generation. Every [dropLocked] increments it, so a call that
+     * failed on generation G can [invalidate] its dead proxy without clobbering a proxy a
+     * concurrent peer already reconnected (generation G+1). This is the single-flight
+     * guarantee: a herd of calls failing on the same generation converges on ONE reconnect.
+     */
+    private var generation: Int = 0
+
+    /** A proxy paired with the [generation] it was leased from, so failures invalidate by generation. */
+    private data class Lease<T>(
+        val proxy: T,
+        val generation: Int,
+    )
+
     /** Returns the cached proxy, connecting on first use. */
-    suspend fun get(): T =
-        mutex.withLock {
-            cachedProxy ?: run {
-                // Resolve the URL BEFORE deriving the client: a missing server URL
-                // must fail fast (rpcBaseUrl's ServerUrlNotConfiguredException guard)
-                // without caching anything.
-                val wsBaseUrl = rpcBaseUrl()
-                connect(rpcClient(), wsBaseUrl).also { cachedProxy = it }
+    suspend fun get(): T = lease().proxy
+
+    /**
+     * Run [block] against the cached proxy with bounded, self-healing recovery.
+     *
+     * - A [TimeoutCancellationException] (our [timeout] tripped) invalidates the proxy so the
+     *   NEXT call reconnects, but never auto-retries — the frame may have reached a handler, so
+     *   a non-idempotent mutation must not double-apply.
+     * - A [CancellationException] with a still-active caller context is the dead-`RpcClient`
+     *   signal (the cancel came from below, not from the caller): invalidate and retry once —
+     *   the frame was never delivered, so retry is safe. A cancelled caller context re-raises.
+     * - A handshake 401 refreshes the token, rebuilds, and retries once. Any other pre-delivery
+     *   transport failure (handshake / connect) invalidates and retries once. Everything else
+     *   propagates — it could have reached a handler.
+     */
+    suspend fun <R> call(
+        timeout: Duration = DEFAULT_RPC_TIMEOUT,
+        block: suspend (T) -> R,
+    ): R {
+        val lease = lease()
+        return try {
+            withTimeout(timeout) { block(lease.proxy) }
+        } catch (e: TimeoutCancellationException) {
+            // The request may be in flight — heal for the NEXT attempt, but never auto-retry here.
+            invalidate(lease.generation)
+            throw e
+        } catch (e: CancellationException) {
+            if (currentCoroutineContext().isActive) {
+                // The caller wasn't cancelled, yet a CancellationException escaped: the cancel came
+                // from below — a dead RpcClient rejecting the frame before delivery. Heal and retry once.
+                invalidate(lease.generation)
+                retryOnce(timeout, block)
+            } else {
+                throw e
             }
+        } catch (e: Throwable) {
+            when {
+                isWsHandshake401(e) -> {
+                    authRecovery.refreshAndRebuild()
+                    invalidate(lease.generation)
+                    retryOnce(timeout, block)
+                }
+
+                isPreDeliveryTransportFailure(e) -> {
+                    invalidate(lease.generation)
+                    retryOnce(timeout, block)
+                }
+
+                else -> throw e
+            }
+        }
+    }
+
+    /**
+     * The single at-most-once retry. Takes a FRESH lease so a herd converges on the one
+     * reconnected proxy. A second failure surfaces: invalidate (unless the caller was cancelled)
+     * and rethrow so the boundary maps it to a typed failure.
+     */
+    private suspend fun <R> retryOnce(
+        timeout: Duration,
+        block: suspend (T) -> R,
+    ): R {
+        val lease = lease()
+        return try {
+            withTimeout(timeout) { block(lease.proxy) }
+        } catch (e: CancellationException) {
+            if (currentCoroutineContext().isActive) invalidate(lease.generation)
+            throw e
+        } catch (e: Throwable) {
+            invalidate(lease.generation)
+            throw e
+        }
+    }
+
+    private suspend fun lease(): Lease<T> =
+        mutex.withLock {
+            val proxy =
+                cachedProxy ?: run {
+                    // Resolve the URL BEFORE deriving the client: a missing server URL
+                    // must fail fast (rpcBaseUrl's ServerUrlNotConfiguredException guard)
+                    // without caching anything.
+                    val wsBaseUrl = rpcBaseUrl()
+                    connect(rpcClient(), wsBaseUrl).also { cachedProxy = it }
+                }
+            Lease(proxy, generation)
         }
 
     override suspend fun invalidate() {
+        mutex.withLock { dropLocked() }
+    }
+
+    /**
+     * Drop the proxy ONLY if [leasedGeneration] is still current — the single-flight guard.
+     * A late loser (its failure arrived after a peer already reconnected) becomes a no-op.
+     */
+    private suspend fun invalidate(leasedGeneration: Int) {
         mutex.withLock {
-            cachedProxy = null
-            cachedRpcClient = null
+            if (leasedGeneration == generation) dropLocked()
         }
+    }
+
+    /** Null the proxy, close the derived RPC client, and bump the generation. Caller holds [mutex]. */
+    private fun dropLocked() {
+        cachedProxy = null
+        // Close the derived `.config { }` child so a dead socket's client doesn't leak. It is a
+        // child of the shared request client (its engine is shared), so closing it is safe — the
+        // request client survives for the next getClient().
+        cachedRpcClient?.close()
+        cachedRpcClient = null
+        generation++
     }
 
     private suspend fun rpcClient(): HttpClient =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isDeadRpcClient
 import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isPreDeliveryTransportFailure
 import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isWsHandshake401
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -118,7 +119,7 @@ internal class RpcProxyCache<T : Any>(
                     retryOnce(timeout, block)
                 }
 
-                isPreDeliveryTransportFailure(e) -> {
+                isPreDeliveryTransportFailure(e) || isDeadRpcClient(e) -> {
                     invalidate(lease.generation)
                     retryOnce(timeout, block)
                 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
@@ -5,6 +5,7 @@ import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isDeadRpcCl
 import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isPreDeliveryTransportFailure
 import com.calypsan.listenup.client.data.remote.RpcFailureClassifier.isWsHandshake401
 import com.calypsan.listenup.client.domain.repository.ServerConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
@@ -21,6 +22,8 @@ import kotlin.time.Duration.Companion.seconds
 /** Upper bound on a single RPC. Guards against a black-holed WebSocket that never resolves. */
 private val DEFAULT_RPC_TIMEOUT = 15.seconds
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * The shared stateful body of every post-login RPC factory: a Mutex-guarded,
  * invalidate-able, **self-healing** cache of one kotlinx.rpc service proxy plus the
@@ -28,13 +31,21 @@ private val DEFAULT_RPC_TIMEOUT = 15.seconds
  *
  * `rpc(url)` returns a cold [kotlinx.rpc.krpc.ktor.client.KtorRpcClient] that opens
  * its WebSocket on the first message, so the proxy is cached and reused. When that
- * socket later dies (server restart, token expiry, network blip) kotlinx.rpc rejects
- * the next call — with a `CancellationException("RpcClient was cancelled")`, a
- * handshake [io.ktor.client.plugins.websocket.WebSocketException], or a connect
- * timeout. [call] centralizes bounded, single-flight recovery for exactly those
- * cases: it invalidates the dead proxy and retries **at most once** on a freshly
- * reconnected proxy, so a transient death heals invisibly instead of surfacing as a
- * silent no-op or an unbounded hang.
+ * socket later dies, [call] centralizes bounded, single-flight recovery — but only for
+ * failures it can prove are **pre-delivery** (the frame was never sent), so a retry can
+ * never double-apply a non-idempotent mutation:
+ *
+ * - **Retry once** on a provably pre-delivery signal: an [io.ktor.client.plugins.websocket.WebSocketException]
+ *   (handshake), a [io.ktor.client.network.sockets.ConnectTimeoutException], a dead-client
+ *   [IllegalStateException] ("RpcClient was cancelled", thrown BEFORE send), or a handshake 401
+ *   (after a token refresh).
+ * - **Never retry — surface as outcome-unknown** a bare `CancellationException` thrown from below
+ *   with a still-active caller ("Client cancelled"): kotlinx.rpc throws this when it closes a
+ *   *pending* (already-SENT) request channel, so the mutation may have committed. The engine
+ *   converts it to a typed [RpcOutcomeUnknownException] rather than retrying (would double-apply) or
+ *   re-raising the raw cancellation (would silently kill the caller's job).
+ * - **Re-raise** a bare `CancellationException` with a cancelled caller context — genuine caller
+ *   cancellation. Our own [TimeoutCancellationException] heals for the next call but never retries.
  *
  * [invalidate] drops both the cached proxy and the derived [HttpClient] — they are
  * principal-bound and must not survive a logout, re-login, or server-URL change
@@ -79,17 +90,9 @@ internal class RpcProxyCache<T : Any>(
     suspend fun get(): T = lease().proxy
 
     /**
-     * Run [block] against the cached proxy with bounded, self-healing recovery.
-     *
-     * - A [TimeoutCancellationException] (our [timeout] tripped) invalidates the proxy so the
-     *   NEXT call reconnects, but never auto-retries — the frame may have reached a handler, so
-     *   a non-idempotent mutation must not double-apply.
-     * - A [CancellationException] with a still-active caller context is the dead-`RpcClient`
-     *   signal (the cancel came from below, not from the caller): invalidate and retry once —
-     *   the frame was never delivered, so retry is safe. A cancelled caller context re-raises.
-     * - A handshake 401 refreshes the token, rebuilds, and retries once. Any other pre-delivery
-     *   transport failure (handshake / connect) invalidates and retries once. Everything else
-     *   propagates — it could have reached a handler.
+     * Run [block] against the cached proxy with bounded, single-flight, self-healing recovery.
+     * See the class KDoc for the full retry/surface policy — the load-bearing invariant is that
+     * only **provably pre-delivery** failures retry, so a non-idempotent mutation never double-applies.
      */
     suspend fun <R> call(
         timeout: Duration = DEFAULT_RPC_TIMEOUT,
@@ -99,50 +102,75 @@ internal class RpcProxyCache<T : Any>(
         return try {
             withTimeout(timeout) { block(lease.proxy) }
         } catch (e: TimeoutCancellationException) {
-            // The request may be in flight — heal for the NEXT attempt, but never auto-retry here.
+            // Our own bound tripped; the frame may be in flight — heal for the NEXT call, never retry.
+            logger.warn { "RPC timed out after $timeout; invalidating for the next attempt (no retry)" }
             invalidate(lease.generation)
             throw e
         } catch (e: Throwable) {
-            recoverOrRethrow(e, lease.generation, timeout, block)
+            recover(e, lease.generation, timeout, block)
         }
     }
 
     /**
-     * Decide whether [e] is a recoverable transport death and, if so, invalidate the dead proxy and
-     * retry once on a fresh connection. Anything that could have reached a handler — a cancelled
-     * caller, or an unknown failure — re-raises unchanged.
+     * Retry ONLY on provably pre-delivery signals; otherwise [surface] the failure. Kept separate
+     * from [call] so the timeout branch stays first (a [TimeoutCancellationException] must never be
+     * mistaken for a from-below cancellation).
      */
-    private suspend fun <R> recoverOrRethrow(
+    private suspend fun <R> recover(
         e: Throwable,
         leasedGeneration: Int,
         timeout: Duration,
         block: suspend (T) -> R,
     ): R {
         when {
-            // A CancellationException with a still-active caller is the dead-RpcClient signal: the
-            // cancel came from below, rejecting the frame before delivery — recoverable.
-            e is CancellationException && currentCoroutineContext().isActive -> Unit
+            // Stale-session handshake 401 — refresh + rebuild, then retry once (or surface if refresh fails).
+            isWsHandshake401(e) -> {
+                return retryAfterAuthRefresh(e, leasedGeneration, timeout, block)
+            }
 
-            // The caller's own context was cancelled — genuine cancellation, re-raise.
-            e is CancellationException -> throw e
+            // Provably pre-delivery: handshake, connect, or a dead-client ISE ("RpcClient was cancelled",
+            // thrown BEFORE send). The frame never left — retry cannot double-apply.
+            isPreDeliveryTransportFailure(e) || isDeadRpcClient(e) -> {
+                logger.info {
+                    "RPC pre-delivery transport failure (${e::class.simpleName}); reconnecting + retrying once"
+                }
+                invalidate(leasedGeneration)
+                return retryOnce(timeout, block)
+            }
 
-            // Stale-session handshake 401 — refresh the token + rebuild, then retry once.
-            isWsHandshake401(e) -> authRecovery.refreshAndRebuild()
-
-            // Any other pre-delivery transport death (handshake, connect, dead client) — retry once.
-            isPreDeliveryTransportFailure(e) || isDeadRpcClient(e) -> Unit
-
-            // Reached a handler, or an unknown fault — propagate.
-            else -> throw e
+            // Everything else — a from-below (post-delivery) cancellation, a cancelled caller, or an
+            // unknown fault — is NOT safe to retry. Surface it.
+            else -> {
+                surface(e, leasedGeneration)
+            }
         }
+    }
+
+    /**
+     * Refresh the bearer token for a handshake 401, then retry once on a rebuilt connection. If the
+     * refresh fails (tokens cleared), re-raise the original 401 instead of firing a doomed retry —
+     * [com.calypsan.listenup.client.core.error.ErrorMapper] maps it to a typed `SessionExpired`.
+     */
+    private suspend fun <R> retryAfterAuthRefresh(
+        e: Throwable,
+        leasedGeneration: Int,
+        timeout: Duration,
+        block: suspend (T) -> R,
+    ): R {
+        logger.info { "RPC handshake 401; refreshing token before retry" }
+        val refreshed = authRecovery.refreshAndRebuild()
         invalidate(leasedGeneration)
+        if (!refreshed) {
+            logger.warn { "Token refresh failed; surfacing the 401 instead of retrying" }
+            throw e
+        }
         return retryOnce(timeout, block)
     }
 
     /**
-     * The single at-most-once retry. Takes a FRESH lease so a herd converges on the one
-     * reconnected proxy. A second failure surfaces: invalidate (unless the caller was cancelled)
-     * and re-raise so the boundary maps it to a typed failure.
+     * The single at-most-once retry, on a FRESH lease so a herd converges on the one reconnected
+     * proxy. Whatever the retry produces is final — its own failures go through [surface], so a
+     * second post-delivery drop becomes an outcome-unknown value, never a re-fired mutation.
      */
     private suspend fun <R> retryOnce(
         timeout: Duration,
@@ -151,13 +179,31 @@ internal class RpcProxyCache<T : Any>(
         val lease = lease()
         return try {
             withTimeout(timeout) { block(lease.proxy) }
-        } catch (e: CancellationException) {
-            if (currentCoroutineContext().isActive) invalidate(lease.generation)
-            throw e
         } catch (e: Throwable) {
-            invalidate(lease.generation)
-            throw e
+            surface(e, lease.generation)
         }
+    }
+
+    /**
+     * Turn a non-retryable failure into the right thrown signal — always throws.
+     *
+     * A from-below cancellation (still-active caller, incl. our own timeout on a retry) means the
+     * frame was SENT and its outcome is unknown: heal the connection and raise the typed
+     * [RpcOutcomeUnknownException] so the boundary folds it to a value (never a re-raised
+     * cancellation that would silently kill the caller's job). A genuinely cancelled caller
+     * re-raises untouched; any other fault invalidates and re-raises for the boundary to map.
+     */
+    private suspend fun surface(
+        e: Throwable,
+        leasedGeneration: Int,
+    ): Nothing {
+        val callerCancelled = e is CancellationException && !currentCoroutineContext().isActive
+        if (!callerCancelled) invalidate(leasedGeneration)
+        if (e is CancellationException && !callerCancelled) {
+            logger.warn { "RPC frame sent but outcome unknown (${e.message}); surfacing as a typed failure (no retry)" }
+            throw RpcOutcomeUnknownException(e)
+        }
+        throw e
     }
 
     private suspend fun lease(): Lease<T> =

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCache.kt
@@ -102,37 +102,47 @@ internal class RpcProxyCache<T : Any>(
             // The request may be in flight — heal for the NEXT attempt, but never auto-retry here.
             invalidate(lease.generation)
             throw e
-        } catch (e: CancellationException) {
-            if (currentCoroutineContext().isActive) {
-                // The caller wasn't cancelled, yet a CancellationException escaped: the cancel came
-                // from below — a dead RpcClient rejecting the frame before delivery. Heal and retry once.
-                invalidate(lease.generation)
-                retryOnce(timeout, block)
-            } else {
-                throw e
-            }
         } catch (e: Throwable) {
-            when {
-                isWsHandshake401(e) -> {
-                    authRecovery.refreshAndRebuild()
-                    invalidate(lease.generation)
-                    retryOnce(timeout, block)
-                }
-
-                isPreDeliveryTransportFailure(e) || isDeadRpcClient(e) -> {
-                    invalidate(lease.generation)
-                    retryOnce(timeout, block)
-                }
-
-                else -> throw e
-            }
+            recoverOrRethrow(e, lease.generation, timeout, block)
         }
+    }
+
+    /**
+     * Decide whether [e] is a recoverable transport death and, if so, invalidate the dead proxy and
+     * retry once on a fresh connection. Anything that could have reached a handler — a cancelled
+     * caller, or an unknown failure — re-raises unchanged.
+     */
+    private suspend fun <R> recoverOrRethrow(
+        e: Throwable,
+        leasedGeneration: Int,
+        timeout: Duration,
+        block: suspend (T) -> R,
+    ): R {
+        when {
+            // A CancellationException with a still-active caller is the dead-RpcClient signal: the
+            // cancel came from below, rejecting the frame before delivery — recoverable.
+            e is CancellationException && currentCoroutineContext().isActive -> Unit
+
+            // The caller's own context was cancelled — genuine cancellation, re-raise.
+            e is CancellationException -> throw e
+
+            // Stale-session handshake 401 — refresh the token + rebuild, then retry once.
+            isWsHandshake401(e) -> authRecovery.refreshAndRebuild()
+
+            // Any other pre-delivery transport death (handshake, connect, dead client) — retry once.
+            isPreDeliveryTransportFailure(e) || isDeadRpcClient(e) -> Unit
+
+            // Reached a handler, or an unknown fault — propagate.
+            else -> throw e
+        }
+        invalidate(leasedGeneration)
+        return retryOnce(timeout, block)
     }
 
     /**
      * The single at-most-once retry. Takes a FRESH lease so a herd converges on the one
      * reconnected proxy. A second failure surfaces: invalidate (unless the caller was cancelled)
-     * and rethrow so the boundary maps it to a typed failure.
+     * and re-raise so the boundary maps it to a typed failure.
      */
     private suspend fun <R> retryOnce(
         timeout: Duration,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
@@ -49,7 +49,7 @@ internal class KtorShelfRpcFactory(
     override suspend fun get(): ShelfService = cache.get()
 
     override suspend fun <T> callResult(block: suspend (ShelfService) -> AppResult<T>): AppResult<T> =
-        cache.rpcCall(block)
+        cache.rpcCall(block = block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ShelfRpcFactory.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.ShelfService
+import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import kotlinx.rpc.krpc.ktor.client.rpc
 import kotlinx.rpc.withService
@@ -17,6 +18,14 @@ internal interface ShelfRpcFactory {
     /** Returns the cached [ShelfService] proxy, connecting on first use. */
     suspend fun get(): ShelfService
 
+    /**
+     * Run [block] against the [ShelfService] proxy through the bounded, self-healing recovery
+     * engine, folding the outcome into an [AppResult]. The canonical mutation/query path — a
+     * dead socket heals invisibly, a surviving fault surfaces typed, a business failure passes
+     * through untouched.
+     */
+    suspend fun <T> callResult(block: suspend (ShelfService) -> AppResult<T>): AppResult<T>
+
     /** Drop the cached proxy and the RPC-flavored HttpClient. */
     suspend fun invalidate()
 }
@@ -29,14 +38,18 @@ internal interface ShelfRpcFactory {
 internal class KtorShelfRpcFactory(
     apiClientFactory: ApiClientFactory,
     serverConfig: ServerConfig,
+    authRecovery: RpcAuthRecovery = RpcAuthRecovery.None,
 ) : ShelfRpcFactory,
     RemoteCache {
     private val cache =
-        RpcProxyCache(apiClientFactory, serverConfig) { client, baseUrl ->
+        RpcProxyCache(apiClientFactory, serverConfig, authRecovery) { client, baseUrl ->
             client.rpc("$baseUrl/api/rpc/authed").withService<ShelfService>()
         }
 
     override suspend fun get(): ShelfService = cache.get()
+
+    override suspend fun <T> callResult(block: suspend (ShelfService) -> AppResult<T>): AppResult<T> =
+        cache.rpcCall(block)
 
     override suspend fun invalidate() = cache.invalidate()
 }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
@@ -60,7 +60,8 @@ internal class CollectionRepositoryImpl(
         libraryId: String,
         name: String,
     ): AppResult<Collection> =
-        rpcFactory.callResult { it.createCollection(libraryId, name) }
+        rpcFactory
+            .callResult { it.createCollection(libraryId, name) }
             .also { if (it is AppResult.Success) mirrorCreatedCollection(libraryId, it.data) }
             .map { it.toDomain() }
 
@@ -78,8 +79,7 @@ internal class CollectionRepositoryImpl(
     override suspend fun addBook(
         collectionId: String,
         bookId: String,
-    ): AppResult<Unit> =
-        rpcFactory.callResult { it.addBookToCollection(CollectionId(collectionId), BookId(bookId)) }
+    ): AppResult<Unit> = rpcFactory.callResult { it.addBookToCollection(CollectionId(collectionId), BookId(bookId)) }
 
     override suspend fun removeBook(
         collectionId: String,
@@ -92,18 +92,20 @@ internal class CollectionRepositoryImpl(
         sharedWithUserId: String,
         permission: SharePermission,
     ): AppResult<CollectionShare> =
-        rpcFactory.callResult {
-            it.shareCollection(CollectionId(collectionId), sharedWithUserId, permission)
-        }.map { it.toDomain() }
+        rpcFactory
+            .callResult {
+                it.shareCollection(CollectionId(collectionId), sharedWithUserId, permission)
+            }.map { it.toDomain() }
 
     override suspend fun updateShare(
         collectionId: String,
         sharedWithUserId: String,
         permission: SharePermission,
     ): AppResult<CollectionShare> =
-        rpcFactory.callResult {
-            it.updateShare(CollectionId(collectionId), sharedWithUserId, permission)
-        }.map { it.toDomain() }
+        rpcFactory
+            .callResult {
+                it.updateShare(CollectionId(collectionId), sharedWithUserId, permission)
+            }.map { it.toDomain() }
 
     override suspend fun revokeShare(
         collectionId: String,

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImpl.kt
@@ -3,8 +3,6 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.dto.CollectionShareDto
 import com.calypsan.listenup.api.dto.CollectionSummary
 import com.calypsan.listenup.api.dto.SharePermission
-import com.calypsan.listenup.api.error.TransportError
-import com.calypsan.listenup.api.result.AppResult as WireAppResult
 import com.calypsan.listenup.client.data.local.db.CollectionBookDao
 import com.calypsan.listenup.client.data.local.db.CollectionEntity
 import com.calypsan.listenup.client.data.local.db.CollectionShareDao
@@ -19,19 +17,9 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.CollectionId
 import com.calypsan.listenup.core.currentEpochMilliseconds
-import com.calypsan.listenup.client.core.error.ErrorMapper
 import com.calypsan.listenup.api.result.map
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withTimeout
-
-private val logger = KotlinLogging.logger {}
-
-/** Upper bound on a single collection RPC. Guards against a black-holed WebSocket that never resolves. */
-private const val RPC_TIMEOUT_MS = 15_000L
 
 /**
  * Collection repository — Room-backed reads, RPC-dispatched mutations.
@@ -72,7 +60,7 @@ internal class CollectionRepositoryImpl(
         libraryId: String,
         name: String,
     ): AppResult<Collection> =
-        rpcCall { rpcFactory.get().createCollection(libraryId, name) }
+        rpcFactory.callResult { it.createCollection(libraryId, name) }
             .also { if (it is AppResult.Success) mirrorCreatedCollection(libraryId, it.data) }
             .map { it.toDomain() }
 
@@ -80,31 +68,32 @@ internal class CollectionRepositoryImpl(
         id: String,
         name: String,
     ): AppResult<Collection> =
-        rpcCall { rpcFactory.get().renameCollection(CollectionId(id), name) }.map { it.toDomain() }
+        rpcFactory.callResult { it.renameCollection(CollectionId(id), name) }.map { it.toDomain() }
 
     override suspend fun delete(id: String): AppResult<Unit> =
-        rpcCall {
-            rpcFactory.get().deleteCollection(CollectionId(id))
+        rpcFactory.callResult {
+            it.deleteCollection(CollectionId(id))
         }
 
     override suspend fun addBook(
         collectionId: String,
         bookId: String,
-    ): AppResult<Unit> = rpcCall { rpcFactory.get().addBookToCollection(CollectionId(collectionId), BookId(bookId)) }
+    ): AppResult<Unit> =
+        rpcFactory.callResult { it.addBookToCollection(CollectionId(collectionId), BookId(bookId)) }
 
     override suspend fun removeBook(
         collectionId: String,
         bookId: String,
     ): AppResult<Unit> =
-        rpcCall { rpcFactory.get().removeBookFromCollection(CollectionId(collectionId), BookId(bookId)) }
+        rpcFactory.callResult { it.removeBookFromCollection(CollectionId(collectionId), BookId(bookId)) }
 
     override suspend fun share(
         collectionId: String,
         sharedWithUserId: String,
         permission: SharePermission,
     ): AppResult<CollectionShare> =
-        rpcCall {
-            rpcFactory.get().shareCollection(CollectionId(collectionId), sharedWithUserId, permission)
+        rpcFactory.callResult {
+            it.shareCollection(CollectionId(collectionId), sharedWithUserId, permission)
         }.map { it.toDomain() }
 
     override suspend fun updateShare(
@@ -112,37 +101,16 @@ internal class CollectionRepositoryImpl(
         sharedWithUserId: String,
         permission: SharePermission,
     ): AppResult<CollectionShare> =
-        rpcCall {
-            rpcFactory.get().updateShare(CollectionId(collectionId), sharedWithUserId, permission)
+        rpcFactory.callResult {
+            it.updateShare(CollectionId(collectionId), sharedWithUserId, permission)
         }.map { it.toDomain() }
 
     override suspend fun revokeShare(
         collectionId: String,
         sharedWithUserId: String,
-    ): AppResult<Unit> = rpcCall { rpcFactory.get().revokeShare(CollectionId(collectionId), sharedWithUserId) }
+    ): AppResult<Unit> = rpcFactory.callResult { it.revokeShare(CollectionId(collectionId), sharedWithUserId) }
 
     // ── Plumbing ────────────────────────────────────────────────────────────────
-
-    /**
-     * Run an RPC call, converting the contract-layer [WireAppResult] into the
-     * client [AppResult]. Re-throws [CancellationException]; all other throwables
-     * become [AppResult.Failure] via [ErrorMapper].
-     */
-    private suspend fun <T> rpcCall(block: suspend () -> WireAppResult<T>): AppResult<T> =
-        try {
-            when (val result = withTimeout(RPC_TIMEOUT_MS) { block() }) {
-                is WireAppResult.Success -> AppResult.Success(result.data)
-                is WireAppResult.Failure -> AppResult.Failure(result.error)
-            }
-        } catch (e: TimeoutCancellationException) {
-            logger.warn(e) { "Collection RPC timed out after ${RPC_TIMEOUT_MS}ms" }
-            AppResult.Failure(TransportError.Timeout())
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            logger.warn(e) { "Collection RPC failed" }
-            AppResult.Failure(ErrorMapper.map(e))
-        }
 
     /**
      * Optimistically mirror a just-created collection into Room so it appears immediately, without

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
@@ -3,10 +3,8 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.shelf.DiscoveredShelf
 import com.calypsan.listenup.api.dto.shelf.ShelfDetail as ShelfDetailDto
-import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.map
-import com.calypsan.listenup.client.core.error.ErrorMapper
 import com.calypsan.listenup.client.data.local.db.ShelfDao
 import com.calypsan.listenup.client.data.local.db.ShelfEntity
 import com.calypsan.listenup.client.data.local.db.ShelfWithBookCount
@@ -19,17 +17,8 @@ import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.core.currentEpochMilliseconds
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withTimeout
-
-private val logger = KotlinLogging.logger {}
-
-/** Upper bound on a single shelf RPC. Guards against a black-holed WebSocket that never resolves. */
-private const val RPC_TIMEOUT_MS = 15_000L
 
 /**
  * Shelf repository — substrate-Room-backed reads, [com.calypsan.listenup.api.ShelfService]
@@ -84,17 +73,17 @@ internal class ShelfRepositoryImpl(
     // ── Discovery (on-demand RPC) ─────────────────────────────────────────────────
 
     override suspend fun getUserShelves(userId: String): AppResult<List<Shelf>> =
-        rpcCall { rpcFactory.get().getUserShelves(UserId(userId)) }
+        rpcFactory.callResult { it.getUserShelves(UserId(userId)) }
             .map { shelves -> shelves.map { it.toDomain() } }
 
     override suspend fun discoverShelves(): AppResult<List<Shelf>> =
-        rpcCall { rpcFactory.get().discoverShelves() }
+        rpcFactory.callResult { it.discoverShelves() }
             .map { discovered -> discovered.map { it.toDomain() } }
 
     // ── Detail (on-demand RPC) ────────────────────────────────────────────────────
 
     override suspend fun getShelfDetail(shelfId: ShelfId): AppResult<ShelfDetail> =
-        rpcCall { rpcFactory.get().getShelf(shelfId) }
+        rpcFactory.callResult { it.getShelf(shelfId) }
             .map { detail ->
                 val coverHashByBook = dao.coverHashesByBookFor(shelfId.value).associate { it.bookId to it.coverHash }
                 detail.toDomain(coverHashByBook)
@@ -107,8 +96,8 @@ internal class ShelfRepositoryImpl(
         description: String?,
         isPrivate: Boolean,
     ): AppResult<Shelf> =
-        rpcCall {
-            rpcFactory.get().createShelf(
+        rpcFactory.callResult {
+            it.createShelf(
                 name = name,
                 description = description ?: "",
                 isPrivate = isPrivate,
@@ -122,8 +111,8 @@ internal class ShelfRepositoryImpl(
         description: String?,
         isPrivate: Boolean,
     ): AppResult<Shelf> =
-        rpcCall {
-            rpcFactory.get().updateShelf(
+        rpcFactory.callResult {
+            it.updateShelf(
                 shelfId = shelfId,
                 name = name,
                 description = description ?: "",
@@ -132,7 +121,7 @@ internal class ShelfRepositoryImpl(
         }.map { it.toDomain() }
 
     override suspend fun deleteShelf(shelfId: ShelfId): AppResult<Unit> =
-        rpcCall { rpcFactory.get().deleteShelf(shelfId) }
+        rpcFactory.callResult { it.deleteShelf(shelfId) }
 
     override suspend fun addBooksToShelf(
         shelfId: ShelfId,
@@ -141,7 +130,7 @@ internal class ShelfRepositoryImpl(
         // The RPC surface adds one book at a time (idempotent); dispatch each and
         // fail fast on the first error. SSE echoes update Room — no optimistic write.
         bookIds.forEach { bookId ->
-            val result = rpcCall { rpcFactory.get().addBookToShelf(shelfId, bookId) }
+            val result = rpcFactory.callResult { it.addBookToShelf(shelfId, bookId) }
             if (result is AppResult.Failure) return result
         }
         return AppResult.Success(Unit)
@@ -150,14 +139,14 @@ internal class ShelfRepositoryImpl(
     override suspend fun removeBookFromShelf(
         shelfId: ShelfId,
         bookId: BookId,
-    ): AppResult<Unit> = rpcCall { rpcFactory.get().removeBookFromShelf(shelfId, bookId) }
+    ): AppResult<Unit> = rpcFactory.callResult { it.removeBookFromShelf(shelfId, bookId) }
 
     override suspend fun reorderBooks(
         shelfId: ShelfId,
         orderedBookIds: List<BookId>,
     ): AppResult<Unit> =
-        rpcCall {
-            rpcFactory.get().reorderShelfBooks(shelfId, orderedBookIds)
+        rpcFactory.callResult {
+            it.reorderShelfBooks(shelfId, orderedBookIds)
         }
 
     // ── Mapping ───────────────────────────────────────────────────────────────────
@@ -194,24 +183,6 @@ internal class ShelfRepositoryImpl(
             coverPaths = coverPaths,
         )
     }
-
-    /**
-     * Run an RPC call and surface the typed [AppResult] directly. Re-throws
-     * [CancellationException]; any other throwable becomes [AppResult.Failure]
-     * via [ErrorMapper].
-     */
-    private suspend fun <T> rpcCall(block: suspend () -> AppResult<T>): AppResult<T> =
-        try {
-            withTimeout(RPC_TIMEOUT_MS) { block() }
-        } catch (e: TimeoutCancellationException) {
-            logger.warn(e) { "Shelf RPC timed out after ${RPC_TIMEOUT_MS}ms" }
-            AppResult.Failure(TransportError.Timeout())
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            logger.warn(e) { "Shelf RPC failed" }
-            AppResult.Failure(ErrorMapper.map(e))
-        }
 
     /**
      * Optimistically mirror a just-created shelf into Room so it appears immediately, without waiting

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
@@ -73,17 +73,20 @@ internal class ShelfRepositoryImpl(
     // ── Discovery (on-demand RPC) ─────────────────────────────────────────────────
 
     override suspend fun getUserShelves(userId: String): AppResult<List<Shelf>> =
-        rpcFactory.callResult { it.getUserShelves(UserId(userId)) }
+        rpcFactory
+            .callResult { it.getUserShelves(UserId(userId)) }
             .map { shelves -> shelves.map { it.toDomain() } }
 
     override suspend fun discoverShelves(): AppResult<List<Shelf>> =
-        rpcFactory.callResult { it.discoverShelves() }
+        rpcFactory
+            .callResult { it.discoverShelves() }
             .map { discovered -> discovered.map { it.toDomain() } }
 
     // ── Detail (on-demand RPC) ────────────────────────────────────────────────────
 
     override suspend fun getShelfDetail(shelfId: ShelfId): AppResult<ShelfDetail> =
-        rpcFactory.callResult { it.getShelf(shelfId) }
+        rpcFactory
+            .callResult { it.getShelf(shelfId) }
             .map { detail ->
                 val coverHashByBook = dao.coverHashesByBookFor(shelfId.value).associate { it.bookId to it.coverHash }
                 detail.toDomain(coverHashByBook)
@@ -96,13 +99,14 @@ internal class ShelfRepositoryImpl(
         description: String?,
         isPrivate: Boolean,
     ): AppResult<Shelf> =
-        rpcFactory.callResult {
-            it.createShelf(
-                name = name,
-                description = description ?: "",
-                isPrivate = isPrivate,
-            )
-        }.also { if (it is AppResult.Success) mirrorCreatedShelf(it.data) }
+        rpcFactory
+            .callResult {
+                it.createShelf(
+                    name = name,
+                    description = description ?: "",
+                    isPrivate = isPrivate,
+                )
+            }.also { if (it is AppResult.Success) mirrorCreatedShelf(it.data) }
             .map { it.toDomain() }
 
     override suspend fun updateShelf(
@@ -111,14 +115,15 @@ internal class ShelfRepositoryImpl(
         description: String?,
         isPrivate: Boolean,
     ): AppResult<Shelf> =
-        rpcFactory.callResult {
-            it.updateShelf(
-                shelfId = shelfId,
-                name = name,
-                description = description ?: "",
-                isPrivate = isPrivate,
-            )
-        }.map { it.toDomain() }
+        rpcFactory
+            .callResult {
+                it.updateShelf(
+                    shelfId = shelfId,
+                    name = name,
+                    description = description ?: "",
+                    isPrivate = isPrivate,
+                )
+            }.map { it.toDomain() }
 
     override suspend fun deleteShelf(shelfId: ShelfId): AppResult<Unit> =
         rpcFactory.callResult { it.deleteShelf(shelfId) }

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ClientSyncModule.kt
@@ -93,6 +93,7 @@ internal val clientSyncModule =
             KtorPlaybackRpcFactory(
                 apiClientFactory = get(),
                 serverConfig = get(),
+                authRecovery = get(),
             )
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CollectionModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/CollectionModule.kt
@@ -33,6 +33,7 @@ internal val collectionModule: Module =
             KtorCollectionRpcFactory(
                 apiClientFactory = get(),
                 serverConfig = get(),
+                authRecovery = get(),
             )
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/NetworkModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/NetworkModule.kt
@@ -5,6 +5,8 @@ import com.calypsan.listenup.client.data.remote.BookApiContract
 import com.calypsan.listenup.client.data.remote.KtorApiClientFactory
 import com.calypsan.listenup.client.data.remote.ContributorApiContract
 import com.calypsan.listenup.client.data.remote.InstanceApiContract
+import com.calypsan.listenup.client.data.remote.RpcAuthRecovery
+import com.calypsan.listenup.client.data.remote.RpcAuthRecoveryImpl
 import com.calypsan.listenup.client.data.remote.SeriesApiContract
 import com.calypsan.listenup.client.data.remote.api.ListenUpApi
 import com.calypsan.listenup.client.domain.repository.AuthRepository
@@ -37,6 +39,17 @@ internal val networkModule: Module =
                 refreshAccessToken = { get<AuthRepository>().refreshAccessToken() },
             )
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
+
+        // RpcAuthRecovery — single-flight token refresh + request-client rebuild for the authed RPC
+        // factories (Shelf/Collection/Playback). Injected into their RpcProxyCache so a handshake-401
+        // heals with one refresh + one retry. Same lazy AuthRepository seam as ApiClientFactory above.
+        single<RpcAuthRecovery> {
+            RpcAuthRecoveryImpl(
+                authSession = get(),
+                refreshAccessToken = { get<AuthRepository>().refreshAccessToken() },
+                apiClientFactory = get(),
+            )
+        }
 
         // AuthRpcFactory is provided by clientAuthModule. It still needs to be
         // invalidated alongside ApiClientFactory whenever the underlying HttpClient

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ShelfModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/ShelfModule.kt
@@ -33,6 +33,7 @@ internal val shelfModule: Module =
             KtorShelfRpcFactory(
                 apiClientFactory = get(),
                 serverConfig = get(),
+                authRecovery = get(),
             )
         } binds arrayOf(com.calypsan.listenup.client.data.remote.RemoteCache::class)
 

--- a/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -326,7 +326,10 @@ class PlaybackPreparer internal constructor(
             if (localPaths.values.all { it != null }) {
                 emptyMap() // fully downloaded — never touch the server (offline-first)
             } else {
-                when (val result = playbackRpcFactory.playbackService().prepare(bookId)) {
+                // Routed through the bounded, self-healing engine so a dead-socket transport throw
+                // becomes a typed, time-bounded AppResult.Failure instead of an unguarded exception
+                // crossing the Swift Export seam as an opaque KotlinError.
+                when (val result = playbackRpcFactory.callResult { it.prepare(bookId) }) {
                     is AppResult.Success -> {
                         result.data.audioFiles.associate { it.fileId to serverUrl + it.url }
                     }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifierTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifierTest.kt
@@ -29,4 +29,13 @@ class RpcFailureClassifierTest :
             RpcFailureClassifier.isPreDeliveryTransportFailure(RuntimeException("boom")) shouldBe false
             RpcFailureClassifier.isWsHandshake401(RuntimeException("nope")) shouldBe false
         }
+
+        test("a dead RpcClient IllegalStateException is recognized regardless of exception type") {
+            // Real kotlinx.rpc surfaces a torn-down client as a plain IllegalStateException, not a
+            // CancellationException — the message is the only reliable signal.
+            RpcFailureClassifier.isDeadRpcClient(IllegalStateException("RpcClient was cancelled")) shouldBe true
+            RpcFailureClassifier.isDeadRpcClient(RuntimeException("rpcclient was cancelled")) shouldBe true
+            RpcFailureClassifier.isDeadRpcClient(IllegalStateException("something else entirely")) shouldBe false
+            RpcFailureClassifier.isDeadRpcClient(RuntimeException()) shouldBe false
+        }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifierTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcFailureClassifierTest.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.data.remote
+
+import io.ktor.client.plugins.websocket.WebSocketException
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.io.IOException
+
+class RpcFailureClassifierTest :
+    FunSpec({
+        test("a 401 WebSocket handshake is recognized as auth-recoverable") {
+            val e = WebSocketException("Handshake exception, expected status code 101 but was 401")
+            RpcFailureClassifier.isWsHandshake401(e) shouldBe true
+        }
+
+        test("a non-401 WebSocket handshake is a pre-delivery transport failure, not an auth one") {
+            val e = WebSocketException("Handshake exception, expected status code 101 but was 500")
+            RpcFailureClassifier.isWsHandshake401(e) shouldBe false
+            RpcFailureClassifier.isPreDeliveryTransportFailure(e) shouldBe true
+        }
+
+        test("any WebSocket handshake failure is pre-delivery — the frame never sent, so retry is safe") {
+            RpcFailureClassifier.isPreDeliveryTransportFailure(
+                WebSocketException("Handshake exception, expected status code 101 but was 401"),
+            ) shouldBe true
+        }
+
+        test("a failure that could have reached a handler is NOT pre-delivery (no auto-retry)") {
+            RpcFailureClassifier.isPreDeliveryTransportFailure(IOException("connection reset mid-stream")) shouldBe false
+            RpcFailureClassifier.isPreDeliveryTransportFailure(RuntimeException("boom")) shouldBe false
+            RpcFailureClassifier.isWsHandshake401(RuntimeException("nope")) shouldBe false
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
@@ -64,8 +64,7 @@ class RpcProxyCacheCallTest :
                 everySuspend { getClient() } calls { HttpClient(MockEngine { respond("") }) { install(WebSockets) } }
             }
 
-        fun mockServerConfig(): ServerConfig =
-            mock { everySuspend { getActiveUrl() } returns ServerUrl("http://localhost") }
+        fun mockServerConfig(): ServerConfig = mock { everySuspend { getActiveUrl() } returns ServerUrl("http://localhost") }
 
         /**
          * Build a cache whose [connect] pops the next scripted behavior and counts invocations.
@@ -224,7 +223,9 @@ class RpcProxyCacheCallTest :
 
                 val result: AppResult<String> = cache.rpcCall { AppResult.Success(it.work()) }
 
-                result.shouldBeInstanceOf<AppResult.Failure>().error
+                result
+                    .shouldBeInstanceOf<AppResult.Failure>()
+                    .error
                     .shouldBeInstanceOf<AuthError.SessionExpired>()
                 recovery.count shouldBe 1 // refreshed exactly once (not again on the retry)
                 connects() shouldBe 2

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
@@ -1,6 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.error.ValidationError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -83,22 +84,28 @@ class RpcProxyCacheCallTest :
             return cache to { connectCount }
         }
 
-        test("dead-proxy CancellationException with a live caller reconnects and returns the retry result") {
+        test("a from-below CancellationException (post-delivery) is surfaced outcome-unknown, NOT retried") {
+            // kotlinx.rpc throws a bare CancellationException("Client cancelled") from below when it
+            // closes a PENDING (already-sent) request channel — the frame was delivered and may have
+            // committed. Retrying would double-apply the mutation. The engine must surface, not retry.
             runTest {
                 val (cache, connects) =
                     scriptedCache(
                         ArrayDeque(
                             listOf(
-                                { throw CancellationException("RpcClient was cancelled") },
-                                { "healed" },
+                                { throw CancellationException("Client cancelled") },
+                                { "must-not-run" },
                             ),
                         ),
                     )
 
-                val result = cache.call { it.work() }
+                val result: AppResult<String> = cache.rpcCall { AppResult.Success(it.work()) }
 
-                result shouldBe "healed"
-                connects() shouldBe 2 // 1 original (dead) + 1 reconnect
+                result
+                    .shouldBeInstanceOf<AppResult.Failure>()
+                    .error
+                    .shouldBeInstanceOf<TransportError.Timeout>()
+                connects() shouldBe 1 // NO retry — the second scripted behavior is never reached
             }
         }
 
@@ -191,7 +198,7 @@ class RpcProxyCacheCallTest :
                             listOf(
                                 {
                                     barrier.await()
-                                    throw CancellationException("RpcClient was cancelled")
+                                    throw IllegalStateException("RpcClient was cancelled")
                                 },
                                 { "healed" },
                             ),
@@ -229,6 +236,40 @@ class RpcProxyCacheCallTest :
                     .shouldBeInstanceOf<AuthError.SessionExpired>()
                 recovery.count shouldBe 1 // refreshed exactly once (not again on the retry)
                 connects() shouldBe 2
+            }
+        }
+
+        test("a handshake 401 whose token refresh fails surfaces SessionExpired without a doomed retry") {
+            runTest {
+                // Refresh fails (tokens cleared) → retrying the handshake would just 401 again.
+                val failingRecovery =
+                    object : RpcAuthRecovery {
+                        var count = 0
+
+                        override suspend fun refreshAndRebuild(): Boolean {
+                            count++
+                            return false
+                        }
+                    }
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                { throw WebSocketException("expected status code 101 but was 401") },
+                                { "must-not-run" },
+                            ),
+                        ),
+                        authRecovery = failingRecovery,
+                    )
+
+                val result: AppResult<String> = cache.rpcCall { AppResult.Success(it.work()) }
+
+                result
+                    .shouldBeInstanceOf<AppResult.Failure>()
+                    .error
+                    .shouldBeInstanceOf<AuthError.SessionExpired>()
+                failingRecovery.count shouldBe 1
+                connects() shouldBe 1 // no retry — the second behavior is never reached
             }
         }
     })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
@@ -1,0 +1,216 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.ValidationError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.core.ServerUrl
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.websocket.WebSocketException
+import io.ktor.client.plugins.websocket.WebSockets
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Unit tests for [RpcProxyCache.call] — the bounded, single-flight, self-healing recovery engine.
+ *
+ * The proxy is a scripted [FakeProxy]: [connect] is a fake counting lambda that pops the next
+ * scripted behavior, so each test controls exactly how the proxy fails and how the reconnect
+ * succeeds. [ApiClientFactory.getClient] returns a real MockEngine-backed [HttpClient] so the
+ * cache's `.config { installKrpc { } }` derivation runs for real; [ServerConfig.getActiveUrl]
+ * returns a fixed URL. No real WebSocket is opened — recovery is exercised structurally.
+ */
+class RpcProxyCacheCallTest :
+    FunSpec({
+
+        /** A scripted proxy whose single method replays [behavior] on every call. */
+        class FakeProxy(
+            private val behavior: suspend () -> String,
+        ) {
+            suspend fun work(): String = behavior()
+        }
+
+        /** Counting [RpcAuthRecovery] so tests can assert refresh-and-rebuild ran exactly once. */
+        class CountingAuthRecovery : RpcAuthRecovery {
+            var count = 0
+                private set
+
+            override suspend fun refreshAndRebuild(): Boolean {
+                count++
+                return true
+            }
+        }
+
+        // A fresh MockEngine client per getClient() so a dropped `.config { }` child can never
+        // interfere with the next lease — the test isolates the recovery engine, not client reuse.
+        fun mockFactory(): ApiClientFactory =
+            mock {
+                everySuspend { getClient() } calls { HttpClient(MockEngine { respond("") }) { install(WebSockets) } }
+            }
+
+        fun mockServerConfig(): ServerConfig =
+            mock { everySuspend { getActiveUrl() } returns ServerUrl("http://localhost") }
+
+        /**
+         * Build a cache whose [connect] pops the next scripted behavior and counts invocations.
+         * The returned pair is (cache, connectCount-getter).
+         */
+        fun scriptedCache(
+            script: ArrayDeque<suspend () -> String>,
+            authRecovery: RpcAuthRecovery = RpcAuthRecovery.None,
+        ): Pair<RpcProxyCache<FakeProxy>, () -> Int> {
+            var connectCount = 0
+            val cache =
+                RpcProxyCache(mockFactory(), mockServerConfig(), authRecovery) { _, _ ->
+                    connectCount++
+                    FakeProxy(script.removeFirst())
+                }
+            return cache to { connectCount }
+        }
+
+        test("dead-proxy CancellationException with a live caller reconnects and returns the retry result") {
+            runTest {
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                { throw CancellationException("RpcClient was cancelled") },
+                                { "healed" },
+                            ),
+                        ),
+                    )
+
+                val result = cache.call { it.work() }
+
+                result shouldBe "healed"
+                connects() shouldBe 2 // 1 original (dead) + 1 reconnect
+            }
+        }
+
+        test("a genuinely cancelled caller context re-raises without invalidating") {
+            runTest {
+                val (cache, connects) = scriptedCache(ArrayDeque(listOf({ awaitCancellation() })))
+
+                // UNDISPATCHED so the body runs to awaitCancellation (past connect) before we cancel.
+                val job = launch(start = CoroutineStart.UNDISPATCHED) { cache.call { it.work() } }
+                job.cancel()
+                job.join()
+
+                // Re-raised (not swallowed into a retry): the job ends cancelled, not completed.
+                job.isCancelled shouldBe true
+                // And the proxy was never invalidated: get() reuses the SAME cached proxy, connect stays 1.
+                cache.get()
+                connects() shouldBe 1
+            }
+        }
+
+        test("a business AppResult.Failure returned by the block passes through — no invalidate, no retry") {
+            runTest {
+                val (cache, connects) = scriptedCache(ArrayDeque(listOf({ "healthy" }, { "unused" })))
+
+                val result: AppResult<String> =
+                    cache.call { AppResult.Failure(ValidationError(message = "duplicate")) }
+
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                // A follow-up succeeds on the SAME cached proxy: the Failure never triggered a reconnect.
+                cache.call { it.work() } shouldBe "healthy"
+                connects() shouldBe 1
+            }
+        }
+
+        test("a hanging block trips the timeout, invalidates, and never auto-retries") {
+            runTest {
+                var calls = 0
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                {
+                                    calls++
+                                    awaitCancellation()
+                                },
+                                { "reconnected" },
+                            ),
+                        ),
+                    )
+
+                var timedOut = false
+                try {
+                    cache.call(timeout = 50.milliseconds) { it.work() }
+                } catch (_: CancellationException) {
+                    // TimeoutCancellationException is a CancellationException subtype.
+                    timedOut = true
+                }
+
+                timedOut shouldBe true
+                calls shouldBe 1 // called exactly once — no auto-retry (no double-mutation)
+                // The proxy WAS invalidated for the next attempt: a follow-up reconnects.
+                cache.call { it.work() } shouldBe "reconnected"
+                connects() shouldBe 2
+            }
+        }
+
+        test("a herd failing on the same generation converges on a single reconnect (single-flight)") {
+            runTest {
+                val barrier = CompletableDeferred<Unit>()
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                {
+                                    barrier.await()
+                                    throw CancellationException("RpcClient was cancelled")
+                                },
+                                { "healed" },
+                            ),
+                        ),
+                    )
+
+                val herd = List(5) { async { cache.call { it.work() } } }
+                barrier.complete(Unit) // release all five parked calls at once
+                val results = herd.awaitAll()
+
+                results shouldBe List(5) { "healed" }
+                connects() shouldBe 2 // 1 original + exactly 1 reconnect — not 6
+            }
+        }
+
+        test("a handshake 401 refreshes once, retries once, and a second 401 surfaces typed") {
+            runTest {
+                val recovery = CountingAuthRecovery()
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                { throw WebSocketException("expected status code 101 but was 401") },
+                                { throw WebSocketException("expected status code 101 but was 401") },
+                            ),
+                        ),
+                        authRecovery = recovery,
+                    )
+
+                val result: AppResult<String> = cache.rpcCall { AppResult.Success(it.work()) }
+
+                result.shouldBeInstanceOf<AppResult.Failure>().error
+                    .shouldBeInstanceOf<AuthError.SessionExpired>()
+                recovery.count shouldBe 1 // refreshed exactly once (not again on the retry)
+                connects() shouldBe 2
+            }
+        }
+    })

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RpcProxyCacheCallTest.kt
@@ -103,6 +103,23 @@ class RpcProxyCacheCallTest :
             }
         }
 
+        test("a dead-RpcClient IllegalStateException reconnects and returns the retry result") {
+            runTest {
+                val (cache, connects) =
+                    scriptedCache(
+                        ArrayDeque(
+                            listOf(
+                                { throw IllegalStateException("RpcClient was cancelled") },
+                                { "healed" },
+                            ),
+                        ),
+                    )
+
+                cache.call { it.work() } shouldBe "healed"
+                connects() shouldBe 2 // 1 original (dead) + 1 reconnect
+            }
+        }
+
         test("a genuinely cancelled caller context re-raises without invalidating") {
             runTest {
                 val (cache, connects) = scriptedCache(ArrayDeque(listOf({ awaitCancellation() })))

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImplTest.kt
@@ -33,14 +33,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 /**
- * Unit tests for [CollectionRepositoryImpl] — Room reads + RPC-dispatched writes.
- *
- * Observation maps Room projections to domain (including JOIN-derived `bookCount`);
- * writes dispatch to a faked [CollectionService] and bridge the contract-layer
- * `WireAppResult` to the client [AppResult]. No optimistic Room writes — Room updates
- * arrive via the sync handler on SSE.
- */
-/**
  * Fake [CollectionRpcFactory] routing [callResult] through the REAL boundary [catchingRpcResult],
  * so repository tests exercise the same throw→Failure semantics the production
  * [com.calypsan.listenup.client.data.remote.RpcProxyCache] engine provides — without a live socket.
@@ -50,12 +42,19 @@ private class FakeCollectionRpcFactory(
 ) : CollectionRpcFactory {
     override suspend fun get(): CollectionService = service
 
-    override suspend fun <T> callResult(block: suspend (CollectionService) -> AppResult<T>): AppResult<T> =
-        catchingRpcResult { block(service) }
+    override suspend fun <T> callResult(block: suspend (CollectionService) -> AppResult<T>): AppResult<T> = catchingRpcResult { block(service) }
 
     override suspend fun invalidate() {}
 }
 
+/**
+ * Unit tests for [CollectionRepositoryImpl] — Room reads + RPC-dispatched writes.
+ *
+ * Observation maps Room projections to domain (including JOIN-derived `bookCount`);
+ * writes dispatch to a faked [CollectionService] and bridge the contract-layer
+ * `WireAppResult` to the client [AppResult]. No optimistic Room writes — Room updates
+ * arrive via the sync handler on SSE.
+ */
 class CollectionRepositoryImplTest :
     FunSpec({
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/CollectionRepositoryImplTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.client.data.local.db.CollectionShareEntity
 import com.calypsan.listenup.client.data.local.db.CollectionWithBookCount
 import com.calypsan.listenup.client.data.local.db.CollectionDao
 import com.calypsan.listenup.client.data.remote.CollectionRpcFactory
+import com.calypsan.listenup.client.data.remote.catchingRpcResult
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.CollectionId
 import dev.mokkery.MockMode
@@ -39,6 +40,22 @@ import kotlinx.coroutines.test.runTest
  * `WireAppResult` to the client [AppResult]. No optimistic Room writes — Room updates
  * arrive via the sync handler on SSE.
  */
+/**
+ * Fake [CollectionRpcFactory] routing [callResult] through the REAL boundary [catchingRpcResult],
+ * so repository tests exercise the same throw→Failure semantics the production
+ * [com.calypsan.listenup.client.data.remote.RpcProxyCache] engine provides — without a live socket.
+ */
+private class FakeCollectionRpcFactory(
+    private val service: CollectionService,
+) : CollectionRpcFactory {
+    override suspend fun get(): CollectionService = service
+
+    override suspend fun <T> callResult(block: suspend (CollectionService) -> AppResult<T>): AppResult<T> =
+        catchingRpcResult { block(service) }
+
+    override suspend fun invalidate() {}
+}
+
 class CollectionRepositoryImplTest :
     FunSpec({
 
@@ -48,11 +65,8 @@ class CollectionRepositoryImplTest :
             bookDao: CollectionBookDao = mock(),
             shareDao: CollectionShareDao = mock(),
             service: CollectionService = mock(),
-        ): CollectionRepositoryImpl {
-            val factory: CollectionRpcFactory = mock()
-            everySuspend { factory.get() } returns service
-            return CollectionRepositoryImpl(collectionDao, bookDao, shareDao, factory)
-        }
+        ): CollectionRepositoryImpl =
+            CollectionRepositoryImpl(collectionDao, bookDao, shareDao, FakeCollectionRpcFactory(service))
 
         fun entity(
             id: String,

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import com.calypsan.listenup.client.data.local.db.ShelfWithBookCount
 import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.local.db.UserEntity
 import com.calypsan.listenup.client.data.remote.ShelfRpcFactory
+import com.calypsan.listenup.client.data.remote.catchingRpcResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ShelfId
 import com.calypsan.listenup.core.Timestamp
@@ -46,6 +47,23 @@ import kotlinx.coroutines.test.runTest
  * optimistic Room writes — Room updates arrive via the sync handler on SSE. Cancellation
  * is re-raised.
  */
+/**
+ * Fake [ShelfRpcFactory] that routes [callResult] through the REAL boundary [catchingRpcResult],
+ * so repository tests exercise the same throw→Failure / cancellation-rethrow semantics the
+ * production [com.calypsan.listenup.client.data.remote.RpcProxyCache] engine provides — without a
+ * live WebSocket. [provide] yields the service (or throws to simulate a pre-delivery transport fault).
+ */
+private class FakeShelfRpcFactory(
+    private val provide: suspend () -> ShelfService,
+) : ShelfRpcFactory {
+    override suspend fun get(): ShelfService = provide()
+
+    override suspend fun <T> callResult(block: suspend (ShelfService) -> AppResult<T>): AppResult<T> =
+        catchingRpcResult { block(provide()) }
+
+    override suspend fun invalidate() {}
+}
+
 class ShelfRepositoryImplTest :
     FunSpec({
 
@@ -64,11 +82,7 @@ class ShelfRepositoryImplTest :
             shelfDao: ShelfDao = mock(MockMode.autofill),
             userDao: UserDao = mock { everySuspend { getCurrentUser() } returns user() },
             service: ShelfService = mock(),
-        ): ShelfRepositoryImpl {
-            val factory: ShelfRpcFactory = mock()
-            everySuspend { factory.get() } returns service
-            return ShelfRepositoryImpl(shelfDao, userDao, factory)
-        }
+        ): ShelfRepositoryImpl = ShelfRepositoryImpl(shelfDao, userDao, FakeShelfRpcFactory { service })
 
         fun shelfEntity(
             id: String,
@@ -315,10 +329,7 @@ class ShelfRepositoryImplTest :
 
         test("getUserShelves surfaces transport failure as AppResult.Failure (rpcCall boundary)") {
             runTest {
-                val factory: ShelfRpcFactory =
-                    mock {
-                        everySuspend { get() } throws RuntimeException("connection refused")
-                    }
+                val factory = FakeShelfRpcFactory { throw RuntimeException("connection refused") }
                 val repo = ShelfRepositoryImpl(mock(), mock { everySuspend { getCurrentUser() } returns user() }, factory)
                 val result = repo.getUserShelves("u1")
                 result.shouldBeInstanceOf<AppResult.Failure>()

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
@@ -39,15 +39,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 /**
- * Unit tests for [ShelfRepositoryImpl] — substrate-Room reads + RPC-dispatched writes.
- *
- * Observation maps Room projections to the domain model (owner fields from the current
- * user, JOIN-derived `bookCount`, surfaced `isPrivate`); writes dispatch to a faked
- * [ShelfService] and surface the typed [AppResult] directly (no throwing bridge). No
- * optimistic Room writes — Room updates arrive via the sync handler on SSE. Cancellation
- * is re-raised.
- */
-/**
  * Fake [ShelfRpcFactory] that routes [callResult] through the REAL boundary [catchingRpcResult],
  * so repository tests exercise the same throw→Failure / cancellation-rethrow semantics the
  * production [com.calypsan.listenup.client.data.remote.RpcProxyCache] engine provides — without a
@@ -58,12 +49,20 @@ private class FakeShelfRpcFactory(
 ) : ShelfRpcFactory {
     override suspend fun get(): ShelfService = provide()
 
-    override suspend fun <T> callResult(block: suspend (ShelfService) -> AppResult<T>): AppResult<T> =
-        catchingRpcResult { block(provide()) }
+    override suspend fun <T> callResult(block: suspend (ShelfService) -> AppResult<T>): AppResult<T> = catchingRpcResult { block(provide()) }
 
     override suspend fun invalidate() {}
 }
 
+/**
+ * Unit tests for [ShelfRepositoryImpl] — substrate-Room reads + RPC-dispatched writes.
+ *
+ * Observation maps Room projections to the domain model (owner fields from the current
+ * user, JOIN-derived `bookCount`, surfaced `isPrivate`); writes dispatch to a faked
+ * [ShelfService] and surface the typed [AppResult] directly (no throwing bridge). No
+ * optimistic Room writes — Room updates arrive via the sync handler on SSE. Cancellation
+ * is re-raised.
+ */
 class ShelfRepositoryImplTest :
     FunSpec({
 

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ClientSyncModuleVerifyTest.kt
@@ -78,6 +78,7 @@ class ClientSyncModuleVerifyTest :
                         ImageStorage::class,
                         DocumentStorage::class,
                         MirroredDomain::class,
+                        com.calypsan.listenup.client.data.remote.RpcAuthRecovery::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/CollectionModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/CollectionModuleVerifyTest.kt
@@ -36,6 +36,7 @@ class CollectionModuleVerifyTest :
                         ApiClientFactory::class,
                         ServerConfig::class,
                         LibraryRepository::class,
+                        com.calypsan.listenup.client.data.remote.RpcAuthRecovery::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ShelfModuleVerifyTest.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/di/ShelfModuleVerifyTest.kt
@@ -33,6 +33,7 @@ class ShelfModuleVerifyTest :
                         ImageRepository::class,
                         ApiClientFactory::class,
                         ServerConfig::class,
+                        com.calypsan.listenup.client.data.remote.RpcAuthRecovery::class,
                     ),
             )
         }

--- a/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
+++ b/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoThrowsInDataLayerRule.kt
@@ -108,6 +108,11 @@ private fun com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration.contai
             // not-connected guard: RPC-proxy factories throw this typed exception when no server
             // URL is configured (an expected pre-connection state). ErrorMapper folds it to a
             // transient NetworkUnavailable; it is a configuration guard, not a swallowed failure.
-            !line.contains("throw ServerUrlNotConfiguredException(")
+            !line.contains("throw ServerUrlNotConfiguredException(") &&
+            // outcome-unknown transport signal: RpcProxyCache throws this when an RPC frame was sent
+            // but the response was lost, so it can't be retried. catchingRpcResult immediately folds
+            // it to a typed AppResult.Failure(TransportError.Timeout) — a transport signal, not a
+            // propagated/swallowed failure (same rationale as ServerUrlNotConfiguredException).
+            !line.contains("throw RpcOutcomeUnknownException(")
     }
 }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/RpcReconnectE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/RpcReconnectE2ETest.kt
@@ -1,0 +1,263 @@
+package com.calypsan.listenup.client.collections
+
+import com.calypsan.listenup.api.CollectionService
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.CollectionSummary
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.CollectionBookDao
+import com.calypsan.listenup.client.data.local.db.CollectionDao
+import com.calypsan.listenup.client.data.local.db.CollectionShareDao
+import com.calypsan.listenup.client.data.remote.ApiClientFactory
+import com.calypsan.listenup.client.data.remote.KtorCollectionRpcFactory
+import com.calypsan.listenup.client.data.remote.RpcProxyCache
+import com.calypsan.listenup.client.data.remote.rpcCall
+import com.calypsan.listenup.client.data.repository.CollectionRepositoryImpl
+import com.calypsan.listenup.client.data.sync.testing.testAuth
+import com.calypsan.listenup.client.di.e2e.TestServerConfig
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.server.api.collectionServiceScopedTo
+import com.calypsan.listenup.server.api.createCollectionService
+import com.calypsan.listenup.server.auth.PrincipalProvider
+import com.calypsan.listenup.server.db.DatabaseConfig
+import com.calypsan.listenup.server.db.DatabaseFactory
+import com.calypsan.listenup.server.db.sqldelight.DriverFactory
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase as ServerSqlDatabase
+import com.calypsan.listenup.server.plugins.JWT_PROVIDER
+import com.calypsan.listenup.server.plugins.userPrincipalOrNull
+import com.calypsan.listenup.server.rpcguard.guard
+import com.calypsan.listenup.server.services.BookRevisionTouch
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.CollectionGrantRepository
+import com.calypsan.listenup.server.sync.CollectionRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.ktor.server.Krpc as ServerKrpc
+import kotlinx.rpc.krpc.ktor.server.rpc as serverRpc
+import kotlinx.rpc.krpc.serialization.json.json as krpcJson
+import kotlinx.rpc.registerService
+import kotlinx.rpc.withService
+import java.nio.file.Files
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Cross-module E2E for RPC transport recovery: the client's [RpcProxyCache] engine driving the
+ * real `:server` [CollectionService] over a live kotlinx.rpc WebSocket that is torn down and
+ * rebuilt mid-session.
+ *
+ * Unlike [CreateAndAddRpcE2ETest] (which uses `testApplication`) these tests own a real
+ * `embeddedServer(CIO)` on a fixed port so the transport can be stopped and restarted — the only
+ * way to reproduce the dead-cached-proxy the recovery engine heals.
+ *
+ * `runBlocking`, not `runTest`: the engine's `withTimeout` bounds run on the real clock, and the
+ * tests do real WebSocket I/O — a virtual clock would auto-advance past the bound and spuriously
+ * time out.
+ */
+class RpcReconnectE2ETest :
+    FunSpec({
+
+        /** Count of live user-created (NORMAL) collections — isolates them from lazy system singletons. */
+        fun normalCollectionCount(driver: SqlDriver): Long =
+            driver
+                .executeQuery(
+                    identifier = null,
+                    sql = "SELECT count(*) FROM collections WHERE type = 'NORMAL' AND deleted_at IS NULL",
+                    mapper = { cursor ->
+                        cursor.next()
+                        QueryResult.Value(cursor.getLong(0)!!)
+                    },
+                    parameters = 0,
+                ).value
+
+        /** Seed a fresh server SQLite with one library + folder + ROOT user; return (db, driver, service). */
+        fun seedServer(): Triple<ServerSqlDatabase, SqlDriver, CollectionService> {
+            val tmp = Files.createTempFile("listenup-reconnect-e2e-", ".db").toFile().apply { deleteOnExit() }
+            DatabaseFactory.init(DatabaseConfig(jdbcUrl = "jdbc:sqlite:${tmp.absolutePath}"))
+            val driver = DriverFactory().createDriver(tmp.absolutePath)
+            val db = ServerSqlDatabase(driver)
+            val now = System.currentTimeMillis()
+            driver.execute(
+                null,
+                "INSERT INTO libraries(id, name, created_at, updated_at, revision) " +
+                    "VALUES ('test-library', 'Test Library', $now, $now, 0)",
+                0,
+            )
+            driver.execute(
+                null,
+                "INSERT INTO library_folders(id, library_id, root_path, created_at, updated_at, revision) " +
+                    "VALUES ('test-folder', 'test-library', '/tmp/test-library', $now, $now, 0)",
+                0,
+            )
+            driver.execute(
+                null,
+                "INSERT INTO users(id, email, email_normalized, password_hash, role, display_name, status, " +
+                    "created_at, updated_at) VALUES " +
+                    "('test-user', 'test-user@x', 'test-user@x', 'x', 'ROOT', 'test-user', 'ACTIVE', $now, $now)",
+                0,
+            )
+            val bus = ChangeBus()
+            val registry = SyncRegistry()
+            val noopTouch =
+                object : BookRevisionTouch {
+                    override suspend fun touchRevision(id: BookId): AppResult<Unit> = AppResult.Success(Unit)
+                }
+            val service =
+                createCollectionService(
+                    collectionRepo = CollectionRepository(db, bus, registry, driver = driver),
+                    collectionBookRepo = CollectionBookRepository(db, bus, registry, driver = driver),
+                    grantRepo = CollectionGrantRepository(db, bus, registry, driver = driver),
+                    bus = bus,
+                    sql = db,
+                    bookRevisionTouch = noopTouch,
+                )
+            return Triple(db, driver, service)
+        }
+
+        /**
+         * Build (but don't start) a CIO server on [port] exposing [service] on `/api/rpc/authed`.
+         * [wrap] can decorate the scoped service (e.g. to inject a delay) — identity by default.
+         */
+        fun buildServer(
+            port: Int,
+            service: CollectionService,
+            wrap: (CollectionService) -> CollectionService = { it },
+        ): EmbeddedServer<*, *> {
+            val module: Application.() -> Unit = {
+                install(ServerKrpc)
+                install(Authentication) { testAuth(defaultUserId = "test-user") }
+                routing {
+                    authenticate(JWT_PROVIDER) {
+                        serverRpc("/api/rpc/authed") {
+                            rpcConfig { serialization { krpcJson(contractJson) } }
+                            registerService<CollectionService> {
+                                val principal =
+                                    call.userPrincipalOrNull() ?: error("authed RPC mount reached without a principal")
+                                guard(wrap(collectionServiceScopedTo(service, PrincipalProvider { principal })))
+                            }
+                        }
+                    }
+                }
+            }
+            return embeddedServer(CIO, port = port, host = "127.0.0.1", module = module)
+        }
+
+        fun stubClient(): HttpClient = HttpClient(OkHttp) { install(WebSockets) }
+
+        test("a create over a dead-then-restarted connection heals with exactly one new row") {
+            runBlocking {
+                val (_, driver, service) = seedServer()
+
+                var server = buildServer(0, service)
+                server.start(wait = false)
+                val port = server.engine.resolvedConnectors().first().port
+                val baseUrl = "http://127.0.0.1:$port"
+
+                val factory =
+                    KtorCollectionRpcFactory(
+                        apiClientFactory = StubApiClientFactory(stubClient()),
+                        serverConfig = TestServerConfig(baseUrl),
+                    )
+                val repo =
+                    CollectionRepositoryImpl(
+                        collectionDao = mock<CollectionDao>(MockMode.autofill),
+                        collectionBookDao = mock<CollectionBookDao>(MockMode.autofill),
+                        collectionShareDao = mock<CollectionShareDao>(MockMode.autofill),
+                        rpcFactory = factory,
+                    )
+
+                // First create over a live connection — caches the proxy.
+                repo.create("test-library", "Staff Picks").shouldBeInstanceOf<AppResult.Success<*>>()
+
+                // Kill the transport, then bring an identical server back on the SAME port.
+                server.stop(gracePeriodMillis = 100, timeoutMillis = 500)
+                server = buildServer(port, service)
+                server.start(wait = false)
+
+                // Second create hits the DEAD cached proxy → the engine reconnects and retries.
+                repo.create("test-library", "Reconnected Picks").shouldBeInstanceOf<AppResult.Success<*>>()
+
+                normalCollectionCount(driver) shouldBe 2L // no phantom dup from the retry
+
+                server.stop(gracePeriodMillis = 100, timeoutMillis = 500)
+            }
+        }
+
+        test("a handler that outlasts the client bound times out without a second mutation") {
+            runBlocking {
+                val (_, driver, service) = seedServer()
+
+                // The scoped service commits the row, THEN stalls past the client's bound.
+                val stalling: (CollectionService) -> CollectionService = { scoped ->
+                    object : CollectionService by scoped {
+                        override suspend fun createCollection(
+                            libraryId: String,
+                            name: String,
+                        ): AppResult<CollectionSummary> {
+                            val committed = scoped.createCollection(libraryId, name)
+                            delay(10_000) // far beyond the 2s client bound below
+                            return committed
+                        }
+                    }
+                }
+
+                val server = buildServer(0, service, wrap = stalling)
+                server.start(wait = false)
+                val port = server.engine.resolvedConnectors().first().port
+                val baseUrl = "http://127.0.0.1:$port"
+
+                val cache =
+                    RpcProxyCache(StubApiClientFactory(stubClient()), TestServerConfig(baseUrl)) { client, url ->
+                        client.rpc("$url/api/rpc/authed").withService<CollectionService>()
+                    }
+
+                val result: AppResult<CollectionSummary> =
+                    cache.rpcCall(timeout = 2.seconds) {
+                        it.createCollection("test-library", "Staff Picks")
+                    }
+
+                result.shouldBeInstanceOf<AppResult.Failure>().error.shouldBeInstanceOf<TransportError.Timeout>()
+                // The handler committed once and the timeout path never retries — exactly one row.
+                normalCollectionCount(driver) shouldBe 1L
+
+                server.stop(gracePeriodMillis = 100, timeoutMillis = 500)
+            }
+        }
+    })
+
+/** Minimal [ApiClientFactory] serving one WebSocket-capable client; only [getClient] is exercised. */
+private class StubApiClientFactory(
+    private val client: HttpClient,
+) : ApiClientFactory {
+    override suspend fun getClient(): HttpClient = client
+
+    override suspend fun getStreamingClient(): HttpClient = client
+
+    override suspend fun getUnauthenticatedStreamingClient(): HttpClient = client
+
+    override suspend fun invalidateRequestClientOnly() {}
+
+    override suspend fun warmUp() {}
+
+    override suspend fun invalidate() {}
+}

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/RpcReconnectE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/RpcReconnectE2ETest.kt
@@ -170,7 +170,11 @@ class RpcReconnectE2ETest :
 
                 var server = buildServer(0, service)
                 server.start(wait = false)
-                val port = server.engine.resolvedConnectors().first().port
+                val port =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
                 val baseUrl = "http://127.0.0.1:$port"
 
                 val factory =
@@ -223,7 +227,11 @@ class RpcReconnectE2ETest :
 
                 val server = buildServer(0, service, wrap = stalling)
                 server.start(wait = false)
-                val port = server.engine.resolvedConnectors().first().port
+                val port =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
                 val baseUrl = "http://127.0.0.1:$port"
 
                 val cache =

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/RpcReconnectE2ETest.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/collections/RpcReconnectE2ETest.kt
@@ -50,6 +50,8 @@ import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.routing.routing
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.rpc.krpc.ktor.client.rpc
@@ -58,7 +60,13 @@ import kotlinx.rpc.krpc.ktor.server.rpc as serverRpc
 import kotlinx.rpc.krpc.serialization.json.json as krpcJson
 import kotlinx.rpc.registerService
 import kotlinx.rpc.withService
+import java.io.Closeable
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -251,7 +259,151 @@ class RpcReconnectE2ETest :
                 server.stop(gracePeriodMillis = 100, timeoutMillis = 500)
             }
         }
+
+        // THE regression guard for the reviewer's blocker: a mutation whose frame is DELIVERED and
+        // committed, then loses its response to a mid-flight connection drop, must surface a Failure
+        // and NOT be retried (which would double-commit). A TCP relay severs the live socket after the
+        // server commits — no server restart — reproducing kotlinx.rpc's bare "Client cancelled" CE.
+        test("a delivered-then-dropped create surfaces Failure with exactly one commit (no double-apply)") {
+            runBlocking {
+                val (_, driver, service) = seedServer()
+
+                val committed = CompletableDeferred<Unit>()
+                val invocations =
+                    java.util.concurrent.atomic
+                        .AtomicInteger(0)
+                val severAfterCommit: (CollectionService) -> CollectionService = { scoped ->
+                    object : CollectionService by scoped {
+                        override suspend fun createCollection(
+                            libraryId: String,
+                            name: String,
+                        ): AppResult<CollectionSummary> {
+                            val n = invocations.incrementAndGet()
+                            val result = scoped.createCollection(libraryId, name) // COMMITS the row
+                            if (n == 1) {
+                                // Hold ONLY the first response so the test can sever it mid-flight. A
+                                // (buggy) retry would arrive as a 2nd invocation, commit again, and
+                                // return immediately — proving the double-apply.
+                                committed.complete(Unit)
+                                delay(30_000)
+                            }
+                            return result
+                        }
+                    }
+                }
+
+                val server = buildServer(0, service, wrap = severAfterCommit)
+                server.start(wait = false)
+                val serverPort =
+                    server.engine
+                        .resolvedConnectors()
+                        .first()
+                        .port
+
+                // Client talks to the relay, which forwards to the real server until we cut it.
+                val relay = TcpRelay.start("127.0.0.1", serverPort)
+                val baseUrl = "http://127.0.0.1:${relay.port}"
+
+                val factory =
+                    KtorCollectionRpcFactory(
+                        apiClientFactory = StubApiClientFactory(stubClient()),
+                        serverConfig = TestServerConfig(baseUrl),
+                    )
+                val repo =
+                    CollectionRepositoryImpl(
+                        collectionDao = mock<CollectionDao>(MockMode.autofill),
+                        collectionBookDao = mock<CollectionBookDao>(MockMode.autofill),
+                        collectionShareDao = mock<CollectionShareDao>(MockMode.autofill),
+                        rpcFactory = factory,
+                    )
+
+                val pending = async { repo.create("test-library", "Staff Picks") }
+                committed.await() // the server has COMMITTED; the client is now awaiting the response
+                delay(200) // let the client park on the pending response
+                // Drop the in-flight connection but keep the relay ACCEPTING — so a (buggy) retry can
+                // reconnect and reach the server, exposing a double-commit. The fix must not retry.
+                relay.cut()
+
+                val result = pending.await()
+
+                // Surfaced honestly (not a phantom Success carrying a retried row's id)...
+                result.shouldBeInstanceOf<AppResult.Failure>()
+                // ...and committed EXACTLY once — a retry here would have double-applied the mutation.
+                normalCollectionCount(driver) shouldBe 1L
+
+                relay.shutdown()
+                server.stop(gracePeriodMillis = 100, timeoutMillis = 500)
+            }
+        }
     })
+
+/**
+ * A dead-simple bidirectional TCP relay. Forwards bytes between a client and [targetPort].
+ *
+ * [cut] drops every CURRENTLY-open connection (severing a live request mid-flight) but keeps the
+ * listener accepting, so a reconnect still reaches the server — the crucial detail that lets a
+ * *buggy* retry expose a double-commit. [shutdown] tears the whole relay down.
+ */
+private class TcpRelay private constructor(
+    private val listener: ServerSocket,
+    private val targetHost: String,
+    private val targetPort: Int,
+) {
+    val port: Int get() = listener.localPort
+    private val liveConnections = CopyOnWriteArrayList<Closeable>()
+
+    @Volatile private var accepting = true
+
+    init {
+        thread(isDaemon = true, name = "relay-accept") {
+            while (accepting) {
+                val downstream = runCatching { listener.accept() }.getOrNull() ?: break
+                val upstream = runCatching { Socket(targetHost, targetPort) }.getOrNull()
+                if (upstream == null) {
+                    runCatching { downstream.close() }
+                    continue
+                }
+                liveConnections.add(downstream)
+                liveConnections.add(upstream)
+                pump(downstream, upstream)
+                pump(upstream, downstream)
+            }
+        }
+    }
+
+    private fun pump(
+        from: Socket,
+        to: Socket,
+    ) {
+        thread(isDaemon = true, name = "relay-pump") {
+            runCatching {
+                from.getInputStream().copyTo(to.getOutputStream())
+                to.getOutputStream().flush()
+            }
+        }
+    }
+
+    /** Sever all in-flight connections; the listener stays open so a reconnect can still get through. */
+    fun cut() {
+        val snapshot = liveConnections.toList()
+        liveConnections.clear()
+        snapshot.forEach { runCatching { it.close() } }
+    }
+
+    /** Full teardown — stop accepting and close everything. */
+    fun shutdown() {
+        accepting = false
+        cut()
+        runCatching { listener.close() }
+    }
+
+    companion object {
+        fun start(
+            targetHost: String,
+            targetPort: Int,
+        ): TcpRelay = TcpRelay(ServerSocket(0, 50, InetAddress.getByName("127.0.0.1")), targetHost, targetPort)
+    }
+}
 
 /** Minimal [ApiClientFactory] serving one WebSocket-capable client; only [getClient] is exercised. */
 private class StubApiClientFactory(

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -1002,7 +1002,8 @@ internal class TestCollectionRpcFactory(
     override suspend fun <T> callResult(
         block: suspend (CollectionService) -> com.calypsan.listenup.api.result.AppResult<T>,
     ): com.calypsan.listenup.api.result.AppResult<T> =
-        com.calypsan.listenup.client.data.remote.catchingRpcResult { block(get()) }
+        com.calypsan.listenup.client.data.remote
+            .catchingRpcResult { block(get()) }
 
     override suspend fun invalidate() {
         mutex.withLock { cachedService = null }

--- a/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
+++ b/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/testing/WithClientSyncEngineAgainstServer.kt
@@ -999,6 +999,11 @@ internal class TestCollectionRpcFactory(
             cachedService ?: connect().also { cachedService = it }
         }
 
+    override suspend fun <T> callResult(
+        block: suspend (CollectionService) -> com.calypsan.listenup.api.result.AppResult<T>,
+    ): com.calypsan.listenup.api.result.AppResult<T> =
+        com.calypsan.listenup.client.data.remote.catchingRpcResult { block(get()) }
+
     override suspend fun invalidate() {
         mutex.withLock { cachedService = null }
     }


### PR DESCRIPTION
## Why

`RpcProxyCache` cached each kotlinx.rpc service's WebSocket **forever**, invalidating only on logout/re-login/URL-change. When that socket died (Wi-Fi handoff, doze, server restart, expired token), the next call either threw or hung — and every repo's `catch (CancellationException) { throw e }` misread the transport-originated cancellation as *caller* cancellation, silently killing the ViewModel coroutine. That single gap was the confirmed common root of **three** shipped bugs: create-shelf/collection silent no-op, the splash hang at startup, and the iOS playback `KotlinError` (unguarded `PlaybackPreparer` RPC).

## What

Centralize bounded, self-healing recovery in one place — `RpcProxyCache.call {}` — so **every factory and repo that routes through it inherits robustness for free**, no per-domain code:

- **Bounded** (15s unary timeout) → no more hangs.
- **Self-healing, single-flight** (generation-guarded invalidate) → a dead connection reconnects on the next call; a herd of concurrent failures triggers exactly one reconnect.
- **At-most-once** → retry fires *only* on failures that prove the RPC frame was never delivered (`isDeadRpcClient` ISE-before-send, `WebSocketException`, `ConnectTimeoutException`, handshake-401-after-refresh). Anything post-delivery surfaces as a typed "outcome unknown" failure and is **never** retried.
- **401-handshake → token refresh → reconnect → retry** via a new `RpcAuthRecovery` seam over the existing refresh machinery (fixes the "expected 101 but was 401" case); refresh-failure short-circuits to `SessionExpired`.
- **Collapses the divergent per-repo `rpcCall` copies** into `catchingRpcResult` / `RpcProxyCache.rpcCall`.

Routed through the engine in this PR: **create-shelf, create-collection, and `PlaybackPreparer`'s streaming-prepare RPC** (the three known offenders). Streaming, the SSE reconnect, and `InstanceRpcFactory` (already robust) are untouched.

## Built + hardened via an adversarial gate

Implemented by a subagent from the agreed design, then **an adversarial reviewer was run before this PR was opened** — and it earned its keep:

> **It found and empirically proved a BLOCKER.** The original `CancellationException`-from-below branch auto-retried — but in kotlinx.rpc 0.11.0-grpc-189 a bare CE from below means the frame was *already delivered and possibly committed* (only the response was lost). On a Wi-Fi blip mid-response, `createCollection` ran **twice** (proven with a real-server + TCP-relay probe: server commits → connection drops → retry → 2 rows, client reports Success with the second row's id).

That path was rewritten to invalidate-but-never-retry and surface a typed failure. The reviewer's probe is now the **permanent regression test** (`RpcReconnectE2ETest` "delivered-then-dropped surfaces Failure with exactly one commit") — verified to fail if the fix is reverted.

## Tests

- `RpcProxyCacheCallTest`: dead-client-ISE retries once; **from-below CE with a live caller does NOT retry** (typed failure); business `AppResult.Failure` passes through with no reconnect; timeout invalidates but never retries; single-flight herd = one reconnect; 401 refresh-once/surface-on-fail.
- `RpcReconnectE2ETest` (real `embeddedServer(CIO)`): heal-on-dead-then-restarted (exactly one new row); **no-double-mutation on delivered-then-dropped**; client-timeout no-retry.
- `RpcFailureClassifierTest`; existing repo/e2e tests updated. Full `:sharedLogic:jvmTest` + `testAndroidHostTest` + spotless + detekt green (critical RPC classes force-reran independently).

## Scope / follow-ups

- **This is the engine + the three offenders.** A fast-follow PR collapses the remaining ~10 unbounded per-repo `rpcCall` copies onto the shared helper + adds a Konsist rule to pin it (pure consolidation, rides on this proven core).
- **One-time on-device check:** the handshake-401 classifier was verified on OkHttp (JVM); the Darwin (iOS) engine's 401 shape wasn't executable in the harness — worth a single simulator confirmation.
